### PR TITLE
feat: add GitHub issue templates and link CONTRIBUTING in README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,118 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[BUG] "
+labels:
+  - bug
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this bug. Please fill out the sections below to help us understand and fix the issue.
+
+        Before submitting:
+        - Search [existing issues](https://github.com/ric03uec/clawrium/issues?q=is%3Aissue+label%3Abug) to avoid duplicates
+        - Make sure you're using the latest version
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight Checklist
+      options:
+        - label: I have searched existing issues and this hasn't been reported yet
+          required: true
+        - label: This is a single bug report (separate reports for different bugs)
+          required: true
+        - label: I am using the latest version of clawrium
+          required: true
+
+  - type: textarea
+    id: customer-outcome
+    attributes:
+      label: What should the user be able to do?
+      description: Describe what the user should be able to accomplish when this bug is fixed
+      placeholder: "User can install zeroclaw without version mismatch errors"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What's happening?
+      description: Describe the current broken behavior
+      placeholder: |
+        When I run `clm claw install zeroclaw`, the command fails with a version mismatch error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should happen?
+      description: Describe the expected behavior
+      placeholder: The claw should install successfully without errors
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Provide clear steps to reproduce the issue
+      placeholder: |
+        1. Run `clm init`
+        2. Run `clm host add myhost --ip 192.168.1.10`
+        3. Run `clm claw install zeroclaw --host myhost`
+        4. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error Messages/Logs
+      description: Paste any error output or logs
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Clawrium Version
+      description: Output of `clm --version`
+      placeholder: "26.3.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Details
+      description: Any relevant environment information (Python version, shell, etc.)
+      placeholder: |
+        Python 3.11.5
+        bash 5.2.15
+        Ubuntu 22.04
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or information
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contributing Guide
+    url: https://github.com/ric03uec/clawrium/blob/main/CONTRIBUTING.md
+    about: Read the contributing guidelines before submitting
+  - name: Documentation
+    url: https://github.com/ric03uec/clawrium#readme
+    about: Check the README for setup and usage instructions

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,73 @@
+name: Documentation
+description: Report missing, incorrect, or unclear documentation
+title: "[DOCS] "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve our documentation. Clear docs help everyone.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight Checklist
+      options:
+        - label: I have searched existing issues for similar documentation requests
+          required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Documentation Type
+      options:
+        - Missing documentation
+        - Incorrect information
+        - Unclear explanation
+        - Outdated content
+        - Typo/grammar
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: Where is the documentation issue? (URL, file path, or section name)
+      placeholder: "README.md, Installation section"
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current State
+      description: What does the documentation currently say (or not say)?
+      placeholder: |
+        The Installation section says to run `pip install clawrium` but this doesn't work...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should it say?
+      description: Suggest the correction or addition
+      placeholder: |
+        Should explain that uv is required:
+        ```
+        uv pip install clawrium
+        ```
+        Or mention that clawrium isn't on PyPI yet and must be installed from source.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context or screenshots
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,87 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[FEATURE] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature. Please describe what you'd like to see.
+
+        Before submitting:
+        - Search [existing issues](https://github.com/ric03uec/clawrium/issues?q=is%3Aissue+label%3Aenhancement) to avoid duplicates
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight Checklist
+      options:
+        - label: I have searched existing issues and this hasn't been requested yet
+          required: true
+        - label: This is a single feature request (separate requests for different features)
+          required: true
+
+  - type: textarea
+    id: customer-outcome
+    attributes:
+      label: What should the user be able to do?
+      description: Describe the outcome from the user's perspective
+      placeholder: "User can backup claw configurations to a remote location"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this solve? What's the current pain point?
+      placeholder: |
+        Currently, there's no way to backup claw configurations. If a host fails,
+        all configuration is lost and must be recreated manually...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How do you envision this working?
+      placeholder: |
+        Add a `clm backup` command that:
+        - Exports all claw configurations to a JSON file
+        - Optionally uploads to S3 or other storage
+        - Supports restore via `clm restore`
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What workarounds or alternatives have you tried?
+      placeholder: |
+        Currently I manually copy ~/.config/clawrium/ but this misses host-specific state...
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this to your workflow?
+      options:
+        - Low - Nice to have
+        - Medium - Would improve my workflow
+        - High - Significant pain point
+        - Critical - Blocking my work
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, mockups, or examples
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/prd.yml
+++ b/.github/ISSUE_TEMPLATE/prd.yml
@@ -1,0 +1,137 @@
+name: PRD (Product Requirements Document)
+description: Propose a larger initiative or project
+title: "[PRD] "
+labels:
+  - prd
+  - planning
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for larger initiatives that need planning and discussion before implementation.
+
+        PRDs should describe the problem, proposed solution, and success criteria clearly enough that any contributor can understand the scope.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight Checklist
+      options:
+        - label: I have searched existing issues and PRDs for similar proposals
+          required: true
+        - label: This is a single cohesive initiative (not multiple unrelated features)
+          required: true
+
+  - type: textarea
+    id: customer-outcome
+    attributes:
+      label: Customer Outcome
+      description: What will users be able to do when this is complete?
+      placeholder: "Users can manage claws across multiple networks from a single control plane"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem are we solving? Why does it matter?
+      placeholder: |
+        Currently, clawrium only supports hosts on the local network. Users with
+        multiple sites (home, office, cloud) must run separate clawrium instances...
+
+        This matters because:
+        - Increases operational overhead
+        - Makes unified monitoring impossible
+        - Complicates claw version management
+    validations:
+      required: true
+
+  - type: textarea
+    id: goals
+    attributes:
+      label: Goals
+      description: What are the specific objectives? What does success look like?
+      placeholder: |
+        - Support hosts across different networks via VPN/tunnel
+        - Unified dashboard for all hosts
+        - Single source of truth for claw configurations
+    validations:
+      required: true
+
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-Goals
+      description: What is explicitly out of scope?
+      placeholder: |
+        - Building our own VPN solution
+        - Real-time streaming of claw logs
+        - Multi-tenant support
+    validations:
+      required: false
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: High-level description of the approach
+      placeholder: |
+        Add a "remote host" type that connects via SSH tunnel:
+
+        1. User configures SSH access to remote host
+        2. Clawrium establishes tunnel on-demand
+        3. Ansible runs over the tunnel
+        4. Host appears in unified list alongside local hosts
+    validations:
+      required: true
+
+  - type: textarea
+    id: success-criteria
+    attributes:
+      label: Success Criteria
+      description: How will we know this is done and working?
+      placeholder: |
+        - [ ] Can add a host accessible only via SSH
+        - [ ] Can install/manage claws on remote host
+        - [ ] Status command shows all hosts (local and remote)
+        - [ ] Documentation updated with remote host setup
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and Open Questions
+      description: What could go wrong? What needs more investigation?
+      placeholder: |
+        Risks:
+        - SSH tunnel stability on poor connections
+        - Latency impact on Ansible operations
+
+        Open questions:
+        - Should we support multiple tunnel providers?
+        - How do we handle host key verification?
+    validations:
+      required: false
+
+  - type: textarea
+    id: milestones
+    attributes:
+      label: Milestones
+      description: How should this be broken down for implementation?
+      placeholder: |
+        1. SSH tunnel infrastructure (2 weeks)
+        2. Remote host type in CLI (1 week)
+        3. Ansible integration (1 week)
+        4. Testing and documentation (1 week)
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any diagrams, references, or prior art
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,54 @@
+name: Question
+description: Ask a question about using clawrium
+title: "[QUESTION] "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question about using clawrium? We're happy to help.
+
+        Before asking:
+        - Check the [README](https://github.com/ric03uec/clawrium#readme) for basic usage
+        - Check the [Contributing Guide](https://github.com/ric03uec/clawrium/blob/main/CONTRIBUTING.md) for development questions
+        - Search [existing issues](https://github.com/ric03uec/clawrium/issues?q=is%3Aissue+label%3Aquestion) for similar questions
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight Checklist
+      options:
+        - label: I have checked the documentation
+          required: true
+        - label: I have searched existing issues for similar questions
+          required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+      placeholder: |
+        How do I configure clawrium to use a custom SSH key for remote hosts?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What are you trying to accomplish? What have you tried?
+      placeholder: |
+        I'm trying to connect to a host that requires a specific SSH key, but I don't
+        see an option in `clm host add`. I tried setting SSH_KEY env var but it didn't work...
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Information
+      description: Any relevant configuration, logs, or environment details
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ clm host remove <name>
 clm host status [name]
 ```
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, workflow, and guidelines.
+
 ## License
 
 Apache 2.0


### PR DESCRIPTION
## Summary

- Add YAML-based issue templates for standardized issue intake
- Link CONTRIBUTING.md from README

## Changes

| File | Purpose |
|------|---------|
| `.github/ISSUE_TEMPLATE/config.yml` | Disable blank issues, add helpful links |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Bug reports with reproduction steps, environment |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Feature/enhancement requests with priority |
| `.github/ISSUE_TEMPLATE/prd.yml` | Product requirements documents for larger initiatives |
| `.github/ISSUE_TEMPLATE/documentation.yml` | Documentation improvements/corrections |
| `.github/ISSUE_TEMPLATE/question.yml` | Support questions |
| `README.md` | Add Contributing section with link |

## Testing

- [x] `make test` passes
- [x] `make lint` passes
- [ ] Manual verification: Templates appear in GitHub "New issue" UI after merge

## ATX Review

<!-- To be filled after review -->

### Review Summary

| Review | Rating | Blocking Issues |
|--------|--------|-----------------|
| 1 | /5 | |

<details>
<summary>Review Details</summary>

**Blocking Issues:**

| Issue | Reasoning | Resolution |
|-------|-----------|------------|
| | | |

**Warnings:**

| Warning | Recommendation |
|---------|----------------|
| | |

**Suggestions:**

- 

</details>

---

Closes #12

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>