### PR TITLE
docs: migrate existing docs and add core guides

### DIFF
--- a/website/docs/guides/_category_.json
+++ b/website/docs/guides/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Guides",
+  "position": 3,
+  "link": {
+    "type": "generated-index",
+    "description": "Step-by-step guides for common Clawrium tasks."
+  }
+}

--- a/website/docs/guides/host-setup.md
+++ b/website/docs/guides/host-setup.md
@@ -1,0 +1,166 @@
+---
+sidebar_position: 2
+---
+
+# Host Setup
+
+Before adding a host to Clawrium, you must prepare it for management. This guide covers the setup process in detail.
+
+## Prerequisites
+
+- SSH access to the target host (as any user with sudo privileges)
+- Clawrium installed (`clm` command available)
+- **On the target host:**
+  - Python 3 (required for hardware detection)
+  - pciutils (optional, for GPU detection via `lspci`)
+
+## Option A: Automatic Setup (Recommended)
+
+The `clm host init` command generates a per-host SSH keypair and attempts to automatically configure the xclm management user:
+
+```bash
+clm host init 192.168.1.100 --user myuser
+```
+
+If you have SSH access to the target host, Clawrium will:
+1. Generate a unique keypair for this host in `~/.config/clawrium/keys/<hostname>/`
+2. Connect as the specified user
+3. Create the `xclm` management user
+4. Configure passwordless sudo
+5. Add the public key to `authorized_keys`
+6. Verify xclm access works
+
+If auto-setup succeeds, skip to [Add Host to Clawrium](#add-host-to-clawrium). If it fails, follow Option B.
+
+## Option B: Manual Setup
+
+If `clm host init` couldn't connect automatically, it displays the public key and setup commands. Run these on the target host:
+
+```bash
+# SSH to host as your current user
+ssh user@hostname
+
+# Create xclm user
+sudo useradd -m -s /bin/bash xclm
+
+# Grant passwordless sudo (required for claw installation)
+echo "xclm ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/xclm
+sudo chmod 440 /etc/sudoers.d/xclm
+
+# Setup .ssh directory
+sudo mkdir -p /home/xclm/.ssh
+sudo chmod 700 /home/xclm/.ssh
+
+# Paste the public key displayed by 'clm host init'
+echo "ssh-ed25519 AAAA... clawrium" | sudo tee /home/xclm/.ssh/authorized_keys
+sudo chmod 600 /home/xclm/.ssh/authorized_keys
+sudo chown -R xclm:xclm /home/xclm/.ssh
+
+# Exit back to your machine
+exit
+```
+
+:::note Security
+xclm has full root access via sudo but no password is set (key-auth only). The private key is stored in `~/.config/clawrium/keys/<hostname>/` with 0600 permissions. Claw instances run as separate unprivileged users created by Clawrium.
+:::
+
+## Add Host to Clawrium
+
+Once the management user is configured, add the host:
+
+```bash
+# Basic - uses per-host keypair from init
+clm host add 192.168.1.100
+
+# With alias for friendly display name
+clm host add 192.168.1.100 --alias myhost
+
+# With custom port
+clm host add 192.168.1.100 --alias myhost --port 2222
+```
+
+:::important
+You must run `clm host init` before `clm host add`. The add command requires a keypair to exist for the host.
+:::
+
+Clawrium will:
+1. Connect using the per-host keypair from `~/.config/clawrium/keys/<hostname>/`
+2. Prompt to accept the host key (first connection only, saved to `~/.ssh/known_hosts`)
+3. Attempt to detect hardware capabilities
+4. Save the host configuration to `~/.config/clawrium/hosts.json`
+
+:::note SSH Support
+Clawrium uses paramiko for SSH connections. ProxyJump, ProxyCommand, and other advanced SSH config options are not supported. Ensure direct network access to the host.
+:::
+
+## Troubleshooting
+
+### Permission denied (publickey)
+
+The host's `authorized_keys` doesn't have the correct public key. Re-run:
+
+```bash
+clm host init 192.168.1.100 --user myuser
+```
+
+This will display the correct public key to add. If auto-setup fails, follow Option B to add it manually.
+
+Required permissions on host:
+- `/home/xclm/.ssh` - 700
+- `/home/xclm/.ssh/authorized_keys` - 600
+
+### Host key verification failed
+
+The host's SSH key has changed since you last connected.
+
+:::warning
+Before removing the old key, verify the change is expected (OS reinstall, hardware replacement). If unexpected, this could indicate a man-in-the-middle attack. Verify the new fingerprint out-of-band (e.g., via console access) before proceeding.
+:::
+
+If the change is expected:
+
+```bash
+ssh-keygen -R hostname
+```
+
+Then retry `clm host add` and verify the new fingerprint.
+
+### Hardware not detected
+
+Hardware detection requires Python 3 on the remote host. Verify:
+
+```bash
+ssh user@hostname "python3 --version"
+```
+
+If Python is missing, install it:
+
+```bash
+ssh user@hostname "sudo apt-get install python3"
+```
+
+For GPU detection, install pciutils:
+
+```bash
+ssh user@hostname "sudo apt-get install pciutils"
+```
+
+Then refresh hardware info:
+
+```bash
+clm host status myhost --refresh
+```
+
+### Re-initialize a host
+
+If you need to regenerate the keypair for a specific host:
+
+```bash
+# Remove the host (also deletes its keypair)
+clm host remove hostname --force
+
+# Re-initialize with fresh keypair
+clm host init hostname --user myuser
+```
+
+This only affects the specified host. Other hosts retain their keypairs.

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -1,0 +1,145 @@
+---
+sidebar_position: 1
+---
+
+# Quickstart
+
+Deploy your first AI assistant claw in under 10 minutes. This guide walks through the complete workflow from installation to a running claw.
+
+## Prerequisites
+
+- Clawrium installed ([Installation Guide](../installation.md))
+- A target machine (physical or VM) with:
+  - Ubuntu 22.04/24.04 or Debian 13
+  - SSH access with sudo privileges
+  - Network connectivity from your management machine
+
+## Step 1: Initialize Clawrium
+
+First, initialize Clawrium on your management machine:
+
+```bash
+clm init
+```
+
+This creates the configuration directory and validates dependencies.
+
+## Step 2: Prepare a Host
+
+Initialize the target host. Clawrium will generate a unique keypair and set up the `xclm` management user:
+
+```bash
+clm host init 192.168.1.100 --user myuser
+```
+
+Replace:
+- `192.168.1.100` with your target host's IP or hostname
+- `myuser` with a user that has sudo privileges on the target
+
+If auto-setup succeeds, you'll see a success message. If it fails, follow the manual setup instructions shown in the output.
+
+## Step 3: Add the Host
+
+Add the initialized host to your fleet:
+
+```bash
+clm host add 192.168.1.100 --alias homelab
+```
+
+The `--alias` flag gives your host a friendly name. Clawrium will:
+1. Connect using the keypair from `host init`
+2. Prompt you to accept the host key (first connection)
+3. Detect hardware capabilities
+4. Save the host to your configuration
+
+Verify with:
+
+```bash
+clm host list
+```
+
+## Step 4: Browse Available Claws
+
+See what claw types are available:
+
+```bash
+clm registry list
+```
+
+Example output:
+```
+Available Claws:
+  openclaw    Open-source AI assistant framework
+  zeroclaw    Lightweight AI assistant for edge devices
+```
+
+Get details about a specific claw:
+
+```bash
+clm registry show zeroclaw
+```
+
+## Step 5: Configure Secrets
+
+Most claws require secrets (API keys, endpoints) to function. Check what secrets a claw needs:
+
+```bash
+clm secret list zc-homelab
+```
+
+Set the required secrets:
+
+```bash
+# For zeroclaw - point to your LLM provider
+clm secret set zc-homelab LLM_PROVIDER_URL
+# Enter: http://192.168.1.50:11434  (your Ollama server, for example)
+
+clm secret set zc-homelab LLM_MODEL
+# Enter: llama3
+```
+
+The secret value is entered via masked prompt (not visible on screen).
+
+## Step 6: Install the Claw
+
+Install zeroclaw on your host:
+
+```bash
+clm install --claw zeroclaw --host homelab
+```
+
+Clawrium will:
+1. Check host compatibility
+2. Verify required secrets are set
+3. Deploy the claw to the host
+4. Start the claw service
+
+## Step 7: Check Status
+
+Verify your fleet status:
+
+```bash
+clm status
+```
+
+You should see your host with the claw running.
+
+## What's Next?
+
+- [Host Setup Guide](./host-setup.md) - Detailed host preparation options
+- [Secret Management](./secret-management.md) - Managing claw secrets
+- Browse more claws with `clm registry list`
+
+## Troubleshooting
+
+### Permission denied during host init
+
+Your SSH user doesn't have sudo privileges or the password was incorrect. Verify you can run `sudo whoami` on the target host.
+
+### Host not compatible with claw
+
+The claw's manifest doesn't support your host's OS, version, or architecture. Run `clm registry show <claw>` to see supported platforms.
+
+### Missing required secrets
+
+Run `clm secret list <claw-name>` to see which secrets are missing. Set them before running `clm install`.

--- a/website/docs/guides/secret-management.md
+++ b/website/docs/guides/secret-management.md
@@ -1,0 +1,141 @@
+---
+sidebar_position: 3
+---
+
+# Secret Management
+
+Claws often require secrets like API keys to function. Clawrium provides commands to securely manage these secrets per claw instance.
+
+## Understanding Secrets
+
+Each claw type defines two categories of secrets in its manifest:
+
+| Category | Description |
+|----------|-------------|
+| **Required** | Claw installation fails if these are missing |
+| **Optional** | Claw works without them but with reduced functionality |
+
+## Viewing Secret Requirements
+
+### Check Registry Manifest
+
+Use `clm registry show` to see what secrets a claw type expects:
+
+```bash
+clm registry show zeroclaw
+```
+
+Example output shows:
+```
+Required Secrets:
+  LLM_PROVIDER_URL    LLM API endpoint URL (e.g., http://192.168.1.100:11434)
+  LLM_MODEL           Model name to use (e.g., llama3, gpt-4)
+
+Optional Secrets:
+  LLM_API_KEY         API key for LLM provider (optional for local)
+```
+
+### Check Claw Instance
+
+For an existing claw instance, list configured secrets and identify missing required ones:
+
+```bash
+clm secret list zc-homelab
+```
+
+Example output:
+```
+Secrets for zc-homelab:
+
+Configured:
+  LLM_PROVIDER_URL    (set 2026-04-01)
+
+Missing Required:
+  LLM_MODEL           Model name to use (e.g., llama3, gpt-4)
+
+Optional (not set):
+  LLM_API_KEY         API key for LLM provider (optional for local)
+```
+
+:::note
+Secret values are never displayed. Only keys, descriptions, and metadata are shown.
+:::
+
+## Setting Secrets
+
+Use `clm secret set` to configure a secret:
+
+```bash
+clm secret set <claw-name> <key>
+```
+
+The value is entered via masked prompt (not visible on screen):
+
+```bash
+$ clm secret set zc-homelab LLM_PROVIDER_URL
+Enter value for LLM_PROVIDER_URL: ********
+Secret set successfully.
+```
+
+### Options
+
+```bash
+# Add a description
+clm secret set zc-homelab LLM_PROVIDER_URL -d "Production Ollama server"
+
+# Skip confirmation when overwriting
+clm secret set zc-homelab LLM_PROVIDER_URL -y
+```
+
+## Removing Secrets
+
+Remove a secret from a claw instance:
+
+```bash
+clm secret remove zc-homelab LLM_API_KEY
+```
+
+:::warning
+Removing a required secret will cause the claw to fail on next restart. You'll need to set it again before the claw can run.
+:::
+
+## Secret Storage
+
+Secrets are stored in `~/.config/clawrium/secrets/<claw-name>/<key>`:
+
+```
+~/.config/clawrium/
+└── secrets/
+    └── zc-homelab/
+        ├── LLM_PROVIDER_URL
+        └── LLM_MODEL
+```
+
+Each secret file:
+- Has 0600 permissions (readable only by owner)
+- Contains the encrypted value
+- Is synced to the host during claw deployment
+
+## Common Secrets by Claw Type
+
+### zeroclaw
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `LLM_PROVIDER_URL` | Yes | LLM API endpoint (e.g., `http://192.168.1.100:11434` for Ollama) |
+| `LLM_MODEL` | Yes | Model to use (e.g., `llama3`, `mistral`) |
+| `LLM_API_KEY` | No | API key if your LLM provider requires authentication |
+
+### openclaw
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `OPENAI_API_KEY` | Yes | OpenAI API key for LLM requests |
+| `ANTHROPIC_API_KEY` | No | Anthropic API key for Claude models |
+
+## Best Practices
+
+1. **Set secrets before installing** - Required secrets must exist before `clm install` succeeds
+2. **Use descriptive comments** - Add `-d` descriptions to remember what each secret is for
+3. **Rotate periodically** - Update secrets if you rotate API keys
+4. **One claw, one set** - Each claw instance has its own secrets; they're not shared

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -1,0 +1,93 @@
+---
+sidebar_position: 2
+---
+
+# Installation
+
+This guide covers installing Clawrium on your management machine (the computer you'll use to control your claw fleet).
+
+## Prerequisites
+
+- **Python 3.10 or higher**
+- **uvx** (recommended) or pip
+
+### Check Python Version
+
+```bash
+python3 --version
+# Should be 3.10 or higher
+```
+
+### Install uvx
+
+If you don't have uvx, install it via pipx or brew:
+
+```bash
+# Using pipx (recommended)
+pipx install uv
+
+# Or using Homebrew on macOS
+brew install uv
+```
+
+## Install Clawrium
+
+### Using uvx (Recommended)
+
+```bash
+uvx clawrium
+```
+
+This runs the latest version of Clawrium without permanent installation. To install permanently:
+
+```bash
+uv tool install clawrium
+```
+
+### Using pip
+
+```bash
+pip install clawrium
+```
+
+## Verify Installation
+
+Run the `clm` command to verify installation:
+
+```bash
+clm --help
+```
+
+You should see:
+
+```
+ Usage: clm [OPTIONS] COMMAND [ARGS]...
+
+ Clawrium - Manage your AI assistant fleet
+
+╭─ Commands ───────────────────────────────────────────────────────────────────╮
+│ init      Initialize Clawrium and check dependencies.                        │
+│ install   Install a claw on a host.                                          │
+│ status    Show fleet status across all hosts.                                │
+│ host      Manage hosts in your fleet                                         │
+│ registry  Browse available claw types                                        │
+│ secret    Manage secrets for claw instances                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+## Initialize Clawrium
+
+Run `clm init` to create the configuration directory and check dependencies:
+
+```bash
+clm init
+```
+
+This creates:
+- `~/.config/clawrium/` directory
+- Validates that required dependencies are available
+
+## Next Steps
+
+- [Quickstart: Deploy your first claw](./guides/quickstart.md)
+- [Host Setup Guide](./guides/host-setup.md)

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /
 ---
 
 # Introduction
@@ -38,32 +39,56 @@ Run any model across your fleet:
 - **Big labs**: OpenAI, Anthropic, Google, Mistral
 - **Local**: Ollama, llama.cpp, vLLM
 
-## Quick Start
+## Quick Reference
 
 ```bash
-# Install Clawrium
-git clone https://github.com/ric03uec/clawrium.git
-cd clawrium && uv sync && uv pip install -e .
-
-# Initialize Clawrium
+# Initialize Clawrium (check dependencies)
 clm init
 
-# Prepare and add a host
+# Initialize a host (generates keypair, sets up management user)
 clm host init 192.168.1.100 --user myuser
+
+# Add an initialized host to the fleet
 clm host add 192.168.1.100 --alias myhost
 
-# Check your fleet
+# List all hosts
 clm host list
+
+# Check host status
 clm host status myhost
+
+# Browse available claw types
+clm registry list
+
+# Install a claw on a host
+clm install --claw zeroclaw --host myhost
+
+# Set a secret for a claw
+clm secret set zc-myhost OPENAI_API_KEY
 ```
 
-## Prerequisites
+## Key Concepts
 
-- Python 3.11+
-- [uv](https://docs.astral.sh/uv/) package manager
-- SSH access to target hosts
+| Concept | Description |
+|---------|-------------|
+| **Host** | A machine in your network that runs one or more claws |
+| **Claw** | An AI assistant instance (zeroclaw, openclaw, etc.) |
+| **Registry** | Platform-defined claw types with versions, dependencies, and requirements |
+
+## User Data
+
+Clawrium stores configuration in `~/.config/clawrium/` (or `$XDG_CONFIG_HOME/clawrium/`):
+
+| Path | Description |
+|------|-------------|
+| `hosts.json` | Registered hosts and metadata (0600 permissions) |
+| `keys/<hostname>/xclm_ed25519` | Private key for SSH to host |
+| `keys/<hostname>/xclm_ed25519.pub` | Public key added to host's authorized_keys |
+| `secrets/<claw-name>/<key>` | Encrypted secrets for claw instances |
 
 ## Next Steps
 
+- [Installation](./installation.md) - Install Clawrium
+- [Quickstart](./guides/quickstart.md) - Deploy your first claw
+- [Host Setup](./guides/host-setup.md) - Detailed host preparation guide
 - [Architecture](./architecture.md) - Understand how Clawrium works
-- [Host Preparation](./guides/host-setup.md) - Detailed host setup guide

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -80,7 +80,15 @@ const config: Config = {
           items: [
             {
               label: 'Getting Started',
-              to: '/docs/intro',
+              to: '/docs/',
+            },
+            {
+              label: 'Installation',
+              to: '/docs/installation',
+            },
+            {
+              label: 'Quickstart',
+              to: '/docs/guides/quickstart',
             },
             {
               label: 'Architecture',

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -29,7 +29,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro">
+            to="/docs/">
             Get Started
           </Link>
           <Link


### PR DESCRIPTION
## Summary

Migrates existing documentation and adds core guides for issue #39.

- Migrated `docs/index.md` content → `website/docs/intro.md`
- Migrated `docs/host-preparation.md` → `website/docs/guides/host-setup.md`
- Added installation guide with prerequisites and uvx setup
- Added quickstart tutorial showing complete first claw deployment
- Added secret management guide explaining required vs optional secrets
- Removed default Docusaurus tutorial content
- Updated footer links and landing page CTA

## Testing

- `make test` - 335 tests pass
- `make lint` - All checks pass
- `npm run build` in website/ - Docusaurus builds successfully

## Files Created/Modified

**New:**
- `website/docs/intro.md` (rewritten)
- `website/docs/installation.md`
- `website/docs/guides/_category_.json`
- `website/docs/guides/quickstart.md`
- `website/docs/guides/host-setup.md`
- `website/docs/guides/secret-management.md`

**Modified:**
- `website/docusaurus.config.ts` - Updated footer links
- `website/src/pages/index.tsx` - Updated CTA button

**Deleted:**
- `website/docs/tutorial-basics/*` - Default Docusaurus content
- `website/docs/tutorial-extras/*` - Default Docusaurus content

Closes #39

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>