### PR TITLE
fix: regenerate complete env and preserve gateway config on agent configure

### DIFF
--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -246,18 +246,30 @@ def _sync_provider_config(host: str, claw_type: str, provider: dict) -> None:
         port_hash = int(hashlib.md5(installed_name.encode()).hexdigest(), 16)
         gateway_port = 40000 + (port_hash % 2000)
 
-    # Build gateway config based on agent type
+    # Build gateway config based on agent type, preserving existing fields
     if claw_type == "zeroclaw":
         gateway_config = {
-            "host": "0.0.0.0",
+            "host": existing_gateway.get("host", "0.0.0.0"),
             "port": gateway_port,
-            "allow_public_bind": True,
+            "allow_public_bind": existing_gateway.get("allow_public_bind", True),
         }
     elif claw_type == "openclaw":
-        gateway_config = {"bind": "lan", "port": gateway_port}
+        gateway_config = {
+            "bind": existing_gateway.get("bind", "lan"),
+            "port": gateway_port,
+        }
     else:
         # Default gateway config
-        gateway_config = {"host": "0.0.0.0", "port": gateway_port}
+        gateway_config = {
+            "host": existing_gateway.get("host", "0.0.0.0"),
+            "port": gateway_port,
+        }
+
+    # Preserve url and auth if they exist
+    if "url" in existing_gateway:
+        gateway_config["url"] = existing_gateway["url"]
+    if "auth" in existing_gateway:
+        gateway_config["auth"] = existing_gateway["auth"]
 
     # Build provider config
     provider_config = {

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -476,6 +476,33 @@ def configure_agent(
                 f"Invalid model name: '{model_name}'. Model names must contain only alphanumeric characters, dots, colons, slashes, underscores, plus, and hyphens.",
             )
 
+    # Validate required provider fields
+    required_provider_fields = ["name", "type", "default_model"]
+    if config_data.get("provider"):
+        if not isinstance(config_data["provider"], dict):
+            return False, "Invalid provider config - expected dict"
+        missing = [
+            f for f in required_provider_fields if not config_data["provider"].get(f)
+        ]
+        if missing:
+            return False, f"Incomplete provider config - missing: {', '.join(missing)}"
+
+        # Ollama providers require endpoint
+        if config_data["provider"].get("type") == "ollama":
+            if not config_data["provider"].get("endpoint"):
+                return False, "Ollama provider requires 'endpoint' field"
+
+    # Validate required gateway fields
+    required_gateway_fields = ["port"]
+    if config_data.get("gateway"):
+        if not isinstance(config_data["gateway"], dict):
+            return False, "Invalid gateway config - expected dict"
+        missing = [
+            f for f in required_gateway_fields if not config_data["gateway"].get(f)
+        ]
+        if missing:
+            return False, f"Incomplete gateway config - missing: {', '.join(missing)}"
+
     # Load provider API key from secrets if provider is configured
     provider_api_key = ""
     if config_data.get("provider") and config_data["provider"].get("name"):

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -31,6 +31,31 @@
         mode: "0600"
       notify: Restart openclaw service
 
+    - name: Ensure openclaw config directory exists
+      ansible.builtin.file:
+        path: "/home/{{ agent_name }}/.openclaw"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0700"
+
+    - name: Write openclaw config from template
+      ansible.builtin.template:
+        src: "{{ template_path }}/openclaw.json.j2"
+        dest: "/home/{{ agent_name }}/.openclaw/openclaw.json"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0600"
+      when: config.provider is defined and config.provider.default_model is defined
+      notify: Restart openclaw service
+
+    - name: Verify model set in openclaw.json
+      ansible.builtin.command:
+        cmd: cat /home/{{ agent_name }}/.openclaw/openclaw.json
+      register: verify_model
+      failed_when: config.provider.default_model not in verify_model.stdout
+      when: config.provider is defined and config.provider.default_model is defined
+
     - name: Ensure service is enabled
       ansible.builtin.systemd:
         name: "{{ agent_type }}-{{ agent_name }}"

--- a/src/clawrium/platform/registry/openclaw/templates/.env.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/.env.j2
@@ -1,5 +1,5 @@
-OPENCLAW_GATEWAY_BIND={{ config.gateway.bind }}
-OPENCLAW_GATEWAY_PORT={{ config.gateway.port }}
+OPENCLAW_GATEWAY_BIND={{ config.gateway.bind | default('lan') }}
+OPENCLAW_GATEWAY_PORT={{ config.gateway.port | default('40000') }}
 {% if config.provider is defined and config.provider %}
 {% if config.provider.type == "anthropic" %}
 {% if lookup('env', 'CLAWRIUM_PROVIDER_API_KEY') %}
@@ -17,6 +17,33 @@ OPENCLAW_DEFAULT_MODEL={{ config.provider.default_model }}
 {% endif %}
 {% elif config.provider.type == "ollama" %}
 OPENCLAW_OLLAMA_URL={{ config.provider.endpoint }}
+{% if config.provider.default_model %}
+OPENCLAW_DEFAULT_MODEL={{ config.provider.default_model }}
+{% endif %}
+{% elif config.provider.type == "openrouter" %}
+{% if lookup('env', 'CLAWRIUM_PROVIDER_API_KEY') %}
+OPENROUTER_API_KEY={{ lookup('env', 'CLAWRIUM_PROVIDER_API_KEY') }}
+{% endif %}
+{% if config.provider.default_model %}
+OPENCLAW_DEFAULT_MODEL={{ config.provider.default_model }}
+{% endif %}
+{% elif config.provider.type == "bedrock" %}
+# Bedrock uses AWS credentials from environment/profile
+{% if config.provider.default_model %}
+OPENCLAW_DEFAULT_MODEL={{ config.provider.default_model }}
+{% endif %}
+{% elif config.provider.type == "vertex" %}
+# Vertex uses Google Cloud credentials
+{% if lookup('env', 'CLAWRIUM_PROVIDER_API_KEY') %}
+GOOGLE_APPLICATION_CREDENTIALS={{ lookup('env', 'CLAWRIUM_PROVIDER_API_KEY') }}
+{% endif %}
+{% if config.provider.default_model %}
+OPENCLAW_DEFAULT_MODEL={{ config.provider.default_model }}
+{% endif %}
+{% elif config.provider.type == "zai" %}
+{% if lookup('env', 'CLAWRIUM_PROVIDER_API_KEY') %}
+ZAI_API_KEY={{ lookup('env', 'CLAWRIUM_PROVIDER_API_KEY') }}
+{% endif %}
 {% if config.provider.default_model %}
 OPENCLAW_DEFAULT_MODEL={{ config.provider.default_model }}
 {% endif %}

--- a/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
@@ -1,0 +1,7 @@
+{
+  "agents": {
+    "defaults": {
+      "model": "{{ config.provider.default_model }}"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #134, #128, #129, #133

## Summary

Fix the `clm agent configure` command to perform complete configuration regeneration for all agent types. Previously, configure only partially updated the .env file, leaving it in a broken state with missing API keys, wrong models, and missing provider-specific environment variables.

## Changes

1. **Add missing provider support** (#128)
   - Added openrouter, bedrock, vertex, zai providers to `.env.j2`
   - Each provider maps to appropriate env var names (OPENROUTER_API_KEY, GOOGLE_APPLICATION_CREDENTIALS, etc.)

2. **Set model in openclaw.json** (#129)
   - Created `openclaw.json.j2` template for model configuration
   - Updated `configure.yaml` to render openclaw.json and verify model is set
   - Ensured `.openclaw` directory exists before templating

3. **Preserve gateway configuration** (#133)
   - Updated `_sync_provider_config()` to preserve existing gateway `url` and `auth` fields
   - Merged with existing instead of replacing completely

4. **Add configuration validation**
   - Validate required provider fields (name, type, default_model)
   - Validate required gateway fields (port)
   - Type validation for provider/gateway dicts
   - Ollama-specific endpoint validation

5. **Fix template robustness**
   - Added defaults for gateway fields to prevent undefined-variable failures
   - Replaced shell verification with command to prevent injection

## Testing

- All 719 tests pass
- Linter passes

## ATX Review Summary

**Final Review: Rating 3/5**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 3/5 | None | All warnings fixed |

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Warnings:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| W1 | `configure.yaml:44-49` | Shell injection risk with user-controlled model name | Fixed - replaced `shell` with `command` |
| W2 | `configure.yaml:34-41` | `.openclaw` directory not guaranteed to exist | Fixed - added `file` task to ensure directory |
| W3 | `.env.j2` + `lifecycle.py` | Ollama endpoint not validated | Fixed - added Ollama endpoint validation |
| W4 | `.env.j2` + `lifecycle.py` | Gateway fields missing defaults | Fixed - added template defaults |

**Suggestions (Non-blocking):**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Type validation for provider/gateway | Acknowledged - added dict type checks |
| S2 | Document config merge vs replace | Acknowledged - current code does complete replacement |
| S3 | Validate API key for non-Ollama providers | Deferred - silent fallback is acceptable for now |
| S4 | Parameter naming consistency | Deferred - out of scope for this fix |

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>