### PR TITLE
docs: reduce homepage logo size

### DIFF
--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -21,12 +21,12 @@
   }
 
   .heroLogo {
-    max-width: 280px;
+    max-width: 150px;
   }
 }
 
 .heroLogo {
-  max-width: 450px;
+  max-width: 200px;
   height: auto;
   margin-bottom: 1.5rem;
   filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.2));


### PR DESCRIPTION
Reduce hero logo from 450px to 200px (desktop) and 280px to 150px (mobile).