### PR TITLE
docs: reorder README sections, add Why Clawrium points, fix website homepage icons and navbar logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,34 +25,6 @@
 
 Clawrium uses Ansible under the hood for SSH-based orchestration. You run `clm` from your control machine, which talks to target hosts over SSH. No agents, no containers, no Kubernetes complexity - just processes running on hosts with a unified management layer.
 
-## Commands
-
-```bash
-# Initialize Clawrium
-clm init
-
-# Host management
-clm host init worker-1              # Generate SSH keys and configure remote host
-clm host add worker-1               # Add initialized host to fleet
-clm host list                       # List all hosts
-clm host status worker-1            # Check host connectivity
-clm host remove worker-1            # Remove host from fleet
-
-# Agent management
-clm agent registry list             # Browse available agents
-clm agent install -t openclaw -H worker-1 -n assistant-1
-clm agent ps                        # View all agents across fleet
-clm agent onboard assistant-1       # Configure agent interactively
-clm ps                              # Quick fleet overview
-
-# Provider management
-clm provider add anthropic          # Add API keys for inference providers
-clm provider list                   # View configured providers
-
-# Chat with agents
-clm chat assistant-1                # Start interactive session
-```
-
 ## Why Clawrium
 
 You're running multiple AI agents - coding assistants, internal tools, experiment harnesses - across machines on your network. Without Clawrium, you SSH into each box, manage configs individually, lose track of token spend, and have no unified view of what's running where.
@@ -60,9 +32,11 @@ You're running multiple AI agents - coding assistants, internal tools, experimen
 Clawrium gives you `kubectl`-style fleet control for AI agents:
 
 - **One CLI, all hosts.** Add machines to your fleet and deploy any claw type to any host.
+- **Specialized agents.** Each claw does one job and does it well. Instead of one overloaded assistant, run a fleet of purpose-built agents - a coding agent, a review agent, a research agent - each with its own context, data, and configuration isolated from the rest.
+- **Local inference.** Use hardware you already have - Mac Minis, [NVIDIA DGX Spark](https://www.nvidia.com/en-us/products/workstations/dgx-spark/), spare servers - as inference providers. Run smaller open models like Gemma, GPT-4o-mini, Kimi, or Llama locally and point multiple agents at them.
+- **Model experimentation.** Swap models across agents to compare performance without touching individual configs.
 - **Lifecycle management.** Upgrades, rollbacks, secrets rotation, backups - handled.
 - **Token tracking & guardrails.** See spend across your fleet. Set limits before someone's experiment burns through your API budget.
-- **Model experimentation.** Swap models across agents to compare performance without touching individual configs.
 
 ## Who this is for
 
@@ -78,7 +52,7 @@ It is _not_ a hosted platform. There's no dashboard, no SaaS, no account signup.
 # Install (pick one)
 uv tool install clawrium
 # or
-python -m pip install clawrium
+pip install clawrium
 
 # Run
 clm --help

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -11,13 +11,16 @@ Clawrium is a CLI tool for managing AI assistant fleets on local networks. Deplo
 
 ## Why Clawrium?
 
-Running AI assistants across multiple machines means dealing with:
-- Different configuration formats for each claw type
-- Manual SSH access to each host
-- Scattered secrets and credentials
-- No unified view of your fleet
+You're running multiple AI agents - coding assistants, internal tools, experiment harnesses - across machines on your network. Without Clawrium, you SSH into each box, manage configs individually, lose track of token spend, and have no unified view of what's running where.
 
-Clawrium solves this by providing a single interface to manage any number of claws across any number of hosts.
+Clawrium gives you `kubectl`-style fleet control for AI agents:
+
+- **One CLI, all hosts.** Add machines to your fleet and deploy any claw type to any host.
+- **Specialized agents.** Each claw does one job and does it well. Instead of one overloaded assistant, run a fleet of purpose-built agents - a coding agent, a review agent, a research agent - each with its own context, data, and configuration isolated from the rest.
+- **Local inference.** Use hardware you already have - Mac Minis, [NVIDIA DGX Spark](https://www.nvidia.com/en-us/products/workstations/dgx-spark/), spare servers - as inference providers. Run smaller open models like Gemma, GPT-4o-mini, Kimi, or Llama locally and point multiple agents at them.
+- **Model experimentation.** Swap models across agents to compare performance without touching individual configs.
+- **Lifecycle management.** Upgrades, rollbacks, secrets rotation, backups - handled.
+- **Token tracking & guardrails.** See spend across your fleet. Set limits before someone's experiment burns through your API budget.
 
 ## Features
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -59,7 +59,7 @@ const config: Config = {
       title: 'Clawrium',
       logo: {
         alt: 'Clawrium Logo',
-        src: 'img/logo.svg',
+        src: 'img/clawrium-logo.png',
       },
       items: [
         {

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -9,15 +9,10 @@ type FeatureItem = {
   description: ReactNode;
 };
 
-function ClawIcon() {
+function GlobeIcon() {
   return (
-    <svg viewBox="0 0 64 64" fill="currentColor" width="64" height="64">
-      <ellipse cx="32" cy="40" rx="18" ry="14" fill="currentColor" opacity="0.9"/>
-      <circle cx="24" cy="38" r="4" fill="white"/>
-      <circle cx="40" cy="38" r="4" fill="white"/>
-      <path d="M28 44 Q32 48 36 44" stroke="white" strokeWidth="2" fill="none" strokeLinecap="round"/>
-      <path d="M14 28 L8 14 L14 22 L18 8 L20 24 L32 6 L32 22 L44 8 L44 24 L50 14 L50 28" 
-            stroke="currentColor" strokeWidth="3" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+    <svg viewBox="0 0 24 24" fill="currentColor" width="64" height="64">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93m6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39"/>
     </svg>
   );
 }
@@ -41,11 +36,11 @@ function UnlockIcon() {
 const FeatureList: FeatureItem[] = [
   {
     title: '🌐 Universal Claw Support',
-    icon: <ClawIcon />,
+    icon: <GlobeIcon />,
     description: (
       <>
-        Manage any claw from a single command center: OpenClaw, ZeroClaw,
-        NemoClaw, NanoClaw, IronClaw, and more.
+        Today, Clawrium supports OpenClaw for end-to-end install, onboarding,
+        and lifecycle management. ZeroClaw and additional claw types are planned.
       </>
     ),
   },


### PR DESCRIPTION
## Summary
- reorder README: diagram → Why Clawrium → Who this is for → Quickstart → Key Concepts → FAQ
- remove Commands section from README (all in documentation website)
- add Specialized Agents and Local Inference bullets to Why Clawrium (both README and website intro)
- fix homepage globe icon (was rendering smiley claw SVG instead of globe)
- fix navbar logo path (was pointing to missing `logo.svg`, now uses `clawrium-logo.png`)

## Testing
- documentation and component changes only
- website redeploy will also pick up contributing.md /clm→/itx rename from PR #191