### PR TITLE
feat(registry): add OpenClaw v2026.4.2 support

### DIFF
--- a/src/clawrium/platform/registry/openclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/openclaw/manifest.yaml
@@ -30,3 +30,21 @@ entries:
       gpu_required: false
       dependencies:
         nodejs: ">=18.0.0"
+  - version: "2026.4.2"
+    os: ubuntu
+    os_version: "24.04"
+    arch: x86_64
+    requirements:
+      min_memory_mb: 2048
+      gpu_required: false
+      dependencies:
+        nodejs: ">=20.0.0"
+  - version: "2026.4.2"
+    os: ubuntu
+    os_version: "22.04"
+    arch: x86_64
+    requirements:
+      min_memory_mb: 2048
+      gpu_required: false
+      dependencies:
+        nodejs: ">=18.0.0"

--- a/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
@@ -13,7 +13,7 @@
       ansible.builtin.git:
         repo: https://github.com/openclaw/openclaw.git
         dest: "/home/opc-{{ inventory_hostname }}/openclaw"
-        version: "{{ claw_version | default('v1.0.0') }}"
+        version: "{{ claw_version | default('v2026.4.2') }}"
       become_user: "opc-{{ inventory_hostname }}"
 
     - name: Install npm dependencies

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -2,6 +2,7 @@
 
 from typer.testing import CliRunner
 from clawrium.cli.main import app
+from clawrium.core.registry import get_claw_info
 
 runner = CliRunner()
 
@@ -15,11 +16,12 @@ def test_registry_list_shows_table():
 
 
 def test_registry_list_shows_version():
-    """Test that registry list includes version."""
+    """Test that registry list includes latest version from manifest."""
     result = runner.invoke(app, ["registry", "list"])
     assert result.exit_code == 0
-    # Should show version from manifest
-    assert "0.1.0" in result.output
+    # Dynamically get expected version from registry
+    claw_info = get_claw_info("openclaw")
+    assert claw_info["latest_version"] in result.output
 
 
 def test_registry_show_openclaw():


### PR DESCRIPTION
## Summary
- Add manifest entries for OpenClaw v2026.4.2 (Ubuntu 24.04/22.04, x86_64)
- Update install playbook default version from v1.0.0 to v2026.4.2
- Improve test robustness by dynamically fetching version from registry

## Test plan
- [x] `make test` - 293 tests pass
- [x] `make lint` - All checks pass
- [ ] `clm registry show openclaw` - Verify v2026.4.2 shows as latest

Closes #20

---

## ATX Review Summary
**Review 1: Rating 2/5**

### Blocking Issues

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `manifest.yaml` | Version `2026.4.2` is future-dated CalVer, may not exist upstream | ✅ Verified release exists (HTTP 200) |
| B2 | `manifest.yaml` | Secrets schema diverges from zeroclaw | ⏭️ Pre-existing, out of scope |
| B3 | `install.yaml` | `inventory_hostname` vs `claw_user` mismatch | ⏭️ Pre-existing, out of scope |
| B4 | `install.yaml` + `install.py` | Secrets exposed in ansible-runner artifacts | ⏭️ Pre-existing, out of scope |
| B5 | `install.yaml` | Systemd unit missing EnvironmentFile for secrets | ⏭️ Pre-existing, out of scope |
| B6 | `manifest.yaml` | No sha256 checksums for integrity verification | ⏭️ Pre-existing, out of scope |
| B7 | `test_cli_registry.py` | Hardcoded version string breaks on version bumps | ✅ Fixed - uses `get_claw_info()` dynamically |

### Warnings

| # | File | Issue | Recommendation |
|---|------|-------|----------------|
| W1 | `install.yaml:19` | `npm install` not idempotent | Use `creates:` guard, `npm ci --ignore-scripts` |
| W2 | `install.yaml:12` | Git clone has no force/update handling | Add `force: yes`, `update: yes` |
| W3 | `install.yaml:1` | `become: yes` at play level | Move per-task for least privilege |
| W4 | `install.yaml:19` | `npm install` runs lifecycle scripts | Use `npm ci --ignore-scripts` |
| W5 | `manifest.yaml` | nodejs dependency differentiation not enforced | Add comment noting TODO status |
| W6 | `test_cli_registry.py` | Error paths untested | Add tests for error scenarios |
| W7 | `install.py:219` | Alias field not sanitized in log path | Apply KEY_ID_PATTERN to alias |

### Suggestions

| # | File | Suggestion |
|---|------|-----------|
| S1 | `manifest.yaml` | Sort entries latest-first or add `latest: true` flag |
| S2 | `install.yaml:46` | Discover npm path dynamically |
| S3 | `install.yaml:33` | Systemd unit mode 0640 instead of 0644 |
| S4 | `ssh_connection.py:206` | Add `look_for_keys=False, allow_agent=False` |
| S5 | `test_cli_registry.py` | Follow `test_<fn>_<scenario>_<expected>` naming |
| S6 | `test_cli_registry.py` | Extract shared `cli_runner` fixture |
| S7 | `manifest.yaml` | Document ARM64/aarch64 support status |

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)