### PR TITLE
test(lifecycle): align ssh key mock patch targets

### DIFF
--- a/tests/test_cli_agent_lifecycle.py
+++ b/tests/test_cli_agent_lifecycle.py
@@ -140,9 +140,7 @@ class TestAgentStart:
         mock_runner.status = "successful"
         mock_runner.events = []
 
-        with patch(
-            "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
-        ):
+        with patch("clawrium.core.keys.get_host_private_key", return_value=key_path):
             with patch(
                 "clawrium.core.lifecycle.ansible_runner.run", return_value=mock_runner
             ):
@@ -192,8 +190,7 @@ class TestAgentStart:
                 "clawrium.core.hosts.get_config_dir", return_value=isolated_config
             ):
                 with patch(
-                    "clawrium.core.lifecycle.get_host_private_key",
-                    return_value=key_path,
+                    "clawrium.core.keys.get_host_private_key", return_value=key_path
                 ):
                     with patch(
                         "clawrium.core.lifecycle.ansible_runner.run",
@@ -250,9 +247,7 @@ class TestAgentStop:
         mock_runner.status = "successful"
         mock_runner.events = []
 
-        with patch(
-            "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
-        ):
+        with patch("clawrium.core.keys.get_host_private_key", return_value=key_path):
             with patch(
                 "clawrium.core.lifecycle.ansible_runner.run", return_value=mock_runner
             ):
@@ -289,9 +284,7 @@ class TestAgentRestart:
         mock_runner.status = "successful"
         mock_runner.events = []
 
-        with patch(
-            "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
-        ):
+        with patch("clawrium.core.keys.get_host_private_key", return_value=key_path):
             with patch(
                 "clawrium.core.lifecycle.ansible_runner.run", return_value=mock_runner
             ):

--- a/tests/test_cli_agent_start.py
+++ b/tests/test_cli_agent_start.py
@@ -216,7 +216,7 @@ def test_start_with_force_when_not_ready_succeeds(isolated_config: Path):
     with patch("clawrium.core.config.get_config_dir", return_value=isolated_config):
         with patch("clawrium.core.hosts.get_config_dir", return_value=isolated_config):
             with patch(
-                "clawrium.core.keys.get_host_private_key", return_value=key_path
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
             ):
                 with patch(
                     "clawrium.core.lifecycle.ansible_runner.run",


### PR DESCRIPTION
## Summary
- Align lifecycle-related test patches with the lifecycle key lookup entry points used during command execution.
- Keep test intent unchanged while reducing brittle mock target mismatches.

## Testing
- `make test`

## ATX Review Summary
**Final Review: Pending**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | Pending | Pending | Pending |

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>