### PR TITLE
docs: standardize agent terminology and fix quickstart commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="docs/assets/clawrium-logo.png" alt="Clawrium" height="40" align="center"> Clawrium - An aquarium for *claws
+# <img src="docs/assets/clawrium-logo.png" alt="Clawrium" height="40" align="center"> Clawrium - An aquarium for agents
 
 <p align="center">
   Fleet management for AI agents on your local network.
@@ -31,8 +31,8 @@ You're running multiple AI agents - coding assistants, internal tools, experimen
 
 Clawrium gives you `kubectl`-style fleet control for AI agents:
 
-- **One CLI, all hosts.** Add machines to your fleet and deploy any claw type to any host.
-- **Specialized agents.** Each claw does one job and does it well. Instead of one overloaded assistant, run a fleet of purpose-built agents - a coding agent, a review agent, a research agent - each with its own context, data, and configuration isolated from the rest.
+- **One CLI, all hosts.** Add machines to your fleet and deploy any agent type to any host.
+- **Specialized agents.** Each agent does one job and does it well. Instead of one overloaded assistant, run a fleet of purpose-built agents - a coding agent, a review agent, a research agent - each with its own context, data, and configuration isolated from the rest.
 - **Local inference.** Use hardware you already have - Mac Minis, [NVIDIA DGX Spark](https://www.nvidia.com/en-us/products/workstations/dgx-spark/), spare servers - as inference providers. Run smaller open models like Gemma, GPT-4o-mini, Kimi, or Llama locally and point multiple agents at them.
 - **Model experimentation.** Swap models across agents to compare performance without touching individual configs.
 - **Lifecycle management.** Upgrades, rollbacks, secrets rotation, backups - handled.
@@ -46,7 +46,7 @@ It is _not_ a hosted platform. There's no dashboard, no SaaS, no account signup.
 
 ## Quickstart
 
-**Requirements:** Python 3.11+, [uv](https://docs.astral.sh/uv/)
+**Requirements:** Python 3.10+, [uv](https://docs.astral.sh/uv/)
 
 ```bash
 # Install (pick one)
@@ -62,16 +62,19 @@ clm init
 
 # Set up a host
 clm host init 192.168.1.100 --user your-username
-clm host add worker-1
+clm host add 192.168.1.100 --alias worker-1
 
 # Add inference provider (e.g., Anthropic for Claude models)
-clm provider add anthropic
+clm provider add anthropic --type anthropic
 
 # Install an agent
-clm agent install --type openclaw --host worker-1 --name my-assistant
+clm agent install --type <agent-type> --host worker-1 --name my-assistant
 
 # Configure the agent
-clm agent onboard my-assistant
+clm agent configure my-assistant
+
+# Start the agent
+clm agent start my-assistant
 
 # Check fleet status
 clm ps
@@ -80,53 +83,61 @@ clm ps
 clm chat my-assistant
 ```
 
-**→ Full setup guide, claw types, and configuration reference: [ric03uec.github.io/clawrium](https://ric03uec.github.io/clawrium/)**
+**→ Full setup guide, agent types, and configuration reference: [ric03uec.github.io/clawrium](https://ric03uec.github.io/clawrium/)**
 
 ## Key Concepts
 
 | Concept | What it is |
 |---------|-----------|
-| **Host** | A machine in your network running one or more claws |
-| **Claw** | An AI assistant instance (OpenClaw, NemoClaw, ZeroClaw, or custom) |
-| **Registry** | Platform-defined claw types with versions, deps, and templates |
+| **Host** | A machine in your network running one or more agents |
+| **Agent** | An installed AI assistant instance managed by Clawrium |
+| **Agent Type** | The implementation/runtime class of an agent |
+| **Agent Name** | The unique identifier for an installed agent instance |
+| **Registry** | Platform-defined agent types with versions, dependencies, and templates |
 
 ## FAQ
 
-### What operating systems are supported?
+### 1. What operating systems are supported?
 
 Right now, Clawrium is only tested on Ubuntu hosts and Ubuntu control machines.
 
 Other Linux distributions may work, but they are not currently part of the test matrix.
 
-### Which claws are supported today?
+### 2. Which agents are supported today?
 
-Right now, only OpenClaw is officially supported and tested end-to-end.
+Right now, one agent type is officially supported and tested end-to-end.
 
-ZeroClaw and additional claws are planned.
+Additional agent types are planned.
 
-### Is Claude subscription supported?
+### 3. Is Claude subscription supported?
 
 No. Clawrium supports API keys only, by design.
 
-### Which channels are supported?
+### 4. Which channels are supported?
 
 Discord is supported right now.
 
 Additional channels are planned.
 
-### Does Clawrium install Docker or Kubernetes?
+### 5. Does Clawrium install Docker or Kubernetes?
 
 No. Clawrium does not require Docker or Kubernetes. It manages agent processes over SSH using Ansible.
 
-### Can I manage multiple hosts with different agent types?
+### 6. Can I manage multiple hosts with different agent types?
 
-Yes. You can register multiple hosts and run different claws on each host (for example, OpenClaw on one host and NemoClaw on another) from the same `clm` control node.
+Yes. You can register multiple hosts and run different agent types on each host from the same `clm` control node.
 
-### Why not Kubernetes?
+### 7. Why doesn't it support x-agent and y-feature?
+
+I'm building Clawrium in my spare time, so I prioritize my own use cases first.
+
+If you want support for a specific agent type or feature, please open an issue and send a PR. See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+
+### 8. Why not Kubernetes?
 
 **Two reasons:**
 
-1. **Most AI agents don't support it.** OpenClaw, NemoClaw, ZeroClaw - these run as local processes, not containerized services. They expect a home directory, local config files, and direct access to the host. Wrapping them in containers adds friction with no payoff.
+1. **Most AI agent runtimes don't support it.** These run as local processes, not containerized services. They expect a home directory, local config files, and direct access to the host. Wrapping them in containers adds friction with no payoff.
 
 2. **K8s is overkill for local fleets.** You're managing 3-10 machines on a LAN, not orchestrating microservices across cloud regions. Kubernetes brings etcd, control planes, networking overlays, RBAC, and a learning curve that dwarfs the problem. You don't need a container scheduler - you need to SSH into a box and run a process.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,28 +1,39 @@
-# Clawrium - An aquarium for *claws
+# Clawrium - An aquarium for agents
 
 Clawrium is a CLI tool for managing AI agent fleets on local networks.
 
 ## Getting Started
 
 1. [Host Preparation](host-preparation.md) - Prepare hosts for management (create xclm user, setup SSH)
-2. Host Management - Add, list, and manage hosts with `clm host` (coming soon)
-3. Agent Deployment - Deploy AI assistants to your fleet (coming soon)
+2. Host Management - Add, list, and manage hosts with `clm host`
+3. Agent Deployment - Deploy AI assistants to your fleet with `clm agent`
 4. [Agent Onboarding](agent-onboarding.md) - Configure newly installed agents through guided workflow
 
 ## Quick Reference
 
 ```bash
+# Initialize config
+clm init
+
 # Initialize a host (generates keypair, attempts auto-setup of xclm user)
 clm host init <hostname> --user <your-ssh-user>
 
 # Add an initialized host to the fleet
-clm host add <hostname>
+clm host add <hostname> --alias <host-alias>
 
 # List all hosts
 clm host list
 
 # Check host status (exits with code 1 if unreachable - useful for scripting)
-clm host status <hostname>
+clm host ps <host-alias>
+
+# Add inference provider
+clm provider add anthropic --type anthropic
+
+# Install, configure, and start an agent
+clm agent install --type <agent-type> --host <host-alias> --name <agent-name>
+clm agent configure <agent-name>
+clm agent start <agent-name>
 
 # Remove a host and its keypair
 clm host remove <hostname>
@@ -47,18 +58,26 @@ When a host is removed with `clm host remove`, both the host entry in `hosts.jso
 
 | Concept | What it is |
 |---------|-----------|
-| **Host** | A machine in your network running one or more claws |
-| **Claw** | An AI assistant instance (OpenClaw, NemoClaw, ZeroClaw, or custom) |
-| **Registry** | Platform-defined claw types with versions, deps, and templates |
+| **Host** | A machine in your network running one or more agents |
+| **Agent** | An installed AI assistant instance managed by Clawrium |
+| **Agent Type** | The implementation/runtime class of an agent |
+| **Agent Name** | The unique identifier for an installed agent instance |
+| **Registry** | Platform-defined agent types with versions, dependencies, and templates |
 
 ## FAQ
 
-### Why not Kubernetes?
+### 1. Why not Kubernetes?
 
 **Two reasons:**
 
-1. **Most AI agents don't support it.** OpenClaw, NemoClaw, ZeroClaw - these run as local processes, not containerized services. They expect a home directory, local config files, and direct access to the host. Wrapping them in containers adds friction with no payoff.
+1. **Most AI agent runtimes don't support it.** These run as local processes, not containerized services. They expect a home directory, local config files, and direct access to the host. Wrapping them in containers adds friction with no payoff.
 
 2. **K8s is overkill for local fleets.** You're managing 3-10 machines on a LAN, not orchestrating microservices across cloud regions. Kubernetes brings etcd, control planes, networking overlays, RBAC, and a learning curve that dwarfs the problem. You don't need a container scheduler - you need to SSH into a box and run a process.
 
 **Clawrium uses Ansible under the hood instead.** Ansible gives you idempotent host management, secrets handling, and multi-machine orchestration without requiring anything on the target machines beyond SSH. Clawrium sits on top of Ansible and adds the agent-specific layer: lifecycle management, token tracking, model swapping, and fleet-wide visibility.
+
+### 2. Why doesn't it support x-agent and y-feature?
+
+I'm building Clawrium in my spare time, so I prioritize my own use cases first.
+
+If you want support for a specific agent type or feature, please open an issue and send a PR. See [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution guidelines.

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -6,7 +6,7 @@ keywords: [install, setup, requirements, uvx, pip, python]
 
 # Installation
 
-This guide covers installing Clawrium on your management machine (the computer you'll use to control your claw fleet).
+This guide covers installing Clawrium on your management machine (the computer you'll use to control your agent fleet).
 
 ## Prerequisites
 
@@ -60,7 +60,7 @@ Run the `clm` command to verify installation:
 clm --help
 ```
 
-You should see:
+You should see output similar to:
 
 ```
  Usage: clm [OPTIONS] COMMAND [ARGS]...
@@ -68,12 +68,12 @@ You should see:
  Clawrium - Manage your AI assistant fleet
 
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ init      Initialize Clawrium and check dependencies.                        │
-│ install   Install a claw on a host.                                          │
-│ status    Show fleet status across all hosts.                                │
+│ init      Initialize Clawrium and check dependencies                         │
 │ host      Manage hosts in your fleet                                         │
-│ registry  Browse available claw types                                        │
-│ secret    Manage secrets for claw instances                                  │
+│ provider  Manage inference providers (LLM APIs)                              │
+│ agent     Manage agents in your fleet                                        │
+│ ps        Show fleet status across all hosts                                 │
+│ chat      Chat with a deployed agent                                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -91,5 +91,5 @@ This creates:
 
 ## Next Steps
 
-- [Quickstart: Deploy your first claw](./guides/quickstart.md)
+- [Quickstart: Deploy your first agent](./guides/quickstart.md)
 - [Host Setup Guide](./guides/host-setup.md)

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,13 +1,13 @@
 ---
 sidebar_position: 1
 slug: /
-description: Clawrium is a CLI tool for managing AI assistant fleets on local networks. Deploy and manage OpenClaw instances across hosts from a single command center.
-keywords: [clawrium, AI assistant, fleet management, CLI tool, multi-host, openclaw]
+description: Clawrium is a CLI tool for managing AI assistant fleets on local networks. Deploy and manage agent instances across hosts from a single command center.
+keywords: [clawrium, AI assistant, fleet management, CLI tool, multi-host, agent]
 ---
 
 # Introduction
 
-Clawrium is a CLI tool for managing AI assistant fleets on local networks. Deploy and manage multiple claw instances across hosts from a single command center.
+Clawrium is a CLI tool for managing AI assistant fleets on local networks. Deploy and manage multiple agent instances across hosts from a single command center.
 
 ## Why Clawrium?
 
@@ -15,8 +15,8 @@ You're running multiple AI agents - coding assistants, internal tools, experimen
 
 Clawrium gives you `kubectl`-style fleet control for AI agents:
 
-- **One CLI, all hosts.** Add machines to your fleet and deploy any claw type to any host.
-- **Specialized agents.** Each claw does one job and does it well. Instead of one overloaded assistant, run a fleet of purpose-built agents - a coding agent, a review agent, a research agent - each with its own context, data, and configuration isolated from the rest.
+- **One CLI, all hosts.** Add machines to your fleet and deploy any agent type to any host.
+- **Specialized agents.** Each agent does one job and does it well. Instead of one overloaded assistant, run a fleet of purpose-built agents - a coding agent, a review agent, a research agent - each with its own context, data, and configuration isolated from the rest.
 - **Local inference.** Use hardware you already have - Mac Minis, [NVIDIA DGX Spark](https://www.nvidia.com/en-us/products/workstations/dgx-spark/), spare servers - as inference providers. Run smaller open models like Gemma, GPT-4o-mini, Kimi, or Llama locally and point multiple agents at them.
 - **Model experimentation.** Swap models across agents to compare performance without touching individual configs.
 - **Lifecycle management.** Upgrades, rollbacks, secrets rotation, backups - handled.
@@ -24,15 +24,15 @@ Clawrium gives you `kubectl`-style fleet control for AI agents:
 
 ## Features
 
-### 🌐 OpenClaw Support (Current)
+### 🌐 Agent Support (Current)
 
-Today, Clawrium supports OpenClaw for end-to-end install, onboarding, and lifecycle management.
+Today, Clawrium supports one agent type for end-to-end install, onboarding, and lifecycle management.
 
-Support for ZeroClaw and additional claw types is planned.
+Support for additional agent types is planned.
 
 ### ⚙️ Normalized Configuration
 
-One config format, every claw. Define your preferences once and Clawrium translates them for each claw's native format.
+One config format, every agent. Define your preferences once and Clawrium translates them for each agent runtime's native format.
 
 ### 🔓 Multi-Model Freedom
 
@@ -57,25 +57,34 @@ clm host add 192.168.1.100 --alias myhost
 clm host list
 
 # Check host status
-clm host status myhost
+clm host ps myhost
 
-# Browse available claw types
-clm registry list
+# Browse available agent types
+clm agent registry list
 
-# Install a claw on a host
-clm install --claw openclaw --host myhost
+# Add inference provider
+clm provider add anthropic --type anthropic
 
-# Set a secret for a claw
-clm secret set oc-myhost OPENAI_API_KEY
+# Install an agent on a host
+clm agent install --type <agent-type> --host myhost --name my-agent
+
+# Set a secret for an agent
+clm agent secret set my-agent OPENAI_API_KEY
+
+# Configure and start the agent
+clm agent configure my-agent
+clm agent start my-agent
 ```
 
 ## Key Concepts
 
 | Concept | Description |
 |---------|-------------|
-| **Host** | A machine in your network that runs one or more claws |
-| **Claw** | An AI assistant instance (currently OpenClaw) |
-| **Registry** | Platform-defined claw types with versions, dependencies, and requirements |
+| **Host** | A machine in your network that runs one or more agents |
+| **Agent** | An installed AI assistant instance managed by Clawrium |
+| **Agent Type** | The implementation/runtime class of an agent |
+| **Agent Name** | The unique identifier for an installed agent instance |
+| **Registry** | Platform-defined agent types with versions, dependencies, and templates |
 
 ## Architecture
 
@@ -85,23 +94,29 @@ Clawrium runs from your control machine and uses SSH + Ansible to manage remote 
 
 ## FAQ
 
-### What operating systems are supported?
+### 1. What operating systems are supported?
 
 Clawrium is currently tested on Ubuntu control machines and Ubuntu target hosts only.
 
-### Which claws are supported today?
+### 2. Which agents are supported today?
 
-OpenClaw is supported right now.
+One agent type is supported right now.
 
-ZeroClaw and additional claw types are planned.
+Additional agent types are planned.
 
-### Is Claude subscription supported?
+### 3. Is Claude subscription supported?
 
 No. API keys are required by design.
 
-### Which channels are supported?
+### 4. Which channels are supported?
 
 Discord is supported right now. Additional channels are planned.
+
+### 5. Why doesn't it support x-agent and y-feature?
+
+I'm building Clawrium in my spare time, so I prioritize my own use cases first.
+
+If you want support for a specific agent type or feature, please open an issue and send a PR. See the [Contributing Guidelines](https://github.com/ric03uec/clawrium/blob/main/CONTRIBUTING.md).
 
 ## User Data
 
@@ -112,11 +127,11 @@ Clawrium stores configuration in `~/.config/clawrium/` (or `$XDG_CONFIG_HOME/cla
 | `hosts.json` | Registered hosts and metadata (0600 permissions) |
 | `keys/<hostname>/xclm_ed25519` | Private key for SSH to host |
 | `keys/<hostname>/xclm_ed25519.pub` | Public key added to host's authorized_keys |
-| `secrets/<claw-name>/<key>` | Encrypted secrets for claw instances |
+| `secrets/<agent-name>/<key>` | Encrypted secrets for agent instances |
 
 ## Next Steps
 
 - [Installation](./installation.md) - Install Clawrium
-- [Quickstart](./guides/quickstart.md) - Deploy your first claw
+- [Quickstart](./guides/quickstart.md) - Deploy your first agent
 - [Host Setup](./guides/host-setup.md) - Detailed host preparation guide
 - [Architecture](./architecture.md) - Understand how Clawrium works


### PR DESCRIPTION
## Summary
- Replace remaining user-facing "claw" terminology with "agent" across core docs pages (`README.md`, `docs/index.md`, `website/docs/intro.md`).
- Number FAQ entries and add a new FAQ clarifying support prioritization (`x-agent` / `y-feature`) with contribution guidance.
- Fix quickstart/install command examples to match current CLI (`agent configure/start`, `host ps`, `agent registry`, `agent secret`, provider `--type`), and refresh installation help text.

## Testing
- Not run (documentation-only changes)

## ATX Review Summary
- Skipped at user request for this documentation-only update.