### PR TITLE
fix(openclaw): sync systemd service file on start/restart

### DIFF
--- a/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
@@ -123,7 +123,7 @@
           WorkingDirectory=/home/{{ agent_name }}/workspace
           EnvironmentFile=/home/{{ agent_name }}/.openclaw/env
           ExecStart={{ openclaw_runtime_binary }} gateway run --allow-unconfigured
-          Restart=on-failure
+          Restart=always
           RestartSec=5
 
           [Install]

--- a/src/clawrium/platform/registry/openclaw/playbooks/start.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/start.yaml
@@ -19,6 +19,43 @@
         msg: "OpenClaw service not installed. Run 'clm agent install' first."
       when: not service_file.stat.exists
 
+    - name: Discover openclaw binary in PATH
+      ansible.builtin.command: which openclaw
+      register: openclaw_which_result
+      changed_when: false
+      failed_when: false
+
+    - name: Set openclaw binary path
+      ansible.builtin.set_fact:
+        openclaw_runtime_binary: "{{ openclaw_which_result.stdout if (openclaw_which_result.rc | default(1)) == 0 else '/home/' ~ agent_name ~ '/.openclaw/bin/openclaw' }}"
+
+    - name: Sync systemd service file
+      ansible.builtin.copy:
+        dest: "/etc/systemd/system/{{ agent_type }}-{{ agent_name }}.service"
+        content: |
+          [Unit]
+          Description=OpenClaw AI Assistant ({{ agent_name }})
+          After=network.target
+
+          [Service]
+          Type=simple
+          User={{ agent_name }}
+          WorkingDirectory=/home/{{ agent_name }}/workspace
+          EnvironmentFile=/home/{{ agent_name }}/.openclaw/env
+          ExecStart={{ openclaw_runtime_binary }} gateway run --allow-unconfigured
+          Restart=always
+          RestartSec=5
+
+          [Install]
+          WantedBy=multi-user.target
+        mode: "0644"
+      register: service_file_changed
+
+    - name: Reload systemd if service file changed
+      ansible.builtin.systemd:
+        daemon_reload: yes
+      when: service_file_changed.changed
+
     - name: Start openclaw service
       ansible.builtin.systemd:
         name: "{{ agent_type }}-{{ agent_name }}"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "clawrium"
-version = "26.4.1"
+version = "26.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },


### PR DESCRIPTION
## Summary
- Change `Restart=on-failure` to `Restart=always` in install.yaml
- Add systemd file sync to start.yaml playbook
- Every start/restart now ensures service file is up-to-date

## Problem
Agent would not auto-restart after clean exits (exit code 0) because `Restart=on-failure` only restarts on non-zero exit codes.

## Solution
1. Updated install template to use `Restart=always`
2. Modified start.yaml to sync the systemd file before starting, so existing agents get the fix on next restart

## Testing
```bash
clm agent restart <agent-name>
# Service file will be synced with Restart=always
```