### PR TITLE
Fix OpenClaw installation timeout by adding system dependencies

### DIFF
--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -298,7 +298,7 @@ def run_installation(
             inventory=inventory,
             playbook=str(claw_playbook),
             quiet=False,  # Show output
-            timeout=600,  # 10 min timeout for claw install
+            timeout=1800,  # 30 min timeout for claw install
         )
 
         if result.status != "successful":

--- a/src/clawrium/platform/playbooks/base.yaml
+++ b/src/clawrium/platform/playbooks/base.yaml
@@ -43,3 +43,10 @@
       ansible.builtin.apt:
         name: build-essential
         state: present
+
+    - name: Install git and GitHub CLI
+      ansible.builtin.apt:
+        name:
+          - git
+          - gh
+        state: present

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1538,3 +1538,90 @@ def test_install_validates_name_format(monkeypatch, tmp_path):
 
     with pytest.raises(InstallationError, match="Invalid name"):
         run_installation("openclaw", "test-host", name="a" * 33)  # Too long
+
+
+def test_install_uses_extended_timeout(monkeypatch, tmp_path):
+    """Test that claw installation uses 30-minute timeout."""
+    from clawrium.core.install import run_installation
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mock_manifest = {
+        "name": "openclaw",
+        "entries": [
+            {
+                "version": "0.1.0",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc123",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.9"},
+                },
+            }
+        ],
+    }
+
+    import clawrium.core.install
+
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+
+    key_file = tmp_path / "test_key"
+    key_file.write_text("fake key")
+
+    compatible_host = {
+        "hostname": "test-host",
+        "agent_name": "xclm",
+        "port": 22,
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    monkeypatch.setattr(clawrium.core.install, "get_host", lambda x: compatible_host)
+
+    compat_result = {
+        "compatible": True,
+        "matched_entry": mock_manifest["entries"][0],
+        "reasons": [],
+    }
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *args, **kwargs: compat_result,
+    )
+
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda x: key_file
+    )
+
+    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: u(clawrium.core.install.get_host(h)))
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", lambda h, c: True
+    )
+
+    class SuccessfulResult:
+        status = "successful"
+
+    mock_run = Mock(return_value=SuccessfulResult())
+
+    import ansible_runner
+
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    # Run installation
+    run_installation("openclaw", "test-host")
+
+    # Verify ansible_runner.run was called twice (base + claw)
+    assert mock_run.call_count == 2
+
+    # Check second call (claw installation) has timeout=1800
+    claw_call = mock_run.call_args_list[1]
+    assert claw_call[1]["timeout"] == 1800, (
+        "Claw installation should use 1800s (30 min) timeout"
+    )

--- a/tests/test_playbooks.py
+++ b/tests/test_playbooks.py
@@ -26,16 +26,55 @@ def test_base_playbook_structure():
 
     content = base_playbook.read_text()
 
-    # Check for required elements
+    # Check for required elements in raw content
     assert "- hosts:" in content, "Should have hosts directive"
     assert "become: yes" in content or "become: true" in content, "Should require sudo"
-    assert "nodejs" in content.lower(), "Should install nodejs"
-    assert "build-essential" in content, "Should install build-essential"
 
-    # Parse YAML to ensure it's valid
+    # Parse YAML to validate structure and package lists
     data = yaml.safe_load(content)
     assert isinstance(data, list), "Playbook should be a list of plays"
     assert len(data) > 0, "Playbook should have at least one play"
+
+    # Extract all tasks from the first play
+    tasks = data[0].get("tasks", [])
+
+    # Find and validate Node.js installation
+    # Look for the specific task "Install Node.js"
+    nodejs_tasks = [
+        t for t in tasks
+        if t.get("name") == "Install Node.js"
+    ]
+    assert len(nodejs_tasks) > 0, "Should have task to install Node.js"
+    nodejs_task = nodejs_tasks[0]
+    apt_module = nodejs_task.get("ansible.builtin.apt", {})
+    assert apt_module.get("name") == "nodejs", (
+        "Node.js task should install nodejs package"
+    )
+
+    # Find and validate build-essential installation
+    build_essential_tasks = [
+        t for t in tasks
+        if "build-essential" in str(t.get("name", "")).lower()
+    ]
+    assert len(build_essential_tasks) > 0, "Should have task to install build-essential"
+    build_essential_task = build_essential_tasks[0]
+    apt_module = build_essential_task.get("ansible.builtin.apt", {})
+    assert apt_module.get("name") == "build-essential", (
+        "build-essential task should install build-essential package"
+    )
+
+    # Find and validate git/gh installation
+    git_gh_tasks = [
+        t for t in tasks
+        if "git" in str(t.get("name", "")).lower() and "github" in str(t.get("name", "")).lower()
+    ]
+    assert len(git_gh_tasks) > 0, "Should have task to install git and GitHub CLI"
+    git_gh_task = git_gh_tasks[0]
+    apt_module = git_gh_task.get("ansible.builtin.apt", {})
+    packages = apt_module.get("name", [])
+    assert isinstance(packages, list), "git/gh task should install list of packages"
+    assert "git" in packages, "Should install git package"
+    assert "gh" in packages, "Should install gh (GitHub CLI) package"
 
 
 def test_openclaw_install_playbook_exists():


### PR DESCRIPTION
## Summary

Fixes OpenClaw installation timeout by installing git and gh system dependencies before agent installation and increasing timeout to 30 minutes.

## Root Cause

OpenClaw's `install-cli.sh` requires Git for npm to install git dependencies. When Git is missing, the script attempts `sudo apt-get update` to install it, which hangs indefinitely because agent users lack sudo permissions by design.

## Changes

1. **Base Playbook** (`src/clawrium/platform/playbooks/base.yaml`):
   - Added git and gh to system package installation
   - These dependencies are required for all agents, not just OpenClaw

2. **Installation Timeout** (`src/clawrium/core/install.py`):
   - Increased timeout from 600s (10 min) to 1800s (30 min)
   - Backup measure for slow installations

3. **Test Coverage**:
   - Added test to verify timeout value is set to 1800s
   - Added YAML-parsed validation for git/gh package installation
   - Tests verify actual package lists, not just text presence

## Testing

- ✅ All 720 tests pass
- ✅ Linting passes
- ✅ Timeout value verified via test
- ✅ Package list validated via YAML parsing

Closes #125