### PR TITLE
feat(core): implement onboarding state machine module

### DIFF
--- a/src/clawrium/core/onboarding.py
+++ b/src/clawrium/core/onboarding.py
@@ -1,0 +1,344 @@
+"""Onboarding state machine for claw instances.
+
+This module manages the onboarding workflow for newly installed claws,
+tracking progress through a fixed set of universal stages.
+"""
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from clawrium.core.hosts import get_host, update_host
+from clawrium.core.registry import load_manifest
+
+__all__ = [
+    "OnboardingState",
+    "StageStatus",
+    "TRANSITIONS",
+    "get_onboarding_state",
+    "transition_state",
+    "complete_stage",
+    "initialize_onboarding",
+    "can_skip_stage",
+    "get_stage_tasks",
+    "run_stage",
+    "InvalidTransitionError",
+    "OnboardingNotFoundError",
+    "ClawNotFoundError",
+]
+
+
+class OnboardingState(str, Enum):
+    """States in the onboarding workflow."""
+
+    PENDING = "pending"  # After install, before onboarding
+    PROVIDERS = "providers"  # Configuring inference provider
+    IDENTITY = "identity"  # Configuring agent persona
+    CHANNELS = "channels"  # Configuring communication
+    VALIDATE = "validate"  # Running verification
+    READY = "ready"  # Onboarding complete
+
+
+class StageStatus(str, Enum):
+    """Status of an individual onboarding stage."""
+
+    PENDING = "pending"
+    COMPLETE = "complete"
+    SKIPPED = "skipped"
+
+
+# Valid state transitions
+TRANSITIONS: dict[str, list[str]] = {
+    "pending": ["providers"],
+    "providers": ["identity"],
+    "identity": ["channels"],
+    "channels": ["validate"],
+    "validate": ["ready", "channels"],  # Fail → back to fix
+    "ready": [],
+}
+
+
+class InvalidTransitionError(Exception):
+    """Raised when attempting an invalid state transition."""
+
+    pass
+
+
+class OnboardingNotFoundError(Exception):
+    """Raised when onboarding record does not exist for a claw."""
+
+    pass
+
+
+class ClawNotFoundError(Exception):
+    """Raised when claw is not found on the host."""
+
+    pass
+
+
+def _get_claw_record(host: str, claw_name: str) -> dict | None:
+    """Get claw record from host.
+
+    Args:
+        host: Hostname or alias
+        claw_name: Name of the claw (e.g., "openclaw")
+
+    Returns:
+        Claw record dict or None if not found
+    """
+    host_data = get_host(host)
+    if not host_data:
+        return None
+    claws = host_data.get("claws", {})
+    return claws.get(claw_name)
+
+
+def get_onboarding_state(host: str, claw_name: str) -> OnboardingState:
+    """Get current onboarding state for a claw.
+
+    Args:
+        host: Hostname or alias
+        claw_name: Name of the claw
+
+    Returns:
+        Current OnboardingState
+
+    Raises:
+        ClawNotFoundError: If claw is not installed on host
+        OnboardingNotFoundError: If onboarding has not been initialized
+    """
+    claw = _get_claw_record(host, claw_name)
+    if claw is None:
+        raise ClawNotFoundError(f"Claw '{claw_name}' not found on host '{host}'")
+
+    onboarding = claw.get("onboarding")
+    if onboarding is None:
+        raise OnboardingNotFoundError(
+            f"Onboarding not initialized for '{claw_name}' on '{host}'"
+        )
+
+    state_value = onboarding.get("state", "pending")
+    return OnboardingState(state_value)
+
+
+def transition_state(host: str, claw_name: str, to_state: OnboardingState) -> bool:
+    """Transition claw to a new onboarding state.
+
+    Validates that the transition is allowed according to TRANSITIONS.
+
+    Args:
+        host: Hostname or alias
+        claw_name: Name of the claw
+        to_state: Target state to transition to
+
+    Returns:
+        True if transition succeeded
+
+    Raises:
+        ClawNotFoundError: If claw is not installed on host
+        OnboardingNotFoundError: If onboarding has not been initialized
+        InvalidTransitionError: If transition is not allowed
+    """
+    current_state = get_onboarding_state(host, claw_name)
+    allowed = TRANSITIONS.get(current_state.value, [])
+
+    if to_state.value not in allowed:
+        raise InvalidTransitionError(
+            f"Cannot transition from '{current_state.value}' to '{to_state.value}'. "
+            f"Allowed transitions: {allowed}"
+        )
+
+    host_data = get_host(host)
+    if not host_data:
+        raise ClawNotFoundError(f"Host '{host}' not found")
+
+    hostname = host_data["hostname"]
+
+    def updater(h: dict) -> dict:
+        h["claws"][claw_name]["onboarding"]["state"] = to_state.value
+        return h
+
+    return update_host(hostname, updater)
+
+
+def complete_stage(
+    host: str,
+    claw_name: str,
+    stage: str,
+    status: StageStatus,
+    metadata: dict[str, Any] | None = None,
+) -> bool:
+    """Mark an onboarding stage as complete or skipped.
+
+    Args:
+        host: Hostname or alias
+        claw_name: Name of the claw
+        stage: Stage name (providers, identity, channels, validate)
+        status: Status to set (complete or skipped)
+        metadata: Optional metadata to store with the stage
+
+    Returns:
+        True if update succeeded
+
+    Raises:
+        ClawNotFoundError: If claw is not installed on host
+        OnboardingNotFoundError: If onboarding has not been initialized
+        ValueError: If stage is not a valid stage name
+    """
+    valid_stages = {"providers", "identity", "channels", "validate"}
+    if stage not in valid_stages:
+        raise ValueError(f"Invalid stage '{stage}'. Valid stages: {valid_stages}")
+
+    claw = _get_claw_record(host, claw_name)
+    if claw is None:
+        raise ClawNotFoundError(f"Claw '{claw_name}' not found on host '{host}'")
+
+    onboarding = claw.get("onboarding")
+    if onboarding is None:
+        raise OnboardingNotFoundError(
+            f"Onboarding not initialized for '{claw_name}' on '{host}'"
+        )
+
+    host_data = get_host(host)
+    if not host_data:
+        raise ClawNotFoundError(f"Host '{host}' not found")
+
+    hostname = host_data["hostname"]
+    now = datetime.now(timezone.utc).isoformat()
+
+    def updater(h: dict) -> dict:
+        stage_data = h["claws"][claw_name]["onboarding"]["stages"][stage]
+        stage_data["status"] = status.value
+        stage_data["completed_at"] = now
+        if metadata:
+            for key, value in metadata.items():
+                stage_data[key] = value
+        return h
+
+    return update_host(hostname, updater)
+
+
+def initialize_onboarding(host: str, claw_name: str) -> bool:
+    """Initialize onboarding record for a claw.
+
+    Creates the onboarding data structure with state=PENDING and all
+    stages initialized to pending status.
+
+    Args:
+        host: Hostname or alias
+        claw_name: Name of the claw
+
+    Returns:
+        True if initialization succeeded
+
+    Raises:
+        ClawNotFoundError: If claw is not installed on host
+    """
+    claw = _get_claw_record(host, claw_name)
+    if claw is None:
+        raise ClawNotFoundError(f"Claw '{claw_name}' not found on host '{host}'")
+
+    host_data = get_host(host)
+    if not host_data:
+        raise ClawNotFoundError(f"Host '{host}' not found")
+
+    hostname = host_data["hostname"]
+    now = datetime.now(timezone.utc).isoformat()
+
+    def updater(h: dict) -> dict:
+        h["claws"][claw_name]["onboarding"] = {
+            "state": OnboardingState.PENDING.value,
+            "started_at": now,
+            "stages": {
+                "providers": {"status": StageStatus.PENDING.value, "completed_at": None, "provider_id": None},
+                "identity": {"status": StageStatus.PENDING.value, "completed_at": None},
+                "channels": {"status": StageStatus.PENDING.value, "completed_at": None},
+                "validate": {"status": StageStatus.PENDING.value, "completed_at": None},
+            },
+        }
+        return h
+
+    return update_host(hostname, updater)
+
+
+def can_skip_stage(claw_type: str, stage: str) -> bool:
+    """Check if a stage can be auto-skipped for a claw type.
+
+    Some claw types may not need certain stages (e.g., a claw without
+    communication features doesn't need the channels stage).
+
+    Args:
+        claw_type: Type of claw (e.g., "openclaw", "zeroclaw")
+        stage: Stage name to check
+
+    Returns:
+        True if the stage can be skipped for this claw type
+    """
+    try:
+        manifest = load_manifest(claw_type)
+    except Exception:
+        return False
+
+    # Check if manifest has skip_stages configuration
+    skip_stages = manifest.get("skip_stages", [])
+    return stage in skip_stages
+
+
+def get_stage_tasks(claw_type: str, stage: str) -> list[dict]:
+    """Get tasks for a stage from the claw manifest.
+
+    Args:
+        claw_type: Type of claw (e.g., "openclaw", "zeroclaw")
+        stage: Stage name
+
+    Returns:
+        List of task dictionaries for the stage. Empty list if no tasks defined.
+    """
+    try:
+        manifest = load_manifest(claw_type)
+    except Exception:
+        return []
+
+    # Check if manifest has onboarding.stages configuration
+    onboarding_config = manifest.get("onboarding", {})
+    stages_config = onboarding_config.get("stages", {})
+    stage_config = stages_config.get(stage, {})
+
+    return stage_config.get("tasks", [])
+
+
+def run_stage(claw_type: str, host: str, claw_name: str, stage: str) -> bool:
+    """Execute tasks for an onboarding stage.
+
+    This is a placeholder for stage execution logic. In practice, this would:
+    1. Get tasks from manifest
+    2. Execute each task (possibly via Ansible)
+    3. Update stage status
+
+    Args:
+        claw_type: Type of claw (e.g., "openclaw", "zeroclaw")
+        host: Hostname or alias
+        claw_name: Name of the claw instance
+        stage: Stage name to execute
+
+    Returns:
+        True if stage completed successfully
+    """
+    # Check if stage can be skipped
+    if can_skip_stage(claw_type, stage):
+        complete_stage(host, claw_name, stage, StageStatus.SKIPPED)
+        return True
+
+    # Get tasks for this stage
+    tasks = get_stage_tasks(claw_type, stage)
+
+    if not tasks:
+        # No tasks defined - mark as complete
+        complete_stage(host, claw_name, stage, StageStatus.COMPLETE)
+        return True
+
+    # Execute tasks (placeholder - actual implementation would run Ansible or similar)
+    # For now, we just mark the stage as complete
+    # Future implementation will iterate through tasks and execute them
+    complete_stage(host, claw_name, stage, StageStatus.COMPLETE)
+    return True

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,395 @@
+"""Tests for onboarding state machine module."""
+
+import json
+import pytest
+from clawrium.core.onboarding import (
+    OnboardingState,
+    StageStatus,
+    TRANSITIONS,
+    get_onboarding_state,
+    transition_state,
+    complete_stage,
+    initialize_onboarding,
+    can_skip_stage,
+    get_stage_tasks,
+    run_stage,
+    InvalidTransitionError,
+    OnboardingNotFoundError,
+    ClawNotFoundError,
+)
+
+
+@pytest.fixture
+def host_with_claw(isolated_config):
+    """Set up hosts.json with a claw installed but no onboarding."""
+    hosts_data = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "server1",
+            "port": 22,
+            "user": "xclm",
+            "claws": {
+                "openclaw": {
+                    "version": "0.1.0",
+                    "status": "installed",
+                    "name": "assistant",
+                    "user": "opc-assistant",
+                }
+            },
+        }
+    ]
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    hosts_path = isolated_config / "hosts.json"
+    hosts_path.write_text(json.dumps(hosts_data))
+
+    return isolated_config
+
+
+@pytest.fixture
+def host_with_onboarding(isolated_config):
+    """Set up hosts.json with a claw that has onboarding initialized."""
+    hosts_data = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "server1",
+            "port": 22,
+            "user": "xclm",
+            "claws": {
+                "openclaw": {
+                    "version": "0.1.0",
+                    "status": "installed",
+                    "name": "assistant",
+                    "user": "opc-assistant",
+                    "onboarding": {
+                        "state": "pending",
+                        "started_at": "2026-04-06T00:00:00+00:00",
+                        "stages": {
+                            "providers": {"status": "pending", "completed_at": None, "provider_id": None},
+                            "identity": {"status": "pending", "completed_at": None},
+                            "channels": {"status": "pending", "completed_at": None},
+                            "validate": {"status": "pending", "completed_at": None},
+                        },
+                    },
+                }
+            },
+        }
+    ]
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    hosts_path = isolated_config / "hosts.json"
+    hosts_path.write_text(json.dumps(hosts_data))
+
+    return isolated_config
+
+
+class TestOnboardingStateEnum:
+    """Tests for OnboardingState enum."""
+
+    def test_all_states_defined(self):
+        """All required states are defined."""
+        assert OnboardingState.PENDING.value == "pending"
+        assert OnboardingState.PROVIDERS.value == "providers"
+        assert OnboardingState.IDENTITY.value == "identity"
+        assert OnboardingState.CHANNELS.value == "channels"
+        assert OnboardingState.VALIDATE.value == "validate"
+        assert OnboardingState.READY.value == "ready"
+
+    def test_state_is_string_enum(self):
+        """OnboardingState inherits from str."""
+        assert isinstance(OnboardingState.PENDING, str)
+        assert OnboardingState.PENDING == "pending"
+
+
+class TestStageStatusEnum:
+    """Tests for StageStatus enum."""
+
+    def test_all_statuses_defined(self):
+        """All required statuses are defined."""
+        assert StageStatus.PENDING.value == "pending"
+        assert StageStatus.COMPLETE.value == "complete"
+        assert StageStatus.SKIPPED.value == "skipped"
+
+    def test_status_is_string_enum(self):
+        """StageStatus inherits from str."""
+        assert isinstance(StageStatus.PENDING, str)
+        assert StageStatus.PENDING == "pending"
+
+
+class TestTransitions:
+    """Tests for TRANSITIONS state machine."""
+
+    def test_pending_transitions(self):
+        """pending can only transition to providers."""
+        assert TRANSITIONS["pending"] == ["providers"]
+
+    def test_providers_transitions(self):
+        """providers can only transition to identity."""
+        assert TRANSITIONS["providers"] == ["identity"]
+
+    def test_identity_transitions(self):
+        """identity can only transition to channels."""
+        assert TRANSITIONS["identity"] == ["channels"]
+
+    def test_channels_transitions(self):
+        """channels can only transition to validate."""
+        assert TRANSITIONS["channels"] == ["validate"]
+
+    def test_validate_transitions(self):
+        """validate can transition to ready or back to channels."""
+        assert "ready" in TRANSITIONS["validate"]
+        assert "channels" in TRANSITIONS["validate"]
+
+    def test_ready_is_terminal(self):
+        """ready has no outgoing transitions."""
+        assert TRANSITIONS["ready"] == []
+
+    def test_all_states_have_transitions(self):
+        """All OnboardingState values are in TRANSITIONS."""
+        for state in OnboardingState:
+            assert state.value in TRANSITIONS
+
+
+class TestGetOnboardingState:
+    """Tests for get_onboarding_state function."""
+
+    def test_get_state_with_onboarding(self, host_with_onboarding):
+        """Returns current state when onboarding exists."""
+        state = get_onboarding_state("server1", "openclaw")
+        assert state == OnboardingState.PENDING
+
+    def test_get_state_claw_not_found(self, host_with_onboarding):
+        """Raises ClawNotFoundError when claw doesn't exist."""
+        with pytest.raises(ClawNotFoundError) as exc_info:
+            get_onboarding_state("server1", "nonexistent")
+        assert "not found" in str(exc_info.value).lower()
+
+    def test_get_state_onboarding_not_initialized(self, host_with_claw):
+        """Raises OnboardingNotFoundError when onboarding not initialized."""
+        with pytest.raises(OnboardingNotFoundError) as exc_info:
+            get_onboarding_state("server1", "openclaw")
+        assert "not initialized" in str(exc_info.value).lower()
+
+    def test_get_state_host_not_found(self, isolated_config):
+        """Raises ClawNotFoundError when host doesn't exist."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_path = isolated_config / "hosts.json"
+        hosts_path.write_text("[]")
+
+        with pytest.raises(ClawNotFoundError):
+            get_onboarding_state("nonexistent", "openclaw")
+
+
+class TestTransitionState:
+    """Tests for transition_state function."""
+
+    def test_valid_transition_pending_to_providers(self, host_with_onboarding):
+        """Allows valid transition from pending to providers."""
+        result = transition_state("server1", "openclaw", OnboardingState.PROVIDERS)
+        assert result is True
+
+        state = get_onboarding_state("server1", "openclaw")
+        assert state == OnboardingState.PROVIDERS
+
+    def test_invalid_transition_pending_to_ready(self, host_with_onboarding):
+        """Rejects invalid transition from pending to ready."""
+        with pytest.raises(InvalidTransitionError) as exc_info:
+            transition_state("server1", "openclaw", OnboardingState.READY)
+        assert "cannot transition" in str(exc_info.value).lower()
+
+    def test_invalid_transition_pending_to_validate(self, host_with_onboarding):
+        """Rejects skipping states."""
+        with pytest.raises(InvalidTransitionError):
+            transition_state("server1", "openclaw", OnboardingState.VALIDATE)
+
+    def test_transition_claw_not_found(self, host_with_onboarding):
+        """Raises ClawNotFoundError for non-existent claw."""
+        with pytest.raises(ClawNotFoundError):
+            transition_state("server1", "nonexistent", OnboardingState.PROVIDERS)
+
+    def test_full_happy_path_transitions(self, host_with_onboarding):
+        """Test complete onboarding workflow transitions."""
+        # pending -> providers
+        transition_state("server1", "openclaw", OnboardingState.PROVIDERS)
+        assert get_onboarding_state("server1", "openclaw") == OnboardingState.PROVIDERS
+
+        # providers -> identity
+        transition_state("server1", "openclaw", OnboardingState.IDENTITY)
+        assert get_onboarding_state("server1", "openclaw") == OnboardingState.IDENTITY
+
+        # identity -> channels
+        transition_state("server1", "openclaw", OnboardingState.CHANNELS)
+        assert get_onboarding_state("server1", "openclaw") == OnboardingState.CHANNELS
+
+        # channels -> validate
+        transition_state("server1", "openclaw", OnboardingState.VALIDATE)
+        assert get_onboarding_state("server1", "openclaw") == OnboardingState.VALIDATE
+
+        # validate -> ready
+        transition_state("server1", "openclaw", OnboardingState.READY)
+        assert get_onboarding_state("server1", "openclaw") == OnboardingState.READY
+
+    def test_validate_can_go_back_to_channels(self, host_with_onboarding):
+        """validate state can transition back to channels on failure."""
+        # Get to validate state
+        transition_state("server1", "openclaw", OnboardingState.PROVIDERS)
+        transition_state("server1", "openclaw", OnboardingState.IDENTITY)
+        transition_state("server1", "openclaw", OnboardingState.CHANNELS)
+        transition_state("server1", "openclaw", OnboardingState.VALIDATE)
+
+        # Go back to channels
+        result = transition_state("server1", "openclaw", OnboardingState.CHANNELS)
+        assert result is True
+        assert get_onboarding_state("server1", "openclaw") == OnboardingState.CHANNELS
+
+
+class TestCompleteStage:
+    """Tests for complete_stage function."""
+
+    def test_complete_stage_success(self, host_with_onboarding):
+        """Marks stage as complete with timestamp."""
+        result = complete_stage("server1", "openclaw", "providers", StageStatus.COMPLETE)
+        assert result is True
+
+        # Verify stage data
+        from clawrium.core.hosts import get_host
+
+        host = get_host("server1")
+        stage = host["claws"]["openclaw"]["onboarding"]["stages"]["providers"]
+        assert stage["status"] == "complete"
+        assert stage["completed_at"] is not None
+
+    def test_complete_stage_with_metadata(self, host_with_onboarding):
+        """Stores metadata with stage completion."""
+        metadata = {"provider_id": "openai-default"}
+        result = complete_stage(
+            "server1", "openclaw", "providers", StageStatus.COMPLETE, metadata
+        )
+        assert result is True
+
+        from clawrium.core.hosts import get_host
+
+        host = get_host("server1")
+        stage = host["claws"]["openclaw"]["onboarding"]["stages"]["providers"]
+        assert stage["provider_id"] == "openai-default"
+
+    def test_complete_stage_skipped(self, host_with_onboarding):
+        """Marks stage as skipped."""
+        result = complete_stage("server1", "openclaw", "channels", StageStatus.SKIPPED)
+        assert result is True
+
+        from clawrium.core.hosts import get_host
+
+        host = get_host("server1")
+        stage = host["claws"]["openclaw"]["onboarding"]["stages"]["channels"]
+        assert stage["status"] == "skipped"
+
+    def test_complete_invalid_stage(self, host_with_onboarding):
+        """Raises ValueError for invalid stage name."""
+        with pytest.raises(ValueError) as exc_info:
+            complete_stage("server1", "openclaw", "invalid", StageStatus.COMPLETE)
+        assert "invalid stage" in str(exc_info.value).lower()
+
+    def test_complete_stage_claw_not_found(self, host_with_onboarding):
+        """Raises ClawNotFoundError for non-existent claw."""
+        with pytest.raises(ClawNotFoundError):
+            complete_stage("server1", "nonexistent", "providers", StageStatus.COMPLETE)
+
+
+class TestInitializeOnboarding:
+    """Tests for initialize_onboarding function."""
+
+    def test_initialize_creates_structure(self, host_with_claw):
+        """Creates complete onboarding data structure."""
+        result = initialize_onboarding("server1", "openclaw")
+        assert result is True
+
+        from clawrium.core.hosts import get_host
+
+        host = get_host("server1")
+        onboarding = host["claws"]["openclaw"]["onboarding"]
+
+        assert onboarding["state"] == "pending"
+        assert onboarding["started_at"] is not None
+        assert "stages" in onboarding
+        assert all(
+            stage in onboarding["stages"]
+            for stage in ["providers", "identity", "channels", "validate"]
+        )
+
+    def test_initialize_all_stages_pending(self, host_with_claw):
+        """All stages start with pending status."""
+        initialize_onboarding("server1", "openclaw")
+
+        from clawrium.core.hosts import get_host
+
+        host = get_host("server1")
+        stages = host["claws"]["openclaw"]["onboarding"]["stages"]
+
+        for stage_name, stage_data in stages.items():
+            assert stage_data["status"] == "pending", f"Stage {stage_name} not pending"
+            assert stage_data["completed_at"] is None
+
+    def test_initialize_claw_not_found(self, host_with_claw):
+        """Raises ClawNotFoundError for non-existent claw."""
+        with pytest.raises(ClawNotFoundError):
+            initialize_onboarding("server1", "nonexistent")
+
+    def test_initialize_host_not_found(self, isolated_config):
+        """Raises ClawNotFoundError for non-existent host."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_path = isolated_config / "hosts.json"
+        hosts_path.write_text("[]")
+
+        with pytest.raises(ClawNotFoundError):
+            initialize_onboarding("nonexistent", "openclaw")
+
+
+class TestCanSkipStage:
+    """Tests for can_skip_stage function."""
+
+    def test_returns_false_for_known_claw(self):
+        """Returns False for claws without skip_stages config."""
+        # openclaw and zeroclaw don't have skip_stages in their manifests
+        result = can_skip_stage("openclaw", "channels")
+        assert result is False
+
+    def test_returns_false_for_unknown_claw(self):
+        """Returns False when manifest cannot be loaded."""
+        result = can_skip_stage("nonexistent-claw", "channels")
+        assert result is False
+
+
+class TestGetStageTasks:
+    """Tests for get_stage_tasks function."""
+
+    def test_returns_empty_for_claw_without_onboarding_config(self):
+        """Returns empty list when manifest has no onboarding.stages."""
+        # Current manifests don't have onboarding config
+        tasks = get_stage_tasks("openclaw", "providers")
+        assert tasks == []
+
+    def test_returns_empty_for_unknown_claw(self):
+        """Returns empty list when manifest cannot be loaded."""
+        tasks = get_stage_tasks("nonexistent-claw", "providers")
+        assert tasks == []
+
+
+class TestRunStage:
+    """Tests for run_stage function."""
+
+    def test_run_stage_no_tasks_completes(self, host_with_onboarding):
+        """Stage with no tasks is marked complete."""
+        result = run_stage("openclaw", "server1", "openclaw", "providers")
+        assert result is True
+
+        from clawrium.core.hosts import get_host
+
+        host = get_host("server1")
+        stage = host["claws"]["openclaw"]["onboarding"]["stages"]["providers"]
+        assert stage["status"] == "complete"
+
+    def test_run_stage_claw_not_found(self, host_with_onboarding):
+        """Raises ClawNotFoundError for non-existent claw."""
+        with pytest.raises(ClawNotFoundError):
+            run_stage("openclaw", "server1", "nonexistent", "providers")


### PR DESCRIPTION
## Summary

- Add `OnboardingState` and `StageStatus` enums for state machine
- Implement state transition validation with TRANSITIONS dict
- Add functions: `get_onboarding_state`, `transition_state`, `complete_stage`, `initialize_onboarding`, `can_skip_stage`, `get_stage_tasks`, `run_stage`
- Use atomic updates via existing `update_host()` pattern
- 36 comprehensive tests covering valid/invalid transitions

## Test Plan

- [x] All 478 tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] 93% coverage on new module
- [x] Tests cover: all state transitions, invalid transitions (should fail), stage completion, initialization

Closes #69

## ATX Review Summary

**Final Review: Rating 1/5 (blocked - files untracked)**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 1/5 | B1, B2, B3, B4 | B1 N/A, B2 Fixed, B3-B4 Out-of-scope |

<details>
<summary>Review 1 Details (Rating 1/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `onboarding.py` | File does not exist (untracked) | N/A - false positive, files untracked during ATX review |
| B2 | `tests/core/test_onboarding.py` | Wrong test location | Fixed - moved to `tests/test_onboarding.py` (flat layout) |
| B3 | `install.py:213,237-248` | Pre-existing: secrets written to ansible artifacts | Out-of-scope - pre-existing issue, not introduced by this PR |
| B4 | `host.py:86-94` | Pre-existing: TOFU bypass with RejectPolicy | Out-of-scope - pre-existing issue, not introduced by this PR |

**Note:** B3 and B4 are pre-existing security issues discovered during the review sweep. They should be tracked in separate issues but are not blockers for this PR.

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>