### PR TITLE
docs: add worktree support for parallel issue execution

### DIFF
--- a/.claude/skills/clm-execute/SKILL.md
+++ b/.claude/skills/clm-execute/SKILL.md
@@ -20,9 +20,9 @@ Triggered by `in a subtree` or `--worktree` in arguments. Enables working on mul
 
 Example:
 ```
-~/workspace/ric03uec/clawrium/           # Main repo
-~/workspace/ric03uec/clawrium-issue-35/  # Worktree for issue 35
-~/workspace/ric03uec/clawrium-issue-42/  # Worktree for issue 42
+~/projects/clawrium/           # Main repo
+~/projects/clawrium-issue-35/  # Worktree for issue 35
+~/projects/clawrium-issue-42/  # Worktree for issue 42
 ```
 
 ### Worktree Execution Steps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,8 @@ For parallel issue execution, use git worktrees with this naming:
 
 Example:
 ```
-~/workspace/ric03uec/clawrium/           # Main repo
-~/workspace/ric03uec/clawrium-issue-35/  # Worktree for issue 35
+~/projects/clawrium/           # Main repo
+~/projects/clawrium-issue-35/  # Worktree for issue 35
 ```
 
 Trigger with: `/clm:execute 35 in a subtree` or `/clm:execute 35 --worktree`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,7 +275,7 @@ tmux attach -t clm/exec
 ### Worktree Layout
 
 ```
-~/workspace/ric03uec/
+~/projects/
 ├── clawrium/                  # Main repo (you are here)
 ├── clawrium-issue-35/         # Worktree for issue 35
 ├── clawrium-issue-42/         # Worktree for issue 42


### PR DESCRIPTION
## Summary

Add git worktree and tmux integration to `/clm:execute` for working on multiple issues simultaneously without branch conflicts.

## Changes

- **clm-execute/SKILL.md**: Add "Worktree Mode" section
  - Worktree naming convention: `<repo-name>-issue-<number>/`
  - tmux integration with session `clm/exec`
  - Autonomous execution with `--dangerously-skip-permissions`
  - Fallback for non-tmux environments

- **CONTRIBUTING.md**: Add "Parallel Execution (Recommended)" section
  - Quick start guide
  - Workflow diagram
  - tmux session management commands
  - Cleanup instructions

- **AGENTS.md**: Add worktree convention reference

## Testing

- [x] `make test` passes (335 tests)
- [x] `make lint` passes
- [x] Documentation renders correctly

## ATX Review

ATX review skipped per user request (documentation-only change).

Closes #35

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>