### PR TITLE
docs(cli): replace deprecated clm install command usage

### DIFF
--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -102,7 +102,7 @@ sequenceDiagram
     participant Registry
     participant Host as Target Host
 
-    User->>CLM: clm install openclaw --host myhost
+    User->>CLM: clm agent install --type openclaw --host myhost
     CLM->>Registry: Get OpenClaw definition
     Registry-->>CLM: Version, dependencies, template
     CLM->>Host: SSH as xclm
@@ -239,7 +239,7 @@ sequenceDiagram
     participant Ansible
     participant Host
 
-    User->>CLI: clm install zeroclaw --host pi-lab
+    User->>CLI: clm agent install --type zeroclaw --host pi-lab
     CLI->>Config: Load host info for pi-lab
     Config-->>CLI: SSH key, connection details
     CLI->>Ansible: Generate playbook
@@ -264,7 +264,7 @@ sequenceDiagram
     User->>CLI: clm secret set API_KEY
     CLI->>CLI: Read value (hidden prompt)
     CLI->>Secrets: Store encrypted value
-    User->>CLI: clm install zeroclaw
+    User->>CLI: clm agent install --type zeroclaw
     CLI->>Secrets: Retrieve secrets
     Secrets-->>CLI: API_KEY value
     CLI->>Ansible: Inject into playbook

--- a/website/docs/guides/fleet-management.md
+++ b/website/docs/guides/fleet-management.md
@@ -93,9 +93,9 @@ Deploy the same claw to multiple hosts:
 
 ```bash
 # Install ZeroClaw on multiple hosts
-clm install zeroclaw --host pi-lab --yes
-clm install zeroclaw --host nuc-01 --yes
-clm install zeroclaw --host dev-server --yes
+clm agent install --type zeroclaw --host pi-lab --yes
+clm agent install --type zeroclaw --host nuc-01 --yes
+clm agent install --type zeroclaw --host dev-server --yes
 ```
 
 ### Managing Configuration
@@ -276,10 +276,10 @@ Each host has an isolated SSH keypair:
 1. **Test on dev hosts first**
    ```bash
    # Deploy to dev
-   clm install zeroclaw --host dev-server --yes
+   clm agent install --type zeroclaw --host dev-server --yes
    # Verify
    # Then deploy to production
-   clm install zeroclaw --host pi-lab --yes
+   clm agent install --type zeroclaw --host pi-lab --yes
    ```
 
 2. **Document host configurations**

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -112,7 +112,7 @@ The secret value is entered via masked prompt (not visible on screen).
 Install OpenClaw on your host:
 
 ```bash
-clm install --claw openclaw --host homelab
+clm agent install --type openclaw --host homelab
 ```
 
 Clawrium will:
@@ -149,4 +149,4 @@ The claw's manifest doesn't support your host's OS, version, or architecture. Ru
 
 ### Missing required secrets
 
-Run `clm secret list <claw-name>` to see which secrets are missing. Set them before running `clm install`.
+Run `clm secret list <claw-name>` to see which secrets are missing. Set them before running `clm agent install`.

--- a/website/docs/guides/secret-management.md
+++ b/website/docs/guides/secret-management.md
@@ -137,7 +137,7 @@ Each secret file:
 
 ## Best Practices
 
-1. **Set secrets before installing** - Required secrets must exist before `clm install` succeeds
+1. **Set secrets before installing** - Required secrets must exist before `clm agent install` succeeds
 2. **Use descriptive comments** - Add `-d` descriptions to remember what each secret is for
 3. **Rotate periodically** - Update secrets if you rotate API keys
 4. **One claw, one set** - Each claw instance has its own secrets; they're not shared

--- a/website/docs/reference/cli/index.md
+++ b/website/docs/reference/cli/index.md
@@ -32,7 +32,7 @@ clm <group> <command> [options]
 |---------|-------------|
 | [`clm init`](#clm-init) | Initialize Clawrium and check dependencies |
 | [`clm status`](#clm-status) | Show fleet status across all hosts |
-| [`clm install`](#clm-install) | Install a claw on a host |
+| [`clm agent install`](#clm-agent-install) | Install an agent on a host |
 
 ## Command Groups
 
@@ -127,34 +127,34 @@ $ clm status --host pi-lab
 
 ---
 
-## clm install
+## clm agent install
 
-Install a claw on a host.
+Install an agent on a host.
 
 ```bash
-clm install [--claw CLAW] [--host HOST] [--yes]
+clm agent install [--type AGENT_TYPE] [--host HOST] [--yes]
 ```
 
-Without flags, prompts for claw and host selection interactively. With `--claw` and `--host` flags, runs directly for scripting.
+Without flags, prompts for agent type and host selection interactively. With `--type` and `--host` flags, runs directly for scripting.
 
 ### Options
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--claw` | `-c` | Claw type to install (e.g., `zeroclaw`) |
+| `--type` | `-t` | Agent type to install (e.g., `zeroclaw`) |
 | `--host` | `-H` | Target host (hostname or alias) |
 | `--yes` | `-y` | Skip confirmation prompt |
 
 ### Interactive Example
 
 ```bash
-$ clm install
+$ clm agent install
 
-Available claws:
+Available agent types:
   1. zeroclaw (v0.1.0) - Zero-config Claude assistant
   2. openclaw (v0.2.0) - OpenAI-powered assistant
 
-Select claw: 1
+Select agent type: 1
 
 Available hosts:
   1. pi-lab (aarch64, 4.0GB)
@@ -165,7 +165,7 @@ Select host: 1
 ╭─────────────────────────────────────────╮
 │          Installation Summary           │
 ├─────────────────────────────────────────┤
-│ Claw: zeroclaw                          │
+│ Agent Type: zeroclaw                    │
 │ Version: 0.1.0                          │
 │ Host: pi-lab                            │
 │ Architecture: aarch64                   │
@@ -180,7 +180,7 @@ Success! zeroclaw v0.1.0 installed on pi-lab
 ### Non-Interactive Example
 
 ```bash
-$ clm install --claw zeroclaw --host pi-lab --yes
+$ clm agent install --type zeroclaw --host pi-lab --yes
 ```
 
 ### Exit Codes


### PR DESCRIPTION
## Summary
- Replace all public `clm install` references in `website/docs` with `clm agent install`.
- Update install examples to use the current `--type` flag instead of deprecated positional/`--claw` usage.
- Refresh architecture and guide snippets so install commands match the actual CLI behavior.

## Testing
- `make lint`
- `make test`
- `grep -R "\\bclm install\\b" website/docs` (no matches)

## ATX Review Summary

**Final Review: Blocked (ATX MCP not connected)**

| Review | Rating | Blocking Issues | Status | Cost | Time |
|--------|--------|-----------------|--------|------|------|
| 1 | N/A | B0 | Blocked (service unavailable) | N/A | N/A |

<details>
<summary>Review 1 Details</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B0 | N/A | ATX MCP returned \"Not connected\" for both `atx_review_changes` and `atx_request_review`. | Unable to resolve in this environment. Documented for follow-up. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `website/docs/*` | Docs could still contain other legacy command namespaces unrelated to `clm install`. | Scope kept to deprecated `clm install` removal requested in this PR. |

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>