### PR TITLE
feat(status): Surface incomplete installations in status commands

### DIFF
--- a/src/clawrium/cli/status.py
+++ b/src/clawrium/cli/status.py
@@ -219,12 +219,22 @@ def status(
                 else:
                     status_display = "[yellow]unknown[/yellow]"
 
-            # Also show install state if failed
+            # Also show install state if failed or incomplete
             install_status = claw_record.get("status", "")
             if install_status == "failed":
-                status_display = "[red]install failed[/red]"
+                error_msg = claw_record.get("error", "unknown error")
+                if isinstance(error_msg, str) and len(error_msg) > 50:
+                    error_display = escape(error_msg[:50]) + "..."
+                elif isinstance(error_msg, str):
+                    error_display = escape(error_msg)
+                else:
+                    error_display = "unknown error"
+                status_display = f"[red]install failed[/red] ({error_display})"
             elif install_status == "installing":
-                status_display = "[yellow]installing...[/yellow]"
+                if claw_record.get("installed_at") is None:
+                    status_display = "[yellow]incomplete install[/yellow]"
+                else:
+                    status_display = "[yellow]installing...[/yellow]"
 
             table.add_row(
                 escape(full_name),

--- a/src/clawrium/cli/status.py
+++ b/src/clawrium/cli/status.py
@@ -1,5 +1,6 @@
 """Fleet status command for viewing agent instances across hosts."""
 
+import logging
 from collections import defaultdict
 from typing import Optional
 
@@ -18,6 +19,7 @@ from clawrium.core.health import (
 
 __all__ = ["status"]
 
+logger = logging.getLogger(__name__)
 console = Console()
 
 
@@ -228,9 +230,15 @@ def status(
                 elif isinstance(error_msg, str):
                     error_display = escape(error_msg)
                 else:
+                    logger.warning(
+                        "Non-string error field for failed install: %s",
+                        type(error_msg).__name__,
+                    )
                     error_display = "unknown error"
                 status_display = f"[red]install failed[/red] ({error_display})"
             elif install_status == "installing":
+                # No installed_at means installation never completed (abandoned/stale),
+                # distinct from actively installing which has a timestamp.
                 if claw_record.get("installed_at") is None:
                     status_display = "[yellow]incomplete install[/yellow]"
                 else:

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -176,7 +176,7 @@ def test_status_host_filter_not_found(mock_hosts_with_claws):
 
 
 def test_status_shows_failed_install():
-    """Failed installation shows install failed status."""
+    """Failed installation shows install failed status with error message."""
     hosts = [
         {
             "hostname": "192.168.1.100",
@@ -192,7 +192,6 @@ def test_status_shows_failed_install():
         }
     ]
 
-    # Health check returns unknown since not really installed
     mock_health = MagicMock(
         return_value={
             "agent": "openclaw",
@@ -212,10 +211,167 @@ def test_status_shows_failed_install():
             result = runner.invoke(app, ["ps"])
 
     assert "install failed" in result.output
+    assert "Playbook failed" in result.output
+
+
+def test_status_shows_failed_install_truncates_long_error():
+    """Failed installation truncates error messages longer than 50 chars."""
+    long_error = "A" * 60
+    hosts = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "server1",
+            "agents": {
+                "openclaw": {
+                    "version": "0.1.0",
+                    "status": "failed",
+                    "error": long_error,
+                    "agent_name": "opc-server1",
+                }
+            },
+        }
+    ]
+
+    mock_health = MagicMock(
+        return_value={
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.STOPPED,
+            "agent_name": "opc-server1",
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": False,
+            "onboarding_stages": None,
+        }
+    )
+
+    with patch("clawrium.cli.status.load_hosts", return_value=hosts):
+        with patch("clawrium.cli.status.check_claw_health", mock_health):
+            result = runner.invoke(app, ["ps"])
+
+    assert "install failed" in result.output
+    assert "A" * 50 + "..." in result.output
+    assert "A" * 60 not in result.output
+
+
+def test_status_shows_failed_install_no_error_field():
+    """Failed installation without error field shows 'unknown error'."""
+    hosts = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "server1",
+            "agents": {
+                "openclaw": {
+                    "version": "0.1.0",
+                    "status": "failed",
+                    "agent_name": "opc-server1",
+                }
+            },
+        }
+    ]
+
+    mock_health = MagicMock(
+        return_value={
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.STOPPED,
+            "agent_name": "opc-server1",
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": False,
+            "onboarding_stages": None,
+        }
+    )
+
+    with patch("clawrium.cli.status.load_hosts", return_value=hosts):
+        with patch("clawrium.cli.status.check_claw_health", mock_health):
+            result = runner.invoke(app, ["ps"])
+
+    assert "install failed" in result.output
+    assert "unknown error" in result.output
 
 
 def test_status_shows_installing_status():
-    """Installing status shows installing indicator."""
+    """Installing status with installed_at shows 'installing...'."""
+    hosts = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "server1",
+            "agents": {
+                "openclaw": {
+                    "version": "0.1.0",
+                    "status": "installing",
+                    "installed_at": "2026-04-10T10:00:00Z",
+                    "agent_name": "opc-server1",
+                }
+            },
+        }
+    ]
+
+    mock_health = MagicMock(
+        return_value={
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.UNKNOWN,
+            "agent_name": "opc-server1",
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": None,
+            "onboarding_stages": None,
+        }
+    )
+    with patch("clawrium.cli.status.load_hosts", return_value=hosts):
+        with patch("clawrium.cli.status.check_claw_health", mock_health):
+            result = runner.invoke(app, ["ps"])
+
+    assert result.exit_code == 0
+    assert "installing" in result.output.lower()
+    assert mock_health.call_count == 1
+
+
+def test_status_shows_incomplete_install():
+    """Installing status without installed_at shows 'incomplete install'."""
+    hosts = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "server1",
+            "agents": {
+                "openclaw": {
+                    "version": "0.1.0",
+                    "status": "installing",
+                    "installed_at": None,
+                    "agent_name": "opc-server1",
+                }
+            },
+        }
+    ]
+
+    mock_health = MagicMock(
+        return_value={
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.UNKNOWN,
+            "agent_name": "opc-server1",
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": None,
+            "onboarding_stages": None,
+        }
+    )
+    with patch("clawrium.cli.status.load_hosts", return_value=hosts):
+        with patch("clawrium.cli.status.check_claw_health", mock_health):
+            result = runner.invoke(app, ["ps"])
+
+    assert result.exit_code == 0
+    assert "incomplete install" in result.output
+
+
+def test_status_shows_incomplete_install_no_installed_at_field():
+    """Installing status with missing installed_at key shows 'incomplete install'."""
     hosts = [
         {
             "hostname": "192.168.1.100",
@@ -248,8 +404,32 @@ def test_status_shows_installing_status():
             result = runner.invoke(app, ["ps"])
 
     assert result.exit_code == 0
-    assert "installing" in result.output.lower()
-    assert mock_health.call_count == 1
+    assert "incomplete install" in result.output
+
+
+def test_status_successful_install_unchanged(mock_hosts_with_claws):
+    """Successfully installed agents display is unchanged."""
+    mock_health = MagicMock(
+        return_value={
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.RUNNING,
+            "agent_name": "opc-server1",
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+        }
+    )
+
+    with patch("clawrium.cli.status.load_hosts", return_value=mock_hosts_with_claws):
+        with patch("clawrium.cli.status.check_claw_health", mock_health):
+            result = runner.invoke(app, ["ps"])
+
+    assert result.exit_code == 0
+    assert "install failed" not in result.output
+    assert "incomplete install" not in result.output
 
 
 def test_status_hosts_file_corrupted():

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -328,7 +328,7 @@ def test_status_shows_installing_status():
             result = runner.invoke(app, ["ps"])
 
     assert result.exit_code == 0
-    assert "installing" in result.output.lower()
+    assert "installing..." in result.output
     assert mock_health.call_count == 1
 
 


### PR DESCRIPTION
## Summary

- Failed installations now display error message (truncated to 50 chars) in status output
- Installing agents without `installed_at` show `[yellow]incomplete install[/yellow]` (abandoned/stale)
- Installing agents with `installed_at` show `[yellow]installing...[/yellow]` (in progress)
- Successfully installed agent display is unchanged

## Testing

- All 790 tests pass
- 6 new test cases added:
  - `test_status_shows_failed_install` - updated to verify error message shown
  - `test_status_shows_failed_install_truncates_long_error` - error >50 chars truncated
  - `test_status_shows_failed_install_no_error_field` - missing error shows "unknown error"
  - `test_status_shows_incomplete_install` - `installed_at=None` shows "incomplete install"
  - `test_status_shows_incomplete_install_no_installed_at_field` - missing key shows "incomplete install"
  - `test_status_successful_install_unchanged` - normal installs unaffected

## ATX Review Summary

**Final Review: Rating 4/5**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 4/5 | None | Ready |

<details>
<summary>Review 1 Details (Rating 4/5)</summary>

**Blocking Issues:** None

**Suggestions:**

| # | File | Suggestion | Action |
|---|------|------------|--------|
| S1 | `test_cli_status.py` | Add boundary test at 50-char truncation | Deferred - low priority |
| S2 | `test_cli_status.py` | Add test for non-string error types | Deferred - low priority |
| S3 | `test_cli_status.py` | Add test for Rich markup in errors | Deferred - low priority |
| S4 | `test_cli_status.py:331` | Change `.lower()` to exact string match | Fixed |
| S5 | `test_cli_status.py` | Extract mock_health_factory fixture | Deferred - low priority |
| S6 | `status.py:234` | Handle `status='installed'` with `installed_at=None` | Deferred - edge case |
| S7 | `status.py:222-237` | Add comment for `installed_at None` semantic | Fixed |
| S8 | `status.py:225-231` | Log warning for non-string error field | Fixed |

</details>

Closes #154

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>