### PR TITLE
fix(install): prevent openclaw re-installation when binary already exists

### DIFF
--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -89,9 +89,7 @@ class InstallResult(TypedDict):
     skip_reason: NotRequired[str | None]
 
 
-def _get_incomplete_installation_details(
-    host: dict, claw_name: str
-) -> list[dict]:
+def _get_incomplete_installation_details(host: dict, claw_name: str) -> list[dict]:
     """Return ALL incomplete installation details for an agent type.
 
     Returns a list of incomplete installations (may be empty).
@@ -115,13 +113,15 @@ def _get_incomplete_installation_details(
         if status in {"installing", "failed"} or (
             status is not None and installed_at is None
         ):
-            incomplete.append({
-                "status": status,
-                "installed_at": installed_at,
-                "error": existing.get("error"),
-                "agent_name": agent_key,
-                "version": existing.get("version"),
-            })
+            incomplete.append(
+                {
+                    "status": status,
+                    "installed_at": installed_at,
+                    "error": existing.get("error"),
+                    "agent_name": agent_key,
+                    "version": existing.get("version"),
+                }
+            )
 
     return incomplete
 
@@ -168,14 +168,7 @@ def _openclaw_install_was_skipped(playbook_result: object) -> bool:
             return True
 
         ansible_facts = result.get("ansible_facts", {})
-        if ansible_facts.get("openclaw_already_installed_and_matching") is True:
-            return True
-
-        msg = result.get("msg", "")
-        if (
-            isinstance(msg, str)
-            and "already installed with matching version" in msg.lower()
-        ):
+        if ansible_facts.get("openclaw_already_installed") is True:
             return True
 
     return False
@@ -252,7 +245,9 @@ def run_installation(
 
     # Handle cleanup if requested - clean up ALL incomplete installations
     if cleanup_failed and incomplete_list:
-        emit("cleanup", f"Removing {len(incomplete_list)} incomplete installation(s)...")
+        emit(
+            "cleanup", f"Removing {len(incomplete_list)} incomplete installation(s)..."
+        )
 
         # Collect all agent keys to remove
         agent_keys_to_remove = [
@@ -555,10 +550,10 @@ def run_installation(
         if claw_name == "openclaw":
             install_skipped = _openclaw_install_was_skipped(result)
             if install_skipped:
-                skip_reason = "already_installed_version_match"
+                skip_reason = "already_installed"
                 emit(
                     "claw",
-                    "OpenClaw already installed with matching version; skipped install task",
+                    "OpenClaw already installed; skipped binary install task",
                 )
         if not install_skipped:
             emit("claw", f"{claw_name} installed successfully")
@@ -621,7 +616,9 @@ def run_installation(
 
                                 # Extract device credentials for operator scope auth
                                 device_id_raw = parsed_facts.get("openclaw_device_id")
-                                device_token_raw = parsed_facts.get("openclaw_device_token")
+                                device_token_raw = parsed_facts.get(
+                                    "openclaw_device_token"
+                                )
                                 device_private_key_raw = parsed_facts.get(
                                     "openclaw_device_private_key"
                                 )
@@ -642,7 +639,9 @@ def run_installation(
                                     device_token = None
 
                                 if isinstance(device_private_key_raw, dict):
-                                    device_private_key = device_private_key_raw.get("value")
+                                    device_private_key = device_private_key_raw.get(
+                                        "value"
+                                    )
                                 elif isinstance(device_private_key_raw, str):
                                     device_private_key = device_private_key_raw
                                 else:

--- a/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
@@ -13,64 +13,30 @@
         create_home: yes
         shell: /bin/bash
 
-    - name: Check if per-agent OpenClaw binary exists
-      ansible.builtin.stat:
-        path: "/home/{{ agent_name }}/.openclaw/bin/openclaw"
-      register: openclaw_agent_binary_stat
-
-    - name: Check if global OpenClaw binary exists
-      ansible.builtin.stat:
-        path: /usr/local/bin/openclaw
-      register: openclaw_global_binary_stat
-
-    - name: Read per-agent OpenClaw version
-      ansible.builtin.command:
-        argv:
-          - /home/{{ agent_name }}/.openclaw/bin/openclaw
-          - --version
-      become_user: "{{ agent_name }}"
-      register: openclaw_agent_version_check
+    - name: Discover openclaw binary in PATH
+      ansible.builtin.command: which openclaw
+      register: openclaw_which_result
       changed_when: false
       failed_when: false
-      when: openclaw_agent_binary_stat.stat.exists and openclaw_agent_binary_stat.stat.executable
 
-    - name: Parse per-agent OpenClaw version
+    - name: Validate discovered binary path
+      ansible.builtin.fail:
+        msg: "Discovered openclaw binary at unsafe path: {{ openclaw_which_result.stdout }}. Expected under /usr/local/bin/, /usr/bin/, or /home/."
+      when: >
+        (openclaw_which_result.rc | default(1)) == 0 and
+        not (openclaw_which_result.stdout.startswith('/usr/local/bin/') or
+             openclaw_which_result.stdout.startswith('/usr/bin/') or
+             openclaw_which_result.stdout.startswith('/home/'))
+
+    - name: Set install skip condition
       ansible.builtin.set_fact:
-        openclaw_agent_installed_version: "{{ (openclaw_agent_version_check.stdout | default('') | regex_search('([0-9]+\\.[0-9]+\\.[0-9]+)', '\\1') | first | default('')) | regex_replace('^v', '') }}"
-      when: openclaw_agent_binary_stat.stat.exists and openclaw_agent_binary_stat.stat.executable
-
-    - name: Read global OpenClaw version
-      ansible.builtin.command:
-        argv:
-          - /usr/local/bin/openclaw
-          - --version
-      register: openclaw_global_version_check
-      changed_when: false
-      failed_when: false
-      when: openclaw_global_binary_stat.stat.exists and openclaw_global_binary_stat.stat.executable
-
-    - name: Parse global OpenClaw version
-      ansible.builtin.set_fact:
-        openclaw_global_installed_version: "{{ (openclaw_global_version_check.stdout | default('') | regex_search('([0-9]+\\.[0-9]+\\.[0-9]+)', '\\1') | first | default('')) | regex_replace('^v', '') }}"
-      when: openclaw_global_binary_stat.stat.exists and openclaw_global_binary_stat.stat.executable
-
-    - name: Compute OpenClaw install skip condition
-      ansible.builtin.set_fact:
-        openclaw_use_global_binary: "{{ (openclaw_global_binary_stat.stat.exists and openclaw_global_binary_stat.stat.executable and (openclaw_global_version_check.rc | default(1)) == 0 and (openclaw_global_installed_version | default('')) == openclaw_target_version) | bool }}"
-        openclaw_use_agent_binary: "{{ (openclaw_agent_binary_stat.stat.exists and openclaw_agent_binary_stat.stat.executable and (openclaw_agent_version_check.rc | default(1)) == 0 and (openclaw_agent_installed_version | default('')) == openclaw_target_version) | bool }}"
-
-    - name: Choose OpenClaw runtime binary path
-      ansible.builtin.set_fact:
-        openclaw_runtime_binary: "{{ '/usr/local/bin/openclaw' if openclaw_use_global_binary else '/home/' ~ agent_name ~ '/.openclaw/bin/openclaw' }}"
-
-    - name: Finalize OpenClaw install skip condition
-      ansible.builtin.set_fact:
-        openclaw_already_installed_and_matching: "{{ (openclaw_use_global_binary or openclaw_use_agent_binary) | bool }}"
+        openclaw_already_installed: "{{ (openclaw_which_result.rc | default(1)) == 0 }}"
+        openclaw_runtime_binary: "{{ openclaw_which_result.stdout if (openclaw_which_result.rc | default(1)) == 0 else '/home/' ~ agent_name ~ '/.openclaw/bin/openclaw' }}"
 
     - name: Mark install as skipped when already installed
       ansible.builtin.debug:
-        msg: "OpenClaw already installed with matching version {{ openclaw_target_version }}."
-      when: openclaw_already_installed_and_matching
+        msg: "OpenClaw already installed at {{ openclaw_which_result.stdout }}. Skipping binary install."
+      when: openclaw_already_installed
 
     - name: Download OpenClaw installer script
       ansible.builtin.get_url:
@@ -82,7 +48,7 @@
         force: yes
         timeout: 30
         checksum: "{{ installer_checksum | default(omit) }}"
-      when: not openclaw_already_installed_and_matching
+      when: not openclaw_already_installed
 
     - name: Install OpenClaw CLI runtime
       ansible.builtin.command:
@@ -98,13 +64,13 @@
           - --no-onboard
         creates: "/home/{{ agent_name }}/.openclaw/bin/openclaw"
       become_user: "{{ agent_name }}"
-      when: not openclaw_already_installed_and_matching
+      when: not openclaw_already_installed
 
     - name: Clean up installer script
       ansible.builtin.file:
         path: "/home/{{ agent_name }}/openclaw-install.sh"
         state: absent
-      when: not openclaw_already_installed_and_matching
+      when: not openclaw_already_installed
 
     - name: Create workspace directory
       ansible.builtin.file:

--- a/tests/test_install_skip.py
+++ b/tests/test_install_skip.py
@@ -113,12 +113,31 @@ def test_install_reuses_existing_installed_name_and_reports_skip(monkeypatch, tm
                 {
                     "event": "runner_on_ok",
                     "event_data": {
-                        "task": "Mark install as skipped when already installed",
+                        "task": "Discover openclaw binary in PATH",
+                        "res": {"stdout": "/usr/local/bin/openclaw", "rc": 0},
+                    },
+                },
+                {
+                    "event": "runner_on_ok",
+                    "event_data": {
+                        "task": "Set install skip condition",
                         "res": {
-                            "msg": "OpenClaw already installed with matching version 2026.4.2."
+                            "ansible_facts": {
+                                "openclaw_already_installed": True,
+                                "openclaw_runtime_binary": "/usr/local/bin/openclaw",
+                            }
                         },
                     },
-                }
+                },
+                {
+                    "event": "runner_on_ok",
+                    "event_data": {
+                        "task": "Mark install as skipped when already installed",
+                        "res": {
+                            "msg": "OpenClaw already installed at /usr/local/bin/openclaw. Skipping binary install."
+                        },
+                    },
+                },
             ],
         ),
     ]
@@ -129,7 +148,7 @@ def test_install_reuses_existing_installed_name_and_reports_skip(monkeypatch, tm
 
     assert result["success"] is True
     assert result["skipped"] is True
-    assert result["skip_reason"] == "already_installed_version_match"
+    assert result["skip_reason"] == "already_installed"
     assert host_state[0]["agents"]["openclaw"]["agent_name"] == "existing-agent"
     assert (
         host_state[0]["agents"]["openclaw"]["config"]["gateway"]["url"]
@@ -138,9 +157,7 @@ def test_install_reuses_existing_installed_name_and_reports_skip(monkeypatch, tm
     assert mock_run.call_count == 2
 
 
-def test_install_existing_agent_with_mismatch_version_does_not_report_skip(
-    monkeypatch, tmp_path
-):
+def test_install_existing_agent_any_version_reports_skip(monkeypatch, tmp_path):
     from clawrium.core.install import run_installation
 
     host = {
@@ -167,19 +184,50 @@ def test_install_existing_agent_with_mismatch_version_does_not_report_skip(
 
     import ansible_runner
 
-    mock_run = Mock(
-        side_effect=[
-            _result_with_events(tmp_path, []),
-            _result_with_events(tmp_path, []),
-        ]
-    )
+    run_side_effect = [
+        _result_with_events(tmp_path, []),
+        _result_with_events(
+            tmp_path,
+            [
+                {
+                    "event": "runner_on_ok",
+                    "event_data": {
+                        "task": "Discover openclaw binary in PATH",
+                        "res": {"stdout": "/usr/local/bin/openclaw", "rc": 0},
+                    },
+                },
+                {
+                    "event": "runner_on_ok",
+                    "event_data": {
+                        "task": "Set install skip condition",
+                        "res": {
+                            "ansible_facts": {
+                                "openclaw_already_installed": True,
+                                "openclaw_runtime_binary": "/usr/local/bin/openclaw",
+                            }
+                        },
+                    },
+                },
+                {
+                    "event": "runner_on_ok",
+                    "event_data": {
+                        "task": "Mark install as skipped when already installed",
+                        "res": {
+                            "msg": "OpenClaw already installed at /usr/local/bin/openclaw. Skipping binary install."
+                        },
+                    },
+                },
+            ],
+        ),
+    ]
+    mock_run = Mock(side_effect=run_side_effect)
     monkeypatch.setattr(ansible_runner, "run", mock_run)
 
     result = run_installation("openclaw", "test-host")
 
     assert result["success"] is True
-    assert result["skipped"] is False
-    assert result["skip_reason"] is None
+    assert result["skipped"] is True
+    assert result["skip_reason"] == "already_installed"
     assert mock_run.call_count == 2
 
 
@@ -191,12 +239,8 @@ def test_openclaw_skip_detection_matches_fact_and_marker():
             {
                 "event": "runner_on_ok",
                 "event_data": {
-                    "task": "Compute OpenClaw install skip condition",
-                    "res": {
-                        "ansible_facts": {
-                            "openclaw_already_installed_and_matching": True
-                        }
-                    },
+                    "task": "Set install skip condition",
+                    "res": {"ansible_facts": {"openclaw_already_installed": True}},
                 },
             }
         ]
@@ -209,7 +253,7 @@ def test_openclaw_skip_detection_matches_fact_and_marker():
                 "event": "runner_on_ok",
                 "event_data": {
                     "task": "Mark install as skipped when already installed",
-                    "res": {"msg": "already installed with matching version"},
+                    "res": {"msg": "already installed at /usr/local/bin/openclaw"},
                 },
             }
         ]
@@ -220,6 +264,21 @@ def test_openclaw_skip_detection_matches_fact_and_marker():
         events = []
 
     assert _openclaw_install_was_skipped(ResultNoSkip()) is False
+
+    class ResultFalsePositive:
+        events = [
+            {
+                "event": "runner_on_ok",
+                "event_data": {
+                    "task": "Download OpenClaw installer script",
+                    "res": {
+                        "msg": "Package already installed by another process, skipping"
+                    },
+                },
+            }
+        ]
+
+    assert _openclaw_install_was_skipped(ResultFalsePositive()) is False
 
 
 def test_install_failure_sets_failed_status_without_installed_timestamp(


### PR DESCRIPTION
## Summary

- Fix openclaw being re-installed on every `clm install` run when binary already exists on the host
- Replace complex version-check logic (6 stat/command/parse tasks + exact equality) with simple `which openclaw` binary discovery
- Add path validation for discovered binary (must be under `/usr/local/bin/`, `/usr/bin/`, or `/home/`)
- Remove fragile substring match from skip detection, add negative test for false positives

## Root Cause

The previous idempotency check used exact version equality (`== openclaw_target_version`) and only looked at two hardcoded paths (`/home/<agent_name>/.openclaw/bin/openclaw` and `/usr/local/bin/openclaw`). When a new agent name is auto-generated each run, the per-agent path doesn't exist, so Ansible never found the binary and re-downloaded every time.

## Testing

- 813 tests pass, lint clean
- Updated mock events to match actual playbook task names
- Added false-positive negative test for `_openclaw_install_was_skipped`

## ATX Review Summary

**Final Review: Rating 4/5**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 3/5 | B1, B2 | All fixed/out-of-scope |
| 2 | 4/5 | None | Ready |

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `test_install_skip.py:8-63` | `_setup_common` duplicates conftest fixture | Out-of-scope — pre-existing pattern in 3 test files |
| B2 | `test_install_skip.py:106-186` | Mock events don't match actual playbook task names | Fixed — events now include Discover/Set skip condition/Mark skipped tasks |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W2 | `install.yaml:116` | No path validation for discovered binary | Fixed — added validation (must be under /usr/local/bin/, /usr/bin/, or /home/) |
| W5 | `test_install_skip.py:196-228` | Fragile substring match in skip detection | Fixed — removed substring match, added negative test |

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>