### PR TITLE
feat(provider): implement provider management CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "paramiko>=3.0.0",
     "pyyaml>=6.0.0",
     "packaging>=24.0",
+    "requests>=2.31.0",
 ]
 
 [project.scripts]

--- a/src/clawrium/cli/main.py
+++ b/src/clawrium/cli/main.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from clawrium.cli.init import init as init_command
 from clawrium.cli.agent import agent_app
 from clawrium.cli.host import host_app
+from clawrium.cli.provider import provider_app
 from clawrium.cli.status import status as status_command
 
 __all__ = ["app"]
@@ -70,6 +71,9 @@ app.add_typer(agent_app, name="agent")
 
 # Register host subcommands (secondary/infrastructure)
 app.add_typer(host_app, name="host")
+
+# Register provider subcommands (inference provider management)
+app.add_typer(provider_app, name="provider")
 
 
 if __name__ == "__main__":

--- a/src/clawrium/cli/provider.py
+++ b/src/clawrium/cli/provider.py
@@ -1,0 +1,579 @@
+"""Provider management commands for Clawrium."""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.markup import escape as rich_escape
+from rich.table import Table
+
+from clawrium.core.providers import (
+    PROVIDER_MODELS,
+    add_provider,
+    fetch_ollama_models,
+    get_models_for_type,
+    get_provider,
+    get_provider_api_key,
+    load_providers,
+    remove_provider,
+    remove_provider_api_key,
+    set_provider_api_key,
+    update_provider,
+    validate_ollama_url,
+    validate_provider_name,
+    validate_provider_type,
+    DuplicateProviderError,
+    InvalidOllamaUrlError,
+    InvalidProviderNameError,
+    InvalidProviderTypeError,
+    OllamaConnectionError,
+    ProvidersFileCorruptedError,
+)
+
+__all__ = ["provider_app"]
+
+console = Console()
+
+provider_app = typer.Typer(
+    name="provider",
+    help="Manage inference providers (LLM APIs)",
+    no_args_is_help=True,
+)
+
+
+def _mask_api_key(key: str | None) -> str:
+    """Mask API key for display, showing first 4 and last 4 chars."""
+    if not key:
+        return "-"
+    if len(key) <= 8:
+        return "*" * len(key)
+    return f"{key[:4]}...{key[-4:]}"
+
+
+def _get_provider_types() -> list[str]:
+    """Get list of supported provider types."""
+    return sorted(PROVIDER_MODELS.keys())
+
+
+@provider_app.command()
+def add(
+    name: str = typer.Argument(..., help="Unique name for this provider configuration"),
+    provider_type: str = typer.Option(
+        ...,
+        "--type",
+        "-t",
+        help="Provider type (openai, anthropic, openrouter, bedrock, vertex, zai, ollama)",
+    ),
+    model: Optional[str] = typer.Option(
+        None,
+        "--model",
+        "-m",
+        help="Default model to use",
+    ),
+    url: Optional[str] = typer.Option(
+        None,
+        "--url",
+        "-u",
+        help="Server URL (required for Ollama)",
+    ),
+) -> None:
+    """Add a new inference provider.
+
+    API keys are collected securely via interactive prompt (not visible in process listing).
+
+    Examples:
+        clm provider add myopenai --type openai
+        clm provider add local-llm --type ollama --url http://myserver.example.com:11434
+        clm provider add work-claude --type anthropic --model claude-sonnet-4-20250514
+    """
+    # Validate provider name
+    try:
+        validate_provider_name(name)
+    except InvalidProviderNameError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    # Validate provider type
+    try:
+        validate_provider_type(provider_type)
+    except InvalidProviderTypeError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    # Check for duplicate
+    try:
+        existing = get_provider(name)
+        if existing:
+            console.print(f"[red]Error:[/red] Provider '{name}' already exists")
+            raise typer.Exit(code=1)
+    except ProvidersFileCorruptedError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    # Handle Ollama specially - requires URL, no API key
+    if provider_type == "ollama":
+        if not url:
+            url = typer.prompt("Ollama server URL", default="http://localhost:11434")
+
+        # Validate URL for security (SSRF prevention)
+        try:
+            url = validate_ollama_url(url)
+        except InvalidOllamaUrlError as e:
+            console.print(f"[red]Error:[/red] {e}")
+            raise typer.Exit(code=1)
+
+        console.print(f"Connecting to Ollama server at {rich_escape(url)}...")
+        try:
+            available_models = fetch_ollama_models(url)
+        except OllamaConnectionError as e:
+            console.print(f"[red]Error:[/red] {e}")
+            raise typer.Exit(code=1)
+
+        if not available_models:
+            console.print("[yellow]Warning:[/yellow] No models found on Ollama server")
+            console.print("Run 'ollama pull <model>' on the server to download models")
+            raise typer.Exit(code=1)
+
+        console.print(f"[green]Found {len(available_models)} models[/green]")
+
+        # Select default model
+        if model and model not in available_models:
+            console.print(f"[yellow]Warning:[/yellow] Model '{rich_escape(model)}' not found on server")
+            model = None
+
+        if not model:
+            console.print("\nAvailable models:")
+            for i, m in enumerate(available_models, 1):
+                console.print(f"  {i}. {rich_escape(m)}")
+
+            choice = typer.prompt(
+                "Select default model (number or name)",
+                default="1",
+            )
+            try:
+                idx = int(choice) - 1
+                if 0 <= idx < len(available_models):
+                    model = available_models[idx]
+                else:
+                    model = choice
+            except ValueError:
+                model = choice
+
+            if model not in available_models:
+                console.print(f"[yellow]Warning:[/yellow] '{rich_escape(model)}' not in discovered models")
+                if not typer.confirm("Continue anyway?"):
+                    raise typer.Exit(code=0)
+
+        # Build Ollama provider record (no API key stored)
+        now = datetime.now(timezone.utc).isoformat()
+        provider_record = {
+            "name": name,
+            "type": provider_type,
+            "endpoint": url,
+            "default_model": model,
+            "available_models": available_models,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+    else:
+        # Cloud provider - requires API key
+        models = get_models_for_type(provider_type)
+
+        # Get API key securely via interactive prompt (B3 fix - no CLI flag)
+        api_key = typer.prompt("API key", hide_input=True)
+
+        if not api_key:
+            console.print("[red]Error:[/red] API key is required")
+            raise typer.Exit(code=1)
+
+        # Select default model
+        if model and models and model not in models:
+            console.print(f"[yellow]Warning:[/yellow] Model '{rich_escape(model)}' not in known models for {provider_type}")
+            if not typer.confirm("Continue anyway?"):
+                raise typer.Exit(code=0)
+
+        if not model and models:
+            console.print(f"\nAvailable models for {provider_type}:")
+            for i, m in enumerate(models, 1):
+                console.print(f"  {i}. {rich_escape(m)}")
+
+            choice = typer.prompt(
+                "Select default model (number or name)",
+                default="1",
+            )
+            try:
+                idx = int(choice) - 1
+                if 0 <= idx < len(models):
+                    model = models[idx]
+                else:
+                    model = choice
+            except ValueError:
+                model = choice
+
+        # Build cloud provider record (API key stored separately in secrets)
+        now = datetime.now(timezone.utc).isoformat()
+        provider_record = {
+            "name": name,
+            "type": provider_type,
+            "default_model": model,
+            "created_at": now,
+            "updated_at": now,
+        }
+
+        # Store API key securely (B1 fix)
+        set_provider_api_key(name, api_key)
+
+    # Add provider
+    try:
+        add_provider(provider_record)
+    except DuplicateProviderError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    console.print(f"[green]Provider '{name}' added successfully![/green]")
+
+
+@provider_app.command(name="list")
+def list_providers() -> None:
+    """List all configured providers."""
+    try:
+        providers = load_providers()
+    except ProvidersFileCorruptedError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    if not providers:
+        console.print("No providers configured. Use 'clm provider add' to add a provider.")
+        return
+
+    table = Table(title="Configured Providers")
+
+    table.add_column("Name", style="cyan")
+    table.add_column("Type", style="white")
+    table.add_column("Model", style="yellow")
+    table.add_column("API Key", style="dim")
+    table.add_column("Added", style="dim")
+
+    for provider in providers:
+        # Format added date
+        added_at = provider.get("created_at", "")
+        if added_at:
+            try:
+                dt = datetime.fromisoformat(added_at.replace("Z", "+00:00"))
+                added = dt.strftime("%Y-%m-%d")
+            except ValueError:
+                added = added_at[:10] if len(added_at) >= 10 else added_at
+        else:
+            added = "-"
+
+        provider_name = provider.get("name", "?")
+        provider_type = provider.get("type", "?")
+
+        # For Ollama, show endpoint instead of masked key
+        if provider_type == "ollama":
+            key_display = rich_escape(provider.get("endpoint", "-"))
+        else:
+            # Fetch API key from secure storage
+            api_key = get_provider_api_key(provider_name)
+            key_display = _mask_api_key(api_key)
+
+        table.add_row(
+            rich_escape(provider_name),
+            rich_escape(provider_type),
+            rich_escape(provider.get("default_model", "-")),
+            key_display,
+            added,
+        )
+
+    console.print(table)
+
+
+@provider_app.command()
+def edit(
+    name: str = typer.Argument(..., help="Provider name to edit"),
+    model: Optional[str] = typer.Option(
+        None,
+        "--model",
+        "-m",
+        help="New default model",
+    ),
+    url: Optional[str] = typer.Option(
+        None,
+        "--url",
+        "-u",
+        help="New server URL (Ollama only)",
+    ),
+    update_key: bool = typer.Option(
+        False,
+        "--update-key",
+        help="Update API key (will prompt securely)",
+    ),
+) -> None:
+    """Edit an existing provider configuration.
+
+    Examples:
+        clm provider edit myopenai --model gpt-4o-mini
+        clm provider edit local-llm --url http://newserver.example.com:11434
+        clm provider edit myopenai --update-key
+    """
+    # Check provider exists
+    try:
+        provider = get_provider(name)
+    except ProvidersFileCorruptedError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    if not provider:
+        console.print(f"[red]Error:[/red] Provider '{name}' not found")
+        raise typer.Exit(code=1)
+
+    # Check if any changes requested
+    if model is None and url is None and not update_key:
+        console.print("[yellow]No changes specified.[/yellow] Use --model, --url, or --update-key to update.")
+        raise typer.Exit(code=0)
+
+    # Validate URL only makes sense for Ollama
+    if url and provider.get("type") != "ollama":
+        console.print("[red]Error:[/red] --url is only valid for Ollama providers")
+        raise typer.Exit(code=1)
+
+    # For Ollama with new URL, validate and refresh models
+    available_models = None
+    if url and provider.get("type") == "ollama":
+        # Validate URL for security
+        try:
+            url = validate_ollama_url(url)
+        except InvalidOllamaUrlError as e:
+            console.print(f"[red]Error:[/red] {e}")
+            raise typer.Exit(code=1)
+
+        console.print(f"Connecting to Ollama server at {rich_escape(url)}...")
+        try:
+            available_models = fetch_ollama_models(url)
+            console.print(f"[green]Found {len(available_models)} models[/green]")
+        except OllamaConnectionError as e:
+            console.print(f"[red]Error:[/red] {e}")
+            raise typer.Exit(code=1)
+
+    # Handle API key update for non-Ollama providers
+    if update_key:
+        if provider.get("type") == "ollama":
+            console.print("[yellow]Warning:[/yellow] Ollama providers don't use API keys")
+        else:
+            new_api_key = typer.prompt("New API key", hide_input=True)
+            if new_api_key:
+                set_provider_api_key(name, new_api_key)
+                console.print("[green]API key updated.[/green]")
+            else:
+                console.print("[yellow]Warning:[/yellow] Empty API key provided, skipping update")
+
+    def apply_updates(p: dict) -> dict:
+        if model is not None:
+            p["default_model"] = model
+        if url is not None and p.get("type") == "ollama":
+            p["endpoint"] = url
+            if available_models is not None:
+                p["available_models"] = available_models
+        p["updated_at"] = datetime.now(timezone.utc).isoformat()
+        return p
+
+    # Only update provider record if model or url changed
+    if model is not None or url is not None:
+        if update_provider(name, apply_updates):
+            console.print(f"[green]Provider '{name}' updated successfully![/green]")
+        else:
+            console.print("[red]Error:[/red] Failed to update provider")
+            raise typer.Exit(code=1)
+    elif update_key and provider.get("type") != "ollama":
+        # Only API key was updated (already done above)
+        console.print(f"[green]Provider '{name}' updated successfully![/green]")
+
+
+@provider_app.command()
+def remove(
+    name: str = typer.Argument(..., help="Provider name to remove"),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation prompt"),
+) -> None:
+    """Remove a provider configuration.
+
+    Examples:
+        clm provider remove myopenai
+        clm provider remove old-provider --force
+    """
+    # Check provider exists
+    try:
+        provider = get_provider(name)
+    except ProvidersFileCorruptedError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    if not provider:
+        console.print(f"[red]Error:[/red] Provider '{name}' not found")
+        raise typer.Exit(code=1)
+
+    # Confirmation (unless --force)
+    if not force:
+        confirmed = typer.confirm(
+            f"Remove provider '{name}'? This cannot be undone."
+        )
+        if not confirmed:
+            console.print("Cancelled.")
+            raise typer.Exit(code=0)
+
+    if remove_provider(name):
+        # Also remove API key from secure storage
+        remove_provider_api_key(name)
+        console.print(f"[green]Provider '{name}' removed successfully.[/green]")
+    else:
+        console.print("[red]Error:[/red] Failed to remove provider")
+        raise typer.Exit(code=1)
+
+
+@provider_app.command()
+def types() -> None:
+    """List supported provider types."""
+    console.print("[bold]Supported provider types:[/bold]\n")
+
+    for provider_type in _get_provider_types():
+        config = PROVIDER_MODELS[provider_type]
+        endpoint = config.get("endpoint")
+        models = config.get("models")
+
+        if provider_type == "ollama":
+            console.print(f"  [cyan]{provider_type}[/cyan] - Self-hosted (dynamic model discovery)")
+        elif endpoint:
+            model_count = len(models) if models else 0
+            console.print(f"  [cyan]{provider_type}[/cyan] - {model_count} models")
+        else:
+            model_count = len(models) if models else 0
+            console.print(f"  [cyan]{provider_type}[/cyan] - {model_count} models (SDK-based)")
+
+
+@provider_app.command()
+def models(
+    identifier: str = typer.Argument(
+        ...,
+        help="Provider type (openai, anthropic, etc.) or provider name",
+    ),
+) -> None:
+    """List available models for a provider type or configured provider.
+
+    Note: Provider types take precedence over configured provider names.
+
+    Examples:
+        clm provider models openai        # List models for OpenAI type
+        clm provider models myopenai      # List models from saved provider config
+    """
+    # Check if it's a provider type
+    if identifier in PROVIDER_MODELS:
+        provider_type = identifier
+        model_list = get_models_for_type(provider_type)
+
+        if model_list is None:
+            if provider_type == "ollama":
+                console.print(
+                    "[yellow]Ollama models are discovered dynamically.[/yellow]\n"
+                    "Add an Ollama provider first, then query by provider name."
+                )
+            else:
+                console.print(f"[yellow]No hardcoded models for {provider_type}[/yellow]")
+            return
+
+        console.print(f"[bold]Available models for {provider_type}:[/bold]\n")
+        for m in model_list:
+            console.print(f"  {rich_escape(m)}")
+        return
+
+    # Otherwise, check if it's a configured provider name
+    try:
+        provider = get_provider(identifier)
+    except ProvidersFileCorruptedError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    if provider:
+        provider_type = provider.get("type", "unknown")
+
+        # For Ollama, show saved available_models
+        if provider_type == "ollama":
+            available = provider.get("available_models", [])
+            if available:
+                console.print(f"[bold]Models on '{identifier}' (Ollama):[/bold]\n")
+                for m in available:
+                    console.print(f"  {rich_escape(m)}")
+            else:
+                console.print(f"[yellow]No models cached for '{identifier}'.[/yellow]")
+                console.print("Run 'clm provider refresh' to fetch models.")
+            return
+
+        # For cloud providers, show hardcoded models
+        model_list = get_models_for_type(provider_type)
+        if model_list:
+            console.print(f"[bold]Available models for '{identifier}' ({provider_type}):[/bold]\n")
+            for m in model_list:
+                console.print(f"  {rich_escape(m)}")
+        else:
+            console.print(f"[yellow]No model list for provider type {provider_type}[/yellow]")
+        return
+
+    # Not found
+    console.print(f"[red]Error:[/red] '{identifier}' is not a valid provider type or configured provider")
+    console.print(f"\nValid provider types: {', '.join(_get_provider_types())}")
+    raise typer.Exit(code=1)
+
+
+@provider_app.command()
+def refresh(
+    name: str = typer.Argument(..., help="Ollama provider name to refresh"),
+) -> None:
+    """Refresh available models from an Ollama server.
+
+    Re-fetches the model list from the Ollama server and updates the saved configuration.
+
+    Examples:
+        clm provider refresh local-llm
+    """
+    # Check provider exists
+    try:
+        provider = get_provider(name)
+    except ProvidersFileCorruptedError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    if not provider:
+        console.print(f"[red]Error:[/red] Provider '{name}' not found")
+        raise typer.Exit(code=1)
+
+    if provider.get("type") != "ollama":
+        console.print("[yellow]Warning:[/yellow] 'refresh' only applies to Ollama providers")
+        console.print(f"Provider '{name}' is type '{provider.get('type')}'")
+        raise typer.Exit(code=0)
+
+    endpoint = provider.get("endpoint")
+    if not endpoint:
+        console.print(f"[red]Error:[/red] Provider '{name}' has no endpoint configured")
+        raise typer.Exit(code=1)
+
+    console.print(f"Connecting to Ollama server at {rich_escape(endpoint)}...")
+    try:
+        available_models = fetch_ollama_models(endpoint)
+    except OllamaConnectionError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    console.print(f"[green]Found {len(available_models)} models[/green]")
+
+    def apply_refresh(p: dict) -> dict:
+        p["available_models"] = available_models
+        p["updated_at"] = datetime.now(timezone.utc).isoformat()
+        return p
+
+    if update_provider(name, apply_refresh):
+        console.print(f"\n[green]Provider '{name}' updated with {len(available_models)} models:[/green]")
+        for m in available_models:
+            console.print(f"  {rich_escape(m)}")
+    else:
+        console.print("[red]Error:[/red] Failed to update provider")
+        raise typer.Exit(code=1)

--- a/src/clawrium/core/providers.py
+++ b/src/clawrium/core/providers.py
@@ -1,0 +1,617 @@
+"""Provider storage operations for Clawrium."""
+
+import fcntl
+import ipaddress
+import json
+import os
+import re
+import socket
+import tempfile
+from contextlib import contextmanager
+from typing import Callable
+from urllib.parse import urlparse
+
+import requests
+
+from clawrium.core.config import get_config_dir, init_config_dir
+
+__all__ = [
+    "PROVIDERS_FILE",
+    "PROVIDER_MODELS",
+    "load_providers",
+    "save_providers",
+    "add_provider",
+    "get_provider",
+    "update_provider",
+    "remove_provider",
+    "validate_provider_name",
+    "validate_provider_type",
+    "validate_ollama_url",
+    "get_models_for_type",
+    "fetch_ollama_models",
+    "get_provider_instance_key",
+    "set_provider_api_key",
+    "get_provider_api_key",
+    "remove_provider_api_key",
+    "ProvidersFileCorruptedError",
+    "DuplicateProviderError",
+    "InvalidProviderTypeError",
+    "InvalidProviderNameError",
+    "OllamaConnectionError",
+    "InvalidOllamaUrlError",
+]
+
+PROVIDERS_FILE = "providers.json"
+
+# Provider name pattern: starts with letter, alphanumeric/underscore/hyphen, 1-64 chars
+PROVIDER_NAME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]{0,63}$")
+
+# Hardcoded model registry for supported providers
+PROVIDER_MODELS: dict[str, dict] = {
+    "openai": {
+        "endpoint": "https://api.openai.com/v1",
+        "models": [
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4-turbo",
+            "gpt-4",
+            "gpt-3.5-turbo",
+            "o1",
+            "o1-mini",
+            "o1-preview",
+        ],
+    },
+    "anthropic": {
+        "endpoint": "https://api.anthropic.com",
+        "models": [
+            "claude-opus-4-20250514",
+            "claude-sonnet-4-20250514",
+            "claude-3-5-sonnet-20241022",
+            "claude-3-5-haiku-20241022",
+            "claude-3-opus-20240229",
+            "claude-3-sonnet-20240229",
+            "claude-3-haiku-20240307",
+        ],
+    },
+    "openrouter": {
+        "endpoint": "https://openrouter.ai/api/v1",
+        "models": [
+            "anthropic/claude-opus-4",
+            "anthropic/claude-sonnet-4",
+            "openai/gpt-4o",
+            "openai/o1",
+            "google/gemini-2.5-pro",
+            "meta-llama/llama-4-maverick",
+            "deepseek/deepseek-chat-v3",
+            "deepseek/deepseek-r1",
+            "qwen/qwen3-235b",
+        ],
+    },
+    "bedrock": {
+        "endpoint": None,  # Uses AWS SDK
+        "models": [
+            "anthropic.claude-opus-4-20250514-v1:0",
+            "anthropic.claude-sonnet-4-20250514-v1:0",
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "anthropic.claude-3-5-haiku-20241022-v1:0",
+            "anthropic.claude-3-haiku-20240307-v1:0",
+            "amazon.titan-text-express-v1",
+            "amazon.titan-text-lite-v1",
+            "meta.llama3-70b-instruct-v1:0",
+        ],
+    },
+    "vertex": {
+        "endpoint": None,  # Uses Google SDK, requires project_id
+        "models": [
+            "gemini-2.5-pro",
+            "gemini-2.5-flash",
+            "gemini-2.5-flash-lite",
+            "gemini-2.0-flash",
+            "gemini-1.5-pro",
+            "gemini-1.5-flash",
+        ],
+    },
+    "zai": {
+        "endpoint": "https://open.bigmodel.cn/api/paas/v4",
+        "models": [
+            "glm-4",
+            "glm-4-plus",
+            "glm-4-air",
+            "glm-4-airx",
+            "glm-4-flash",
+            "glm-4-long",
+            "glm-4v",
+            "glm-4v-plus",
+        ],
+    },
+    "ollama": {
+        "endpoint": None,  # User-provided
+        "models": None,  # Dynamic discovery via fetch_ollama_models()
+    },
+}
+
+
+class ProvidersFileCorruptedError(Exception):
+    """Raised when providers.json cannot be parsed."""
+
+    pass
+
+
+class DuplicateProviderError(Exception):
+    """Raised when trying to add a provider that already exists."""
+
+    pass
+
+
+class InvalidProviderTypeError(Exception):
+    """Raised when an invalid provider type is specified."""
+
+    pass
+
+
+class InvalidProviderNameError(Exception):
+    """Raised when an invalid provider name is specified."""
+
+    pass
+
+
+class OllamaConnectionError(Exception):
+    """Raised when connection to Ollama server fails."""
+
+    pass
+
+
+class InvalidOllamaUrlError(Exception):
+    """Raised when Ollama URL is invalid or points to a restricted address."""
+
+    pass
+
+
+def validate_provider_name(name: str | None) -> None:
+    """Validate provider name format.
+
+    Args:
+        name: Provider name to validate.
+
+    Raises:
+        InvalidProviderNameError: If name is None or doesn't match pattern.
+    """
+    if not isinstance(name, str):
+        raise InvalidProviderNameError("Provider name must be a string")
+
+    if not PROVIDER_NAME_PATTERN.match(name):
+        raise InvalidProviderNameError(
+            f"Invalid provider name '{name}'. "
+            "Must start with a letter, contain only alphanumeric characters, "
+            "underscores, or hyphens, and be 1-64 characters long."
+        )
+
+
+def validate_provider_type(provider_type: str) -> None:
+    """Validate provider type.
+
+    Args:
+        provider_type: Provider type to validate.
+
+    Raises:
+        InvalidProviderTypeError: If type is not in PROVIDER_MODELS.
+    """
+    if provider_type not in PROVIDER_MODELS:
+        valid_types = ", ".join(sorted(PROVIDER_MODELS.keys()))
+        raise InvalidProviderTypeError(
+            f"Invalid provider type '{provider_type}'. Valid types: {valid_types}"
+        )
+
+
+def _is_private_ip(ip_str: str) -> bool:
+    """Check if an IP address is private, loopback, link-local, or reserved.
+
+    Args:
+        ip_str: IP address string.
+
+    Returns:
+        True if the IP is private/reserved, False otherwise.
+    """
+    try:
+        ip = ipaddress.ip_address(ip_str)
+        return (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            # AWS/cloud metadata endpoint
+            or ip_str.startswith("169.254.")
+        )
+    except ValueError:
+        # Not a valid IP address
+        return False
+
+
+def validate_ollama_url(url: str) -> str:
+    """Validate Ollama server URL for security.
+
+    Ensures the URL:
+    - Has http or https scheme
+    - Does not point to private, loopback, link-local, or reserved IP addresses
+    - Does not point to cloud metadata endpoints (169.254.169.254)
+
+    Args:
+        url: URL to validate.
+
+    Returns:
+        Normalized URL (trailing slash removed).
+
+    Raises:
+        InvalidOllamaUrlError: If URL is invalid or points to a restricted address.
+    """
+    url = url.strip().rstrip("/")
+
+    try:
+        parsed = urlparse(url)
+    except Exception as e:
+        raise InvalidOllamaUrlError(f"Invalid URL format: {e}")
+
+    # Check scheme
+    if parsed.scheme not in ("http", "https"):
+        raise InvalidOllamaUrlError(
+            f"Invalid URL scheme '{parsed.scheme}'. Only http and https are allowed."
+        )
+
+    # Get hostname
+    hostname = parsed.hostname
+    if not hostname:
+        raise InvalidOllamaUrlError("URL must include a hostname")
+
+    # Resolve hostname to IP and check if it's private/reserved
+    try:
+        # Get all IP addresses for the hostname
+        addr_info = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+        for family, _, _, _, sockaddr in addr_info:
+            ip_str = sockaddr[0]
+            if _is_private_ip(ip_str):
+                raise InvalidOllamaUrlError(
+                    f"URL resolves to private/reserved IP address '{ip_str}'. "
+                    "Only publicly routable addresses are allowed for security."
+                )
+    except socket.gaierror:
+        # Hostname doesn't resolve - let requests.get handle this later
+        pass
+    except InvalidOllamaUrlError:
+        raise
+    except Exception:
+        # Other resolution errors - let requests.get handle this later
+        pass
+
+    return url
+
+
+def get_models_for_type(provider_type: str) -> list[str] | None:
+    """Get available models for a provider type.
+
+    Args:
+        provider_type: Provider type to get models for.
+
+    Returns:
+        List of model names, or None for dynamic providers (like Ollama).
+
+    Raises:
+        InvalidProviderTypeError: If type is not valid.
+    """
+    validate_provider_type(provider_type)
+    return PROVIDER_MODELS[provider_type]["models"]
+
+
+def fetch_ollama_models(endpoint: str, timeout: int = 10) -> list[str]:
+    """Fetch available models from an Ollama server.
+
+    Args:
+        endpoint: Base URL of Ollama server (e.g., http://localhost:11434).
+                  Must be validated with validate_ollama_url() first.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        List of model names available on the server.
+
+    Raises:
+        OllamaConnectionError: If connection fails or response is invalid.
+    """
+    # Normalize endpoint (remove trailing slash)
+    endpoint = endpoint.rstrip("/")
+    url = f"{endpoint}/api/tags"
+
+    try:
+        response = requests.get(url, timeout=timeout, allow_redirects=False, verify=True)
+        response.raise_for_status()
+        data = response.json()
+
+        # Ollama returns {"models": [{"name": "llama3:latest", ...}, ...]}
+        models = data.get("models", [])
+        if not isinstance(models, list):
+            raise OllamaConnectionError(
+                "Invalid response from Ollama server: expected 'models' to be a list"
+            )
+
+        return [m.get("name", "") for m in models if isinstance(m, dict) and m.get("name")]
+
+    except requests.exceptions.ConnectionError:
+        raise OllamaConnectionError(
+            f"Could not connect to Ollama server at {endpoint}. "
+            "Ensure the server is running."
+        )
+    except requests.exceptions.Timeout:
+        raise OllamaConnectionError(
+            f"Connection to Ollama server at {endpoint} timed out."
+        )
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code if e.response is not None else "unknown"
+        raise OllamaConnectionError(f"Ollama server returned error: {status}")
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        raise OllamaConnectionError(f"Invalid response from Ollama server: {e}")
+
+
+# Provider API key storage using secrets module
+
+
+def get_provider_instance_key(provider_name: str) -> str:
+    """Generate secrets instance key for a provider.
+
+    Args:
+        provider_name: Name of the provider.
+
+    Returns:
+        Instance key in format "provider:{name}".
+    """
+    return f"provider:{provider_name}"
+
+
+def set_provider_api_key(provider_name: str, api_key: str) -> bool:
+    """Store API key for a provider securely.
+
+    Uses the secrets module to store the API key.
+
+    Args:
+        provider_name: Name of the provider.
+        api_key: API key to store.
+
+    Returns:
+        True if new secret created, False if existing secret updated.
+    """
+    from clawrium.core.secrets import set_instance_secret
+
+    instance_key = get_provider_instance_key(provider_name)
+    return set_instance_secret(instance_key, "API_KEY", api_key, description=f"API key for provider {provider_name}")
+
+
+def get_provider_api_key(provider_name: str) -> str | None:
+    """Retrieve API key for a provider.
+
+    Args:
+        provider_name: Name of the provider.
+
+    Returns:
+        API key if found, None otherwise.
+    """
+    from clawrium.core.secrets import get_instance_secrets
+
+    instance_key = get_provider_instance_key(provider_name)
+    secrets = get_instance_secrets(instance_key)
+    if "API_KEY" in secrets:
+        return secrets["API_KEY"]["value"]
+    return None
+
+
+def remove_provider_api_key(provider_name: str) -> bool:
+    """Remove API key for a provider.
+
+    Args:
+        provider_name: Name of the provider.
+
+    Returns:
+        True if secret was removed, False if it didn't exist.
+    """
+    from clawrium.core.secrets import remove_instance_secret
+
+    instance_key = get_provider_instance_key(provider_name)
+    return remove_instance_secret(instance_key, "API_KEY")
+
+
+def load_providers() -> list[dict]:
+    """Load providers from JSON file.
+
+    Returns:
+        List of provider dictionaries. Empty list if file doesn't exist.
+
+    Raises:
+        ProvidersFileCorruptedError: If providers.json exists but cannot be parsed.
+    """
+    providers_path = get_config_dir() / PROVIDERS_FILE
+    if not providers_path.exists():
+        return []
+
+    try:
+        with open(providers_path) as f:
+            data = json.load(f)
+            # Validate it's a list of dicts
+            if not isinstance(data, list):
+                raise ProvidersFileCorruptedError(
+                    f"providers.json is not a list: {providers_path}"
+                )
+            if not all(isinstance(p, dict) for p in data):
+                raise ProvidersFileCorruptedError(
+                    f"providers.json contains invalid entries (expected list of objects): {providers_path}"
+                )
+            return data
+    except json.JSONDecodeError as e:
+        raise ProvidersFileCorruptedError(
+            f"providers.json is corrupted: {e}. "
+            f"Backup the file and delete it to recover: {providers_path}"
+        ) from e
+
+
+@contextmanager
+def _providers_lock():
+    """Context manager for exclusive access to providers.json.
+
+    Uses fcntl.flock for advisory locking to prevent TOCTOU races
+    when multiple processes try to modify providers.json concurrently.
+    """
+    config_dir = init_config_dir()
+    lock_path = config_dir / ".providers.lock"
+
+    # Create lock file if it doesn't exist
+    lock_fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+
+def _save_providers_atomic(providers: list[dict], config_dir) -> None:
+    """Internal: Write providers atomically without acquiring lock.
+
+    This function performs the atomic write (temp file + rename).
+    Caller MUST hold the _providers_lock().
+
+    Args:
+        providers: List of provider dictionaries.
+        config_dir: Path to config directory.
+    """
+    providers_path = config_dir / PROVIDERS_FILE
+    fd, tmp_path = tempfile.mkstemp(dir=config_dir, suffix=".tmp")
+    try:
+        # Set restrictive permissions on temp file before writing (survives rename)
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w") as f:
+            json.dump(providers, f, indent=2)
+        os.replace(tmp_path, providers_path)
+    except Exception:
+        # Clean up temp file on failure
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def save_providers(providers: list[dict]) -> None:
+    """Save providers to JSON file atomically with file locking.
+
+    Creates config directory if it doesn't exist.
+    Uses atomic write (temp file + rename) to prevent data loss on crash.
+    Uses fcntl.flock to prevent concurrent write races.
+
+    Args:
+        providers: List of provider dictionaries to save.
+    """
+    # Ensure config directory exists
+    config_dir = init_config_dir()
+
+    with _providers_lock():
+        _save_providers_atomic(providers, config_dir)
+
+
+def add_provider(provider: dict) -> None:
+    """Add a provider to the registry atomically.
+
+    Acquires exclusive lock for the entire load-modify-save operation
+    to prevent TOCTOU races from concurrent add_provider calls.
+
+    Args:
+        provider: Provider dictionary to add.
+
+    Raises:
+        DuplicateProviderError: If provider name already exists.
+        InvalidProviderNameError: If provider name is invalid.
+    """
+    name = provider.get("name")
+    validate_provider_name(name)
+
+    with _providers_lock():
+        providers = load_providers()
+
+        # Check for duplicate
+        for existing in providers:
+            if existing.get("name") == name:
+                raise DuplicateProviderError(f"Provider '{name}' already exists")
+
+        providers.append(provider)
+
+        # Save without re-acquiring lock
+        config_dir = init_config_dir()
+        _save_providers_atomic(providers, config_dir)
+
+
+def get_provider(name: str) -> dict | None:
+    """Get a provider by name.
+
+    Args:
+        name: Provider name to search for.
+
+    Returns:
+        Provider dictionary if found, None otherwise.
+    """
+    providers = load_providers()
+    for provider in providers:
+        if provider.get("name") == name:
+            return provider
+    return None
+
+
+def update_provider(name: str, updater: Callable[[dict], dict]) -> bool:
+    """Atomically update a provider record.
+
+    Acquires exclusive lock, loads providers, applies updater function,
+    and saves in a single atomic operation. Prevents TOCTOU races.
+
+    Args:
+        name: The name of the provider to update.
+        updater: Function that takes provider dict and returns updated provider dict.
+
+    Returns:
+        True if provider was found and updated, False if not found.
+    """
+    with _providers_lock():
+        providers = load_providers()
+        found = False
+        for i, provider in enumerate(providers):
+            if provider.get("name") == name:
+                providers[i] = updater(provider)
+                found = True
+                break
+
+        if found:
+            # Save without re-acquiring lock (we already hold it)
+            config_dir = init_config_dir()
+            _save_providers_atomic(providers, config_dir)
+
+        return found
+
+
+def remove_provider(name: str) -> bool:
+    """Remove a provider by name atomically.
+
+    Acquires exclusive lock for the entire load-modify-save operation
+    to prevent TOCTOU races from concurrent remove_provider calls.
+
+    Args:
+        name: The provider name to remove.
+
+    Returns:
+        True if provider was found and removed, False otherwise.
+    """
+    with _providers_lock():
+        providers = load_providers()
+        filtered = [p for p in providers if p.get("name") != name]
+
+        if len(filtered) == len(providers):
+            # No provider was removed
+            return False
+
+        # Save without re-acquiring lock
+        config_dir = init_config_dir()
+        _save_providers_atomic(filtered, config_dir)
+
+        return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,6 +136,34 @@ def sample_host_data():
 
 
 @pytest.fixture
+def sample_provider_data():
+    """Return sample provider data for testing."""
+    return {
+        "name": "test-openai",
+        "type": "openai",
+        "default_model": "gpt-4o",
+        "api_key": "sk-test123456789",
+        "created_at": "2026-04-05T12:00:00+00:00",
+        "updated_at": "2026-04-05T12:00:00+00:00",
+    }
+
+
+@pytest.fixture
+def sample_ollama_provider():
+    """Return sample Ollama provider data for testing."""
+    return {
+        "name": "local-llm",
+        "type": "ollama",
+        "endpoint": "http://localhost:11434",
+        "default_model": "llama3:latest",
+        "available_models": ["llama3:latest", "mistral:latest", "codellama:latest"],
+        "api_key": None,
+        "created_at": "2026-04-05T12:00:00+00:00",
+        "updated_at": "2026-04-05T12:00:00+00:00",
+    }
+
+
+@pytest.fixture
 def hosts_with_installed_claw(isolated_config):
     """Set up hosts.json with one installed openclaw claw.
 

--- a/tests/test_cli_provider.py
+++ b/tests/test_cli_provider.py
@@ -1,0 +1,522 @@
+"""Tests for provider CLI commands."""
+
+import json
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+from clawrium.cli.main import app
+from clawrium.core.providers import PROVIDERS_FILE, save_providers
+
+
+runner = CliRunner()
+
+
+class TestProviderTypes:
+    """Tests for 'clm provider types' command."""
+
+    def test_types_lists_all_providers(self, isolated_config):
+        """'clm provider types' lists all supported provider types."""
+        result = runner.invoke(app, ["provider", "types"])
+
+        assert result.exit_code == 0
+        assert "openai" in result.output
+        assert "anthropic" in result.output
+        assert "openrouter" in result.output
+        assert "bedrock" in result.output
+        assert "vertex" in result.output
+        assert "zai" in result.output
+        assert "ollama" in result.output
+
+
+class TestProviderModels:
+    """Tests for 'clm provider models' command."""
+
+    def test_models_by_type(self, isolated_config):
+        """'clm provider models openai' lists OpenAI models."""
+        result = runner.invoke(app, ["provider", "models", "openai"])
+
+        assert result.exit_code == 0
+        assert "gpt-4o" in result.output
+        assert "gpt-4o-mini" in result.output
+
+    def test_models_ollama_type_shows_message(self, isolated_config):
+        """'clm provider models ollama' shows dynamic discovery message."""
+        result = runner.invoke(app, ["provider", "models", "ollama"])
+
+        assert result.exit_code == 0
+        assert "dynamically" in result.output.lower()
+
+    def test_models_by_provider_name(self, isolated_config, sample_provider_data):
+        """'clm provider models <name>' shows models for configured provider."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_provider_data])
+
+        result = runner.invoke(app, ["provider", "models", "test-openai"])
+
+        assert result.exit_code == 0
+        assert "gpt-4o" in result.output
+
+    def test_models_ollama_provider_shows_available(self, isolated_config, sample_ollama_provider):
+        """'clm provider models <ollama-name>' shows cached models."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_ollama_provider])
+
+        result = runner.invoke(app, ["provider", "models", "local-llm"])
+
+        assert result.exit_code == 0
+        assert "llama3:latest" in result.output
+        assert "mistral:latest" in result.output
+
+    def test_models_invalid_identifier(self, isolated_config):
+        """'clm provider models <invalid>' shows error."""
+        result = runner.invoke(app, ["provider", "models", "nonexistent"])
+
+        assert result.exit_code == 1
+        assert "not a valid provider type" in result.output.lower()
+
+
+class TestProviderList:
+    """Tests for 'clm provider list' command."""
+
+    def test_list_empty(self, isolated_config):
+        """'clm provider list' shows message when no providers."""
+        result = runner.invoke(app, ["provider", "list"])
+
+        assert result.exit_code == 0
+        assert "no providers configured" in result.output.lower()
+
+    def test_list_with_providers(self, isolated_config, sample_provider_data):
+        """'clm provider list' shows configured providers."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_provider_data])
+
+        result = runner.invoke(app, ["provider", "list"])
+
+        assert result.exit_code == 0
+        assert "test-openai" in result.output
+        assert "openai" in result.output
+        assert "gpt-4o" in result.output
+
+    def test_list_ollama_shows_endpoint(self, isolated_config, sample_ollama_provider):
+        """'clm provider list' shows endpoint for Ollama instead of API key."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_ollama_provider])
+
+        result = runner.invoke(app, ["provider", "list"])
+
+        assert result.exit_code == 0
+        assert "localhost:11434" in result.output
+
+    def test_list_corrupted_file(self, isolated_config):
+        """'clm provider list' handles corrupted providers.json."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        (isolated_config / PROVIDERS_FILE).write_text("not valid json")
+
+        result = runner.invoke(app, ["provider", "list"])
+
+        assert result.exit_code == 1
+        assert "corrupted" in result.output.lower()
+
+
+class TestProviderAdd:
+    """Tests for 'clm provider add' command."""
+
+    def test_add_requires_type(self, isolated_config):
+        """'clm provider add' requires --type option."""
+        result = runner.invoke(app, ["provider", "add", "myopenai"])
+
+        assert result.exit_code != 0
+        assert "type" in result.output.lower()
+
+    def test_add_invalid_type(self, isolated_config):
+        """'clm provider add' rejects invalid provider type."""
+        result = runner.invoke(app, ["provider", "add", "myopenai", "--type", "invalid"])
+
+        assert result.exit_code == 1
+        assert "invalid provider type" in result.output.lower()
+
+    def test_add_invalid_name(self, isolated_config):
+        """'clm provider add' rejects invalid provider name."""
+        # Need to provide API key via prompt
+        result = runner.invoke(
+            app,
+            ["provider", "add", "1invalid", "--type", "openai"],
+            input="sk-test\n1\n",
+        )
+
+        assert result.exit_code == 1
+        assert "invalid provider name" in result.output.lower()
+
+    def test_add_openai_prompts_for_api_key(self, isolated_config):
+        """'clm provider add' prompts for API key securely."""
+        result = runner.invoke(
+            app,
+            ["provider", "add", "myopenai", "--type", "openai", "--model", "gpt-4o"],
+            input="sk-test123\n",
+        )
+
+        assert result.exit_code == 0
+        assert "added successfully" in result.output.lower()
+
+        # Verify provider was created
+        providers_path = isolated_config / PROVIDERS_FILE
+        assert providers_path.exists()
+
+        with open(providers_path) as f:
+            providers = json.load(f)
+
+        assert len(providers) == 1
+        assert providers[0]["name"] == "myopenai"
+        assert providers[0]["type"] == "openai"
+        assert providers[0]["default_model"] == "gpt-4o"
+        # API key should NOT be in providers.json (stored in secrets)
+        assert "api_key" not in providers[0]
+
+    def test_add_duplicate_fails(self, isolated_config, sample_provider_data):
+        """'clm provider add' fails for duplicate name."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_provider_data])
+
+        result = runner.invoke(
+            app,
+            ["provider", "add", "test-openai", "--type", "anthropic"],
+            input="sk-test\n1\n",
+        )
+
+        assert result.exit_code == 1
+        assert "already exists" in result.output.lower()
+
+    def test_add_ollama_validates_url(self, isolated_config):
+        """'clm provider add --type ollama' validates URL for security."""
+        # Try to add Ollama with a private IP (should fail validation)
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [(2, 1, 0, "", ("192.168.1.100", 0))]
+            result = runner.invoke(
+                app,
+                [
+                    "provider", "add", "local-llm",
+                    "--type", "ollama",
+                    "--url", "http://myserver.local:11434",
+                ],
+            )
+
+        assert result.exit_code == 1
+        assert "private" in result.output.lower()
+
+    def test_add_ollama_success(self, isolated_config):
+        """'clm provider add --type ollama' works with valid public URL."""
+        # Mock URL validation to allow the URL
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [(2, 1, 0, "", ("93.184.216.34", 0))]
+
+            # Mock the Ollama server connection
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "models": [{"name": "llama3:latest"}]
+            }
+            mock_response.raise_for_status = MagicMock()
+
+            with patch("clawrium.core.providers.requests.get", return_value=mock_response):
+                result = runner.invoke(
+                    app,
+                    [
+                        "provider", "add", "local-llm",
+                        "--type", "ollama",
+                        "--url", "http://ollama.example.com:11434",
+                        "--model", "llama3:latest",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        assert "added successfully" in result.output.lower()
+
+    def test_add_ollama_no_models_fails(self, isolated_config):
+        """'clm provider add --type ollama' fails when no models on server."""
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [(2, 1, 0, "", ("93.184.216.34", 0))]
+
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"models": []}
+            mock_response.raise_for_status = MagicMock()
+
+            with patch("clawrium.core.providers.requests.get", return_value=mock_response):
+                result = runner.invoke(
+                    app,
+                    [
+                        "provider", "add", "local-llm",
+                        "--type", "ollama",
+                        "--url", "http://ollama.example.com:11434",
+                    ],
+                )
+
+        assert result.exit_code == 1
+        assert "no models" in result.output.lower()
+
+    def test_add_ollama_connection_failure(self, isolated_config):
+        """'clm provider add --type ollama' handles connection failure."""
+        import requests
+
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [(2, 1, 0, "", ("93.184.216.34", 0))]
+
+            with patch(
+                "clawrium.core.providers.requests.get",
+                side_effect=requests.exceptions.ConnectionError(),
+            ):
+                result = runner.invoke(
+                    app,
+                    [
+                        "provider", "add", "local-llm",
+                        "--type", "ollama",
+                        "--url", "http://ollama.example.com:11434",
+                    ],
+                )
+
+        assert result.exit_code == 1
+        assert "could not connect" in result.output.lower()
+
+
+class TestProviderEdit:
+    """Tests for 'clm provider edit' command."""
+
+    def test_edit_not_found(self, isolated_config):
+        """'clm provider edit' fails for nonexistent provider."""
+        result = runner.invoke(app, ["provider", "edit", "nonexistent", "--model", "gpt-4"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_edit_no_changes(self, isolated_config, sample_provider_data):
+        """'clm provider edit' with no options shows warning."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_provider_data])
+
+        result = runner.invoke(app, ["provider", "edit", "test-openai"])
+
+        assert result.exit_code == 0
+        assert "no changes" in result.output.lower()
+
+    def test_edit_model(self, isolated_config, sample_provider_data):
+        """'clm provider edit --model' updates model."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_provider_data])
+
+        result = runner.invoke(
+            app,
+            ["provider", "edit", "test-openai", "--model", "gpt-4o-mini"],
+        )
+
+        assert result.exit_code == 0
+        assert "updated successfully" in result.output.lower()
+
+        # Verify update
+        providers_path = isolated_config / PROVIDERS_FILE
+        with open(providers_path) as f:
+            providers = json.load(f)
+        assert providers[0]["default_model"] == "gpt-4o-mini"
+
+    def test_edit_url_non_ollama_fails(self, isolated_config, sample_provider_data):
+        """'clm provider edit --url' fails for non-Ollama provider."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_provider_data])
+
+        result = runner.invoke(
+            app,
+            ["provider", "edit", "test-openai", "--url", "http://example.com:11434"],
+        )
+
+        assert result.exit_code == 1
+        assert "only valid for ollama" in result.output.lower()
+
+    def test_edit_ollama_url_success(self, isolated_config, sample_ollama_provider):
+        """'clm provider edit --url' updates Ollama endpoint."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_ollama_provider])
+
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [(2, 1, 0, "", ("93.184.216.34", 0))]
+
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "models": [{"name": "llama3:latest"}, {"name": "phi3:latest"}]
+            }
+            mock_response.raise_for_status = MagicMock()
+
+            with patch("clawrium.core.providers.requests.get", return_value=mock_response):
+                result = runner.invoke(
+                    app,
+                    ["provider", "edit", "local-llm", "--url", "http://newserver.example.com:11434"],
+                )
+
+        assert result.exit_code == 0
+        assert "updated successfully" in result.output.lower()
+
+        # Verify endpoint was updated
+        providers_path = isolated_config / PROVIDERS_FILE
+        with open(providers_path) as f:
+            providers = json.load(f)
+        assert providers[0]["endpoint"] == "http://newserver.example.com:11434"
+
+    def test_edit_ollama_url_connection_failure(self, isolated_config, sample_ollama_provider):
+        """'clm provider edit --url' handles connection failure."""
+        import requests
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_ollama_provider])
+
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [(2, 1, 0, "", ("93.184.216.34", 0))]
+
+            with patch(
+                "clawrium.core.providers.requests.get",
+                side_effect=requests.exceptions.ConnectionError(),
+            ):
+                result = runner.invoke(
+                    app,
+                    ["provider", "edit", "local-llm", "--url", "http://newserver.example.com:11434"],
+                )
+
+        assert result.exit_code == 1
+        assert "could not connect" in result.output.lower()
+
+    def test_edit_update_key(self, isolated_config, sample_provider_data):
+        """'clm provider edit --update-key' prompts for new API key."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_provider_data])
+
+        result = runner.invoke(
+            app,
+            ["provider", "edit", "test-openai", "--update-key"],
+            input="sk-new-key\n",
+        )
+
+        assert result.exit_code == 0
+        assert "updated" in result.output.lower()
+
+
+class TestProviderRemove:
+    """Tests for 'clm provider remove' command."""
+
+    def test_remove_not_found(self, isolated_config):
+        """'clm provider remove' fails for nonexistent provider."""
+        result = runner.invoke(app, ["provider", "remove", "nonexistent", "--force"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_remove_with_confirmation(self, isolated_config, sample_provider_data):
+        """'clm provider remove' prompts for confirmation."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_provider_data])
+
+        # Decline confirmation
+        result = runner.invoke(app, ["provider", "remove", "test-openai"], input="n\n")
+
+        assert result.exit_code == 0
+        assert "cancelled" in result.output.lower()
+
+        # Provider should still exist
+        providers_path = isolated_config / PROVIDERS_FILE
+        with open(providers_path) as f:
+            providers = json.load(f)
+        assert len(providers) == 1
+
+    def test_remove_with_force(self, isolated_config, sample_provider_data):
+        """'clm provider remove --force' removes without confirmation."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_provider_data])
+
+        result = runner.invoke(app, ["provider", "remove", "test-openai", "--force"])
+
+        assert result.exit_code == 0
+        assert "removed successfully" in result.output.lower()
+
+        # Provider should be gone
+        providers_path = isolated_config / PROVIDERS_FILE
+        with open(providers_path) as f:
+            providers = json.load(f)
+        assert len(providers) == 0
+
+
+class TestProviderRefresh:
+    """Tests for 'clm provider refresh' command."""
+
+    def test_refresh_not_found(self, isolated_config):
+        """'clm provider refresh' fails for nonexistent provider."""
+        result = runner.invoke(app, ["provider", "refresh", "nonexistent"])
+
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_refresh_non_ollama(self, isolated_config, sample_provider_data):
+        """'clm provider refresh' warns for non-Ollama provider."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_provider_data])
+
+        result = runner.invoke(app, ["provider", "refresh", "test-openai"])
+
+        # S3 fix: exits 0 for wrong provider type (not an actual failure)
+        assert result.exit_code == 0
+        assert "ollama" in result.output.lower()
+
+    def test_refresh_ollama_success(self, isolated_config, sample_ollama_provider):
+        """'clm provider refresh' updates Ollama models."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_ollama_provider])
+
+        # Mock new models from server
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "models": [
+                {"name": "llama3:latest"},
+                {"name": "mistral:latest"},
+                {"name": "phi3:latest"},  # New model
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("clawrium.core.providers.requests.get", return_value=mock_response):
+            result = runner.invoke(app, ["provider", "refresh", "local-llm"])
+
+        assert result.exit_code == 0
+        assert "updated" in result.output.lower()
+        assert "phi3:latest" in result.output
+
+        # Verify models were updated
+        providers_path = isolated_config / PROVIDERS_FILE
+        with open(providers_path) as f:
+            providers = json.load(f)
+        assert "phi3:latest" in providers[0]["available_models"]
+
+    def test_refresh_ollama_connection_failure(self, isolated_config, sample_ollama_provider):
+        """'clm provider refresh' handles connection failure."""
+        import requests
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([sample_ollama_provider])
+
+        with patch(
+            "clawrium.core.providers.requests.get",
+            side_effect=requests.exceptions.ConnectionError(),
+        ):
+            result = runner.invoke(app, ["provider", "refresh", "local-llm"])
+
+        assert result.exit_code == 1
+        assert "could not connect" in result.output.lower()
+
+    def test_refresh_ollama_missing_endpoint(self, isolated_config):
+        """'clm provider refresh' handles missing endpoint."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        # Provider without endpoint field
+        provider_no_endpoint = {
+            "name": "broken-ollama",
+            "type": "ollama",
+            "default_model": "llama3:latest",
+            "available_models": [],
+        }
+        save_providers([provider_no_endpoint])
+
+        result = runner.invoke(app, ["provider", "refresh", "broken-ollama"])
+
+        assert result.exit_code == 1
+        assert "no endpoint" in result.output.lower()

--- a/tests/test_core_providers.py
+++ b/tests/test_core_providers.py
@@ -1,0 +1,574 @@
+"""Tests for provider storage module."""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+from clawrium.core.providers import (
+    PROVIDERS_FILE,
+    PROVIDER_MODELS,
+    load_providers,
+    save_providers,
+    add_provider,
+    get_provider,
+    update_provider,
+    remove_provider,
+    validate_provider_name,
+    validate_provider_type,
+    validate_ollama_url,
+    get_models_for_type,
+    fetch_ollama_models,
+    get_provider_instance_key,
+    set_provider_api_key,
+    get_provider_api_key,
+    remove_provider_api_key,
+    ProvidersFileCorruptedError,
+    DuplicateProviderError,
+    InvalidProviderNameError,
+    InvalidProviderTypeError,
+    OllamaConnectionError,
+    InvalidOllamaUrlError,
+)
+
+
+class TestValidation:
+    """Tests for validation functions."""
+
+    def test_validate_provider_name_valid(self):
+        """validate_provider_name accepts valid names."""
+        valid_names = [
+            "myopenai",
+            "my-openai",
+            "my_openai",
+            "MyOpenAI",
+            "a",
+            "A1",
+            "provider123",
+            "a" * 64,  # Max length
+        ]
+        for name in valid_names:
+            try:
+                validate_provider_name(name)  # Should not raise
+            except InvalidProviderNameError:
+                pytest.fail(f"'{name}' should be valid but raised InvalidProviderNameError")
+
+    def test_validate_provider_name_invalid(self):
+        """validate_provider_name rejects invalid names."""
+        invalid_names = [
+            "",  # Empty
+            "1provider",  # Starts with number
+            "-provider",  # Starts with hyphen
+            "_provider",  # Starts with underscore
+            "my provider",  # Contains space
+            "my.provider",  # Contains dot
+            "my/provider",  # Contains slash
+            "../path",  # Path traversal attempt
+            "a" * 65,  # Too long
+        ]
+        for name in invalid_names:
+            with pytest.raises(InvalidProviderNameError):
+                validate_provider_name(name)
+
+    def test_validate_provider_name_none(self):
+        """validate_provider_name raises for None input."""
+        with pytest.raises(InvalidProviderNameError) as exc_info:
+            validate_provider_name(None)
+        assert "must be a string" in str(exc_info.value).lower()
+
+    def test_validate_provider_name_non_string(self):
+        """validate_provider_name raises for non-string input."""
+        with pytest.raises(InvalidProviderNameError):
+            validate_provider_name(123)
+
+    def test_validate_provider_type_valid(self):
+        """validate_provider_type accepts all valid types."""
+        for provider_type in PROVIDER_MODELS.keys():
+            validate_provider_type(provider_type)  # Should not raise
+
+    def test_validate_provider_type_invalid(self):
+        """validate_provider_type rejects unknown types."""
+        with pytest.raises(InvalidProviderTypeError) as exc_info:
+            validate_provider_type("unknown-provider")
+        assert "invalid provider type" in str(exc_info.value).lower()
+
+    def test_get_models_for_type_returns_models(self):
+        """get_models_for_type returns model list for valid types."""
+        models = get_models_for_type("openai")
+        assert isinstance(models, list)
+        assert "gpt-4o" in models
+
+    def test_get_models_for_type_ollama_returns_none(self):
+        """get_models_for_type returns None for Ollama (dynamic discovery)."""
+        models = get_models_for_type("ollama")
+        assert models is None
+
+    def test_get_models_for_type_invalid_raises(self):
+        """get_models_for_type raises for invalid type."""
+        with pytest.raises(InvalidProviderTypeError):
+            get_models_for_type("invalid")
+
+
+class TestOllamaUrlValidation:
+    """Tests for Ollama URL validation (SSRF prevention)."""
+
+    def test_validate_ollama_url_valid_http(self):
+        """validate_ollama_url accepts valid http URLs."""
+        # Mock socket.getaddrinfo to return public IP
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [
+                (2, 1, 0, "", ("93.184.216.34", 0))  # example.com IP
+            ]
+            url = validate_ollama_url("http://example.com:11434")
+            assert url == "http://example.com:11434"
+
+    def test_validate_ollama_url_valid_https(self):
+        """validate_ollama_url accepts valid https URLs."""
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [
+                (2, 1, 0, "", ("93.184.216.34", 0))
+            ]
+            url = validate_ollama_url("https://example.com:11434")
+            assert url == "https://example.com:11434"
+
+    def test_validate_ollama_url_strips_trailing_slash(self):
+        """validate_ollama_url removes trailing slashes."""
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [
+                (2, 1, 0, "", ("93.184.216.34", 0))
+            ]
+            url = validate_ollama_url("http://example.com:11434/")
+            assert url == "http://example.com:11434"
+
+    def test_validate_ollama_url_rejects_ftp(self):
+        """validate_ollama_url rejects ftp scheme."""
+        with pytest.raises(InvalidOllamaUrlError) as exc_info:
+            validate_ollama_url("ftp://example.com")
+        assert "only http and https" in str(exc_info.value).lower()
+
+    def test_validate_ollama_url_rejects_file(self):
+        """validate_ollama_url rejects file scheme."""
+        with pytest.raises(InvalidOllamaUrlError) as exc_info:
+            validate_ollama_url("file:///etc/passwd")
+        assert "only http and https" in str(exc_info.value).lower()
+
+    def test_validate_ollama_url_rejects_private_ip(self):
+        """validate_ollama_url rejects private IP addresses."""
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [
+                (2, 1, 0, "", ("192.168.1.100", 0))
+            ]
+            with pytest.raises(InvalidOllamaUrlError) as exc_info:
+                validate_ollama_url("http://myserver.local:11434")
+            assert "private" in str(exc_info.value).lower()
+
+    def test_validate_ollama_url_rejects_loopback(self):
+        """validate_ollama_url rejects loopback addresses."""
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [
+                (2, 1, 0, "", ("127.0.0.1", 0))
+            ]
+            with pytest.raises(InvalidOllamaUrlError) as exc_info:
+                validate_ollama_url("http://localhost:11434")
+            assert "private" in str(exc_info.value).lower()
+
+    def test_validate_ollama_url_rejects_metadata_endpoint(self):
+        """validate_ollama_url rejects AWS metadata endpoint."""
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [
+                (2, 1, 0, "", ("169.254.169.254", 0))
+            ]
+            with pytest.raises(InvalidOllamaUrlError) as exc_info:
+                validate_ollama_url("http://169.254.169.254")
+            assert "private" in str(exc_info.value).lower()
+
+    def test_validate_ollama_url_allows_unresolvable_hostname(self):
+        """validate_ollama_url allows hostnames that don't resolve (let requests handle)."""
+        import socket as sock
+
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.side_effect = sock.gaierror("Name resolution failed")
+            # Should not raise - let requests.get handle the error later
+            url = validate_ollama_url("http://nonexistent.example.com:11434")
+            assert url == "http://nonexistent.example.com:11434"
+
+
+class TestOllamaDiscovery:
+    """Tests for Ollama model discovery."""
+
+    def test_fetch_ollama_models_success(self):
+        """fetch_ollama_models returns model names on success."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "models": [
+                {"name": "llama3:latest", "size": 1234567890},
+                {"name": "mistral:latest", "size": 987654321},
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("clawrium.core.providers.requests.get", return_value=mock_response):
+            models = fetch_ollama_models("http://example.com:11434")
+
+        assert models == ["llama3:latest", "mistral:latest"]
+
+    def test_fetch_ollama_models_empty(self):
+        """fetch_ollama_models returns empty list when no models."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"models": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("clawrium.core.providers.requests.get", return_value=mock_response):
+            models = fetch_ollama_models("http://example.com:11434")
+
+        assert models == []
+
+    def test_fetch_ollama_models_connection_error(self):
+        """fetch_ollama_models raises OllamaConnectionError on connection failure."""
+        import requests
+
+        with patch(
+            "clawrium.core.providers.requests.get",
+            side_effect=requests.exceptions.ConnectionError("Connection refused"),
+        ):
+            with pytest.raises(OllamaConnectionError) as exc_info:
+                fetch_ollama_models("http://example.com:11434")
+            assert "could not connect" in str(exc_info.value).lower()
+
+    def test_fetch_ollama_models_timeout(self):
+        """fetch_ollama_models raises OllamaConnectionError on timeout."""
+        import requests
+
+        with patch(
+            "clawrium.core.providers.requests.get",
+            side_effect=requests.exceptions.Timeout("Request timed out"),
+        ):
+            with pytest.raises(OllamaConnectionError) as exc_info:
+                fetch_ollama_models("http://example.com:11434")
+            assert "timed out" in str(exc_info.value).lower()
+
+    def test_fetch_ollama_models_http_error(self):
+        """fetch_ollama_models raises OllamaConnectionError on HTTP error."""
+        import requests
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            response=mock_response
+        )
+
+        with patch("clawrium.core.providers.requests.get", return_value=mock_response):
+            with pytest.raises(OllamaConnectionError) as exc_info:
+                fetch_ollama_models("http://example.com:11434")
+            assert "error" in str(exc_info.value).lower()
+
+    def test_fetch_ollama_models_http_error_no_response(self):
+        """fetch_ollama_models handles HTTPError with no response object."""
+        import requests
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            response=None
+        )
+
+        with patch("clawrium.core.providers.requests.get", return_value=mock_response):
+            with pytest.raises(OllamaConnectionError) as exc_info:
+                fetch_ollama_models("http://example.com:11434")
+            assert "unknown" in str(exc_info.value).lower()
+
+    def test_fetch_ollama_models_invalid_json(self):
+        """fetch_ollama_models raises OllamaConnectionError on invalid JSON."""
+        mock_response = MagicMock()
+        mock_response.json.side_effect = json.JSONDecodeError("Invalid", "", 0)
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("clawrium.core.providers.requests.get", return_value=mock_response):
+            with pytest.raises(OllamaConnectionError) as exc_info:
+                fetch_ollama_models("http://example.com:11434")
+            assert "invalid response" in str(exc_info.value).lower()
+
+    def test_fetch_ollama_models_uses_allow_redirects_false(self):
+        """fetch_ollama_models disables redirects for security."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"models": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("clawrium.core.providers.requests.get", return_value=mock_response) as mock_get:
+            fetch_ollama_models("http://example.com:11434")
+            mock_get.assert_called_once()
+            call_kwargs = mock_get.call_args[1]
+            assert call_kwargs.get("allow_redirects") is False
+            assert call_kwargs.get("verify") is True
+
+
+class TestProviderApiKeyStorage:
+    """Tests for secure API key storage."""
+
+    def test_get_provider_instance_key(self):
+        """get_provider_instance_key returns correct format."""
+        key = get_provider_instance_key("myopenai")
+        assert key == "provider:myopenai"
+
+    def test_set_and_get_provider_api_key(self, isolated_config):
+        """set_provider_api_key stores and get_provider_api_key retrieves."""
+        set_provider_api_key("testprovider", "sk-test123")
+        retrieved = get_provider_api_key("testprovider")
+        assert retrieved == "sk-test123"
+
+    def test_get_provider_api_key_not_found(self, isolated_config):
+        """get_provider_api_key returns None when not found."""
+        result = get_provider_api_key("nonexistent")
+        assert result is None
+
+    def test_remove_provider_api_key(self, isolated_config):
+        """remove_provider_api_key removes stored key."""
+        set_provider_api_key("testprovider", "sk-test123")
+        assert get_provider_api_key("testprovider") == "sk-test123"
+
+        result = remove_provider_api_key("testprovider")
+        assert result is True
+        assert get_provider_api_key("testprovider") is None
+
+    def test_remove_provider_api_key_not_found(self, isolated_config):
+        """remove_provider_api_key returns False when key doesn't exist."""
+        result = remove_provider_api_key("nonexistent")
+        assert result is False
+
+
+class TestProviderStorage:
+    """Tests for provider CRUD operations."""
+
+    def test_load_providers_no_file(self, isolated_config):
+        """load_providers returns empty list when file doesn't exist."""
+        providers = load_providers()
+        assert providers == []
+
+    def test_load_providers_valid_json(self, isolated_config):
+        """load_providers returns list of providers from valid JSON."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_path = isolated_config / PROVIDERS_FILE
+        test_data = [
+            {"name": "openai-1", "type": "openai"},
+            {"name": "claude-1", "type": "anthropic"},
+        ]
+        providers_path.write_text(json.dumps(test_data))
+
+        providers = load_providers()
+        assert providers == test_data
+
+    def test_load_providers_invalid_json(self, isolated_config):
+        """load_providers raises ProvidersFileCorruptedError on invalid JSON."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_path = isolated_config / PROVIDERS_FILE
+        providers_path.write_text("not valid json {{{")
+
+        with pytest.raises(ProvidersFileCorruptedError) as exc_info:
+            load_providers()
+        assert "corrupted" in str(exc_info.value).lower()
+
+    def test_load_providers_non_list_json(self, isolated_config):
+        """load_providers raises ProvidersFileCorruptedError when JSON is not a list."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_path = isolated_config / PROVIDERS_FILE
+        providers_path.write_text('{"key": "value"}')
+
+        with pytest.raises(ProvidersFileCorruptedError) as exc_info:
+            load_providers()
+        assert "not a list" in str(exc_info.value).lower()
+
+    def test_load_providers_list_with_non_dict_items(self, isolated_config):
+        """load_providers raises ProvidersFileCorruptedError when list contains non-dicts."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_path = isolated_config / PROVIDERS_FILE
+        providers_path.write_text('[1, 2, "string"]')
+
+        with pytest.raises(ProvidersFileCorruptedError) as exc_info:
+            load_providers()
+        assert "invalid entries" in str(exc_info.value).lower()
+
+    def test_save_providers_creates_file(self, isolated_config):
+        """save_providers creates providers.json with correct content."""
+        test_providers = [{"name": "test", "type": "openai"}]
+
+        save_providers(test_providers)
+
+        providers_path = isolated_config / PROVIDERS_FILE
+        assert providers_path.exists()
+
+        with open(providers_path) as f:
+            saved_data = json.load(f)
+        assert saved_data == test_providers
+
+    def test_save_providers_creates_dir(self, tmp_path, monkeypatch):
+        """save_providers creates config directory if it doesn't exist."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        config_dir = tmp_path / "clawrium"
+
+        assert not config_dir.exists()
+
+        test_providers = [{"name": "test", "type": "openai"}]
+        save_providers(test_providers)
+
+        assert config_dir.exists()
+        assert (config_dir / PROVIDERS_FILE).exists()
+
+    def test_save_providers_file_permissions(self, isolated_config):
+        """save_providers creates file with 0600 permissions."""
+        test_providers = [{"name": "test", "type": "openai"}]
+        save_providers(test_providers)
+
+        providers_path = isolated_config / PROVIDERS_FILE
+        mode = providers_path.stat().st_mode & 0o777
+        assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    def test_add_provider_appends(self, isolated_config):
+        """add_provider appends to existing providers."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        initial = [{"name": "existing", "type": "openai"}]
+        save_providers(initial)
+
+        new_provider = {"name": "newprovider", "type": "anthropic"}
+        add_provider(new_provider)
+
+        providers = load_providers()
+        assert len(providers) == 2
+        assert providers[0] == initial[0]
+        assert providers[1] == new_provider
+
+    def test_add_provider_duplicate_raises(self, isolated_config):
+        """add_provider raises DuplicateProviderError when name exists."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        initial = [{"name": "existing", "type": "openai"}]
+        save_providers(initial)
+
+        duplicate = {"name": "existing", "type": "anthropic"}
+
+        with pytest.raises(DuplicateProviderError) as exc_info:
+            add_provider(duplicate)
+        assert "already exists" in str(exc_info.value).lower()
+
+    def test_add_provider_invalid_name_raises(self, isolated_config):
+        """add_provider raises InvalidProviderNameError for invalid names."""
+        provider = {"name": "1invalid", "type": "openai"}
+
+        with pytest.raises(InvalidProviderNameError):
+            add_provider(provider)
+
+    def test_add_provider_missing_name_raises(self, isolated_config):
+        """add_provider raises InvalidProviderNameError when name is missing."""
+        provider = {"type": "openai"}
+
+        with pytest.raises(InvalidProviderNameError):
+            add_provider(provider)
+
+    def test_get_provider_found(self, isolated_config):
+        """get_provider returns provider when found."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        test_providers = [
+            {"name": "provider1", "type": "openai"},
+            {"name": "provider2", "type": "anthropic"},
+        ]
+        save_providers(test_providers)
+
+        provider = get_provider("provider1")
+
+        assert provider is not None
+        assert provider["name"] == "provider1"
+        assert provider["type"] == "openai"
+
+    def test_get_provider_not_found(self, isolated_config):
+        """get_provider returns None when not found."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        test_providers = [{"name": "existing", "type": "openai"}]
+        save_providers(test_providers)
+
+        provider = get_provider("nonexistent")
+
+        assert provider is None
+
+    def test_update_provider_success(self, isolated_config):
+        """update_provider updates provider and returns True."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        initial = [{"name": "test", "type": "openai", "model": "gpt-4"}]
+        save_providers(initial)
+
+        def update_model(p):
+            p["model"] = "gpt-4o"
+            return p
+
+        result = update_provider("test", update_model)
+
+        assert result is True
+        providers = load_providers()
+        assert providers[0]["model"] == "gpt-4o"
+
+    def test_update_provider_not_found(self, isolated_config):
+        """update_provider returns False when provider not found."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([{"name": "existing", "type": "openai"}])
+
+        def noop(p):
+            return p
+
+        result = update_provider("nonexistent", noop)
+
+        assert result is False
+
+    def test_remove_provider_success(self, isolated_config):
+        """remove_provider removes provider and returns True."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        test_providers = [
+            {"name": "provider1", "type": "openai"},
+            {"name": "provider2", "type": "anthropic"},
+        ]
+        save_providers(test_providers)
+
+        result = remove_provider("provider1")
+
+        assert result is True
+        providers = load_providers()
+        assert len(providers) == 1
+        assert providers[0]["name"] == "provider2"
+
+    def test_remove_provider_not_found(self, isolated_config):
+        """remove_provider returns False when not found."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        save_providers([{"name": "existing", "type": "openai"}])
+
+        result = remove_provider("nonexistent")
+
+        assert result is False
+        providers = load_providers()
+        assert len(providers) == 1
+
+
+class TestProviderModelsConstant:
+    """Tests for PROVIDER_MODELS constant."""
+
+    def test_all_expected_providers_present(self):
+        """PROVIDER_MODELS contains all expected provider types."""
+        expected = {"openai", "anthropic", "openrouter", "bedrock", "vertex", "zai", "ollama"}
+        assert set(PROVIDER_MODELS.keys()) == expected
+
+    def test_cloud_providers_have_models(self):
+        """Cloud providers have non-empty model lists."""
+        cloud_providers = ["openai", "anthropic", "openrouter", "bedrock", "vertex", "zai"]
+        for provider_type in cloud_providers:
+            models = PROVIDER_MODELS[provider_type]["models"]
+            assert isinstance(models, list)
+            assert len(models) > 0, f"{provider_type} should have models"
+
+    def test_ollama_has_no_hardcoded_models(self):
+        """Ollama provider has None for models (dynamic discovery)."""
+        assert PROVIDER_MODELS["ollama"]["models"] is None
+
+    def test_providers_with_endpoints(self):
+        """Providers with fixed endpoints have them set."""
+        assert PROVIDER_MODELS["openai"]["endpoint"] == "https://api.openai.com/v1"
+        assert PROVIDER_MODELS["anthropic"]["endpoint"] == "https://api.anthropic.com"
+        assert PROVIDER_MODELS["openrouter"]["endpoint"] == "https://openrouter.ai/api/v1"
+
+    def test_sdk_providers_have_no_endpoint(self):
+        """SDK-based providers have None for endpoint."""
+        assert PROVIDER_MODELS["bedrock"]["endpoint"] is None
+        assert PROVIDER_MODELS["vertex"]["endpoint"] is None
+        assert PROVIDER_MODELS["ollama"]["endpoint"] is None

--- a/uv.lock
+++ b/uv.lock
@@ -97,6 +97,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
 name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -179,6 +188,111 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "clawrium"
 version = "0.1.0"
 source = { editable = "." }
@@ -187,6 +301,7 @@ dependencies = [
     { name = "packaging" },
     { name = "paramiko" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "rich" },
     { name = "typer" },
 ]
@@ -204,6 +319,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=24.0" },
     { name = "paramiko", specifier = ">=3.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "requests", specifier = ">=2.31.0" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
@@ -424,6 +540,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -690,6 +815,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -812,4 +952,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]


### PR DESCRIPTION
## Summary

- Adds `clm provider` command group for centralized inference provider management
- Supports 7 provider types: openai, anthropic, openrouter, bedrock, vertex, zai, ollama
- Implements secure API key storage via secrets.py module
- Dynamic model discovery for Ollama servers with SSRF protection

## Commands

| Command | Description |
|---------|-------------|
| `clm provider add` | Add new provider with secure API key prompt |
| `clm provider list` | Display all configured providers |
| `clm provider edit` | Modify provider settings |
| `clm provider remove` | Delete provider configuration |
| `clm provider types` | Show supported provider types |
| `clm provider models` | List available models for a provider type |
| `clm provider refresh` | Update Ollama model list |

## Test plan

- [x] All 442 tests pass
- [x] Lint passes (ruff check)
- [x] Provider add/list/edit/remove workflow tested
- [x] SSRF validation rejects private IPs
- [x] API keys stored securely via secrets module

## ATX Review Summary

**Final Review: Rating 2/5** (based on spec document, not implementation)

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 2/5 | B1, B2, B3 | All fixed |
| 2 | 1/5 | None new | Spec-based review |

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `providers.py` | API keys stored in plaintext | Fixed - uses secrets.py module |
| B2 | `providers.py` | SSRF via unvalidated URLs | Fixed - validate_ollama_url() with IP checks |
| B3 | `provider.py` | --api-key CLI flag exposes credentials | Fixed - removed flag, uses secure prompt |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `providers.py` | None guard for response.status_code | Fixed |
| W2 | `providers.py` | None/non-string check in validate_provider_name | Fixed |
| W5 | `provider.py` | rich_escape() for user strings | Fixed |
| W6 | `provider.py` | Exit code for --url on non-Ollama | Fixed |
| W7 | `providers.py` | allow_redirects=False for requests | Fixed |

</details>

<details>
<summary>Review 2 Details (Rating 1/5)</summary>

Note: The second ATX review analyzed the v3 spec document from issue #53 comments rather than the actual implementation. The reviewer noted "None of the target files (`core/providers.py`, `cli/provider.py`) exist yet" despite them being already implemented. All blocking issues identified in the spec had already been addressed in the actual code.

</details>

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>