### PR TITLE
feat(agent): block claw start for incomplete onboarding

### DIFF
--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -36,6 +36,13 @@ console = Console()
 
 VALID_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9._-]+$")
 
+STAGE_TO_CURRENT_STATE = {
+    "providers": OnboardingState.PROVIDERS,
+    "identity": OnboardingState.IDENTITY,
+    "channels": OnboardingState.CHANNELS,
+    "validate": OnboardingState.VALIDATE,
+}
+
 STAGE_TO_NEXT_STATE = {
     "providers": OnboardingState.IDENTITY,
     "identity": OnboardingState.CHANNELS,
@@ -397,8 +404,11 @@ def _run_validate_stage(host: str, claw_type: str, yes: bool) -> bool:
     Returns:
         True if stage completed successfully
     """
-    console.print("[1/2] Verify configuration files... [green]✓[/green]")
-    console.print("[2/2] Run agent self-test... [green]✓[/green]")
+    console.print("[yellow]Validation not yet implemented - skipped[/yellow]")
+    console.print()
+    console.print(
+        "Future validation will verify configuration files and run agent self-test."
+    )
 
     try:
         complete_stage(host, claw_type, "validate", StageStatus.COMPLETE)
@@ -571,6 +581,16 @@ def configure(
                 stage_name, i + 1, total_stages, stage_descriptions[stage_name]
             )
 
+            # Transition to the stage's state before running it
+            current_stage_state = STAGE_TO_CURRENT_STATE.get(stage_name)
+            current_state = get_onboarding_state(host_alias, claw_type)
+            if current_stage_state and current_state != current_stage_state:
+                try:
+                    transition_state(host_alias, claw_type, current_stage_state)
+                except InvalidTransitionError as e:
+                    console.print(f"[red]Error:[/red] {e}")
+                    raise typer.Exit(code=1)
+
             success = stage_functions[stage_name](host_alias, claw_type, yes)
 
             if not success:
@@ -583,7 +603,8 @@ def configure(
             try:
                 transition_state(host_alias, claw_type, next_state)
             except InvalidTransitionError as e:
-                console.print(f"[yellow]Warning:[/yellow] {e}")
+                console.print(f"[red]Error:[/red] {e}")
+                raise typer.Exit(code=1)
 
             _stage_complete(stage_name)
 
@@ -603,7 +624,11 @@ def configure(
 
 
 def _show_start_blocked_error(
-    claw_name: str, host_alias: str, claw_type: str, current_state: OnboardingState
+    claw_name: str,
+    host_alias: str,
+    claw_type: str,
+    current_state: OnboardingState,
+    claw_record: dict,
 ) -> None:
     """Display error when start is blocked by incomplete onboarding."""
     STAGES = [
@@ -623,14 +648,6 @@ def _show_start_blocked_error(
             f"Run 'clm agent configure {rich_escape(claw_name)}' to begin onboarding."
         )
         console.print()
-        return
-
-    host_data = get_host(host_alias)
-    if not host_data:
-        return
-
-    claw_record = _get_installed_claw(host_alias, claw_type)
-    if not claw_record:
         return
 
     onboarding = claw_record.get("onboarding", {})
@@ -686,14 +703,14 @@ def remove(
         f"[yellow]Not implemented:[/yellow] remove '{rich_escape(claw_name)}'"
     )
     console.print("This command will allow removing agents in a future release.")
-    raise typer.Exit(code=0)
+    raise typer.Exit(code=1)
 
 
 @agent_app.command()
 def start(
     claw_name: str = typer.Argument(..., help="Claw name to start"),
     force: bool = typer.Option(
-        False, "--force", help="Force start even if onboarding incomplete"
+        False, "--force", "-f", help="Force start even if onboarding incomplete"
     ),
 ) -> None:
     """Start an agent.
@@ -758,7 +775,9 @@ def start(
             console.print("[dim]Agent start functionality coming soon.[/dim]")
             raise typer.Exit(code=0)
 
-        _show_start_blocked_error(claw_name, host_alias, claw_type, current_state)
+        _show_start_blocked_error(
+            claw_name, host_alias, claw_type, current_state, claw_record
+        )
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
         console.print("\nCancelled.")

--- a/src/clawrium/core/onboarding.py
+++ b/src/clawrium/core/onboarding.py
@@ -118,7 +118,12 @@ def get_onboarding_state(host: str, claw_name: str) -> OnboardingState:
         )
 
     state_value = onboarding.get("state", "pending")
-    return OnboardingState(state_value)
+    try:
+        return OnboardingState(state_value)
+    except ValueError:
+        raise OnboardingNotFoundError(
+            f"Unknown onboarding state '{state_value}' for '{claw_name}' on '{host}'"
+        )
 
 
 def transition_state(host: str, claw_name: str, to_state: OnboardingState) -> bool:
@@ -184,6 +189,7 @@ def complete_stage(
         ClawNotFoundError: If claw is not installed on host
         OnboardingNotFoundError: If onboarding has not been initialized
         ValueError: If stage is not a valid stage name
+        InvalidTransitionError: If completing this stage is not permitted in current state
     """
     valid_stages = {"providers", "identity", "channels", "validate"}
     if stage not in valid_stages:
@@ -198,6 +204,29 @@ def complete_stage(
         raise OnboardingNotFoundError(
             f"Onboarding not initialized for '{claw_name}' on '{host}'"
         )
+
+    # Verify current state permits completing this stage
+    # Skip validation for SKIPPED status (stages can be skipped at any time)
+    if status != StageStatus.SKIPPED:
+        # State-to-stage mapping: current state -> stages that can be completed
+        # States represent "currently working on" so a state can complete its own stage
+        state_to_allowed_stages = {
+            "pending": ["providers"],  # Can start providers from pending
+            "providers": ["providers"],  # Can complete providers while in providers state
+            "identity": ["identity"],  # Can complete identity while in identity state
+            "channels": ["channels"],  # Can complete channels while in channels state
+            "validate": ["validate"],  # Can complete validate while in validate state
+            "ready": [],  # No stages to complete when ready
+        }
+
+        current_state = get_onboarding_state(host, claw_name)
+        allowed_stages = state_to_allowed_stages.get(current_state.value, [])
+
+        if stage not in allowed_stages:
+            raise InvalidTransitionError(
+                f"Cannot complete stage '{stage}' while in state '{current_state.value}'. "
+                f"Allowed stages in this state: {allowed_stages}"
+            )
 
     host_data = get_host(host)
     if not host_data:

--- a/tests/test_cli_agent.py
+++ b/tests/test_cli_agent.py
@@ -162,7 +162,7 @@ def test_agent_remove_placeholder():
     """clm agent remove shows not implemented message."""
     result = runner.invoke(app, ["agent", "remove", "opc-work"])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     assert "not implemented" in result.output.lower()
 
 

--- a/tests/test_cli_agent_start.py
+++ b/tests/test_cli_agent_start.py
@@ -2,10 +2,12 @@
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
 from clawrium.cli.main import app
+from clawrium.core.onboarding import ClawNotFoundError
 
 runner = CliRunner()
 
@@ -130,14 +132,14 @@ def test_start_providers_state_blocked(isolated_config: Path):
 
 
 def test_start_identity_state_blocked(isolated_config: Path):
-    """Start when state=IDENTITY (2/4) shows correct stage count."""
+    """Start when state=IDENTITY (1/4) shows correct stage count."""
     create_host_with_claw(isolated_config, onboarding_state="identity")
 
     result = runner.invoke(app, ["agent", "start", "opc-work"])
 
     assert result.exit_code == 1
     assert "Cannot start" in result.output
-    assert "IDENTITY (1/4)" in result.output or "IDENTITY" in result.output
+    assert "IDENTITY (1/4)" in result.output
     assert "Incomplete stages" in result.output
     assert "channels" in result.output
     assert "validate" in result.output
@@ -246,7 +248,7 @@ def test_start_corrupted_hosts_file_fails(isolated_config: Path):
     result = runner.invoke(app, ["agent", "start", "opc-work"])
 
     assert result.exit_code == 1
-    assert "hosts.json" in result.output.lower() or "corrupted" in result.output.lower()
+    assert "clm host list" in result.output
 
 
 def test_start_missing_onboarding_initializes(isolated_config: Path):
@@ -295,3 +297,68 @@ def test_start_missing_onboarding_initializes(isolated_config: Path):
     assert result.exit_code == 1
     assert "Cannot start" in result.output
     assert "onboarding not started" in result.output
+
+
+def test_start_keyboard_interrupt_during_execution(isolated_config: Path):
+    """Start handles KeyboardInterrupt gracefully."""
+    create_host_with_claw(isolated_config, onboarding_state="ready")
+
+    with patch("clawrium.cli.agent.get_host", side_effect=KeyboardInterrupt):
+        result = runner.invoke(app, ["agent", "start", "opc-work"])
+
+    assert result.exit_code == 1
+    assert "Cancelled" in result.output
+
+
+def test_start_claw_not_found_during_initialization(isolated_config: Path):
+    """Start handles ClawNotFoundError when initialize_onboarding fails."""
+    hosts_file = isolated_config / "hosts.json"
+    isolated_config.mkdir(parents=True, exist_ok=True)
+
+    # Create host with claw but no onboarding record
+    hosts_data = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "work",
+            "key_id": "work",
+            "port": 22,
+            "user": "xclm",
+            "auth_method": "key",
+            "hardware": {
+                "architecture": "x86_64",
+                "processor_cores": 4,
+                "memtotal_mb": 8192,
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "distribution": "ubuntu",
+                "distribution_version": "24.04",
+                "gpu": {"present": False},
+            },
+            "metadata": {
+                "added_at": "2026-04-06T00:00:00Z",
+                "last_seen": "2026-04-06T00:00:00Z",
+                "tags": [],
+            },
+            "claws": {
+                "opc": {
+                    "version": "0.1.0",
+                    "status": "installed",
+                    "name": "assistant",
+                    "user": "opc-assistant",
+                }
+            },
+        }
+    ]
+
+    hosts_file.write_text(json.dumps(hosts_data, indent=2))
+
+    # Mock initialize_onboarding to raise ClawNotFoundError
+    with patch(
+        "clawrium.cli.agent.initialize_onboarding",
+        side_effect=ClawNotFoundError("Claw 'opc' not found on host 'work'"),
+    ):
+        result = runner.invoke(app, ["agent", "start", "opc-work"])
+
+    assert result.exit_code == 1
+    assert "Error:" in result.output
+    assert "not found" in result.output


### PR DESCRIPTION
## Summary

Implements guardrail that prevents starting a claw until onboarding state is READY (#74).

### Changes
- ✅ Replace `start()` stub with full guardrail implementation
- ✅ Add `--force/-f` flag to bypass onboarding check (with warning)
- ✅ Add `_show_start_blocked_error()` helper for formatted error output
- ✅ Handle `HostsFileCorruptedError` gracefully
- ✅ Add `KeyboardInterrupt` guard
- ✅ Handle invalid onboarding state values gracefully
- ✅ Fix state machine correctness issues (B3, B4)
- ✅ Make validate stage honest about not being implemented (B2)
- ✅ Fix unimplemented command exit codes (B1)
- ✅ Comprehensive test suite (14 tests covering all states and edge cases)
- ✅ Update placeholder test in `test_cli_agent.py`

### Error Output Examples

**PENDING state:**
```
Error: Cannot start opc-myhost - onboarding not started

Run 'clm agent configure opc-myhost' to begin onboarding.
```

**Incomplete state (e.g., IDENTITY):**
```
Error: Cannot start opc-myhost - onboarding incomplete

Current state: IDENTITY (1/4)

Incomplete stages:
  ○ channels   - Configure communication channels
  ○ validate   - Verify agent configuration

Run 'clm agent configure opc-myhost' to complete onboarding.

To force start anyway (not recommended):
  clm agent start opc-myhost --force
```

**Force flag:**
```
Warning: Starting agent with incomplete onboarding
Starting agent: opc on myhost
```

## Testing

All 586 tests pass including 14 new tests for the start guardrail:

- ✅ Start when state=READY → succeeds
- ✅ Start when state=PENDING → blocked, shows configure hint
- ✅ Start when state=PROVIDERS/IDENTITY/CHANNELS/VALIDATE → blocked, shows incomplete stages
- ✅ Start with `--force` when not READY → shows warning, succeeds
- ✅ Start with invalid claw name → error
- ✅ Start with unknown host → error
- ✅ Start with claw not installed → error
- ✅ Start with corrupted hosts.json → graceful error
- ✅ Start with missing onboarding record → initializes and shows error
- ✅ Start with KeyboardInterrupt → cancelled gracefully
- ✅ Start with ClawNotFoundError during initialization → clean error

## ATX Review Summary

**Review 2: Rating 3/5 → All blocking issues fixed**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 2/5 | B1, B2, B3, B4 from review 1 | All fixed |
| 2 | 3/5 | B1, B2, B3, B4, B5 | All fixed |

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues Fixed:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `agent.py:628-634` | `_show_start_blocked_error()` re-fetches data without catching errors | Fixed - Pass `claw_record` as parameter, eliminate redundant reads |
| B2 | `core/onboarding.py:121` | `OnboardingState()` raises `ValueError` for invalid states | Fixed - Wrap in try/except, raise `OnboardingNotFoundError` with clear message |
| B3 | `tests/test_cli_agent_start.py` | `KeyboardInterrupt` path untested | Fixed - Add `test_start_keyboard_interrupt_during_execution` |
| B4 | `tests/test_cli_agent_start.py` | `ClawNotFoundError` fallback untested | Fixed - Add `test_start_claw_not_found_during_initialization` |

**Warnings Fixed:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `agent.py:695-697` | Missing `-f` short alias for `--force` | Fixed - Added `-f` short alias |
| W2 | `tests/test_cli_agent_start.py:140` | Dead code in assertion with `or` fallback | Fixed - Removed fallback, assert exact string |
| W4 | PR description | Misleading state machine description | Fixed - Clarified test coverage, updated counts |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Blocking Issues Fixed:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `agent.py:673-685` | `clm agent remove` exits code 0 for unimplemented op | Fixed - Changed to exit code 1, updated test |
| B2 | `agent.py:389-410` + `onboarding.py` | `_run_validate_stage` prints fake checkmarks | Fixed - Show honest `[yellow]Skipped — not yet implemented[/yellow]` |
| B3 | `onboarding.py:169-223` | `complete_stage` allows split-brain state | Fixed - Add state verification with state-to-allowed-stages mapping |
| B4 | `agent.py:582-587` | `InvalidTransitionError` treated as warning | Fixed - Hard failure (exit 1) + add pre-stage state transitions |
| B5 | `tests/test_cli_agent_start.py:241-251` | Weak `or` assertion | Fixed - Pin to deterministic "clm host list" substring |

**State Machine Improvements (B3, B4):**

- Added state verification in `complete_stage`:
  - PENDING → can complete providers
  - PROVIDERS → can complete providers  
  - IDENTITY → can complete identity
  - CHANNELS → can complete channels
  - VALIDATE → can complete validate
  - Skipped stages bypass validation
- Added pre-stage state transitions:
  - Transition to stage state BEFORE running it
  - Prevents `InvalidTransitionError` during normal flow
  - Created `STAGE_TO_CURRENT_STATE` mapping

</details>

Closes #74

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>