### PR TITLE
fix(openclaw): add proper ollama provider config generation

### DIFF
--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -309,6 +309,10 @@ def _sync_provider_config(
     # Build complete config data
     config_data = {"gateway": gateway_config, "provider": provider_config}
 
+    # Preserve existing channels config (Discord pairing, etc.)
+    if existing_config.get("channels"):
+        config_data["channels"] = existing_config["channels"]
+
     # Call configure_agent to apply configuration via Ansible
     success, error = configure_agent(
         host,

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -305,12 +305,17 @@ def _sync_provider_config(
         "endpoint": provider.get("endpoint", ""),
         "default_model": provider.get("default_model", ""),
     }
+    # Pass through optional ollama config fields
+    if provider.get("context_window"):
+        provider_config["context_window"] = provider["context_window"]
+    if provider.get("max_tokens"):
+        provider_config["max_tokens"] = provider["max_tokens"]
 
     # Build complete config data
     config_data = {"gateway": gateway_config, "provider": provider_config}
 
     # Preserve existing channels config (Discord pairing, etc.)
-    if existing_config.get("channels"):
+    if "channels" in existing_config:
         config_data["channels"] = existing_config["channels"]
 
     # Call configure_agent to apply configuration via Ansible

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -46,6 +46,7 @@
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
         mode: "0600"
+      no_log: true
       when: config.provider is defined and config.provider.default_model is defined
       notify: Restart openclaw service
 

--- a/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
@@ -106,7 +106,8 @@
 {% if config.identity is defined %}
   "identity": {{ config.identity | tojson }},
 {% endif %}
-{% if config.provider is defined and config.provider.type == "ollama" and config.provider.endpoint %}
+{% if config.provider is defined and config.provider.type == "ollama" and config.provider.endpoint and config.provider.default_model is defined and config.provider.default_model %}
+{% set ollama_model_id = config.provider.default_model | replace('ollama/', '', 1) %}
   "models": {
     "providers": {
       "ollama": {
@@ -115,13 +116,13 @@
         "api": "ollama",
         "models": [
           {
-            "id": {{ config.provider.default_model | tojson }},
-            "name": {{ config.provider.default_model | tojson }},
+            "id": {{ ollama_model_id | tojson }},
+            "name": {{ ollama_model_id | tojson }},
             "reasoning": false,
             "input": ["text"],
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
-            "contextWindow": 131072,
-            "maxTokens": 16384
+            "contextWindow": {{ config.provider.context_window | default(131072) }},
+            "maxTokens": {{ config.provider.max_tokens | default(16384) }}
           }
         ]
       }

--- a/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
@@ -121,8 +121,8 @@
             "reasoning": false,
             "input": ["text"],
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
-            "contextWindow": {{ config.provider.context_window | default(131072) }},
-            "maxTokens": {{ config.provider.max_tokens | default(16384) }}
+            "contextWindow": {{ config.provider.context_window | default(131072) | int }},
+            "maxTokens": {{ config.provider.max_tokens | default(16384) | int }}
           }
         ]
       }

--- a/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
@@ -9,9 +9,11 @@
 {% endif %}
 {% if config.provider is defined and config.provider.default_model is defined %}
 {% if config.provider.type == "openrouter" and not config.provider.default_model.startswith("openrouter/") %}
-      "model": {{ ("openrouter/" ~ config.provider.default_model) | tojson }},
+      "model": { "primary": {{ ("openrouter/" ~ config.provider.default_model) | tojson }} },
+{% elif config.provider.type == "ollama" and not config.provider.default_model.startswith("ollama/") %}
+      "model": { "primary": {{ ("ollama/" ~ config.provider.default_model) | tojson }} },
 {% else %}
-      "model": {{ config.provider.default_model | tojson }},
+      "model": { "primary": {{ config.provider.default_model | tojson }} },
 {% endif %}
 {% elif agents_defaults.model is defined %}
       "model": {{ agents_defaults.model | tojson }},
@@ -104,7 +106,28 @@
 {% if config.identity is defined %}
   "identity": {{ config.identity | tojson }},
 {% endif %}
-{% if config.models is defined %}
+{% if config.provider is defined and config.provider.type == "ollama" and config.provider.endpoint %}
+  "models": {
+    "providers": {
+      "ollama": {
+        "baseUrl": {{ config.provider.endpoint | tojson }},
+        "apiKey": "ollama-local",
+        "api": "ollama",
+        "models": [
+          {
+            "id": {{ config.provider.default_model | tojson }},
+            "name": {{ config.provider.default_model | tojson }},
+            "reasoning": false,
+            "input": ["text"],
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+            "contextWindow": 131072,
+            "maxTokens": 16384
+          }
+        ]
+      }
+    }
+  },
+{% elif config.models is defined %}
   "models": {{ config.models | tojson }},
 {% endif %}
 {% if config.tools is defined %}

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -1212,3 +1212,139 @@ class TestConfigurePreservesGatewayAuth:
         # Verify URL was preserved
         gateway_config = captured_config[0]["gateway"]
         assert gateway_config["url"] == "ws://custom-host:9999"
+
+    def test_preserves_channels_during_provider_switch(self, isolated_config: Path):
+        """Test that channels config is preserved when switching providers."""
+        from clawrium.cli.agent import _sync_provider_config
+
+        create_test_keypair(isolated_config, "work")
+
+        # Create host with channels config
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = [
+            {
+                "hostname": "192.168.1.100",
+                "key_id": "work",
+                "port": 22,
+                "agent_name": "xclm",
+                "alias": "work",
+                "auth_method": "key",
+                "agents": {
+                    "openclaw": {
+                        "version": "0.1.0",
+                        "status": "installed",
+                        "agent_name": "assistant",
+                        "onboarding": {"state": "ready"},
+                        "config": {
+                            "gateway": {"port": 40000, "bind": "lan"},
+                            "provider": {
+                                "name": "old-provider",
+                                "type": "openrouter",
+                                "default_model": "openai/gpt-4o",
+                            },
+                            "channels": {
+                                "discord": {
+                                    "enabled": True,
+                                    "token": {"source": "env", "id": "DISCORD_BOT_TOKEN"},
+                                    "allowFrom": ["123456789"],
+                                }
+                            },
+                        },
+                    }
+                },
+            }
+        ]
+        hosts_file.write_text(json.dumps(hosts_data, indent=2))
+
+        # New provider to switch to
+        provider = {
+            "name": "new-provider",
+            "type": "ollama",
+            "endpoint": "http://localhost:11434",
+            "default_model": "llama3.1:8b",
+        }
+
+        # Capture the config_data passed to configure_agent
+        captured_config = []
+
+        def mock_configure(
+            hostname, claw_name, config_data, agent_name=None, on_event=None
+        ):
+            captured_config.append(config_data.copy())
+            return True, None
+
+        with patch(
+            "clawrium.core.lifecycle.configure_agent", side_effect=mock_configure
+        ):
+            _sync_provider_config(
+                "work", "openclaw", provider, installed_name="openclaw"
+            )
+
+        # Verify channels were preserved
+        assert "channels" in captured_config[0]
+        assert captured_config[0]["channels"]["discord"]["enabled"] is True
+        assert captured_config[0]["channels"]["discord"]["allowFrom"] == ["123456789"]
+
+    def test_does_not_add_channels_when_absent(self, isolated_config: Path):
+        """Test that channels key is not added when not present in existing config."""
+        from clawrium.cli.agent import _sync_provider_config
+
+        create_test_keypair(isolated_config, "work")
+
+        # Create host without channels config
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = [
+            {
+                "hostname": "192.168.1.100",
+                "key_id": "work",
+                "port": 22,
+                "agent_name": "xclm",
+                "alias": "work",
+                "auth_method": "key",
+                "agents": {
+                    "openclaw": {
+                        "version": "0.1.0",
+                        "status": "installed",
+                        "agent_name": "assistant",
+                        "onboarding": {"state": "ready"},
+                        "config": {
+                            "gateway": {"port": 40000, "bind": "lan"},
+                            "provider": {
+                                "name": "old-provider",
+                                "type": "openrouter",
+                                "default_model": "openai/gpt-4o",
+                            },
+                            # No channels key
+                        },
+                    }
+                },
+            }
+        ]
+        hosts_file.write_text(json.dumps(hosts_data, indent=2))
+
+        provider = {
+            "name": "new-provider",
+            "type": "ollama",
+            "endpoint": "http://localhost:11434",
+            "default_model": "llama3.1:8b",
+        }
+
+        captured_config = []
+
+        def mock_configure(
+            hostname, claw_name, config_data, agent_name=None, on_event=None
+        ):
+            captured_config.append(config_data.copy())
+            return True, None
+
+        with patch(
+            "clawrium.core.lifecycle.configure_agent", side_effect=mock_configure
+        ):
+            _sync_provider_config(
+                "work", "openclaw", provider, installed_name="openclaw"
+            )
+
+        # Verify channels key was not added
+        assert "channels" not in captured_config[0]

--- a/tests/test_configure_claw.py
+++ b/tests/test_configure_claw.py
@@ -564,6 +564,88 @@ class TestOpenClawTemplate:
         assert success is True, f"Configuration failed: {error}"
         assert error is None
 
+    def test_template_ollama_renders_models_block(self):
+        """Test that ollama provider generates models.providers.ollama block."""
+        config = {
+            "provider": {
+                "type": "ollama",
+                "endpoint": "http://localhost:11434",
+                "default_model": "llama3.1:8b",
+            },
+        }
+        result = self._render_template(config)
+
+        # Verify models.providers.ollama structure
+        assert "models" in result
+        assert "providers" in result["models"]
+        assert "ollama" in result["models"]["providers"]
+        ollama = result["models"]["providers"]["ollama"]
+        assert ollama["baseUrl"] == "http://localhost:11434"
+        assert ollama["apiKey"] == "ollama-local"
+        assert ollama["api"] == "ollama"
+        assert len(ollama["models"]) == 1
+        assert ollama["models"][0]["id"] == "llama3.1:8b"
+        assert ollama["models"][0]["name"] == "llama3.1:8b"
+        assert ollama["models"][0]["contextWindow"] == 131072
+        assert ollama["models"][0]["maxTokens"] == 16384
+
+    def test_template_ollama_no_models_block_without_endpoint(self):
+        """Test that ollama without endpoint does not generate models block."""
+        config = {
+            "provider": {
+                "type": "ollama",
+                "default_model": "llama3.1:8b",
+                # No endpoint
+            },
+        }
+        result = self._render_template(config)
+
+        # models block should not exist
+        assert "models" not in result
+
+    def test_template_ollama_no_models_block_without_default_model(self):
+        """Test that ollama without default_model does not crash."""
+        config = {
+            "provider": {
+                "type": "ollama",
+                "endpoint": "http://localhost:11434",
+                # No default_model
+            },
+        }
+        result = self._render_template(config)
+
+        # Should not crash, models block should not exist
+        assert "models" not in result
+
+    def test_template_ollama_strips_prefix_in_models_id(self):
+        """Test that pre-prefixed ollama model has correct id without double prefix."""
+        config = {
+            "provider": {
+                "type": "ollama",
+                "endpoint": "http://localhost:11434",
+                "default_model": "ollama/llama3.1:8b",  # Already prefixed
+            },
+        }
+        result = self._render_template(config)
+
+        # models[].id should be stripped of ollama/ prefix
+        assert result["models"]["providers"]["ollama"]["models"][0]["id"] == "llama3.1:8b"
+        # But model.primary should keep the prefix
+        assert result["agents"]["defaults"]["model"]["primary"] == "ollama/llama3.1:8b"
+
+    def test_template_ollama_model_gets_prefix(self):
+        """Test that unprefixed ollama model gets ollama/ prefix in model.primary."""
+        config = {
+            "provider": {
+                "type": "ollama",
+                "endpoint": "http://localhost:11434",
+                "default_model": "llama3.1:8b",  # Not prefixed
+            },
+        }
+        result = self._render_template(config)
+
+        assert result["agents"]["defaults"]["model"]["primary"] == "ollama/llama3.1:8b"
+
 
 class TestEnvTemplate:
     """Tests for OpenClaw .env.j2 template rendering."""

--- a/tests/test_configure_claw.py
+++ b/tests/test_configure_claw.py
@@ -355,7 +355,7 @@ class TestOpenClawTemplate:
         }
         result = self._render_template(config)
 
-        assert result["agents"]["defaults"]["model"] == "anthropic/claude-sonnet-4-6"
+        assert result["agents"]["defaults"]["model"] == {"primary": "anthropic/claude-sonnet-4-6"}
         assert result["agents"]["defaults"]["workspace"] == "~/.openclaw/workspace"
         assert result["agents"]["defaults"]["maxConcurrent"] == 4
         assert result["gateway"]["port"] == 18789
@@ -381,7 +381,7 @@ class TestOpenClawTemplate:
         }
         result = self._render_template(config)
 
-        assert result["agents"]["defaults"]["model"] == "openai/gpt-5.4"
+        assert result["agents"]["defaults"]["model"] == {"primary": "openai/gpt-5.4"}
         assert result["agents"]["defaults"]["maxConcurrent"] == 8
         assert result["agents"]["defaults"]["skills"] == ["researcher", "coder"]
         assert result["gateway"]["port"] == 40123
@@ -457,7 +457,7 @@ class TestOpenClawTemplate:
         result = self._render_template(config)
 
         # Should parse as valid JSON (proves escaping worked)
-        assert result["agents"]["defaults"]["model"] == 'model"with"quotes'
+        assert result["agents"]["defaults"]["model"] == {"primary": 'model"with"quotes'}
         assert result["gateway"]["bind"] == "bind\nwith\nnewlines"
 
     def test_template_renders_agent_list(self):


### PR DESCRIPTION
## Summary
- Preserve channels config (Discord pairing) when switching providers
- Generate `models.providers.ollama` section with baseUrl, api, models array
- Use model object format `{ primary: "ollama/model-name" }`
- Add `ollama/` prefix to model names for proper routing
- Include contextWindow and maxTokens in model definition

## Test plan
- [x] `make test` passes (911 tests)
- [x] Configure agent with ollama provider
- [x] Verify openclaw starts without config errors
- [x] Verify model routing works correctly

## ATX Review Summary

**Final Rating: 3/5** | **Total Cost: $6.07**

| Review | Rating | Cost | Blocking Issues | Status |
|--------|--------|------|-----------------|--------|
| 1 | 2.7/5 | $2.72 | B1, B2, B3 | All fixed |
| 2 | 3/5 | $3.35 | B1, B2 | All fixed |

<details>
<summary>Review 1 Details (Rating 2.7/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `openclaw.json.j2:118-119` | Template crash when default_model undefined | Fixed - added guard |
| B2 | `tests/test_configure_claw.py` | No test for ollama models block | Fixed - added tests |
| B3 | `tests/test_configure_claw.py` | No test for channels preservation | Fixed - added tests |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `openclaw.json.j2:118` | Model prefix inconsistency in models[].id | Fixed - strip ollama/ prefix |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `openclaw.json.j2:124-125` | context_window/max_tokens missing \| int filter | Fixed |
| B2 | `agent.py:301-307` | context_window/max_tokens not passed through | Fixed |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `configure.yaml:42` | Missing no_log: true | Fixed |
| W2 | `agent.py:313` | Channels falsy check drops empty dict | Fixed - use "in" |
| W3 | `configure.yaml:133` | ignore_errors undocumented | Deferred |
| W4 | `openclaw.json.j2:107-108` | Endpoint whitespace not trimmed | Deferred |

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>