### PR TITLE
docs: fix installation instructions to use uv

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Your Machine (clm CLI)
 
 ```bash
 # Install
-pip install clawrium
+uv tool install clawrium
 
 # Add a host
 clm host init 192.168.1.100 --user myuser

--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ It is _not_ a hosted platform. There's no dashboard, no SaaS, no account signup.
 **Requirements:** Python 3.10+, [uv](https://docs.astral.sh/uv/)
 
 ```bash
-# Install (pick one)
+# Install
 uv tool install clawrium
-# or
-pip install clawrium
+
+# Or run without installing
+uvx --from clawrium clm --help
 
 # Run
 clm --help

--- a/src/clawrium/cli/main.py
+++ b/src/clawrium/cli/main.py
@@ -114,7 +114,7 @@ def tui() -> None:
         launch_tui()
     except ImportError:
         console.print(
-            "[red]Error:[/red] TUI requires textual. Install with: pip install clawrium"
+            "[red]Error:[/red] TUI requires textual. Reinstall with: uv tool install --force clawrium"
         )
         raise typer.Exit(code=1)
 

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -18,12 +18,10 @@ Deploy your first OpenClaw instance in under 10 minutes. This guide walks throug
 
 ## Install Clawrium
 
-Use one of the following commands on your control machine:
+Install on your control machine:
 
 ```bash
 uv tool install clawrium
-# or
-python -m pip install clawrium
 ```
 
 ## Step 1: Initialize Clawrium

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 description: Install Clawrium CLI on your management machine. Requirements, installation methods, and initial setup.
-keywords: [install, setup, requirements, uvx, pip, python]
+keywords: [install, setup, requirements, uv, uvx, python]
 ---
 
 # Installation
@@ -11,7 +11,7 @@ This guide covers installing Clawrium on your management machine (the computer y
 ## Prerequisites
 
 - **Python 3.10 or higher**
-- **uvx** (recommended) or pip
+- **uv** ([install guide](https://docs.astral.sh/uv/getting-started/installation/))
 
 ### Check Python Version
 
@@ -20,13 +20,13 @@ python3 --version
 # Should be 3.10 or higher
 ```
 
-### Install uvx
+### Install uv
 
-If you don't have uvx, install it via pipx or brew:
+If you don't have uv, install it:
 
 ```bash
-# Using pipx (recommended)
-pipx install uv
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Or using Homebrew on macOS
 brew install uv
@@ -34,23 +34,19 @@ brew install uv
 
 ## Install Clawrium
 
-### Using uvx (Recommended)
-
-```bash
-uvx clawrium
-```
-
-This runs the latest version of Clawrium without permanent installation. To install permanently:
+### Install Permanently (Recommended)
 
 ```bash
 uv tool install clawrium
 ```
 
-### Using pip
+### Run Without Installing
 
 ```bash
-pip install clawrium
+uvx --from clawrium clm --help
 ```
+
+This runs the latest version without permanent installation.
 
 ## Verify Installation
 

--- a/website/docs/reference/cli/index.md
+++ b/website/docs/reference/cli/index.md
@@ -10,13 +10,13 @@ Clawrium provides the `clm` command-line interface for managing your AI claw fle
 ## Installation
 
 ```bash
-uvx clawrium
+uv tool install clawrium
 ```
 
-Or install globally:
+Or run without installing:
 
 ```bash
-uv tool install clawrium
+uvx --from clawrium clm --help
 ```
 
 ## Command Structure


### PR DESCRIPTION
## Summary
- Replace `pip install` with `uv tool install` across all docs
- Fix incorrect `uvx clawrium` to `uvx --from clawrium clm`
- Update README, AGENTS.md, and website documentation
- Fix error message in CLI

## Testing
Verified installation works with:
```bash
uv tool install clawrium
clm --help
```