### PR TITLE
feat(validation): implement validation stage for agent onboarding

### DIFF
--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -414,6 +414,12 @@ def _run_channels_stage(host: str, claw_type: str, yes: bool) -> bool:
 def _run_validate_stage(host: str, claw_type: str, yes: bool) -> bool:
     """Run the VALIDATE onboarding stage.
 
+    Performs comprehensive validation of agent configuration:
+    1. Verify SOUL.md personality file exists
+    2. Check provider is configured
+    3. Validate API key exists
+    4. Test provider connectivity
+
     Args:
         host: Host alias
         claw_type: Claw type
@@ -422,11 +428,101 @@ def _run_validate_stage(host: str, claw_type: str, yes: bool) -> bool:
     Returns:
         True if stage completed successfully
     """
-    console.print("[yellow]Validation not yet implemented - skipped[/yellow]")
-    console.print()
-    console.print(
-        "Future validation will verify configuration files and run agent self-test."
+    from clawrium.core.validation import (
+        validate_soul_md,
+        validate_provider_config,
+        validate_provider_api_key,
+        verify_provider_connectivity,
+        validate_agent_installation,
     )
+
+    all_errors = []
+    all_warnings = []
+
+    console.print("[1/4] Validating agent installation...")
+    install_result = validate_agent_installation(host, claw_type)
+    if install_result.passed:
+        console.print("  [green]✓[/green] Agent installed")
+    else:
+        console.print("  [red]✗[/red] Agent installation check failed")
+        for error in install_result.errors:
+            console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+        all_errors.extend(install_result.errors)
+
+    console.print("[2/4] Validating personality file (SOUL.md)...")
+    soul_result = validate_soul_md(claw_type)
+    if soul_result.passed:
+        console.print("  [green]✓[/green] SOUL.md exists and readable")
+        for warning in soul_result.warnings:
+            console.print(f"    [yellow]Warning:[/yellow] {rich_escape(warning)}")
+            all_warnings.append(warning)
+    else:
+        console.print("  [red]✗[/red] SOUL.md validation failed")
+        for error in soul_result.errors:
+            console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+        all_errors.extend(soul_result.errors)
+
+    console.print("[3/4] Validating provider configuration...")
+    provider_result = validate_provider_config(host, claw_type)
+    if provider_result.passed:
+        provider_id = provider_result.details.get("provider_id", "unknown")
+        provider_type = provider_result.details.get("provider_type", "unknown")
+        console.print(
+            f"  [green]✓[/green] Provider: {rich_escape(provider_id)} ({rich_escape(provider_type)})"
+        )
+
+        console.print("  Checking API key...")
+        key_result = validate_provider_api_key(provider_id)
+        if key_result.passed:
+            if key_result.details.get("key_configured") or key_result.details.get(
+                "uses_cloud_auth"
+            ):
+                console.print("  [green]✓[/green] API credentials configured")
+            else:
+                console.print(
+                    "  [green]✓[/green] Provider configured (no API key needed)"
+                )
+        else:
+            console.print("  [red]✗[/red] API key validation failed")
+            for error in key_result.errors:
+                console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+            all_errors.extend(key_result.errors)
+    else:
+        console.print("  [red]✗[/red] Provider configuration missing")
+        for error in provider_result.errors:
+            console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+        all_errors.extend(provider_result.errors)
+
+    console.print("[4/4] Testing provider connectivity...")
+    if provider_result.passed:
+        provider_id = provider_result.details.get("provider_id")
+        conn_result = verify_provider_connectivity(provider_id)
+        if conn_result.passed:
+            console.print("  [green]✓[/green] Provider connectivity OK")
+            for warning in conn_result.warnings:
+                console.print(f"    [yellow]Warning:[/yellow] {rich_escape(warning)}")
+                all_warnings.append(warning)
+        else:
+            console.print("  [red]✗[/red] Provider connectivity test failed")
+            for error in conn_result.errors:
+                console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+            all_errors.extend(conn_result.errors)
+    else:
+        console.print("  [dim]Skipped (no provider configured)[/dim]")
+
+    console.print()
+    if all_errors:
+        console.print(f"[red]Validation failed with {len(all_errors)} error(s)[/red]")
+        if all_warnings:
+            console.print(f"[yellow]Warnings: {len(all_warnings)}[/yellow]")
+        return False
+
+    if all_warnings:
+        console.print(
+            f"[yellow]Validation passed with {len(all_warnings)} warning(s)[/yellow]"
+        )
+    else:
+        console.print("[green]Validation passed[/green]")
 
     try:
         complete_stage(host, claw_type, "validate", StageStatus.COMPLETE)

--- a/src/clawrium/core/validation.py
+++ b/src/clawrium/core/validation.py
@@ -1,0 +1,682 @@
+"""Validation utilities for agent onboarding.
+
+This module provides validation functions to verify agent configuration
+and connectivity before transitioning to READY state.
+"""
+
+import json
+import socket
+import urllib.request
+import urllib.error
+from dataclasses import dataclass, field
+from typing import Any
+
+from clawrium.core.config import get_config_dir
+from clawrium.core.hosts import get_host
+
+__all__ = [
+    "ValidationResult",
+    "validate_soul_md",
+    "validate_provider_config",
+    "validate_provider_api_key",
+    "verify_provider_connectivity",
+    "validate_agent_installation",
+    "ERROR_MESSAGES",
+    "WARNING_MESSAGES",
+]
+
+
+@dataclass
+class ValidationResult:
+    """Result of a validation check.
+
+    Attributes:
+        passed: True if validation passed, False if errors found.
+        errors: List of error messages (blocking issues).
+        warnings: List of warning messages (non-blocking issues).
+        details: Additional details about what was checked.
+    """
+
+    passed: bool
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+ERROR_MESSAGES = {
+    "soul_md_missing": (
+        "SOUL.md personality file not found. "
+        "Run 'clm agent configure <claw> --stage identity' first."
+    ),
+    "soul_md_unreadable": "SOUL.md exists but cannot be read: {error}",
+    "provider_not_found": (
+        "No provider assigned to this agent. "
+        "Run 'clm agent configure <claw> --stage providers' first."
+    ),
+    "provider_config_missing": "Provider '{provider}' not found in configuration.",
+    "api_key_missing": (
+        "No API key configured for provider '{provider}'. "
+        "Run 'clm provider add' with --api-key to set it."
+    ),
+    "api_key_invalid": (
+        "API key for '{provider}' appears to be invalid. Check your API key is correct."
+    ),
+    "connection_failed": (
+        "Could not connect to {provider} API. Check your network connection."
+    ),
+    "connection_timeout": "Connection to {provider} timed out after {timeout}s.",
+    "rate_limited": ("Rate limited by {provider}. Wait a moment or upgrade your plan."),
+    "insufficient_quota": (
+        "Insufficient quota for {provider}. "
+        "Check your account balance or upgrade your plan."
+    ),
+    "ollama_not_running": (
+        "Ollama server is not running at {endpoint}. Start it with: ollama serve"
+    ),
+    "ollama_no_models": (
+        "No models found on Ollama server. Pull a model with: ollama pull <model>"
+    ),
+    "bedrock_credentials": (
+        "AWS credentials not configured for Bedrock. "
+        "Run 'aws configure' or set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY."
+    ),
+    "vertex_credentials": (
+        "GCP credentials not configured for Vertex AI. "
+        "Set GOOGLE_APPLICATION_CREDENTIALS or run 'gcloud auth application-default login'."
+    ),
+    "agent_not_installed": (
+        "Agent binary not found on host. "
+        "Run 'clm agent install --claw {claw_type} --host {host}' first."
+    ),
+    "agent_wrong_permissions": (
+        "Agent binary has incorrect permissions. Expected {expected}, found {actual}."
+    ),
+    "onboarding_not_found": "Onboarding record not found for {claw_name} on {host}.",
+}
+
+WARNING_MESSAGES = {
+    "soul_md_empty": "SOUL.md file is empty. Agent will use default personality.",
+    "soul_md_large": "SOUL.md is larger than 10KB. Consider shortening for better performance.",
+    "ollama_no_models": "No models found on Ollama server. Pull a model with: ollama pull <model>",
+}
+
+
+def validate_soul_md(claw_type: str) -> ValidationResult:
+    """Validate SOUL.md personality file exists and is readable.
+
+    Args:
+        claw_type: Type of claw (e.g., "openclaw", "zeroclaw").
+
+    Returns:
+        ValidationResult with pass/fail status and any errors/warnings.
+    """
+    config_dir = get_config_dir()
+    soul_path = config_dir / "claws" / claw_type / "SOUL.md"
+
+    if not soul_path.exists():
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["soul_md_missing"]],
+            details={"path": str(soul_path), "exists": False},
+        )
+
+    try:
+        content = soul_path.read_text()
+    except Exception as e:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["soul_md_unreadable"].format(error=str(e))],
+            details={"path": str(soul_path), "exists": True, "readable": False},
+        )
+
+    warnings = []
+    if not content.strip():
+        warnings.append(WARNING_MESSAGES["soul_md_empty"])
+    elif len(content) > 10240:
+        warnings.append(WARNING_MESSAGES["soul_md_large"])
+
+    return ValidationResult(
+        passed=True,
+        warnings=warnings,
+        details={
+            "path": str(soul_path),
+            "exists": True,
+            "readable": True,
+            "size": len(content),
+        },
+    )
+
+
+def validate_provider_config(host: str, claw_name: str) -> ValidationResult:
+    """Validate provider is configured for this agent.
+
+    Reads onboarding metadata to find the assigned provider.
+
+    Args:
+        host: Host alias or hostname.
+        claw_name: Name of the claw instance.
+
+    Returns:
+        ValidationResult with provider info or error.
+    """
+    from clawrium.core.onboarding import _get_claw_record
+
+    claw_record = _get_claw_record(host, claw_name)
+    if claw_record is None:
+        return ValidationResult(
+            passed=False,
+            errors=[
+                ERROR_MESSAGES["onboarding_not_found"].format(
+                    claw_name=claw_name, host=host
+                )
+            ],
+        )
+
+    onboarding = claw_record.get("onboarding", {})
+    stages = onboarding.get("stages", {})
+    providers_stage = stages.get("providers", {})
+    provider_id = providers_stage.get("provider_id")
+
+    if not provider_id:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["provider_not_found"]],
+            details={"onboarding_state": onboarding.get("state")},
+        )
+
+    from clawrium.core.providers import get_provider
+
+    provider = get_provider(provider_id)
+    if not provider:
+        return ValidationResult(
+            passed=False,
+            errors=[
+                ERROR_MESSAGES["provider_config_missing"].format(provider=provider_id)
+            ],
+            details={"provider_id": provider_id},
+        )
+
+    return ValidationResult(
+        passed=True,
+        details={
+            "provider_id": provider_id,
+            "provider_type": provider.get("type"),
+            "default_model": provider.get("default_model"),
+        },
+    )
+
+
+def validate_provider_api_key(provider_name: str) -> ValidationResult:
+    """Check if API key is configured for a provider.
+
+    Args:
+        provider_name: Name of the provider.
+
+    Returns:
+        ValidationResult indicating if API key is configured.
+    """
+    from clawrium.core.providers import get_provider_api_key, get_provider
+
+    provider = get_provider(provider_name)
+    if not provider:
+        return ValidationResult(
+            passed=False,
+            errors=[
+                ERROR_MESSAGES["provider_config_missing"].format(provider=provider_name)
+            ],
+        )
+
+    provider_type = provider.get("type", "")
+
+    if provider_type == "ollama":
+        return ValidationResult(
+            passed=True, details={"type": "ollama", "key_required": False}
+        )
+
+    if provider_type in ("bedrock", "vertex"):
+        return ValidationResult(
+            passed=True,
+            details={
+                "type": provider_type,
+                "key_required": False,
+                "uses_cloud_auth": True,
+            },
+        )
+
+    api_key = get_provider_api_key(provider_name)
+    if not api_key:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["api_key_missing"].format(provider=provider_name)],
+            details={"type": provider_type, "key_configured": False},
+        )
+
+    return ValidationResult(
+        passed=True,
+        details={"type": provider_type, "key_configured": True},
+    )
+
+
+def verify_provider_connectivity(
+    provider_name: str, timeout: int = 10
+) -> ValidationResult:
+    """Test connectivity to provider API.
+
+    Performs a minimal API call to verify credentials and connectivity.
+
+    Args:
+        provider_name: Name of the provider.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        ValidationResult with connectivity status.
+    """
+    from clawrium.core.providers import (
+        get_provider,
+        get_provider_api_key,
+    )
+
+    provider = get_provider(provider_name)
+    if not provider:
+        return ValidationResult(
+            passed=False,
+            errors=[
+                ERROR_MESSAGES["provider_config_missing"].format(provider=provider_name)
+            ],
+        )
+
+    provider_type = provider.get("type", "")
+
+    if provider_type == "ollama":
+        return _test_ollama_connectivity(provider, timeout)
+
+    if provider_type == "bedrock":
+        return _test_bedrock_connectivity(provider, timeout)
+
+    if provider_type == "vertex":
+        return _test_vertex_connectivity(provider, timeout)
+
+    api_key = get_provider_api_key(provider_name)
+    if not api_key:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["api_key_missing"].format(provider=provider_name)],
+        )
+
+    if provider_type == "openai":
+        return _test_openai_connectivity(api_key, timeout)
+
+    if provider_type == "anthropic":
+        return _test_anthropic_connectivity(api_key, timeout)
+
+    if provider_type == "openrouter":
+        return _test_openrouter_connectivity(api_key, timeout)
+
+    if provider_type == "zai":
+        return _test_zai_connectivity(api_key, timeout)
+
+    return ValidationResult(
+        passed=True,
+        warnings=[f"Connectivity test not implemented for {provider_type}"],
+    )
+
+
+def _make_request(
+    url: str,
+    headers: dict[str, str],
+    method: str = "GET",
+    data: bytes | None = None,
+    timeout: int = 10,
+) -> tuple[int, dict | None, str | None]:
+    """Make HTTP request and return status code, response body, and error.
+
+    Uses urllib to avoid additional dependencies.
+    """
+    req = urllib.request.Request(url, headers=headers, method=method)
+    if data:
+        req.data = data
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+            return response.status, json.loads(body) if body else None, None
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8") if e.fp else ""
+        return e.code, json.loads(body) if body else None, str(e)
+    except urllib.error.URLError as e:
+        return 0, None, str(e.reason)
+    except socket.timeout:
+        return 0, None, "timeout"
+    except json.JSONDecodeError as e:
+        return 0, None, f"Invalid response: {e}"
+
+
+def _test_openai_connectivity(api_key: str, timeout: int) -> ValidationResult:
+    """Test OpenAI API connectivity."""
+    url = "https://api.openai.com/v1/models"
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    status, body, error = _make_request(url, headers, timeout=timeout)
+
+    if error == "timeout":
+        return ValidationResult(
+            passed=False,
+            errors=[
+                ERROR_MESSAGES["connection_timeout"].format(
+                    provider="OpenAI", timeout=timeout
+                )
+            ],
+        )
+
+    if status == 0:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["connection_failed"].format(provider="OpenAI")],
+            details={"error": error},
+        )
+
+    if status == 401:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["api_key_invalid"].format(provider="OpenAI")],
+        )
+
+    if status == 429:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["rate_limited"].format(provider="OpenAI")],
+        )
+
+    if status >= 500:
+        return ValidationResult(
+            passed=False,
+            errors=[f"OpenAI API error: HTTP {status}"],
+        )
+
+    if status == 200:
+        models = []
+        if body and "data" in body:
+            models = [
+                m.get("id", "") for m in body.get("data", []) if isinstance(m, dict)
+            ]
+        return ValidationResult(
+            passed=True,
+            details={"endpoint": url, "models_available": len(models)},
+        )
+
+    return ValidationResult(passed=True)
+
+
+def _test_anthropic_connectivity(api_key: str, timeout: int) -> ValidationResult:
+    """Test Anthropic API connectivity using a minimal message request."""
+    url = "https://api.anthropic.com/v1/messages"
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+    }
+    data = json.dumps(
+        {
+            "model": "claude-3-haiku-20240307",
+            "max_tokens": 1,
+            "messages": [{"role": "user", "content": "Hi"}],
+        }
+    ).encode()
+
+    status, body, error = _make_request(
+        url, headers, method="POST", data=data, timeout=timeout
+    )
+
+    if error == "timeout":
+        return ValidationResult(
+            passed=False,
+            errors=[
+                ERROR_MESSAGES["connection_timeout"].format(
+                    provider="Anthropic", timeout=timeout
+                )
+            ],
+        )
+
+    if status == 0:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["connection_failed"].format(provider="Anthropic")],
+            details={"error": error},
+        )
+
+    if status == 401:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["api_key_invalid"].format(provider="Anthropic")],
+        )
+
+    if status == 429:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["rate_limited"].format(provider="Anthropic")],
+        )
+
+    if status in (200, 201):
+        return ValidationResult(passed=True, details={"endpoint": url})
+
+    if status >= 400:
+        error_msg = body.get("error", {}).get("message", "") if body else ""
+        if "invalid_api_key" in str(body).lower():
+            return ValidationResult(
+                passed=False,
+                errors=[ERROR_MESSAGES["api_key_invalid"].format(provider="Anthropic")],
+            )
+        return ValidationResult(
+            passed=True, details={"status": status, "message": error_msg}
+        )
+
+    return ValidationResult(passed=True)
+
+
+def _test_openrouter_connectivity(api_key: str, timeout: int) -> ValidationResult:
+    """Test OpenRouter API connectivity."""
+    url = "https://openrouter.ai/api/v1/models"
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    status, body, error = _make_request(url, headers, timeout=timeout)
+
+    if error == "timeout":
+        return ValidationResult(
+            passed=False,
+            errors=[
+                ERROR_MESSAGES["connection_timeout"].format(
+                    provider="OpenRouter", timeout=timeout
+                )
+            ],
+        )
+
+    if status == 0:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["connection_failed"].format(provider="OpenRouter")],
+            details={"error": error},
+        )
+
+    if status == 401:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["api_key_invalid"].format(provider="OpenRouter")],
+        )
+
+    if status == 200:
+        return ValidationResult(passed=True, details={"endpoint": url})
+
+    return ValidationResult(passed=True)
+
+
+def _test_zai_connectivity(api_key: str, timeout: int) -> ValidationResult:
+    """Test ZAI (GLM) API connectivity."""
+    url = "https://open.bigmodel.cn/api/paas/v4/models"
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    status, body, error = _make_request(url, headers, timeout=timeout)
+
+    if error == "timeout":
+        return ValidationResult(
+            passed=False,
+            errors=[
+                ERROR_MESSAGES["connection_timeout"].format(
+                    provider="ZAI", timeout=timeout
+                )
+            ],
+        )
+
+    if status == 0:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["connection_failed"].format(provider="ZAI")],
+            details={"error": error},
+        )
+
+    if status == 401:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["api_key_invalid"].format(provider="ZAI")],
+        )
+
+    if status == 200:
+        return ValidationResult(passed=True, details={"endpoint": url})
+
+    return ValidationResult(passed=True)
+
+
+def _test_ollama_connectivity(provider: dict, timeout: int) -> ValidationResult:
+    """Test Ollama server connectivity."""
+    endpoint = provider.get("endpoint", "http://localhost:11434")
+
+    if endpoint.endswith("/"):
+        endpoint = endpoint.rstrip("/")
+
+    url = f"{endpoint}/api/tags"
+
+    try:
+        req = urllib.request.Request(url)
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+            data = json.loads(body) if body else {}
+            models = data.get("models", [])
+            model_names = [m.get("name", "") for m in models if isinstance(m, dict)]
+
+            warnings = []
+            if not model_names:
+                warnings.append(WARNING_MESSAGES["ollama_no_models"])
+
+            return ValidationResult(
+                passed=True,
+                warnings=warnings,
+                details={"endpoint": endpoint, "models": model_names},
+            )
+    except urllib.error.URLError as e:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["ollama_not_running"].format(endpoint=endpoint)],
+            details={"endpoint": endpoint, "error": str(e.reason)},
+        )
+    except socket.timeout:
+        return ValidationResult(
+            passed=False,
+            errors=[
+                ERROR_MESSAGES["connection_timeout"].format(
+                    provider="Ollama", timeout=timeout
+                )
+            ],
+        )
+    except Exception as e:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["ollama_not_running"].format(endpoint=endpoint)],
+            details={"error": str(e)},
+        )
+
+
+def _test_bedrock_connectivity(provider: dict, timeout: int) -> ValidationResult:
+    """Test AWS Bedrock connectivity by checking credentials."""
+    import os
+
+    aws_key = os.environ.get("AWS_ACCESS_KEY_ID") or os.environ.get("AWS_ACCESS_KEY")
+    aws_secret = os.environ.get("AWS_SECRET_ACCESS_KEY") or os.environ.get(
+        "AWS_SECRET_KEY"
+    )
+
+    if not aws_key or not aws_secret:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["bedrock_credentials"]],
+        )
+
+    return ValidationResult(
+        passed=True,
+        details={"type": "bedrock", "credentials_configured": True},
+    )
+
+
+def _test_vertex_connectivity(provider: dict, timeout: int) -> ValidationResult:
+    """Test GCP Vertex AI connectivity by checking credentials."""
+    import os
+
+    creds_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+
+    if creds_path:
+        from pathlib import Path
+
+        if Path(creds_path).exists():
+            return ValidationResult(
+                passed=True,
+                details={"type": "vertex", "credentials_file": creds_path},
+            )
+
+    return ValidationResult(
+        passed=False,
+        errors=[ERROR_MESSAGES["vertex_credentials"]],
+    )
+
+
+def validate_agent_installation(host: str, claw_name: str) -> ValidationResult:
+    """Validate agent is installed on the host.
+
+    This is a placeholder for agent installation validation.
+    In the future, this will verify:
+    - Claw binary/installation exists
+    - File permissions are correct
+    - User/group ownership is correct
+
+    Args:
+        host: Host alias or hostname.
+        claw_name: Name of the claw instance.
+
+    Returns:
+        ValidationResult with installation status.
+    """
+    host_data = get_host(host)
+    if not host_data:
+        return ValidationResult(
+            passed=False,
+            errors=[f"Host '{host}' not found."],
+        )
+
+    claws = host_data.get("claws", {})
+    claw_data = claws.get(claw_name)
+
+    if not claw_data:
+        return ValidationResult(
+            passed=False,
+            errors=[
+                ERROR_MESSAGES["agent_not_installed"].format(
+                    claw_type=claw_name, host=host
+                )
+            ],
+        )
+
+    return ValidationResult(
+        passed=True,
+        details={
+            "claw_name": claw_name,
+            "version": claw_data.get("version"),
+            "status": claw_data.get("status"),
+        },
+    )

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -477,9 +477,149 @@ class TestRunValidateStage:
         """Returns False when complete_stage fails."""
         from clawrium.cli.agent import _run_validate_stage
 
-        with patch(
-            "clawrium.cli.agent.complete_stage", side_effect=Exception("failed")
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(isolated_config, onboarding_state="validate")
+        create_provider(isolated_config)
+
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = json.loads(hosts_file.read_text())
+        hosts_data[0]["claws"]["openclaw"]["onboarding"]["stages"]["providers"][
+            "provider_id"
+        ] = "test-openai"
+        hosts_file.write_text(json.dumps(hosts_data, indent=2))
+
+        soul_dir = isolated_config / "claws" / "openclaw"
+        soul_dir.mkdir(parents=True)
+        (soul_dir / "SOUL.md").write_text("Test personality")
+
+        secrets_file = isolated_config / "secrets.json"
+        secrets_file.write_text(
+            json.dumps(
+                {
+                    "provider:test-openai": {
+                        "API_KEY": {
+                            "key": "API_KEY",
+                            "value": "sk-test-key",
+                            "created_at": "2026-01-01T00:00:00Z",
+                            "updated_at": "2026-01-01T00:00:00Z",
+                            "description": "",
+                        }
+                    }
+                }
+            )
+        )
+
+        with (
+            patch(
+                "clawrium.core.validation._make_request", return_value=(200, {}, None)
+            ),
+            patch("clawrium.cli.agent.complete_stage", side_effect=Exception("failed")),
         ):
+            result = _run_validate_stage("work", "openclaw", True)
+
+        assert result is False
+
+    def test_soul_md_missing_fails(self, isolated_config: Path):
+        """Returns False when SOUL.md is missing."""
+        from clawrium.cli.agent import _run_validate_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(isolated_config, onboarding_state="validate")
+        create_provider(isolated_config)
+
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = json.loads(hosts_file.read_text())
+        hosts_data[0]["claws"]["openclaw"]["onboarding"]["stages"]["providers"][
+            "provider_id"
+        ] = "test-openai"
+        hosts_file.write_text(json.dumps(hosts_data, indent=2))
+
+        with patch("clawrium.cli.agent.complete_stage"):
+            result = _run_validate_stage("work", "openclaw", True)
+
+        assert result is False
+
+    def test_validation_passes_with_all_checks(self, isolated_config: Path):
+        """Returns True when all validation checks pass."""
+        from clawrium.cli.agent import _run_validate_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(isolated_config, onboarding_state="validate")
+        create_provider(isolated_config)
+
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = json.loads(hosts_file.read_text())
+        hosts_data[0]["claws"]["openclaw"]["onboarding"]["stages"]["providers"][
+            "provider_id"
+        ] = "test-openai"
+        hosts_file.write_text(json.dumps(hosts_data, indent=2))
+
+        soul_dir = isolated_config / "claws" / "openclaw"
+        soul_dir.mkdir(parents=True)
+        (soul_dir / "SOUL.md").write_text("Test personality")
+
+        secrets_file = isolated_config / "secrets.json"
+        secrets_file.write_text(
+            json.dumps(
+                {
+                    "provider:test-openai": {
+                        "API_KEY": {
+                            "key": "API_KEY",
+                            "value": "sk-test-key",
+                            "created_at": "2026-01-01T00:00:00Z",
+                            "updated_at": "2026-01-01T00:00:00Z",
+                            "description": "",
+                        }
+                    }
+                }
+            )
+        )
+
+        with (
+            patch(
+                "clawrium.core.validation._make_request", return_value=(200, {}, None)
+            ),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            result = _run_validate_stage("work", "openclaw", True)
+
+        assert result is True
+
+    def test_provider_not_configured_fails(self, isolated_config: Path):
+        """Returns False when provider is not configured."""
+        from clawrium.cli.agent import _run_validate_stage
+
+        create_test_keypair(isolated_config, "work")
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = [
+            {
+                "hostname": "192.168.1.100",
+                "key_id": "work",
+                "alias": "work",
+                "claws": {
+                    "openclaw": {
+                        "version": "0.1.0",
+                        "status": "installed",
+                        "onboarding": {
+                            "state": "validate",
+                            "stages": {
+                                "providers": {"status": "pending", "provider_id": None},
+                                "identity": {"status": "complete"},
+                                "channels": {"status": "complete"},
+                                "validate": {"status": "pending"},
+                            },
+                        },
+                    }
+                },
+            }
+        ]
+        hosts_file.write_text(json.dumps(hosts_data))
+
+        soul_dir = isolated_config / "claws" / "openclaw"
+        soul_dir.mkdir(parents=True)
+        (soul_dir / "SOUL.md").write_text("Test personality")
+
+        with patch("clawrium.cli.agent.complete_stage"):
             result = _run_validate_stage("work", "openclaw", True)
 
         assert result is False

--- a/tests/test_core_validation.py
+++ b/tests/test_core_validation.py
@@ -1,0 +1,556 @@
+"""Tests for the validation module."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from clawrium.core.validation import (
+    ValidationResult,
+    validate_soul_md,
+    validate_provider_config,
+    validate_provider_api_key,
+    verify_provider_connectivity,
+    validate_agent_installation,
+    ERROR_MESSAGES,
+    WARNING_MESSAGES,
+)
+
+
+class TestValidationResult:
+    """Tests for ValidationResult dataclass."""
+
+    def test_passed_result(self):
+        """ValidationResult with passed=True is successful."""
+        result = ValidationResult(passed=True)
+        assert result.passed is True
+        assert result.errors == []
+        assert result.warnings == []
+
+    def test_failed_result(self):
+        """ValidationResult with errors indicates failure."""
+        result = ValidationResult(passed=False, errors=["Something failed"])
+        assert result.passed is False
+        assert len(result.errors) == 1
+        assert "Something failed" in result.errors
+
+    def test_result_with_warnings(self):
+        """ValidationResult can have warnings even when passed."""
+        result = ValidationResult(passed=True, warnings=["Minor issue"])
+        assert result.passed is True
+        assert len(result.warnings) == 1
+
+    def test_result_with_details(self):
+        """ValidationResult can store details dict."""
+        result = ValidationResult(passed=True, details={"key": "value"})
+        assert result.details["key"] == "value"
+
+
+class TestValidateSoulMd:
+    """Tests for validate_soul_md function."""
+
+    def test_soul_md_missing(self, isolated_config: Path):
+        """Returns failure when SOUL.md doesn't exist."""
+        result = validate_soul_md("openclaw")
+        assert result.passed is False
+        assert len(result.errors) == 1
+        assert "SOUL.md" in result.errors[0]
+
+    def test_soul_md_exists_and_readable(self, isolated_config: Path):
+        """Returns success when SOUL.md exists and is readable."""
+        soul_dir = isolated_config / "claws" / "openclaw"
+        soul_dir.mkdir(parents=True)
+        (soul_dir / "SOUL.md").write_text("# OpenClaw Personality\n\nBe helpful.")
+
+        result = validate_soul_md("openclaw")
+        assert result.passed is True
+        assert len(result.errors) == 0
+
+    def test_soul_md_empty_warning(self, isolated_config: Path):
+        """Returns warning when SOUL.md is empty."""
+        soul_dir = isolated_config / "claws" / "openclaw"
+        soul_dir.mkdir(parents=True)
+        (soul_dir / "SOUL.md").write_text("")
+
+        result = validate_soul_md("openclaw")
+        assert result.passed is True
+        assert len(result.warnings) == 1
+        assert "empty" in result.warnings[0].lower()
+
+    def test_soul_md_large_warning(self, isolated_config: Path):
+        """Returns warning when SOUL.md is larger than 10KB."""
+        soul_dir = isolated_config / "claws" / "openclaw"
+        soul_dir.mkdir(parents=True)
+        (soul_dir / "SOUL.md").write_text("x" * 11000)
+
+        result = validate_soul_md("openclaw")
+        assert result.passed is True
+        assert len(result.warnings) == 1
+        assert "larger" in result.warnings[0].lower()
+
+
+class TestValidateProviderConfig:
+    """Tests for validate_provider_config function."""
+
+    def test_provider_not_assigned(self, isolated_config: Path):
+        """Returns failure when provider not assigned."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = [
+            {
+                "hostname": "192.168.1.100",
+                "claws": {
+                    "openclaw": {
+                        "onboarding": {
+                            "state": "validate",
+                            "stages": {
+                                "providers": {"status": "pending", "provider_id": None}
+                            },
+                        }
+                    }
+                },
+            }
+        ]
+        hosts_file.write_text(json.dumps(hosts_data))
+
+        result = validate_provider_config("192.168.1.100", "openclaw")
+        assert result.passed is False
+        assert len(result.errors) == 1
+
+    def test_provider_assigned(self, isolated_config: Path):
+        """Returns success when provider is assigned."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_file = isolated_config / "providers.json"
+        providers_file.write_text(
+            json.dumps(
+                [{"name": "test-openai", "type": "openai", "default_model": "gpt-4"}]
+            )
+        )
+
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = [
+            {
+                "hostname": "192.168.1.100",
+                "claws": {
+                    "openclaw": {
+                        "onboarding": {
+                            "state": "validate",
+                            "stages": {
+                                "providers": {
+                                    "status": "complete",
+                                    "provider_id": "test-openai",
+                                }
+                            },
+                        }
+                    }
+                },
+            }
+        ]
+        hosts_file.write_text(json.dumps(hosts_data))
+
+        result = validate_provider_config("192.168.1.100", "openclaw")
+        assert result.passed is True
+        assert result.details.get("provider_id") == "test-openai"
+
+    def test_provider_config_missing(self, isolated_config: Path):
+        """Returns failure when provider ID not found in providers."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = [
+            {
+                "hostname": "192.168.1.100",
+                "claws": {
+                    "openclaw": {
+                        "onboarding": {
+                            "state": "validate",
+                            "stages": {
+                                "providers": {
+                                    "status": "complete",
+                                    "provider_id": "nonexistent",
+                                }
+                            },
+                        }
+                    }
+                },
+            }
+        ]
+        hosts_file.write_text(json.dumps(hosts_data))
+
+        result = validate_provider_config("192.168.1.100", "openclaw")
+        assert result.passed is False
+        assert "not found" in result.errors[0].lower()
+
+
+class TestValidateProviderApiKey:
+    """Tests for validate_provider_api_key function."""
+
+    def test_provider_not_found(self, isolated_config: Path):
+        """Returns failure when provider doesn't exist."""
+        result = validate_provider_api_key("nonexistent")
+        assert result.passed is False
+        assert "not found" in result.errors[0].lower()
+
+    def test_ollama_no_key_needed(self, isolated_config: Path):
+        """Ollama doesn't require API key."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_file = isolated_config / "providers.json"
+        providers_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "test-ollama",
+                        "type": "ollama",
+                        "endpoint": "http://localhost:11434",
+                    }
+                ]
+            )
+        )
+
+        result = validate_provider_api_key("test-ollama")
+        assert result.passed is True
+        assert result.details.get("key_required") is False
+
+    def test_bedrock_uses_cloud_auth(self, isolated_config: Path):
+        """Bedrock uses AWS credentials, not API key."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_file = isolated_config / "providers.json"
+        providers_file.write_text(
+            json.dumps([{"name": "test-bedrock", "type": "bedrock"}])
+        )
+
+        result = validate_provider_api_key("test-bedrock")
+        assert result.passed is True
+        assert result.details.get("uses_cloud_auth") is True
+
+    def test_openai_missing_key(self, isolated_config: Path):
+        """Returns failure when OpenAI API key missing."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_file = isolated_config / "providers.json"
+        providers_file.write_text(
+            json.dumps([{"name": "test-openai", "type": "openai"}])
+        )
+
+        result = validate_provider_api_key("test-openai")
+        assert result.passed is False
+        assert "API key" in result.errors[0]
+
+    def test_openai_has_key(self, isolated_config: Path):
+        """Returns success when API key is configured."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_file = isolated_config / "providers.json"
+        providers_file.write_text(
+            json.dumps([{"name": "test-openai", "type": "openai"}])
+        )
+
+        secrets_file = isolated_config / "secrets.json"
+        secrets_file.write_text(
+            json.dumps(
+                {
+                    "provider:test-openai": {
+                        "API_KEY": {
+                            "key": "API_KEY",
+                            "value": "sk-test-key",
+                            "created_at": "2026-01-01T00:00:00Z",
+                            "updated_at": "2026-01-01T00:00:00Z",
+                            "description": "",
+                        }
+                    }
+                }
+            )
+        )
+
+        result = validate_provider_api_key("test-openai")
+        assert result.passed is True
+        assert result.details.get("key_configured") is True
+
+
+class TestTestProviderConnectivity:
+    """Tests for verify_provider_connectivity function."""
+
+    def test_provider_not_found(self, isolated_config: Path):
+        """Returns failure when provider doesn't exist."""
+        result = verify_provider_connectivity("nonexistent")
+        assert result.passed is False
+
+    def test_openai_missing_key(self, isolated_config: Path):
+        """Returns failure when API key missing for connectivity test."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_file = isolated_config / "providers.json"
+        providers_file.write_text(
+            json.dumps([{"name": "test-openai", "type": "openai"}])
+        )
+
+        result = verify_provider_connectivity("test-openai")
+        assert result.passed is False
+        assert "API key" in result.errors[0]
+
+    @patch("clawrium.core.validation._make_request")
+    def test_openai_success(self, mock_request, isolated_config: Path):
+        """Returns success on valid OpenAI response."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_file = isolated_config / "providers.json"
+        providers_file.write_text(
+            json.dumps([{"name": "test-openai", "type": "openai"}])
+        )
+
+        secrets_file = isolated_config / "secrets.json"
+        secrets_file.write_text(
+            json.dumps(
+                {
+                    "provider:test-openai": {
+                        "API_KEY": {
+                            "key": "API_KEY",
+                            "value": "sk-test-key",
+                            "created_at": "2026-01-01T00:00:00Z",
+                            "updated_at": "2026-01-01T00:00:00Z",
+                            "description": "",
+                        }
+                    }
+                }
+            )
+        )
+
+        mock_request.return_value = (200, {"data": [{"id": "gpt-4"}]}, None)
+
+        result = verify_provider_connectivity("test-openai")
+        assert result.passed is True
+
+    @patch("clawrium.core.validation._make_request")
+    def test_openai_invalid_key(self, mock_request, isolated_config: Path):
+        """Returns failure on 401 response."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_file = isolated_config / "providers.json"
+        providers_file.write_text(
+            json.dumps([{"name": "test-openai", "type": "openai"}])
+        )
+
+        secrets_file = isolated_config / "secrets.json"
+        secrets_file.write_text(
+            json.dumps(
+                {
+                    "provider:test-openai": {
+                        "API_KEY": {
+                            "key": "API_KEY",
+                            "value": "invalid-key",
+                            "created_at": "2026-01-01T00:00:00Z",
+                            "updated_at": "2026-01-01T00:00:00Z",
+                            "description": "",
+                        }
+                    }
+                }
+            )
+        )
+
+        mock_request.return_value = (401, None, "Unauthorized")
+
+        result = verify_provider_connectivity("test-openai")
+        assert result.passed is False
+        assert "invalid" in result.errors[0].lower()
+
+    @patch("clawrium.core.validation._make_request")
+    def test_openai_rate_limited(self, mock_request, isolated_config: Path):
+        """Returns failure on 429 response."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_file = isolated_config / "providers.json"
+        providers_file.write_text(
+            json.dumps([{"name": "test-openai", "type": "openai"}])
+        )
+
+        secrets_file = isolated_config / "secrets.json"
+        secrets_file.write_text(
+            json.dumps(
+                {
+                    "provider:test-openai": {
+                        "API_KEY": {
+                            "key": "API_KEY",
+                            "value": "sk-test-key",
+                            "created_at": "2026-01-01T00:00:00Z",
+                            "updated_at": "2026-01-01T00:00:00Z",
+                            "description": "",
+                        }
+                    }
+                }
+            )
+        )
+
+        mock_request.return_value = (429, None, "Rate limited")
+
+        result = verify_provider_connectivity("test-openai")
+        assert result.passed is False
+        assert "rate" in result.errors[0].lower()
+
+    @patch("clawrium.core.validation._make_request")
+    def test_anthropic_success(self, mock_request, isolated_config: Path):
+        """Returns success on valid Anthropic response."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_file = isolated_config / "providers.json"
+        providers_file.write_text(
+            json.dumps([{"name": "test-anthropic", "type": "anthropic"}])
+        )
+
+        secrets_file = isolated_config / "secrets.json"
+        secrets_file.write_text(
+            json.dumps(
+                {
+                    "provider:test-anthropic": {
+                        "API_KEY": {
+                            "key": "API_KEY",
+                            "value": "sk-ant-test",
+                            "created_at": "2026-01-01T00:00:00Z",
+                            "updated_at": "2026-01-01T00:00:00Z",
+                            "description": "",
+                        }
+                    }
+                }
+            )
+        )
+
+        mock_request.return_value = (200, {}, None)
+
+        result = verify_provider_connectivity("test-anthropic")
+        assert result.passed is True
+
+
+class TestTestOllamaConnectivity:
+    """Tests for Ollama connectivity."""
+
+    def test_ollama_running(self, isolated_config: Path):
+        """Returns success when Ollama is running."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_file = isolated_config / "providers.json"
+        providers_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "test-ollama",
+                        "type": "ollama",
+                        "endpoint": "http://localhost:11434",
+                    }
+                ]
+            )
+        )
+
+        with patch("clawrium.core.validation.urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = json.dumps(
+                {"models": [{"name": "llama3:latest"}]}
+            ).encode()
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_response
+
+            result = verify_provider_connectivity("test-ollama")
+            assert result.passed is True
+            assert "llama3:latest" in result.details.get("models", [])
+
+    def test_ollama_no_models(self, isolated_config: Path):
+        """Returns warning when Ollama has no models."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        providers_file = isolated_config / "providers.json"
+        providers_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "test-ollama",
+                        "type": "ollama",
+                        "endpoint": "http://localhost:11434",
+                    }
+                ]
+            )
+        )
+
+        with patch("clawrium.core.validation.urllib.request.urlopen") as mock_urlopen:
+            mock_response = MagicMock()
+            mock_response.read.return_value = json.dumps({"models": []}).encode()
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_response
+
+            result = verify_provider_connectivity("test-ollama")
+            assert result.passed is True
+            assert len(result.warnings) == 1
+            assert "no models" in result.warnings[0].lower()
+
+
+class TestValidateAgentInstallation:
+    """Tests for validate_agent_installation function."""
+
+    def test_host_not_found(self, isolated_config: Path):
+        """Returns failure when host doesn't exist."""
+        result = validate_agent_installation("nonexistent", "openclaw")
+        assert result.passed is False
+        assert "not found" in result.errors[0].lower()
+
+    def test_claw_not_installed(self, isolated_config: Path):
+        """Returns failure when claw not installed."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = [{"hostname": "192.168.1.100", "claws": {}}]
+        hosts_file.write_text(json.dumps(hosts_data))
+
+        result = validate_agent_installation("192.168.1.100", "openclaw")
+        assert result.passed is False
+        assert (
+            "not found" in result.errors[0].lower()
+            or "not installed" in result.errors[0].lower()
+        )
+
+    def test_claw_installed(self, isolated_config: Path):
+        """Returns success when claw is installed."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = [
+            {
+                "hostname": "192.168.1.100",
+                "claws": {
+                    "openclaw": {
+                        "version": "0.1.0",
+                        "status": "installed",
+                    }
+                },
+            }
+        ]
+        hosts_file.write_text(json.dumps(hosts_data))
+
+        result = validate_agent_installation("192.168.1.100", "openclaw")
+        assert result.passed is True
+        assert result.details.get("version") == "0.1.0"
+
+
+class TestErrorMessages:
+    """Tests for error message templates."""
+
+    def test_error_messages_exist(self):
+        """All expected error messages are defined."""
+        expected_keys = [
+            "soul_md_missing",
+            "soul_md_unreadable",
+            "provider_not_found",
+            "provider_config_missing",
+            "api_key_missing",
+            "api_key_invalid",
+            "connection_failed",
+            "connection_timeout",
+            "rate_limited",
+        ]
+        for key in expected_keys:
+            assert key in ERROR_MESSAGES, f"Missing error message: {key}"
+
+    def test_warning_messages_exist(self):
+        """All expected warning messages are defined."""
+        expected_keys = [
+            "soul_md_empty",
+            "soul_md_large",
+        ]
+        for key in expected_keys:
+            assert key in WARNING_MESSAGES, f"Missing warning message: {key}"
+
+    def test_error_messages_formattable(self):
+        """Error messages can be formatted with placeholders."""
+        msg = ERROR_MESSAGES["soul_md_unreadable"]
+        formatted = msg.format(error="test error")
+        assert "test error" in formatted
+
+        msg = ERROR_MESSAGES["connection_timeout"]
+        formatted = msg.format(provider="OpenAI", timeout=10)
+        assert "OpenAI" in formatted
+        assert "10" in formatted


### PR DESCRIPTION
## Summary

Implements the validation stage in agent onboarding to verify configuration correctness and provide actionable error messages when issues are found.

**Key Changes:**
- New `src/clawrium/core/validation.py` module with structured validation utilities
- Implemented `_run_validate_stage()` in agent CLI with 4-step validation process
- Connectivity tests for all providers (OpenAI, Anthropic, OpenRouter, ZAI, Ollama, Bedrock, Vertex)
- Comprehensive test coverage (30 tests for validation module)

**Validation Steps:**
1. Agent installation check
2. SOUL.md personality file validation
3. Provider configuration verification
4. Provider API connectivity test

**Error Messages:**
- Specific, actionable messages for each failure type
- Suggestions for common fixes (e.g., "Run `clm agent configure --stage identity`")

Closes #89