### PR TITLE
fix(providers): allow local/private IPs for Ollama provider

### DIFF
--- a/src/clawrium/core/providers.py
+++ b/src/clawrium/core/providers.py
@@ -228,13 +228,34 @@ def _is_private_ip(ip_str: str) -> bool:
         return False
 
 
+def _is_metadata_endpoint(ip_str: str) -> bool:
+    """Check if an IP address is a cloud metadata endpoint.
+
+    Blocks the link-local range used by cloud provider metadata services
+    (AWS 169.254.169.254, GCP 169.254.169.254, etc.).
+
+    Args:
+        ip_str: IP address string.
+
+    Returns:
+        True if the IP is a cloud metadata endpoint, False otherwise.
+    """
+    try:
+        ip = ipaddress.ip_address(ip_str)
+        return ip.is_link_local
+    except ValueError:
+        return False
+
+
 def validate_ollama_url(url: str) -> str:
     """Validate Ollama server URL for security.
 
     Ensures the URL:
     - Has http or https scheme
-    - Does not point to private, loopback, link-local, or reserved IP addresses
-    - Does not point to cloud metadata endpoints (169.254.169.254)
+    - Does not point to cloud metadata endpoints (169.254.x.x)
+
+    Private and loopback addresses are allowed because Ollama is a self-hosted
+    service typically running on local networks (e.g. http://192.168.1.17:11434).
 
     Args:
         url: URL to validate.
@@ -263,16 +284,16 @@ def validate_ollama_url(url: str) -> str:
     if not hostname:
         raise InvalidOllamaUrlError("URL must include a hostname")
 
-    # Resolve hostname to IP and check if it's private/reserved
+    # Resolve hostname to IP and block cloud metadata endpoints only.
+    # Private/loopback IPs are allowed — Ollama runs on local networks.
     try:
-        # Get all IP addresses for the hostname
         addr_info = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
         for family, _, _, _, sockaddr in addr_info:
             ip_str = sockaddr[0]
-            if _is_private_ip(ip_str):
+            if _is_metadata_endpoint(ip_str):
                 raise InvalidOllamaUrlError(
-                    f"URL resolves to private/reserved IP address '{ip_str}'. "
-                    "Only publicly routable addresses are allowed for security."
+                    f"URL resolves to a cloud metadata endpoint '{ip_str}'. "
+                    "This address is not allowed for security."
                 )
     except socket.gaierror:
         # Hostname doesn't resolve - let requests.get handle this later

--- a/tests/test_cli_provider.py
+++ b/tests/test_cli_provider.py
@@ -186,22 +186,21 @@ class TestProviderAdd:
         assert result.exit_code == 1
         assert "already exists" in result.output.lower()
 
-    def test_add_ollama_validates_url(self, isolated_config):
-        """'clm provider add --type ollama' validates URL for security."""
-        # Try to add Ollama with a private IP (should fail validation)
+    def test_add_ollama_rejects_metadata_endpoint(self, isolated_config):
+        """'clm provider add --type ollama' rejects cloud metadata endpoints."""
         with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
-            mock_gai.return_value = [(2, 1, 0, "", ("192.168.1.100", 0))]
+            mock_gai.return_value = [(2, 1, 0, "", ("169.254.169.254", 0))]
             result = runner.invoke(
                 app,
                 [
-                    "provider", "add", "local-llm",
+                    "provider", "add", "bad-provider",
                     "--type", "ollama",
-                    "--url", "http://myserver.local:11434",
+                    "--url", "http://169.254.169.254",
                 ],
             )
 
         assert result.exit_code == 1
-        assert "private" in result.output.lower()
+        assert "metadata" in result.output.lower()
 
     def test_add_ollama_success(self, isolated_config):
         """'clm provider add --type ollama' works with valid public URL."""

--- a/tests/test_core_providers.py
+++ b/tests/test_core_providers.py
@@ -151,35 +151,42 @@ class TestOllamaUrlValidation:
             validate_ollama_url("file:///etc/passwd")
         assert "only http and https" in str(exc_info.value).lower()
 
-    def test_validate_ollama_url_rejects_private_ip(self):
-        """validate_ollama_url rejects private IP addresses."""
+    def test_validate_ollama_url_allows_private_ip(self):
+        """validate_ollama_url allows private IP addresses (Ollama is self-hosted)."""
         with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
             mock_gai.return_value = [
                 (2, 1, 0, "", ("192.168.1.100", 0))
             ]
-            with pytest.raises(InvalidOllamaUrlError) as exc_info:
-                validate_ollama_url("http://myserver.local:11434")
-            assert "private" in str(exc_info.value).lower()
+            url = validate_ollama_url("http://myserver.local:11434")
+            assert url == "http://myserver.local:11434"
 
-    def test_validate_ollama_url_rejects_loopback(self):
-        """validate_ollama_url rejects loopback addresses."""
+    def test_validate_ollama_url_allows_lan_ip(self):
+        """validate_ollama_url allows LAN IP addresses like 192.168.x.x."""
+        with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
+            mock_gai.return_value = [
+                (2, 1, 0, "", ("192.168.1.17", 0))
+            ]
+            url = validate_ollama_url("http://192.168.1.17:11434")
+            assert url == "http://192.168.1.17:11434"
+
+    def test_validate_ollama_url_allows_loopback(self):
+        """validate_ollama_url allows loopback addresses (Ollama is self-hosted)."""
         with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
             mock_gai.return_value = [
                 (2, 1, 0, "", ("127.0.0.1", 0))
             ]
-            with pytest.raises(InvalidOllamaUrlError) as exc_info:
-                validate_ollama_url("http://localhost:11434")
-            assert "private" in str(exc_info.value).lower()
+            url = validate_ollama_url("http://localhost:11434")
+            assert url == "http://localhost:11434"
 
     def test_validate_ollama_url_rejects_metadata_endpoint(self):
-        """validate_ollama_url rejects AWS metadata endpoint."""
+        """validate_ollama_url rejects cloud metadata endpoints (169.254.x.x)."""
         with patch("clawrium.core.providers.socket.getaddrinfo") as mock_gai:
             mock_gai.return_value = [
                 (2, 1, 0, "", ("169.254.169.254", 0))
             ]
             with pytest.raises(InvalidOllamaUrlError) as exc_info:
                 validate_ollama_url("http://169.254.169.254")
-            assert "private" in str(exc_info.value).lower()
+            assert "metadata" in str(exc_info.value).lower()
 
     def test_validate_ollama_url_allows_unresolvable_hostname(self):
         """validate_ollama_url allows hostnames that don't resolve (let requests handle)."""


### PR DESCRIPTION
## Summary
- Replaced broad `_is_private_ip()` SSRF guard in `validate_ollama_url()` with a narrower `_is_metadata_endpoint()` check
- Private/loopback IPs (192.168.x.x, 127.x.x.x) are now allowed for Ollama — it's a self-hosted service
- Cloud metadata range (169.254.x.x) is still blocked
- Connectivity is validated by the existing `fetch_ollama_models()` call hitting `/api/tags`

## Test plan
- [ ] `test_validate_ollama_url_allows_private_ip` — 192.168.x.x accepted
- [ ] `test_validate_ollama_url_allows_lan_ip` — 192.168.1.17 accepted  
- [ ] `test_validate_ollama_url_allows_loopback` — 127.0.0.1 accepted
- [ ] `test_validate_ollama_url_rejects_metadata_endpoint` — 169.254.x.x still blocked
- [ ] `test_add_ollama_rejects_metadata_endpoint` — CLI rejects metadata endpoint
- [ ] All 592 tests pass

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)