### PR TITLE
docs(guides): split channel onboarding into channels docs

### DIFF
--- a/website/docs/guides/agent-onboarding.md
+++ b/website/docs/guides/agent-onboarding.md
@@ -172,70 +172,10 @@ Configure governance identity:
 
 **Purpose:** Set up how the agent communicates with users.
 
-**Available channels** (varies by agent):
+For channel-specific setup and credential requirements, see:
 
-| Channel | Description | Best For |
-|---------|-------------|----------|
-| CLI | Command line interface | Development, scripting |
-| Discord | Community engagement | Communities, gaming, team collaboration |
-
-**Example - CLI channel (default):**
-```bash
-Select default communication channel:
-  1. cli (recommended)
-  2. discord
-
-Select [1-2]: 1
-✓ Default channel: cli
-```
-
-**Example - Discord channel:**
-```bash
-Select default communication channel:
-  1. cli (recommended)
-  2. discord
-
-Select [1-2]: 2
-✓ Default channel: discord
-
-Discord Configuration
-Discord bot token: [hidden input]
-Discord server (guild) ID: 123456789012345678
-Discord channel ID: 987654321098765432
-
-✓ Discord bot token stored securely
-Syncing channel config to agent... ✓
-```
-
-#### Discord Setup Requirements
-
-Before configuring Discord as your channel, you need:
-
-1. **Create a Discord Bot:**
-   - Go to [Discord Developer Portal](https://discord.com/developers/applications)
-   - Create a new application
-   - Navigate to "Bot" section and create a bot
-   - Copy the bot token (keep it secret!)
-
-2. **Get Server (Guild) ID:**
-   - Enable Developer Mode in Discord (User Settings > Advanced > Developer Mode)
-   - Right-click your server name and select "Copy Server ID"
-   - IDs are 17-19 digit numbers (e.g., `123456789012345678`)
-
-3. **Get Channel ID:**
-   - Right-click the channel where your agent should respond
-   - Select "Copy Channel ID"
-   - IDs are 17-19 digit numbers (e.g., `987654321098765432`)
-
-4. **Invite Bot to Server:**
-   - In Developer Portal, go to OAuth2 > URL Generator
-   - Select scopes: `bot`, `applications.commands`
-   - Select permissions: `Send Messages`, `Read Message History`, `View Channels`
-   - Use generated URL to invite bot to your server
-
-:::tip
-The Discord bot token is stored securely as a per-instance secret and synced to the agent's environment as `DISCORD_BOT_TOKEN`.
-:::
+- [Channels Guide](./channels/channels.md)
+- [Discord Channel Setup](./channels/discord.md)
 
 :::info
 For ZeroClaw, only CLI is supported and auto-configured.
@@ -467,6 +407,7 @@ The wizard will respect your intent even if the stage is normally skippable.
 
 ## Next Steps
 
+- [Channels Guide](./channels/channels.md) - Configure communication channels and integrations
 - [Secret Management](./secret-management.md) - Managing provider API keys
 - [Fleet Management](./fleet-management.md) - Operating multiple agents
 - [CLI Reference: agent](../reference/cli/agent.md) - Full command documentation

--- a/website/docs/guides/channels/_category_.json
+++ b/website/docs/guides/channels/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Channels",
+  "position": 5,
+  "link": {
+    "type": "generated-index",
+    "description": "Communication channel setup guides for Clawrium agents."
+  }
+}

--- a/website/docs/guides/channels/channels.md
+++ b/website/docs/guides/channels/channels.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 1
+description: Configure communication channels for your agents during onboarding.
+keywords: [channels, communication, onboarding, cli, discord]
+---
+
+# Channels
+
+The Channels stage configures how your agent communicates with users.
+
+## Available Channels
+
+Available channels vary by agent type.
+
+| Channel | Description | Best For |
+|---------|-------------|----------|
+| CLI | Command line interface | Development, scripting |
+| Discord | Community engagement | Communities, gaming, team collaboration |
+
+## Example - CLI channel (default)
+
+```bash
+Select default communication channel:
+  1. cli (recommended)
+  2. discord
+
+Select [1-2]: 1
+✓ Default channel: cli
+```
+
+## Channel-Specific Setup
+
+- [Discord Channel Setup](./discord.md)
+
+:::info
+For ZeroClaw, only CLI is supported and auto-configured.
+:::

--- a/website/docs/guides/channels/discord.md
+++ b/website/docs/guides/channels/discord.md
@@ -1,0 +1,58 @@
+---
+sidebar_position: 2
+description: Set up Discord channel credentials and permissions for agent onboarding.
+keywords: [discord, channels, onboarding, bot token, guild id, channel id]
+---
+
+# Discord Channel Setup
+
+Use this guide when selecting Discord as your default channel during onboarding.
+
+## Example - Discord channel
+
+```bash
+Select default communication channel:
+  1. cli (recommended)
+  2. discord
+
+Select [1-2]: 2
+✓ Default channel: discord
+
+Discord Configuration
+Discord bot token: [hidden input]
+Discord server (guild) ID: 123456789012345678
+Discord channel ID: 987654321098765432
+
+✓ Discord bot token stored securely
+Syncing channel config to agent... ✓
+```
+
+## Discord Setup Requirements
+
+Before configuring Discord as your channel, you need:
+
+1. **Create a Discord Bot:**
+   - Go to [Discord Developer Portal](https://discord.com/developers/applications)
+   - Create a new application
+   - Navigate to "Bot" section and create a bot
+   - Copy the bot token (keep it secret!)
+
+2. **Get Server (Guild) ID:**
+   - Enable Developer Mode in Discord (User Settings > Advanced > Developer Mode)
+   - Right-click your server name and select "Copy Server ID"
+   - IDs are 17-19 digit numbers (e.g., `123456789012345678`)
+
+3. **Get Channel ID:**
+   - Right-click the channel where your agent should respond
+   - Select "Copy Channel ID"
+   - IDs are 17-19 digit numbers (e.g., `987654321098765432`)
+
+4. **Invite Bot to Server:**
+   - In Developer Portal, go to OAuth2 > URL Generator
+   - Select scopes: `bot`, `applications.commands`
+   - Select permissions: `Send Messages`, `Read Message History`, `View Channels`
+   - Use generated URL to invite bot to your server
+
+:::tip
+The Discord bot token is stored securely as a per-instance secret and synced to the agent's environment as `DISCORD_BOT_TOKEN`.
+:::


### PR DESCRIPTION
## Summary
- Move the Channels-stage documentation out of `agent-onboarding.md` into a dedicated nested Channels guide section.
- Add `website/docs/guides/channels/channels.md` as the onboarding channel overview page.
- Add `website/docs/guides/channels/discord.md` with Discord credential/setup steps moved from onboarding.
- Update `agent-onboarding.md` to link to the new Channels and Discord pages.

## Testing
- Docs-only change; no code paths modified.
- Verified markdown links and sidebar metadata in changed files.

## ATX Review Summary

**Final Review: Rating N/A (ATX unavailable in environment)**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | N/A | None reported (review not executed) | ATX MCP returned `Not connected` |

<details>
<summary>Review 1 Details (ATX unavailable)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | N/A | ATX review service unavailable (`Not connected`) | Could not run in this environment |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | N/A | No ATX feedback was produced | Documented limitation in PR |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Run ATX review in connected environment before merge | Pending |

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>