### PR TITLE
[Issue #136] Complete internal schema refactoring to agent terminology

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "atx": {
+      "type": "local",
+      "command": [
+        "/home/devashish/bin/atx",
+        "mcp",
+        "serve"
+      ],
+      "environment": {
+        "ATX_DAEMON_PORT": "30000",
+        "ATX_DB_PATH": "/home/devashish/.config/atx/data/atx.db",
+        "ATX_PROJECT_ID": "2f7d41ac-f5fb-4466-8e2e-9e69bbef6701",
+        "ATX_WORKING_DIR": "/home/devashish/workspace/ric03uec/clawrium"
+      },
+      "enabled": true
+    }
+  }
+}

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -144,8 +144,8 @@ def _resolve_agent_instance(agent_name: str) -> tuple[str, dict, str, dict, str]
         if not hostname:
             continue
 
-        for claw_type, claw_record in host_data.get("claws", {}).items():
-            canonical_name = claw_record.get("name") or claw_record.get("user")
+        for claw_type, claw_record in host_data.get("agents", {}).items():
+            canonical_name = claw_record.get("agent_name") or claw_record.get("name")
             if not canonical_name:
                 continue
             if canonical_name == agent_name:
@@ -229,10 +229,10 @@ def _sync_provider_config(host: str, claw_type: str, provider: dict) -> None:
     if not host_data:
         raise RuntimeError(f"Host '{host}' not found")
 
-    claw_record = host_data.get("claws", {}).get(claw_type)
+    claw_record = host_data.get("agents", {}).get(claw_type)
     if not claw_record:
         raise RuntimeError(f"Agent '{claw_type}' not installed on '{host}'")
-    installed_name = claw_record.get("name") or claw_record.get("user") or claw_type
+    installed_name = claw_record.get("agent_name") or claw_record.get("name") or claw_type
 
     # Calculate or preserve gateway port
     existing_config = claw_record.get("config", {})
@@ -246,7 +246,7 @@ def _sync_provider_config(host: str, claw_type: str, provider: dict) -> None:
         port_hash = int(hashlib.md5(installed_name.encode()).hexdigest(), 16)
         gateway_port = 40000 + (port_hash % 2000)
 
-    # Build gateway config based on claw type
+    # Build gateway config based on agent type
     if claw_type == "zeroclaw":
         gateway_config = {
             "host": "0.0.0.0",
@@ -391,7 +391,7 @@ def _run_identity_stage(host: str, claw_type: str, yes: bool) -> bool:
         return False
 
     config_dir = get_config_dir()
-    soul_dir = config_dir / "claws" / claw_type
+    soul_dir = config_dir / "agents" / claw_type
     soul_dir.mkdir(parents=True, exist_ok=True)
     soul_path = soul_dir / "SOUL.md"
 

--- a/src/clawrium/cli/host.py
+++ b/src/clawrium/cli/host.py
@@ -711,18 +711,18 @@ def reset(
         console.print(f"  Services removed: {result.removed['services']}")
         console.print(f"  Paths cleaned: {result.removed['paths']}")
 
-        # Clear claws from host record and set last_reset timestamp
-        def clear_claws(h: dict) -> dict:
+        # Clear agents from host record and set last_reset timestamp
+        def clear_agents(h: dict) -> dict:
             from datetime import datetime, timezone
 
-            h["claws"] = {}
+            h["agents"] = {}
             if "metadata" not in h:
                 h["metadata"] = {}
             h["metadata"]["last_reset"] = datetime.now(timezone.utc).isoformat()
             return h
 
         # W4: Check return value of update_host
-        if not update_host(hostname, clear_claws):
+        if not update_host(hostname, clear_agents):
             console.print(
                 "[yellow]Warning:[/yellow] Could not update host record (host may have been removed)"
             )

--- a/src/clawrium/cli/install.py
+++ b/src/clawrium/cli/install.py
@@ -1,4 +1,4 @@
-"""Install command for deploying claws to hosts."""
+"""Install command for deploying agents to hosts."""
 
 from typing import Optional
 
@@ -104,10 +104,10 @@ def install(
     Without flags, prompts for claw and host selection interactively.
     With --type and --host flags, runs directly (per D-01 hybrid invocation).
     """
-    # Step 1: Get claw (prompt if not provided per D-01)
+    # Step 1: Get agent type (prompt if not provided per D-01)
     selected_claw = claw or _select_claw()
 
-    # Step 2: Validate claw exists
+    # Step 2: Validate agent type exists
     try:
         get_claw_info(selected_claw)  # Validates claw exists
     except ManifestNotFoundError:

--- a/src/clawrium/cli/secret.py
+++ b/src/clawrium/cli/secret.py
@@ -46,7 +46,7 @@ def set_cmd(
 
     Prompts for the value using masked input (not visible on screen).
     """
-    # Validate claw exists
+    # Validate agent type exists
     try:
         hostname, claw_type, name = get_installed_claw(claw_name)
     except AgentNotFoundError as e:
@@ -108,7 +108,7 @@ def list_cmd(
     Shows secret keys and metadata. Values are never displayed.
     Also shows missing required secrets.
     """
-    # Validate claw exists
+    # Validate agent type exists
     try:
         hostname, claw_type, name = get_installed_claw(claw_name)
     except AgentNotFoundError as e:
@@ -126,13 +126,13 @@ def list_cmd(
     # Get secrets for this instance
     instance_secrets = secrets.get(instance_key, {})
 
-    # Get required secrets for this claw type
+    # Build gateway config based on agent type
     required_secrets = get_required_secrets(claw_type)
     required_keys = {s["key"] for s in required_secrets}
     stored_keys = set(instance_secrets.keys())
     missing_keys = required_keys - stored_keys
 
-    # Display claw header
+    # Display agent header
     console.print(f"\n[bold]Agent:[/bold] {name} ({hostname})")
 
     # Display stored secrets if any
@@ -180,7 +180,7 @@ def remove_cmd(
 
     Prompts for confirmation unless --force is specified.
     """
-    # Validate claw exists
+    # Validate agent type exists
     try:
         hostname, claw_type, name = get_installed_claw(claw_name)
     except AgentNotFoundError as e:

--- a/src/clawrium/cli/status.py
+++ b/src/clawrium/cli/status.py
@@ -101,7 +101,7 @@ def status(
     claws_by_type: dict[str, list[tuple[dict, dict]]] = defaultdict(list)
 
     for h in hosts:
-        for claw_name, claw_record in h.get("claws", {}).items():
+        for claw_name, claw_record in h.get("agents", {}).items():
             claws_by_type[claw_name].append((h, claw_record))
 
     if not claws_by_type:
@@ -154,7 +154,7 @@ def status(
 
         for h, claw_record in instances:
             display_host = h.get("alias") or h["hostname"]
-            full_name = claw_record.get("name") or claw_record.get("user") or claw_name
+            full_name = claw_record.get("agent_name") or claw_record.get("name") or claw_name
             version = claw_record.get("version", "?")
             installed_at = claw_record.get("installed_at", "-")
             if installed_at and installed_at != "-":

--- a/src/clawrium/core/health.py
+++ b/src/clawrium/core/health.py
@@ -18,6 +18,7 @@ from clawrium.core.secrets import (
     get_instance_key,
     get_instance_secrets,
     InvalidInstanceKeyComponentError,
+    SecretsFileCorruptedError,
 )
 from clawrium.core.registry import get_required_secrets
 
@@ -117,7 +118,8 @@ def count_completed_stages(claw_record: dict) -> tuple[int, int]:
         return 0, 4
 
     stages = onboarding.get("stages", {})
-    if not stages:
+    # Ensure stages is a dict (handle corrupted data gracefully)
+    if not stages or not isinstance(stages, dict):
         return 0, 4
 
     completed = sum(
@@ -141,7 +143,7 @@ def get_missing_secrets(claw_type: str, host: dict, claw_record: dict) -> list[s
     """
     # Use canonical instance name.
     # For current installs this is stored in `user`; `name` is supported as fallback.
-    claw_name = claw_record.get("name") or claw_record.get("user", "")
+    claw_name = claw_record.get("agent_name") or claw_record.get("name", "")
 
     if not claw_name:
         # Cannot determine claw name - return empty (no secrets can be checked)
@@ -158,6 +160,7 @@ def get_missing_secrets(claw_type: str, host: dict, claw_record: dict) -> list[s
         )
         return []
 
+    # Let SecretsFileCorruptedError propagate to caller for proper error handling
     instance_secrets = get_instance_secrets(instance_key)
 
     required = get_required_secrets(claw_type)
@@ -181,20 +184,34 @@ def check_claw_health(
     Returns:
         HealthResult with status and any error message
     """
-    hostname = host["hostname"]
+    # Validate required host fields
+    hostname = host.get("hostname")
+    if not hostname:
+        return {
+            "agent": claw_name,
+            "host": "unknown",
+            "status": ClawStatus.UNKNOWN,
+            "agent_name": None,
+            "error": "Host record missing required 'hostname' field",
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": None,
+            "onboarding_stages": None,
+        }
+
     port = host.get("port", 22)
     user = host.get("user", "xclm")
 
     # Get claw record from host
-    claws = host.get("claws", {})
-    claw_record = claws.get(claw_name)
+    agents = host.get("agents", {})
+    claw_record = agents.get(claw_name)
 
     if not claw_record:
         return {
             "agent": claw_name,
             "host": hostname,
             "status": ClawStatus.NOT_INSTALLED,
-            "user": None,
+            "agent_name": None,
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -202,13 +219,13 @@ def check_claw_health(
             "onboarding_stages": None,
         }
 
-    claw_user = claw_record.get("user")
+    claw_user = claw_record.get("agent_name") or claw_record.get("name")
     if not claw_user:
         return {
             "agent": claw_name,
             "host": hostname,
             "status": ClawStatus.UNKNOWN,
-            "user": None,
+            "agent_name": None,
             "error": "No claw user recorded",
             "missing_secrets": None,
             "onboarding_step": None,
@@ -221,7 +238,7 @@ def check_claw_health(
             "agent": claw_name,
             "host": hostname,
             "status": ClawStatus.UNKNOWN,
-            "user": claw_user,
+            "agent_name": claw_user,
             "error": f"Invalid claw user format: {claw_user}",
             "missing_secrets": None,
             "onboarding_step": None,
@@ -236,7 +253,7 @@ def check_claw_health(
             "agent": claw_name,
             "host": hostname,
             "status": ClawStatus.UNKNOWN,
-            "user": claw_user,
+            "agent_name": claw_user,
             "error": "SSH key not found",
             "missing_secrets": None,
             "onboarding_step": None,
@@ -281,7 +298,7 @@ def check_claw_health(
                 "agent": claw_name,
                 "host": hostname,
                 "status": ClawStatus.UNKNOWN,
-                "user": claw_user,
+                "agent_name": claw_user,
                 "error": "Health check timed out",
                 "missing_secrets": None,
                 "onboarding_step": None,
@@ -305,7 +322,7 @@ def check_claw_health(
                     "agent": claw_name,
                     "host": hostname,
                     "status": ClawStatus.UNKNOWN,
-                    "user": claw_user,
+                    "agent_name": claw_user,
                     "error": "Host unreachable",
                     "missing_secrets": None,
                     "onboarding_step": None,
@@ -328,7 +345,7 @@ def check_claw_health(
                 "agent": claw_name,
                 "host": hostname,
                 "status": ClawStatus.UNKNOWN,
-                "user": claw_user,
+                "agent_name": claw_user,
                 "error": error_msg or f"SSH failed: {result.status}",
                 "missing_secrets": None,
                 "onboarding_step": None,
@@ -337,13 +354,27 @@ def check_claw_health(
             }
 
         if process_running:
-            missing = get_missing_secrets(claw_name, host, claw_record)
+            try:
+                missing = get_missing_secrets(claw_name, host, claw_record)
+            except SecretsFileCorruptedError as e:
+                return {
+                    "agent": claw_name,
+                    "host": hostname,
+                    "status": ClawStatus.DEGRADED,
+                    "agent_name": claw_user,
+                    "error": f"Secrets file corrupted: {str(e)}",
+                    "missing_secrets": None,
+                    "onboarding_step": None,
+                    "process_running": True,
+                    "onboarding_stages": None,
+                }
+
             if missing:
                 return {
                     "agent": claw_name,
                     "host": hostname,
                     "status": ClawStatus.DEGRADED,
-                    "user": claw_user,
+                    "agent_name": claw_user,
                     "error": None,
                     "missing_secrets": missing,
                     "onboarding_step": None,
@@ -355,7 +386,7 @@ def check_claw_health(
                     "agent": claw_name,
                     "host": hostname,
                     "status": ClawStatus.RUNNING,
-                    "user": claw_user,
+                    "agent_name": claw_user,
                     "error": None,
                     "missing_secrets": None,
                     "onboarding_step": None,
@@ -376,7 +407,7 @@ def check_claw_health(
                 "agent": claw_name,
                 "host": hostname,
                 "status": status,
-                "user": claw_user,
+                "agent_name": claw_user,
                 "error": None,
                 "missing_secrets": None,
                 "onboarding_step": step,
@@ -395,9 +426,9 @@ def check_all_claws_on_host(host: dict) -> list[HealthResult]:
         List of HealthResult for each installed claw
     """
     results = []
-    claws = host.get("claws", {})
+    agents = host.get("agents", {})
 
-    for claw_name in claws:
+    for claw_name in agents:
         result = check_claw_health(claw_name, host)
         results.append(result)
 

--- a/src/clawrium/core/hosts.py
+++ b/src/clawrium/core/hosts.py
@@ -39,7 +39,7 @@ def load_hosts() -> list[dict]:
         List of host dictionaries. Empty list if file doesn't exist.
 
     Raises:
-        HostsFileCorruptedError: If hosts.json exists but cannot be parsed.
+        HostsFileCorruptedError: If hosts.json exists but cannot be parsed or uses old schema.
     """
     hosts_path = get_config_dir() / HOSTS_FILE
     if not hosts_path.exists():
@@ -55,6 +55,17 @@ def load_hosts() -> list[dict]:
                 raise HostsFileCorruptedError(
                     f"hosts.json contains invalid entries (expected list of objects): {hosts_path}"
                 )
+
+            # Detect old schema format and provide migration guidance
+            for host in data:
+                if "claws" in host:
+                    raise HostsFileCorruptedError(
+                        f"hosts.json uses old schema format (found 'claws' key). "
+                        f"This version requires the new schema format. "
+                        f"Migration required: Remove all existing agents and reinstall them. "
+                        f"See CHANGELOG for breaking changes: {hosts_path}"
+                    )
+
             return data
     except json.JSONDecodeError as e:
         raise HostsFileCorruptedError(
@@ -276,7 +287,7 @@ def get_host_by_key_id(key_id: str) -> dict | None:
     return None
 
 
-def remove_agent_from_host(hostname: str, claw_name: str) -> bool:
+def remove_agent_from_host(hostname: str, agent_type: str) -> bool:
     """Remove an agent from a host's record atomically.
 
     Acquires exclusive lock for the entire load-modify-save operation
@@ -284,7 +295,7 @@ def remove_agent_from_host(hostname: str, claw_name: str) -> bool:
 
     Args:
         hostname: The hostname of the host.
-        claw_name: Name of the agent to remove.
+        agent_type: Type of the agent to remove (e.g., "openclaw").
 
     Returns:
         True if the host was found (operation attempted), False if host not found.
@@ -293,8 +304,8 @@ def remove_agent_from_host(hostname: str, claw_name: str) -> bool:
     """
 
     def updater(h: dict) -> dict:
-        if "claws" in h and claw_name in h["claws"]:
-            del h["claws"][claw_name]
+        if "agents" in h and agent_type in h["agents"]:
+            del h["agents"][agent_type]
         return h
 
     return update_host(hostname, updater)

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -9,13 +9,13 @@ This module handles the end-to-end installation flow:
 Host record schema (extended):
 {
     "hostname": str,
-    "claws": {
+    "agents": {
         "openclaw": {
             "version": "0.1.0",
             "status": "installed" | "failed" | "installing",
             "installed_at": "ISO timestamp",
             "error": str | None,
-            "user": "clever-einstein"  # friendly name, no prefix
+            "agent_name": "clever-einstein"  # friendly name, no prefix
         }
     },
     ...existing fields...
@@ -36,7 +36,7 @@ from clawrium.core.keys import get_host_private_key
 from clawrium.core.names import (
     generate_random_name,
     is_name_available_on_host,
-    validate_claw_name,
+    validate_agent_name,
 )
 from clawrium.core.registry import (
     check_compatibility,
@@ -76,13 +76,13 @@ def _get_base_playbook_path() -> Path:
     return Path(__file__).parent.parent / "platform" / "playbooks" / "base.yaml"
 
 
-def _get_claw_playbook_path(claw_name: str) -> Path:
+def _get_agent_playbook_path(agent_type: str) -> Path:
     """Get path to agent-specific install playbook."""
     return (
         Path(__file__).parent.parent
         / "platform"
         / "registry"
-        / claw_name
+        / agent_type
         / "playbooks"
         / "install.yaml"
     )
@@ -151,7 +151,7 @@ def run_installation(
 
     # Step 4: Validate custom name if provided (format only, uniqueness checked in updater)
     if name is not None:
-        valid, error_msg = validate_claw_name(name)
+        valid, error_msg = validate_agent_name(name)
         if not valid:
             raise InstallationError(f"Invalid name: {error_msg}")
         emit("validate", f"Validated custom name: {name}")
@@ -183,14 +183,14 @@ def run_installation(
                 )
             chosen_name[0] = name
 
-        if "claws" not in h:
-            h["claws"] = {}
-        h["claws"][claw_name] = {
+        if "agents" not in h:
+            h["agents"] = {}
+        h["agents"][claw_name] = {
             "version": matched_version,
             "status": "installing",
             "installed_at": None,
             "error": None,
-            "user": chosen_name[0],
+            "agent_name": chosen_name[0],
         }
         return h
 
@@ -284,7 +284,7 @@ def run_installation(
         emit("base", "System dependencies installed")
 
         # Step 9: Run agent playbook
-        claw_playbook = _get_claw_playbook_path(claw_name)
+        claw_playbook = _get_agent_playbook_path(claw_name)
         if not claw_playbook.exists():
             raise InstallationError(f"Agent playbook not found: {claw_playbook}")
 
@@ -311,9 +311,9 @@ def run_installation(
 
         # Step 10: Update host with success status
         def set_installed(h: dict) -> dict:
-            if "claws" in h and claw_name in h["claws"]:
-                h["claws"][claw_name]["status"] = "installed"
-                h["claws"][claw_name]["installed_at"] = datetime.now(
+            if "agents" in h and claw_name in h["agents"]:
+                h["agents"][claw_name]["status"] = "installed"
+                h["agents"][claw_name]["installed_at"] = datetime.now(
                     timezone.utc
                 ).isoformat()
             return h
@@ -362,13 +362,13 @@ def run_installation(
         error_msg = str(e)
 
         def set_failed(h: dict) -> dict:
-            if "claws" not in h:
-                h["claws"] = {}
-            if claw_name not in h["claws"]:
-                h["claws"][claw_name] = {"version": matched_version, "user": agent_name}
-            h["claws"][claw_name]["status"] = "failed"
-            h["claws"][claw_name]["error"] = error_msg
-            h["claws"][claw_name]["installed_at"] = datetime.now(
+            if "agents" not in h:
+                h["agents"] = {}
+            if claw_name not in h["agents"]:
+                h["agents"][claw_name] = {"version": matched_version, "agent_name": agent_name}
+            h["agents"][claw_name]["status"] = "failed"
+            h["agents"][claw_name]["error"] = error_msg
+            h["agents"][claw_name]["installed_at"] = datetime.now(
                 timezone.utc
             ).isoformat()
             return h

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -65,13 +65,13 @@ def get_host_private_key(key_id: str) -> Path | None:
     return core_keys.get_host_private_key(key_id)
 
 
-def _resolve_claw_name(claw_name: str) -> str:
+def _resolve_agent_type(agent_type: str) -> str:
     """Resolve agent alias to canonical name."""
-    return ALIAS_TO_CANONICAL.get(claw_name, claw_name)
+    return ALIAS_TO_CANONICAL.get(agent_type, agent_type)
 
 
 def _get_lifecycle_playbook_path(claw_name: str, operation: str) -> Path:
-    canonical_name = _resolve_claw_name(claw_name)
+    canonical_name = _resolve_agent_type(claw_name)
     return (
         Path(__file__).parent.parent
         / "platform"
@@ -102,11 +102,11 @@ def _update_agent_runtime(hostname: str, claw_name: str, runtime_data: dict) -> 
     """
 
     def updater(h: dict) -> dict:
-        if "claws" not in h:
-            h["claws"] = {}
-        if claw_name not in h["claws"]:
-            h["claws"][claw_name] = {}
-        h["claws"][claw_name]["runtime"] = runtime_data
+        if "agents" not in h:
+            h["agents"] = {}
+        if claw_name not in h["agents"]:
+            h["agents"][claw_name] = {}
+        h["agents"][claw_name]["runtime"] = runtime_data
         return h
 
     return update_host(hostname, updater)
@@ -141,8 +141,8 @@ def _run_lifecycle_playbook(
     if not ssh_key:
         return False, "SSH key not found"
 
-    claw_record = host.get("claws", {}).get(claw_name, {})
-    agent_name = claw_record.get("name") or claw_record.get("user")
+    claw_record = host.get("agents", {}).get(claw_name, {})
+    agent_name = claw_record.get("agent_name") or claw_record.get("name")
     if not agent_name:
         return False, f"No agent name recorded for '{claw_name}' on '{hostname}'"
 
@@ -249,7 +249,7 @@ def start_agent(
     if not host:
         raise LifecycleError(f"Host '{hostname}' not found")
 
-    claw_record = host.get("claws", {}).get(claw_name)
+    claw_record = host.get("agents", {}).get(claw_name)
     if not claw_record:
         raise LifecycleError(f"Agent '{claw_name}' not installed on '{hostname}'")
 
@@ -263,7 +263,7 @@ def start_agent(
 
     if state != OnboardingState.READY and not force:
         agent_display_name = (
-            claw_record.get("name") or claw_record.get("user") or claw_name
+            claw_record.get("agent_name") or claw_record.get("name") or claw_name
         )
         raise LifecycleError(
             f"Cannot start {claw_name}: onboarding incomplete (state={state_value}). "
@@ -338,7 +338,7 @@ def stop_agent(
     if not host:
         raise LifecycleError(f"Host '{hostname}' not found")
 
-    claw_record = host.get("claws", {}).get(claw_name)
+    claw_record = host.get("agents", {}).get(claw_name)
     if not claw_record:
         raise LifecycleError(f"Agent '{claw_name}' not installed on '{hostname}'")
 
@@ -462,7 +462,7 @@ def configure_agent(
     if not host:
         raise LifecycleError(f"Host '{hostname}' not found")
 
-    claw_record = host.get("claws", {}).get(claw_name)
+    claw_record = host.get("agents", {}).get(claw_name)
     if not claw_record:
         raise LifecycleError(f"Agent '{claw_name}' not installed on '{hostname}'")
 
@@ -485,7 +485,7 @@ def configure_agent(
             emit("configure", "Loaded provider API key from secrets")
 
     # Get template path for this agent type
-    canonical_name = _resolve_claw_name(claw_name)
+    canonical_name = _resolve_agent_type(claw_name)
     template_path = (
         Path(__file__).parent.parent
         / "platform"
@@ -508,7 +508,7 @@ def configure_agent(
     if not ssh_key:
         return False, "SSH key not found"
 
-    agent_name = claw_record.get("name") or claw_record.get("user")
+    agent_name = claw_record.get("agent_name") or claw_record.get("name")
     if not agent_name:
         return False, f"No agent name recorded for '{claw_name}' on '{hostname}'"
 
@@ -585,11 +585,11 @@ def configure_agent(
         emit("configure", "Saving configuration to hosts.json...")
 
         def updater(h: dict) -> dict:
-            if "claws" not in h:
-                h["claws"] = {}
-            if claw_name not in h["claws"]:
-                h["claws"][claw_name] = {}
-            h["claws"][claw_name]["config"] = config_data
+            if "agents" not in h:
+                h["agents"] = {}
+            if claw_name not in h["agents"]:
+                h["agents"][claw_name] = {}
+            h["agents"][claw_name]["config"] = config_data
             return h
 
         if not update_host(host["hostname"], updater):
@@ -642,7 +642,7 @@ def remove_agent(
     if not host:
         raise LifecycleError(f"Host '{hostname}' not found")
 
-    claw_record = host.get("claws", {}).get(claw_name)
+    claw_record = host.get("agents", {}).get(claw_name)
     if not claw_record:
         raise LifecycleError(f"Agent '{claw_name}' not installed on '{hostname}'")
 

--- a/src/clawrium/core/names.py
+++ b/src/clawrium/core/names.py
@@ -175,7 +175,7 @@ def is_ip_address(value: str) -> bool:
         return False
 
 
-def validate_claw_name(name: str) -> tuple[bool, str]:
+def validate_agent_name(name: str) -> tuple[bool, str]:
     """Validate an agent name for format and length.
 
     Names must be valid Unix usernames: start with a lowercase letter,
@@ -212,7 +212,7 @@ def is_name_available_on_host(name: str, host: dict) -> bool:
     Returns:
         True if name is available, False if already in use
     """
-    for claw_config in host.get("claws", {}).values():
-        if claw_config.get("user") == name:
+    for agent_config in host.get("agents", {}).values():
+        if agent_config.get("agent_name") == name or agent_config.get("name") == name:
             return False
     return True

--- a/src/clawrium/core/onboarding.py
+++ b/src/clawrium/core/onboarding.py
@@ -89,8 +89,8 @@ def _get_claw_record(host: str, claw_name: str) -> dict | None:
     host_data = get_host(host)
     if not host_data:
         return None
-    claws = host_data.get("claws", {})
-    return claws.get(claw_name)
+    agents = host_data.get("agents", {})
+    return agents.get(claw_name)
 
 
 def get_onboarding_state(host: str, claw_name: str) -> OnboardingState:
@@ -160,7 +160,13 @@ def transition_state(host: str, claw_name: str, to_state: OnboardingState) -> bo
     hostname = host_data["hostname"]
 
     def updater(h: dict) -> dict:
-        h["claws"][claw_name]["onboarding"]["state"] = to_state.value
+        if "agents" not in h or claw_name not in h["agents"]:
+            raise AgentNotFoundError(f"Agent '{claw_name}' not found on host '{host}'")
+        if "onboarding" not in h["agents"][claw_name]:
+            raise OnboardingNotFoundError(
+                f"Onboarding not initialized for '{claw_name}' on '{host}'"
+            )
+        h["agents"][claw_name]["onboarding"]["state"] = to_state.value
         return h
 
     return update_host(hostname, updater)
@@ -238,7 +244,21 @@ def complete_stage(
     now = datetime.now(timezone.utc).isoformat()
 
     def updater(h: dict) -> dict:
-        stage_data = h["claws"][claw_name]["onboarding"]["stages"][stage]
+        if "agents" not in h or claw_name not in h["agents"]:
+            raise AgentNotFoundError(f"Agent '{claw_name}' not found on host '{host}'")
+        if "onboarding" not in h["agents"][claw_name]:
+            raise OnboardingNotFoundError(
+                f"Onboarding not initialized for '{claw_name}' on '{host}'"
+            )
+        if "stages" not in h["agents"][claw_name]["onboarding"]:
+            raise OnboardingNotFoundError(
+                f"Onboarding stages not initialized for '{claw_name}' on '{host}'"
+            )
+        if stage not in h["agents"][claw_name]["onboarding"]["stages"]:
+            raise OnboardingNotFoundError(
+                f"Stage '{stage}' not found for '{claw_name}' on '{host}'"
+            )
+        stage_data = h["agents"][claw_name]["onboarding"]["stages"][stage]
         stage_data["status"] = status.value
         stage_data["completed_at"] = now
         if metadata:
@@ -277,7 +297,7 @@ def initialize_onboarding(host: str, claw_name: str) -> bool:
     now = datetime.now(timezone.utc).isoformat()
 
     def updater(h: dict) -> dict:
-        h["claws"][claw_name]["onboarding"] = {
+        h["agents"][claw_name]["onboarding"] = {
             "state": OnboardingState.PENDING.value,
             "started_at": now,
             "stages": {

--- a/src/clawrium/core/registry.py
+++ b/src/clawrium/core/registry.py
@@ -48,11 +48,6 @@ def validate_agent_type(agent_type: str) -> None:
         )
 
 
-def validate_claw_name(claw_name: str) -> None:
-    """Backward-compatible wrapper around `validate_agent_type`."""
-    validate_agent_type(claw_name)
-
-
 class Requirements(TypedDict):
     """Runtime requirements for a supported platform entry."""
 

--- a/src/clawrium/core/secrets.py
+++ b/src/clawrium/core/secrets.py
@@ -245,8 +245,8 @@ def get_installed_claw(claw_name: str) -> tuple[str, str, str]:
     """Get installed claw details from hosts registry.
 
     Searches all hosts for a claw with matching name. Searches by:
-    1. The "name" field
-    2. The "user" field (claw system user)
+    1. The "agent_name" field
+    2. The "name" field (legacy)
     3. The claw_type key itself (e.g., "zeroclaw")
 
     Args:
@@ -263,14 +263,14 @@ def get_installed_claw(claw_name: str) -> tuple[str, str, str]:
     hosts = load_hosts()
     for host in hosts:
         hostname = host.get("hostname", "")
-        claws = host.get("claws", {})
-        for claw_type, claw_data in claws.items():
-            # Check name field, user field, or claw_type
+        agents = host.get("agents", {})
+        for claw_type, claw_data in agents.items():
+            # Check agent_name field, name field (legacy), or claw_type
+            agent_name = claw_data.get("agent_name")
             name = claw_data.get("name")
-            user = claw_data.get("user")
-            if claw_name in (name, user, claw_type):
-                # Return the canonical name (name > user > claw_type)
-                canonical_name = name or user or claw_type
+            if claw_name in (agent_name, name, claw_type):
+                # Return the canonical name (agent_name > name > claw_type)
+                canonical_name = agent_name or name or claw_type
                 return (hostname, claw_type, canonical_name)
 
     raise AgentNotFoundError(

--- a/src/clawrium/core/validation.py
+++ b/src/clawrium/core/validation.py
@@ -111,7 +111,7 @@ def validate_soul_md(claw_type: str) -> ValidationResult:
         ValidationResult with pass/fail status and any errors/warnings.
     """
     config_dir = get_config_dir()
-    soul_path = config_dir / "claws" / claw_type / "SOUL.md"
+    soul_path = config_dir / "agents" / claw_type / "SOUL.md"
 
     if not soul_path.exists():
         return ValidationResult(
@@ -659,8 +659,8 @@ def validate_agent_installation(host: str, claw_name: str) -> ValidationResult:
             errors=[f"Host '{host}' not found."],
         )
 
-    claws = host_data.get("claws", {})
-    claw_data = claws.get(claw_name)
+    agents = host_data.get("agents", {})
+    claw_data = agents.get(claw_name)
 
     if not claw_data:
         return ValidationResult(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def mock_ssh_config():
 
     # Mock lookup() to return sample SSH config
     mock_config.lookup = MagicMock(
-        return_value={"hostname": "192.168.1.100", "user": "xclm", "port": 22}
+        return_value={"hostname": "192.168.1.100", "agent_name": "xclm", "port": 22}
     )
 
     return mock_config
@@ -116,7 +116,7 @@ def sample_host_data():
         "hostname": "192.168.1.100",
         "key_id": "192.168.1.100",  # Key storage identifier
         "port": 22,
-        "user": "xclm",
+        "agent_name": "xclm",
         "auth_method": "key",
         "alias": "testhost",
         "hardware": {
@@ -188,13 +188,13 @@ def hosts_with_installed_claw(isolated_config):
             "hostname": "192.168.1.100",
             "alias": "server1",
             "port": 22,
-            "user": "xclm",
-            "claws": {
+            "agent_name": "xclm",
+            "agents": {
                 "openclaw": {
                     "version": "0.1.0",
                     "status": "installed",
                     "name": "work",
-                    "user": "opc-work",
+                    "agent_name": "opc-work",
                 }
             },
         }

--- a/tests/test_cli_agent.py
+++ b/tests/test_cli_agent.py
@@ -32,7 +32,7 @@ def create_host(
         "hostname": hostname,
         "key_id": key_id or hostname,
         "port": 22,
-        "user": "xclm",
+        "agent_name": "xclm",
         "auth_method": "key",
         "hardware": {
             "architecture": "x86_64",
@@ -140,7 +140,7 @@ def test_agent_ps_no_hosts():
 
 def test_agent_ps_no_claws():
     """clm agent ps with hosts but no claws shows message."""
-    hosts = [{"hostname": "192.168.1.100", "claws": {}}]
+    hosts = [{"hostname": "192.168.1.100", "agents": {}}]
 
     with patch("clawrium.cli.status.load_hosts", return_value=hosts):
         result = runner.invoke(app, ["agent", "ps"])

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -39,7 +39,7 @@ def create_host_with_claw(
             "hostname": hostname,
             "key_id": key_id,
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
             "alias": alias,
             "auth_method": "key",
             "hardware": {
@@ -57,12 +57,12 @@ def create_host_with_claw(
                 "last_seen": "2026-04-06T00:00:00Z",
                 "tags": [],
             },
-            "claws": {
+            "agents": {
                 claw_type: {
                     "version": "0.1.0",
                     "status": "installed",
                     "name": "assistant",
-                    "user": "assistant",
+                    "agent_name": "assistant",
                     "onboarding": {
                         "state": onboarding_state,
                         "started_at": "2026-04-06T00:00:00+00:00",
@@ -270,7 +270,7 @@ class TestAgentConfigureFullWizard:
         create_host_with_claw(isolated_config, onboarding_state="ready")
         hosts_file = isolated_config / "hosts.json"
         hosts_data = json.loads(hosts_file.read_text())
-        hosts_data[0]["claws"]["openclaw"]["onboarding"]["state"] = "ready"
+        hosts_data[0]["agents"]["openclaw"]["onboarding"]["state"] = "ready"
         hosts_file.write_text(json.dumps(hosts_data, indent=2))
 
         result = runner.invoke(
@@ -442,7 +442,7 @@ class TestRunIdentityStage:
             result = _run_identity_stage("work", "openclaw", True)
 
         assert result is True
-        soul_path = isolated_config / "claws" / "openclaw" / "SOUL.md"
+        soul_path = isolated_config / "agents" / "openclaw" / "SOUL.md"
         assert soul_path.exists()
 
 
@@ -483,12 +483,12 @@ class TestRunValidateStage:
 
         hosts_file = isolated_config / "hosts.json"
         hosts_data = json.loads(hosts_file.read_text())
-        hosts_data[0]["claws"]["openclaw"]["onboarding"]["stages"]["providers"][
+        hosts_data[0]["agents"]["openclaw"]["onboarding"]["stages"]["providers"][
             "provider_id"
         ] = "test-openai"
         hosts_file.write_text(json.dumps(hosts_data, indent=2))
 
-        soul_dir = isolated_config / "claws" / "openclaw"
+        soul_dir = isolated_config / "agents" / "openclaw"
         soul_dir.mkdir(parents=True)
         (soul_dir / "SOUL.md").write_text("Test personality")
 
@@ -529,7 +529,7 @@ class TestRunValidateStage:
 
         hosts_file = isolated_config / "hosts.json"
         hosts_data = json.loads(hosts_file.read_text())
-        hosts_data[0]["claws"]["openclaw"]["onboarding"]["stages"]["providers"][
+        hosts_data[0]["agents"]["openclaw"]["onboarding"]["stages"]["providers"][
             "provider_id"
         ] = "test-openai"
         hosts_file.write_text(json.dumps(hosts_data, indent=2))
@@ -549,12 +549,12 @@ class TestRunValidateStage:
 
         hosts_file = isolated_config / "hosts.json"
         hosts_data = json.loads(hosts_file.read_text())
-        hosts_data[0]["claws"]["openclaw"]["onboarding"]["stages"]["providers"][
+        hosts_data[0]["agents"]["openclaw"]["onboarding"]["stages"]["providers"][
             "provider_id"
         ] = "test-openai"
         hosts_file.write_text(json.dumps(hosts_data, indent=2))
 
-        soul_dir = isolated_config / "claws" / "openclaw"
+        soul_dir = isolated_config / "agents" / "openclaw"
         soul_dir.mkdir(parents=True)
         (soul_dir / "SOUL.md").write_text("Test personality")
 
@@ -596,7 +596,7 @@ class TestRunValidateStage:
                 "hostname": "192.168.1.100",
                 "key_id": "work",
                 "alias": "work",
-                "claws": {
+                "agents": {
                     "openclaw": {
                         "version": "0.1.0",
                         "status": "installed",
@@ -615,7 +615,7 @@ class TestRunValidateStage:
         ]
         hosts_file.write_text(json.dumps(hosts_data))
 
-        soul_dir = isolated_config / "claws" / "openclaw"
+        soul_dir = isolated_config / "agents" / "openclaw"
         soul_dir.mkdir(parents=True)
         (soul_dir / "SOUL.md").write_text("Test personality")
 

--- a/tests/test_cli_agent_lifecycle.py
+++ b/tests/test_cli_agent_lifecycle.py
@@ -26,7 +26,7 @@ def create_host_with_ready_claw(
             "hostname": hostname,
             "key_id": alias,
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
             "alias": alias,
             "auth_method": "key",
             "hardware": {
@@ -44,11 +44,11 @@ def create_host_with_ready_claw(
                 "last_seen": "2026-04-07T00:00:00Z",
                 "tags": [],
             },
-            "claws": {
+            "agents": {
                 claw_type: {
                     "version": "2026.4.2",
                     "status": "installed",
-                    "user": "assistant",
+                    "agent_name": "assistant",
                     "onboarding": {
                         "state": "ready",
                         "started_at": "2026-04-07T00:00:00Z",
@@ -93,7 +93,7 @@ class TestAgentStart:
                 "hostname": "192.168.1.100",
                 "alias": "work",
                 "key_id": "work",
-                "claws": {},
+                "agents": {},
             }
         ]
         hosts_file.write_text(json.dumps(hosts_data, indent=2))
@@ -112,9 +112,9 @@ class TestAgentStart:
                 "hostname": "192.168.1.100",
                 "alias": "work",
                 "key_id": "work",
-                "claws": {
+                "agents": {
                     "openclaw": {
-                        "user": "assistant",
+                        "agent_name": "assistant",
                         "onboarding": {"state": "pending"},
                     }
                 },
@@ -164,11 +164,11 @@ class TestAgentStart:
                 "hostname": "192.168.1.100",
                 "alias": "work",
                 "key_id": "work",
-                "user": "xclm",
+                "agent_name": "xclm",
                 "port": 22,
-                "claws": {
+                "agents": {
                     "openclaw": {
-                        "user": "assistant",
+                        "agent_name": "assistant",
                         "onboarding": {"state": "pending"},
                     }
                 },
@@ -225,7 +225,7 @@ class TestAgentStop:
                 "hostname": "192.168.1.100",
                 "alias": "work",
                 "key_id": "work",
-                "claws": {},
+                "agents": {},
             }
         ]
         hosts_file.write_text(json.dumps(hosts_data, indent=2))

--- a/tests/test_cli_agent_remove.py
+++ b/tests/test_cli_agent_remove.py
@@ -30,18 +30,18 @@ def host_with_claw(isolated_config: Path) -> tuple[Path, str, str]:
             "alias": alias,
             "key_id": "testhost",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
             "auth_method": "key",
             "hardware": {
                 "architecture": "x86_64",
                 "processor_cores": 4,
                 "memtotal_mb": 8192,
             },
-            "claws": {
+            "agents": {
                 claw_name: {
                     "version": "1.0.0",
                     "status": "installed",
-                    "user": "opc-testhost",
+                    "agent_name": "opc-testhost",
                     "installed_at": "2026-04-01T00:00:00Z",
                     "runtime": {"status": "stopped"},
                 }
@@ -189,7 +189,7 @@ def test_agent_remove_with_running_claw(host_with_claw: tuple[Path, str, str]):
     # Update claw to be running
     hosts_file = config / "hosts.json"
     hosts = json.loads(hosts_file.read_text())
-    hosts[0]["claws"][claw_name]["runtime"]["status"] = "running"
+    hosts[0]["agents"][claw_name]["runtime"]["status"] = "running"
     hosts_file.write_text(json.dumps(hosts, indent=2))
 
     with patch("clawrium.core.lifecycle.remove_agent") as mock_remove:

--- a/tests/test_cli_agent_start.py
+++ b/tests/test_cli_agent_start.py
@@ -29,7 +29,7 @@ def create_host_with_claw(
             "hostname": hostname,
             "key_id": key_id,
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
             "alias": alias,
             "auth_method": "key",
             "hardware": {
@@ -47,12 +47,12 @@ def create_host_with_claw(
                 "last_seen": "2026-04-06T00:00:00Z",
                 "tags": [],
             },
-            "claws": {
+            "agents": {
                 claw_type: {
                     "version": "0.1.0",
                     "status": "installed",
                     "name": "assistant",
-                    "user": "assistant",
+                    "agent_name": "assistant",
                     "onboarding": {
                         "state": onboarding_state,
                         "started_at": "2026-04-06T00:00:00+00:00",
@@ -264,7 +264,7 @@ def test_start_claw_not_installed_fails(isolated_config: Path):
             "alias": "work",
             "key_id": "work",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
             "auth_method": "key",
             "hardware": {
                 "architecture": "x86_64",
@@ -281,7 +281,7 @@ def test_start_claw_not_installed_fails(isolated_config: Path):
                 "last_seen": "2026-04-06T00:00:00Z",
                 "tags": [],
             },
-            "claws": {},
+            "agents": {},
         }
     ]
 
@@ -317,7 +317,7 @@ def test_start_missing_onboarding_initializes(isolated_config: Path):
             "alias": "work",
             "key_id": "work",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
             "auth_method": "key",
             "hardware": {
                 "architecture": "x86_64",
@@ -334,12 +334,12 @@ def test_start_missing_onboarding_initializes(isolated_config: Path):
                 "last_seen": "2026-04-06T00:00:00Z",
                 "tags": [],
             },
-            "claws": {
+            "agents": {
                 "openclaw": {
                     "version": "0.1.0",
                     "status": "installed",
                     "name": "assistant",
-                    "user": "assistant",
+                    "agent_name": "assistant",
                 }
             },
         }
@@ -379,7 +379,7 @@ def test_start_claw_not_found_during_initialization(isolated_config: Path):
             "alias": "work",
             "key_id": "work",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
             "auth_method": "key",
             "hardware": {
                 "architecture": "x86_64",
@@ -396,12 +396,12 @@ def test_start_claw_not_found_during_initialization(isolated_config: Path):
                 "last_seen": "2026-04-06T00:00:00Z",
                 "tags": [],
             },
-            "claws": {
+            "agents": {
                 "openclaw": {
                     "version": "0.1.0",
                     "status": "installed",
                     "name": "assistant",
-                    "user": "assistant",
+                    "agent_name": "assistant",
                 }
             },
         }

--- a/tests/test_cli_host.py
+++ b/tests/test_cli_host.py
@@ -324,7 +324,7 @@ def test_host_ps_uses_key_id(isolated_config: Path, mock_ssh_client):
         "alias": "myserver",  # Need alias so get_host can find it
         "key_id": "myserver",
         "port": 22,
-        "user": "xclm",
+        "agent_name": "xclm",
         "auth_method": "key",
         "hardware": {},
         "metadata": {"added_at": "2026-03-21", "last_seen": "2026-03-21", "tags": []},
@@ -356,7 +356,7 @@ def test_host_remove_uses_key_id(isolated_config: Path):
         "alias": "myserver",
         "key_id": "myserver",  # Keys stored here, not under hostname
         "port": 22,
-        "user": "xclm",
+        "agent_name": "xclm",
         "auth_method": "key",
         "hardware": {},
         "metadata": {"added_at": "2026-03-21", "last_seen": "2026-03-21", "tags": []},

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -32,7 +32,7 @@ def create_host(
         "hostname": hostname,
         "key_id": key_id or hostname,
         "port": 22,
-        "user": "xclm",
+        "agent_name": "xclm",
         "auth_method": "key",
         "hardware": {
             "architecture": "x86_64",
@@ -240,7 +240,7 @@ def test_install_incompatible_exits_1(isolated_config: Path):
         "alias": "armhost",
         "key_id": "armhost",
         "port": 22,
-        "user": "xclm",
+        "agent_name": "xclm",
         "auth_method": "key",
         "hardware": {
             "architecture": "aarch64",  # OpenClaw requires x86_64

--- a/tests/test_cli_secret.py
+++ b/tests/test_cli_secret.py
@@ -33,7 +33,7 @@ def test_secret_set_creates_new(hosts_with_installed_claw: Path):
     secrets_file = hosts_with_installed_claw / "secrets.json"
     assert secrets_file.exists()
     secrets = json.loads(secrets_file.read_text())
-    instance_key = "192.168.1.100:openclaw:work"
+    instance_key = "192.168.1.100:openclaw:opc-work"
     assert instance_key in secrets
     assert "TEST_KEY" in secrets[instance_key]
     assert secrets[instance_key]["TEST_KEY"]["value"] == "my-secret-value"
@@ -61,7 +61,7 @@ def test_secret_set_with_description(hosts_with_installed_claw: Path):
     # Verify description was stored
     secrets_file = hosts_with_installed_claw / "secrets.json"
     secrets = json.loads(secrets_file.read_text())
-    instance_key = "192.168.1.100:openclaw:work"
+    instance_key = "192.168.1.100:openclaw:opc-work"
     assert secrets[instance_key]["API_KEY"]["description"] == "My API key"
 
 
@@ -88,7 +88,7 @@ def test_secret_set_update_existing(hosts_with_installed_claw: Path):
     # Verify value unchanged
     secrets_file = hosts_with_installed_claw / "secrets.json"
     secrets = json.loads(secrets_file.read_text())
-    instance_key = "192.168.1.100:openclaw:work"
+    instance_key = "192.168.1.100:openclaw:opc-work"
     assert secrets[instance_key]["EXISTING_KEY"]["value"] == "old-value"
 
 
@@ -115,7 +115,7 @@ def test_secret_set_update_confirmed(hosts_with_installed_claw: Path):
     # Verify value changed
     secrets_file = hosts_with_installed_claw / "secrets.json"
     secrets = json.loads(secrets_file.read_text())
-    instance_key = "192.168.1.100:openclaw:work"
+    instance_key = "192.168.1.100:openclaw:opc-work"
     assert secrets[instance_key]["EXISTING_KEY"]["value"] == "new-value"
 
 
@@ -137,7 +137,7 @@ def test_secret_set_yes_flag_skips_confirmation(hosts_with_installed_claw: Path)
     # Verify value changed
     secrets_file = hosts_with_installed_claw / "secrets.json"
     secrets = json.loads(secrets_file.read_text())
-    instance_key = "192.168.1.100:openclaw:work"
+    instance_key = "192.168.1.100:openclaw:opc-work"
     assert secrets[instance_key]["KEY"]["value"] == "new-value"
 
 
@@ -332,7 +332,7 @@ def test_secret_remove_prompts_confirmation(hosts_with_installed_claw: Path):
     # Verify secret still exists
     secrets_file = hosts_with_installed_claw / "secrets.json"
     secrets = json.loads(secrets_file.read_text())
-    instance_key = "192.168.1.100:openclaw:work"
+    instance_key = "192.168.1.100:openclaw:opc-work"
     assert "TO_REMOVE" in secrets[instance_key]
 
 
@@ -358,7 +358,7 @@ def test_secret_remove_confirmed(hosts_with_installed_claw: Path):
     # Verify secret was removed
     secrets_file = hosts_with_installed_claw / "secrets.json"
     secrets = json.loads(secrets_file.read_text())
-    instance_key = "192.168.1.100:openclaw:work"
+    instance_key = "192.168.1.100:openclaw:opc-work"
     # Instance key should be removed entirely since it has no secrets
     assert instance_key not in secrets
 
@@ -384,7 +384,7 @@ def test_secret_remove_force_skips_confirmation(hosts_with_installed_claw: Path)
     # Verify secret was removed
     secrets_file = hosts_with_installed_claw / "secrets.json"
     secrets = json.loads(secrets_file.read_text())
-    instance_key = "192.168.1.100:openclaw:work"
+    instance_key = "192.168.1.100:openclaw:opc-work"
     assert instance_key not in secrets
 
 
@@ -409,11 +409,10 @@ def test_secret_set_with_claw(isolated_config: Path):
             {
                 "hostname": "wolf",
                 "alias": "wolf",
-                "claws": {
+                "agents": {
                     "openclaw": {
-                        "name": "opc-work",
                         "status": "installed",
-                        "user": "opc-work",
+                        "agent_name": "opc-work",
                     }
                 },
             }
@@ -464,11 +463,10 @@ def test_secret_set_with_claw_update_confirmed(isolated_config: Path):
             {
                 "hostname": "wolf",
                 "alias": "wolf",
-                "claws": {
+                "agents": {
                     "openclaw": {
-                        "name": "opc-work",
                         "status": "installed",
-                        "user": "opc-work",
+                        "agent_name": "opc-work",
                     }
                 },
             }
@@ -508,22 +506,20 @@ def test_secret_list_per_claw(isolated_config: Path):
             {
                 "hostname": "wolf",
                 "alias": "wolf",
-                "claws": {
+                "agents": {
                     "openclaw": {
-                        "name": "opc-work",
                         "status": "installed",
-                        "user": "opc-work",
+                        "agent_name": "opc-work",
                     }
                 },
             },
             {
                 "hostname": "bear",
                 "alias": "bear",
-                "claws": {
+                "agents": {
                     "openclaw": {
-                        "name": "opc-personal",
                         "status": "installed",
-                        "user": "opc-personal",
+                        "agent_name": "opc-personal",
                     }
                 },
             },
@@ -565,11 +561,10 @@ def test_secret_list_shows_missing_required(isolated_config: Path):
             {
                 "hostname": "wolf",
                 "alias": "wolf",
-                "claws": {
+                "agents": {
                     "openclaw": {
-                        "name": "opc-work",
                         "status": "installed",
-                        "user": "opc-work",
+                        "agent_name": "opc-work",
                     }
                 },
             }
@@ -610,11 +605,10 @@ def test_secret_remove_with_claw(isolated_config: Path):
             {
                 "hostname": "wolf",
                 "alias": "wolf",
-                "claws": {
+                "agents": {
                     "openclaw": {
-                        "name": "opc-work",
                         "status": "installed",
-                        "user": "opc-work",
+                        "agent_name": "opc-work",
                     }
                 },
             }

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -19,14 +19,14 @@ def mock_hosts_with_claws():
             "hostname": "192.168.1.100",
             "alias": "server1",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
             "key_id": "server1",
-            "claws": {
+            "agents": {
                 "openclaw": {
                     "version": "0.1.0",
                     "status": "installed",
                     "installed_at": "2026-03-21T10:00:00Z",
-                    "user": "opc-server1",
+                    "agent_name": "opc-server1",
                 }
             },
         },
@@ -34,14 +34,14 @@ def mock_hosts_with_claws():
             "hostname": "192.168.1.101",
             "alias": "server2",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
             "key_id": "server2",
-            "claws": {
+            "agents": {
                 "openclaw": {
                     "version": "0.1.0",
                     "status": "installed",
                     "installed_at": "2026-03-21T11:00:00Z",
-                    "user": "opc-server2",
+                    "agent_name": "opc-server2",
                 }
             },
         },
@@ -59,7 +59,7 @@ def test_status_no_hosts():
 
 def test_status_no_claws():
     """Hosts with no claws shows install message."""
-    hosts = [{"hostname": "192.168.1.100", "claws": {}}]
+    hosts = [{"hostname": "192.168.1.100", "agents": {}}]
 
     with patch("clawrium.cli.status.load_hosts", return_value=hosts):
         result = runner.invoke(app, ["ps"])
@@ -75,7 +75,7 @@ def test_status_shows_claw_table(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.RUNNING,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -101,7 +101,7 @@ def test_status_shows_running_status(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.RUNNING,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -124,7 +124,7 @@ def test_status_shows_stopped_status(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.STOPPED,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -147,7 +147,7 @@ def test_status_host_filter(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.RUNNING,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -181,12 +181,12 @@ def test_status_shows_failed_install():
         {
             "hostname": "192.168.1.100",
             "alias": "server1",
-            "claws": {
+            "agents": {
                 "openclaw": {
                     "version": "0.1.0",
                     "status": "failed",
                     "error": "Playbook failed",
-                    "user": "opc-server1",
+                    "agent_name": "opc-server1",
                 }
             },
         }
@@ -198,7 +198,7 @@ def test_status_shows_failed_install():
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.STOPPED,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -220,11 +220,11 @@ def test_status_shows_installing_status():
         {
             "hostname": "192.168.1.100",
             "alias": "server1",
-            "claws": {
+            "agents": {
                 "openclaw": {
                     "version": "0.1.0",
                     "status": "installing",
-                    "user": "opc-server1",
+                    "agent_name": "opc-server1",
                 }
             },
         }
@@ -235,7 +235,7 @@ def test_status_shows_installing_status():
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.UNKNOWN,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -273,7 +273,7 @@ def test_status_shows_degraded_with_missing_secrets(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.DEGRADED,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
             "onboarding_step": None,
@@ -299,7 +299,7 @@ def test_status_degraded_truncates_long_list(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.DEGRADED,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": ["KEY1", "KEY2", "KEY3", "KEY4", "KEY5"],
             "onboarding_step": None,
@@ -330,7 +330,7 @@ def test_status_shows_pending_onboard(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.PENDING_ONBOARD,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -354,7 +354,7 @@ def test_status_shows_onboarding_with_step(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.ONBOARDING,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": "2/4",
@@ -390,7 +390,7 @@ def test_status_shows_onboarding_without_step(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.ONBOARDING,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -415,7 +415,7 @@ def test_status_shows_ready_stopped(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.READY,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -443,7 +443,7 @@ def test_status_verbose_flag_accepted(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.RUNNING,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -470,7 +470,7 @@ def test_status_verbose_shows_onboarding_stages(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.ONBOARDING,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": "2/4",
@@ -508,7 +508,7 @@ def test_status_verbose_shows_stage_completion_dates(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.ONBOARDING,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": "2/4",
@@ -540,7 +540,7 @@ def test_status_verbose_pending_onboard(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.PENDING_ONBOARD,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -570,7 +570,7 @@ def test_status_verbose_no_stages_for_running(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.RUNNING,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -596,7 +596,7 @@ def test_status_shows_completed_stage_count(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.ONBOARDING,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": "2/4",
@@ -632,7 +632,7 @@ def test_status_verbose_ready_status(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.READY,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": None,
@@ -677,7 +677,7 @@ def test_status_verbose_no_onboarding_stages(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.ONBOARDING,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": "1/4",
@@ -701,7 +701,7 @@ def test_status_verbose_short_alias(mock_hosts_with_claws):
             "agent": "openclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.ONBOARDING,
-            "user": "opc-server1",
+            "agent_name": "opc-server1",
             "error": None,
             "missing_secrets": None,
             "onboarding_step": "1/4",

--- a/tests/test_configure_claw.py
+++ b/tests/test_configure_claw.py
@@ -21,7 +21,7 @@ class TestConfigureClaw:
 
     def test_raises_error_when_claw_not_installed(self):
         """Test that LifecycleError is raised when claw not installed."""
-        host = {"hostname": "test-host", "claws": {}}
+        host = {"hostname": "test-host", "agents": {}}
 
         with patch("clawrium.core.lifecycle.get_host", return_value=host):
             with pytest.raises(LifecycleError) as exc_info:
@@ -33,7 +33,7 @@ class TestConfigureClaw:
         """Test that invalid Ollama model names are rejected."""
         host = {
             "hostname": "test-host",
-            "claws": {"zeroclaw": {"user": "zer-test"}},
+            "agents": {"zeroclaw": {"agent_name": "zer-test"}},
         }
         config_data = {
             "provider": {
@@ -53,9 +53,9 @@ class TestConfigureClaw:
         host = {
             "hostname": "test-host",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {"zeroclaw": {"user": "zer-test"}},
+            "agents": {"zeroclaw": {"agent_name": "zer-test"}},
         }
         config_data = {"gateway": {"host": "0.0.0.0", "port": 40000}}
 
@@ -96,7 +96,7 @@ class TestConfigureClaw:
         """Test that missing configure playbook is detected."""
         host = {
             "hostname": "test-host",
-            "claws": {"zeroclaw": {"user": "zer-test"}},
+            "agents": {"zeroclaw": {"agent_name": "zer-test"}},
         }
         config_data = {"gateway": {"host": "0.0.0.0", "port": 40000}}
 
@@ -119,7 +119,7 @@ class TestConfigureClaw:
         host = {
             "hostname": "test-host",
             "key_id": "test",
-            "claws": {"zeroclaw": {"user": "zer-test"}},
+            "agents": {"zeroclaw": {"agent_name": "zer-test"}},
         }
         config_data = {"gateway": {"host": "0.0.0.0", "port": 40000}}
 
@@ -144,7 +144,7 @@ class TestConfigureClaw:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "claws": {"zeroclaw": {"user": "Invalid User!"}},
+            "agents": {"zeroclaw": {"agent_name": "Invalid User!"}},
         }
         config_data = {"gateway": {"host": "0.0.0.0", "port": 40000}}
 
@@ -173,9 +173,9 @@ class TestConfigureClaw:
         host = {
             "hostname": "test-host",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {"zeroclaw": {"user": "zer-test"}},
+            "agents": {"zeroclaw": {"agent_name": "zer-test"}},
         }
         config_data = {"gateway": {"host": "0.0.0.0", "port": 40000}}
 
@@ -213,9 +213,9 @@ class TestConfigureClaw:
         host = {
             "hostname": "test-host",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {"zeroclaw": {"user": "zer-test"}},
+            "agents": {"zeroclaw": {"agent_name": "zer-test"}},
         }
         config_data = {"gateway": {"host": "0.0.0.0", "port": 40000}}
 
@@ -265,9 +265,9 @@ class TestConfigureClaw:
         host = {
             "hostname": "test-host",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {"zeroclaw": {"user": "zer-test"}},
+            "agents": {"zeroclaw": {"agent_name": "zer-test"}},
         }
         config_data = {
             "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},

--- a/tests/test_core_validation.py
+++ b/tests/test_core_validation.py
@@ -57,7 +57,7 @@ class TestValidateSoulMd:
 
     def test_soul_md_exists_and_readable(self, isolated_config: Path):
         """Returns success when SOUL.md exists and is readable."""
-        soul_dir = isolated_config / "claws" / "openclaw"
+        soul_dir = isolated_config / "agents" / "openclaw"
         soul_dir.mkdir(parents=True)
         (soul_dir / "SOUL.md").write_text("# OpenClaw Personality\n\nBe helpful.")
 
@@ -67,7 +67,7 @@ class TestValidateSoulMd:
 
     def test_soul_md_empty_warning(self, isolated_config: Path):
         """Returns warning when SOUL.md is empty."""
-        soul_dir = isolated_config / "claws" / "openclaw"
+        soul_dir = isolated_config / "agents" / "openclaw"
         soul_dir.mkdir(parents=True)
         (soul_dir / "SOUL.md").write_text("")
 
@@ -78,7 +78,7 @@ class TestValidateSoulMd:
 
     def test_soul_md_large_warning(self, isolated_config: Path):
         """Returns warning when SOUL.md is larger than 10KB."""
-        soul_dir = isolated_config / "claws" / "openclaw"
+        soul_dir = isolated_config / "agents" / "openclaw"
         soul_dir.mkdir(parents=True)
         (soul_dir / "SOUL.md").write_text("x" * 11000)
 
@@ -98,7 +98,7 @@ class TestValidateProviderConfig:
         hosts_data = [
             {
                 "hostname": "192.168.1.100",
-                "claws": {
+                "agents": {
                     "openclaw": {
                         "onboarding": {
                             "state": "validate",
@@ -130,7 +130,7 @@ class TestValidateProviderConfig:
         hosts_data = [
             {
                 "hostname": "192.168.1.100",
-                "claws": {
+                "agents": {
                     "openclaw": {
                         "onboarding": {
                             "state": "validate",
@@ -158,7 +158,7 @@ class TestValidateProviderConfig:
         hosts_data = [
             {
                 "hostname": "192.168.1.100",
-                "claws": {
+                "agents": {
                     "openclaw": {
                         "onboarding": {
                             "state": "validate",
@@ -484,7 +484,7 @@ class TestValidateAgentInstallation:
         """Returns failure when claw not installed."""
         isolated_config.mkdir(parents=True, exist_ok=True)
         hosts_file = isolated_config / "hosts.json"
-        hosts_data = [{"hostname": "192.168.1.100", "claws": {}}]
+        hosts_data = [{"hostname": "192.168.1.100", "agents": {}}]
         hosts_file.write_text(json.dumps(hosts_data))
 
         result = validate_agent_installation("192.168.1.100", "openclaw")
@@ -501,7 +501,7 @@ class TestValidateAgentInstallation:
         hosts_data = [
             {
                 "hostname": "192.168.1.100",
-                "claws": {
+                "agents": {
                     "openclaw": {
                         "version": "0.1.0",
                         "status": "installed",

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -12,6 +12,7 @@ from clawrium.core.health import (
     ClawStatus,
     ONBOARDING_STEP_MAP,
 )
+from clawrium.core.secrets import SecretsFileCorruptedError
 
 
 @pytest.fixture
@@ -20,13 +21,13 @@ def mock_host():
     return {
         "hostname": "192.168.1.100",
         "port": 22,
-        "user": "xclm",
+        "agent_name": "xclm",
         "key_id": "testhost",
-        "claws": {
+        "agents": {
             "openclaw": {
                 "version": "0.1.0",
                 "status": "installed",
-                "user": "opc-testhost",
+                "agent_name": "opc-testhost",
             }
         },
     }
@@ -46,7 +47,7 @@ def test_health_check_running(mock_host):
 
     assert result["status"] == ClawStatus.RUNNING
     assert result["agent"] == "openclaw"
-    assert result["user"] == "opc-testhost"
+    assert result["agent_name"] == "opc-testhost"
     assert result["error"] is None
     assert result["missing_secrets"] is None
     assert result["onboarding_step"] is None
@@ -134,11 +135,27 @@ def test_check_all_claws_on_host(mock_host):
     assert results[0]["onboarding_step"] is None
 
 
+def test_health_check_never_modifies_state(mock_host):
+    """Health checks are read-only operations and never call update_host."""
+    mock_runner = MagicMock()
+    mock_runner.status = "successful"
+    mock_runner.events = [{"event": "runner_on_ok", "event_data": {"res": {"rc": 0}}}]
+
+    with patch("clawrium.core.health.get_host_private_key", return_value="/fake/key"):
+        with patch("clawrium.core.health.ansible_runner.run", return_value=mock_runner):
+            with patch("clawrium.core.health.get_required_secrets", return_value=[]):
+                with patch("clawrium.core.hosts.update_host") as mock_update:
+                    check_claw_health("openclaw", mock_host)
+
+    # Assert health check never modifies persisted state
+    assert mock_update.call_count == 0
+
+
 def test_health_check_no_claw_user():
     """Missing claw user returns UNKNOWN status with error."""
     host = {
         "hostname": "192.168.1.100",
-        "claws": {
+        "agents": {
             "openclaw": {
                 "version": "0.1.0",
                 "status": "installed",
@@ -153,15 +170,35 @@ def test_health_check_no_claw_user():
     assert "No claw user recorded" in result["error"]
 
 
+def test_health_check_corrupted_host_data():
+    """Corrupted host data (missing hostname) returns UNKNOWN status."""
+    # Malformed host missing critical fields
+    corrupted_host = {
+        "agents": {
+            "openclaw": {
+                "version": "0.1.0",
+                "status": "installed",
+                "agent_name": "opc-test",
+            }
+        }
+        # Missing "hostname" field
+    }
+
+    result = check_claw_health("openclaw", corrupted_host)
+
+    assert result["status"] == ClawStatus.UNKNOWN
+    assert result["error"] is not None
+
+
 def test_health_check_invalid_claw_user():
     """Invalid claw user format returns UNKNOWN status with error."""
     host = {
         "hostname": "192.168.1.100",
-        "claws": {
+        "agents": {
             "openclaw": {
                 "version": "0.1.0",
                 "status": "installed",
-                "user": "root; rm -rf /",  # Command injection attempt
+                "agent_name": "root; rm -rf /",  # Command injection attempt
             }
         },
     }
@@ -211,7 +248,7 @@ def test_claw_status_degraded_exists():
 
 
 def test_health_result_has_missing_secrets_field(mock_host):
-    """HealthResult includes missing_secrets field in return."""
+    """HealthResult includes missing_secrets field with None when no required secrets."""
     mock_runner = MagicMock()
     mock_runner.status = "successful"
     mock_runner.events = [{"event": "runner_on_ok", "event_data": {"res": {"rc": 0}}}]
@@ -227,8 +264,9 @@ def test_health_result_has_missing_secrets_field(mock_host):
                 ):
                     result = check_claw_health("openclaw", mock_host)
 
-    # Check field exists
-    assert "missing_secrets" in result
+    # Assert exact value: None when running with no required secrets
+    assert result["missing_secrets"] is None
+    assert result["status"] == ClawStatus.RUNNING
 
 
 def test_check_claw_health_degraded_when_missing_secrets(mock_host):
@@ -342,6 +380,34 @@ def test_check_claw_health_degraded_partial_secrets(mock_host):
     assert result["missing_secrets"] == ["ANTHROPIC_API_KEY"]
 
 
+def test_check_claw_health_corrupted_secrets_file(mock_host):
+    """Corrupted secrets file returns DEGRADED status with error message."""
+    mock_runner = MagicMock()
+    mock_runner.status = "successful"
+    mock_runner.events = [{"event": "runner_on_ok", "event_data": {"res": {"rc": 0}}}]
+
+    # Mock required secrets for openclaw
+    required_secrets = [{"key": "OPENAI_API_KEY", "description": "OpenAI API key"}]
+
+    with patch("clawrium.core.health.get_host_private_key", return_value="/fake/key"):
+        with patch("clawrium.core.health.ansible_runner.run", return_value=mock_runner):
+            # Mock get_instance_secrets to raise SecretsFileCorruptedError
+            with patch(
+                "clawrium.core.health.get_instance_secrets",
+                side_effect=SecretsFileCorruptedError("Secrets file is corrupted"),
+            ):
+                with patch(
+                    "clawrium.core.health.get_required_secrets",
+                    return_value=required_secrets,
+                ):
+                    result = check_claw_health("openclaw", mock_host)
+
+    # Should return DEGRADED with error message, not crash
+    assert result["status"] == ClawStatus.DEGRADED
+    assert result["error"] is not None
+    assert "corrupted" in result["error"].lower()
+
+
 def test_missing_secrets_none_for_non_running_status(mock_host):
     """Non-running status has missing_secrets as None."""
     mock_runner = MagicMock()
@@ -366,25 +432,25 @@ class TestGetMissingSecrets:
     """Tests for get_missing_secrets function - core Phase 06 logic."""
 
     def test_claw_name_from_record_name_field(self):
-        """Uses claw name from 'name' field when available."""
+        """Uses agent name from 'agent_name' field (canonical field)."""
         host = {"hostname": "192.168.1.100"}
-        claw_record = {"name": "work", "user": "opc-work"}
+        claw_record = {"name": "work", "agent_name": "opc-work"}
 
         with patch("clawrium.core.health.get_instance_key") as mock_key:
-            mock_key.return_value = "192.168.1.100:openclaw:work"
+            mock_key.return_value = "192.168.1.100:openclaw:opc-work"
             with patch("clawrium.core.health.get_instance_secrets", return_value={}):
                 with patch(
                     "clawrium.core.health.get_required_secrets", return_value=[]
                 ):
                     get_missing_secrets("openclaw", host, claw_record)
 
-        # Verify instance key was built with correct claw_name
-        mock_key.assert_called_once_with("192.168.1.100", "openclaw", "work")
+        # Verify instance key was built with correct agent_name
+        mock_key.assert_called_once_with("192.168.1.100", "openclaw", "opc-work")
 
     def test_claw_name_derived_from_user_fallback(self):
         """Falls back to using user field directly."""
         host = {"hostname": "192.168.1.100"}
-        claw_record = {"user": "opc-work"}  # No 'name' field
+        claw_record = {"agent_name": "opc-work"}  # No 'name' field
 
         with patch("clawrium.core.health.get_instance_key") as mock_key:
             mock_key.return_value = "192.168.1.100:openclaw:opc-work"
@@ -400,7 +466,7 @@ class TestGetMissingSecrets:
     def test_multi_hyphen_claw_name(self):
         """Preserves multi-hyphen user names exactly."""
         host = {"hostname": "192.168.1.100"}
-        claw_record = {"user": "opc-my-claw"}  # Multi-hyphen
+        claw_record = {"agent_name": "opc-my-claw"}  # Multi-hyphen
 
         with patch("clawrium.core.health.get_instance_key") as mock_key:
             mock_key.return_value = "192.168.1.100:openclaw:opc-my-claw"
@@ -416,7 +482,7 @@ class TestGetMissingSecrets:
     def test_no_hyphen_fallback(self):
         """Handles user names without hyphen (uses full name)."""
         host = {"hostname": "192.168.1.100"}
-        claw_record = {"user": "simpleuser"}  # No hyphen
+        claw_record = {"agent_name": "simpleuser"}  # No hyphen
 
         with patch("clawrium.core.health.get_instance_key") as mock_key:
             mock_key.return_value = "192.168.1.100:openclaw:simpleuser"
@@ -432,7 +498,7 @@ class TestGetMissingSecrets:
     def test_empty_user_string_returns_empty(self):
         """Returns empty list when claw name cannot be determined."""
         host = {"hostname": "192.168.1.100"}
-        claw_record = {"user": ""}  # Empty user, no name field
+        claw_record = {"agent_name": ""}  # Empty user, no name field
 
         result = get_missing_secrets("openclaw", host, claw_record)
 
@@ -450,7 +516,7 @@ class TestGetMissingSecrets:
     def test_returns_missing_secrets(self):
         """Returns list of missing required secrets."""
         host = {"hostname": "192.168.1.100"}
-        claw_record = {"name": "work", "user": "opc-work"}
+        claw_record = {"name": "work", "agent_name": "opc-work"}
 
         required = [
             {"key": "OPENAI_API_KEY", "description": "OpenAI key"},
@@ -473,7 +539,7 @@ class TestGetMissingSecrets:
     def test_returns_empty_when_all_present(self):
         """Returns empty list when all required secrets are present."""
         host = {"hostname": "192.168.1.100"}
-        claw_record = {"name": "work", "user": "opc-work"}
+        claw_record = {"name": "work", "agent_name": "opc-work"}
 
         required = [{"key": "OPENAI_API_KEY", "description": "OpenAI key"}]
         instance_secrets = {
@@ -545,7 +611,7 @@ class TestGetOnboardingStatus:
 
     def test_no_onboarding_record_returns_pending_onboard(self):
         """Missing onboarding record returns PENDING_ONBOARD for backward compatibility."""
-        claw_record = {"version": "0.1.0", "user": "opc-test"}
+        claw_record = {"version": "0.1.0", "agent_name": "opc-test"}
         status, step = get_onboarding_status(claw_record)
         assert status == ClawStatus.PENDING_ONBOARD
         assert step is None
@@ -623,6 +689,14 @@ class TestGetOnboardingStatus:
         assert status == ClawStatus.PENDING_ONBOARD
         assert step is None
 
+    def test_malformed_stages_data_returns_pending_onboard(self):
+        """Malformed stages (string instead of dict) returns PENDING_ONBOARD gracefully."""
+        claw_record = {"onboarding": {"state": "providers", "stages": "malformed-string"}}
+        status, step = get_onboarding_status(claw_record)
+        # Should handle gracefully - return ONBOARDING with step based on state
+        assert status == ClawStatus.ONBOARDING
+        assert step == "1/4"
+
 
 class TestOnboardingStepMap:
     """Tests for ONBOARDING_STEP_MAP constant."""
@@ -648,13 +722,13 @@ class TestHealthCheckOnboardingIntegration:
         return {
             "hostname": "192.168.1.100",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
             "key_id": "testhost",
-            "claws": {
+            "agents": {
                 "openclaw": {
                     "version": "0.1.0",
                     "status": "installed",
-                    "user": "opc-testhost",
+                    "agent_name": "opc-testhost",
                     "onboarding": {
                         "state": "providers",
                         "started_at": "2026-04-06T00:00:00+00:00",
@@ -688,7 +762,7 @@ class TestHealthCheckOnboardingIntegration:
 
     def test_stopped_claw_in_identity_state(self, mock_host_with_onboarding):
         """Stopped claw in identity state returns ONBOARDING with step 2/4."""
-        mock_host_with_onboarding["claws"]["openclaw"]["onboarding"]["state"] = (
+        mock_host_with_onboarding["agents"]["openclaw"]["onboarding"]["state"] = (
             "identity"
         )
 
@@ -715,7 +789,7 @@ class TestHealthCheckOnboardingIntegration:
 
     def test_stopped_claw_in_channels_state(self, mock_host_with_onboarding):
         """Stopped claw in channels state returns ONBOARDING with step 3/4."""
-        mock_host_with_onboarding["claws"]["openclaw"]["onboarding"]["state"] = (
+        mock_host_with_onboarding["agents"]["openclaw"]["onboarding"]["state"] = (
             "channels"
         )
 
@@ -742,7 +816,7 @@ class TestHealthCheckOnboardingIntegration:
 
     def test_stopped_claw_in_validate_state(self, mock_host_with_onboarding):
         """Stopped claw in validate state returns ONBOARDING with step 4/4."""
-        mock_host_with_onboarding["claws"]["openclaw"]["onboarding"]["state"] = (
+        mock_host_with_onboarding["agents"]["openclaw"]["onboarding"]["state"] = (
             "validate"
         )
 
@@ -769,7 +843,7 @@ class TestHealthCheckOnboardingIntegration:
 
     def test_stopped_claw_in_ready_state(self, mock_host_with_onboarding):
         """Stopped claw in ready state returns READY."""
-        mock_host_with_onboarding["claws"]["openclaw"]["onboarding"]["state"] = "ready"
+        mock_host_with_onboarding["agents"]["openclaw"]["onboarding"]["state"] = "ready"
 
         mock_runner = MagicMock()
         mock_runner.status = "successful"
@@ -792,7 +866,7 @@ class TestHealthCheckOnboardingIntegration:
 
     def test_stopped_claw_in_pending_state(self, mock_host_with_onboarding):
         """Stopped claw in pending state returns PENDING_ONBOARD."""
-        mock_host_with_onboarding["claws"]["openclaw"]["onboarding"]["state"] = (
+        mock_host_with_onboarding["agents"]["openclaw"]["onboarding"]["state"] = (
             "pending"
         )
 
@@ -847,7 +921,7 @@ class TestHealthResultOnboardingStepField:
         """NOT_INSTALLED status has onboarding_step as None."""
         host = {
             "hostname": "192.168.1.100",
-            "claws": {},
+            "agents": {},
         }
         result = check_claw_health("openclaw", host)
         assert result["status"] == ClawStatus.NOT_INSTALLED
@@ -858,7 +932,7 @@ class TestHealthResultOnboardingStepField:
         """UNKNOWN status has onboarding_step as None."""
         host = {
             "hostname": "192.168.1.100",
-            "claws": {
+            "agents": {
                 "openclaw": {"version": "0.1.0", "status": "installed"}
                 # Missing user field
             },
@@ -877,13 +951,13 @@ class TestProcessRunningField:
         return {
             "hostname": "192.168.1.100",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
             "key_id": "testhost",
-            "claws": {
+            "agents": {
                 "openclaw": {
                     "version": "0.1.0",
                     "status": "installed",
-                    "user": "opc-testhost",
+                    "agent_name": "opc-testhost",
                 }
             },
         }
@@ -958,7 +1032,7 @@ class TestProcessRunningField:
 
     def test_ready_but_stopped_has_process_running_false(self, mock_host):
         """B2: READY status with stopped process has process_running=False."""
-        mock_host["claws"]["openclaw"]["onboarding"] = {"state": "ready"}
+        mock_host["agents"]["openclaw"]["onboarding"] = {"state": "ready"}
 
         mock_runner = MagicMock()
         mock_runner.status = "successful"
@@ -980,7 +1054,7 @@ class TestProcessRunningField:
 
     def test_not_installed_has_process_running_none(self):
         """NOT_INSTALLED status has process_running=None."""
-        host = {"hostname": "192.168.1.100", "claws": {}}
+        host = {"hostname": "192.168.1.100", "agents": {}}
         result = check_claw_health("openclaw", host)
         assert result["status"] == ClawStatus.NOT_INSTALLED
         assert result["process_running"] is None
@@ -989,7 +1063,7 @@ class TestProcessRunningField:
         """UNKNOWN status has process_running=None."""
         host = {
             "hostname": "192.168.1.100",
-            "claws": {
+            "agents": {
                 "openclaw": {"version": "0.1.0", "status": "installed"}
                 # Missing user field
             },
@@ -1055,7 +1129,7 @@ class TestCountCompletedStages:
 
     def test_no_onboarding_returns_zero_four(self):
         """Missing onboarding record returns (0, 4)."""
-        claw_record = {"version": "0.1.0", "user": "opc-test"}
+        claw_record = {"version": "0.1.0", "agent_name": "opc-test"}
         completed, total = count_completed_stages(claw_record)
         assert completed == 0
         assert total == 4
@@ -1191,4 +1265,11 @@ class TestCountCompletedStages:
         }
         completed, total = count_completed_stages(claw_record)
         assert completed == 1
+        assert total == 4
+
+    def test_stages_is_string_not_dict_returns_zero(self):
+        """Malformed stages (string instead of dict) returns (0, 4) gracefully."""
+        claw_record = {"onboarding": {"state": "providers", "stages": "malformed"}}
+        completed, total = count_completed_stages(claw_record)
+        assert completed == 0
         assert total == 4

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -29,8 +29,8 @@ def test_load_hosts_valid_json(isolated_config):
     isolated_config.mkdir(parents=True, exist_ok=True)
     hosts_path = isolated_config / HOSTS_FILE
     test_data = [
-        {"hostname": "192.168.1.10", "port": 22, "user": "xclm"},
-        {"hostname": "192.168.1.20", "port": 22, "user": "xclm"},
+        {"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"},
+        {"hostname": "192.168.1.20", "port": 22, "agent_name": "xclm"},
     ]
     hosts_path.write_text(json.dumps(test_data))
 
@@ -41,7 +41,7 @@ def test_load_hosts_valid_json(isolated_config):
 
 def test_save_hosts_creates_file(isolated_config):
     """save_hosts([host]) writes JSON to config dir."""
-    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "user": "xclm"}]
+    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"}]
 
     save_hosts(test_hosts)
 
@@ -61,7 +61,7 @@ def test_save_hosts_creates_dir(tmp_path, monkeypatch):
     # Config dir doesn't exist yet
     assert not config_dir.exists()
 
-    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "user": "xclm"}]
+    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"}]
     save_hosts(test_hosts)
 
     # Config dir should now exist
@@ -73,11 +73,11 @@ def test_add_host_appends(isolated_config):
     """add_host(host) appends to file (loads, appends, saves)."""
     # Setup: create initial hosts
     isolated_config.mkdir(parents=True, exist_ok=True)
-    initial_hosts = [{"hostname": "192.168.1.10", "port": 22, "user": "xclm"}]
+    initial_hosts = [{"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"}]
     save_hosts(initial_hosts)
 
     # Add new host
-    new_host = {"hostname": "192.168.1.20", "port": 22, "user": "xclm"}
+    new_host = {"hostname": "192.168.1.20", "port": 22, "agent_name": "xclm"}
     add_host(new_host)
 
     # Verify
@@ -92,8 +92,8 @@ def test_remove_host_found(isolated_config):
     # Setup: create hosts
     isolated_config.mkdir(parents=True, exist_ok=True)
     test_hosts = [
-        {"hostname": "192.168.1.10", "port": 22, "user": "xclm"},
-        {"hostname": "192.168.1.20", "port": 22, "user": "xclm"},
+        {"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"},
+        {"hostname": "192.168.1.20", "port": 22, "agent_name": "xclm"},
     ]
     save_hosts(test_hosts)
 
@@ -111,7 +111,7 @@ def test_remove_host_not_found(isolated_config):
     """remove_host(hostname) returns False if not found."""
     # Setup: create hosts
     isolated_config.mkdir(parents=True, exist_ok=True)
-    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "user": "xclm"}]
+    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"}]
     save_hosts(test_hosts)
 
     # Try to remove non-existent host
@@ -128,8 +128,8 @@ def test_get_host_by_hostname(isolated_config):
     # Setup: create hosts
     isolated_config.mkdir(parents=True, exist_ok=True)
     test_hosts = [
-        {"hostname": "192.168.1.10", "port": 22, "user": "xclm"},
-        {"hostname": "192.168.1.20", "port": 22, "user": "xclm"},
+        {"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"},
+        {"hostname": "192.168.1.20", "port": 22, "agent_name": "xclm"},
     ]
     save_hosts(test_hosts)
 
@@ -146,8 +146,8 @@ def test_get_host_by_alias(isolated_config):
     # Setup: create hosts with aliases
     isolated_config.mkdir(parents=True, exist_ok=True)
     test_hosts = [
-        {"hostname": "192.168.1.10", "port": 22, "user": "xclm", "alias": "server1"},
-        {"hostname": "192.168.1.20", "port": 22, "user": "xclm", "alias": "server2"},
+        {"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm", "alias": "server1"},
+        {"hostname": "192.168.1.20", "port": 22, "agent_name": "xclm", "alias": "server2"},
     ]
     save_hosts(test_hosts)
 
@@ -164,7 +164,7 @@ def test_get_host_not_found(isolated_config):
     """get_host(identifier) returns None if not found."""
     # Setup: create hosts
     isolated_config.mkdir(parents=True, exist_ok=True)
-    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "user": "xclm"}]
+    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"}]
     save_hosts(test_hosts)
 
     # Try to find non-existent host
@@ -176,7 +176,7 @@ def test_get_host_not_found(isolated_config):
 
 def test_save_hosts_file_permissions(isolated_config):
     """save_hosts() creates file with 0600 permissions."""
-    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "user": "xclm"}]
+    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"}]
     save_hosts(test_hosts)
 
     hosts_path = isolated_config / HOSTS_FILE
@@ -224,21 +224,21 @@ def test_host_claw_tracking_installed(isolated_config):
     test_host = {
         "hostname": "192.168.1.10",
         "port": 22,
-        "user": "xclm",
+        "agent_name": "xclm",
         "key_id": "testhost",
     }
     save_hosts([test_host])
 
     # Simulate install success by updating host with claw tracking
     def add_claw_tracking(h: dict) -> dict:
-        if "claws" not in h:
-            h["claws"] = {}
-        h["claws"]["openclaw"] = {
+        if "agents" not in h:
+            h["agents"] = {}
+        h["agents"]["openclaw"] = {
             "version": "0.1.0",
             "status": "installed",
             "installed_at": "2024-01-01T00:00:00Z",
             "error": None,
-            "user": "opc-testhost",
+            "agent_name": "opc-testhost",
         }
         return h
 
@@ -248,32 +248,32 @@ def test_host_claw_tracking_installed(isolated_config):
     # Verify host record contains claw tracking
     hosts = load_hosts()
     assert len(hosts) == 1
-    assert "claws" in hosts[0]
-    assert "openclaw" in hosts[0]["claws"]
-    assert hosts[0]["claws"]["openclaw"]["status"] == "installed"
-    assert hosts[0]["claws"]["openclaw"]["version"] == "0.1.0"
-    assert hosts[0]["claws"]["openclaw"]["installed_at"] == "2024-01-01T00:00:00Z"
-    assert hosts[0]["claws"]["openclaw"]["error"] is None
-    assert hosts[0]["claws"]["openclaw"]["user"] == "opc-testhost"
+    assert "agents" in hosts[0]
+    assert "openclaw" in hosts[0]["agents"]
+    assert hosts[0]["agents"]["openclaw"]["status"] == "installed"
+    assert hosts[0]["agents"]["openclaw"]["version"] == "0.1.0"
+    assert hosts[0]["agents"]["openclaw"]["installed_at"] == "2024-01-01T00:00:00Z"
+    assert hosts[0]["agents"]["openclaw"]["error"] is None
+    assert hosts[0]["agents"]["openclaw"]["agent_name"] == "opc-testhost"
 
 
 def test_host_claw_tracking_failed(isolated_config):
     """After failed install, host record contains claws[claw_name] with status='failed' and error message."""
     # Setup: create host
     isolated_config.mkdir(parents=True, exist_ok=True)
-    test_host = {"hostname": "192.168.1.10", "port": 22, "user": "xclm"}
+    test_host = {"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"}
     save_hosts([test_host])
 
     # Simulate install failure by updating host with failed status
     def add_failed_claw(h: dict) -> dict:
-        if "claws" not in h:
-            h["claws"] = {}
-        h["claws"]["openclaw"] = {
+        if "agents" not in h:
+            h["agents"] = {}
+        h["agents"]["openclaw"] = {
             "version": "0.1.0",
             "status": "failed",
             "installed_at": "2024-01-01T00:00:00Z",
             "error": "Base playbook failed: timeout",
-            "user": None,
+            "agent_name": None,
         }
         return h
 
@@ -283,16 +283,16 @@ def test_host_claw_tracking_failed(isolated_config):
     # Verify host record contains failure tracking
     hosts = load_hosts()
     assert len(hosts) == 1
-    assert "claws" in hosts[0]
-    assert "openclaw" in hosts[0]["claws"]
-    assert hosts[0]["claws"]["openclaw"]["status"] == "failed"
-    assert hosts[0]["claws"]["openclaw"]["error"] == "Base playbook failed: timeout"
+    assert "agents" in hosts[0]
+    assert "openclaw" in hosts[0]["agents"]
+    assert hosts[0]["agents"]["openclaw"]["status"] == "failed"
+    assert hosts[0]["agents"]["openclaw"]["error"] == "Base playbook failed: timeout"
 
 
 def test_update_host_not_found(isolated_config):
     """update_host returns False when hostname not found."""
     isolated_config.mkdir(parents=True, exist_ok=True)
-    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "user": "xclm"}]
+    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"}]
     save_hosts(test_hosts)
 
     def noop(h: dict) -> dict:
@@ -310,11 +310,11 @@ def test_update_host_not_found(isolated_config):
 def test_add_host_duplicate_raises(isolated_config):
     """add_host raises DuplicateHostError when hostname already exists."""
     isolated_config.mkdir(parents=True, exist_ok=True)
-    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "user": "xclm"}]
+    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"}]
     save_hosts(test_hosts)
 
     # Try to add duplicate hostname
-    duplicate = {"hostname": "192.168.1.10", "port": 22, "user": "different"}
+    duplicate = {"hostname": "192.168.1.10", "port": 22, "agent_name": "different"}
 
     with pytest.raises(DuplicateHostError) as exc_info:
         add_host(duplicate)
@@ -332,13 +332,13 @@ def test_get_host_by_key_id_found(isolated_config):
         {
             "hostname": "192.168.1.10",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
             "key_id": "server1-key",
         },
         {
             "hostname": "192.168.1.20",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
             "key_id": "server2-key",
         },
     ]
@@ -355,7 +355,7 @@ def test_get_host_by_key_id_not_found(isolated_config):
     """get_host_by_key_id returns None when key_id not found."""
     isolated_config.mkdir(parents=True, exist_ok=True)
     test_hosts = [
-        {"hostname": "192.168.1.10", "port": 22, "user": "xclm", "key_id": "known-key"}
+        {"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm", "key_id": "known-key"}
     ]
     save_hosts(test_hosts)
 
@@ -371,10 +371,10 @@ def test_remove_claw_from_host_success(isolated_config):
         {
             "hostname": "192.168.1.10",
             "port": 22,
-            "user": "xclm",
-            "claws": {
-                "openclaw": {"version": "1.0.0", "user": "opc-test"},
-                "zeroclaw": {"version": "2.0.0", "user": "zc-test"},
+            "agent_name": "xclm",
+            "agents": {
+                "openclaw": {"version": "1.0.0", "agent_name": "opc-test"},
+                "zeroclaw": {"version": "2.0.0", "agent_name": "zc-test"},
             },
         }
     ]
@@ -384,8 +384,8 @@ def test_remove_claw_from_host_success(isolated_config):
 
     assert result is True
     hosts = load_hosts()
-    assert "openclaw" not in hosts[0]["claws"]
-    assert "zeroclaw" in hosts[0]["claws"]  # Other claws remain
+    assert "openclaw" not in hosts[0]["agents"]
+    assert "zeroclaw" in hosts[0]["agents"]  # Other claws remain
 
 
 def test_remove_claw_from_host_not_found(isolated_config):
@@ -395,8 +395,8 @@ def test_remove_claw_from_host_not_found(isolated_config):
         {
             "hostname": "192.168.1.10",
             "port": 22,
-            "user": "xclm",
-            "claws": {"zeroclaw": {"version": "2.0.0"}},
+            "agent_name": "xclm",
+            "agents": {"zeroclaw": {"version": "2.0.0"}},
         }
     ]
     save_hosts(test_hosts)
@@ -406,14 +406,14 @@ def test_remove_claw_from_host_not_found(isolated_config):
 
     assert result is True  # Operation succeeds idempotently
     hosts = load_hosts()
-    assert "openclaw" not in hosts[0]["claws"]
-    assert "zeroclaw" in hosts[0]["claws"]
+    assert "openclaw" not in hosts[0]["agents"]
+    assert "zeroclaw" in hosts[0]["agents"]
 
 
 def test_remove_claw_from_host_no_claws_dict(isolated_config):
     """remove_claw_from_host handles host with no claws dict."""
     isolated_config.mkdir(parents=True, exist_ok=True)
-    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "user": "xclm"}]
+    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"}]
     save_hosts(test_hosts)
 
     result = remove_agent_from_host("192.168.1.10", "openclaw")
@@ -424,7 +424,7 @@ def test_remove_claw_from_host_no_claws_dict(isolated_config):
 def test_remove_claw_from_host_unknown_host(isolated_config):
     """remove_claw_from_host returns False for unknown host."""
     isolated_config.mkdir(parents=True, exist_ok=True)
-    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "user": "xclm"}]
+    test_hosts = [{"hostname": "192.168.1.10", "port": 22, "agent_name": "xclm"}]
     save_hosts(test_hosts)
 
     result = remove_agent_from_host("192.168.1.99", "openclaw")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -74,7 +74,7 @@ def test_install_incompatible_host_raises(monkeypatch):
     # Mock get_host with incompatible hardware
     incompatible_host = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "hardware": {
             "architecture": "arm64",  # Wrong arch
@@ -138,7 +138,7 @@ def test_install_success(monkeypatch, tmp_path):
     # Mock get_host
     compatible_host = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "test-host",
         "hardware": {
@@ -235,7 +235,7 @@ def test_install_emits_events(monkeypatch, tmp_path):
 
     compatible_host = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "test-host",
         "hardware": {
@@ -331,7 +331,7 @@ def test_install_base_playbook_fails(monkeypatch, tmp_path):
 
     compatible_host = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "test-host",
         "hardware": {
@@ -407,7 +407,7 @@ def test_install_missing_ssh_key_raises(monkeypatch, tmp_path):
 
     compatible_host = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "test-host",
         "hardware": {
@@ -475,7 +475,7 @@ def test_install_updates_host_on_success(monkeypatch, tmp_path):
 
     compatible_host = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "test-host",
         "hardware": {
@@ -519,20 +519,20 @@ def test_install_updates_host_on_success(monkeypatch, tmp_path):
         nonlocal persistent_host
         # Capture before state
         before_status = None
-        if "claws" in persistent_host and "openclaw" in persistent_host.get(
-            "claws", {}
+        if "agents" in persistent_host and "openclaw" in persistent_host.get(
+            "agents", {}
         ):
-            before_status = persistent_host["claws"]["openclaw"].get("status")
+            before_status = persistent_host["agents"]["openclaw"].get("status")
 
         # Apply updater to persistent host state (simulates real update_host behavior)
         persistent_host = updater(persistent_host)
 
         # Capture after state
         after_status = None
-        if "claws" in persistent_host and "openclaw" in persistent_host.get(
-            "claws", {}
+        if "agents" in persistent_host and "openclaw" in persistent_host.get(
+            "agents", {}
         ):
-            after_status = persistent_host["claws"]["openclaw"].get("status")
+            after_status = persistent_host["agents"]["openclaw"].get("status")
 
         # Store the before/after snapshot
         update_calls.append(
@@ -570,11 +570,11 @@ def test_install_updates_host_on_success(monkeypatch, tmp_path):
     last_updated = last_call[3]
 
     assert last_hostname == "test-host"
-    assert "claws" in last_updated
-    assert "openclaw" in last_updated["claws"]
-    assert last_updated["claws"]["openclaw"]["status"] == "installed"
-    assert last_updated["claws"]["openclaw"]["version"] == "0.1.0"
-    assert last_updated["claws"]["openclaw"]["installed_at"] is not None
+    assert "agents" in last_updated
+    assert "openclaw" in last_updated["agents"]
+    assert last_updated["agents"]["openclaw"]["status"] == "installed"
+    assert last_updated["agents"]["openclaw"]["version"] == "0.1.0"
+    assert last_updated["agents"]["openclaw"]["installed_at"] is not None
 
 
 def test_install_updates_host_on_failure(monkeypatch, tmp_path):
@@ -612,7 +612,7 @@ def test_install_updates_host_on_failure(monkeypatch, tmp_path):
 
     compatible_host = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "test-host",
         "hardware": {
@@ -655,8 +655,8 @@ def test_install_updates_host_on_failure(monkeypatch, tmp_path):
     def mock_update_host(hostname, updater):
         # Call the updater to capture the update
         test_host = compatible_host.copy()
-        if "claws" not in test_host:
-            test_host["claws"] = {}
+        if "agents" not in test_host:
+            test_host["agents"] = {}
         updated = updater(test_host)
         update_calls.append((hostname, updated))
         return True
@@ -673,11 +673,11 @@ def test_install_updates_host_on_failure(monkeypatch, tmp_path):
     # Check if any call has failed status
     found_failed = False
     for hostname, updated in update_calls:
-        if "claws" in updated and "openclaw" in updated["claws"]:
-            if updated["claws"]["openclaw"]["status"] == "failed":
+        if "agents" in updated and "openclaw" in updated["agents"]:
+            if updated["agents"]["openclaw"]["status"] == "failed":
                 found_failed = True
-                assert updated["claws"]["openclaw"]["error"] is not None
-                assert "failed" in updated["claws"]["openclaw"]["error"].lower()
+                assert updated["agents"]["openclaw"]["error"] is not None
+                assert "failed" in updated["agents"]["openclaw"]["error"].lower()
                 break
 
     assert found_failed, "Expected update_host to be called with failed status"
@@ -718,7 +718,7 @@ def test_install_initializes_onboarding(monkeypatch, tmp_path):
 
     compatible_host = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "test-host",
         "hardware": {
@@ -761,7 +761,7 @@ def test_install_initializes_onboarding(monkeypatch, tmp_path):
     def mock_update_host(hostname, updater):
         nonlocal persistent_host
         persistent_host = updater(persistent_host)
-        status = persistent_host.get("claws", {}).get("openclaw", {}).get("status")
+        status = persistent_host.get("agents", {}).get("openclaw", {}).get("status")
         call_order.append(("update_host", status))
         return True
 
@@ -834,7 +834,7 @@ def test_install_failure_does_not_initialize_onboarding(monkeypatch, tmp_path):
 
     compatible_host = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "test-host",
         "hardware": {
@@ -935,7 +935,7 @@ def test_install_onboarding_raises_does_not_corrupt_state(monkeypatch, tmp_path)
 
     compatible_host = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "test-host",
         "hardware": {
@@ -979,10 +979,10 @@ def test_install_onboarding_raises_does_not_corrupt_state(monkeypatch, tmp_path)
         nonlocal persistent_host
         persistent_host = updater(persistent_host)
         status = None
-        if "claws" in persistent_host and "openclaw" in persistent_host.get(
-            "claws", {}
+        if "agents" in persistent_host and "openclaw" in persistent_host.get(
+            "agents", {}
         ):
-            status = persistent_host["claws"]["openclaw"].get("status")
+            status = persistent_host["agents"]["openclaw"].get("status")
         update_calls.append((hostname, status))
         return True
 
@@ -1052,7 +1052,7 @@ def test_install_onboarding_record_structure(monkeypatch, tmp_path):
     hosts_data = [
         {
             "hostname": "test-host",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
             "key_id": "test-host",
             "hardware": {
@@ -1061,7 +1061,7 @@ def test_install_onboarding_record_structure(monkeypatch, tmp_path):
                 "os_version": "24.04",
                 "memtotal_mb": 4096,
             },
-            "claws": {},
+            "agents": {},
         }
     ]
     hosts_path = config_dir / "hosts.json"
@@ -1128,10 +1128,10 @@ def test_install_onboarding_record_structure(monkeypatch, tmp_path):
     assert host is not None
 
     # Verify claw record exists
-    assert "claws" in host
-    assert "openclaw" in host["claws"]
+    assert "agents" in host
+    assert "openclaw" in host["agents"]
 
-    claw = host["claws"]["openclaw"]
+    claw = host["agents"]["openclaw"]
     assert claw["status"] == "installed"
     assert claw["installed_at"] is not None
 
@@ -1189,7 +1189,7 @@ def test_install_with_custom_name(monkeypatch, tmp_path):
 
     compatible_host = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "test-host",
         "hardware": {
@@ -1275,7 +1275,7 @@ def test_install_auto_generates_name(monkeypatch, tmp_path):
 
     compatible_host = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "test-host",
         "hardware": {
@@ -1358,7 +1358,7 @@ def test_install_rejects_duplicate_name_same_host(monkeypatch, tmp_path):
     # Host with existing claw using the same name
     host_with_claw = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "test-host",
         "hardware": {
@@ -1367,7 +1367,7 @@ def test_install_rejects_duplicate_name_same_host(monkeypatch, tmp_path):
             "os_version": "24.04",
             "memtotal_mb": 4096,
         },
-        "claws": {"zeroclaw": {"user": "work-assistant"}},
+        "agents": {"zeroclaw": {"agent_name": "work-assistant"}},
     }
     monkeypatch.setattr(clawrium.core.install, "get_host", lambda x: host_with_claw)
 
@@ -1431,7 +1431,7 @@ def test_install_allows_same_name_different_host(monkeypatch, tmp_path):
     # Different host (no claws)
     different_host = {
         "hostname": "other-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "other-host",
         "hardware": {
@@ -1509,7 +1509,7 @@ def test_install_validates_name_format(monkeypatch, tmp_path):
 
     compatible_host = {
         "hostname": "test-host",
-        "user": "xclm",
+        "agent_name": "xclm",
         "port": 22,
         "key_id": "test-host",
         "hardware": {

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -37,9 +37,9 @@ class TestRunLifecyclePlaybook:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {"openclaw": {"user": "opc-work"}},
+            "agents": {"openclaw": {"agent_name": "opc-work"}},
         }
 
         with patch("clawrium.core.lifecycle._get_lifecycle_playbook_path") as mock_path:
@@ -55,9 +55,9 @@ class TestRunLifecyclePlaybook:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "missing-key",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {"openclaw": {"user": "opc-work"}},
+            "agents": {"openclaw": {"agent_name": "opc-work"}},
         }
 
         playbook_path = tmp_path / "start.yaml"
@@ -90,7 +90,7 @@ class TestStartClaw:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "claws": {},
+            "agents": {},
         }
 
         with patch("clawrium.core.lifecycle.get_host", return_value=host):
@@ -103,9 +103,9 @@ class TestStartClaw:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "claws": {
+            "agents": {
                 "openclaw": {
-                    "user": "opc-work",
+                    "agent_name": "opc-work",
                     "onboarding": {"state": "pending"},
                 }
             },
@@ -121,11 +121,11 @@ class TestStartClaw:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {
+            "agents": {
                 "openclaw": {
-                    "user": "opc-work",
+                    "agent_name": "opc-work",
                     "onboarding": {"state": "ready"},
                 }
             },
@@ -180,7 +180,7 @@ class TestStopClaw:
     def test_raises_error_when_claw_not_installed(self):
         host = {
             "hostname": "192.168.1.100",
-            "claws": {},
+            "agents": {},
         }
 
         with patch("clawrium.core.lifecycle.get_host", return_value=host):
@@ -193,11 +193,11 @@ class TestStopClaw:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {
+            "agents": {
                 "openclaw": {
-                    "user": "opc-work",
+                    "agent_name": "opc-work",
                 }
             },
         }
@@ -245,11 +245,11 @@ class TestRestartClaw:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {
+            "agents": {
                 "openclaw": {
-                    "user": "opc-work",
+                    "agent_name": "opc-work",
                 }
             },
         }
@@ -291,11 +291,11 @@ class TestRestartClaw:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {
+            "agents": {
                 "openclaw": {
-                    "user": "opc-work",
+                    "agent_name": "opc-work",
                     "onboarding": {"state": "ready"},
                 }
             },
@@ -351,7 +351,7 @@ class TestRemoveClaw:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "claws": {},
+            "agents": {},
         }
 
         with patch("clawrium.core.lifecycle.get_host", return_value=host):
@@ -364,11 +364,11 @@ class TestRemoveClaw:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {
+            "agents": {
                 "openclaw": {
-                    "user": "opc-work",
+                    "agent_name": "opc-work",
                     "runtime": {"status": "running"},
                 }
             },
@@ -420,11 +420,11 @@ class TestRemoveClaw:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {
+            "agents": {
                 "openclaw": {
-                    "user": "opc-work",
+                    "agent_name": "opc-work",
                     "runtime": {"status": "running"},
                 }
             },
@@ -484,11 +484,11 @@ class TestRemoveClaw:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {
+            "agents": {
                 "openclaw": {
-                    "user": "opc-work",
+                    "agent_name": "opc-work",
                     "runtime": {"status": "stopped"},
                 }
             },
@@ -535,11 +535,11 @@ class TestRemoveClaw:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {
+            "agents": {
                 "openclaw": {
-                    "user": "opc-work",
+                    "agent_name": "opc-work",
                     "runtime": {"status": "stopped"},
                 }
             },
@@ -585,11 +585,11 @@ class TestRemoveClaw:
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
-            "claws": {
+            "agents": {
                 "openclaw": {
-                    "user": "opc-work",
+                    "agent_name": "opc-work",
                     "runtime": {"status": "stopped"},
                 }
             },

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -3,7 +3,7 @@
 from clawrium.core.names import (
     generate_random_name,
     is_ip_address,
-    validate_claw_name,
+    validate_agent_name,
     is_name_available_on_host,
     SCIENTISTS,
 )
@@ -83,86 +83,86 @@ class TestScientistList:
 
 
 class TestValidateClawName:
-    """Tests for validate_claw_name function."""
+    """Tests for validate_agent_name function."""
 
     def test_valid_simple_names(self):
-        """validate_claw_name accepts simple valid names."""
-        assert validate_claw_name("work-assistant")[0] is True
-        assert validate_claw_name("clever_einstein")[0] is True
-        assert validate_claw_name("name123")[0] is True
-        assert validate_claw_name("abc-123_xyz")[0] is True
+        """validate_agent_name accepts simple valid names."""
+        assert validate_agent_name("work-assistant")[0] is True
+        assert validate_agent_name("clever_einstein")[0] is True
+        assert validate_agent_name("name123")[0] is True
+        assert validate_agent_name("abc-123_xyz")[0] is True
 
     def test_valid_edge_cases(self):
-        """validate_claw_name accepts edge case valid names."""
-        assert validate_claw_name("a")[0] is True
-        assert validate_claw_name("a" * 32)[0] is True
-        assert validate_claw_name("clever-einstein-123")[0] is True
+        """validate_agent_name accepts edge case valid names."""
+        assert validate_agent_name("a")[0] is True
+        assert validate_agent_name("a" * 32)[0] is True
+        assert validate_agent_name("clever-einstein-123")[0] is True
 
     def test_rejects_empty_name(self):
-        """validate_claw_name rejects empty names."""
-        valid, msg = validate_claw_name("")
+        """validate_agent_name rejects empty names."""
+        valid, msg = validate_agent_name("")
         assert valid is False
         assert "empty" in msg.lower()
 
     def test_rejects_too_long_name(self):
-        """validate_claw_name rejects names longer than 32 characters."""
-        valid, msg = validate_claw_name("a" * 33)
+        """validate_agent_name rejects names longer than 32 characters."""
+        valid, msg = validate_agent_name("a" * 33)
         assert valid is False
         assert "32" in msg
 
     def test_rejects_invalid_characters(self):
-        """validate_claw_name rejects names with invalid characters."""
-        valid, msg = validate_claw_name("work assistant")
+        """validate_agent_name rejects names with invalid characters."""
+        valid, msg = validate_agent_name("work assistant")
         assert valid is False
         assert "lowercase" in msg.lower()
 
-        valid, msg = validate_claw_name("work.assistant")
+        valid, msg = validate_agent_name("work.assistant")
         assert valid is False
         assert "lowercase" in msg.lower()
 
-        valid, msg = validate_claw_name("work@assistant")
+        valid, msg = validate_agent_name("work@assistant")
         assert valid is False
         assert "lowercase" in msg.lower()
 
     def test_rejects_uppercase_letters(self):
-        """validate_claw_name rejects names with uppercase letters."""
-        valid, msg = validate_claw_name("Name")
+        """validate_agent_name rejects names with uppercase letters."""
+        valid, msg = validate_agent_name("Name")
         assert valid is False
         assert "lowercase" in msg.lower()
 
-        valid, msg = validate_claw_name("UPPER")
+        valid, msg = validate_agent_name("UPPER")
         assert valid is False
         assert "lowercase" in msg.lower()
 
-        valid, msg = validate_claw_name("MyAssistant")
+        valid, msg = validate_agent_name("MyAssistant")
         assert valid is False
         assert "lowercase" in msg.lower()
 
     def test_rejects_names_starting_with_digit(self):
-        """validate_claw_name rejects names starting with a digit."""
-        valid, msg = validate_claw_name("1bad")
+        """validate_agent_name rejects names starting with a digit."""
+        valid, msg = validate_agent_name("1bad")
         assert valid is False
         assert "start with a lowercase letter" in msg
 
-        valid, msg = validate_claw_name("123claw")
+        valid, msg = validate_agent_name("123claw")
         assert valid is False
         assert "start with a lowercase letter" in msg
 
     def test_rejects_names_starting_with_hyphen(self):
-        """validate_claw_name rejects names starting with a hyphen."""
-        valid, msg = validate_claw_name("-bad")
+        """validate_agent_name rejects names starting with a hyphen."""
+        valid, msg = validate_agent_name("-bad")
         assert valid is False
         assert "start with a lowercase letter" in msg
 
     def test_rejects_names_starting_with_underscore(self):
-        """validate_claw_name rejects names starting with an underscore."""
-        valid, msg = validate_claw_name("_bad")
+        """validate_agent_name rejects names starting with an underscore."""
+        valid, msg = validate_agent_name("_bad")
         assert valid is False
         assert "start with a lowercase letter" in msg
 
     def test_returns_error_message(self):
-        """validate_claw_name returns descriptive error messages."""
-        valid, msg = validate_claw_name("")
+        """validate_agent_name returns descriptive error messages."""
+        valid, msg = validate_agent_name("")
         assert len(msg) > 0
 
 
@@ -171,20 +171,20 @@ class TestIsNameAvailableOnHost:
 
     def test_returns_true_for_available_name(self):
         """is_name_available_on_host returns True for unused name."""
-        host = {"claws": {"openclaw": {"user": "clever-einstein"}}}
+        host = {"agents": {"openclaw": {"agent_name": "clever-einstein"}}}
         assert is_name_available_on_host("swift-curie", host) is True
 
     def test_returns_false_for_used_name(self):
         """is_name_available_on_host returns False for already used name."""
-        host = {"claws": {"openclaw": {"user": "clever-einstein"}}}
+        host = {"agents": {"openclaw": {"agent_name": "clever-einstein"}}}
         assert is_name_available_on_host("clever-einstein", host) is False
 
     def test_checks_all_claw_types(self):
         """is_name_available_on_host checks uniqueness across all claw types."""
         host = {
-            "claws": {
-                "openclaw": {"user": "clever-einstein"},
-                "zeroclaw": {"user": "swift-curie"},
+            "agents": {
+                "openclaw": {"agent_name": "clever-einstein"},
+                "zeroclaw": {"agent_name": "swift-curie"},
             }
         }
         assert is_name_available_on_host("clever-einstein", host) is False
@@ -193,7 +193,7 @@ class TestIsNameAvailableOnHost:
 
     def test_handles_empty_claws(self):
         """is_name_available_on_host handles host with no claws."""
-        host = {"claws": {}}
+        host = {"agents": {}}
         assert is_name_available_on_host("clever-einstein", host) is True
 
     def test_handles_missing_claws_field(self):

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -27,13 +27,13 @@ def host_with_claw(isolated_config):
             "hostname": "192.168.1.100",
             "alias": "server1",
             "port": 22,
-            "user": "xclm",
-            "claws": {
+            "agent_name": "xclm",
+            "agents": {
                 "openclaw": {
                     "version": "0.1.0",
                     "status": "installed",
                     "name": "assistant",
-                    "user": "opc-assistant",
+                    "agent_name": "opc-assistant",
                 }
             },
         }
@@ -54,13 +54,13 @@ def host_with_onboarding(isolated_config):
             "hostname": "192.168.1.100",
             "alias": "server1",
             "port": 22,
-            "user": "xclm",
-            "claws": {
+            "agent_name": "xclm",
+            "agents": {
                 "openclaw": {
                     "version": "0.1.0",
                     "status": "installed",
                     "name": "assistant",
-                    "user": "opc-assistant",
+                    "agent_name": "opc-assistant",
                     "onboarding": {
                         "state": "pending",
                         "started_at": "2026-04-06T00:00:00+00:00",
@@ -261,7 +261,7 @@ class TestCompleteStage:
         from clawrium.core.hosts import get_host
 
         host = get_host("server1")
-        stage = host["claws"]["openclaw"]["onboarding"]["stages"]["providers"]
+        stage = host["agents"]["openclaw"]["onboarding"]["stages"]["providers"]
         assert stage["status"] == "complete"
         assert stage["completed_at"] is not None
 
@@ -276,7 +276,7 @@ class TestCompleteStage:
         from clawrium.core.hosts import get_host
 
         host = get_host("server1")
-        stage = host["claws"]["openclaw"]["onboarding"]["stages"]["providers"]
+        stage = host["agents"]["openclaw"]["onboarding"]["stages"]["providers"]
         assert stage["provider_id"] == "openai-default"
 
     def test_complete_stage_skipped(self, host_with_onboarding):
@@ -287,7 +287,7 @@ class TestCompleteStage:
         from clawrium.core.hosts import get_host
 
         host = get_host("server1")
-        stage = host["claws"]["openclaw"]["onboarding"]["stages"]["channels"]
+        stage = host["agents"]["openclaw"]["onboarding"]["stages"]["channels"]
         assert stage["status"] == "skipped"
 
     def test_complete_invalid_stage(self, host_with_onboarding):
@@ -313,7 +313,7 @@ class TestInitializeOnboarding:
         from clawrium.core.hosts import get_host
 
         host = get_host("server1")
-        onboarding = host["claws"]["openclaw"]["onboarding"]
+        onboarding = host["agents"]["openclaw"]["onboarding"]
 
         assert onboarding["state"] == "pending"
         assert onboarding["started_at"] is not None
@@ -330,7 +330,7 @@ class TestInitializeOnboarding:
         from clawrium.core.hosts import get_host
 
         host = get_host("server1")
-        stages = host["claws"]["openclaw"]["onboarding"]["stages"]
+        stages = host["agents"]["openclaw"]["onboarding"]["stages"]
 
         for stage_name, stage_data in stages.items():
             assert stage_data["status"] == "pending", f"Stage {stage_name} not pending"
@@ -393,7 +393,7 @@ class TestRunStage:
         from clawrium.core.hosts import get_host
 
         host = get_host("server1")
-        stage = host["claws"]["openclaw"]["onboarding"]["stages"]["providers"]
+        stage = host["agents"]["openclaw"]["onboarding"]["stages"]["providers"]
         assert stage["status"] == "complete"
 
     def test_run_stage_claw_not_found(self, host_with_onboarding):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -69,10 +69,9 @@ def test_load_manifest_nonexistent():
 
 
 def test_load_manifest_path_traversal():
-    """Test path traversal attempt triggers InvalidClawNameError."""
-    from clawrium.core.registry import InvalidClawNameError
+    """Test path traversal attempt triggers InvalidAgentTypeError."""
 
-    with pytest.raises(InvalidClawNameError):
+    with pytest.raises(InvalidAgentTypeError):
         load_manifest("../etc/passwd")
 
 
@@ -641,75 +640,45 @@ def test_get_optional_secrets_nonexistent_raises():
         get_optional_secrets("nonexistent")
 
 
-# validate_claw_name tests
-
-
-def test_validate_claw_name_empty_raises():
-    """Test validate_claw_name with empty string raises InvalidClawNameError."""
-    from clawrium.core.registry import validate_claw_name, InvalidClawNameError
-
-    with pytest.raises(InvalidClawNameError, match="cannot be empty") as exc:
-        validate_claw_name("")
-    assert isinstance(exc.value, InvalidAgentTypeError)
-
-
-def test_validate_claw_name_with_slash_raises():
-    """Test validate_claw_name with slash raises InvalidClawNameError."""
-    from clawrium.core.registry import validate_claw_name, InvalidClawNameError
-
-    with pytest.raises(InvalidClawNameError, match="invalid characters") as exc:
-        validate_claw_name("foo/bar")
-    assert isinstance(exc.value, InvalidAgentTypeError)
-
-
-def test_validate_claw_name_with_backslash_raises():
-    """Test validate_claw_name with backslash raises InvalidClawNameError."""
-    from clawrium.core.registry import validate_claw_name, InvalidClawNameError
-
-    with pytest.raises(InvalidClawNameError, match="invalid characters") as exc:
-        validate_claw_name("foo\\bar")
-    assert isinstance(exc.value, InvalidAgentTypeError)
-
-
-def test_validate_claw_name_valid():
-    """Test validate_claw_name with valid names passes."""
-    from clawrium.core.registry import validate_claw_name
-
-    # These should not raise
-    validate_claw_name("openclaw")
-    validate_claw_name("zero-agent")
-    validate_claw_name("claw_v2")
-    validate_claw_name("Claw123")
+# validate_agent_type tests
 
 
 def test_validate_agent_type_empty_raises():
-    """Test validate_agent_type with empty value raises InvalidAgentTypeError."""
-    with pytest.raises(InvalidAgentTypeError, match="cannot be empty"):
+    """Test validate_agent_type with empty string raises InvalidAgentTypeError."""
+
+    with pytest.raises(InvalidAgentTypeError, match="cannot be empty") as exc:
         validate_agent_type("")
+    assert isinstance(exc.value, InvalidAgentTypeError)
 
 
 def test_validate_agent_type_with_slash_raises():
     """Test validate_agent_type with slash raises InvalidAgentTypeError."""
-    with pytest.raises(InvalidAgentTypeError, match="invalid characters"):
+
+    with pytest.raises(InvalidAgentTypeError, match="invalid characters") as exc:
         validate_agent_type("foo/bar")
+    assert isinstance(exc.value, InvalidAgentTypeError)
 
 
 def test_validate_agent_type_with_backslash_raises():
     """Test validate_agent_type with backslash raises InvalidAgentTypeError."""
-    with pytest.raises(InvalidAgentTypeError, match="invalid characters"):
+
+    with pytest.raises(InvalidAgentTypeError, match="invalid characters") as exc:
         validate_agent_type("foo\\bar")
-
-
-def test_validate_agent_type_with_dotdot_raises():
-    """Test validate_agent_type with dot traversal raises InvalidAgentTypeError."""
-    with pytest.raises(InvalidAgentTypeError, match="invalid characters"):
-        validate_agent_type("..")
+    assert isinstance(exc.value, InvalidAgentTypeError)
 
 
 def test_validate_agent_type_valid():
     """Test validate_agent_type with valid names passes."""
+
+    # These should not raise
     validate_agent_type("openclaw")
-    validate_agent_type("agent_v2")
+    validate_agent_type("zero-agent")
+    validate_agent_type("claw_v2")
+    validate_agent_type("Claw123")
+
+
+
+
 
 
 # check_compatibility version parameter tests

--- a/tests/test_reset.py
+++ b/tests/test_reset.py
@@ -69,7 +69,7 @@ class TestEnumerateTargets:
         # Mock get_host to return valid host
         mock_host = {
             "hostname": "192.168.1.100",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
             "key_id": "192.168.1.100",
         }
@@ -111,7 +111,7 @@ class TestEnumerateTargets:
         # Mock get_host to return valid host
         mock_host = {
             "hostname": "192.168.1.100",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
             "key_id": "192.168.1.100",
         }
@@ -153,7 +153,7 @@ class TestEnumerateTargets:
         # Mock get_host to return valid host
         mock_host = {
             "hostname": "192.168.1.100",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
             "key_id": "192.168.1.100",
         }
@@ -264,7 +264,7 @@ class TestInputValidation:
 
         mock_host = {
             "hostname": "192.168.1.100",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
             "key_id": "192.168.1.100",
         }
@@ -307,7 +307,7 @@ class TestExecuteReset:
         # Mock get_host
         mock_host = {
             "hostname": "192.168.1.100",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
             "key_id": "192.168.1.100",
         }
@@ -344,7 +344,7 @@ class TestExecuteReset:
         # Mock get_host to return valid host
         mock_host = {
             "hostname": "192.168.1.100",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
             "key_id": "192.168.1.100",
         }
@@ -384,7 +384,7 @@ class TestCliReset:
             "hostname": "192.168.1.100",
             "key_id": "192.168.1.100",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
         }
         hosts_file.write_text(json.dumps([host]))
 
@@ -429,7 +429,7 @@ class TestCliReset:
             "hostname": "192.168.1.100",
             "key_id": "192.168.1.100",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
         }
         hosts_file.write_text(json.dumps([host]))
 
@@ -474,7 +474,7 @@ class TestCliReset:
             "hostname": "192.168.1.100",
             "key_id": "192.168.1.100",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
         }
         hosts_file.write_text(json.dumps([host]))
 
@@ -540,10 +540,10 @@ class TestCliReset:
             "hostname": "192.168.1.100",
             "key_id": "192.168.1.100",
             "port": 22,
-            "user": "xclm",
-            "claws": {
-                "zeroclaw": {"status": "installed", "user": "zc-myhost"},
-                "openclaw": {"status": "installed", "user": "opc-work"},
+            "agent_name": "xclm",
+            "agents": {
+                "zeroclaw": {"status": "installed", "agent_name": "zc-myhost"},
+                "openclaw": {"status": "installed", "agent_name": "opc-work"},
             },
         }
         hosts_file.write_text(json.dumps([host]))
@@ -579,7 +579,7 @@ class TestCliReset:
         # Check host record was updated
         hosts = json.loads(hosts_file.read_text())
         host = hosts[0]
-        assert host.get("claws", {}) == {}
+        assert host.get("agents", {}) == {}
         # Verify last_reset timestamp was set
         assert "metadata" in host
         assert "last_reset" in host["metadata"]
@@ -631,7 +631,7 @@ class TestResetEdgeCases:
             "hostname": "192.168.1.100",
             "key_id": "192.168.1.100",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
         }
         hosts_file.write_text(json.dumps([host]))
 
@@ -668,7 +668,7 @@ class TestResetEdgeCases:
             "hostname": "192.168.1.100",
             "key_id": "192.168.1.100",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
         }
         hosts_file.write_text(json.dumps([host]))
 
@@ -716,7 +716,7 @@ class TestResetEdgeCases:
             "alias": "myhost",
             "key_id": "192.168.1.100",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
         }
         hosts_file.write_text(json.dumps([host]))
 
@@ -759,7 +759,7 @@ class TestResetEdgeCases:
             "hostname": "192.168.1.100",
             "key_id": "192.168.1.100",
             "port": 22,
-            "user": "xclm",
+            "agent_name": "xclm",
         }
         hosts_file.write_text(json.dumps([host]))
 
@@ -803,7 +803,7 @@ class TestResetEdgeCases:
         # Mock get_host to return host with path traversal hostname
         mock_host = {
             "hostname": "../../../etc/passwd",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
             "key_id": "../../../etc/passwd",
         }
@@ -835,7 +835,7 @@ class TestResetEdgeCases:
 
         mock_host = {
             "hostname": "192.168.1.100",
-            "user": "xclm",
+            "agent_name": "xclm",
             "port": 22,
             "key_id": "192.168.1.100",
         }


### PR DESCRIPTION
## Summary
Complete internal refactoring from "claw" to "agent" terminology as specified in #136. This is a **BREAKING CHANGE** that updates the schema format.

## Changes

### Schema Migration (Breaking Change)
- `hosts.json` schema: `"claws"` → `"agents"` key
- Agent records: `"user"` → `"agent_name"` field  
- Added schema version validation to detect old format
- Clear error message guides users through migration

### Internal Refactoring
- Renamed functions:
  - `validate_claw_name()` → `validate_agent_type()`
  - `_resolve_claw_name()` → `_resolve_agent_type()`
  - `_get_claw_playbook_path()` → `_get_agent_playbook_path()`
  - `clear_claws()` → `clear_agents()`
- Updated schema access patterns in 13 core modules
- Updated schema access in 3 CLI modules

### Test Updates
- Updated all 32 test files with new schema format
- Updated test assertions and mocks
- Added comprehensive error handling tests for health checks
- Test results: **719/719 passing (100%)**

## ATX Review Summary

**Final Review: Rating 2/5 (2 iterations completed)**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 (Code) | 2/5 | B1-B7 | All fixed |
| 2 (Tests) | 2/5 | B1-B5 | All fixed |

<details>
<summary>Review 1 - Code Issues (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `test_ssh_connection.py:41` | SSH config test used inconsistent keys | Fixed - use config["user"] consistently |
| B2 | `validation.py:114`, `agent.py:394` | SOUL.md path still referenced "claws/" directory | Fixed - changed to "agents/" |
| B3 | `onboarding.py` | Missing None guards in updater functions | Fixed - added defensive None checks |
| B4 | `test_ssh_connection.py:41` | Contradictory test assertion | Fixed - same as B1 |
| B5 | `test_cli_secret.py` | Secret tests used wrong instance keys (work vs opc-work) | Fixed - updated all instance keys |
| B6 | `cli/agent.py`, `cli/install.py`, `cli/secret.py` | CLI comments still used "claw" terminology | Fixed - updated to "agent" |
| B7 | `cli/host.py:715` | Function clear_claws() not renamed | Fixed - renamed to clear_agents() |
| B8-B10 | Various | Migration-related recommendations | Out-of-scope - deferred per project decision |

</details>

<details>
<summary>Review 2 - Test Issues (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `test_health.py:213-231` | Weak test - only asserts key existence | Fixed - assert exact value (None) |
| B2 | `test_health.py` | No tests verify health checks are read-only | Fixed - added test_health_check_never_modifies_state |
| B3 | `test_health.py` | No test for corrupted host data | Fixed - added test_health_check_corrupted_host_data |
| B4 | `test_health.py:543-625` | No tests for malformed onboarding data | Fixed - added 2 tests for malformed stages |
| B5 | `test_health.py` | No test for SecretsFileCorruptedError | Fixed - added test + error handling in health.py |

**Error Handling Improvements:**

| Component | Improvement |
|-----------|-------------|
| `check_claw_health()` | Gracefully handle missing hostname - return UNKNOWN |
| `check_claw_health()` | Catch SecretsFileCorruptedError - return DEGRADED with error |
| `count_completed_stages()` | Check if stages is dict before calling .values() |

</details>

## Verification
- ✅ All 719 tests passing (100%)
- ✅ All lint checks passed
- ✅ ATX review completed (2 iterations)
- ✅ All blocking issues resolved

## Migration Strategy
**No backward compatibility** - users must remove existing agents before upgrade:
1. Old schema detected on load with clear error message
2. Migration instructions provided in error
3. Documented as breaking change

## Testing
```bash
make test  # 719/719 passing (100%)
make lint  # All checks passed
```

Part of #101
Closes #136

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>