### PR TITLE
fix(openclaw): default tools.exec.host to gateway

### DIFF
--- a/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
@@ -131,9 +131,18 @@
 {% elif config.models is defined %}
   "models": {{ config.models | tojson }},
 {% endif %}
-{% if config.tools is defined %}
-  "tools": {{ config.tools | tojson }},
+{% set tools = config.tools | default({}) %}
+{% set tools_exec = tools.exec | default({}) %}
+  "tools": {
+    "exec": {
+      "host": {{ tools_exec.host | default('gateway') | tojson }}
+    }
+{% if tools | length > 0 %}
+    {% for key, value in tools.items() if key != 'exec' %}
+    ,"{{ key }}": {{ value | tojson }}
+    {% endfor %}
 {% endif %}
+  },
 {% if config.bindings is defined %}
   "bindings": {{ config.bindings | tojson }},
 {% endif %}


### PR DESCRIPTION
## Summary
When sandbox mode is off (default), `tools.exec.host` should default to `gateway` to prevent the "sandbox runtime unavailable" error.

## Problem
```
exec host=sandbox is configured, but sandbox runtime is unavailable for this session.
```

## Solution
Updated `openclaw.json.j2` template to always include `tools.exec.host` with a default of `gateway`.