### PR TITLE
docs: Add FAQ explaining why Clawrium doesn't use Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ It is _not_ a hosted platform. There's no dashboard, no SaaS, no account signup.
 | **Claw** | An AI assistant instance (OpenClaw, NemoClaw, ZeroClaw, or custom) |
 | **Registry** | Platform-defined claw types with versions, deps, and templates |
 
+## FAQ
+
+### Why not Kubernetes?
+
+**Two reasons:**
+
+1. **Most AI agents don't support it.** OpenClaw, NemoClaw, ZeroClaw — these run as local processes, not containerized services. They expect a home directory, local config files, and direct access to the host. Wrapping them in containers adds friction with no payoff.
+
+2. **K8s is overkill for local fleets.** You're managing 3–10 machines on a LAN, not orchestrating microservices across cloud regions. Kubernetes brings etcd, control planes, networking overlays, RBAC, and a learning curve that dwarfs the problem. You don't need a container scheduler — you need to SSH into a box and run a process.
+
+**Clawrium uses Ansible under the hood instead.** Ansible gives you idempotent host management, secrets handling, and multi-machine orchestration without requiring anything on the target machines beyond SSH. Clawrium sits on top of Ansible and adds the agent-specific layer: lifecycle management, token tracking, model swapping, and fleet-wide visibility.
+
 ## Tech Stack
 
 Python · [Typer](https://typer.tiangolo.com/) · [ansible-runner](https://ansible-runner.readthedocs.io/) · [uv](https://docs.astral.sh/uv/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,3 +42,23 @@ Current files stored in `~/.config/clawrium/` (or `$XDG_CONFIG_HOME/clawrium/` i
 **Note:** Clawrium also modifies `~/.ssh/known_hosts` when accepting host keys on first connection (TOFU - Trust On First Use).
 
 When a host is removed with `clm host remove`, both the host entry in `hosts.json` and the per-host keypair in `keys/<hostname>/` are deleted.
+
+## Key Concepts
+
+| Concept | What it is |
+|---------|-----------|
+| **Host** | A machine in your network running one or more claws |
+| **Claw** | An AI assistant instance (OpenClaw, NemoClaw, ZeroClaw, or custom) |
+| **Registry** | Platform-defined claw types with versions, deps, and templates |
+
+## FAQ
+
+### Why not Kubernetes?
+
+**Two reasons:**
+
+1. **Most AI agents don't support it.** OpenClaw, NemoClaw, ZeroClaw — these run as local processes, not containerized services. They expect a home directory, local config files, and direct access to the host. Wrapping them in containers adds friction with no payoff.
+
+2. **K8s is overkill for local fleets.** You're managing 3–10 machines on a LAN, not orchestrating microservices across cloud regions. Kubernetes brings etcd, control planes, networking overlays, RBAC, and a learning curve that dwarfs the problem. You don't need a container scheduler — you need to SSH into a box and run a process.
+
+**Clawrium uses Ansible under the hood instead.** Ansible gives you idempotent host management, secrets handling, and multi-machine orchestration without requiring anything on the target machines beyond SSH. Clawrium sits on top of Ansible and adds the agent-specific layer: lifecycle management, token tracking, model swapping, and fleet-wide visibility.


### PR DESCRIPTION
## Summary

Adds FAQ section to README and documentation explaining why Clawrium uses Ansible instead of Kubernetes for local fleet management.

## Changes

### README.md
- Added FAQ section after "Key Concepts"
- Explains two main reasons against K8s:
  1. Most AI agents (OpenClaw, NemoClaw, ZeroClaw) don't support containerization
  2. K8s is overkill for 3-10 machines on a LAN
- Details how Ansible provides simpler SSH-based orchestration

### docs/index.md
- Added "Key Concepts" table for consistency with README
- Added same FAQ section for documentation site

## Rationale

Common question from users familiar with K8s-based orchestration. This FAQ preemptively addresses why Clawrium takes a different approach suited for local agent fleets.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>