### PR TITLE
feat(openclaw): workspace setup and SOUL.md sync

### DIFF
--- a/.claude/skills/itx-review-pr/SKILL.md
+++ b/.claude/skills/itx-review-pr/SKILL.md
@@ -43,6 +43,7 @@ Request a code review using ATX agents.
 
    **PR**: #<number> - <title>
    **Rating**: <X>/5
+   **Cost**: $<cost> | **Time**: <time> | **Agents**: <comma-separated list>
 
    ### Blocking Issues
    <table or "None">
@@ -56,6 +57,9 @@ Request a code review using ATX agents.
    ### Verdict
    <READY FOR MERGE / NEEDS CHANGES>
    ```
+
+   > **Note**: Extract cost, time, and agents from ATX response metadata.
+   > ATX does not expose model information per agent.
 
 ## Notes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,11 +28,14 @@ MANDATORY: All PRs must include @atx-ci review before merging.
 
 ### Review Summary
 
-**Final Review: Rating /5**
+**Final Review: Rating /5** <!-- filled after ATX review -->
+**Total Cost: $ | Total Time: ** <!-- filled after ATX review -->
 
-| Review | Rating | Blocking Issues | Status |
-|--------|--------|-----------------|--------|
-| 1 | /5 | | |
+| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
+|--------|--------|-----------------|--------|------|------|--------|
+| 1 | /5 | | | | | |
+
+<!-- Note: ATX does not expose model information per agent. -->
 
 <details>
 <summary>Review 1 Details</summary>
@@ -59,14 +62,17 @@ MANDATORY: All PRs must include @atx-ci review before merging.
 
 <!--
 <atx-example>
-Example of a completed ATX review section (from PR #21):
+Example of a completed ATX review section (from PR #205):
 
 **Final Review: Rating 4/5**
+**Total Cost: $10.15 | Total Time: 23m 55s**
 
-| Review | Rating | Blocking Issues | Status |
-|--------|--------|-----------------|--------|
-| 1 | 2/5 | B1-B7 | B1,B7 fixed; B2-B6 out-of-scope |
-| 2 | 4/5 | None | Ready |
+| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
+|--------|--------|-----------------|--------|------|------|--------|
+| 1 | 2/5 | B1-B7 | B1,B7 fixed; B2-B6 out-of-scope | $3.57 | 8m 26s | leader, cli-ux, lifecycle-state, test-coverage, ansible-playbook |
+| 2 | 4/5 | None | Ready | $6.58 | 15m 29s | leader, cli-ux |
+
+<!-- Note: ATX does not expose model information per agent. -->
 
 <details>
 <summary>Review 1 Details (Rating 2/5)</summary>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@ Detailed explanation of changes.
 Closes #XX
 
 ATX Review Summary
-Review 1: Rating 2/5 | Cost: $0.12 | Time: 45s
+Review 1: Rating 2/5 | Cost: $0.12 | Time: 45s | Agents: leader, cli-ux
 Blocking issues:
 | # | Status | Issue |
 |---|--------|-------|
@@ -217,11 +217,14 @@ Include detailed ATX review after Summary and Testing sections:
 ## ATX Review Summary
 
 **Final Review: Rating 4/5**
+**Total Cost: $0.20 | Total Time: 1m 17s**
 
-| Review | Rating | Blocking Issues | Status | Cost | Time |
-|--------|--------|-----------------|--------|------|------|
-| 1 | 2/5 | B1, B2, B3 | All fixed | $0.12 | 45s |
-| 2 | 4/5 | None | Ready | $0.08 | 32s |
+| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
+|--------|--------|-----------------|--------|------|------|--------|
+| 1 | 2/5 | B1, B2, B3 | All fixed | $0.12 | 45s | leader, cli-ux, test-coverage |
+| 2 | 4/5 | None | Ready | $0.08 | 32s | leader, cli-ux |
+
+> **Note**: ATX does not expose model information per agent.
 
 <details>
 <summary>Review 1 Details (Rating 2/5)</summary>
@@ -252,7 +255,7 @@ Include detailed ATX review after Summary and Testing sections:
 Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
 ```
 
-See PRs #19 and #21 for real examples of this format.
+See PRs #19, #21, and #205 for real examples of this format.
 </pr-format>
 
 <enforcement>

--- a/docs/agent-support/channels/cli.md
+++ b/docs/agent-support/channels/cli.md
@@ -1,0 +1,108 @@
+# CLI Channel
+
+**Status:** ✅ Supported (All Agents)
+
+The CLI channel provides terminal-based interaction with your agent.
+
+## Features
+
+- **Interactive chat:** Real-time conversation in terminal
+- **Command history:** Navigate previous messages
+- **Piping support:** Pipe input/output to other commands
+- **Scripting:** Automate via shell scripts
+- **No dependencies:** Works over SSH, no browser needed
+
+## Setup
+
+CLI is automatically configured for all agents. No additional setup required.
+
+## Usage
+
+### Interactive Chat
+
+```bash
+# Start chatting
+clm chat <agent-name>
+
+# Example
+clm chat my-assistant
+```
+
+### One-off Queries
+
+```bash
+# Single query (if supported by agent)
+echo "What's the weather?" | clm chat my-assistant --stdin
+```
+
+### Scripting
+
+```bash
+#!/bin/bash
+# automated-task.sh
+
+RESPONSE=$(echo "Analyze this log file" | clm chat log-analyzer --stdin)
+echo "$RESPONSE"
+```
+
+## Key Bindings
+
+During chat:
+
+| Key | Action |
+|-----|--------|
+| `↑` / `↓` | Navigate history |
+| `Ctrl+C` | Exit chat |
+| `Ctrl+L` | Clear screen |
+| `Tab` | Auto-complete (if supported) |
+
+## Configuration
+
+CLI channel has minimal configuration:
+
+```json
+{
+  "cli": {
+    "enabled": true,
+    "history_size": 100
+  }
+}
+```
+
+## Limitations
+
+- Single user only
+- No rich media (images render as links)
+- Requires terminal/SSH access
+- No persistent history across sessions
+
+## Best Practices
+
+1. **SSH key-based access:** For remote hosts, use SSH keys
+2. **Screen/tmux:** Use terminal multiplexers for long sessions
+3. **Logging:** Pipe output to files for record keeping
+4. **Aliases:** Create shell aliases for frequently used agents
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+alias ask='clm chat my-assistant'
+```
+
+## Troubleshooting
+
+**"Connection refused"**
+- Ensure agent is running: `clm ps`
+- Start agent if needed: `clm agent start <name>`
+
+**"Agent not responding"**
+- Check agent logs: `clm agent logs <name>`
+- Verify provider connectivity: `clm provider status <provider>`
+
+**"Slow responses"**
+- Normal for complex queries
+- Check network latency to host
+- Consider local Ollama provider for faster responses
+
+---
+
+[Back to Channels](index.md)

--- a/docs/agent-support/channels/discord.md
+++ b/docs/agent-support/channels/discord.md
@@ -1,0 +1,134 @@
+# Discord Channel
+
+**Status:** ✅ Supported (OpenClaw only)
+
+Discord channel allows your agent to operate as a bot in Discord servers.
+
+## Features
+
+- **Server bot:** Responds to messages in Discord channels
+- **Allowlisting:** Control which users can interact
+- **Channel restrictions:** Limit to specific channels
+- **Thread support:** Conversations in threads
+- **Rich formatting:** Markdown, embeds, reactions
+
+## Setup
+
+### 1. Create Discord Application
+
+1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
+2. Click **New Application**
+3. Name it (e.g., "My Claw Agent")
+4. Go to **Bot** section
+5. Click **Add Bot**
+6. Enable **Message Content Intent** (required for reading messages)
+7. Copy the **Token** (starts with `MTA...` or similar)
+
+### 2. Invite Bot to Server
+
+1. Go to **OAuth2** → **URL Generator**
+2. Select scopes:
+   - `bot`
+   - `applications.commands` (optional, for slash commands)
+3. Select bot permissions:
+   - **Send Messages**
+   - **Read Message History**
+   - **Embed Links**
+   - **Add Reactions**
+   - **Use External Emojis**
+   - **Read Messages/View Channels**
+4. Copy the generated URL
+5. Open URL in browser and select your server
+
+### 3. Configure Channel in Clawrium
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+```
+
+When prompted for channels:
+1. Select **Discord**
+2. Enter bot token (from step 1)
+3. Enter your Discord server (guild) ID:
+   - Enable Developer Mode in Discord (Settings → Advanced)
+   - Right-click server name → **Copy Server ID**
+4. Enter channel ID:
+   - Right-click channel → **Copy Channel ID**
+5. Enter your user ID (for auto-approve):
+   - Right-click your username → **Copy User ID**
+
+### 4. Start Agent
+
+```bash
+clm agent start my-agent
+```
+
+The bot will come online in your Discord server.
+
+## Configuration Details
+
+The Discord configuration includes:
+
+```json
+{
+  "discord": {
+    "enabled": true,
+    "token": {
+      "source": "env",
+      "id": "DISCORD_BOT_TOKEN"
+    },
+    "allowFrom": ["USER_ID_1", "USER_ID_2"],
+    "groupPolicy": "allowlist",
+    "guilds": {
+      "GUILD_ID": {
+        "users": ["USER_ID_1"],
+        "channels": {
+          "CHANNEL_ID": {
+            "allow": true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Security
+
+- Bot token is stored securely (not in plain text)
+- Allowlist controls who can trigger the agent
+- Channel restrictions limit where it responds
+- Consider creating a dedicated channel for the bot
+
+## Usage
+
+Once running, interact with the bot by:
+- Mentioning it: `@MyBot analyze this code`
+- Sending messages in allowed channels
+- The bot will respond in the same channel
+
+## Troubleshooting
+
+**"Bot not responding"**
+- Check bot is online in Discord
+- Verify bot token is correct
+- Check allowlist includes your user ID
+- Ensure channel is in allowed channels list
+
+**"Token invalid"**
+- Regenerate token in Discord Developer Portal
+- Re-run: `clm agent configure <name> --stage channels`
+
+**"Missing permissions"**
+- Re-invite bot with correct permissions
+- Check bot role has required permissions in server
+
+**"Message intent required"**
+- Enable **Message Content Intent** in Bot settings
+- This is required for the bot to read message content
+
+---
+
+[Back to Channels](index.md)

--- a/docs/agent-support/channels/index.md
+++ b/docs/agent-support/channels/index.md
@@ -1,0 +1,55 @@
+# Channels
+
+Channels define how users interact with your agents. Different agents support different channels based on their design goals.
+
+## Available Channels
+
+| Channel | Agents | Use Case |
+|---------|--------|----------|
+| **[CLI](cli.md)** | All | Terminal-based interaction |
+| **[Discord](discord.md)** | OpenClaw | Discord server bot |
+| **[Slack](slack.md)** | OpenClaw (planned) | Slack workspace bot |
+| **[Web](web.md)** | OpenClaw (planned) | Browser-based chat |
+| **[WhatsApp](whatsapp.md)** | Not planned | Mobile messaging |
+
+## Channel Comparison
+
+| Feature | CLI | Discord | Slack | Web |
+|---------|-----|---------|-------|-----|
+| **Setup Complexity** | Low | Medium | Medium | High |
+| **Multi-user** | No | Yes | Yes | Yes |
+| **Access Control** | OS-level | Roles | Permissions | Auth |
+| **Rich Media** | Limited | Yes | Yes | Yes |
+| **Mobile Support** | SSH app | Discord app | Slack app | Browser |
+
+## Channel vs Provider
+
+- **Provider** = The AI model (OpenAI, Anthropic, etc.)
+- **Channel** = How users talk to the agent (CLI, Discord, etc.)
+
+An agent uses:
+- 1 provider (the LLM backend)
+- 1+ channels (how users interact)
+
+## Configuration
+
+Channels are configured during agent onboarding:
+
+```bash
+clm agent configure <agent-name>
+# Select channel during the channels stage
+```
+
+## Switching Channels
+
+To change an agent's channel:
+
+```bash
+clm agent configure <agent-name> --stage channels
+```
+
+Note: Some agents (like ZeroClaw) only support CLI and cannot switch channels.
+
+---
+
+See individual channel pages for detailed setup instructions.

--- a/docs/agent-support/channels/slack.md
+++ b/docs/agent-support/channels/slack.md
@@ -19,9 +19,9 @@ Slack channel will allow your agent to operate as a bot in Slack workspaces.
 
 **Target:** Q2 2026
 
-**Milestone:** [SEA (Secondary Engagement & Automation)](../milestones)
+**Milestone:** [SEA](https://github.com/ric03uec/clawrium/milestone/2)
 
-Track progress: [GitHub Issue #TBD](../../issues)
+Track progress: [GitHub Issue #229](https://github.com/ric03uec/clawrium/issues/229)
 
 ---
 

--- a/docs/agent-support/channels/slack.md
+++ b/docs/agent-support/channels/slack.md
@@ -1,0 +1,81 @@
+# Slack Channel
+
+**Status:** 🚧 In Development
+
+Slack channel will allow your agent to operate as a bot in Slack workspaces.
+
+---
+
+## Planned Features
+
+- **Workspace bot:** Responds to messages in Slack channels
+- **Direct messages:** One-on-one conversations
+- **Slash commands:** `/ask` style commands
+- **App Home:** Persistent interface for the bot
+- **Thread support:** Conversations in threads
+- **Rich formatting:** Slack blocks, attachments
+
+## Timeline
+
+**Target:** Q2 2026
+
+**Milestone:** [SEA (Secondary Engagement & Automation)](../milestones)
+
+Track progress: [GitHub Issue #TBD](../../issues)
+
+---
+
+## Preliminary Setup (Subject to Change)
+
+### 1. Create Slack App
+
+1. Go to [Slack API](https://api.slack.com/apps)
+2. Click **Create New App**
+3. Choose **From scratch**
+4. Name it and select your workspace
+
+### 2. Configure Bot Token Scopes
+
+Under **OAuth & Permissions**, add scopes:
+- `app_mentions:read`
+- `channels:history`
+- `chat:write`
+- `im:history`
+- `im:write`
+- `users:read`
+
+### 3. Install to Workspace
+
+1. Click **Install to Workspace**
+2. Authorize the app
+3. Copy the **Bot User OAuth Token**
+
+### 4. Configure in Clawrium (When Available)
+
+```bash
+clm agent configure my-agent
+# Select Slack when prompted
+```
+
+---
+
+## Differences from Discord
+
+| Feature | Discord | Slack |
+|---------|---------|-------|
+| **Scope** | Server (guild) | Workspace |
+| **Permissions** | Role-based | Scope-based |
+| **DMs** | Not supported | Supported |
+| **Slash commands** | Not planned | Planned |
+| **Threads** | Supported | Supported |
+| **Rich UI** | Embeds | Blocks |
+
+---
+
+## Vote for Priority
+
+Add a 👍 reaction to [the Slack channel issue](../../issues) to help prioritize.
+
+---
+
+[Back to Channels](index.md)

--- a/docs/agent-support/channels/web.md
+++ b/docs/agent-support/channels/web.md
@@ -1,0 +1,82 @@
+# Web Interface Channel
+
+**Status:** 🚧 In Development
+
+A browser-based chat interface for interacting with agents.
+
+---
+
+## Planned Features
+
+- **Web UI:** Clean, responsive chat interface
+- **Authentication:** Login required for access
+- **Multiple agents:** Switch between agents in UI
+- **History:** Persistent conversation history
+- **Mobile support:** Responsive design for mobile browsers
+- **File uploads:** Share files with agents
+- **Rich content:** Code highlighting, markdown rendering
+
+## Timeline
+
+**Target:** Q2 2026
+
+**Milestone:** [SEA (Secondary Engagement & Automation)](../milestones)
+
+Track progress: [GitHub Issue #TBD](../../issues)
+
+---
+
+## Architecture
+
+The web channel will consist of:
+
+1. **Backend API:** WebSocket or Server-Sent Events for real-time chat
+2. **Frontend:** React/Vue-based chat interface
+3. **Authentication:** Token-based or OAuth
+4. **Proxy:** Nginx or similar for serving static files
+
+## Comparison with Other Channels
+
+| Feature | CLI | Discord | Web |
+|---------|-----|---------|-----|
+| **Setup** | None | Medium | High |
+| **Access** | SSH/Terminal | Discord account | Browser |
+| **Mobile** | SSH app | Discord app | Browser |
+| **Multi-user** | No | Yes | Yes (planned) |
+| **History** | Session only | Discord | Persistent |
+| **Files** | Limited | Yes | Yes (planned) |
+
+---
+
+## Preliminary Usage (Subject to Change)
+
+### Configuration
+
+```bash
+clm agent configure my-agent
+# Select Web Interface when available
+```
+
+### Access
+
+```bash
+# Get web interface URL
+clm agent web-url my-agent
+# Opens: https://agent-host:8443/chat/my-agent
+```
+
+### Authentication
+
+Access will require:
+- Pre-shared token, or
+- User account (if multi-user enabled)
+
+---
+
+## Vote for Priority
+
+Add a 👍 reaction to [the web channel issue](../../issues) to help prioritize.
+
+---
+
+[Back to Channels](index.md)

--- a/docs/agent-support/channels/whatsapp.md
+++ b/docs/agent-support/channels/whatsapp.md
@@ -1,0 +1,99 @@
+# WhatsApp Channel
+
+**Status:** 📋 Not Currently Planned
+
+WhatsApp Business API integration for agent communication.
+
+---
+
+## Why Not Planned?
+
+WhatsApp integration is not currently on the Clawrium roadmap for the following reasons:
+
+1. **Complexity:** WhatsApp Business API requires Meta approval and business verification
+2. **Cost:** Per-conversation pricing model
+3. **Use Case:** Limited demand for WhatsApp automation in current user base
+4. **Alternatives:** Discord and Slack cover most messaging needs
+5. **Priority:** Development focused on Slack and Web channels first
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need WhatsApp support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](../../issues/new?labels=enhancement,channel&title=Add+WhatsApp+channel+support)
+
+Include:
+- Your use case (personal, business, etc.)
+- Expected volume of messages
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+We'd love your contribution! Implementation would involve:
+
+1. WhatsApp Business API integration
+2. Webhook handling for incoming messages
+3. Message templating (required for initial contact)
+4. Rate limiting and conversation tracking
+5. Business verification documentation
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+---
+
+## What Would Be Needed
+
+### Technical Requirements
+
+**WhatsApp Business API:**
+- Meta Business account
+- Business verification
+- Phone number for WhatsApp
+- Cloud API or On-premises API setup
+
+**Implementation:**
+- Webhook endpoint for message callbacks
+- Message template management
+- Conversation session tracking
+- Media message support (optional)
+
+### Pricing Considerations
+
+WhatsApp charges per conversation:
+- User-initiated: ~$0.005-0.08 USD depending on region
+- Business-initiated (with template): ~$0.05-0.15 USD
+- 24-hour session window
+
+See [WhatsApp Business Pricing](https://business.whatsapp.com/products/business-platform) for current rates.
+
+### Use Cases
+
+WhatsApp would be suitable for:
+- Customer support bots
+- Appointment reminders
+- Order notifications
+- Personal assistants
+
+---
+
+## Alternatives
+
+If you need mobile messaging:
+
+- **Discord:** Free, works on mobile, rich features
+- **Slack:** (Coming Q2 2026) Mobile apps available
+- **Web Interface:** (Coming Q2 2026) Mobile browser access
+
+---
+
+## Vote for This Feature
+
+Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+
+---
+
+[Back to Channels](index.md)

--- a/docs/agent-support/index.md
+++ b/docs/agent-support/index.md
@@ -1,0 +1,61 @@
+# Agent Support
+
+Clawrium supports multiple agent types, each designed for different use cases. This section provides detailed support matrices for each agent.
+
+## Available Agents
+
+### Production Ready
+
+| Agent | Description | Status |
+|-------|-------------|--------|
+| **[OpenClaw](openclaw.md)** | Full-featured agent with multi-channel support | ✅ Production Ready |
+
+### In Development
+
+| Agent | Description | Status |
+|-------|-------------|--------|
+| **[ZeroClaw](zeroclaw.md)** | Minimal CLI-only agent for simple automation | 🚧 In Development |
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Fully supported and tested |
+| 🚧 | In development / Planned |
+| ❌ | Not supported |
+| 📋 | Not planned (PRs welcome) |
+
+## Quick Comparison
+
+| Feature | OpenClaw | ZeroClaw |
+|---------|:--------:|:--------:|
+| **Multi-Provider** | ✅ | 🚧 |
+| **CLI Channel** | ✅ | 🚧 |
+| **Discord** | ✅ | ❌ |
+| **Custom Identity** | ✅ (SOUL.md) | ❌ |
+| **Integrations** | 🚧 | ❌ |
+| **Onboarding Wizard** | ✅ | 🚧 |
+
+## Choosing an Agent
+
+**Use OpenClaw when:**
+- You need Discord or multi-channel support
+- You want customizable identity/personality
+- You need integrations with external tools
+- You want a full-featured assistant
+
+**Use ZeroClaw when:**
+- You only need CLI interaction
+- You want minimal resource usage
+- You need quick automation scripts
+- You prefer simple, no-frills setup
+
+## Adding New Agents
+
+To request support for a new agent type or feature:
+
+1. Check the existing agent matrices for current capabilities
+2. Open an issue describing your use case
+3. Reference the relevant agent matrix in your request
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution guidelines.

--- a/docs/agent-support/integrations/confluence.md
+++ b/docs/agent-support/integrations/confluence.md
@@ -1,0 +1,112 @@
+# Confluence Integration
+
+**Status:** 📋 Not Currently Planned
+
+Atlassian Confluence integration for documentation and knowledge base access.
+
+---
+
+## Why Not Planned?
+
+Confluence integration is not currently on the Clawrium roadmap for the following reasons:
+
+1. **Scope:** Confluence is primarily a documentation/wiki tool, less relevant for agent workflows
+2. **Complexity:** Confluence API is complex for read operations
+3. **Use Case:** Agents typically don't need to write documentation
+4. **Priority:** Jira integration covers the more common Atlassian use case
+5. **Alternatives:** Notion integration (if requested) would serve similar needs
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need Confluence support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](../../issues/new?labels=enhancement,integration&title=Add+Confluence+integration+support)
+
+Include:
+- Your specific use case
+- Read-only vs read-write needs
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+We'd love your contribution! Implementation would involve:
+
+1. Confluence REST API client
+2. Authentication (API token or OAuth)
+3. Page search and retrieval
+4. Content parsing (handle Confluence markup)
+5. Optional: Page creation/updates
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+---
+
+## What Would Be Needed
+
+### Authentication
+
+- **API Token:** Personal access token
+- **Username + Token:** For server instances
+- **OAuth 2.0:** For app integrations
+
+### Use Cases
+
+If implemented, Confluence integration could:
+
+- **Search documentation:** Find relevant pages
+- **Answer questions:** Use docs as knowledge base
+- **Summarize content:** Extract key information
+- **Create pages:** Log agent activities
+- **Update docs:** Maintain runbooks
+
+### API Challenges
+
+Confluence API has some complexities:
+
+- Storage format is Confluence markup (not plain markdown)
+- Versioning requires handling
+- Space/page hierarchy navigation
+- Permission model is complex
+
+---
+
+## Alternatives
+
+### Use Jira Instead
+
+For many use cases, [Jira integration](jira.md) (when available) with issue descriptions may suffice.
+
+### Direct API Calls
+
+```bash
+curl -u email@example.com:$CONFLUENCE_TOKEN \
+     "https://your-domain.atlassian.net/wiki/rest/api/content?spaceKey=TEAM&expand=body.storage"
+```
+
+### RAG over Exported Docs
+
+Export Confluence pages and use RAG (Retrieval-Augmented Generation) via the agent's knowledge base.
+
+---
+
+## Related Integrations
+
+| Integration | Status | Use Case |
+|-------------|--------|----------|
+| **Jira** | 🚧 Q2 2026 | Issue tracking |
+| **Notion** | 📋 Not planned | Docs/notes (alternative) |
+| **Confluence** | 📋 Not planned | Wiki/docs |
+
+---
+
+## Vote for This Feature
+
+Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+
+---
+
+[Back to Integrations](index.md)

--- a/docs/agent-support/integrations/github.md
+++ b/docs/agent-support/integrations/github.md
@@ -1,0 +1,156 @@
+# GitHub Integration
+
+**Status:** 🚧 In Development
+
+GitHub integration allows agents to interact with repositories, pull requests, and issues.
+
+---
+
+## Planned Features
+
+- **PR Reviews:** Comment on pull requests
+- **Issue Management:** Read and create issues
+- **Code Search:** Search repositories
+- **Actions:** Trigger and monitor workflows
+- **Webhooks:** React to GitHub events
+- **Notifications:** Summarize activity
+
+## Timeline
+
+**Target:** Q2 2026
+
+**Milestone:** [SEA (Secondary Engagement & Automation)](../milestones)
+
+Track progress: [GitHub Issue #TBD](../../issues)
+
+---
+
+## Use Cases
+
+### Code Review Assistant
+
+```
+User: Review PR #123 in myorg/myrepo
+Agent: Analyzing PR #123...
+      
+      Summary:
+      - 5 files changed, 250 lines added
+      - No obvious security issues
+      - 2 suggestions:
+        1. Consider adding error handling on line 45
+        2. Missing docstring for new function
+```
+
+### Issue Triage
+
+```
+User: Summarize open issues from last week
+Agent: Found 12 new issues:
+      
+      Priority breakdown:
+      - 3 high priority (label: bug)
+      - 7 medium priority (label: enhancement)  
+      - 2 low priority (label: question)
+      
+      2 issues need more info (label: needs-repro)
+```
+
+### Release Notes
+
+```
+User: Draft release notes for v2.1.0
+Agent: Analyzing commits since v2.0.0...
+      
+      ## What's New
+      
+      ### Features
+      - Add OAuth support (#234)
+      - New dashboard widgets (#245)
+      
+      ### Bug Fixes
+      - Fix memory leak in worker (#240)
+      - Correct timezone handling (#238)
+```
+
+---
+
+## Preliminary Setup (Subject to Change)
+
+### 1. Create GitHub App
+
+1. Go to [GitHub Developer Settings](https://github.com/settings/apps)
+2. Click **New GitHub App**
+3. Configure:
+   - Name: `My Claw Agent`
+   - Homepage URL: Your URL
+   - Callback URL: Not needed for CLI
+4. Set permissions:
+   - Repository: Read & Write
+   - Pull requests: Read & Write
+   - Issues: Read & Write
+   - Actions: Read (optional)
+5. Create app and generate private key
+
+### 2. Install App
+
+1. Install the app on your repositories
+2. Note the installation ID
+
+### 3. Configure in Clawrium (When Available)
+
+```bash
+clm agent configure my-agent
+# Select GitHub integration when prompted
+```
+
+---
+
+## Authentication
+
+GitHub integration will support:
+
+- **GitHub App:** Recommended for organizations
+- **Personal Access Token:** For personal use
+- **Fine-grained PAT:** New GitHub feature
+
+---
+
+## Permissions Required
+
+| Feature | Permission | Level |
+|---------|------------|-------|
+| Read issues | Issues | Read |
+| Create issues | Issues | Write |
+| Read PRs | Pull requests | Read |
+| Comment on PRs | Pull requests | Write |
+| Trigger workflows | Actions | Write |
+
+---
+
+## Alternatives (Current Workaround)
+
+Until native integration is available:
+
+1. **CLI Tools:** Use `gh` CLI in agent scripts
+   ```bash
+   clm chat my-agent
+   # In chat: Run "gh issue list --repo myorg/myrepo"
+   ```
+
+2. **API via curl:** Make direct API calls
+   ```bash
+   curl -H "Authorization: token $GITHUB_TOKEN" \
+        https://api.github.com/repos/myorg/myrepo/issues
+   ```
+
+3. **MCP Tools:** (Coming Q2 2026) Use GitHub MCP server
+
+---
+
+## Vote for Priority
+
+Add a 👍 reaction to [the GitHub integration issue](../../issues) to help prioritize.
+
+---
+
+[Back to Integrations](index.md)

--- a/docs/agent-support/integrations/gitlab.md
+++ b/docs/agent-support/integrations/gitlab.md
@@ -1,0 +1,124 @@
+# GitLab Integration
+
+**Status:** 📋 Not Currently Planned
+
+GitLab integration for merge requests, issues, and CI/CD pipelines.
+
+---
+
+## Why Not Planned?
+
+GitLab integration is not currently on the Clawrium roadmap for the following reasons:
+
+1. **Overlap:** GitHub integration (in development) covers most Git hosting needs
+2. **Demand:** Lower community demand compared to GitHub
+3. **Priority:** Jira and GitHub prioritized first
+4. **Resources:** Limited development bandwidth
+5. **API Similarity:** GitLab API is similar enough to GitHub that adaptation would be straightforward if needed
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need GitLab support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](../../issues/new?labels=enhancement,integration&title=Add+GitLab+integration+support)
+
+Include:
+- Your use case (personal, enterprise, etc.)
+- Self-hosted vs GitLab.com
+- Which features you need most (MRs, issues, CI/CD, etc.)
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+We'd love your contribution! Implementation would be similar to [GitHub integration](github.md):
+
+1. GitLab API client (REST or GraphQL)
+2. OAuth or PAT authentication
+3. MR/issue operations
+4. CI/CD pipeline status
+5. Webhook handling
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+---
+
+## What Would Be Needed
+
+### Authentication
+
+- **Personal Access Token:** For GitLab.com or self-hosted
+- **OAuth 2.0:** For app-based authentication
+- **CI/CD Token:** For pipeline integration
+
+### API Scope
+
+```
+api (read, write)
+read_repository
+write_repository
+read_user
+```
+
+### Features to Implement
+
+- List/view merge requests
+- Create MR comments
+- Read/create issues
+- View pipeline status
+- Trigger pipeline runs
+- Search code
+
+---
+
+## Alternatives
+
+### Use GitHub Integration
+
+If you can mirror to GitHub:
+
+```bash
+# Mirror GitLab to GitHub
+git remote add github https://github.com/user/repo.git
+git push github main
+```
+
+Then use [GitHub integration](github.md) when available.
+
+### Direct API Calls
+
+Agents can use curl to call GitLab API directly:
+
+```bash
+curl -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+     https://gitlab.com/api/v4/projects/123/issues
+```
+
+### MCP Tools
+
+(Coming Q2 2026) Use generic HTTP MCP tools to interact with GitLab API.
+
+---
+
+## Comparison: GitHub vs GitLab
+
+| Feature | GitHub | GitLab |
+|---------|--------|--------|
+| **Market Share** | ~70% | ~20% |
+| **Self-hosted** | Enterprise only | Free option |
+| **CI/CD** | GitHub Actions | Built-in (stronger) |
+| **API** | REST + GraphQL | REST + GraphQL |
+| **Integration Priority** | 🚧 Q2 2026 | 📋 Not planned |
+
+---
+
+## Vote for This Feature
+
+Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+
+---
+
+[Back to Integrations](index.md)

--- a/docs/agent-support/integrations/index.md
+++ b/docs/agent-support/integrations/index.md
@@ -1,0 +1,62 @@
+# Integrations
+
+Integrations allow agents to interact with external tools and services, extending their capabilities beyond chat.
+
+## Available Integrations
+
+| Integration | Agents | Use Case |
+|-------------|--------|----------|
+| **[GitHub](github.md)** | OpenClaw (planned) | PR reviews, issues |
+| **[Jira](jira.md)** | OpenClaw (planned) | Issue tracking |
+| **[GitLab](gitlab.md)** | Not planned | Alternative to GitHub |
+| **[Confluence](confluence.md)** | Not planned | Documentation |
+| **[Linear](linear.md)** | Not planned | Issue tracking |
+| **[Notion](notion.md)** | Not planned | Knowledge base |
+
+## Integration vs Provider vs Channel
+
+| Component | Purpose | Example |
+|-----------|---------|---------|
+| **Provider** | AI model backend | OpenAI GPT-4 |
+| **Channel** | How users talk to agent | Discord, CLI |
+| **Integration** | What the agent can do | Read GitHub issues |
+
+## How Integrations Work
+
+Integrations typically:
+
+1. **Read data:** Fetch information from external services
+2. **Take actions:** Create/update items in external services
+3. **Receive events:** Webhooks for real-time updates
+4. **Use credentials:** API keys or OAuth tokens
+
+## Configuration
+
+Integrations will be configured during agent onboarding or separately:
+
+```bash
+# Future command (not yet available)
+clm agent configure <agent-name> --integrations
+```
+
+## Security
+
+- API tokens stored securely
+- Scoped permissions (least privilege)
+- Audit logging for actions
+- Per-integration credential isolation
+
+## Requesting New Integrations
+
+To request a new integration:
+
+1. Check if it exists in [📋 Not Planned](gitlab.md) section
+2. [Open an issue](../../issues/new) describing:
+   - The service (e.g., PagerDuty, Zendesk)
+   - Use case
+   - Required actions (read, write, both)
+3. Consider contributing a PR
+
+---
+
+See individual integration pages for detailed setup instructions.

--- a/docs/agent-support/integrations/jira.md
+++ b/docs/agent-support/integrations/jira.md
@@ -1,0 +1,147 @@
+# Jira Integration
+
+**Status:** 🚧 In Development
+
+Jira integration allows agents to interact with Jira issues, projects, and workflows.
+
+---
+
+## Planned Features
+
+- **Issue Management:** Read, create, and update issues
+- **Search:** JQL query support
+- **Comments:** Add and read comments
+- **Transitions:** Move issues through workflows
+- **Sprint Management:** View and update sprints
+- **Reporting:** Summarize project status
+
+## Timeline
+
+**Target:** Q2 2026
+
+**Milestone:** [SEA](https://github.com/ric03uec/clawrium/milestone/2)
+
+Track progress: [GitHub Issue #230](https://github.com/ric03uec/clawrium/issues/230)
+
+---
+
+## Use Cases
+
+### Daily Standup Summary
+
+```
+User: What's the status of PROJ sprint?
+Agent: Sprint "March 2026":
+      
+      Completed: 12/20 issues (60%)
+      In Progress: 5 issues
+      Blocked: 3 issues
+      
+      Blocked issues:
+      - PROJ-123: Waiting for API keys
+      - PROJ-124: Dependency on external team
+      - PROJ-125: Requirements unclear
+```
+
+### Issue Creation
+
+```
+User: Create a bug for the login issue
+Agent: Creating issue...
+      
+      Title: Login fails with 500 error
+      Type: Bug
+      Priority: High
+      
+      PROJ-456 created and assigned to you.
+```
+
+### Ticket Triage
+
+```
+User: Show me high priority bugs from this week
+Agent: Found 5 high priority bugs:
+      
+      1. PROJ-401: Memory leak (Created: 2 days ago)
+      2. PROJ-402: Database timeout (Created: 3 days ago)
+      3. PROJ-403: Race condition (Created: 4 days ago)
+      
+      2 issues are unassigned.
+```
+
+---
+
+## Preliminary Setup (Subject to Change)
+
+### 1. Create API Token
+
+1. Log in to Jira
+2. Go to **Account Settings** → **Security** → **API Tokens**
+3. Click **Create API Token**
+4. Name it (e.g., "Claw Agent")
+5. Copy the token
+
+### 2. Get Instance URL
+
+- Cloud: `https://your-domain.atlassian.net`
+- Server: `https://jira.yourcompany.com`
+
+### 3. Configure in Clawrium (When Available)
+
+```bash
+clm agent configure my-agent
+# Select Jira integration when prompted
+```
+
+---
+
+## Authentication
+
+Jira integration will support:
+
+- **API Token:** For Jira Cloud
+- **OAuth 2.0:** For enterprise SSO
+- **Basic Auth:** For Jira Server/Data Center (legacy)
+
+---
+
+## Permissions Required
+
+| Feature | Permission |
+|---------|------------|
+| Read issues | Browse Projects |
+| Create issues | Create Issues |
+| Update issues | Edit Issues |
+| Add comments | Add Comments |
+| Transition issues | Transition Issues |
+| View sprints | View Agile |
+
+---
+
+## Alternatives (Current Workaround)
+
+Until native integration is available:
+
+1. **Jira CLI:** Use command-line tools
+   ```bash
+   jira issue list --project PROJ --status "In Progress"
+   ```
+
+2. **API via curl:** Direct Jira REST API calls
+   ```bash
+   curl -u email@example.com:$JIRA_TOKEN \
+        https://your-domain.atlassian.net/rest/api/3/search \
+        -d '{"jql": "project = PROJ"}'
+   ```
+
+3. **MCP Tools:** (Coming Q2 2026) Use Jira MCP server
+
+---
+
+## Vote for Priority
+
+Add a 👍 reaction to [the Jira integration issue](../../issues) to help prioritize.
+
+---
+
+[Back to Integrations](index.md)

--- a/docs/agent-support/integrations/linear.md
+++ b/docs/agent-support/integrations/linear.md
@@ -1,0 +1,123 @@
+# Linear Integration
+
+**Status:** 📋 Not Currently Planned
+
+Linear integration for modern issue tracking.
+
+---
+
+## Why Not Planned?
+
+Linear integration is not currently on the Clawrium roadmap for the following reasons:
+
+1. **Niche:** Linear is popular in startup/tech circles but has smaller market share than Jira
+2. **Overlap:** Jira integration (in development) serves the primary issue tracking need
+3. **Priority:** GitHub and Jira cover most project management use cases
+4. **Resources:** Limited development bandwidth
+5. **API Maturity:** Linear's API is newer and still evolving
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need Linear support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](../../issues/new?labels=enhancement,integration&title=Add+Linear+integration+support)
+
+Include:
+- Your use case (team size, workflow)
+- Features you need most
+- Whether Linear is a hard requirement vs nice-to-have
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+We'd love your contribution! Linear has a well-designed GraphQL API:
+
+1. Linear GraphQL API client
+2. Personal API key authentication
+3. Issue CRUD operations
+4. Cycle/sprint management
+5. Real-time via webhooks
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+---
+
+## What Would Be Needed
+
+### Authentication
+
+- **Personal API Key:** Get from Linear Settings → API
+
+### API Capabilities
+
+Linear's GraphQL API supports:
+
+- Issues (create, read, update, delete)
+- Cycles (sprints)
+- Projects
+- Teams
+- Comments
+- Attachments
+- Webhooks
+
+### Use Cases
+
+If implemented, Linear integration could:
+
+- **Daily standups:** Summarize cycle progress
+- **Issue creation:** Create tickets from chat
+- **Triage:** Find unassigned/high priority issues
+- **Reporting:** Cycle velocity, burndown
+- **Git linking:** View linked PRs
+
+---
+
+## Alternatives
+
+### Use Jira Integration
+
+[Jira integration](jira.md) will be available Q2 2026 and serves similar needs.
+
+### Use GitHub Issues
+
+[GitHub integration](github.md) (Q2 2026) if you're using GitHub for code.
+
+### Notion Database
+
+If you use Notion, database integration (if requested) could track issues.
+
+### Direct API Calls
+
+```bash
+curl -H "Authorization: $LINEAR_API_KEY" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     https://api.linear.app/graphql \
+     -d '{"query": "query { issues { nodes { id title state { name } } } }" }'
+```
+
+---
+
+## Comparison: Linear vs Jira
+
+| Feature | Linear | Jira |
+|---------|--------|------|
+| **Target** | Startups, modern teams | Enterprise, all sizes |
+| **Speed** | Fast, opinionated | Slower, customizable |
+| **Market Share** | ~5% | ~70% |
+| **API** | GraphQL, modern | REST + GraphQL |
+| **Integration Priority** | 📋 Not planned | 🚧 Q2 2026 |
+
+---
+
+## Vote for This Feature
+
+Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+
+---
+
+[Back to Integrations](index.md)

--- a/docs/agent-support/integrations/notion.md
+++ b/docs/agent-support/integrations/notion.md
@@ -1,0 +1,118 @@
+# Notion Integration
+
+**Status:** 📋 Not Currently Planned
+
+Notion integration for knowledge base, notes, and databases.
+
+---
+
+## Why Not Planned?
+
+Notion integration is not currently on the Clawrium roadmap for the following reasons:
+
+1. **Scope:** Notion serves more as a personal/team wiki than an agent integration target
+2. **Use Case:** Less clear how agents would productively interact with Notion
+3. **Priority:** GitHub and Jira cover the main workflow integrations
+4. **Resources:** Limited development bandwidth
+5. **Alternative:** Can be implemented via MCP tools when available
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need Notion support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](../../issues/new?labels=enhancement,integration&title=Add+Notion+integration+support)
+
+Include:
+- Your specific use case
+- Read-only (search) vs read-write needs
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+We'd love your contribution! Notion has a well-documented API:
+
+1. Notion API client
+2. Internal integration token authentication
+3. Page/database search
+4. Content retrieval
+5. Optional: Page creation/updates
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+---
+
+## What Would Be Needed
+
+### Authentication
+
+1. Go to [Notion Integrations](https://www.notion.so/my-integrations)
+2. Create new integration
+3. Copy the **Internal Integration Token**
+4. Share specific pages/databases with the integration
+
+### API Capabilities
+
+Notion API supports:
+
+- Search across pages and databases
+- Read page content (blocks)
+- Query databases
+- Create/update pages
+- Append blocks
+
+### Use Cases
+
+If implemented, Notion integration could:
+
+- **Knowledge base:** Search and retrieve documentation
+- **Meeting notes:** Find relevant past notes
+- **Project tracking:** Read project database
+- **Task management:** Update todo lists
+- **Content creation:** Draft blog posts, docs
+
+---
+
+## Alternatives
+
+### Use as Knowledge Base
+
+Export Notion content and use as agent knowledge base (RAG) instead of direct integration.
+
+### Direct API Calls
+
+```bash
+curl -H "Authorization: Bearer $NOTION_TOKEN" \
+     -H "Notion-Version: 2022-06-28" \
+     https://api.notion.com/v1/search \
+     -d '{"query": "meeting notes"}'
+```
+
+### MCP Tools (Coming Q2 2026)
+
+Use generic HTTP MCP tools or Notion-specific MCP server when available.
+
+---
+
+## Comparison: Notion vs Confluence
+
+| Feature | Notion | Confluence |
+|---------|--------|------------|
+| **Target** | Teams, individuals | Enterprise |
+| **Pricing** | Freemium | Paid (Atlassian) |
+| **API** | REST, good docs | REST, complex |
+| **Use Case** | Notes, docs, databases | Wiki, documentation |
+| **Integration Priority** | 📋 Not planned | 📋 Not planned |
+
+---
+
+## Vote for This Feature
+
+Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+
+---
+
+[Back to Integrations](index.md)

--- a/docs/agent-support/openclaw.md
+++ b/docs/agent-support/openclaw.md
@@ -1,0 +1,166 @@
+# OpenClaw Support Matrix
+
+OpenClaw is a full-featured agent supporting multiple LLM providers, communication channels, and third-party integrations.
+
+**Status:** ✅ Production Ready
+
+**Best for:** Discord bots, multi-channel assistants, complex workflows
+
+---
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Fully supported and tested |
+| 🚧 | In development / Planned |
+| ❌ | Not supported |
+| 📋 | Not planned (PRs welcome) |
+
+---
+
+## Provider Support
+
+OpenClaw supports all major LLM providers:
+
+| Provider | Status | Configuration | Models |
+|----------|:------:|---------------|--------|
+| **[OpenAI](providers/openai.md)** | ✅ | [Setup Guide](providers/openai.md) | GPT-4o, GPT-4, GPT-3.5, o1 |
+| **[Anthropic](providers/anthropic.md)** | ✅ | [Setup Guide](providers/anthropic.md) | Claude Opus, Sonnet, Haiku |
+| **[OpenRouter](providers/openrouter.md)** | ✅ | [Setup Guide](providers/openrouter.md) | Multi-provider gateway |
+| **[AWS Bedrock](providers/bedrock.md)** | ✅ | [Setup Guide](providers/bedrock.md) | Claude, Llama, Titan |
+| **[Google Vertex](providers/vertex.md)** | ✅ | [Setup Guide](providers/vertex.md) | Gemini series |
+| **[ZAI / BigModel](providers/zai.md)** | ✅ | [Setup Guide](providers/zai.md) | GLM series |
+| **[Ollama](providers/ollama.md)** | ✅ | [Setup Guide](providers/ollama.md) | Self-hosted models |
+| **[Azure OpenAI](providers/azure-openai.md)** | 📋 | [Not Planned](providers/azure-openai.md) | — |
+
+**Quick Setup:**
+```bash
+clm provider add <name> --type <provider-type>
+```
+
+---
+
+## Channel Support
+
+Channels define how users interact with the agent:
+
+| Channel | Status | Configuration | Notes |
+|---------|:------:|---------------|-------|
+| **[CLI](channels/cli.md)** | ✅ | [Setup Guide](channels/cli.md) | Interactive terminal chat |
+| **[Discord](channels/discord.md)** | ✅ | [Setup Guide](channels/discord.md) | Bot with allowlisting |
+| **[Slack](channels/slack.md)** | 🚧 | [Milestone SEA](channels/slack.md) | Coming Q2 2026 |
+| **[Web Interface](channels/web.md)** | 🚧 | [Milestone SEA](channels/web.md) | Browser-based chat |
+| **[WhatsApp](channels/whatsapp.md)** | 📋 | [Not Planned](channels/whatsapp.md) | PRs welcome |
+
+**During Onboarding:**
+```bash
+clm agent configure <agent-name>
+# Select channel during the channels stage
+```
+
+---
+
+## Integration Support
+
+Integrations allow the agent to interact with external tools and services:
+
+| Integration | Status | Configuration | Use Case |
+|-------------|:------:|---------------|----------|
+| **[GitHub](integrations/github.md)** | 🚧 | [Milestone SEA](integrations/github.md) | PR reviews, issues |
+| **[Jira](integrations/jira.md)** | 🚧 | [Milestone SEA](integrations/jira.md) | Issue tracking |
+| **[GitLab](integrations/gitlab.md)** | 📋 | [Not Planned](integrations/gitlab.md) | PRs welcome |
+| **[Confluence](integrations/confluence.md)** | 📋 | [Not Planned](integrations/confluence.md) | PRs welcome |
+| **[Linear](integrations/linear.md)** | 📋 | [Not Planned](integrations/linear.md) | PRs welcome |
+| **[Notion](integrations/notion.md)** | 📋 | [Not Planned](integrations/notion.md) | PRs welcome |
+
+---
+
+## Additional Features
+
+| Feature | Status | Notes |
+|---------|:------:|-------|
+| **Custom Identity** | ✅ | SOUL.md + IDENTITY.md |
+| **Multi-Provider** | ✅ | Switch providers per request |
+| **Secrets Management** | ✅ | Per-instance secret storage |
+| **Token Tracking** | 🚧 | Coming Q2 2026 |
+| **MCP Tools** | 🚧 | Coming Q2 2026 |
+| **Auto-Restart** | ✅ | Supervisor-managed |
+| **Log Streaming** | ✅ | Real-time log access |
+| **Onboarding Wizard** | ✅ | Guided 4-stage setup |
+
+---
+
+## Getting Started
+
+### 1. Install OpenClaw
+
+```bash
+clm agent install --type openclaw --host <host-alias> --name my-assistant
+```
+
+### 2. Configure the Agent
+
+```bash
+clm agent configure my-assistant
+```
+
+The wizard will guide you through:
+- Provider selection
+- Identity configuration (SOUL.md, IDENTITY.md)
+- Channel setup (CLI, Discord, etc.)
+- Validation
+
+### 3. Start the Agent
+
+```bash
+clm agent start my-assistant
+```
+
+### 4. Chat with the Agent
+
+```bash
+clm chat my-assistant
+```
+
+---
+
+## Troubleshooting
+
+<details>
+<summary><strong>"Discord bot token invalid"</strong></summary>
+
+1. Verify the bot token in Discord Developer Portal
+2. Re-run: `clm agent configure <name> --stage channels`
+3. Ensure the bot has proper server permissions
+</details>
+
+<details>
+<summary><strong>"Provider connectivity failed"</strong></summary>
+
+1. Check provider status: `clm provider status <provider-name>`
+2. Verify API key is set: `clm provider list`
+3. Test network connectivity from the host
+</details>
+
+<details>
+<summary><strong>"Onboarding incomplete"</strong></summary>
+
+Run the full onboarding wizard:
+```bash
+clm agent configure <agent-name>
+```
+
+Or configure a specific stage:
+```bash
+clm agent configure <agent-name> --stage <stage-name>
+```
+</details>
+
+---
+
+## Next Steps
+
+- [Agent Onboarding](../agent-onboarding.md) - Detailed onboarding guide
+- [CLI Reference](../reference/cli/agent.md) - Full command documentation
+- [Provider Configuration](../host-preparation.md) - Setting up inference providers

--- a/docs/agent-support/providers/anthropic.md
+++ b/docs/agent-support/providers/anthropic.md
@@ -1,0 +1,95 @@
+# Anthropic Provider
+
+**Status:** ✅ Supported
+
+Official Anthropic Claude API integration.
+
+## Supported Models
+
+- `claude-opus-4-20250514` - Most capable
+- `claude-sonnet-4-20250514` - Balanced performance
+- `claude-3-5-sonnet-20241022` - Previous generation
+- `claude-3-5-haiku-20241022` - Fast, cost-effective
+- `claude-3-opus-20240229` - Original Opus
+- `claude-3-sonnet-20240229` - Original Sonnet
+- `claude-3-haiku-20240307` - Original Haiku
+
+## Setup
+
+### 1. Get API Key
+
+1. Visit [Anthropic Console](https://console.anthropic.com/)
+2. Create or log in to your account
+3. Go to **API keys** → **Create Key**
+4. Copy the key (starts with `sk-ant-`)
+
+### 2. Add to Clawrium
+
+```bash
+clm provider add my-claude --type anthropic
+```
+
+You will be prompted to enter your API key securely.
+
+### 3. Select Model
+
+Choose a default model during setup:
+- `claude-opus-4-20250514` (best quality)
+- `claude-sonnet-4-20250514` (recommended balance)
+- `claude-3-5-haiku-20241022` (fastest)
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Change default model
+clm provider edit my-claude --model claude-sonnet-4-20250514
+
+# Update API key
+clm provider edit my-claude --update-key
+
+# Remove provider
+clm provider remove my-claude
+```
+
+## Pricing Considerations
+
+| Model | Input (per 1M tokens) | Output (per 1M tokens) |
+|-------|----------------------|------------------------|
+| Claude Opus 4 | $15.00 | $75.00 |
+| Claude Sonnet 4 | $3.00 | $15.00 |
+| Claude 3.5 Haiku | $0.25 | $1.25 |
+
+*Prices subject to change. Check [Anthropic pricing](https://www.anthropic.com/pricing) for current rates.*
+
+## Why Claude?
+
+- **Longer context:** Up to 200K tokens on some models
+- **Strong reasoning:** Excellent for complex tasks
+- **Constitutional AI:** Built-in safety measures
+- **Vision support:** Some models support image input
+
+## Usage in Agents
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+# Select my-claude when prompted for provider
+```
+
+## Troubleshooting
+
+**"Invalid API key"**
+- Verify the key starts with `sk-ant-`
+- Check your Anthropic console for active keys
+
+**"Rate limit exceeded"**
+- Check your Anthropic usage dashboard
+- Contact Anthropic for rate limit increases
+
+---
+
+[Back to Providers](index.md)

--- a/docs/agent-support/providers/azure-openai.md
+++ b/docs/agent-support/providers/azure-openai.md
@@ -1,0 +1,83 @@
+# Azure OpenAI Provider
+
+**Status:** 📋 Not Currently Planned
+
+Azure OpenAI Service provides OpenAI models through Microsoft Azure infrastructure.
+
+---
+
+## Why Not Planned?
+
+Azure OpenAI is not currently on the Clawrium roadmap for the following reasons:
+
+1. **Overlap:** Standard OpenAI provider already covers GPT models
+2. **Complexity:** Azure AD authentication adds setup friction
+3. **Priority:** Community demand has been low compared to other providers
+4. **Focus:** Development resources are focused on Ollama, Bedrock, and Vertex
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need Azure OpenAI support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](../../issues/new?labels=enhancement,provider&title=Add+Azure+OpenAI+provider+support)
+
+Include:
+- Your use case
+- Why existing providers don't meet your needs
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+We'd love your contribution! Implementation would involve:
+
+1. Add Azure provider type to `src/clawrium/core/providers.py`
+2. Handle Azure AD authentication (service principal or managed identity)
+3. Support Azure-specific endpoints and model deployment names
+4. Add tests and documentation
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+### Option 3: Use OpenRouter
+
+As a workaround, you can use [OpenRouter](openrouter.md) which may provide Azure-hosted models:
+
+```bash
+clm provider add my-router --type openrouter
+# Select Azure-hosted models if available
+```
+
+---
+
+## What Would Be Needed
+
+If implementing Azure OpenAI support, the following would be required:
+
+**Authentication Options:**
+- Service Principal (Client ID, Client Secret, Tenant ID)
+- Managed Identity (for Azure-hosted agents)
+- Azure CLI credentials (for development)
+
+**Configuration:**
+- Azure OpenAI Endpoint (e.g., `https://<resource>.openai.azure.com/`)
+- Deployment name (Azure uses custom deployment names, not model names)
+- API version
+
+**Differences from Standard OpenAI:**
+- Model access controlled by Azure
+- Different authentication flow
+- Custom deployment names instead of model names
+- Regional availability varies
+
+---
+
+## Vote for This Feature
+
+Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+
+---
+
+[Back to Providers](index.md)

--- a/docs/agent-support/providers/bedrock.md
+++ b/docs/agent-support/providers/bedrock.md
@@ -1,0 +1,117 @@
+# AWS Bedrock Provider
+
+**Status:** ✅ Supported
+
+Amazon Bedrock provides managed access to foundation models through AWS infrastructure.
+
+## Supported Models
+
+- `anthropic.claude-opus-4-20250514-v1:0` - Most capable Claude
+- `anthropic.claude-sonnet-4-20250514-v1:0` - Balanced Claude
+- `anthropic.claude-3-5-sonnet-20241022-v2:0` - Previous generation
+- `anthropic.claude-3-5-haiku-20241022-v1:0` - Fast Claude
+- `anthropic.claude-3-haiku-20240307-v1:0` - Original Haiku
+- `amazon.titan-text-express-v1` - Amazon Titan
+- `amazon.titan-text-lite-v1` - Lightweight Titan
+- `meta.llama3-70b-instruct-v1:0` - Meta Llama 3
+
+## Setup
+
+### 1. AWS Credentials
+
+You need AWS credentials with Bedrock access:
+
+1. Go to [AWS IAM Console](https://console.aws.amazon.com/iam/)
+2. Create or use an existing user
+3. Attach policy: `AmazonBedrockFullAccess`
+4. Create access key (Access Key ID + Secret Access Key)
+
+### 2. Enable Model Access
+
+1. Go to [Amazon Bedrock Console](https://console.aws.amazon.com/bedrock/)
+2. Navigate to **Model access**
+3. Request access for desired models (Claude, Llama, etc.)
+4. Wait for approval (usually instant)
+
+### 3. Add to Clawrium
+
+```bash
+clm provider add my-bedrock --type bedrock
+```
+
+You will be prompted to enter:
+- AWS Access Key ID
+- AWS Secret Access Key
+
+### 4. Select Model
+
+Choose a default model during setup:
+- `anthropic.claude-opus-4-20250514-v1:0` (best quality)
+- `anthropic.claude-sonnet-4-20250514-v1:0` (recommended)
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Change default model
+clm provider edit my-bedrock --model anthropic.claude-sonnet-4-20250514-v1:0
+
+# Update AWS credentials
+clm provider edit my-bedrock --update-key
+
+# Remove provider
+clm provider remove my-bedrock
+```
+
+## Pricing
+
+Bedrock uses on-demand pricing per 1K tokens. Check [AWS Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) for current rates.
+
+Example approximate costs:
+- Claude Sonnet 4: ~$3/1M input tokens, ~$15/1M output tokens
+- Llama 3 70B: ~$0.72/1M input tokens
+
+## Benefits
+
+- **AWS ecosystem:** Integrates with existing AWS infrastructure
+- **Compliance:** SOC 2, HIPAA, GDPR compliant
+- **Private connectivity:** VPC endpoints available
+- **No API keys:** Uses AWS IAM for authentication
+
+## Security
+
+- Credentials stored securely (not in plain text)
+- IAM policies control access
+- CloudTrail logs API calls
+- No data leaves your AWS account
+
+## Usage in Agents
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+# Select my-bedrock when prompted for provider
+```
+
+## Troubleshooting
+
+**"Access denied"**
+- Verify IAM user has `AmazonBedrockFullAccess`
+- Check model access is enabled in Bedrock console
+- Ensure credentials are correct
+
+**"Model not available"**
+- Request model access in Bedrock console
+- Some models require approval (can take 24-48 hours)
+- Check your AWS region supports the model
+
+**"Rate limit exceeded"**
+- Request quota increase in AWS Support Center
+- Consider using provisioned throughput
+
+---
+
+[Back to Providers](index.md)

--- a/docs/agent-support/providers/index.md
+++ b/docs/agent-support/providers/index.md
@@ -1,0 +1,82 @@
+# Providers
+
+LLM providers supply the AI models that power your agents. Clawrium supports multiple providers, allowing you to choose the best model for your use case.
+
+## Supported Providers
+
+| Provider | Type | Best For |
+|----------|------|----------|
+| **[OpenAI](openai.md)** | Cloud | GPT-4o, latest models |
+| **[Anthropic](anthropic.md)** | Cloud | Claude, long context |
+| **[OpenRouter](openrouter.md)** | Gateway | Multi-provider access |
+| **[AWS Bedrock](bedrock.md)** | Cloud | AWS ecosystem, compliance |
+| **[Google Vertex](vertex.md)** | Cloud | Gemini, Google Cloud |
+| **[ZAI / BigModel](zai.md)** | Cloud | GLM models, China region |
+| **[Ollama](ollama.md)** | Self-hosted | Local inference, privacy |
+
+## Provider Comparison
+
+| Feature | OpenAI | Anthropic | Ollama |
+|---------|--------|-----------|--------|
+| **Setup** | API key | API key | Server URL |
+| **Cost** | Pay per token | Pay per token | Hardware only |
+| **Latency** | Network | Network | Local/Network |
+| **Privacy** | Cloud | Cloud | On-premise |
+| **Model Choice** | Fixed list | Fixed list | Unlimited |
+
+## Quick Setup
+
+Add a provider in one command:
+
+```bash
+# Cloud provider (OpenAI, Anthropic, etc.)
+clm provider add my-openai --type openai
+
+# Self-hosted (Ollama)
+clm provider add local-llm --type ollama --url http://192.168.1.50:11434
+```
+
+Then assign it to an agent during onboarding:
+
+```bash
+clm agent configure <agent-name>
+# Select provider during the providers stage
+```
+
+## Managing Providers
+
+```bash
+# List all providers
+clm provider list
+
+# View available models
+clm provider models <provider-name>
+
+# Edit a provider
+clm provider edit <provider-name> --model <new-model>
+
+# Remove a provider
+clm provider remove <provider-name>
+```
+
+## Security
+
+- API keys are stored securely (not in plain text)
+- Keys are never logged or displayed in full
+- Per-provider isolation
+
+## Troubleshooting
+
+**"Provider connectivity failed"**
+- Verify API key is valid
+- Check network connectivity from the host
+- Ensure provider service is operational
+
+**"No models available"** (Ollama)
+- SSH to the Ollama host
+- Run: `ollama list` to verify models are pulled
+- Pull models: `ollama pull <model-name>`
+
+---
+
+See individual provider pages for detailed setup instructions.

--- a/docs/agent-support/providers/ollama.md
+++ b/docs/agent-support/providers/ollama.md
@@ -1,0 +1,140 @@
+# Ollama Provider
+
+**Status:** ✅ Supported
+
+Ollama lets you run open-source LLMs locally on your own hardware.
+
+## Supported Models
+
+Ollama supports 100+ models including:
+
+- `llama3.3` - Meta's Llama 3.3
+- `llama3.2` - Meta's Llama 3.2
+- `llama3.1` - Meta's Llama 3.1
+- `llama3` - Meta's Llama 3
+- `mistral` - Mistral AI
+- `mixtral` - Mixtral 8x7B
+- `gemma2` - Google Gemma 2
+- `qwen2.5` - Alibaba Qwen
+- `phi4` - Microsoft Phi-4
+- `deepseek-r1` - DeepSeek R1
+
+And many more at [ollama.com/library](https://ollama.com/library)
+
+## Setup
+
+### 1. Install Ollama
+
+On your target host (or any machine on your network):
+
+```bash
+# macOS/Linux
+curl -fsSL https://ollama.com/install.sh | sh
+
+# Or download from https://ollama.com/download
+```
+
+### 2. Pull Models
+
+```bash
+# Pull a model
+ollama pull llama3.2
+
+# List available models
+ollama list
+```
+
+### 3. Configure Server Access
+
+By default, Ollama only accepts local connections. To allow remote access:
+
+```bash
+# Set environment variable
+export OLLAMA_HOST=0.0.0.0:11434
+
+# Or edit systemd service
+sudo systemctl edit ollama.service
+```
+
+Add:
+```ini
+[Service]
+Environment="OLLAMA_HOST=0.0.0.0:11434"
+```
+
+Then restart:
+```bash
+sudo systemctl restart ollama
+```
+
+### 4. Add to Clawrium
+
+```bash
+clm provider add local-ollama --type ollama --url http://192.168.1.50:11434
+```
+
+Clawrium will:
+1. Connect to the Ollama server
+2. Fetch available models
+3. Let you select a default
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Refresh model list (after pulling new models)
+clm provider refresh local-ollama
+
+# Change default model
+clm provider edit local-ollama --model llama3.2
+
+# Update server URL
+clm provider edit local-ollama --url http://new-server:11434
+
+# Remove provider
+clm provider remove local-ollama
+```
+
+## Hardware Requirements
+
+| Model | RAM Required | GPU Recommended |
+|-------|--------------|-----------------|
+| llama3.2 (3B) | 8GB | Optional |
+| llama3.1 (8B) | 16GB | 8GB VRAM |
+| llama3.3 (70B) | 64GB | 40GB+ VRAM |
+| mixtral (47B) | 32GB | 24GB VRAM |
+
+## Benefits
+
+- **Privacy:** Data never leaves your network
+- **No API costs:** Pay only for hardware/electricity
+- **No rate limits:** Unlimited requests
+- **Offline capable:** Works without internet
+- **Model variety:** 100+ open-source models
+
+## Troubleshooting
+
+**"Connection refused"**
+- Verify Ollama is running: `ollama serve`
+- Check `OLLAMA_HOST` is set for remote access
+- Ensure firewall allows port 11434
+
+**"Model not found"**
+- Pull the model first: `ollama pull <model>`
+- Check available models: `ollama list`
+
+**"Out of memory"**
+- Use a smaller model (e.g., llama3.2 instead of llama3.1)
+- Add more RAM or VRAM
+- Use CPU-only mode (slower): `ollama run <model> --cpu`
+
+**"Slow responses"**
+- GPU acceleration significantly improves speed
+- Consider quantization (Q4, Q5, Q8)
+- Check GPU utilization with `nvidia-smi`
+
+---
+
+[Back to Providers](index.md)

--- a/docs/agent-support/providers/openai.md
+++ b/docs/agent-support/providers/openai.md
@@ -1,0 +1,103 @@
+# OpenAI Provider
+
+**Status:** ✅ Supported
+
+Official OpenAI API integration for GPT models.
+
+## Supported Models
+
+- `gpt-4o` - Latest flagship model
+- `gpt-4o-mini` - Fast, cost-effective
+- `gpt-4-turbo` - Previous generation
+- `gpt-4` - Original GPT-4
+- `gpt-3.5-turbo` - Cost-optimized
+- `o1` - Reasoning model
+- `o1-mini` - Fast reasoning
+- `o1-preview` - Reasoning preview
+
+## Setup
+
+### 1. Get API Key
+
+1. Visit [OpenAI Platform](https://platform.openai.com/)
+2. Create or log in to your account
+3. Go to **API keys** → **Create new secret key**
+4. Copy the key (starts with `sk-`)
+
+### 2. Add to Clawrium
+
+```bash
+clm provider add my-openai --type openai
+```
+
+You will be prompted to enter your API key securely.
+
+### 3. Select Model
+
+Choose a default model during setup:
+- `gpt-4o` (recommended for most use cases)
+- `gpt-4o-mini` (faster, cheaper)
+- `gpt-4-turbo` (if you need specific features)
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Change default model
+clm provider edit my-openai --model gpt-4o-mini
+
+# Update API key
+clm provider edit my-openai --update-key
+
+# Remove provider
+clm provider remove my-openai
+```
+
+## Pricing Considerations
+
+| Model | Input (per 1M tokens) | Output (per 1M tokens) |
+|-------|----------------------|------------------------|
+| gpt-4o | $5.00 | $15.00 |
+| gpt-4o-mini | $0.15 | $0.60 |
+| gpt-4-turbo | $10.00 | $30.00 |
+| gpt-3.5-turbo | $0.50 | $1.50 |
+
+*Prices subject to change. Check [OpenAI pricing](https://openai.com/pricing) for current rates.*
+
+## Usage in Agents
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+# Select my-openai when prompted for provider
+```
+
+Or change later:
+
+```bash
+clm agent configure my-agent --stage providers
+```
+
+## Troubleshooting
+
+**"Invalid API key"**
+- Verify the key starts with `sk-`
+- Ensure the key hasn't been revoked
+- Check your OpenAI account has available credits
+
+**"Rate limit exceeded"**
+- Check your OpenAI usage dashboard
+- Consider upgrading your account tier
+- Implement retry logic in your agent
+
+**"Model not found"**
+- Verify the model name is correct
+- Some models may require beta access
+- Check [OpenAI model documentation](https://platform.openai.com/docs/models)
+
+---
+
+[Back to Providers](index.md)

--- a/docs/agent-support/providers/openrouter.md
+++ b/docs/agent-support/providers/openrouter.md
@@ -1,0 +1,104 @@
+# OpenRouter Provider
+
+**Status:** ✅ Supported
+
+OpenRouter provides unified access to multiple AI models through a single API.
+
+## Supported Models
+
+OpenRouter supports 100+ models including:
+
+- `anthropic/claude-opus-4`
+- `anthropic/claude-sonnet-4`
+- `openai/gpt-4o`
+- `openai/o1`
+- `google/gemini-2.5-pro`
+- `meta-llama/llama-4-maverick`
+- `deepseek/deepseek-chat-v3`
+- `deepseek/deepseek-r1`
+- `qwen/qwen3-235b`
+
+## Setup
+
+### 1. Get API Key
+
+1. Visit [OpenRouter](https://openrouter.ai/)
+2. Create or log in to your account
+3. Go to **Keys** → **Create Key**
+4. Copy the key
+
+### 2. Add to Clawrium
+
+```bash
+clm provider add my-router --type openrouter
+```
+
+You will be prompted to enter your API key securely.
+
+### 3. Select Model
+
+Choose from OpenRouter's extensive model list:
+- `anthropic/claude-opus-4` (best quality)
+- `google/gemini-2.5-pro` (competitive pricing)
+- `openai/gpt-4o` (familiar API)
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Change default model
+clm provider edit my-router --model anthropic/claude-sonnet-4
+
+# Update API key
+clm provider edit my-router --update-key
+
+# Remove provider
+clm provider remove my-router
+```
+
+## Benefits
+
+- **Model fallback:** Automatically route to available models
+- **Unified billing:** One account for multiple providers
+- **Competitive pricing:** Often cheaper than direct provider access
+- **Model variety:** Access to open-source and proprietary models
+
+## Pricing
+
+OpenRouter adds a small fee on top of provider costs. Check [OpenRouter pricing](https://openrouter.ai/docs#pricing) for current rates.
+
+## Usage in Agents
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+# Select my-router when prompted for provider
+```
+
+## Model Routing
+
+You can switch models without changing providers:
+
+```bash
+clm provider edit my-router --model deepseek/deepseek-chat-v3
+```
+
+Then restart your agent to use the new model.
+
+## Troubleshooting
+
+**"Model not available"**
+- Check OpenRouter model status page
+- Some models may have temporary outages
+- Try a fallback model
+
+**"Credits exhausted"**
+- Add credits in OpenRouter dashboard
+- Set up auto-recharge for production use
+
+---
+
+[Back to Providers](index.md)

--- a/docs/agent-support/providers/vertex.md
+++ b/docs/agent-support/providers/vertex.md
@@ -1,0 +1,129 @@
+# Google Vertex AI Provider
+
+**Status:** ✅ Supported
+
+Google Cloud Vertex AI provides access to Gemini models.
+
+## Supported Models
+
+- `gemini-2.5-pro` - Latest flagship model
+- `gemini-2.5-flash` - Fast, efficient
+- `gemini-2.5-flash-lite` - Lightweight version
+- `gemini-2.0-flash` - Previous generation
+- `gemini-1.5-pro` - Earlier pro model
+- `gemini-1.5-flash` - Earlier flash model
+
+## Setup
+
+### 1. Google Cloud Setup
+
+1. Create or select a [Google Cloud project](https://console.cloud.google.com/)
+2. Enable the Vertex AI API:
+   ```bash
+   gcloud services enable aiplatform.googleapis.com
+   ```
+3. Ensure billing is enabled
+
+### 2. Authentication
+
+Clawrium uses Application Default Credentials (ADC). Set up authentication:
+
+```bash
+# Install gcloud CLI if not already installed
+# https://cloud.google.com/sdk/docs/install
+
+# Authenticate
+gcloud auth application-default login
+```
+
+Or use a service account:
+
+```bash
+# Create service account
+gcloud iam service-accounts create clawrium-provider \
+  --display-name="Clawrium Provider"
+
+# Grant Vertex AI User role
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="serviceAccount:clawrium-provider@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/aiplatform.user"
+
+# Create and download key
+gcloud iam service-accounts keys create key.json \
+  --iam-account=clawrium-provider@PROJECT_ID.iam.gserviceaccount.com
+
+# Set environment variable
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
+```
+
+### 3. Add to Clawrium
+
+```bash
+clm provider add my-vertex --type vertex
+```
+
+Note: Vertex AI uses Google Cloud authentication, not an API key.
+
+### 4. Select Model
+
+Choose a default model during setup:
+- `gemini-2.5-pro` (best quality)
+- `gemini-2.5-flash` (recommended balance)
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Change default model
+clm provider edit my-vertex --model gemini-2.5-flash
+
+# Remove provider
+clm provider remove my-vertex
+```
+
+## Pricing
+
+Vertex AI uses pay-per-use pricing. Check [Vertex AI pricing](https://cloud.google.com/vertex-ai/pricing) for current rates.
+
+Approximate costs:
+- Gemini 2.5 Pro: ~$1.25/1M input tokens, ~$10/1M output tokens
+- Gemini 2.5 Flash: ~$0.15/1M input tokens, ~$0.60/1M output tokens
+
+## Benefits
+
+- **Google Cloud integration:** Works with GCP services
+- **Enterprise features:** Fine-tuning, batch prediction
+- **Global infrastructure:** Low latency worldwide
+- **Gemini models:** Google's most capable models
+
+## Usage in Agents
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+# Select my-vertex when prompted for provider
+```
+
+## Troubleshooting
+
+**"Permission denied"**
+- Verify Vertex AI API is enabled
+- Check IAM permissions (needs `aiplatform.user`)
+- Ensure billing is enabled
+
+**"Authentication failed"**
+- Run `gcloud auth application-default login`
+- Check `GOOGLE_APPLICATION_CREDENTIALS` is set correctly
+- Verify service account has proper roles
+
+**"Model not found"**
+- Check your region supports the model
+- Verify the model name is correct
+- Some models may be in preview/limited availability
+
+---
+
+[Back to Providers](index.md)

--- a/docs/agent-support/providers/zai.md
+++ b/docs/agent-support/providers/zai.md
@@ -1,0 +1,96 @@
+# ZAI / BigModel Provider
+
+**Status:** ✅ Supported
+
+Zhipu AI (ZAI) BigModel platform provides access to GLM (General Language Model) series.
+
+## Supported Models
+
+- `glm-4` - General purpose
+- `glm-4-plus` - Enhanced capabilities
+- `glm-4-air` - Fast inference
+- `glm-4-airx` - Extended context
+- `glm-4-flash` - Ultra-fast
+- `glm-4-long` - Long context
+- `glm-4v` - Vision capable
+- `glm-4v-plus` - Enhanced vision
+
+## Setup
+
+### 1. Get API Key
+
+1. Visit [BigModel Platform](https://open.bigmodel.cn/)
+2. Create or log in to your account
+3. Go to **API Keys** → **Create API Key**
+4. Copy the key
+
+### 2. Add to Clawrium
+
+```bash
+clm provider add my-zai --type zai
+```
+
+You will be prompted to enter your API key securely.
+
+### 3. Select Model
+
+Choose a default model during setup:
+- `glm-4` (general purpose)
+- `glm-4-plus` (enhanced)
+- `glm-4-flash` (fastest)
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Change default model
+clm provider edit my-zai --model glm-4-plus
+
+# Update API key
+clm provider edit my-zai --update-key
+
+# Remove provider
+clm provider remove my-zai
+```
+
+## Pricing
+
+ZAI offers competitive pricing, especially for the China region. Check [BigModel pricing](https://open.bigmodel.cn/pricing) for current rates.
+
+## Benefits
+
+- **China region:** Optimized for China-based deployments
+- **GLM models:** Strong Chinese language support
+- **Vision models:** GLM-4V supports image understanding
+- **Competitive pricing:** Often cheaper than western providers
+
+## Usage in Agents
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+# Select my-zai when prompted for provider
+```
+
+## Region Considerations
+
+- API endpoint: `https://open.bigmodel.cn/api/paas/v4`
+- Optimized for China region
+- May have higher latency from other regions
+
+## Troubleshooting
+
+**"Invalid API key"**
+- Verify the key is active in BigModel console
+- Check account has available credits
+
+**"High latency"**
+- Expected if connecting from outside China
+- Consider using a different provider for non-China deployments
+
+---
+
+[Back to Providers](index.md)

--- a/docs/agent-support/zeroclaw.md
+++ b/docs/agent-support/zeroclaw.md
@@ -1,0 +1,180 @@
+# ZeroClaw Support Matrix
+
+ZeroClaw is a minimal CLI-only agent designed for simple automation tasks and quick scripts.
+
+**Status:** 🚧 In Development
+
+**Best for:** CLI automation, minimal resource usage, quick tasks
+
+---
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Fully supported and tested |
+| 🚧 | In development / Planned |
+| ❌ | Not supported |
+| 📋 | Not planned (PRs welcome) |
+
+---
+
+## Provider Support
+
+ZeroClaw will support a limited set of providers focused on efficiency:
+
+| Provider | Status | Configuration | Models |
+|----------|:------:|---------------|--------|
+| **[OpenAI](providers/openai.md)** | 🚧 | [In Development](providers/openai.md) | GPT-4o-mini, GPT-3.5 |
+| **[Anthropic](providers/anthropic.md)** | 🚧 | [In Development](providers/anthropic.md) | Claude Haiku |
+| **[Ollama](providers/ollama.md)** | 🚧 | [In Development](providers/ollama.md) | Local models |
+| **[OpenRouter](providers/openrouter.md)** | ❌ | — | Not planned |
+| **[AWS Bedrock](providers/bedrock.md)** | ❌ | — | Not planned |
+| **[Google Vertex](providers/vertex.md)** | ❌ | — | Not planned |
+| **[ZAI / BigModel](providers/zai.md)** | ❌ | — | Not planned |
+| **[Azure OpenAI](providers/azure-openai.md)** | ❌ | — | Not planned |
+
+**Notes:**
+- ZeroClaw focuses on lightweight providers
+- Self-hosted (Ollama) is prioritized for cost efficiency
+- Complex providers (Bedrock, Vertex) are excluded by design
+
+---
+
+## Channel Support
+
+ZeroClaw is CLI-only by design:
+
+| Channel | Status | Configuration | Notes |
+|---------|:------:|---------------|-------|
+| **[CLI](channels/cli.md)** | 🚧 | [In Development](channels/cli.md) | Terminal-only |
+| **Discord** | ❌ | — | Not supported (use OpenClaw) |
+| **[Slack](channels/slack.md)** | ❌ | — | Not supported |
+| **[Web Interface](channels/web.md)** | ❌ | — | Not supported |
+| **[WhatsApp](channels/whatsapp.md)** | ❌ | — | Not supported |
+
+**Philosophy:**
+ZeroClaw intentionally excludes multi-channel support to maintain simplicity. For Discord or web interfaces, use [OpenClaw](openclaw.md).
+
+---
+
+## Integration Support
+
+ZeroClaw does not support external integrations by design:
+
+| Integration | Status | Configuration | Notes |
+|-------------|:------:|---------------|-------|
+| **GitHub** | ❌ | — | Not supported |
+| **Jira** | ❌ | — | Not supported |
+| **GitLab** | ❌ | — | Not supported |
+| **Confluence** | ❌ | — | Not supported |
+| **Linear** | ❌ | — | Not supported |
+| **Notion** | ❌ | — | Not supported |
+
+**Philosophy:**
+ZeroClaw is designed for simple, self-contained automation. It focuses on:
+- Quick CLI tasks
+- Local file operations
+- Simple API calls via curl/httpie
+- Scripting and piping
+
+For integrations with GitHub, Jira, etc., use [OpenClaw](openclaw.md).
+
+---
+
+## Feature Support
+
+| Feature | Status | Notes |
+|---------|:------:|-------|
+| **Custom Identity** | ❌ | Minimal identity only (no SOUL.md) |
+| **Multi-Provider** | 🚧 | Basic switching planned |
+| **Secrets Management** | 🚧 | Per-instance storage planned |
+| **Token Tracking** | ❌ | Not planned |
+| **MCP Tools** | ❌ | Not planned |
+| **Auto-Restart** | 🚧 | Supervisor-managed planned |
+| **Log Streaming** | 🚧 | Planned |
+| **Onboarding Wizard** | 🚧 | Simplified 2-stage setup |
+
+---
+
+## Comparison with OpenClaw
+
+| Aspect | ZeroClaw | OpenClaw |
+|--------|----------|----------|
+| **Setup Time** | 1-2 minutes | 3-5 minutes |
+| **Channels** | CLI only | CLI, Discord, Web |
+| **Identity** | Minimal | Fully customizable |
+| **Providers** | 3 (lightweight) | 7+ (all major) |
+| **Integrations** | None | GitHub, Jira, etc. |
+| **Resource Usage** | Low | Moderate |
+| **Use Case** | Automation | Assistants |
+
+---
+
+## Getting Started (When Available)
+
+### 1. Install ZeroClaw
+
+```bash
+clm agent install --type zeroclaw --host <host-alias> --name my-script
+```
+
+### 2. Configure (Minimal)
+
+```bash
+clm agent configure my-script
+# Auto-skips identity, configures CLI channel only
+```
+
+### 3. Start and Chat
+
+```bash
+clm agent start my-script
+clm chat my-script
+```
+
+---
+
+## Development Status
+
+ZeroClaw is currently in development. Expected features:
+
+- **v0.1.0** (Target: Q2 2026)
+  - CLI channel support
+  - OpenAI and Anthropic providers
+  - Basic onboarding
+  - Start/stop lifecycle
+
+- **v0.2.0** (Target: Q3 2026)
+  - Ollama support
+  - Log streaming
+  - Secrets management
+
+Track progress: [GitHub Milestone SEA](../milestones)
+
+---
+
+## When to Use ZeroClaw vs OpenClaw
+
+**Choose ZeroClaw when:**
+- ✅ You only need CLI interaction
+- ✅ You want minimal resource usage
+- ✅ You need quick automation scripts
+- ✅ You don't need custom identity
+- ✅ You don't need Discord or web interface
+- ✅ You want fast setup (1-2 minutes)
+
+**Choose OpenClaw when:**
+- ✅ You need Discord or web interface
+- ✅ You want customizable personality
+- ✅ You need external integrations (GitHub, Jira)
+- ✅ You need full feature set
+- ✅ You want multi-provider flexibility
+
+---
+
+## Next Steps
+
+- [OpenClaw Support Matrix](openclaw.md) - Full-featured alternative
+- [Agent Onboarding](../agent-onboarding.md) - Onboarding process overview
+- [CLI Reference](../reference/cli/agent.md) - Command documentation

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -427,15 +427,22 @@ def _run_identity_stage(
 ) -> bool:
     """Run the IDENTITY onboarding stage.
 
+    Creates local identity files and syncs them to the remote workspace.
+
     Args:
         host: Host alias
         claw_type: Claw type
         yes: Skip confirmation prompts
+        installed_name: Agent instance name
 
     Returns:
         True if stage completed successfully
     """
-    console.print("[1/2] Create personality file (SOUL.md)")
+    from clawrium.core.lifecycle import configure_agent
+
+    agent_name = installed_name or claw_type
+
+    console.print("[1/3] Create personality file (SOUL.md)")
 
     if yes:
         personality = "You are a helpful coding assistant focused on reliability and code quality."
@@ -454,15 +461,16 @@ def _run_identity_stage(
         )
         return False
 
+    # Write SOUL.md to agent-specific directory
     config_dir = get_config_dir()
-    soul_dir = config_dir / "agents" / claw_type
-    soul_dir.mkdir(parents=True, exist_ok=True)
-    soul_path = soul_dir / "SOUL.md"
+    identity_dir = config_dir / "agents" / claw_type / agent_name / "identity"
+    identity_dir.mkdir(parents=True, exist_ok=True)
+    soul_path = identity_dir / "SOUL.md"
 
     try:
         _atomic_write_file(
             str(soul_path),
-            f"# {claw_type.upper()} Personality\n\n{personality}\n",
+            f"# {agent_name.upper()} Personality\n\n{personality}\n",
         )
         console.print(f"  [green]✓[/green] Created {soul_path}")
     except Exception as e:
@@ -471,19 +479,79 @@ def _run_identity_stage(
         )
         return False
 
-    console.print("\n[2/2] Create identity file")
+    console.print("\n[2/3] Create identity files")
     console.print("  [green]✓[/green] Using default identity configuration")
 
-    try:
-        complete_stage(
-            host, installed_name or claw_type, "identity", StageStatus.COMPLETE
-        )
-        return True
-    except Exception as e:
-        console.print(
-            f"[red]Error:[/red] Failed to save identity stage: {rich_escape(str(e))}"
-        )
+    # Sync identity files to remote workspace
+    console.print("\n[3/3] Sync identity files to remote workspace")
+
+    # Get existing config to pass to configure_agent
+    host_data = get_host(host)
+    if not host_data:
+        console.print(f"[red]Error:[/red] Host '{host}' not found")
         return False
+
+    claw_record = host_data.get("agents", {}).get(agent_name, {})
+    existing_config = claw_record.get("config", {})
+
+    # If no config exists yet (before providers stage), use minimal config
+    if not existing_config:
+        existing_config = {"gateway": {}, "provider": {}}
+
+    # Validate soul_path is within config directory (prevent path traversal)
+    try:
+        if not soul_path.resolve().is_relative_to(config_dir):
+            console.print(f"[red]Error:[/red] Invalid soul_path: {soul_path}")
+            return False
+    except ValueError:
+        console.print(f"[red]Error:[/red] Invalid soul_path: {soul_path}")
+        return False
+
+    # Trigger workspace sync with identity files
+    identity_files = {
+        "soul_path": str(soul_path),
+        "sync_workspace": True,
+    }
+
+    console.print("  Syncing to remote... ", end="")
+    try:
+        success, error = configure_agent(
+            host,
+            claw_type,
+            existing_config,
+            agent_name=agent_name,
+            extra_vars={"identity_files": identity_files},
+        )
+        if success:
+            console.print("[green]✓[/green]")
+        else:
+            console.print("[red]✗[/red]")
+            console.print(f"  [yellow]Warning:[/yellow] Workspace sync failed: {error}")
+            console.print("  [dim]Identity files saved locally. Sync later with 'clm agent sync'[/dim]")
+            # Don't fail the stage - local files are saved
+    except Exception as e:
+        console.print("[red]✗[/red]")
+        console.print(f"  [yellow]Warning:[/yellow] Workspace sync failed: {rich_escape(str(e))}")
+        console.print("  [dim]Identity files saved locally. Sync later with 'clm agent sync'[/dim]")
+        # Don't fail the stage - local files are saved
+
+    # Only call complete_stage if we're actually in the identity state
+    # Re-runs from other states should not attempt to complete the stage
+    onboarding = claw_record.get("onboarding", {})
+    current_state = onboarding.get("state", "pending")
+
+    if current_state == "identity":
+        try:
+            complete_stage(
+                host, agent_name, "identity", StageStatus.COMPLETE
+            )
+        except Exception as e:
+            console.print(
+                f"[red]Error:[/red] Failed to save identity stage: {rich_escape(str(e))}"
+            )
+            return False
+
+    return True
 
 
 def _sync_channel_config(
@@ -1360,15 +1428,22 @@ def sync(
     claw_name: str = typer.Argument(
         ..., help="Agent instance name to sync (use 'clm agent ps' to list agents)"
     ),
+    workspace: bool = typer.Option(
+        False,
+        "--workspace",
+        "-w",
+        help="Sync workspace files only (no restart)",
+    ),
 ) -> None:
-    """Sync configuration and restart an agent.
+    """Sync configuration and optionally restart an agent.
 
-    Pushes latest configuration to the agent host and restarts the agent
-    to apply changes.
+    Pushes latest configuration to the agent host. By default, restarts
+    the agent to apply changes. Use --workspace for workspace-only sync
+    without restart.
 
     Examples:
         clm agent sync wise-hypatia
-        clm agent sync work-assistant
+        clm agent sync work-assistant --workspace
     """
     from clawrium.core.lifecycle import sync_agent, LifecycleError
 
@@ -1380,23 +1455,24 @@ def sync(
         if not display_host:
             display_host = hostname
 
+        action = "Syncing workspace for" if workspace else "Syncing agent:"
         console.print(
-            f"[green]Syncing agent:[/green] {rich_escape(installed_name)} on {rich_escape(display_host)}"
+            f"[green]{action}[/green] {rich_escape(installed_name)} on {rich_escape(display_host)}"
         )
 
         def on_event(stage: str, message: str) -> None:
-            # W2: Fixed - configure stage gets dim, sync stage gets normal
+            # configure stage gets dim, sync stage gets normal
             if stage == "configure":
                 console.print(f"  [dim]{message}[/dim]")
             else:
                 console.print(f"  {message}")
 
-        # W3: Fixed - always pass agent_name since _resolve_agent_instance resolved it
         try:
             result = sync_agent(
                 hostname,
                 claw_type,
                 agent_name=installed_name,
+                workspace_only=workspace,
                 on_event=on_event,
             )
         except LifecycleError as e:
@@ -1404,10 +1480,13 @@ def sync(
             raise typer.Exit(code=1)
 
         if result["success"]:
-            console.print(
-                "[green]✓[/green] Configuration synced and agent restarted"
-            )
-            console.print("  Run 'clm agent ps' to check status")
+            if workspace:
+                console.print("[green]✓[/green] Workspace synced (no restart)")
+            else:
+                console.print(
+                    "[green]✓[/green] Configuration synced and agent restarted"
+                )
+                console.print("  Run 'clm agent ps' to check status")
         else:
             console.print(f"[red]✗[/red] Failed to sync agent: {result['error']}")
             raise typer.Exit(code=1)

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -6,6 +6,7 @@ This is the primary interface for managing AI assistants.
 import os
 import re
 import tempfile
+from pathlib import Path
 from typing import Optional
 
 import typer
@@ -424,6 +425,7 @@ def _run_identity_stage(
     claw_type: str,
     yes: bool,
     installed_name: str | None = None,
+    identity_files: list[Path] | None = None,
 ) -> bool:
     """Run the IDENTITY onboarding stage.
 
@@ -434,53 +436,87 @@ def _run_identity_stage(
         claw_type: Claw type
         yes: Skip confirmation prompts
         installed_name: Agent instance name
+        identity_files: Optional list of identity files to import
 
     Returns:
         True if stage completed successfully
     """
     from clawrium.core.lifecycle import configure_agent
+    import shutil
 
     agent_name = installed_name or claw_type
-
-    console.print("[1/3] Create personality file (SOUL.md)")
-
-    if yes:
-        personality = "You are a helpful coding assistant focused on reliability and code quality."
-    else:
-        console.print(
-            "  Describe your agent's personality (max 2000 chars, press Enter for default):"
-        )
-        personality = typer.prompt(
-            "> ",
-            default="You are a helpful coding assistant focused on reliability and code quality.",
-        )
-
-    if len(personality) > 2000:
-        console.print(
-            "[red]Error:[/red] Personality description exceeds 2000 character limit"
-        )
-        return False
-
-    # Write SOUL.md to agent-specific directory
     config_dir = get_config_dir()
     identity_dir = config_dir / "agents" / claw_type / agent_name / "identity"
     identity_dir.mkdir(parents=True, exist_ok=True)
-    soul_path = identity_dir / "SOUL.md"
 
-    try:
-        _atomic_write_file(
-            str(soul_path),
-            f"# {agent_name.upper()} Personality\n\n{personality}\n",
-        )
-        console.print(f"  [green]✓[/green] Created {soul_path}")
-    except Exception as e:
-        console.print(
-            f"[red]Error:[/red] Failed to write SOUL.md: {rich_escape(str(e))}"
-        )
-        return False
+    # If files provided via --file, copy them to identity directory
+    if identity_files:
+        console.print("[1/3] Import identity files")
+        for src_file in identity_files:
+            dest_file = identity_dir / src_file.name
+            try:
+                shutil.copy2(src_file, dest_file)
+                console.print(f"  [green]✓[/green] Imported {src_file.name}")
+            except Exception as e:
+                console.print(
+                    f"[red]Error:[/red] Failed to copy {src_file.name}: {rich_escape(str(e))}"
+                )
+                return False
+
+        # Check if SOUL.md was provided, if not create default
+        soul_path = identity_dir / "SOUL.md"
+        if not soul_path.exists():
+            console.print("  [dim]SOUL.md not provided, creating default...[/dim]")
+            try:
+                _atomic_write_file(
+                    str(soul_path),
+                    f"# {agent_name.upper()} Personality\n\nYou are a helpful coding assistant focused on reliability and code quality.\n",
+                )
+                console.print("  [green]✓[/green] Created default SOUL.md")
+            except Exception as e:
+                console.print(
+                    f"[red]Error:[/red] Failed to write SOUL.md: {rich_escape(str(e))}"
+                )
+                return False
+    else:
+        # Interactive mode - prompt for personality
+        console.print("[1/3] Create personality file (SOUL.md)")
+
+        if yes:
+            personality = "You are a helpful coding assistant focused on reliability and code quality."
+        else:
+            console.print(
+                "  Describe your agent's personality (max 2000 chars, press Enter for default):"
+            )
+            personality = typer.prompt(
+                "> ",
+                default="You are a helpful coding assistant focused on reliability and code quality.",
+            )
+
+        if len(personality) > 2000:
+            console.print(
+                "[red]Error:[/red] Personality description exceeds 2000 character limit"
+            )
+            return False
+
+        soul_path = identity_dir / "SOUL.md"
+
+        try:
+            _atomic_write_file(
+                str(soul_path),
+                f"# {agent_name.upper()} Personality\n\n{personality}\n",
+            )
+            console.print(f"  [green]✓[/green] Created {soul_path}")
+        except Exception as e:
+            console.print(
+                f"[red]Error:[/red] Failed to write SOUL.md: {rich_escape(str(e))}"
+            )
+            return False
 
     console.print("\n[2/3] Create identity files")
     console.print("  [green]✓[/green] Using default identity configuration")
+
+    soul_path = identity_dir / "SOUL.md"
 
     # Sync identity files to remote workspace
     console.print("\n[3/3] Sync identity files to remote workspace")
@@ -508,7 +544,7 @@ def _run_identity_stage(
         return False
 
     # Trigger workspace sync with identity files
-    identity_files = {
+    identity_vars = {
         "soul_path": str(soul_path),
         "sync_workspace": True,
     }
@@ -520,7 +556,7 @@ def _run_identity_stage(
             claw_type,
             existing_config,
             agent_name=agent_name,
-            extra_vars={"identity_files": identity_files},
+            extra_vars={"identity_files": identity_vars},
         )
         if success:
             console.print("[green]✓[/green]")
@@ -875,6 +911,10 @@ def _run_validate_stage(
         return False
 
 
+# Allowed identity file names for --file option
+IDENTITY_FILE_ALLOWLIST = {"SOUL.md", "AGENTS.md", "TOOLS.md", "IDENTITY.md"}
+
+
 @agent_app.command()
 def configure(
     claw_name: str = typer.Argument(
@@ -887,6 +927,14 @@ def configure(
         help="Run single stage (providers, identity, channels, validate)",
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip prompts, use defaults"),
+    file: Optional[list[Path]] = typer.Option(
+        None,
+        "--file",
+        "-f",
+        help="Import identity file (SOUL.md, AGENTS.md, TOOLS.md, IDENTITY.md). Repeatable. Only valid with --stage identity.",
+        exists=True,
+        readable=True,
+    ),
 ) -> None:
     """Configure agent settings through an interactive wizard.
 
@@ -897,7 +945,26 @@ def configure(
         clm agent configure wise-hypatia
         clm agent configure clever-einstein --stage providers
         clm agent configure work-assistant --yes
+        clm agent configure wolf-i --stage identity --file ~/SOUL.md
     """
+    # Validate --file is only used with --stage identity
+    if file and stage != "identity":
+        console.print(
+            "[red]Error:[/red] --file can only be used with --stage identity"
+        )
+        raise typer.Exit(code=1)
+
+    # Validate file names are in allowlist
+    if file:
+        for f in file:
+            if f.name not in IDENTITY_FILE_ALLOWLIST:
+                console.print(
+                    f"[red]Error:[/red] Invalid identity file '{rich_escape(f.name)}'"
+                )
+                console.print(
+                    f"Allowed files: {', '.join(sorted(IDENTITY_FILE_ALLOWLIST))}"
+                )
+                raise typer.Exit(code=1)
     try:
         (
             hostname,
@@ -968,7 +1035,10 @@ def configure(
         }[stage]
 
         try:
-            success = stage_func(hostname, claw_type, yes, installed_name)
+            if stage == "identity":
+                success = stage_func(hostname, claw_type, yes, installed_name, file)
+            else:
+                success = stage_func(hostname, claw_type, yes, installed_name)
         except KeyboardInterrupt:
             console.print("\nCancelled.")
             raise typer.Exit(code=1)

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -7,6 +7,7 @@ running on remote hosts via systemd service management.
 import logging
 import os
 import re
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, TypedDict
@@ -92,6 +93,30 @@ def _get_logs_dir() -> Path:
     logs_dir = get_config_dir() / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
     return logs_dir
+
+
+def _cleanup_ansible_artifacts(operation_log_dir: Path) -> None:
+    """Clean up ansible-runner artifacts that may contain secrets.
+
+    B3 fix: ansible-runner stores inventory and vars in artifacts/,
+    which can contain API keys and tokens. Remove after all runs.
+    """
+    artifacts_dir = operation_log_dir / "artifacts"
+    if artifacts_dir.exists():
+        try:
+            shutil.rmtree(artifacts_dir)
+            logger.debug("Cleaned up ansible artifacts at %s", artifacts_dir)
+        except Exception as e:
+            logger.warning("Failed to clean up ansible artifacts: %s", e)
+
+    # Also clean up env/ directory which may contain inventory with secrets
+    env_dir = operation_log_dir / "env"
+    if env_dir.exists():
+        try:
+            shutil.rmtree(env_dir)
+            logger.debug("Cleaned up ansible env at %s", env_dir)
+        except Exception as e:
+            logger.warning("Failed to clean up ansible env: %s", e)
 
 
 def _resolve_agent_record(
@@ -273,6 +298,9 @@ def _run_lifecycle_playbook(
 
     except Exception as e:
         return False, str(e)
+    finally:
+        # W4 fix: Always clean up artifacts containing secrets (success, failure, or exception)
+        _cleanup_ansible_artifacts(operation_log_dir)
 
 
 def start_agent(
@@ -496,17 +524,19 @@ def sync_agent(
     hostname: str,
     claw_name: str,
     agent_name: str | None = None,
+    workspace_only: bool = False,
     on_event: Callable[[str, str], None] | None = None,
 ) -> LifecycleResult:
-    """Sync configuration and restart an agent instance.
+    """Sync configuration and optionally restart an agent instance.
 
-    Orchestrates: configure_agent -> restart_agent.
+    Orchestrates: configure_agent -> restart_agent (unless workspace_only).
     This is a single command to ensure an agent is running the latest configuration.
 
     Args:
         hostname: Hostname or alias of target host
         claw_name: Type of agent to sync (e.g., "openclaw")
         agent_name: Optional specific instance name
+        workspace_only: If True, only sync workspace files without restarting
         on_event: Optional callback for progress events
 
     Returns:
@@ -531,7 +561,8 @@ def sync_agent(
         raise LifecycleError(f"Agent '{target}' not installed on '{hostname}'")
     agent_key, agent_type, claw_record = resolved
 
-    # B1: Check onboarding state - agent must be READY to sync
+    # Check onboarding state - agent must be past PENDING to sync
+    # This allows syncing during onboarding (e.g., after identity stage)
     onboarding = claw_record.get("onboarding", {})
     state_value = onboarding.get("state", "pending")
 
@@ -540,11 +571,17 @@ def sync_agent(
     except ValueError:
         state = OnboardingState.PENDING
 
-    if state != OnboardingState.READY:
+    if state == OnboardingState.PENDING:
         raise LifecycleError(
-            f"Cannot sync {agent_key}: onboarding incomplete (state={state_value}). "
+            f"Cannot sync {agent_key}: onboarding not started (state={state_value}). "
             f"Run 'clm agent configure {agent_key}' first."
         )
+
+    # Auto-coerce workspace_only=True for non-READY states
+    # start_agent() enforces state==READY, so restart would fail
+    if state != OnboardingState.READY and not workspace_only:
+        workspace_only = True
+        emit("sync", f"Note: Agent not fully onboarded (state={state_value}), syncing workspace only")
 
     # Get existing config to re-apply
     existing_config = claw_record.get("config", {})
@@ -575,8 +612,20 @@ def sync_agent(
             "error": f"Configure failed: {config_error}",
         }
 
-    # Step 2: Restart agent
-    # B2: Wrap in try/except to maintain LifecycleResult return contract
+    # Step 2: Restart agent (unless workspace_only)
+    if workspace_only:
+        emit("sync", f"Workspace sync complete for {agent_key} (no restart)")
+        return {
+            "success": True,
+            "agent": agent_key,
+            "host": hostname,
+            "operation": "sync",
+            "pid": None,
+            "started_at": None,
+            "error": None,
+        }
+
+    # Wrap in try/except to maintain LifecycleResult return contract
     emit("sync", f"Restarting {agent_key}...")
     try:
         restart_result = restart_agent(
@@ -625,6 +674,7 @@ def configure_agent(
     claw_name: str,
     config_data: dict,
     agent_name: str | None = None,
+    extra_vars: dict | None = None,
     on_event: Callable[[str, str], None] | None = None,
 ) -> tuple[bool, str | None]:
     """Configure an agent instance on a remote host.
@@ -637,6 +687,8 @@ def configure_agent(
         hostname: Hostname or alias of target host
         claw_name: Type of agent to configure (e.g., "zeroclaw", "openclaw")
         config_data: Configuration dictionary containing gateway and provider settings
+        agent_name: Optional specific instance name
+        extra_vars: Optional extra Ansible vars (not persisted to hosts.json)
         on_event: Optional callback for progress events
 
     Returns:
@@ -722,7 +774,7 @@ def configure_agent(
             discord_bot_token = instance_secrets["DISCORD_BOT_TOKEN"]["value"]
             emit("configure", "Loaded Discord bot token from secrets")
     except Exception as e:
-        logger.warning("Failed to load Discord bot token for %s: %s", agent_name, e)
+        logger.warning("Failed to load Discord bot token for %s: %s", agent_key, e)
 
     # Get template path for this agent type
     canonical_name = _resolve_agent_type(resolved_type)
@@ -759,6 +811,19 @@ def configure_agent(
         )
 
     # Build Ansible inventory with API key passed directly
+    ansible_vars = {
+        "agent_name": unix_agent_name,
+        "agent_type": resolved_type,
+        "config": config_data,
+        "template_path": str(template_path),
+        "provider_api_key": provider_api_key,
+        "discord_bot_token": discord_bot_token,
+    }
+
+    # Merge extra_vars (not persisted to hosts.json)
+    if extra_vars:
+        ansible_vars.update(extra_vars)
+
     inventory = {
         "all": {
             "hosts": {
@@ -768,14 +833,7 @@ def configure_agent(
                     "ansible_ssh_private_key_file": str(ssh_key),
                 }
             },
-            "vars": {
-                "agent_name": unix_agent_name,
-                "agent_type": resolved_type,
-                "config": config_data,
-                "template_path": str(template_path),
-                "provider_api_key": provider_api_key,
-                "discord_bot_token": discord_bot_token,
-            },
+            "vars": ansible_vars,
         }
     }
 
@@ -858,6 +916,9 @@ def configure_agent(
 
     except Exception as e:
         return False, str(e)
+    finally:
+        # W4 fix: Always clean up artifacts containing secrets (success, failure, or exception)
+        _cleanup_ansible_artifacts(operation_log_dir)
 
 
 def remove_agent(

--- a/src/clawrium/core/validation.py
+++ b/src/clawrium/core/validation.py
@@ -101,17 +101,31 @@ WARNING_MESSAGES = {
 }
 
 
-def validate_soul_md(claw_type: str) -> ValidationResult:
+def validate_soul_md(claw_type: str, agent_name: str | None = None) -> ValidationResult:
     """Validate SOUL.md personality file exists and is readable.
 
     Args:
         claw_type: Type of claw (e.g., "openclaw", "zeroclaw").
+        agent_name: Optional agent instance name. If provided, checks
+            the new agent-specific identity path first.
 
     Returns:
         ValidationResult with pass/fail status and any errors/warnings.
     """
     config_dir = get_config_dir()
-    soul_path = config_dir / "agents" / claw_type / "SOUL.md"
+
+    # Check new agent-specific path first (if agent_name provided)
+    # New path: agents/<type>/<agent-name>/identity/SOUL.md
+    if agent_name:
+        new_path = config_dir / "agents" / claw_type / agent_name / "identity" / "SOUL.md"
+        if new_path.exists():
+            soul_path = new_path
+        else:
+            # Fall back to legacy path
+            soul_path = config_dir / "agents" / claw_type / "SOUL.md"
+    else:
+        # Legacy path: agents/<type>/SOUL.md
+        soul_path = config_dir / "agents" / claw_type / "SOUL.md"
 
     if not soul_path.exists():
         return ValidationResult(

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -29,6 +29,51 @@
         group: "{{ agent_name }}"
         mode: "0700"
 
+    # Workspace setup for identity files
+    - name: Ensure workspace directory exists
+      ansible.builtin.file:
+        path: "/home/{{ agent_name }}/.openclaw/workspace"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0700"
+
+    - name: Copy SOUL.md to workspace
+      ansible.builtin.copy:
+        src: "{{ identity_files.soul_path }}"
+        dest: "/home/{{ agent_name }}/.openclaw/workspace/SOUL.md"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0644"
+      when: identity_files is defined and identity_files.soul_path is defined
+
+    - name: Render AGENTS.md from template
+      ansible.builtin.template:
+        src: "{{ template_path }}/AGENTS.md.j2"
+        dest: "/home/{{ agent_name }}/.openclaw/workspace/AGENTS.md"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0644"
+      when: identity_files is defined and identity_files.sync_workspace | default(false)
+
+    - name: Render TOOLS.md from template
+      ansible.builtin.template:
+        src: "{{ template_path }}/TOOLS.md.j2"
+        dest: "/home/{{ agent_name }}/.openclaw/workspace/TOOLS.md"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0644"
+      when: identity_files is defined and identity_files.sync_workspace | default(false)
+
+    - name: Render IDENTITY.md from template
+      ansible.builtin.template:
+        src: "{{ template_path }}/IDENTITY.md.j2"
+        dest: "/home/{{ agent_name }}/.openclaw/workspace/IDENTITY.md"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0644"
+      when: identity_files is defined and identity_files.sync_workspace | default(false)
+
     - name: Write openclaw .env from template
       ansible.builtin.template:
         src: "{{ template_path }}/.env.j2"
@@ -50,74 +95,44 @@
       when: config.provider is defined and config.provider.default_model is defined
       notify: Restart openclaw service
 
-    - name: Verify openclaw.json configuration
-      no_log: true
-      ansible.builtin.shell: |
-        CONFIG_FILE="/home/{{ agent_name }}/.openclaw/openclaw.json"
-        if [ ! -f "$CONFIG_FILE" ]; then
-          echo "ERROR: Configuration file not found at $CONFIG_FILE"
-          exit 1
-        fi
-
-        # Verify JSON is valid
-        if ! python3 -m json.tool "$CONFIG_FILE" > /dev/null 2>&1; then
-          echo "ERROR: Invalid JSON in $CONFIG_FILE"
-          exit 1
-        fi
-
-        # Verify critical fields using Python JSON parsing
-        # Pass expected values as command-line args to avoid shell injection
-        python3 - "$CONFIG_FILE" {{ config | to_json | quote }} << 'EOF'
-        import json
-        import sys
-
-        config_file = sys.argv[1]
-        expected_config = json.loads(sys.argv[2])
-
-        with open(config_file, "r") as f:
-            config = json.load(f)
-
-        errors = []
-
-        # Verify model is set if provider configured
-        if expected_config.get("provider", {}).get("default_model"):
-            model = config.get("agents", {}).get("defaults", {}).get("model")
-            expected_model = expected_config["provider"]["default_model"]
-            if not model or expected_model not in str(model):
-                errors.append(
-                    f"Model '{expected_model}' not found in agents.defaults.model"
-                )
-
-        # Verify gateway port
-        if expected_config.get("gateway", {}).get("port"):
-            gateway_port = config.get("gateway", {}).get("port")
-            expected_port = expected_config["gateway"]["port"]
-            if gateway_port != expected_port:
-                errors.append(
-                    f"Gateway port mismatch: expected {expected_port}, got {gateway_port}"
-                )
-
-        # Verify gateway bind
-        if expected_config.get("gateway", {}).get("bind"):
-            gateway_bind = config.get("gateway", {}).get("bind")
-            expected_bind = expected_config["gateway"]["bind"]
-            if gateway_bind != expected_bind:
-                errors.append(
-                    f"Gateway bind mismatch: expected {expected_bind}, got {gateway_bind}"
-                )
-
-        if errors:
-            for error in errors:
-                print(f"ERROR: {error}", file=sys.stderr)
-            sys.exit(1)
-
-        print("Configuration verified successfully")
-        EOF
-      args:
-        executable: /bin/bash
-      register: verify_config
-      failed_when: verify_config.rc != 0
+    # B1/B2/B3 fix: Wrap verification in block/always for cleanup; use command not script
+    - name: Config verification block
       when: config.provider is defined and config.provider.default_model is defined
+      block:
+        - name: Write expected config for verification
+          no_log: true
+          ansible.builtin.copy:
+            content: "{{ config | to_json }}"
+            dest: "/tmp/clawrium_expected_config_{{ agent_name }}.json"
+            mode: "0600"
+
+        - name: Copy verify script to remote
+          ansible.builtin.copy:
+            src: "{{ template_path }}/verify_config.py"
+            dest: "/tmp/clawrium_verify_config_{{ agent_name }}.py"
+            mode: "0700"
+
+        - name: Verify openclaw.json configuration
+          no_log: true
+          ansible.builtin.command:
+            argv:
+              - python3
+              - "/tmp/clawrium_verify_config_{{ agent_name }}.py"
+              - "/home/{{ agent_name }}/.openclaw/openclaw.json"
+              - "/tmp/clawrium_expected_config_{{ agent_name }}.json"
+          register: verify_config
+          failed_when: verify_config.rc != 0
+
+      always:
+        - name: Clean up expected config temp file
+          ansible.builtin.file:
+            path: "/tmp/clawrium_expected_config_{{ agent_name }}.json"
+            state: absent
+
+        - name: Clean up verify script
+          ansible.builtin.file:
+            path: "/tmp/clawrium_verify_config_{{ agent_name }}.py"
+            state: absent
 
     - name: Ensure service is enabled
       ansible.builtin.systemd:

--- a/src/clawrium/platform/registry/openclaw/templates/AGENTS.md.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/AGENTS.md.j2
@@ -1,0 +1,41 @@
+# Sub-Agents
+
+This file defines sub-agents that can be delegated tasks by the primary agent.
+
+## Available Sub-Agents
+
+Define specialized sub-agents for different task domains.
+
+### Default Sub-Agent
+
+```yaml
+name: assistant
+description: General-purpose assistant for common tasks
+capabilities:
+  - Answer questions
+  - Provide explanations
+  - Help with basic tasks
+```
+
+## Sub-Agent Configuration
+
+Sub-agents inherit the primary agent's model configuration unless overridden.
+
+### Example Custom Sub-Agent
+
+```yaml
+name: code-reviewer
+description: Specialized agent for code review tasks
+model: {{ (config.provider | default({})).default_model | default('default') }}
+capabilities:
+  - Static code analysis
+  - Best practices review
+  - Security vulnerability detection
+  - Performance suggestions
+```
+
+## Delegation Rules
+
+- Delegate specialized tasks to appropriate sub-agents
+- Primary agent handles general queries and coordination
+- Sub-agents report results back to primary agent

--- a/src/clawrium/platform/registry/openclaw/templates/IDENTITY.md.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/IDENTITY.md.j2
@@ -1,0 +1,38 @@
+# Agent Identity
+
+Metadata and context for this agent instance.
+
+## Instance Information
+
+**Agent Name**: {{ agent_name }}
+**Agent Type**: {{ agent_type }}
+**Created**: {{ ansible_date_time.iso8601 | default('unknown') }}
+
+## Configuration
+
+**Model**: {{ (config.provider | default({})).default_model | default('not configured') }}
+**Provider**: {{ (config.provider | default({})).type | default('not configured') }}
+**Gateway Port**: {{ (config.gateway | default({})).port | default('not configured') }}
+
+## Workspace
+
+**Location**: /home/{{ agent_name }}/.openclaw/workspace/
+**Files**:
+- SOUL.md - Agent personality and behavior
+- AGENTS.md - Sub-agent definitions
+- TOOLS.md - Tool usage guidance
+- IDENTITY.md - This file
+
+## Management
+
+This agent is managed by Clawrium.
+
+**Commands**:
+- `clm agent ps` - Check agent status
+- `clm agent sync {{ agent_name }}` - Sync configuration
+- `clm agent restart {{ agent_name }}` - Restart agent
+- `clm agent stop {{ agent_name }}` - Stop agent
+
+## Notes
+
+Add any instance-specific notes or context here.

--- a/src/clawrium/platform/registry/openclaw/templates/TOOLS.md.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/TOOLS.md.j2
@@ -1,0 +1,53 @@
+# Tools
+
+This file provides guidance on tool usage for the agent.
+
+## Available Tools
+
+The agent has access to the following tool categories:
+
+### File Operations
+- Read files from the workspace
+- Write and edit files
+- Search file contents
+
+### Shell Commands
+- Execute shell commands (with user approval)
+- Run scripts and build tools
+- Manage processes
+
+### Web Access
+- Fetch web pages
+- Search the web
+- Access APIs
+
+## Tool Usage Guidelines
+
+### Safety First
+- Always confirm destructive operations with the user
+- Never execute commands that could compromise security
+- Validate inputs before passing to tools
+
+### Efficiency
+- Batch related operations when possible
+- Use appropriate tools for the task
+- Avoid unnecessary network calls
+
+### Transparency
+- Explain what tools will be used and why
+- Report tool results clearly
+- Handle errors gracefully
+
+## Tool Restrictions
+
+The following operations require explicit user confirmation:
+- File deletion
+- System configuration changes
+- Network operations to unknown hosts
+- Installation of packages or dependencies
+
+## Custom Tool Configuration
+
+Agent-specific tool settings:
+- Workspace: {{ config.workspace | default('~/.openclaw/workspace') }}
+- Sandbox mode: {{ config.sandbox_mode | default('off') }}

--- a/src/clawrium/platform/registry/openclaw/templates/verify_config.py
+++ b/src/clawrium/platform/registry/openclaw/templates/verify_config.py
@@ -12,7 +12,10 @@ import sys
 
 def main():
     if len(sys.argv) != 3:
-        print("Usage: verify_config.py <config_file> <expected_config_file>", file=sys.stderr)
+        print(
+            "Usage: verify_config.py <config_file> <expected_config_file>",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     config_file = sys.argv[1]
@@ -34,7 +37,9 @@ def main():
         with open(expected_file, "r") as f:
             expected_config = json.load(f)
     except FileNotFoundError:
-        print(f"ERROR: Expected config file not found at {expected_file}", file=sys.stderr)
+        print(
+            f"ERROR: Expected config file not found at {expected_file}", file=sys.stderr
+        )
         sys.exit(1)
     except json.JSONDecodeError:
         print(f"ERROR: Invalid JSON in {expected_file}", file=sys.stderr)
@@ -42,19 +47,39 @@ def main():
 
     errors = []
 
+    def _expected_model_id(expected: dict) -> str | None:
+        provider = expected.get("provider", {})
+        default_model = provider.get("default_model")
+        if not default_model:
+            return None
+
+        provider_type = provider.get("type")
+        if provider_type == "openrouter" and not str(default_model).startswith(
+            "openrouter/"
+        ):
+            return f"openrouter/{default_model}"
+        if provider_type == "ollama" and not str(default_model).startswith("ollama/"):
+            return f"ollama/{default_model}"
+        return str(default_model)
+
     # Verify model is set if provider configured
-    # W2 fix: Use exact equality instead of substring matching
-    if expected_config.get("provider", {}).get("default_model"):
+    expected_model = _expected_model_id(expected_config)
+    if expected_model:
         model = config.get("agents", {}).get("defaults", {}).get("model")
-        expected_model = expected_config["provider"]["default_model"]
-        if not model:
+        if not isinstance(model, dict):
             errors.append(
-                f"Model not found in agents.defaults.model, expected '{expected_model}'"
+                "Model schema mismatch: expected agents.defaults.model to be an object with key 'primary'"
             )
-        elif str(model) != expected_model:
-            errors.append(
-                f"Model mismatch: expected '{expected_model}', got '{model}'"
-            )
+        else:
+            actual_model = model.get("primary")
+            if not actual_model:
+                errors.append(
+                    "Model schema mismatch: missing agents.defaults.model.primary"
+                )
+            elif str(actual_model) != expected_model:
+                errors.append(
+                    f"Model mismatch: expected '{expected_model}', got '{actual_model}'"
+                )
 
     # Verify gateway port
     if expected_config.get("gateway", {}).get("port"):

--- a/src/clawrium/platform/registry/openclaw/templates/verify_config.py
+++ b/src/clawrium/platform/registry/openclaw/templates/verify_config.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Verify openclaw.json configuration against expected values.
+
+This script is called by Ansible to verify the configuration file
+was rendered correctly. It reads the actual and expected config files
+and validates critical fields match.
+"""
+
+import json
+import sys
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: verify_config.py <config_file> <expected_config_file>", file=sys.stderr)
+        sys.exit(1)
+
+    config_file = sys.argv[1]
+    expected_file = sys.argv[2]
+
+    # Verify config file exists
+    try:
+        with open(config_file, "r") as f:
+            config = json.load(f)
+    except FileNotFoundError:
+        print(f"ERROR: Configuration file not found at {config_file}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError:
+        print(f"ERROR: Invalid JSON in {config_file}", file=sys.stderr)
+        sys.exit(1)
+
+    # Load expected config
+    try:
+        with open(expected_file, "r") as f:
+            expected_config = json.load(f)
+    except FileNotFoundError:
+        print(f"ERROR: Expected config file not found at {expected_file}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError:
+        print(f"ERROR: Invalid JSON in {expected_file}", file=sys.stderr)
+        sys.exit(1)
+
+    errors = []
+
+    # Verify model is set if provider configured
+    # W2 fix: Use exact equality instead of substring matching
+    if expected_config.get("provider", {}).get("default_model"):
+        model = config.get("agents", {}).get("defaults", {}).get("model")
+        expected_model = expected_config["provider"]["default_model"]
+        if not model:
+            errors.append(
+                f"Model not found in agents.defaults.model, expected '{expected_model}'"
+            )
+        elif str(model) != expected_model:
+            errors.append(
+                f"Model mismatch: expected '{expected_model}', got '{model}'"
+            )
+
+    # Verify gateway port
+    if expected_config.get("gateway", {}).get("port"):
+        gateway_port = config.get("gateway", {}).get("port")
+        expected_port = expected_config["gateway"]["port"]
+        if gateway_port != expected_port:
+            errors.append(
+                f"Gateway port mismatch: expected {expected_port}, got {gateway_port}"
+            )
+
+    # Verify gateway bind
+    if expected_config.get("gateway", {}).get("bind"):
+        gateway_bind = config.get("gateway", {}).get("bind")
+        expected_bind = expected_config["gateway"]["bind"]
+        if gateway_bind != expected_bind:
+            errors.append(
+                f"Gateway bind mismatch: expected {expected_bind}, got {gateway_bind}"
+            )
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        sys.exit(1)
+
+    print("Configuration verified successfully")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -237,9 +237,15 @@ class TestAgentConfigureSingleStage:
             )
 
             assert result.exit_code == 0
-            mock_run.assert_called_once_with(
-                "192.168.1.100", "openclaw", True, "assistant"
-            )
+            # Identity stage has extra identity_files parameter (None when not provided)
+            if stage_name == "identity":
+                mock_run.assert_called_once_with(
+                    "192.168.1.100", "openclaw", True, "assistant", None
+                )
+            else:
+                mock_run.assert_called_once_with(
+                    "192.168.1.100", "openclaw", True, "assistant"
+                )
 
     def test_single_stage_failure(self, isolated_config: Path):
         """Stage failure exits with code 1."""

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -441,15 +441,42 @@ class TestRunIdentityStage:
         assert result is False
 
     def test_creates_soul_md_file(self, isolated_config: Path):
-        """Creates SOUL.md in config directory."""
+        """Creates SOUL.md in agent-specific identity directory and syncs to remote."""
         from clawrium.cli.agent import _run_identity_stage
+        from unittest.mock import MagicMock
+
+        mock_host = {
+            "hostname": "192.168.1.100",
+            "agents": {
+                "openclaw": {
+                    "type": "openclaw",
+                    "config": {},
+                    "onboarding": {"state": "identity"},
+                }
+            },
+        }
+
+        mock_configure = MagicMock(return_value=(True, None))
 
         with patch("clawrium.cli.agent.complete_stage"):
-            result = _run_identity_stage("work", "openclaw", True)
+            with patch("clawrium.cli.agent.get_host", return_value=mock_host):
+                with patch(
+                    "clawrium.core.lifecycle.configure_agent", mock_configure
+                ):
+                    result = _run_identity_stage("work", "openclaw", True)
 
         assert result is True
-        soul_path = isolated_config / "agents" / "openclaw" / "SOUL.md"
+        # New path: agents/<type>/<agent-name>/identity/SOUL.md
+        soul_path = isolated_config / "agents" / "openclaw" / "openclaw" / "identity" / "SOUL.md"
         assert soul_path.exists()
+
+        # Verify configure_agent was called with identity_files in extra_vars
+        mock_configure.assert_called_once()
+        call_kwargs = mock_configure.call_args.kwargs
+        assert "extra_vars" in call_kwargs
+        assert "identity_files" in call_kwargs["extra_vars"]
+        assert call_kwargs["extra_vars"]["identity_files"]["sync_workspace"] is True
+        assert "soul_path" in call_kwargs["extra_vars"]["identity_files"]
 
 
 class TestRunChannelsStage:

--- a/tests/test_cli_agent_lifecycle.py
+++ b/tests/test_cli_agent_lifecycle.py
@@ -356,7 +356,7 @@ class TestAgentSync:
 
         result = runner.invoke(app, ["agent", "sync", "assistant"])
         assert result.exit_code == 1
-        assert "onboarding incomplete" in result.output
+        assert "onboarding not started" in result.output
 
     def test_sync_agent_no_config_fails(self, isolated_config: Path):
         """Sync when agent has no config fails."""
@@ -532,3 +532,116 @@ class TestAgentSync:
         assert result.exit_code == 1
         assert "Failed to sync" in result.output
         assert "Restart failed" in result.output
+
+    def test_sync_with_workspace_flag_skips_restart(
+        self, isolated_config: Path, tmp_path: Path
+    ):
+        """Sync with --workspace flag skips restart and shows correct message."""
+        hosts_file = isolated_config / "hosts.json"
+        isolated_config.mkdir(parents=True, exist_ok=True)
+
+        hosts_data = [
+            {
+                "hostname": "192.168.1.100",
+                "key_id": "work",
+                "port": 22,
+                "agent_name": "xclm",
+                "alias": "work",
+                "agents": {
+                    "assistant": {
+                        "type": "openclaw",
+                        "config": {
+                            "gateway": {"port": 40000},
+                            "provider": {
+                                "name": "test",
+                                "type": "ollama",
+                                "endpoint": "http://localhost:11434",
+                                "default_model": "llama3",
+                            },
+                        },
+                        "onboarding": {"state": "ready"},
+                    }
+                },
+            }
+        ]
+        hosts_file.write_text(json.dumps(hosts_data, indent=2))
+
+        with patch(
+            "clawrium.core.lifecycle.configure_agent",
+            return_value=(True, None),
+        ) as mock_configure:
+            with patch(
+                "clawrium.core.lifecycle.restart_agent",
+            ) as mock_restart:
+                result = runner.invoke(
+                    app, ["agent", "sync", "assistant", "--workspace"]
+                )
+
+        assert result.exit_code == 0
+        assert "Syncing workspace for" in result.output
+        assert "Workspace synced (no restart)" in result.output
+        # Configure should be called
+        mock_configure.assert_called_once()
+        # Restart should NOT be called
+        mock_restart.assert_not_called()
+
+    def test_sync_without_workspace_flag_calls_restart(
+        self, isolated_config: Path, tmp_path: Path
+    ):
+        """B4/B6 fix: Sync without --workspace flag calls restart_agent with correct args."""
+        hosts_file = isolated_config / "hosts.json"
+        isolated_config.mkdir(parents=True, exist_ok=True)
+
+        hosts_data = [
+            {
+                "hostname": "192.168.1.100",
+                "key_id": "work",
+                "port": 22,
+                "agent_name": "xclm",
+                "alias": "work",
+                "agents": {
+                    "assistant": {
+                        "type": "openclaw",
+                        "config": {
+                            "gateway": {"port": 40000},
+                            "provider": {
+                                "name": "test",
+                                "type": "ollama",
+                                "endpoint": "http://localhost:11434",
+                                "default_model": "llama3",
+                            },
+                        },
+                        "onboarding": {"state": "ready"},
+                    }
+                },
+            }
+        ]
+        hosts_file.write_text(json.dumps(hosts_data, indent=2))
+
+        with patch(
+            "clawrium.core.lifecycle.configure_agent",
+            return_value=(True, None),
+        ) as mock_configure:
+            with patch(
+                "clawrium.core.lifecycle.restart_agent",
+                return_value={
+                    "success": True,
+                    "agent": "assistant",
+                    "host": "192.168.1.100",
+                    "operation": "restart",
+                    "pid": None,
+                    "started_at": "2026-04-14T12:00:00Z",
+                    "error": None,
+                },
+            ) as mock_restart:
+                result = runner.invoke(app, ["agent", "sync", "assistant"])
+
+        assert result.exit_code == 0
+        # Configure should be called
+        mock_configure.assert_called_once()
+        # B6 fix: Verify restart_agent called with correct arguments
+        mock_restart.assert_called_once()
+        call_args = mock_restart.call_args
+        assert call_args.args[0] == "192.168.1.100"  # hostname
+        assert call_args.args[1] == "openclaw"  # agent_type
+        assert call_args.kwargs.get("agent_name") == "assistant"

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -15,6 +15,7 @@ from clawrium.core.lifecycle import (
     _get_lifecycle_playbook_path,
     _run_lifecycle_playbook,
     _resolve_agent_record,
+    _cleanup_ansible_artifacts,
 )
 
 
@@ -771,7 +772,7 @@ class TestSyncAgent:
             with pytest.raises(LifecycleError) as exc_info:
                 sync_agent("192.168.1.100", "openclaw")
 
-        assert "onboarding incomplete" in str(exc_info.value)
+        assert "onboarding not started" in str(exc_info.value)
 
     def test_raises_error_when_no_config(self):
         """Sync when no config exists fails."""
@@ -1078,3 +1079,162 @@ class TestSyncAgent:
         assert "Syncing" in sync_events[0][1]
         # Last should be "Sync complete"
         assert "complete" in sync_events[-1][1].lower()
+
+    def test_workspace_only_skips_restart(self):
+        """workspace_only=True skips restart step."""
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "opc-work": {
+                    "type": "openclaw",
+                    "onboarding": {"state": "ready"},
+                    "config": {
+                        "gateway": {"port": 40000},
+                        "provider": {
+                            "name": "test",
+                            "type": "ollama",
+                            "endpoint": "http://localhost:11434",
+                            "default_model": "llama3",
+                        },
+                    },
+                }
+            },
+        }
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle.configure_agent",
+                return_value=(True, None),
+            ) as mock_configure:
+                with patch(
+                    "clawrium.core.lifecycle.restart_agent"
+                ) as mock_restart:
+                    result = sync_agent(
+                        "192.168.1.100", "openclaw", workspace_only=True
+                    )
+
+        assert result["success"] is True
+        assert result["operation"] == "sync"
+        # Configure should be called
+        mock_configure.assert_called_once()
+        # Restart should NOT be called
+        mock_restart.assert_not_called()
+
+    def test_allows_intermediate_onboarding_states(self):
+        """Sync allows onboarding states after PENDING (providers, identity, etc.)."""
+        # Test with PROVIDERS state (intermediate)
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "opc-work": {
+                    "type": "openclaw",
+                    "onboarding": {"state": "providers"},  # Intermediate state
+                    "config": {
+                        "gateway": {"port": 40000},
+                        "provider": {
+                            "name": "test",
+                            "type": "ollama",
+                            "endpoint": "http://localhost:11434",
+                            "default_model": "llama3",
+                        },
+                    },
+                }
+            },
+        }
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle.configure_agent",
+                return_value=(True, None),
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.restart_agent",
+                ) as mock_restart:
+                    # Should NOT raise - intermediate states allowed
+                    result = sync_agent("192.168.1.100", "openclaw")
+
+        assert result["success"] is True
+        # W3 fix: Verify restart_agent NOT called for intermediate states
+        # (workspace_only auto-coerced to True)
+        mock_restart.assert_not_called()
+
+
+class TestCleanupAnsibleArtifacts:
+    """B5 fix: Tests for _cleanup_ansible_artifacts()."""
+
+    def test_cleans_artifacts_dir(self, tmp_path: Path):
+        """Removes artifacts directory."""
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+        (artifacts_dir / "job_events").mkdir()
+        (artifacts_dir / "job_events" / "event.json").write_text("{}")
+
+        _cleanup_ansible_artifacts(tmp_path)
+
+        assert not artifacts_dir.exists()
+
+    def test_cleans_env_dir(self, tmp_path: Path):
+        """Removes env directory."""
+        env_dir = tmp_path / "env"
+        env_dir.mkdir()
+        (env_dir / "inventory.json").write_text('{"secrets": "here"}')
+
+        _cleanup_ansible_artifacts(tmp_path)
+
+        assert not env_dir.exists()
+
+    def test_cleans_both_dirs(self, tmp_path: Path):
+        """Removes both artifacts and env directories."""
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+        env_dir = tmp_path / "env"
+        env_dir.mkdir()
+
+        _cleanup_ansible_artifacts(tmp_path)
+
+        assert not artifacts_dir.exists()
+        assert not env_dir.exists()
+
+    def test_skips_nonexistent_dirs(self, tmp_path: Path):
+        """Does not error when directories don't exist."""
+        # No artifacts or env dir created
+        _cleanup_ansible_artifacts(tmp_path)  # Should not raise
+
+    def test_handles_permission_errors(self, tmp_path: Path):
+        """Logs warning on permission errors."""
+        import stat
+
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+        # Make parent read-only to prevent deletion
+        tmp_path.chmod(stat.S_IRUSR | stat.S_IXUSR)
+
+        try:
+            _cleanup_ansible_artifacts(tmp_path)  # Should not raise
+            # Artifacts still exist due to permission error
+            assert artifacts_dir.exists()
+        finally:
+            # Restore permissions for cleanup
+            tmp_path.chmod(stat.S_IRWXU)
+
+    def test_partial_failure_continues(self, tmp_path: Path):
+        """Continues to env cleanup even if artifacts cleanup fails."""
+        with patch("clawrium.core.lifecycle.shutil.rmtree") as mock_rmtree:
+            # First call (artifacts) fails, second (env) succeeds
+            mock_rmtree.side_effect = [PermissionError("denied"), None]
+
+            artifacts_dir = tmp_path / "artifacts"
+            artifacts_dir.mkdir()
+            env_dir = tmp_path / "env"
+            env_dir.mkdir()
+
+            _cleanup_ansible_artifacts(tmp_path)
+
+            # Both attempts should be made
+            assert mock_rmtree.call_count == 2

--- a/tests/test_playbooks.py
+++ b/tests/test_playbooks.py
@@ -139,8 +139,9 @@ def test_openclaw_configure_playbook_structure():
     assert "Verify openclaw.json configuration" in content, (
         "Should include configuration validation task"
     )
-    assert 'python3 - "$CONFIG_FILE"' in content, (
-        "Should verify fields with embedded Python"
+    # B2 fix: Now uses external script instead of embedded Python
+    assert "verify_config.py" in content, (
+        "Should use external verify_config.py script"
     )
 
     data = yaml.safe_load(content)
@@ -180,3 +181,69 @@ def test_openclaw_stop_playbook_uses_openclaw_process_check():
     assert len(data) > 0, "Playbook should have at least one play"
     assert "pgrep -u {{ agent_name }} openclaw" in content
     assert "pgrep -u {{ agent_name }} node" not in content
+
+
+def test_openclaw_configure_playbook_has_workspace_tasks():
+    """Configure playbook should have workspace sync tasks."""
+    from importlib.resources import files
+    import yaml
+
+    openclaw_package = files("clawrium.platform.registry.openclaw")
+    playbook_path = openclaw_package / "playbooks" / "configure.yaml"
+
+    content = playbook_path.read_text()
+    data = yaml.safe_load(content)
+
+    assert isinstance(data, list), "Playbook should be a list of plays"
+    assert len(data) > 0, "Playbook should have at least one play"
+
+    # Get all task names
+    tasks = data[0].get("tasks", [])
+    task_names = [t.get("name", "") for t in tasks]
+
+    # Verify workspace tasks exist
+    assert any("workspace directory" in name.lower() for name in task_names), (
+        "Should have workspace directory creation task"
+    )
+    assert any("soul.md" in name.lower() for name in task_names), (
+        "Should have SOUL.md copy task"
+    )
+    assert any("agents.md" in name.lower() for name in task_names), (
+        "Should have AGENTS.md render task"
+    )
+    assert any("tools.md" in name.lower() for name in task_names), (
+        "Should have TOOLS.md render task"
+    )
+    assert any("identity.md" in name.lower() for name in task_names), (
+        "Should have IDENTITY.md render task"
+    )
+
+
+def test_identity_templates_exist():
+    """Identity templates should exist for workspace sync."""
+    from importlib.resources import files
+
+    openclaw_package = files("clawrium.platform.registry.openclaw")
+    template_dir = openclaw_package / "templates"
+
+    # Verify templates exist
+    assert (template_dir / "AGENTS.md.j2").is_file(), "AGENTS.md.j2 template should exist"
+    assert (template_dir / "TOOLS.md.j2").is_file(), "TOOLS.md.j2 template should exist"
+    assert (template_dir / "IDENTITY.md.j2").is_file(), "IDENTITY.md.j2 template should exist"
+
+
+def test_verify_config_script_exists():
+    """B2 fix: verify_config.py script should exist for config validation."""
+    from importlib.resources import files
+
+    openclaw_package = files("clawrium.platform.registry.openclaw")
+    template_dir = openclaw_package / "templates"
+
+    verify_script = template_dir / "verify_config.py"
+    assert verify_script.is_file(), "verify_config.py should exist"
+
+    # Verify it's a valid Python script
+    content = verify_script.read_text()
+    assert "#!/usr/bin/env python3" in content, "Should have Python shebang"
+    assert "def main():" in content, "Should have main function"
+    assert "sys.exit" in content, "Should use sys.exit for return codes"

--- a/tests/test_verify_config_script.py
+++ b/tests/test_verify_config_script.py
@@ -1,0 +1,106 @@
+"""Tests for openclaw verify_config.py model schema checks."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_verify_script(
+    tmp_path: Path, config: dict, expected: dict
+) -> subprocess.CompletedProcess:
+    from importlib.resources import files
+
+    template_dir = files("clawrium.platform.registry.openclaw") / "templates"
+    script_path = template_dir / "verify_config.py"
+
+    config_path = tmp_path / "openclaw.json"
+    expected_path = tmp_path / "expected.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    expected_path.write_text(json.dumps(expected), encoding="utf-8")
+
+    return subprocess.run(
+        [sys.executable, str(script_path), str(config_path), str(expected_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_verify_config_accepts_model_primary_for_ollama(tmp_path: Path):
+    config = {
+        "agents": {"defaults": {"model": {"primary": "ollama/qwen3-coder:30b-128k"}}},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    expected = {
+        "provider": {"type": "ollama", "default_model": "qwen3-coder:30b-128k"},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+
+    result = _run_verify_script(tmp_path, config, expected)
+    assert result.returncode == 0
+    assert "Configuration verified successfully" in result.stdout
+
+
+def test_verify_config_rejects_legacy_string_model(tmp_path: Path):
+    config = {
+        "agents": {"defaults": {"model": "ollama/qwen3-coder:30b-128k"}},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    expected = {
+        "provider": {"type": "ollama", "default_model": "qwen3-coder:30b-128k"},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+
+    result = _run_verify_script(tmp_path, config, expected)
+    assert result.returncode == 1
+    assert "Model schema mismatch" in result.stderr
+
+
+def test_verify_config_rejects_missing_primary_key(tmp_path: Path):
+    config = {
+        "agents": {"defaults": {"model": {"id": "ollama/qwen3-coder:30b-128k"}}},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    expected = {
+        "provider": {"type": "ollama", "default_model": "qwen3-coder:30b-128k"},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+
+    result = _run_verify_script(tmp_path, config, expected)
+    assert result.returncode == 1
+    assert "missing agents.defaults.model.primary" in result.stderr
+
+
+def test_verify_config_rejects_model_mismatch(tmp_path: Path):
+    config = {
+        "agents": {"defaults": {"model": {"primary": "ollama/other-model"}}},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    expected = {
+        "provider": {"type": "ollama", "default_model": "qwen3-coder:30b-128k"},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+
+    result = _run_verify_script(tmp_path, config, expected)
+    assert result.returncode == 1
+    assert "Model mismatch" in result.stderr
+
+
+def test_verify_config_normalizes_openrouter_prefix(tmp_path: Path):
+    config = {
+        "agents": {
+            "defaults": {"model": {"primary": "openrouter/anthropic/claude-sonnet-4"}}
+        },
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    expected = {
+        "provider": {
+            "type": "openrouter",
+            "default_model": "anthropic/claude-sonnet-4",
+        },
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+
+    result = _run_verify_script(tmp_path, config, expected)
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

- Enables workspace sync during intermediate onboarding states (not just READY)
- Adds identity file templates (AGENTS.md, TOOLS.md, IDENTITY.md) for remote workspace
- Integrates workspace sync into configure playbook with proper cleanup
- Wires identity stage to sync files via `clm agent sync --workspace`
- Adds `--workspace` CLI flag for workspace-only sync without restart
- Refactors config verification to use external Python script with block/always pattern

## Test Plan

- [x] `make test` - All 957 tests pass
- [x] `make lint` - Clean
- [x] ATX review - Rating 4/5, all actionable blockers fixed

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $10.15 | Total Time: 23m 55s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1-B7 | Fixed | $3.57 | 8m 26s | leader, cli-ux, lifecycle-state, test-coverage, ansible-playbook |
| 2 | 2/5 | B1-B4 | Fixed | $2.84 | 4m 25s | leader, lifecycle-state, cli-ux, secrets-provider, test-coverage, ansible-playbook |
| 3 | 2/5 | B1-B7 | Fixed | $1.86 | 6m 26s | leader, test-coverage, lifecycle-state, secrets-provider, cli-ux, ansible-playbook |
| 4 | 4/5 | B1 (pre-existing), B2 | B1 out-of-scope, B2 fixed | $1.88 | 4m 36s | leader, test-coverage, cli-ux, secrets-provider, ansible-playbook, lifecycle-state |

> **Note**: ATX does not expose model information per agent. Agent costs are aggregated from leader + all specialist reviewers.

<details>
<summary>Review 4 Details (Final - Rating 4/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `validation.py:682` | Broken lookup for orchestrator validation | Out-of-scope (pre-existing bug) |
| B2 | `configure.yaml` | /tmp path collision for verify script | Fixed - scoped with agent_name |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W2 | `lifecycle.py` | logger uses agent_name vs agent_key | Fixed |
| W3 | `test_lifecycle.py` | Missing assert_not_called for restart | Fixed |

</details>

<details>
<summary>Review 3 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `configure.yaml` | Temp file cleanup not in always block | Fixed - block/always construct |
| B2/B3 | `configure.yaml` | Shell injection via script module | Fixed - ansible.builtin.command with argv |
| B4 | `templates/*.j2` | Config values in Jinja2 | Fixed - safe default access |
| B5 | `test_lifecycle.py` | No cleanup function tests | Fixed - added 6 tests |
| B6 | `test_lifecycle.py` | Weak assertions | Fixed - verify call args |
| B7 | `test_lifecycle.py` | Missing error path tests | Fixed |

</details>

<details>
<summary>Review 2 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `test_lifecycle.py` | Wrong patch target | Fixed - use lifecycle module |
| B2 | `configure.yaml` | Heredoc security risk | Fixed - external verify_config.py |
| B3 | `lifecycle.py` | Secrets in ansible artifacts | Fixed - _cleanup_ansible_artifacts() |
| B4 | `test_lifecycle.py` | Missing workspace_only test | Fixed - added test |

</details>

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `lifecycle.py` | complete_stage called unconditionally | Fixed - state check |
| B2 | `lifecycle.py` | Relaxed sync vs strict start_agent | Fixed - auto-coerce workspace_only |
| B3 | `validation.py` | Path traversal via soul_path | Fixed - validation added |
| B5 | `test_cli_agent_configure.py` | Test needs extra_vars assertion | Fixed |
| B6 | `validation.py` | validate_soul_md wrong path | Fixed |
| B7 | `test_cli_agent_lifecycle.py` | Missing CLI --workspace test | Fixed |

</details>

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>