### PR TITLE
chore: bump version to 26.04.02

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ clm ps
 
 - Repository: https://github.com/ric03uec/clawrium
 - Project Board: https://github.com/users/ric03uec/projects/1
-- Version: 26.04.01
+- Version: 26.04.02
 
 ## Tech Stack
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawrium"
-version = "26.04.01"
+version = "26.04.02"
 description = "CLI tool for managing AI assistant fleets"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump version to 26.04.02 in pyproject.toml and AGENTS.md
- Fixes PyPI publish failure where version wasn't updated before release

## Testing
Version string changes only - no functional changes.