### PR TITLE
feat(install): initialize onboarding on claw installation

### DIFF
--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -42,6 +42,7 @@ from clawrium.core.secrets import (
     get_instance_key,
     get_instance_secrets,
 )
+from clawrium.core.onboarding import initialize_onboarding
 
 logger = logging.getLogger(__name__)
 
@@ -284,7 +285,26 @@ def run_installation(
             return h
 
         update_host(host["hostname"], set_installed)
-        emit("complete", f"Installation complete. Logs at {install_log_dir}")
+
+        # Step 11: Initialize onboarding record (non-fatal if it fails)
+        try:
+            if not initialize_onboarding(host["hostname"], claw_name):
+                try:
+                    emit("warn", f"Onboarding setup incomplete — run `clm onboard init {host['hostname']} {claw_name}` to retry")
+                except Exception:
+                    logger.warning("Failed to emit onboarding warning event", exc_info=True)
+        except Exception as e:
+            logger.warning("Onboarding init failed: %s", e, exc_info=True)
+            try:
+                emit("warn", f"Onboarding setup failed — run `clm onboard init {host['hostname']} {claw_name}` to retry")
+            except Exception:
+                logger.warning("Failed to emit onboarding warning event", exc_info=True)
+
+        # Step 12: Emit completion event (non-fatal if callback fails)
+        try:
+            emit("complete", f"Installation complete. Logs at {install_log_dir}")
+        except Exception:
+            logger.warning("Failed to emit completion event", exc_info=True)
 
         return {
             "success": True,
@@ -296,7 +316,7 @@ def run_installation(
         }
 
     except Exception as e:
-        # Step 11: Update host with failure status
+        # Step 13: Update host with failure status
         error_msg = str(e)
 
         def set_failed(h: dict) -> dict:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -163,6 +163,9 @@ def test_install_success(monkeypatch, tmp_path):
     # Mock update_host to avoid real filesystem access
     monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: True)
 
+    # Mock initialize_onboarding to avoid real filesystem access
+    monkeypatch.setattr(clawrium.core.install, "initialize_onboarding", lambda h, c: True)
+
     # Mock ansible_runner.run
     class SuccessfulResult:
         status = "successful"
@@ -248,6 +251,9 @@ def test_install_emits_events(monkeypatch, tmp_path):
 
     # Mock update_host to avoid real filesystem access
     monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: True)
+
+    # Mock initialize_onboarding to avoid real filesystem access
+    monkeypatch.setattr(clawrium.core.install, "initialize_onboarding", lambda h, c: True)
 
     class SuccessfulResult:
         status = "successful"
@@ -503,6 +509,9 @@ def test_install_updates_host_on_success(monkeypatch, tmp_path):
 
     monkeypatch.setattr(clawrium.core.install, "update_host", mock_update_host)
 
+    # Mock initialize_onboarding to avoid real filesystem access
+    monkeypatch.setattr(clawrium.core.install, "initialize_onboarding", lambda h, c: True)
+
     # Run installation
     run_installation("openclaw", "test-host")
 
@@ -629,3 +638,434 @@ def test_install_updates_host_on_failure(monkeypatch, tmp_path):
                 break
 
     assert found_failed, "Expected update_host to be called with failed status"
+
+
+def test_install_initializes_onboarding(monkeypatch, tmp_path):
+    """Test that successful install initializes onboarding record after host update."""
+    from clawrium.core.install import run_installation
+
+    # Isolate test from real filesystem
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    # Mock dependencies
+    mock_manifest = {
+        "name": "openclaw",
+        "entries": [
+            {
+                "version": "0.1.0",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc123",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.9"},
+                },
+            }
+        ],
+    }
+
+    import clawrium.core.install
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+
+    key_file = tmp_path / "test_key"
+    key_file.write_text("fake key")
+
+    compatible_host = {
+        "hostname": "test-host",
+        "user": "xclm",
+        "port": 22,
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    monkeypatch.setattr(clawrium.core.install, "get_host", lambda x: compatible_host)
+
+    compat_result = {
+        "compatible": True,
+        "matched_entry": mock_manifest["entries"][0],
+        "reasons": [],
+    }
+    monkeypatch.setattr(
+        clawrium.core.install, "check_compatibility", lambda *args, **kwargs: compat_result
+    )
+
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda x: key_file
+    )
+
+    class SuccessfulResult:
+        status = "successful"
+
+    mock_run = Mock(return_value=SuccessfulResult())
+
+    import ansible_runner
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    # Track call ordering with accumulated state
+    call_order = []
+    persistent_host = compatible_host.copy()
+
+    def mock_update_host(hostname, updater):
+        nonlocal persistent_host
+        persistent_host = updater(persistent_host)
+        status = persistent_host.get("claws", {}).get("openclaw", {}).get("status")
+        call_order.append(("update_host", status))
+        return True
+
+    monkeypatch.setattr(clawrium.core.install, "update_host", mock_update_host)
+
+    def mock_initialize_onboarding(host, claw_name):
+        call_order.append(("initialize_onboarding", claw_name))
+        return True
+
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", mock_initialize_onboarding
+    )
+
+    # Run installation
+    result = run_installation("openclaw", "test-host")
+
+    # Verify installation succeeded
+    assert result["success"] is True
+
+    # Verify exact sequence: update_host(installing) -> update_host(installed) -> initialize_onboarding
+    assert len(call_order) == 3, f"Expected exactly 3 calls, got {len(call_order)}: {call_order}"
+    assert call_order[0] == ("update_host", "installing"), f"First call should be update_host(installing), got {call_order[0]}"
+    assert call_order[1] == ("update_host", "installed"), f"Second call should be update_host(installed), got {call_order[1]}"
+    assert call_order[2][0] == "initialize_onboarding", f"Third call should be initialize_onboarding, got {call_order[2]}"
+    assert call_order[2][1] == "openclaw", "initialize_onboarding should be called with claw_name='openclaw'"
+
+
+def test_install_failure_does_not_initialize_onboarding(monkeypatch, tmp_path):
+    """Test that failed install does NOT initialize onboarding record."""
+    from clawrium.core.install import run_installation, InstallationError
+
+    # Isolate test from real filesystem
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    # Mock dependencies
+    mock_manifest = {
+        "name": "openclaw",
+        "entries": [
+            {
+                "version": "0.1.0",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc123",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.9"},
+                },
+            }
+        ],
+    }
+
+    import clawrium.core.install
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+
+    key_file = tmp_path / "test_key"
+    key_file.write_text("fake key")
+
+    compatible_host = {
+        "hostname": "test-host",
+        "user": "xclm",
+        "port": 22,
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    monkeypatch.setattr(clawrium.core.install, "get_host", lambda x: compatible_host)
+
+    compat_result = {
+        "compatible": True,
+        "matched_entry": mock_manifest["entries"][0],
+        "reasons": [],
+    }
+    monkeypatch.setattr(
+        clawrium.core.install, "check_compatibility", lambda *args, **kwargs: compat_result
+    )
+
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda x: key_file
+    )
+
+    # Mock update_host to avoid real filesystem access
+    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: True)
+
+    # Mock ansible_runner.run to fail
+    class FailedResult:
+        status = "failed"
+
+    mock_run = Mock(return_value=FailedResult())
+
+    import ansible_runner
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    # Track initialize_onboarding calls
+    onboarding_calls = []
+
+    def mock_initialize_onboarding(host, claw_name):
+        onboarding_calls.append((host, claw_name))
+        return True
+
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", mock_initialize_onboarding
+    )
+
+    # Run installation (should fail)
+    with pytest.raises(InstallationError):
+        run_installation("openclaw", "test-host")
+
+    # Verify initialize_onboarding was NOT called
+    assert len(onboarding_calls) == 0, "initialize_onboarding should not be called on failure"
+
+
+def test_install_onboarding_raises_does_not_corrupt_state(monkeypatch, tmp_path):
+    """Test that onboarding failure does not mark successful install as failed.
+
+    When initialize_onboarding raises an exception, the install should still
+    report success because the claw was actually installed successfully.
+    Uses generic Exception to prove the catch is general (not narrowed to specific types).
+    """
+    from clawrium.core.install import run_installation
+
+    # Isolate test from real filesystem
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    # Mock dependencies
+    mock_manifest = {
+        "name": "openclaw",
+        "entries": [
+            {
+                "version": "0.1.0",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc123",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.9"},
+                },
+            }
+        ],
+    }
+
+    import clawrium.core.install
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+
+    key_file = tmp_path / "test_key"
+    key_file.write_text("fake key")
+
+    compatible_host = {
+        "hostname": "test-host",
+        "user": "xclm",
+        "port": 22,
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    monkeypatch.setattr(clawrium.core.install, "get_host", lambda x: compatible_host)
+
+    compat_result = {
+        "compatible": True,
+        "matched_entry": mock_manifest["entries"][0],
+        "reasons": [],
+    }
+    monkeypatch.setattr(
+        clawrium.core.install, "check_compatibility", lambda *args, **kwargs: compat_result
+    )
+
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda x: key_file
+    )
+
+    class SuccessfulResult:
+        status = "successful"
+
+    mock_run = Mock(return_value=SuccessfulResult())
+
+    import ansible_runner
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    # Track update_host calls to verify host status
+    update_calls = []
+    persistent_host = compatible_host.copy()
+
+    def mock_update_host(hostname, updater):
+        nonlocal persistent_host
+        persistent_host = updater(persistent_host)
+        status = None
+        if "claws" in persistent_host and "openclaw" in persistent_host.get("claws", {}):
+            status = persistent_host["claws"]["openclaw"].get("status")
+        update_calls.append((hostname, status))
+        return True
+
+    monkeypatch.setattr(clawrium.core.install, "update_host", mock_update_host)
+
+    # Mock initialize_onboarding to raise a generic exception (B4 - tests general catch)
+    def mock_initialize_onboarding_fails(host, claw_name):
+        raise Exception(f"Generic onboarding failure for {claw_name} on {host}")
+
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", mock_initialize_onboarding_fails
+    )
+
+    # Capture emitted events
+    events = []
+
+    def on_event(stage, message):
+        events.append((stage, message))
+
+    # Run installation - should succeed despite onboarding failure
+    result = run_installation("openclaw", "test-host", on_event=on_event)
+
+    # Verify installation succeeded (onboarding failure should not corrupt state)
+    assert result["success"] is True, "Install should succeed even if onboarding init fails"
+    assert result["error"] is None
+
+    # B7: Verify exactly 2 update_host calls (installing + installed), no spurious set_failed
+    assert len(update_calls) == 2, f"Expected exactly 2 update_host calls, got {len(update_calls)}: {update_calls}"
+
+    # Verify statuses: installing -> installed (no 'failed')
+    statuses = [s for _, s in update_calls]
+    assert statuses == ["installing", "installed"], f"Expected ['installing', 'installed'], got {statuses}"
+    assert "failed" not in statuses, "Host should never be marked as 'failed'"
+
+    # Verify warning event was emitted about onboarding failure
+    warn_events = [e for e in events if e[0] == "warn"]
+    assert len(warn_events) >= 1, "Should emit warning when onboarding fails"
+    assert "clm onboard init" in warn_events[0][1], "Warning should include retry command"
+
+
+def test_install_onboarding_record_structure(monkeypatch, tmp_path):
+    """Test that onboarding record has correct structure after successful install.
+
+    This test verifies the full integration by NOT mocking initialize_onboarding,
+    allowing the real function to create the onboarding record.
+    """
+    import json
+    from clawrium.core.install import run_installation
+    from clawrium.core.hosts import get_host
+
+    # Isolate test from real filesystem
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    # Create clawrium config directory and hosts.json
+    config_dir = tmp_path / "clawrium"
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    # Pre-create host with claw in "installing" state (will be updated)
+    hosts_data = [
+        {
+            "hostname": "test-host",
+            "user": "xclm",
+            "port": 22,
+            "key_id": "test-host",
+            "hardware": {
+                "architecture": "x86_64",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "memtotal_mb": 4096,
+            },
+            "claws": {},
+        }
+    ]
+    hosts_path = config_dir / "hosts.json"
+    hosts_path.write_text(json.dumps(hosts_data))
+
+    # Mock dependencies
+    mock_manifest = {
+        "name": "openclaw",
+        "entries": [
+            {
+                "version": "0.1.0",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc123",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.9"},
+                },
+            }
+        ],
+    }
+
+    import clawrium.core.install
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+
+    key_file = tmp_path / "test_key"
+    key_file.write_text("fake key")
+
+    compat_result = {
+        "compatible": True,
+        "matched_entry": mock_manifest["entries"][0],
+        "reasons": [],
+    }
+    monkeypatch.setattr(
+        clawrium.core.install, "check_compatibility", lambda *args, **kwargs: compat_result
+    )
+
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda x: key_file
+    )
+
+    class SuccessfulResult:
+        status = "successful"
+
+    mock_run = Mock(return_value=SuccessfulResult())
+
+    import ansible_runner
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    # Run installation (uses real update_host and initialize_onboarding)
+    result = run_installation("openclaw", "test-host")
+
+    # Verify installation succeeded
+    assert result["success"] is True
+
+    # Get updated host record
+    host = get_host("test-host")
+    assert host is not None
+
+    # Verify claw record exists
+    assert "claws" in host
+    assert "openclaw" in host["claws"]
+
+    claw = host["claws"]["openclaw"]
+    assert claw["status"] == "installed"
+    assert claw["installed_at"] is not None
+
+    # Verify onboarding record structure
+    assert "onboarding" in claw, "Onboarding record should exist after install"
+
+    onboarding = claw["onboarding"]
+    assert onboarding["state"] == "pending"
+    assert onboarding["started_at"] is not None
+
+    # Verify all stages exist and are pending
+    assert "stages" in onboarding
+    expected_stages = {"providers", "identity", "channels", "validate"}
+    assert set(onboarding["stages"].keys()) == expected_stages
+
+    for stage_name, stage_data in onboarding["stages"].items():
+        assert stage_data["status"] == "pending", f"Stage {stage_name} should be pending"
+        assert stage_data["completed_at"] is None, f"Stage {stage_name} completed_at should be None"


### PR DESCRIPTION
## Summary
- Add automatic onboarding initialization after successful claw installation
- Wrap onboarding init in isolated try/except (non-fatal on failure)
- Emit warning with retry command if onboarding fails
- Wrap emit() calls in try/except to prevent callback errors from corrupting install state

## Test plan
- [x] `test_install_initializes_onboarding`: verifies call ordering
- [x] `test_install_failure_does_not_initialize_onboarding`: ensures failure path
- [x] `test_install_onboarding_raises_does_not_corrupt_state`: validates exception handling
- [x] `test_install_onboarding_record_structure`: integration test for full flow
- [x] All 524 tests pass
- [x] Lint passes

## ATX Review Summary

**Final Review: Rating 4/5**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 2/5 | B1, B2, B4, B5 | All fixed |
| 2 | 3/5 | B6, B7 | All fixed |
| 3 | 4/5 | None | Ready |

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `install.py:289` | initialize_onboarding inside broad try/except | Fixed - wrapped in own try/except |
| B2 | `install.py:289` | No user feedback on onboarding failure | Fixed - added warning events |
| B3 | `onboarding.py` | TOCTOU race condition | Out-of-scope - pre-existing, not introduced by this change |
| B4 | `tests/test_install.py` | No test for onboarding exception | Fixed - added test |
| B5 | `tests/test_install.py` | Test ordering assertion incomplete | Fixed - added exact sequence assertions |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B6 | `install.py:294` | emit() in onboarding except unguarded | Fixed - wrapped in try/except |
| B7 | `tests/test_install.py` | Test doesn't assert call count | Fixed - added == 2 assertion |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `install.py:291,298` | Inconsistent warning messages | Fixed - both now include host/claw_name |
| W2 | `install.py:297` | logger.warning missing exc_info | Fixed - added exc_info=True |

</details>

<details>
<summary>Review 3 Details (Rating 4/5)</summary>

**No blocking issues.** Ready to merge.

**Remaining warnings (pre-existing, out-of-scope):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W3 | `onboarding.py:246` | started_at set at init vs spec says null | Out-of-scope - pre-existing |
| W4 | `install.py:221` | host_display unsanitized in path | Out-of-scope - pre-existing |
| W5 | `install.py:336` | emit('error') unguarded | Noted - pre-existing, tracked for follow-up |

</details>

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>