### PR TITLE
fix(status): show agent type instead of instance name in ps output

### DIFF
--- a/src/clawrium/cli/status.py
+++ b/src/clawrium/cli/status.py
@@ -244,9 +244,11 @@ def status(
                 else:
                     status_display = "[yellow]installing...[/yellow]"
 
+            agent_type = claw_record.get("type", claw_name)
+
             table.add_row(
                 escape(full_name),
-                escape(claw_name),
+                escape(agent_type),
                 escape(display_host),
                 version,
                 status_display,

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -10,12 +10,12 @@ Host record schema (extended):
 {
     "hostname": str,
     "agents": {
-        "openclaw": {
+        "clever-einstein": {  # Agent NAME as key (allows multiple per type)
+            "type": "openclaw",  # Agent type (zeroclaw, openclaw, etc.)
             "version": "0.1.0",
             "status": "installed" | "failed" | "installing",
             "installed_at": "ISO timestamp",
             "error": str | None,
-            "agent_name": "clever-einstein"  # friendly name, no prefix
         }
     },
     ...existing fields...


### PR DESCRIPTION
## Summary

Fixes bug where `clm agent ps` displayed agent instance names (e.g., "clear-avogadro") in the "Agent Type" column instead of agent types (e.g., "openclaw").

**Root Cause**: Display bug in `status.py:249` - code used dictionary key (agent instance name) instead of reading the `type` field from the agent record.

**Impact**: Display only - no functional issues, just confusing output for users.

## Changes

- **src/clawrium/cli/status.py:247-254**: Extract `type` field from agent record with fallback to instance name for backward compatibility
- **src/clawrium/core/install.py:9-22**: Updated schema docs to correctly show agent name as dict key (not agent type)

## Testing

✅ All 813 tests pass  
✅ Lint checks pass  
✅ Manual verification: `clm agent ps` now correctly shows "openclaw" in Agent Type column (previously showed "clear-avogadro")

## ATX Review Summary

**Final Review: Rating 4/5**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 4/5 | None | Ready |

<details>
<summary>Review 1 Details (Rating 4/5)</summary>

**No Blocking Issues** - Fix is production-ready.

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `tests/test_cli_status.py:24-46` | Test fixtures use old schema (type as key) instead of new schema (name as key). Tests pass due to backward compat but fixtures don't match actual data model. | Acknowledged - will address in follow-up cleanup task |
| W2 | `src/clawrium/core/health.py:181` | Docstring says `claw_name` is e.g. "openclaw" (a type), but it's actually an instance name. Misleading. | Acknowledged - deferred to cleanup task |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Add `logger.debug(...)` when falling back to `claw_name` to surface data quality issues during troubleshooting | Acknowledged - deferred to cleanup task |
| S2 | Rename `claw_name` variable to `agent_name` for clarity to distinguish from agent type | Acknowledged - deferred to cleanup task |

**Verified Items:**
- ✅ All 813 tests pass
- ✅ Lint is clean
- ✅ Correct field usage: `claw_name` is agent NAME (key), `claw_record['type']` is agent TYPE
- ✅ `escape()` correctly applied to user-facing strings
- ✅ Fallback to `claw_name` handles backward compatibility
- ✅ No impact on sorting, filtering, or table layout

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>