### PR TITLE
feat(install): skip openclaw reinstall when version matches

### DIFF
--- a/src/clawrium/cli/install.py
+++ b/src/clawrium/cli/install.py
@@ -263,11 +263,16 @@ def install(
         )
 
         # Success
-        console.print(
-            f"[green]Success![/green] {selected_claw} v{result['version']} installed as '{name}' on {display_host}"
-            if name
-            else f"[green]Success![/green] {selected_claw} v{result['version']} installed on {display_host}"
-        )
+        if result.get("skipped"):
+            console.print(
+                f"[green]Success![/green] {selected_claw} v{result['version']} already installed on {display_host} (skipped)"
+            )
+        else:
+            console.print(
+                f"[green]Success![/green] {selected_claw} v{result['version']} installed as '{name}' on {display_host}"
+                if name
+                else f"[green]Success![/green] {selected_claw} v{result['version']} installed on {display_host}"
+            )
 
     except IncompleteInstallationError as e:
         if cleanup_failed:
@@ -280,9 +285,14 @@ def install(
                 result = _run_installation_with_progress(
                     selected_claw, selected_host, None, True, False
                 )
-                console.print(
-                    f"[green]Success![/green] {selected_claw} v{result['version']} installed on {display_host}"
-                )
+                if result.get("skipped"):
+                    console.print(
+                        f"[green]Success![/green] {selected_claw} v{result['version']} already installed on {display_host} (skipped)"
+                    )
+                else:
+                    console.print(
+                        f"[green]Success![/green] {selected_claw} v{result['version']} installed on {display_host}"
+                    )
             except InstallationError as retry_error:
                 console.print(f"[red]Installation failed:[/red] {retry_error}")
                 raise typer.Exit(code=1)
@@ -296,11 +306,16 @@ def install(
                 )
 
                 # Success
-                console.print(
-                    f"[green]Success![/green] {selected_claw} v{result['version']} installed as '{name}' on {display_host}"
-                    if name
-                    else f"[green]Success![/green] {selected_claw} v{result['version']} installed on {display_host}"
-                )
+                if result.get("skipped"):
+                    console.print(
+                        f"[green]Success![/green] {selected_claw} v{result['version']} already installed on {display_host} (skipped)"
+                    )
+                else:
+                    console.print(
+                        f"[green]Success![/green] {selected_claw} v{result['version']} installed as '{name}' on {display_host}"
+                        if name
+                        else f"[green]Success![/green] {selected_claw} v{result['version']} installed on {display_host}"
+                    )
 
             except InstallationError as retry_error:
                 console.print(f"[red]Installation failed:[/red] {retry_error}")

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -85,6 +85,8 @@ class InstallResult(TypedDict):
     playbooks_run: list[str]
     error: str | None
     incomplete_installation: NotRequired[dict | None]
+    skipped: NotRequired[bool]
+    skip_reason: NotRequired[str | None]
 
 
 def _get_incomplete_installation_details(host: dict, claw_name: str) -> dict | None:
@@ -135,6 +137,35 @@ def _get_logs_dir() -> Path:
     logs_dir = get_config_dir() / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
     return logs_dir
+
+
+def _openclaw_install_was_skipped(playbook_result: object) -> bool:
+    """Detect whether OpenClaw install task was skipped by Ansible conditions."""
+    events = getattr(playbook_result, "events", None) or []
+
+    for event in events:
+        if event.get("event") != "runner_on_ok":
+            continue
+
+        event_data = event.get("event_data", {})
+        task_name = event_data.get("task", "")
+        result = event_data.get("res", {})
+
+        if task_name == "Mark install as skipped when already installed":
+            return True
+
+        ansible_facts = result.get("ansible_facts", {})
+        if ansible_facts.get("openclaw_already_installed_and_matching") is True:
+            return True
+
+        msg = result.get("msg", "")
+        if (
+            isinstance(msg, str)
+            and "already installed with matching version" in msg.lower()
+        ):
+            return True
+
+    return False
 
 
 def run_installation(
@@ -219,6 +250,7 @@ def run_installation(
         # Remove secrets for this instance
         if incomplete_details.get("agent_name"):
             from clawrium.core.secrets import load_secrets, save_secrets
+
             instance_key = get_instance_key(
                 host["hostname"], claw_name, incomplete_details["agent_name"]
             )
@@ -234,7 +266,7 @@ def run_installation(
                 emit(
                     "warn",
                     f"Failed to remove secrets for {instance_key}. "
-                    "Manual cleanup may be required."
+                    "Manual cleanup may be required.",
                 )
 
         emit("cleanup", "Cleanup complete. Starting fresh installation...")
@@ -265,6 +297,7 @@ def run_installation(
     # Step 5: Set installing state with uniqueness check under lock
     # Use a list to capture the chosen name from inside the updater
     chosen_name = [None]
+    reusing_existing_installed = [False]
 
     def set_installing(h: dict) -> dict:
         # Check for incomplete installation under lock (unless cleanup or resume)
@@ -276,21 +309,45 @@ def run_installation(
                 )
 
         if name is None:
-            # Auto-generate name with retry loop for uniqueness
-            max_attempts = 10
-            for attempt in range(max_attempts):
-                candidate = generate_random_name()
-                if is_name_available_on_host(candidate, h):
-                    chosen_name[0] = candidate
-                    break
+            existing_installed = h.get("agents", {}).get(claw_name, {})
+            if (
+                not resume
+                and not cleanup_failed
+                and existing_installed.get("status") == "installed"
+                and existing_installed.get("agent_name")
+            ):
+                chosen_name[0] = existing_installed["agent_name"]
+                reusing_existing_installed[0] = True
+                return_name = chosen_name[0]
+                if return_name:
+                    logger.info(
+                        "Reusing existing installed agent name under lock: %s",
+                        return_name,
+                    )
             else:
-                raise InstallationError(
-                    f"Could not generate a unique name after {max_attempts} attempts. "
-                    "Use --name to specify one."
-                )
+                # Auto-generate name with retry loop for uniqueness
+                max_attempts = 10
+                for attempt in range(max_attempts):
+                    candidate = generate_random_name()
+                    if is_name_available_on_host(candidate, h):
+                        chosen_name[0] = candidate
+                        break
+                else:
+                    raise InstallationError(
+                        f"Could not generate a unique name after {max_attempts} attempts. "
+                        "Use --name to specify one."
+                    )
         else:
             # Use custom name, check uniqueness under lock (unless resuming)
-            if not resume and not is_name_available_on_host(name, h):
+            same_as_existing = (
+                claw_name in h.get("agents", {})
+                and h["agents"][claw_name].get("agent_name") == name
+            )
+            if (
+                not resume
+                and not (reusing_existing_installed[0] and same_as_existing)
+                and not is_name_available_on_host(name, h)
+            ):
                 raise InstallationError(
                     f"Name '{name}' already in use on this host. "
                     "Names must be unique across all agents on a host."
@@ -300,8 +357,8 @@ def run_installation(
         if "agents" not in h:
             h["agents"] = {}
 
-        # Update status to installing (preserving existing data if resuming)
-        if resume:
+        # Update status to installing (preserving existing data if resuming/reusing)
+        if resume or reusing_existing_installed[0]:
             if claw_name not in h["agents"]:
                 raise InstallationError("Cannot resume: agent was removed")
             h["agents"][claw_name]["status"] = "installing"
@@ -325,6 +382,8 @@ def run_installation(
     # Emit message after lock is released and agent_name is set
     if resume:
         emit("validate", f"Resuming with existing name: {agent_name}")
+    elif reusing_existing_installed[0]:
+        emit("validate", f"Using existing installed name: {agent_name}")
     elif name is None:
         emit("validate", f"Generated unique name: {agent_name}")
     else:
@@ -459,7 +518,18 @@ def run_installation(
                 f"Check logs at {claw_data_dir}/artifacts/"
             )
         playbooks_run.append(str(claw_playbook))
-        emit("claw", f"{claw_name} installed successfully")
+        install_skipped = False
+        skip_reason = None
+        if claw_name == "openclaw":
+            install_skipped = _openclaw_install_was_skipped(result)
+            if install_skipped:
+                skip_reason = "already_installed_version_match"
+                emit(
+                    "claw",
+                    "OpenClaw already installed with matching version; skipped install task",
+                )
+        if not install_skipped:
+            emit("claw", f"{claw_name} installed successfully")
 
         # Step 9.5: Extract gateway token from Ansible facts (OpenClaw only)
         gateway_token = None
@@ -469,6 +539,7 @@ def run_installation(
             try:
                 # ansible-runner stores facts in artifacts/<run_id>/fact_cache/<hostname>
                 import json
+
                 artifacts_dir = Path(result.config.artifact_dir)
                 fact_cache_dir = artifacts_dir / "fact_cache"
 
@@ -554,6 +625,8 @@ def run_installation(
             "playbooks_run": playbooks_run,
             "error": None,
             "incomplete_installation": incomplete_details,
+            "skipped": install_skipped,
+            "skip_reason": skip_reason,
         }
 
     except Exception as e:
@@ -570,9 +643,7 @@ def run_installation(
                 }
             h["agents"][claw_name]["status"] = "failed"
             h["agents"][claw_name]["error"] = error_msg
-            h["agents"][claw_name]["installed_at"] = datetime.now(
-                timezone.utc
-            ).isoformat()
+            h["agents"][claw_name]["installed_at"] = None
             return h
 
         update_host(host["hostname"], set_failed)

--- a/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
@@ -2,12 +2,46 @@
 - hosts: all
   become: yes
   tasks:
+    - name: Normalize target OpenClaw version
+      ansible.builtin.set_fact:
+        openclaw_target_version: "{{ (claw_version | default('v2026.4.2')) | regex_replace('^v', '') }}"
+
     - name: Create agent user
       ansible.builtin.user:
         name: "{{ agent_name }}"
         state: present
         create_home: yes
         shell: /bin/bash
+
+    - name: Check if OpenClaw binary exists
+      ansible.builtin.stat:
+        path: "/home/{{ agent_name }}/.openclaw/bin/openclaw"
+      register: openclaw_binary_stat
+
+    - name: Read installed OpenClaw version
+      ansible.builtin.command:
+        argv:
+          - /home/{{ agent_name }}/.openclaw/bin/openclaw
+          - --version
+      become_user: "{{ agent_name }}"
+      register: openclaw_version_check
+      changed_when: false
+      failed_when: false
+      when: openclaw_binary_stat.stat.exists and openclaw_binary_stat.stat.executable
+
+    - name: Parse installed OpenClaw version
+      ansible.builtin.set_fact:
+        openclaw_installed_version: "{{ (openclaw_version_check.stdout | default('') | regex_search('([0-9]+\\.[0-9]+\\.[0-9]+)', '\\1') | first | default('')) | regex_replace('^v', '') }}"
+      when: openclaw_binary_stat.stat.exists and openclaw_binary_stat.stat.executable
+
+    - name: Compute OpenClaw install skip condition
+      ansible.builtin.set_fact:
+        openclaw_already_installed_and_matching: "{{ (openclaw_binary_stat.stat.exists and openclaw_binary_stat.stat.executable and (openclaw_version_check.rc | default(1)) == 0 and (openclaw_installed_version | default('')) == openclaw_target_version) | bool }}"
+
+    - name: Mark install as skipped when already installed
+      ansible.builtin.debug:
+        msg: "OpenClaw already installed with matching version {{ openclaw_target_version }}."
+      when: openclaw_already_installed_and_matching
 
     - name: Download OpenClaw installer script
       ansible.builtin.get_url:
@@ -17,6 +51,7 @@
         force: yes
         timeout: 30
         checksum: "{{ installer_checksum | default(omit) }}"
+      when: not openclaw_already_installed_and_matching
 
     - name: Install OpenClaw CLI runtime
       ansible.builtin.command:
@@ -28,15 +63,17 @@
           - --install-method
           - npm
           - --version
-          - "{{ claw_version | default('v2026.4.2') | regex_replace('^v', '') }}"
+          - "{{ openclaw_target_version }}"
           - --no-onboard
         creates: "/home/{{ agent_name }}/.openclaw/bin/openclaw"
       become_user: "{{ agent_name }}"
+      when: not openclaw_already_installed_and_matching
 
     - name: Clean up installer script
       ansible.builtin.file:
         path: "/tmp/openclaw-install-{{ agent_name }}.sh"
         state: absent
+      when: not openclaw_already_installed_and_matching
 
     - name: Create workspace directory
       ansible.builtin.file:

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -185,6 +185,34 @@ def test_install_yes_skips_confirmation(isolated_config: Path):
         mock_install.assert_called_once()
 
 
+def test_install_yes_shows_skip_message_when_already_installed(isolated_config: Path):
+    """clm install --yes reports skip when backend marks install as skipped."""
+    create_test_keypair(isolated_config, "testhost")
+    create_host(isolated_config, "192.168.1.100", alias="testhost", key_id="testhost")
+
+    with patch("clawrium.cli.install.run_installation") as mock_install:
+        mock_install.return_value = {
+            "success": True,
+            "agent": "openclaw",
+            "version": "2026.4.2",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+            "skipped": True,
+            "skip_reason": "already_installed_version_match",
+        }
+
+        result = runner.invoke(
+            app,
+            ["agent", "install", "--type", "openclaw", "--host", "testhost", "--yes"],
+            env=os.environ,
+        )
+
+        assert result.exit_code == 0
+        assert "already installed" in result.output.lower()
+        assert "skipped" in result.output.lower()
+
+
 def test_install_cancelled_exits_0(isolated_config: Path):
     """Declining confirmation exits cleanly with code 0."""
     # Setup: create host and keypair

--- a/tests/test_install_skip.py
+++ b/tests/test_install_skip.py
@@ -1,0 +1,254 @@
+"""Tests for installed-version skip behavior during install."""
+
+from unittest.mock import Mock
+
+import pytest
+
+
+def _setup_common(monkeypatch, tmp_path, host_record: dict, version: str = "2026.4.2"):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mock_manifest = {
+        "name": "openclaw",
+        "entries": [
+            {
+                "version": version,
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc123",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"nodejs": ">=20.0.0"},
+                },
+            }
+        ],
+    }
+
+    import clawrium.core.install
+
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *args, **kwargs: {
+            "compatible": True,
+            "matched_entry": mock_manifest["entries"][0],
+            "reasons": [],
+        },
+    )
+
+    host_state = [host_record]
+
+    def mock_get_host(_):
+        return host_state[0]
+
+    def mock_update_host(_, updater):
+        host_state[0] = updater(host_state[0])
+        return True
+
+    monkeypatch.setattr(clawrium.core.install, "get_host", mock_get_host)
+    monkeypatch.setattr(clawrium.core.install, "update_host", mock_update_host)
+
+    key_file = tmp_path / "test_key"
+    key_file.write_text("fake key")
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda _: key_file
+    )
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", lambda h, c: True
+    )
+
+    return host_state
+
+
+def _result_with_events(tmp_path, events):
+    class SuccessfulResult:
+        status = "successful"
+
+        class Config:
+            artifact_dir = str(tmp_path / "artifacts")
+
+        config = Config()
+
+    SuccessfulResult.events = events
+
+    return SuccessfulResult()
+
+
+def test_install_reuses_existing_installed_name_and_reports_skip(monkeypatch, tmp_path):
+    from clawrium.core.install import run_installation
+
+    host = {
+        "hostname": "test-host",
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+        "agents": {
+            "openclaw": {
+                "status": "installed",
+                "installed_at": "2026-04-10T00:00:00+00:00",
+                "error": None,
+                "agent_name": "existing-agent",
+                "version": "2026.4.2",
+                "config": {"gateway": {"url": "ws://example:40001"}},
+            }
+        },
+    }
+
+    host_state = _setup_common(monkeypatch, tmp_path, host)
+
+    import ansible_runner
+
+    run_side_effect = [
+        _result_with_events(tmp_path, []),
+        _result_with_events(
+            tmp_path,
+            [
+                {
+                    "event": "runner_on_ok",
+                    "event_data": {
+                        "task": "Mark install as skipped when already installed",
+                        "res": {
+                            "msg": "OpenClaw already installed with matching version 2026.4.2."
+                        },
+                    },
+                }
+            ],
+        ),
+    ]
+    mock_run = Mock(side_effect=run_side_effect)
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    result = run_installation("openclaw", "test-host")
+
+    assert result["success"] is True
+    assert result["skipped"] is True
+    assert result["skip_reason"] == "already_installed_version_match"
+    assert host_state[0]["agents"]["openclaw"]["agent_name"] == "existing-agent"
+    assert (
+        host_state[0]["agents"]["openclaw"]["config"]["gateway"]["url"]
+        == "ws://example:40001"
+    )
+    assert mock_run.call_count == 2
+
+
+def test_install_existing_agent_with_mismatch_version_does_not_report_skip(
+    monkeypatch, tmp_path
+):
+    from clawrium.core.install import run_installation
+
+    host = {
+        "hostname": "test-host",
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+        "agents": {
+            "openclaw": {
+                "status": "installed",
+                "installed_at": "2026-04-10T00:00:00+00:00",
+                "error": None,
+                "agent_name": "existing-agent",
+                "version": "2026.3.1",
+            }
+        },
+    }
+
+    _setup_common(monkeypatch, tmp_path, host)
+
+    import ansible_runner
+
+    mock_run = Mock(
+        side_effect=[
+            _result_with_events(tmp_path, []),
+            _result_with_events(tmp_path, []),
+        ]
+    )
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    result = run_installation("openclaw", "test-host")
+
+    assert result["success"] is True
+    assert result["skipped"] is False
+    assert result["skip_reason"] is None
+    assert mock_run.call_count == 2
+
+
+def test_openclaw_skip_detection_matches_fact_and_marker():
+    from clawrium.core.install import _openclaw_install_was_skipped
+
+    class Result:
+        events = [
+            {
+                "event": "runner_on_ok",
+                "event_data": {
+                    "task": "Compute OpenClaw install skip condition",
+                    "res": {
+                        "ansible_facts": {
+                            "openclaw_already_installed_and_matching": True
+                        }
+                    },
+                },
+            }
+        ]
+
+    assert _openclaw_install_was_skipped(Result()) is True
+
+    class ResultByTask:
+        events = [
+            {
+                "event": "runner_on_ok",
+                "event_data": {
+                    "task": "Mark install as skipped when already installed",
+                    "res": {"msg": "already installed with matching version"},
+                },
+            }
+        ]
+
+    assert _openclaw_install_was_skipped(ResultByTask()) is True
+
+    class ResultNoSkip:
+        events = []
+
+    assert _openclaw_install_was_skipped(ResultNoSkip()) is False
+
+
+def test_install_failure_sets_failed_status_without_installed_timestamp(
+    monkeypatch, tmp_path
+):
+    from clawrium.core.install import InstallationError, run_installation
+
+    host = {
+        "hostname": "test-host",
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    host_state = _setup_common(monkeypatch, tmp_path, host)
+
+    import clawrium.core.install
+
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "_get_base_playbook_path",
+        lambda: tmp_path / "missing-base.yaml",
+    )
+
+    with pytest.raises(InstallationError, match="Base playbook not found"):
+        run_installation("openclaw", "test-host")
+
+    assert host_state[0]["agents"]["openclaw"]["status"] == "failed"
+    assert host_state[0]["agents"]["openclaw"]["installed_at"] is None


### PR DESCRIPTION
## Summary
- Make OpenClaw installation idempotent in `install.yaml` by checking binary existence and installed version, then skipping installer tasks when the requested version is already present.
- Reuse existing installed OpenClaw agent identity under lock in `run_installation()` and surface explicit skip outcomes (`skipped`, `skip_reason`) to CLI output.
- Add regression coverage for skip detection and failed-state metadata handling, plus CLI skip message coverage.

## Testing
- `make test`
- `make lint`

## ATX Review Summary

**Final Review: Rating 3/5**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 2/5 | B1, B2, B3, plus test-quality blockers | B1/B2 fixed; test blockers improved; B3 acknowledged as intentional existing behavior |
| 2 | 3/5 | None | Ready |

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `src/clawrium/core/install.py` | Failed installs wrote `installed_at` timestamp | Fixed - failed state now keeps `installed_at=None` |
| B2 | `src/clawrium/core/install.py` | Installed-agent reuse read state outside lock | Fixed - reuse decision moved into lock-scoped updater |
| B3 | `src/clawrium/core/install.py` | Onboarding init flagged as non-fatal behavior | Acknowledged - existing behavior kept intentionally and covered by existing tests |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `src/clawrium/core/install.py` | Additional secrets-lock hardening suggested | Deferred |
| W2 | `tests/test_install_skip.py` | Additional edge-case/test-hardening suggestions | Partially addressed; remaining deferred |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Improve CLI messaging DRYness and contextual wording | Deferred |
| S2 | Add optional playbook retries/systemd hardening | Deferred |

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>