### PR TITLE
feat(skills): add sub-issue linking for parent-child relationships

### DIFF
--- a/.claude/skills/clm-plan-build/SKILL.md
+++ b/.claude/skills/clm-plan-build/SKILL.md
@@ -32,13 +32,26 @@ Create a high-level implementation plan for a GitHub issue with product output a
    - **Simple issue** (< 3 files, single concern): No subtasks needed
    - **Complex issue** (multiple files, multiple concerns): Create subtasks
 
-5. **If Subtasks Needed**: Create subtask issues
-   ```bash
-   gh issue create \
-     --title "[Parent #<parent>] <subtask description>" \
-     --label "ready" \
-     --body "<subtask details>"
-   ```
+5. **If Subtasks Needed**: Create subtask issues and link as sub-issues
+    ```bash
+    # Create subtask
+    CHILD_URL=$(gh issue create \
+      --title "[Parent #<parent>] <subtask description>" \
+      --label "ready" \
+      --body "<subtask details>")
+    CHILD_NUM=$(basename $CHILD_URL)
+    
+    # Link as sub-issue using GraphQL
+    gh api graphql -f query='
+      mutation($parentId: ID!, $childId: ID!) {
+        addSubIssue(input: {issueId: $parentId, subIssueId: $childId}) {
+          issue { number }
+          subIssue { number }
+        }
+      }' \
+      -f parentId=$(gh api graphql -f query='query($owner: String!, $repo: String!, $issue: Int!) { repository(owner: $owner, name: $repo) { issue(number: $issue) { id } } }' -f owner=OWNER -f repo=REPO -F issue=$PARENT_NUM | jq -r '.data.repository.issue.id') \
+      -f childId=$(gh api graphql -f query='query($owner: String!, $repo: String!, $issue: Int!) { repository(owner: $owner, name: $repo) { issue(number: $issue) { id } } }' -f owner=OWNER -f repo=REPO -F issue=$CHILD_NUM | jq -r '.data.repository.issue.id')
+    ```
 
 6. **Post Plan**: Add plan as comment on parent issue
    ```markdown

--- a/.claude/skills/clm-plan-scaffold/SKILL.md
+++ b/.claude/skills/clm-plan-scaffold/SKILL.md
@@ -71,13 +71,26 @@ Create a phased execution plan from a plan-build output, defining entry/exit cri
    </details>
    ```
 
-7. **Create Subtasks (if multi-phase)**:
-   ```bash
-   gh issue create \
-     --title "[Parent #<parent>] Phase N: <name>" \
-     --label "ready" \
-     --body "<phase details>"
-   ```
+7. **Create Subtasks (if multi-phase)** and link as sub-issues:
+    ```bash
+    # Create subtask
+    CHILD_URL=$(gh issue create \
+      --title "[Parent #<parent>] Phase N: <name>" \
+      --label "ready" \
+      --body "<phase details>")
+    CHILD_NUM=$(basename $CHILD_URL)
+    
+    # Link as sub-issue using GraphQL
+    gh api graphql -f query='
+      mutation($parentId: ID!, $childId: ID!) {
+        addSubIssue(input: {issueId: $parentId, subIssueId: $childId}) {
+          issue { number }
+          subIssue { number }
+        }
+      }' \
+      -f parentId=$(gh api graphql -f query='query($owner: String!, $repo: String!, $issue: Int!) { repository(owner: $owner, name: $repo) { issue(number: $issue) { id } } }' -f owner=OWNER -f repo=REPO -F issue=$PARENT_NUM | jq -r '.data.repository.issue.id') \
+      -f childId=$(gh api graphql -f query='query($owner: String!, $repo: String!, $issue: Int!) { repository(owner: $owner, name: $repo) { issue(number: $issue) { id } } }' -f owner=OWNER -f repo=REPO -F issue=$CHILD_NUM | jq -r '.data.repository.issue.id')
+    ```
 
 8. **Update Labels**:
    ```bash

--- a/.opencode/skills/clm-plan-build/SKILL.md
+++ b/.opencode/skills/clm-plan-build/SKILL.md
@@ -32,13 +32,26 @@ Create a high-level implementation plan for a GitHub issue with product output a
    - **Simple issue** (< 3 files, single concern): No subtasks needed
    - **Complex issue** (multiple files, multiple concerns): Create subtasks
 
-5. **If Subtasks Needed**: Create subtask issues
-   ```bash
-   gh issue create \
-     --title "[Parent #<parent>] <subtask description>" \
-     --label "ready" \
-     --body "<subtask details>"
-   ```
+5. **If Subtasks Needed**: Create subtask issues and link as sub-issues
+    ```bash
+    # Create subtask
+    CHILD_URL=$(gh issue create \
+      --title "[Parent #<parent>] <subtask description>" \
+      --label "ready" \
+      --body "<subtask details>")
+    CHILD_NUM=$(basename $CHILD_URL)
+    
+    # Link as sub-issue using GraphQL
+    gh api graphql -f query='
+      mutation($parentId: ID!, $childId: ID!) {
+        addSubIssue(input: {issueId: $parentId, subIssueId: $childId}) {
+          issue { number }
+          subIssue { number }
+        }
+      }' \
+      -f parentId=$(gh api graphql -f query='query($owner: String!, $repo: String!, $issue: Int!) { repository(owner: $owner, name: $repo) { issue(number: $issue) { id } } }' -f owner=OWNER -f repo=REPO -F issue=$PARENT_NUM | jq -r '.data.repository.issue.id') \
+      -f childId=$(gh api graphql -f query='query($owner: String!, $repo: String!, $issue: Int!) { repository(owner: $owner, name: $repo) { issue(number: $issue) { id } } }' -f owner=OWNER -f repo=REPO -F issue=$CHILD_NUM | jq -r '.data.repository.issue.id')
+    ```
 
 6. **Post Plan**: Add plan as comment on parent issue
    ```markdown

--- a/.opencode/skills/clm-plan-scaffold/SKILL.md
+++ b/.opencode/skills/clm-plan-scaffold/SKILL.md
@@ -71,13 +71,26 @@ Create a phased execution plan from a plan-build output, defining entry/exit cri
    </details>
    ```
 
-7. **Create Subtasks (if multi-phase)**:
-   ```bash
-   gh issue create \
-     --title "[Parent #<parent>] Phase N: <name>" \
-     --label "ready" \
-     --body "<phase details>"
-   ```
+7. **Create Subtasks (if multi-phase)** and link as sub-issues:
+    ```bash
+    # Create subtask
+    CHILD_URL=$(gh issue create \
+      --title "[Parent #<parent>] Phase N: <name>" \
+      --label "ready" \
+      --body "<phase details>")
+    CHILD_NUM=$(basename $CHILD_URL)
+    
+    # Link as sub-issue using GraphQL
+    gh api graphql -f query='
+      mutation($parentId: ID!, $childId: ID!) {
+        addSubIssue(input: {issueId: $parentId, subIssueId: $childId}) {
+          issue { number }
+          subIssue { number }
+        }
+      }' \
+      -f parentId=$(gh api graphql -f query='query($owner: String!, $repo: String!, $issue: Int!) { repository(owner: $owner, name: $repo) { issue(number: $issue) { id } } }' -f owner=OWNER -f repo=REPO -F issue=$PARENT_NUM | jq -r '.data.repository.issue.id') \
+      -f childId=$(gh api graphql -f query='query($owner: String!, $repo: String!, $issue: Int!) { repository(owner: $owner, name: $repo) { issue(number: $issue) { id } } }' -f owner=OWNER -f repo=REPO -F issue=$CHILD_NUM | jq -r '.data.repository.issue.id')
+    ```
 
 8. **Update Labels**:
    ```bash


### PR DESCRIPTION
## Summary

Updates clm-plan-build and clm-plan-scaffold skills to automatically link subtasks as GitHub sub-issues using the `addSubIssue` GraphQL mutation.

## Changes

- Modified `.opencode/skills/clm-plan-build/SKILL.md`
- Modified `.opencode/skills/clm-plan-scaffold/SKILL.md`  
- Modified `.claude/skills/clm-plan-build/SKILL.md`
- Modified `.claude/skills/clm-plan-scaffold/SKILL.md`

After creating a subtask with `gh issue create`, the skills now call `gh api graphql` with the `addSubIssue` mutation to establish the parent-child relationship.

## Testing

- [x] All 335 tests pass
- [x] Lint check passes
- [x] Verified `addSubIssue` mutation works (tested linking issue #50 to #42)

Closes #42