### PR TITLE
fix(registry): prefer latest version in compatibility check

### DIFF
--- a/src/clawrium/core/registry.py
+++ b/src/clawrium/core/registry.py
@@ -183,7 +183,7 @@ def list_claws() -> list[str]:
 
         return sorted(claws)
 
-    except Exception as e:
+    except (ModuleNotFoundError, FileNotFoundError) as e:
         logger.error("Failed to list claws: %s", e)
         return []
 
@@ -263,6 +263,14 @@ def get_optional_secrets(claw_name: str) -> list[SecretDefinition]:
     return manifest.get("optional_secrets", [])
 
 
+def _parse_version_safe(version_str: str) -> Version:
+    """Parse version string to Version object, returning 0.0.0 for invalid versions."""
+    try:
+        return Version(version_str)
+    except InvalidVersion:
+        return Version("0.0.0")
+
+
 def check_compatibility(
     claw_name: str,
     hardware: dict,
@@ -290,16 +298,34 @@ def check_compatibility(
     """
     manifest = load_manifest(claw_name)
 
-    # Filter entries by version if specified
+    # Filter entries by version if specified (using semver comparison)
     entries = manifest["entries"]
     if version:
-        entries = [e for e in entries if e["version"] == version]
+        try:
+            requested_version = Version(version)
+        except InvalidVersion:
+            return {
+                "compatible": False,
+                "matched_entry": None,
+                "reasons": [f"Invalid version format: {version}"],
+            }
+        entries = [
+            e for e in entries
+            if _parse_version_safe(e["version"]) == requested_version
+        ]
         if not entries:
             return {
                 "compatible": False,
                 "matched_entry": None,
                 "reasons": [f"Version {version} not found in manifest"],
             }
+    else:
+        # Sort entries by version descending so latest version is preferred
+        entries = sorted(
+            entries,
+            key=lambda e: _parse_version_safe(e["version"]),
+            reverse=True,
+        )
 
     # Collect all failure reasons across all entries
     all_reasons = []
@@ -308,22 +334,17 @@ def check_compatibility(
     for entry in entries:
         reasons = []
 
-        # Check OS match
-        if entry["os"] != hardware.get("os"):
+        # Check platform match (OS, version, arch) - only one reason per entry
+        os_match = entry["os"] == hardware.get("os")
+        version_match = entry["os_version"] == hardware.get("os_version")
+        arch_match = entry["arch"] == hardware.get("architecture")
+
+        if not os_match or not version_match:
             reasons.append(
                 f"Requires {entry['os']} {entry['os_version']}, "
                 f"host has {hardware.get('os', 'unknown')} {hardware.get('os_version', 'unknown')}"
             )
-
-        # Check OS version match
-        elif entry["os_version"] != hardware.get("os_version"):
-            reasons.append(
-                f"Requires {entry['os']} {entry['os_version']}, "
-                f"host has {hardware.get('os', 'unknown')} {hardware.get('os_version', 'unknown')}"
-            )
-
-        # Check architecture match
-        if entry["arch"] != hardware.get("architecture"):
+        elif not arch_match:
             reasons.append(
                 f"Requires {entry['arch']}, host has {hardware.get('architecture', 'unknown')}"
             )
@@ -340,8 +361,11 @@ def check_compatibility(
         # Check GPU requirement (use .get() for safety)
         if requirements.get("gpu_required", False):
             gpu = hardware.get("gpu", {})
-            if not gpu.get("present"):
+            gpu_present = gpu.get("present")
+            if gpu_present is False:
                 reasons.append("Requires GPU, host has none")
+            elif gpu_present is None:
+                reasons.append("Requires GPU, but GPU detection failed")
 
         # TODO: Dependency checking deferred to future phase
         # Hardware dict doesn't include installed package versions yet

--- a/src/clawrium/platform/registry/zeroclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/manifest.yaml
@@ -1,15 +1,17 @@
 name: zeroclaw
 description: "Lightweight AI assistant for edge devices and Raspberry Pi"
-secrets:
+
+# Secrets required for this claw (install will fail if missing)
+required_secrets:
   - key: LLM_PROVIDER_URL
     description: "LLM API endpoint URL (e.g., http://192.168.1.100:11434)"
-    required: true
   - key: LLM_MODEL
     description: "Model name to use (e.g., llama3, gpt-4)"
-    required: true
+
+# Optional secrets (claw works without them but with reduced functionality)
+optional_secrets:
   - key: LLM_API_KEY
     description: "API key for LLM provider (optional for local)"
-    required: false
 # Note: Same statically-linked binary is used across OS versions (Ubuntu 22.04/24.04)
 # so SHA256 checksums are identical per architecture.
 entries:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -428,3 +428,281 @@ def test_check_compatibility_zeroclaw_ubuntu_x86_64():
     assert result["matched_entry"] is not None
     assert result["matched_entry"]["arch"] == "x86_64"
     assert result["matched_entry"]["os"] == "ubuntu"
+
+
+def test_check_compatibility_prefers_latest_version():
+    """Test that check_compatibility returns latest version when multiple match."""
+    from clawrium.core.registry import check_compatibility, get_claw_info
+
+    hardware = {
+        "os": "ubuntu",
+        "os_version": "24.04",
+        "architecture": "x86_64",
+        "memtotal_mb": 4096,
+        "gpu": {"present": False, "vendor": None, "error": None},
+        "processor_cores": 4,
+        "processor_count": 1,
+        "mounts": [],
+    }
+
+    result = check_compatibility("openclaw", hardware)
+
+    assert result["compatible"] is True
+    assert result["matched_entry"] is not None
+
+    # The matched version should be the latest version
+    info = get_claw_info("openclaw")
+    assert result["matched_entry"]["version"] == info["latest_version"]
+
+
+# Secret function tests
+
+
+def test_get_required_secrets_returns_list():
+    """Test get_required_secrets returns list of SecretDefinition dicts."""
+    from clawrium.core.registry import get_required_secrets
+
+    secrets = get_required_secrets("openclaw")
+
+    assert isinstance(secrets, list)
+    assert len(secrets) > 0
+    # Each secret should have key and description
+    for secret in secrets:
+        assert "key" in secret
+        assert "description" in secret
+
+
+def test_get_required_secrets_zeroclaw():
+    """Test get_required_secrets for zeroclaw returns expected secrets."""
+    from clawrium.core.registry import get_required_secrets
+
+    secrets = get_required_secrets("zeroclaw")
+
+    assert isinstance(secrets, list)
+    assert len(secrets) >= 2
+    keys = [s["key"] for s in secrets]
+    assert "LLM_PROVIDER_URL" in keys
+    assert "LLM_MODEL" in keys
+
+
+def test_get_optional_secrets_returns_list():
+    """Test get_optional_secrets returns list of SecretDefinition dicts."""
+    from clawrium.core.registry import get_optional_secrets
+
+    secrets = get_optional_secrets("openclaw")
+
+    assert isinstance(secrets, list)
+    # openclaw has optional secrets defined
+    for secret in secrets:
+        assert "key" in secret
+        assert "description" in secret
+
+
+def test_get_required_secrets_nonexistent_raises():
+    """Test get_required_secrets with nonexistent claw raises ManifestNotFoundError."""
+    from clawrium.core.registry import get_required_secrets
+
+    with pytest.raises(ManifestNotFoundError, match="not found"):
+        get_required_secrets("nonexistent")
+
+
+def test_get_optional_secrets_nonexistent_raises():
+    """Test get_optional_secrets with nonexistent claw raises ManifestNotFoundError."""
+    from clawrium.core.registry import get_optional_secrets
+
+    with pytest.raises(ManifestNotFoundError, match="not found"):
+        get_optional_secrets("nonexistent")
+
+
+# validate_claw_name tests
+
+
+def test_validate_claw_name_empty_raises():
+    """Test validate_claw_name with empty string raises InvalidClawNameError."""
+    from clawrium.core.registry import validate_claw_name, InvalidClawNameError
+
+    with pytest.raises(InvalidClawNameError, match="cannot be empty"):
+        validate_claw_name("")
+
+
+def test_validate_claw_name_with_slash_raises():
+    """Test validate_claw_name with slash raises InvalidClawNameError."""
+    from clawrium.core.registry import validate_claw_name, InvalidClawNameError
+
+    with pytest.raises(InvalidClawNameError, match="invalid characters"):
+        validate_claw_name("foo/bar")
+
+
+def test_validate_claw_name_with_backslash_raises():
+    """Test validate_claw_name with backslash raises InvalidClawNameError."""
+    from clawrium.core.registry import validate_claw_name, InvalidClawNameError
+
+    with pytest.raises(InvalidClawNameError, match="invalid characters"):
+        validate_claw_name("foo\\bar")
+
+
+def test_validate_claw_name_valid():
+    """Test validate_claw_name with valid names passes."""
+    from clawrium.core.registry import validate_claw_name
+
+    # These should not raise
+    validate_claw_name("openclaw")
+    validate_claw_name("zero-claw")
+    validate_claw_name("claw_v2")
+    validate_claw_name("Claw123")
+
+
+# check_compatibility version parameter tests
+
+
+def test_check_compatibility_specific_version_match():
+    """Test check_compatibility with specific version that exists."""
+    from clawrium.core.registry import check_compatibility
+
+    hardware = {
+        "os": "ubuntu",
+        "os_version": "24.04",
+        "architecture": "x86_64",
+        "memtotal_mb": 4096,
+        "gpu": {"present": False, "vendor": None, "error": None},
+        "processor_cores": 4,
+        "processor_count": 1,
+        "mounts": [],
+    }
+
+    # openclaw has version 0.1.0 for Ubuntu 24.04
+    result = check_compatibility("openclaw", hardware, version="0.1.0")
+
+    assert result["compatible"] is True
+    assert result["matched_entry"]["version"] == "0.1.0"
+
+
+def test_check_compatibility_specific_version_not_found():
+    """Test check_compatibility with specific version that doesn't exist."""
+    from clawrium.core.registry import check_compatibility
+
+    hardware = {
+        "os": "ubuntu",
+        "os_version": "24.04",
+        "architecture": "x86_64",
+        "memtotal_mb": 4096,
+        "gpu": {"present": False, "vendor": None, "error": None},
+        "processor_cores": 4,
+        "processor_count": 1,
+        "mounts": [],
+    }
+
+    result = check_compatibility("openclaw", hardware, version="99.99.99")
+
+    assert result["compatible"] is False
+    assert result["matched_entry"] is None
+    assert any("not found" in r for r in result["reasons"])
+
+
+def test_check_compatibility_invalid_version_format():
+    """Test check_compatibility with invalid version format."""
+    from clawrium.core.registry import check_compatibility
+
+    hardware = {
+        "os": "ubuntu",
+        "os_version": "24.04",
+        "architecture": "x86_64",
+        "memtotal_mb": 4096,
+        "gpu": {"present": False, "vendor": None, "error": None},
+        "processor_cores": 4,
+        "processor_count": 1,
+        "mounts": [],
+    }
+
+    result = check_compatibility("openclaw", hardware, version="not-a-version")
+
+    assert result["compatible"] is False
+    assert any("invalid version" in r.lower() for r in result["reasons"])
+
+
+# GPU requirement tests
+
+
+def test_check_compatibility_gpu_required_but_missing(monkeypatch):
+    """Test compatibility check when GPU required but not present."""
+    from clawrium.core.registry import check_compatibility
+    from clawrium.core import registry
+
+    # Create a fake manifest with GPU required
+    fake_manifest = {
+        "name": "gpuclaw",
+        "description": "GPU-requiring claw",
+        "entries": [
+            {
+                "version": "1.0.0",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": True,
+                    "dependencies": {},
+                },
+            }
+        ],
+    }
+
+    monkeypatch.setattr(registry, "load_manifest", lambda x: fake_manifest)
+
+    hardware = {
+        "os": "ubuntu",
+        "os_version": "24.04",
+        "architecture": "x86_64",
+        "memtotal_mb": 4096,
+        "gpu": {"present": False, "vendor": None, "error": None},
+        "processor_cores": 4,
+        "processor_count": 1,
+        "mounts": [],
+    }
+
+    result = check_compatibility("gpuclaw", hardware)
+
+    assert result["compatible"] is False
+    assert any("gpu" in r.lower() for r in result["reasons"])
+
+
+def test_check_compatibility_gpu_detection_failed(monkeypatch):
+    """Test compatibility check when GPU detection failed (present=None)."""
+    from clawrium.core.registry import check_compatibility
+    from clawrium.core import registry
+
+    fake_manifest = {
+        "name": "gpuclaw",
+        "description": "GPU-requiring claw",
+        "entries": [
+            {
+                "version": "1.0.0",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": True,
+                    "dependencies": {},
+                },
+            }
+        ],
+    }
+
+    monkeypatch.setattr(registry, "load_manifest", lambda x: fake_manifest)
+
+    hardware = {
+        "os": "ubuntu",
+        "os_version": "24.04",
+        "architecture": "x86_64",
+        "memtotal_mb": 4096,
+        "gpu": {"present": None, "vendor": None, "error": "detection failed"},
+        "processor_cores": 4,
+        "processor_count": 1,
+        "mounts": [],
+    }
+
+    result = check_compatibility("gpuclaw", hardware)
+
+    assert result["compatible"] is False
+    assert any("detection failed" in r.lower() for r in result["reasons"])


### PR DESCRIPTION
## Summary

- Fix version mismatch bug where `clm install` showed `v0.1.0` instead of latest `v2026.4.2`
- Root cause: `check_compatibility()` returned first matching entry regardless of version order in manifest
- Now sorts entries by version descending so latest version is preferred

## Changes

- Sort manifest entries by semver before compatibility matching
- Use semver comparison for version filtering (not string equality)
- Narrow exception handling in `list_claws()` to expected types only
- Handle GPU detection failure (`present=None`) separately from no GPU (`present=False`)
- Fix arch check to only run when OS/version match (avoid inflated reason counts)
- Migrate zeroclaw manifest from legacy `secrets` schema to `required_secrets`/`optional_secrets`

## Test plan

- [x] `make test` passes (335 tests)
- [x] `make lint` passes
- [x] New test `test_check_compatibility_prefers_latest_version` validates fix
- [x] 14 new tests added for previously uncovered code paths

## ATX Review Summary

**Review 1: Rating 3/5**

### Blocking Issues

| # | Location | Issue | Fix |
|---|----------|-------|-----|
| B1 | `zeroclaw/manifest.yaml` vs `registry.py:247` | zeroclaw manifest uses flat `secrets` list with inline `required: true/false` — not the `required_secrets`/`optional_secrets` split that `ClawManifest` TypedDict expects. `get_required_secrets('zeroclaw')` returns `[]`, silently skipping required secrets. | ✅ Migrated to `required_secrets`/`optional_secrets` schema |

### Warnings Addressed

| # | Location | Issue | Fix |
|---|----------|-------|-----|
| W1 | `registry.py:334` | Arch check is standalone `if`, not `elif`. When OS mismatches, both OS and arch reasons appended. | ✅ Restructured to only check arch when OS/version match |
| W2 | `registry.py:295-296` | Version filter uses string equality, not semver. | ✅ Added `_parse_version_safe()` helper, use semver comparison |
| W3 | `registry.py:186` | `list_claws()` swallows all exceptions with bare `except Exception`. | ✅ Narrowed to `(ModuleNotFoundError, FileNotFoundError)` |
| W4 | `registry.py:349-352` | GPU check treats `None` (detection failed) same as `False` (no GPU). | ✅ Added separate handling for `present is None` |
| W5 | `tests/test_registry.py` | `get_required_secrets()` and `get_optional_secrets()` have zero tests. | ✅ Added 5 tests |
| W6 | `tests/test_registry.py:220-242` | `gpu_required` branch untested. | ✅ Added 2 tests with monkeypatched manifest |
| W7 | `tests/test_registry.py` | `validate_claw_name()` edge cases untested. | ✅ Added 4 tests (empty, slash, backslash, valid) |
| W8 | `tests/test_registry.py` | `check_compatibility()` version parameter branch uncovered. | ✅ Added 3 tests (match, not found, invalid format) |

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.ai/code)