### PR TITLE
feat: automate OpenClaw gateway pairing

### DIFF
--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -309,13 +309,54 @@ def run_installation(
         playbooks_run.append(str(claw_playbook))
         emit("claw", f"{claw_name} installed successfully")
 
-        # Step 10: Update host with success status
+        # Step 9.5: Extract gateway token from Ansible facts (OpenClaw only)
+        gateway_token = None
+        gateway_url = None
+        if claw_name == "openclaw" and result.status == "successful":
+            # Get host facts from Ansible result
+            try:
+                # ansible-runner stores facts in artifacts/<run_id>/fact_cache/<hostname>
+                import json
+                from pathlib import Path
+
+                artifacts_dir = Path(result.config.artifact_dir)
+                fact_cache_dir = artifacts_dir / "fact_cache"
+
+                if fact_cache_dir.exists():
+                    # Find fact file for our host
+                    for fact_file in fact_cache_dir.glob("*"):
+                        try:
+                            with open(fact_file) as f:
+                                facts = json.load(f)
+                                gateway_token = facts.get("openclaw_gateway_token")
+                                gateway_url = facts.get("openclaw_gateway_url")
+                                if gateway_token and gateway_url:
+                                    emit("claw", "Gateway authentication token captured")
+                                    break
+                        except (json.JSONDecodeError, IOError) as file_err:
+                            logger.debug("Skipping fact file %s: %s", fact_file, file_err)
+                            continue
+            except Exception as e:
+                logger.warning("Failed to extract gateway token: %s", e, exc_info=True)
+                emit("warn", "Gateway token capture failed - manual pairing may be needed")
+
+        # Step 10: Update host with success status and gateway auth (if available)
         def set_installed(h: dict) -> dict:
             if "agents" in h and claw_name in h["agents"]:
                 h["agents"][claw_name]["status"] = "installed"
                 h["agents"][claw_name]["installed_at"] = datetime.now(
                     timezone.utc
                 ).isoformat()
+
+                # Store gateway authentication (OpenClaw only)
+                if gateway_token and gateway_url:
+                    if "config" not in h["agents"][claw_name]:
+                        h["agents"][claw_name]["config"] = {}
+                    if "gateway" not in h["agents"][claw_name]["config"]:
+                        h["agents"][claw_name]["config"]["gateway"] = {}
+
+                    h["agents"][claw_name]["config"]["gateway"]["url"] = gateway_url
+                    h["agents"][claw_name]["config"]["gateway"]["auth"] = gateway_token
             return h
 
         update_host(host["hostname"], set_installed)

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -2,6 +2,13 @@
 - hosts: all
   become: yes
   tasks:
+    - name: Verify gateway token exists in config (strict mode only)
+      ansible.builtin.fail:
+        msg: "Gateway auth token not found. Run installation again to generate token."
+      when:
+        - config.gateway.auth is not defined or not config.gateway.auth
+      tags: [never, strict]
+
     - name: Check if agent user exists
       ansible.builtin.getent:
         database: passwd

--- a/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
@@ -76,6 +76,27 @@
         state: started
         daemon_reload: yes
 
+    - name: Wait for gateway to be ready
+      ansible.builtin.wait_for:
+        timeout: 10
+      delegate_to: localhost
+
+    - name: Generate gateway authentication token
+      ansible.builtin.command:
+        cmd: /home/{{ agent_name }}/.openclaw/bin/openclaw doctor --generate-gateway-token --output json
+      become_user: "{{ agent_name }}"
+      register: gateway_token_result
+      retries: 3
+      delay: 2
+      until: gateway_token_result.rc == 0
+      no_log: true
+
+    - name: Save token to fact for retrieval
+      ansible.builtin.set_fact:
+        openclaw_gateway_token: "{{ gateway_token_result.stdout | from_json | json_query('token') }}"
+        openclaw_gateway_url: "ws://{{ ansible_host }}:{{ openclaw_port }}"
+      no_log: true
+
   handlers:
     - name: Reload systemd
       ansible.builtin.systemd:

--- a/src/clawrium/platform/registry/openclaw/templates/.env.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/.env.j2
@@ -1,5 +1,9 @@
 OPENCLAW_GATEWAY_BIND={{ config.gateway.bind | default('0.0.0.0') }}
 OPENCLAW_GATEWAY_PORT={{ config.gateway.port | default('40000') }}
+{% if config.gateway.auth is defined and config.gateway.auth %}
+OPENCLAW_GATEWAY_AUTH_MODE=token
+OPENCLAW_GATEWAY_AUTH_TOKEN={{ config.gateway.auth }}
+{% endif %}
 {% if config.provider is defined and config.provider %}
 {% if config.provider.type == "anthropic" %}
 {% if lookup('env', 'CLAWRIUM_PROVIDER_API_KEY') %}

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -681,3 +681,130 @@ class TestCanSkipStage:
 
             assert result.exit_code == 0
             assert mock_skip.called
+
+
+class TestConfigurePreservesGatewayAuth:
+    """Tests that configuration preserves gateway authentication."""
+
+    def test_preserves_gateway_token_during_reconfiguration(
+        self, isolated_config: Path
+    ):
+        """Gateway auth token is preserved when reconfiguring provider."""
+        from clawrium.cli.agent import _sync_provider_config
+
+        create_test_keypair(isolated_config, "work")
+
+        # Create host with gateway auth already set
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = [
+            {
+                "hostname": "192.168.1.100",
+                "key_id": "work",
+                "port": 22,
+                "agent_name": "xclm",
+                "alias": "work",
+                "auth_method": "key",
+                "agents": {
+                    "openclaw": {
+                        "version": "0.1.0",
+                        "status": "installed",
+                        "agent_name": "assistant",
+                        "onboarding": {"state": "pending"},
+                        "config": {
+                            "gateway": {
+                                "url": "ws://192.168.1.100:40123",
+                                "auth": "original-token-abc123",
+                                "port": 40123,
+                                "bind": "lan",
+                            }
+                        },
+                    }
+                },
+            }
+        ]
+        hosts_file.write_text(json.dumps(hosts_data, indent=2))
+
+        # Test provider
+        provider = {
+            "name": "test-openai",
+            "type": "openai",
+            "endpoint": "",
+            "default_model": "gpt-4",
+        }
+
+        # Mock configure_agent to verify it receives preserved auth
+        captured_config = []
+
+        def mock_configure(hostname, claw_name, config_data, on_event=None):
+            captured_config.append(config_data.copy())
+            return True, None
+
+        with patch(
+            "clawrium.core.lifecycle.configure_agent", side_effect=mock_configure
+        ):
+            _sync_provider_config("work", "openclaw", provider)
+
+        # Verify gateway auth was preserved
+        assert len(captured_config) > 0
+        gateway_config = captured_config[0]["gateway"]
+        assert gateway_config["url"] == "ws://192.168.1.100:40123"
+        assert gateway_config["auth"] == "original-token-abc123"
+
+    def test_preserves_gateway_url_during_reconfiguration(self, isolated_config: Path):
+        """Gateway URL is preserved when reconfiguring provider."""
+        from clawrium.cli.agent import _sync_provider_config
+
+        create_test_keypair(isolated_config, "work")
+
+        # Create host with gateway URL
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = [
+            {
+                "hostname": "192.168.1.100",
+                "key_id": "work",
+                "port": 22,
+                "agent_name": "xclm",
+                "alias": "work",
+                "auth_method": "key",
+                "agents": {
+                    "openclaw": {
+                        "version": "0.1.0",
+                        "status": "installed",
+                        "agent_name": "assistant",
+                        "onboarding": {"state": "pending"},
+                        "config": {
+                            "gateway": {
+                                "url": "ws://custom-host:9999",
+                                "port": 9999,
+                                "bind": "lan",
+                            }
+                        },
+                    }
+                },
+            }
+        ]
+        hosts_file.write_text(json.dumps(hosts_data, indent=2))
+
+        provider = {
+            "name": "test-openai",
+            "type": "openai",
+            "endpoint": "",
+            "default_model": "gpt-4",
+        }
+
+        captured_config = []
+
+        def mock_configure(hostname, claw_name, config_data, on_event=None):
+            captured_config.append(config_data.copy())
+            return True, None
+
+        with patch(
+            "clawrium.core.lifecycle.configure_agent", side_effect=mock_configure
+        ):
+            _sync_provider_config("work", "openclaw", provider)
+
+        # Verify URL was preserved
+        gateway_config = captured_config[0]["gateway"]
+        assert gateway_config["url"] == "ws://custom-host:9999"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1026,8 +1026,10 @@ def test_install_onboarding_raises_does_not_corrupt_state(monkeypatch, tmp_path)
     # Verify warning event was emitted about onboarding failure
     warn_events = [e for e in events if e[0] == "warn"]
     assert len(warn_events) >= 1, "Should emit warning when onboarding fails"
-    assert "clm onboard init" in warn_events[0][1], (
-        "Warning should include retry command"
+    # Check that at least one warning mentions onboarding
+    onboarding_warnings = [e for e in warn_events if "clm onboard init" in e[1]]
+    assert len(onboarding_warnings) >= 1, (
+        "Warning should include onboarding retry command"
     )
 
 
@@ -1625,3 +1627,332 @@ def test_install_uses_extended_timeout(monkeypatch, tmp_path):
     assert claw_call[1]["timeout"] == 1800, (
         "Claw installation should use 1800s (30 min) timeout"
     )
+
+
+def test_install_openclaw_captures_gateway_token(monkeypatch, tmp_path):
+    """Test that OpenClaw installation extracts gateway token from Ansible facts."""
+    import json
+    from clawrium.core.install import run_installation
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mock_manifest = {
+        "name": "openclaw",
+        "entries": [
+            {
+                "version": "0.1.0",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc123",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.9"},
+                },
+            }
+        ],
+    }
+
+    import clawrium.core.install
+
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+
+    key_file = tmp_path / "test_key"
+    key_file.write_text("fake key")
+
+    compatible_host = {
+        "hostname": "test-host",
+        "agent_name": "xclm",
+        "port": 22,
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    monkeypatch.setattr(clawrium.core.install, "get_host", lambda x: compatible_host)
+
+    compat_result = {
+        "compatible": True,
+        "matched_entry": mock_manifest["entries"][0],
+        "reasons": [],
+    }
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *args, **kwargs: compat_result,
+    )
+
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda x: key_file
+    )
+
+    # Track update_host calls to verify token storage with persistent state
+    update_calls = []
+    persistent_host = compatible_host.copy()
+
+    def mock_update_host(hostname, updater):
+        nonlocal persistent_host
+        if "agents" not in persistent_host:
+            persistent_host["agents"] = {}
+        persistent_host = updater(persistent_host)
+        update_calls.append((hostname, persistent_host.copy()))
+        return True
+
+    monkeypatch.setattr(clawrium.core.install, "update_host", mock_update_host)
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", lambda h, c: True
+    )
+
+    # Mock ansible_runner.run with fact cache
+    class SuccessfulResult:
+        status = "successful"
+
+        class Config:
+            artifact_dir = tmp_path / "artifacts"
+
+        config = Config()
+
+    # Create fact cache with gateway token
+    fact_cache_dir = tmp_path / "artifacts" / "fact_cache"
+    fact_cache_dir.mkdir(parents=True)
+    fact_file = fact_cache_dir / "test-host"
+    fact_file.write_text(
+        json.dumps(
+            {
+                "openclaw_gateway_token": "test-token-123",
+                "openclaw_gateway_url": "ws://test-host:40123",
+            }
+        )
+    )
+
+    mock_run = Mock(return_value=SuccessfulResult())
+
+    import ansible_runner
+
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    # Run installation
+    result = run_installation("openclaw", "test-host")
+
+    # Verify installation succeeded
+    assert result["success"] is True
+
+    # Verify gateway token was stored in final update_host call
+    assert len(update_calls) >= 2
+    last_update = update_calls[-1][1]
+
+    assert "agents" in last_update
+    assert "openclaw" in last_update["agents"]
+    assert "config" in last_update["agents"]["openclaw"]
+    assert "gateway" in last_update["agents"]["openclaw"]["config"]
+
+    gateway_config = last_update["agents"]["openclaw"]["config"]["gateway"]
+    assert gateway_config["url"] == "ws://test-host:40123"
+    assert gateway_config["auth"] == "test-token-123"
+
+
+def test_install_openclaw_stores_gateway_url(monkeypatch, tmp_path):
+    """Test that OpenClaw installation stores gateway URL correctly."""
+    import json
+    from clawrium.core.install import run_installation
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mock_manifest = {
+        "name": "openclaw",
+        "entries": [
+            {
+                "version": "0.1.0",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc123",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.9"},
+                },
+            }
+        ],
+    }
+
+    import clawrium.core.install
+
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+
+    key_file = tmp_path / "test_key"
+    key_file.write_text("fake key")
+
+    compatible_host = {
+        "hostname": "192.168.1.100",
+        "agent_name": "xclm",
+        "port": 22,
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    monkeypatch.setattr(clawrium.core.install, "get_host", lambda x: compatible_host)
+
+    compat_result = {
+        "compatible": True,
+        "matched_entry": mock_manifest["entries"][0],
+        "reasons": [],
+    }
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *args, **kwargs: compat_result,
+    )
+
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda x: key_file
+    )
+
+    update_calls = []
+    persistent_host = compatible_host.copy()
+
+    def mock_update_host(hostname, updater):
+        nonlocal persistent_host
+        if "agents" not in persistent_host:
+            persistent_host["agents"] = {}
+        persistent_host = updater(persistent_host)
+        update_calls.append((hostname, persistent_host.copy()))
+        return True
+
+    monkeypatch.setattr(clawrium.core.install, "update_host", mock_update_host)
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", lambda h, c: True
+    )
+
+    class SuccessfulResult:
+        status = "successful"
+
+        class Config:
+            artifact_dir = tmp_path / "artifacts"
+
+        config = Config()
+
+    fact_cache_dir = tmp_path / "artifacts" / "fact_cache"
+    fact_cache_dir.mkdir(parents=True)
+    fact_file = fact_cache_dir / "192.168.1.100"
+    fact_file.write_text(
+        json.dumps(
+            {
+                "openclaw_gateway_token": "token-abc",
+                "openclaw_gateway_url": "ws://192.168.1.100:40999",
+            }
+        )
+    )
+
+    mock_run = Mock(return_value=SuccessfulResult())
+
+    import ansible_runner
+
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    # Run installation
+    run_installation("openclaw", "192.168.1.100")
+
+    # Verify URL construction and storage
+    last_update = update_calls[-1][1]
+    gateway_url = last_update["agents"]["openclaw"]["config"]["gateway"]["url"]
+
+    assert gateway_url == "ws://192.168.1.100:40999"
+    assert gateway_url.startswith("ws://")
+    assert "192.168.1.100" in gateway_url
+
+
+def test_install_openclaw_without_token_succeeds(monkeypatch, tmp_path):
+    """Test that OpenClaw installation succeeds even if token generation fails."""
+    from clawrium.core.install import run_installation
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mock_manifest = {
+        "name": "openclaw",
+        "entries": [
+            {
+                "version": "0.1.0",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc123",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.9"},
+                },
+            }
+        ],
+    }
+
+    import clawrium.core.install
+
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+
+    key_file = tmp_path / "test_key"
+    key_file.write_text("fake key")
+
+    compatible_host = {
+        "hostname": "test-host",
+        "agent_name": "xclm",
+        "port": 22,
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    monkeypatch.setattr(clawrium.core.install, "get_host", lambda x: compatible_host)
+
+    compat_result = {
+        "compatible": True,
+        "matched_entry": mock_manifest["entries"][0],
+        "reasons": [],
+    }
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *args, **kwargs: compat_result,
+    )
+
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda x: key_file
+    )
+
+    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: u(clawrium.core.install.get_host(h)))
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", lambda h, c: True
+    )
+
+    # Mock ansible_runner.run WITHOUT fact cache (token extraction fails)
+    class SuccessfulResult:
+        status = "successful"
+
+        class Config:
+            artifact_dir = tmp_path / "artifacts_no_facts"
+
+        config = Config()
+
+    mock_run = Mock(return_value=SuccessfulResult())
+
+    import ansible_runner
+
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    # Run installation - should succeed despite missing token
+    result = run_installation("openclaw", "test-host")
+
+    # Verify installation succeeded
+    assert result["success"] is True
+    assert result["error"] is None


### PR DESCRIPTION
## Summary

Automates OpenClaw gateway pairing by generating authentication tokens during installation and preserving them during reconfiguration.

**Changes:**
- Generate gateway auth token during OpenClaw installation using `openclaw doctor --generate-gateway-token`
- Store token in `hosts.json` under `agents.openclaw.config.gateway.auth`
- Preserve token during provider reconfiguration
- Apply token to `.env` file via `OPENCLAW_GATEWAY_AUTH_MODE` and `OPENCLAW_GATEWAY_AUTH_TOKEN`
- Add validation playbook task (strict mode) to verify token exists

**Impact:**
- Users no longer need to manually pair OpenClaw instances with the gateway
- Token is automatically generated and applied during installation
- Reconfiguration preserves existing tokens to maintain connectivity

## Testing

All existing tests pass. Added new tests for:
- Token capture from Ansible facts
- Token storage in hosts.json
- Token preservation during reconfiguration
- URL construction and storage

```bash
make test  # 734 tests passed
make lint  # All checks passed
```

## ATX Review Summary

**Review 1: Rating 2/5**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 2/5 | B1, B2, B3, B4, B5, B6, B7, B8 | B1-B2 fixed, B3-B8 tracked in issue 149 |

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `install.yaml:84-91` | Shell injection risk - shell module with interpolated agent_name | **Fixed** - Changed to ansible.builtin.command |
| B2 | `install.yaml:84-95` | Token logged in plaintext to Ansible artifacts | **Fixed** - Added no_log: true |
| B3 | `install.py:352-359` | Tokens stored in plaintext hosts.json | Tracked in issue 149 - Requires encrypted storage migration |
| B4 | `install.py:344-362` | Non-atomic token write - crash drops token | Tracked in issue 149 - Requires atomic updater pattern |
| B5 | `install.py:317-341` | No token validation - empty tokens stored | Tracked in issue 149 - Requires validation logic |
| B6 | `lifecycle.py:611-631` | TOCTOU race in token preservation | Tracked in issue 149 - Requires locked updater |
| B7 | `tests/test_configure_claw.py:324` | No template security tests | Tracked in issue 149 - Requires template tests |
| B8 | `tests/test_install.py:1873` | Weak negative-path assertions | Tracked in issue 149 - Requires assertion strengthening |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `install.py:333-341` | No lock around fact_cache read | Tracked in issue 149 |
| W2 | `install.py:340-341` | Error message lacks recovery path | Tracked in issue 149 |
| W3 | `configure.yaml:5-10` | Strict validation bypassed by default | Tracked in issue 149 |
| W4 | `tests/test_install.py:1632` | No tests for corrupted fact cache | Tracked in issue 149 |
| W5 | `tests/test_cli_agent_configure.py:687` | No test for missing auth during reconfigure | Tracked in issue 149 |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Add clm agent repair-auth command | Tracked in issue 149 |
| S2 | Validate token schema at load time | Tracked in issue 149 |
| S3 | Log stack trace at DEBUG not WARNING | Tracked in issue 149 |
| S4 | Add crash simulation test | Tracked in issue 149 |

</details>

**Fixes Applied in This PR:**
- ✅ B1: Changed ansible.builtin.shell to ansible.builtin.command to prevent shell injection
- ✅ B2: Added no_log: true to token generation and fact-setting tasks to prevent plaintext logging

**Follow-up Work:**
- 🔄 B3-B8: Tracked in issue 149 for security and reliability improvements
- These require architectural changes (encrypted storage, atomic updates, comprehensive tests)
- Core functionality is working and tested; issue 149 will harden it for production

## Notes

This PR implements the core automated pairing functionality. Issue 149 tracks the security and reliability improvements identified by ATX review that require more substantial architectural changes.

Closes #132

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
