### PR TITLE
fix(readme): point build badge to test workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ric03uec/clawrium/actions/workflows/ci.yml"><img src="https://github.com/ric03uec/clawrium/actions/workflows/ci.yml/badge.svg" alt="Build"></a>
+  <a href="https://github.com/ric03uec/clawrium/actions/workflows/test.yml"><img src="https://github.com/ric03uec/clawrium/actions/workflows/test.yml/badge.svg" alt="Build"></a>
   <a href="https://pypi.org/project/clawrium/"><img src="https://img.shields.io/pypi/v/clawrium" alt="PyPI"></a>
   <a href="https://pypi.org/project/clawrium/"><img src="https://img.shields.io/pypi/pyversions/clawrium" alt="Python"></a>
   <a href="https://github.com/ric03uec/clawrium/blob/main/LICENSE"><img src="https://img.shields.io/github/license/ric03uec/clawrium" alt="License"></a>


### PR DESCRIPTION
## Summary
- update README build badge link and image source from `ci.yml` to `test.yml`
- fix broken badge rendering on the repository landing page

## Testing
- verified `https://github.com/ric03uec/clawrium/actions/workflows/test.yml/badge.svg` returns a valid SVG