### PR TITLE
fix: detect incomplete agent installations on retry

### DIFF
--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -26,7 +26,7 @@ import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, TypedDict
+from typing import Callable, NotRequired, TypedDict
 
 import ansible_runner
 
@@ -58,6 +58,21 @@ class InstallationError(Exception):
     pass
 
 
+class IncompleteInstallationError(InstallationError):
+    """Raised when an incomplete installation already exists for an agent type."""
+
+    def __init__(self, hostname: str, claw_name: str, details: dict):
+        self.hostname = hostname
+        self.claw_name = claw_name
+        self.details = details
+        status = details.get("status", "unknown")
+        agent_name = details.get("agent_name") or claw_name
+        super().__init__(
+            "Incomplete installation detected for "
+            f"'{agent_name}' on host '{hostname}' (status: {status})."
+        )
+
+
 class InstallResult(TypedDict):
     """Result of installation operation."""
 
@@ -67,6 +82,31 @@ class InstallResult(TypedDict):
     host: str
     playbooks_run: list[str]
     error: str | None
+    incomplete_installation: NotRequired[dict | None]
+
+
+def _get_incomplete_installation_details(host: dict, claw_name: str) -> dict | None:
+    """Return existing incomplete installation details for an agent type, if any."""
+    existing = host.get("agents", {}).get(claw_name)
+    if not existing:
+        return None
+
+    status = existing.get("status")
+    installed_at = existing.get("installed_at")
+    # Detect explicit incomplete states from prior attempts.
+    # Also treat a status-bearing record with no installed_at timestamp as incomplete.
+    if status in {"installing", "failed"} or (
+        status is not None and installed_at is None
+    ):
+        return {
+            "status": status,
+            "installed_at": installed_at,
+            "error": existing.get("error"),
+            "agent_name": existing.get("agent_name"),
+            "version": existing.get("version"),
+        }
+
+    return None
 
 
 def _get_base_playbook_path() -> Path:
@@ -155,6 +195,17 @@ def run_installation(
         if not valid:
             raise InstallationError(f"Invalid name: {error_msg}")
         emit("validate", f"Validated custom name: {name}")
+
+    incomplete_details = _get_incomplete_installation_details(host, claw_name)
+    if incomplete_details and incomplete_details.get("status") == "installing":
+        raise IncompleteInstallationError(
+            host["hostname"], claw_name, incomplete_details
+        )
+    if incomplete_details:
+        emit(
+            "validate",
+            "Found previous incomplete installation state; proceeding with retry.",
+        )
 
     # Step 5: Set installing state with uniqueness check under lock
     # Use a list to capture the chosen name from inside the updater
@@ -331,14 +382,21 @@ def run_installation(
                                 gateway_token = facts.get("openclaw_gateway_token")
                                 gateway_url = facts.get("openclaw_gateway_url")
                                 if gateway_token and gateway_url:
-                                    emit("claw", "Gateway authentication token captured")
+                                    emit(
+                                        "claw", "Gateway authentication token captured"
+                                    )
                                     break
                         except (json.JSONDecodeError, IOError) as file_err:
-                            logger.debug("Skipping fact file %s: %s", fact_file, file_err)
+                            logger.debug(
+                                "Skipping fact file %s: %s", fact_file, file_err
+                            )
                             continue
             except Exception as e:
                 logger.warning("Failed to extract gateway token: %s", e, exc_info=True)
-                emit("warn", "Gateway token capture failed - manual pairing may be needed")
+                emit(
+                    "warn",
+                    "Gateway token capture failed - manual pairing may be needed",
+                )
 
         # Step 10: Update host with success status and gateway auth (if available)
         def set_installed(h: dict) -> dict:
@@ -396,6 +454,7 @@ def run_installation(
             "host": host["hostname"],
             "playbooks_run": playbooks_run,
             "error": None,
+            "incomplete_installation": incomplete_details,
         }
 
     except Exception as e:
@@ -406,7 +465,10 @@ def run_installation(
             if "agents" not in h:
                 h["agents"] = {}
             if claw_name not in h["agents"]:
-                h["agents"][claw_name] = {"version": matched_version, "agent_name": agent_name}
+                h["agents"][claw_name] = {
+                    "version": matched_version,
+                    "agent_name": agent_name,
+                }
             h["agents"][claw_name]["status"] = "failed"
             h["agents"][claw_name]["error"] = error_msg
             h["agents"][claw_name]["installed_at"] = datetime.now(

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -227,6 +227,37 @@ def test_install_error_exits_1(isolated_config: Path):
         assert "playbook" in result.output.lower()
 
 
+def test_install_incomplete_error_exits_1(isolated_config: Path):
+    """IncompleteInstallationError shows error message and exits 1."""
+    create_test_keypair(isolated_config, "testhost")
+    create_host(isolated_config, "192.168.1.100", alias="testhost", key_id="testhost")
+
+    from clawrium.core.install import IncompleteInstallationError
+
+    with patch("clawrium.cli.install.run_installation") as mock_install:
+        mock_install.side_effect = IncompleteInstallationError(
+            hostname="192.168.1.100",
+            claw_name="openclaw",
+            details={
+                "status": "failed",
+                "installed_at": None,
+                "error": "Base playbook failed",
+                "agent_name": "work-assistant",
+                "version": "0.1.0",
+            },
+        )
+
+        result = runner.invoke(
+            app,
+            ["agent", "install", "--type", "openclaw", "--host", "testhost", "--yes"],
+            env=os.environ,
+        )
+
+        assert result.exit_code == 1
+        assert "incomplete installation detected" in result.output.lower()
+        assert "work-assistant" in result.output.lower()
+
+
 def test_install_incompatible_exits_1(isolated_config: Path):
     """Incompatible host shows reasons and exits 1."""
     # Setup: create host with incompatible hardware (ARM instead of x86_64)
@@ -291,21 +322,19 @@ def test_install_hosts_file_corrupted(isolated_config: Path):
     assert "corrupted" in result.output.lower() or "error" in result.output.lower()
 
 
-
-
 def test_install_claw_flag_rejected(isolated_config: Path):
     """Test that the old --claw flag is rejected with proper error message."""
     # Setup: create host and keypair
     create_test_keypair(isolated_config, "testhost")
     create_host(isolated_config, "192.168.1.100", alias="testhost", key_id="testhost")
-    
+
     # Try using the old --claw flag
     result = runner.invoke(
         app,
         ["agent", "install", "--claw", "openclaw", "--host", "testhost"],
         env=os.environ,
     )
-    
+
     # Should exit with error code 2 (Typer's "no such option" error)
     assert result.exit_code == 2
     # Should mention the flag issue

--- a/tests/test_install_incomplete_detection.py
+++ b/tests/test_install_incomplete_detection.py
@@ -1,0 +1,180 @@
+"""Tests for incomplete installation detection during install retries."""
+
+from unittest.mock import Mock
+
+import pytest
+
+
+def _setup_common(monkeypatch, tmp_path, host_record: dict) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mock_manifest = {
+        "name": "openclaw",
+        "entries": [
+            {
+                "version": "0.1.0",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc123",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.9"},
+                },
+            }
+        ],
+    }
+
+    import clawrium.core.install
+
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *args, **kwargs: {
+            "compatible": True,
+            "matched_entry": mock_manifest["entries"][0],
+            "reasons": [],
+        },
+    )
+    monkeypatch.setattr(clawrium.core.install, "get_host", lambda x: host_record)
+
+    key_file = tmp_path / "test_key"
+    key_file.write_text("fake key")
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda x: key_file
+    )
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "update_host",
+        lambda h, u: u(clawrium.core.install.get_host(h)),
+    )
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", lambda h, c: True
+    )
+
+    class SuccessfulResult:
+        status = "successful"
+
+    import ansible_runner
+
+    monkeypatch.setattr(ansible_runner, "run", Mock(return_value=SuccessfulResult()))
+
+
+def test_detect_incomplete_installing(monkeypatch, tmp_path):
+    from clawrium.core.install import IncompleteInstallationError, run_installation
+
+    host = {
+        "hostname": "test-host",
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+        "agents": {
+            "openclaw": {
+                "status": "installing",
+                "installed_at": None,
+                "error": None,
+                "agent_name": "work-assistant",
+                "version": "0.1.0",
+            }
+        },
+    }
+    _setup_common(monkeypatch, tmp_path, host)
+
+    with pytest.raises(IncompleteInstallationError) as exc_info:
+        run_installation("openclaw", "test-host")
+
+    assert exc_info.value.details["status"] == "installing"
+    assert exc_info.value.details["agent_name"] == "work-assistant"
+
+
+def test_detect_incomplete_failed(monkeypatch, tmp_path):
+    from clawrium.core.install import run_installation
+
+    host = {
+        "hostname": "test-host",
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+        "agents": {
+            "openclaw": {
+                "status": "failed",
+                "installed_at": None,
+                "error": "base playbook failed",
+                "agent_name": "work-assistant",
+                "version": "0.1.0",
+            }
+        },
+    }
+    _setup_common(monkeypatch, tmp_path, host)
+
+    result = run_installation("openclaw", "test-host")
+    assert result["success"] is True
+    assert result["incomplete_installation"]["status"] == "failed"
+
+
+def test_detect_incomplete_installed_without_timestamp(monkeypatch, tmp_path):
+    from clawrium.core.install import run_installation
+
+    host = {
+        "hostname": "test-host",
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+        "agents": {
+            "openclaw": {
+                "status": "installed",
+                "installed_at": None,
+                "error": None,
+                "agent_name": "work-assistant",
+                "version": "0.1.0",
+            }
+        },
+    }
+    _setup_common(monkeypatch, tmp_path, host)
+
+    result = run_installation("openclaw", "test-host")
+    assert result["success"] is True
+    assert result["incomplete_installation"]["status"] == "installed"
+
+
+def test_no_detection_for_installed(monkeypatch, tmp_path):
+    from clawrium.core.install import run_installation
+
+    host = {
+        "hostname": "test-host",
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+        "agents": {
+            "openclaw": {
+                "status": "installed",
+                "installed_at": "2026-04-10T00:00:00+00:00",
+                "error": None,
+                "agent_name": "existing-agent",
+                "version": "0.1.0",
+            }
+        },
+    }
+    _setup_common(monkeypatch, tmp_path, host)
+
+    result = run_installation("openclaw", "test-host")
+    assert result["success"] is True
+    assert result["incomplete_installation"] is None


### PR DESCRIPTION
## Summary
- Add incomplete-installation detection in `run_installation()` before the install state transition.
- Block duplicate in-progress installs (`status=installing`) while allowing failed retries and surfacing incomplete metadata in the install result.
- Add focused test coverage for core detection and CLI error handling (`IncompleteInstallationError`).

## Testing
- `make test`
- `make lint`

## ATX Review Summary

**Final Review: Rating 4/5**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 3.5/5 | None | Follow-up warnings addressed |
| 2 | 3/5 | B1 | Fixed |
| 3 | 4/5 | None | Ready |

<details>
<summary>Review 1 Details (Rating 3.5/5)</summary>

**Blocking Issues:** None

**Warnings:**
- W1 Fixed: Clarified/guarded incomplete detection semantics and coverage.
- W2 Fixed: Added partial install detection tests.
- W3 Fixed: Added CLI coverage for incomplete-installation error path.

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Blocking Issues:**
- B1 Fixed: Failed-state retries were being blocked; updated behavior to block only active `installing` state and allow failed retry flow.

**Warnings:**
- TOCTOU follow-up acknowledged as architectural improvement outside this issue scope.

</details>

<details>
<summary>Review 3 Details (Rating 4/5)</summary>

No blocking issues. Approved for merge.

</details>

Closes #152

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>