### PR TITLE
chore: apply formatting cleanup across cli and tests

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -14,7 +14,8 @@
         "ATX_PROJECT_ID": "2f7d41ac-f5fb-4466-8e2e-9e69bbef6701",
         "ATX_WORKING_DIR": "/home/devashish/workspace/ric03uec/clawrium"
       },
-      "enabled": true
+      "enabled": true,
+      "timeout": 600000
     }
   }
 }

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -14,8 +14,7 @@
         "ATX_PROJECT_ID": "2f7d41ac-f5fb-4466-8e2e-9e69bbef6701",
         "ATX_WORKING_DIR": "/home/devashish/workspace/ric03uec/clawrium"
       },
-      "enabled": true,
-      "timeout": 600000
+      "enabled": true
     }
   }
 }

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -232,7 +232,9 @@ def _sync_provider_config(host: str, claw_type: str, provider: dict) -> None:
     claw_record = host_data.get("agents", {}).get(claw_type)
     if not claw_record:
         raise RuntimeError(f"Agent '{claw_type}' not installed on '{host}'")
-    installed_name = claw_record.get("agent_name") or claw_record.get("name") or claw_type
+    installed_name = (
+        claw_record.get("agent_name") or claw_record.get("name") or claw_type
+    )
 
     # Calculate or preserve gateway port
     existing_config = claw_record.get("config", {})

--- a/src/clawrium/cli/status.py
+++ b/src/clawrium/cli/status.py
@@ -154,7 +154,9 @@ def status(
 
         for h, claw_record in instances:
             display_host = h.get("alias") or h["hostname"]
-            full_name = claw_record.get("agent_name") or claw_record.get("name") or claw_name
+            full_name = (
+                claw_record.get("agent_name") or claw_record.get("name") or claw_name
+            )
             version = claw_record.get("version", "?")
             installed_at = claw_record.get("installed_at", "-")
             if installed_at and installed_at != "-":

--- a/src/clawrium/core/onboarding.py
+++ b/src/clawrium/core/onboarding.py
@@ -224,7 +224,12 @@ def complete_stage(
             "identity": ["identity"],  # Can complete identity while in identity state
             "channels": ["channels"],  # Can complete channels while in channels state
             "validate": ["validate"],  # Can complete validate while in validate state
-            "ready": ["providers", "identity", "channels", "validate"],  # Allow reconfiguration when ready
+            "ready": [
+                "providers",
+                "identity",
+                "channels",
+                "validate",
+            ],  # Allow reconfiguration when ready
         }
 
         current_state = get_onboarding_state(host, claw_name)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -691,7 +691,9 @@ class TestGetOnboardingStatus:
 
     def test_malformed_stages_data_returns_pending_onboard(self):
         """Malformed stages (string instead of dict) returns PENDING_ONBOARD gracefully."""
-        claw_record = {"onboarding": {"state": "providers", "stages": "malformed-string"}}
+        claw_record = {
+            "onboarding": {"state": "providers", "stages": "malformed-string"}
+        }
         status, step = get_onboarding_status(claw_record)
         # Should handle gracefully - return ONBOARDING with step based on state
         assert status == ClawStatus.ONBOARDING

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -168,7 +168,11 @@ def test_install_success(monkeypatch, tmp_path):
     )
 
     # Mock update_host to avoid real filesystem access
-    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: u(clawrium.core.install.get_host(h)))
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "update_host",
+        lambda h, u: u(clawrium.core.install.get_host(h)),
+    )
 
     # Mock initialize_onboarding to avoid real filesystem access
     monkeypatch.setattr(
@@ -263,7 +267,11 @@ def test_install_emits_events(monkeypatch, tmp_path):
     )
 
     # Mock update_host to avoid real filesystem access
-    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: u(clawrium.core.install.get_host(h)))
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "update_host",
+        lambda h, u: u(clawrium.core.install.get_host(h)),
+    )
 
     # Mock initialize_onboarding to avoid real filesystem access
     monkeypatch.setattr(
@@ -359,7 +367,11 @@ def test_install_base_playbook_fails(monkeypatch, tmp_path):
     )
 
     # Mock update_host to avoid real filesystem access
-    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: u(clawrium.core.install.get_host(h)))
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "update_host",
+        lambda h, u: u(clawrium.core.install.get_host(h)),
+    )
 
     # Mock ansible_runner.run to fail
     class FailedResult:
@@ -431,7 +443,11 @@ def test_install_missing_ssh_key_raises(monkeypatch, tmp_path):
     )
 
     # Mock update_host to avoid real filesystem access
-    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: u(clawrium.core.install.get_host(h)))
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "update_host",
+        lambda h, u: u(clawrium.core.install.get_host(h)),
+    )
 
     # Mock get_host_private_key to return None
     monkeypatch.setattr(clawrium.core.install, "get_host_private_key", lambda x: None)
@@ -862,7 +878,11 @@ def test_install_failure_does_not_initialize_onboarding(monkeypatch, tmp_path):
     )
 
     # Mock update_host to avoid real filesystem access
-    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: u(clawrium.core.install.get_host(h)))
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "update_host",
+        lambda h, u: u(clawrium.core.install.get_host(h)),
+    )
 
     # Mock ansible_runner.run to fail
     class FailedResult:
@@ -1218,7 +1238,11 @@ def test_install_with_custom_name(monkeypatch, tmp_path):
         clawrium.core.install, "get_host_private_key", lambda x: key_file
     )
 
-    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: u(clawrium.core.install.get_host(h)))
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "update_host",
+        lambda h, u: u(clawrium.core.install.get_host(h)),
+    )
     monkeypatch.setattr(
         clawrium.core.install, "initialize_onboarding", lambda h, c: True
     )
@@ -1304,7 +1328,11 @@ def test_install_auto_generates_name(monkeypatch, tmp_path):
         clawrium.core.install, "get_host_private_key", lambda x: key_file
     )
 
-    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: u(clawrium.core.install.get_host(h)))
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "update_host",
+        lambda h, u: u(clawrium.core.install.get_host(h)),
+    )
     monkeypatch.setattr(
         clawrium.core.install, "initialize_onboarding", lambda h, c: True
     )
@@ -1392,7 +1420,11 @@ def test_install_rejects_duplicate_name_same_host(monkeypatch, tmp_path):
         clawrium.core.install, "get_host_private_key", lambda x: key_file
     )
 
-    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: u(clawrium.core.install.get_host(h)))
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "update_host",
+        lambda h, u: u(clawrium.core.install.get_host(h)),
+    )
 
     # Try to install with duplicate name
     with pytest.raises(InstallationError, match="already in use"):
@@ -1460,7 +1492,11 @@ def test_install_allows_same_name_different_host(monkeypatch, tmp_path):
         clawrium.core.install, "get_host_private_key", lambda x: key_file
     )
 
-    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: u(clawrium.core.install.get_host(h)))
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "update_host",
+        lambda h, u: u(clawrium.core.install.get_host(h)),
+    )
     monkeypatch.setattr(
         clawrium.core.install, "initialize_onboarding", lambda h, c: True
     )
@@ -1602,7 +1638,11 @@ def test_install_uses_extended_timeout(monkeypatch, tmp_path):
         clawrium.core.install, "get_host_private_key", lambda x: key_file
     )
 
-    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: u(clawrium.core.install.get_host(h)))
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "update_host",
+        lambda h, u: u(clawrium.core.install.get_host(h)),
+    )
     monkeypatch.setattr(
         clawrium.core.install, "initialize_onboarding", lambda h, c: True
     )
@@ -1930,7 +1970,11 @@ def test_install_openclaw_without_token_succeeds(monkeypatch, tmp_path):
         clawrium.core.install, "get_host_private_key", lambda x: key_file
     )
 
-    monkeypatch.setattr(clawrium.core.install, "update_host", lambda h, u: u(clawrium.core.install.get_host(h)))
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "update_host",
+        lambda h, u: u(clawrium.core.install.get_host(h)),
+    )
     monkeypatch.setattr(
         clawrium.core.install, "initialize_onboarding", lambda h, c: True
     )

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -408,9 +408,7 @@ class TestRemoveClaw:
                                     "clawrium.core.lifecycle.remove_agent_from_host",
                                     return_value=True,
                                 ):
-                                    result = remove_agent(
-                                        "192.168.1.100", "openclaw"
-                                    )
+                                    result = remove_agent("192.168.1.100", "openclaw")
 
         assert result["success"] is True
         assert result["operation"] == "remove"
@@ -473,9 +471,7 @@ class TestRemoveClaw:
                                     "clawrium.core.lifecycle.remove_agent_from_host",
                                     return_value=True,
                                 ):
-                                    result = remove_agent(
-                                        "192.168.1.100", "openclaw"
-                                    )
+                                    result = remove_agent("192.168.1.100", "openclaw")
 
         # Should still succeed with removal
         assert result["success"] is True

--- a/tests/test_playbooks.py
+++ b/tests/test_playbooks.py
@@ -40,10 +40,7 @@ def test_base_playbook_structure():
 
     # Find and validate Node.js installation
     # Look for the specific task "Install Node.js"
-    nodejs_tasks = [
-        t for t in tasks
-        if t.get("name") == "Install Node.js"
-    ]
+    nodejs_tasks = [t for t in tasks if t.get("name") == "Install Node.js"]
     assert len(nodejs_tasks) > 0, "Should have task to install Node.js"
     nodejs_task = nodejs_tasks[0]
     apt_module = nodejs_task.get("ansible.builtin.apt", {})
@@ -53,8 +50,7 @@ def test_base_playbook_structure():
 
     # Find and validate build-essential installation
     build_essential_tasks = [
-        t for t in tasks
-        if "build-essential" in str(t.get("name", "")).lower()
+        t for t in tasks if "build-essential" in str(t.get("name", "")).lower()
     ]
     assert len(build_essential_tasks) > 0, "Should have task to install build-essential"
     build_essential_task = build_essential_tasks[0]
@@ -65,8 +61,10 @@ def test_base_playbook_structure():
 
     # Find and validate git/gh installation
     git_gh_tasks = [
-        t for t in tasks
-        if "git" in str(t.get("name", "")).lower() and "github" in str(t.get("name", "")).lower()
+        t
+        for t in tasks
+        if "git" in str(t.get("name", "")).lower()
+        and "github" in str(t.get("name", "")).lower()
     ]
     assert len(git_gh_tasks) > 0, "Should have task to install git and GitHub CLI"
     git_gh_task = git_gh_tasks[0]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -677,10 +677,6 @@ def test_validate_agent_type_valid():
     validate_agent_type("Claw123")
 
 
-
-
-
-
 # check_compatibility version parameter tests
 
 


### PR DESCRIPTION
## Summary
- Apply non-functional formatting cleanup across CLI and test modules for readability/consistency.
- Remove the accidental `.opencode/opencode.json` change from this branch.

## Testing
- `make test` (779 passed)

## ATX Review Summary
- `atx_review_changes` completed with no blocking issues.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>