### PR TITLE
feat(cli): add --cleanup-failed flag to install command

### DIFF
--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -78,10 +78,17 @@ def install(
         "-n",
         help="Agent name for the instance (max 32 chars, alphanumeric/hyphens/underscores)",
     ),
+    cleanup_failed: bool = typer.Option(
+        False,
+        "--cleanup-failed",
+        help="Remove incomplete or failed installation of this agent type before retrying",
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
 ) -> None:
     """Install an agent on a host."""
-    install_command(claw=claw, host=host, name=name, yes=yes)
+    install_command(
+        claw=claw, host=host, name=name, cleanup_failed=cleanup_failed, yes=yes
+    )
 
 
 @agent_app.command()

--- a/src/clawrium/cli/install.py
+++ b/src/clawrium/cli/install.py
@@ -87,7 +87,9 @@ def _select_host() -> str:
     return selected.get("alias") or selected["hostname"]
 
 
-def _handle_incomplete_installation(error: IncompleteInstallationError) -> tuple[bool, bool]:
+def _handle_incomplete_installation(
+    error: IncompleteInstallationError,
+) -> tuple[bool, bool]:
     """Prompt user to handle incomplete installation.
 
     Returns:
@@ -184,6 +186,11 @@ def install(
         help="Agent name for the instance (max 32 chars, alphanumeric/hyphens/underscores). "
         "Names are unique per host and immutable after installation.",
     ),
+    cleanup_failed: bool = typer.Option(
+        False,
+        "--cleanup-failed",
+        help="Remove incomplete or failed installation of this agent type before retrying",
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
 ) -> None:
     """Install an agent on a host.
@@ -248,7 +255,6 @@ def install(
     # Step 6: Run installation with progress spinner (per D-02)
     console.print()  # Blank line before progress
 
-    cleanup_failed = False
     resume = False
 
     try:
@@ -264,24 +270,41 @@ def install(
         )
 
     except IncompleteInstallationError as e:
-        # Handle incomplete installation with interactive prompt
-        cleanup_failed, resume = _handle_incomplete_installation(e)
-        # Retry installation with user's choice
-        try:
-            result = _run_installation_with_progress(
-                selected_claw, selected_host, name, cleanup_failed, resume
-            )
-
-            # Success
+        if cleanup_failed:
+            agent_name = e.details.get("agent_name") or e.claw_name
             console.print(
-                f"[green]Success![/green] {selected_claw} v{result['version']} installed as '{name}' on {display_host}"
-                if name
-                else f"[green]Success![/green] {selected_claw} v{result['version']} installed on {display_host}"
+                f"[yellow]Removing incomplete installation of {selected_claw} "
+                f"({agent_name}) from {display_host} and retrying...[/yellow]"
             )
+            try:
+                result = _run_installation_with_progress(
+                    selected_claw, selected_host, None, True, False
+                )
+                console.print(
+                    f"[green]Success![/green] {selected_claw} v{result['version']} installed on {display_host}"
+                )
+            except InstallationError as retry_error:
+                console.print(f"[red]Installation failed:[/red] {retry_error}")
+                raise typer.Exit(code=1)
+        else:
+            # Handle incomplete installation with interactive prompt
+            cleanup_failed, resume = _handle_incomplete_installation(e)
+            # Retry installation with user's choice
+            try:
+                result = _run_installation_with_progress(
+                    selected_claw, selected_host, name, cleanup_failed, resume
+                )
 
-        except InstallationError as retry_error:
-            console.print(f"[red]Installation failed:[/red] {retry_error}")
-            raise typer.Exit(code=1)
+                # Success
+                console.print(
+                    f"[green]Success![/green] {selected_claw} v{result['version']} installed as '{name}' on {display_host}"
+                    if name
+                    else f"[green]Success![/green] {selected_claw} v{result['version']} installed on {display_host}"
+                )
+
+            except InstallationError as retry_error:
+                console.print(f"[red]Installation failed:[/red] {retry_error}")
+                raise typer.Exit(code=1)
 
     except InstallationError as e:
         # Error display per D-10

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -251,7 +251,15 @@ def test_install_incomplete_error_exits_1(isolated_config: Path):
         with patch("typer.prompt", return_value=3):
             result = runner.invoke(
                 app,
-                ["agent", "install", "--type", "openclaw", "--host", "testhost", "--yes"],
+                [
+                    "agent",
+                    "install",
+                    "--type",
+                    "openclaw",
+                    "--host",
+                    "testhost",
+                    "--yes",
+                ],
                 env=os.environ,
             )
 
@@ -342,3 +350,209 @@ def test_install_claw_flag_rejected(isolated_config: Path):
     assert result.exit_code == 2
     # Should mention the flag issue
     assert "no such option" in result.output.lower() or "claw" in result.output.lower()
+
+
+def test_install_cleanup_failed_flag_is_forwarded_to_run_installation(
+    isolated_config: Path,
+):
+    """--cleanup-failed flag is passed as cleanup_failed=True to run_installation."""
+    create_test_keypair(isolated_config, "testhost")
+    create_host(isolated_config, "192.168.1.100", alias="testhost", key_id="testhost")
+
+    with patch("clawrium.cli.install.run_installation") as mock_install:
+        mock_install.return_value = {
+            "success": True,
+            "agent": "openclaw",
+            "version": "1.0.0",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+        }
+
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "install",
+                "--type",
+                "openclaw",
+                "--host",
+                "testhost",
+                "--yes",
+                "--cleanup-failed",
+            ],
+            env=os.environ,
+        )
+
+        assert result.exit_code == 0
+        mock_install.assert_called_once()
+        assert mock_install.call_args.kwargs["cleanup_failed"] is True
+
+
+def test_install_without_cleanup_failed_defaults_to_false(isolated_config: Path):
+    """Without --cleanup-failed, cleanup_failed=False is passed to run_installation."""
+    create_test_keypair(isolated_config, "testhost")
+    create_host(isolated_config, "192.168.1.100", alias="testhost", key_id="testhost")
+
+    with patch("clawrium.cli.install.run_installation") as mock_install:
+        mock_install.return_value = {
+            "success": True,
+            "agent": "openclaw",
+            "version": "1.0.0",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+        }
+
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "install",
+                "--type",
+                "openclaw",
+                "--host",
+                "testhost",
+                "--yes",
+            ],
+            env=os.environ,
+        )
+
+        assert result.exit_code == 0
+        mock_install.assert_called_once()
+        assert mock_install.call_args.kwargs["cleanup_failed"] is False
+
+
+def test_install_cleanup_failed_skips_prompt(isolated_config: Path):
+    """--cleanup-failed skips interactive prompt on IncompleteInstallationError."""
+    create_test_keypair(isolated_config, "testhost")
+    create_host(isolated_config, "192.168.1.100", alias="testhost", key_id="testhost")
+
+    from clawrium.core.install import IncompleteInstallationError
+
+    with patch("clawrium.cli.install.run_installation") as mock_install:
+        mock_install.side_effect = [
+            IncompleteInstallationError(
+                hostname="192.168.1.100",
+                claw_name="openclaw",
+                details={
+                    "status": "failed",
+                    "installed_at": None,
+                    "error": "Base playbook failed",
+                    "agent_name": "work-assistant",
+                    "version": "0.1.0",
+                },
+            ),
+            {
+                "success": True,
+                "agent": "openclaw",
+                "version": "1.0.0",
+                "host": "192.168.1.100",
+                "playbooks_run": [],
+                "error": None,
+            },
+        ]
+
+        with patch("typer.prompt") as mock_prompt:
+            result = runner.invoke(
+                app,
+                [
+                    "agent",
+                    "install",
+                    "--type",
+                    "openclaw",
+                    "--host",
+                    "testhost",
+                    "--yes",
+                    "--cleanup-failed",
+                ],
+                env=os.environ,
+            )
+
+        assert result.exit_code == 0
+        assert "success" in result.output.lower()
+        assert mock_install.call_count == 2
+        second_call = mock_install.call_args_list[1]
+        assert second_call.kwargs["cleanup_failed"] is True
+        mock_prompt.assert_not_called()
+
+
+def test_install_cleanup_failed_retry_fails(isolated_config: Path):
+    """When --cleanup-failed retry also fails, InstallationError is shown."""
+    create_test_keypair(isolated_config, "testhost")
+    create_host(isolated_config, "192.168.1.100", alias="testhost", key_id="testhost")
+
+    from clawrium.core.install import IncompleteInstallationError, InstallationError
+
+    with patch("clawrium.cli.install.run_installation") as mock_install:
+        mock_install.side_effect = [
+            IncompleteInstallationError(
+                hostname="192.168.1.100",
+                claw_name="openclaw",
+                details={
+                    "status": "failed",
+                    "installed_at": None,
+                    "error": "Base playbook failed",
+                    "agent_name": "work-assistant",
+                    "version": "0.1.0",
+                },
+            ),
+            InstallationError("Retry playbook failed"),
+        ]
+
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "install",
+                "--type",
+                "openclaw",
+                "--host",
+                "testhost",
+                "--yes",
+                "--cleanup-failed",
+            ],
+            env=os.environ,
+        )
+
+        assert result.exit_code == 1
+        assert "failed" in result.output.lower()
+
+
+def test_install_without_cleanup_failed_shows_prompt(isolated_config: Path):
+    """Without --cleanup-failed, IncompleteInstallationError shows interactive prompt."""
+    create_test_keypair(isolated_config, "testhost")
+    create_host(isolated_config, "192.168.1.100", alias="testhost", key_id="testhost")
+
+    from clawrium.core.install import IncompleteInstallationError
+
+    with patch("clawrium.cli.install.run_installation") as mock_install:
+        mock_install.side_effect = IncompleteInstallationError(
+            hostname="192.168.1.100",
+            claw_name="openclaw",
+            details={
+                "status": "failed",
+                "installed_at": None,
+                "error": "Base playbook failed",
+                "agent_name": "work-assistant",
+                "version": "0.1.0",
+            },
+        )
+
+        with patch("typer.prompt", return_value=3) as mock_prompt:
+            result = runner.invoke(
+                app,
+                [
+                    "agent",
+                    "install",
+                    "--type",
+                    "openclaw",
+                    "--host",
+                    "testhost",
+                    "--yes",
+                ],
+                env=os.environ,
+            )
+
+        assert "incomplete installation" in result.output.lower()
+        mock_prompt.assert_called()


### PR DESCRIPTION
## Summary

- Add `--cleanup-failed` CLI flag to the `install` command allowing users to force cleanup of incomplete/failed installations before starting a new installation, without needing the interactive prompt.
- Flag is added to both the `agent.py` wrapper and `install.py` implementation.
- When `--cleanup-failed` is set and an `IncompleteInstallationError` is raised, the CLI skips the interactive prompt and retries with `cleanup_failed=True`, passing `name=None` to force fresh name generation.
- User-visible feedback message shows which agent type and name is being cleaned up.

## Testing

- 795 tests pass, lint clean
- Added 5 new CLI tests:
  - `test_install_cleanup_failed_flag_is_forwarded_to_run_installation` - verifies flag is passed as `cleanup_failed=True`
  - `test_install_without_cleanup_failed_defaults_to_false` - verifies default is `False`
  - `test_install_cleanup_failed_skips_prompt` - verifies no interactive prompt when flag is set
  - `test_install_cleanup_failed_retry_fails` - verifies error handling on retry failure
  - `test_install_without_cleanup_failed_shows_prompt` - verifies prompt shown without flag

## ATX Review Summary

**Final Review: Rating 3/5 (CLI mechanics correct, pre-existing core issues out of scope)**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 3/5 | B1, B2 | Fixed |
| 2 | 3/5 | B3, B4 | Fixed |

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `test_cli_install.py` | Weak assertion using `.get()` | Fixed - direct kwarg access |
| B2 | `test_cli_install.py` | Missing prompt skip assertion | Fixed - `mock_prompt.assert_not_called()` |

**Out-of-scope:**

| # | File | Issue |
|---|------|-------|
| B3 | `core/install.py:223-236` | Pre-existing secrets cleanup swallowing |
| B4 | `core/install.py:269-274` | Pre-existing TOCTOU race in core |
| B5 | `core/install.py:206-238` | Pre-existing orphaned onboarding state |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B3 | `cli/install.py:273-280` | Name reuse on retry | Fixed - pass `name=None` |
| B4 | `cli/install.py:273-281` | No user feedback | Fixed - added cleanup message |

**Out-of-scope:**

| # | File | Issue |
|---|------|-------|
| B1 | `core/install.py:209-238` | Pre-existing cleanup verification gap |
| B2 | `cli/install.py:273-289` | Pre-existing race condition in core |

</details>

Closes #155

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>