### PR TITLE
fix(packaging): add Python classifiers for PyPI badge metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,13 @@ version = "26.04.01"
 description = "CLI tool for managing AI assistant fleets"
 readme = "README.md"
 requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 dependencies = [
     "typer>=0.12.0",
     "rich>=14.0.0",


### PR DESCRIPTION
## Summary
- add Python trove classifiers to `pyproject.toml`
- provide metadata used by the PyPI python-version badge endpoint (`shields.io/pypi/pyversions`)

## Testing
- metadata-only change; no runtime behavior changed
- verified `requires-python` remains `>=3.10`