### PR TITLE
docs(website): add agent support matrix to website docs

### DIFF
--- a/website/docs/agent-support/channels/cli.md
+++ b/website/docs/agent-support/channels/cli.md
@@ -1,0 +1,108 @@
+# CLI Channel
+
+**Status:** ✅ Supported (All Agents)
+
+The CLI channel provides terminal-based interaction with your agent.
+
+## Features
+
+- **Interactive chat:** Real-time conversation in terminal
+- **Command history:** Navigate previous messages
+- **Piping support:** Pipe input/output to other commands
+- **Scripting:** Automate via shell scripts
+- **No dependencies:** Works over SSH, no browser needed
+
+## Setup
+
+CLI is automatically configured for all agents. No additional setup required.
+
+## Usage
+
+### Interactive Chat
+
+```bash
+# Start chatting
+clm chat <agent-name>
+
+# Example
+clm chat my-assistant
+```
+
+### One-off Queries
+
+```bash
+# Single query (if supported by agent)
+echo "What's the weather?" | clm chat my-assistant --stdin
+```
+
+### Scripting
+
+```bash
+#!/bin/bash
+# automated-task.sh
+
+RESPONSE=$(echo "Analyze this log file" | clm chat log-analyzer --stdin)
+echo "$RESPONSE"
+```
+
+## Key Bindings
+
+During chat:
+
+| Key | Action |
+|-----|--------|
+| `↑` / `↓` | Navigate history |
+| `Ctrl+C` | Exit chat |
+| `Ctrl+L` | Clear screen |
+| `Tab` | Auto-complete (if supported) |
+
+## Configuration
+
+CLI channel has minimal configuration:
+
+```json
+{
+  "cli": {
+    "enabled": true,
+    "history_size": 100
+  }
+}
+```
+
+## Limitations
+
+- Single user only
+- No rich media (images render as links)
+- Requires terminal/SSH access
+- No persistent history across sessions
+
+## Best Practices
+
+1. **SSH key-based access:** For remote hosts, use SSH keys
+2. **Screen/tmux:** Use terminal multiplexers for long sessions
+3. **Logging:** Pipe output to files for record keeping
+4. **Aliases:** Create shell aliases for frequently used agents
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+alias ask='clm chat my-assistant'
+```
+
+## Troubleshooting
+
+**"Connection refused"**
+- Ensure agent is running: `clm ps`
+- Start agent if needed: `clm agent start <name>`
+
+**"Agent not responding"**
+- Check agent logs: `clm agent logs <name>`
+- Verify provider connectivity: `clm provider status <provider>`
+
+**"Slow responses"**
+- Normal for complex queries
+- Check network latency to host
+- Consider local Ollama provider for faster responses
+
+---
+
+[Back to Channels](index.md)

--- a/website/docs/agent-support/channels/discord.md
+++ b/website/docs/agent-support/channels/discord.md
@@ -1,0 +1,134 @@
+# Discord Channel
+
+**Status:** ✅ Supported (OpenClaw only)
+
+Discord channel allows your agent to operate as a bot in Discord servers.
+
+## Features
+
+- **Server bot:** Responds to messages in Discord channels
+- **Allowlisting:** Control which users can interact
+- **Channel restrictions:** Limit to specific channels
+- **Thread support:** Conversations in threads
+- **Rich formatting:** Markdown, embeds, reactions
+
+## Setup
+
+### 1. Create Discord Application
+
+1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
+2. Click **New Application**
+3. Name it (e.g., "My Claw Agent")
+4. Go to **Bot** section
+5. Click **Add Bot**
+6. Enable **Message Content Intent** (required for reading messages)
+7. Copy the **Token** (starts with `MTA...` or similar)
+
+### 2. Invite Bot to Server
+
+1. Go to **OAuth2** → **URL Generator**
+2. Select scopes:
+   - `bot`
+   - `applications.commands` (optional, for slash commands)
+3. Select bot permissions:
+   - **Send Messages**
+   - **Read Message History**
+   - **Embed Links**
+   - **Add Reactions**
+   - **Use External Emojis**
+   - **Read Messages/View Channels**
+4. Copy the generated URL
+5. Open URL in browser and select your server
+
+### 3. Configure Channel in Clawrium
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+```
+
+When prompted for channels:
+1. Select **Discord**
+2. Enter bot token (from step 1)
+3. Enter your Discord server (guild) ID:
+   - Enable Developer Mode in Discord (Settings → Advanced)
+   - Right-click server name → **Copy Server ID**
+4. Enter channel ID:
+   - Right-click channel → **Copy Channel ID**
+5. Enter your user ID (for auto-approve):
+   - Right-click your username → **Copy User ID**
+
+### 4. Start Agent
+
+```bash
+clm agent start my-agent
+```
+
+The bot will come online in your Discord server.
+
+## Configuration Details
+
+The Discord configuration includes:
+
+```json
+{
+  "discord": {
+    "enabled": true,
+    "token": {
+      "source": "env",
+      "id": "DISCORD_BOT_TOKEN"
+    },
+    "allowFrom": ["USER_ID_1", "USER_ID_2"],
+    "groupPolicy": "allowlist",
+    "guilds": {
+      "GUILD_ID": {
+        "users": ["USER_ID_1"],
+        "channels": {
+          "CHANNEL_ID": {
+            "allow": true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Security
+
+- Bot token is stored securely (not in plain text)
+- Allowlist controls who can trigger the agent
+- Channel restrictions limit where it responds
+- Consider creating a dedicated channel for the bot
+
+## Usage
+
+Once running, interact with the bot by:
+- Mentioning it: `@MyBot analyze this code`
+- Sending messages in allowed channels
+- The bot will respond in the same channel
+
+## Troubleshooting
+
+**"Bot not responding"**
+- Check bot is online in Discord
+- Verify bot token is correct
+- Check allowlist includes your user ID
+- Ensure channel is in allowed channels list
+
+**"Token invalid"**
+- Regenerate token in Discord Developer Portal
+- Re-run: `clm agent configure <name> --stage channels`
+
+**"Missing permissions"**
+- Re-invite bot with correct permissions
+- Check bot role has required permissions in server
+
+**"Message intent required"**
+- Enable **Message Content Intent** in Bot settings
+- This is required for the bot to read message content
+
+---
+
+[Back to Channels](index.md)

--- a/website/docs/agent-support/channels/index.md
+++ b/website/docs/agent-support/channels/index.md
@@ -1,0 +1,55 @@
+# Channels
+
+Channels define how users interact with your agents. Different agents support different channels based on their design goals.
+
+## Available Channels
+
+| Channel | Agents | Use Case |
+|---------|--------|----------|
+| **[CLI](cli.md)** | All | Terminal-based interaction |
+| **[Discord](discord.md)** | OpenClaw | Discord server bot |
+| **[Slack](slack.md)** | OpenClaw (planned) | Slack workspace bot |
+| **[Web](web.md)** | OpenClaw (planned) | Browser-based chat |
+| **[WhatsApp](whatsapp.md)** | Not planned | Mobile messaging |
+
+## Channel Comparison
+
+| Feature | CLI | Discord | Slack | Web |
+|---------|-----|---------|-------|-----|
+| **Setup Complexity** | Low | Medium | Medium | High |
+| **Multi-user** | No | Yes | Yes | Yes |
+| **Access Control** | OS-level | Roles | Permissions | Auth |
+| **Rich Media** | Limited | Yes | Yes | Yes |
+| **Mobile Support** | SSH app | Discord app | Slack app | Browser |
+
+## Channel vs Provider
+
+- **Provider** = The AI model (OpenAI, Anthropic, etc.)
+- **Channel** = How users talk to the agent (CLI, Discord, etc.)
+
+An agent uses:
+- 1 provider (the LLM backend)
+- 1+ channels (how users interact)
+
+## Configuration
+
+Channels are configured during agent onboarding:
+
+```bash
+clm agent configure <agent-name>
+# Select channel during the channels stage
+```
+
+## Switching Channels
+
+To change an agent's channel:
+
+```bash
+clm agent configure <agent-name> --stage channels
+```
+
+Note: Some agents (like ZeroClaw) only support CLI and cannot switch channels.
+
+---
+
+See individual channel pages for detailed setup instructions.

--- a/website/docs/agent-support/channels/slack.md
+++ b/website/docs/agent-support/channels/slack.md
@@ -1,0 +1,81 @@
+# Slack Channel
+
+**Status:** 🚧 In Development
+
+Slack channel will allow your agent to operate as a bot in Slack workspaces.
+
+---
+
+## Planned Features
+
+- **Workspace bot:** Responds to messages in Slack channels
+- **Direct messages:** One-on-one conversations
+- **Slash commands:** `/ask` style commands
+- **App Home:** Persistent interface for the bot
+- **Thread support:** Conversations in threads
+- **Rich formatting:** Slack blocks, attachments
+
+## Timeline
+
+**Target:** Q2 2026
+
+**Milestone:** [SEA](https://github.com/ric03uec/clawrium/milestone/2)
+
+Track progress: [GitHub Issue #229](https://github.com/ric03uec/clawrium/issues/229)
+
+---
+
+## Preliminary Setup (Subject to Change)
+
+### 1. Create Slack App
+
+1. Go to [Slack API](https://api.slack.com/apps)
+2. Click **Create New App**
+3. Choose **From scratch**
+4. Name it and select your workspace
+
+### 2. Configure Bot Token Scopes
+
+Under **OAuth & Permissions**, add scopes:
+- `app_mentions:read`
+- `channels:history`
+- `chat:write`
+- `im:history`
+- `im:write`
+- `users:read`
+
+### 3. Install to Workspace
+
+1. Click **Install to Workspace**
+2. Authorize the app
+3. Copy the **Bot User OAuth Token**
+
+### 4. Configure in Clawrium (When Available)
+
+```bash
+clm agent configure my-agent
+# Select Slack when prompted
+```
+
+---
+
+## Differences from Discord
+
+| Feature | Discord | Slack |
+|---------|---------|-------|
+| **Scope** | Server (guild) | Workspace |
+| **Permissions** | Role-based | Scope-based |
+| **DMs** | Not supported | Supported |
+| **Slash commands** | Not planned | Planned |
+| **Threads** | Supported | Supported |
+| **Rich UI** | Embeds | Blocks |
+
+---
+
+## Vote for Priority
+
+Add a 👍 reaction to [the Slack channel issue](../../issues) to help prioritize.
+
+---
+
+[Back to Channels](index.md)

--- a/website/docs/agent-support/channels/web.md
+++ b/website/docs/agent-support/channels/web.md
@@ -1,0 +1,82 @@
+# Web Interface Channel
+
+**Status:** 🚧 In Development
+
+A browser-based chat interface for interacting with agents.
+
+---
+
+## Planned Features
+
+- **Web UI:** Clean, responsive chat interface
+- **Authentication:** Login required for access
+- **Multiple agents:** Switch between agents in UI
+- **History:** Persistent conversation history
+- **Mobile support:** Responsive design for mobile browsers
+- **File uploads:** Share files with agents
+- **Rich content:** Code highlighting, markdown rendering
+
+## Timeline
+
+**Target:** Q2 2026
+
+**Milestone:** [SEA (Secondary Engagement & Automation)](../milestones)
+
+Track progress: [GitHub Issue #TBD](../../issues)
+
+---
+
+## Architecture
+
+The web channel will consist of:
+
+1. **Backend API:** WebSocket or Server-Sent Events for real-time chat
+2. **Frontend:** React/Vue-based chat interface
+3. **Authentication:** Token-based or OAuth
+4. **Proxy:** Nginx or similar for serving static files
+
+## Comparison with Other Channels
+
+| Feature | CLI | Discord | Web |
+|---------|-----|---------|-----|
+| **Setup** | None | Medium | High |
+| **Access** | SSH/Terminal | Discord account | Browser |
+| **Mobile** | SSH app | Discord app | Browser |
+| **Multi-user** | No | Yes | Yes (planned) |
+| **History** | Session only | Discord | Persistent |
+| **Files** | Limited | Yes | Yes (planned) |
+
+---
+
+## Preliminary Usage (Subject to Change)
+
+### Configuration
+
+```bash
+clm agent configure my-agent
+# Select Web Interface when available
+```
+
+### Access
+
+```bash
+# Get web interface URL
+clm agent web-url my-agent
+# Opens: https://agent-host:8443/chat/my-agent
+```
+
+### Authentication
+
+Access will require:
+- Pre-shared token, or
+- User account (if multi-user enabled)
+
+---
+
+## Vote for Priority
+
+Add a 👍 reaction to [the web channel issue](../../issues) to help prioritize.
+
+---
+
+[Back to Channels](index.md)

--- a/website/docs/agent-support/channels/whatsapp.md
+++ b/website/docs/agent-support/channels/whatsapp.md
@@ -1,0 +1,99 @@
+# WhatsApp Channel
+
+**Status:** 📋 Not Currently Planned
+
+WhatsApp Business API integration for agent communication.
+
+---
+
+## Why Not Planned?
+
+WhatsApp integration is not currently on the Clawrium roadmap for the following reasons:
+
+1. **Complexity:** WhatsApp Business API requires Meta approval and business verification
+2. **Cost:** Per-conversation pricing model
+3. **Use Case:** Limited demand for WhatsApp automation in current user base
+4. **Alternatives:** Discord and Slack cover most messaging needs
+5. **Priority:** Development focused on Slack and Web channels first
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need WhatsApp support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](../../issues/new?labels=enhancement,channel&title=Add+WhatsApp+channel+support)
+
+Include:
+- Your use case (personal, business, etc.)
+- Expected volume of messages
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+We'd love your contribution! Implementation would involve:
+
+1. WhatsApp Business API integration
+2. Webhook handling for incoming messages
+3. Message templating (required for initial contact)
+4. Rate limiting and conversation tracking
+5. Business verification documentation
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+---
+
+## What Would Be Needed
+
+### Technical Requirements
+
+**WhatsApp Business API:**
+- Meta Business account
+- Business verification
+- Phone number for WhatsApp
+- Cloud API or On-premises API setup
+
+**Implementation:**
+- Webhook endpoint for message callbacks
+- Message template management
+- Conversation session tracking
+- Media message support (optional)
+
+### Pricing Considerations
+
+WhatsApp charges per conversation:
+- User-initiated: ~$0.005-0.08 USD depending on region
+- Business-initiated (with template): ~$0.05-0.15 USD
+- 24-hour session window
+
+See [WhatsApp Business Pricing](https://business.whatsapp.com/products/business-platform) for current rates.
+
+### Use Cases
+
+WhatsApp would be suitable for:
+- Customer support bots
+- Appointment reminders
+- Order notifications
+- Personal assistants
+
+---
+
+## Alternatives
+
+If you need mobile messaging:
+
+- **Discord:** Free, works on mobile, rich features
+- **Slack:** (Coming Q2 2026) Mobile apps available
+- **Web Interface:** (Coming Q2 2026) Mobile browser access
+
+---
+
+## Vote for This Feature
+
+Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+
+---
+
+[Back to Channels](index.md)

--- a/website/docs/agent-support/index.md
+++ b/website/docs/agent-support/index.md
@@ -1,0 +1,61 @@
+# Agent Support
+
+Clawrium supports multiple agent types, each designed for different use cases. This section provides detailed support matrices for each agent.
+
+## Available Agents
+
+### Production Ready
+
+| Agent | Description | Status |
+|-------|-------------|--------|
+| **[OpenClaw](openclaw.md)** | Full-featured agent with multi-channel support | ✅ Production Ready |
+
+### In Development
+
+| Agent | Description | Status |
+|-------|-------------|--------|
+| **[ZeroClaw](zeroclaw.md)** | Minimal CLI-only agent for simple automation | 🚧 In Development |
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Fully supported and tested |
+| 🚧 | In development / Planned |
+| ❌ | Not supported |
+| 📋 | Not planned (PRs welcome) |
+
+## Quick Comparison
+
+| Feature | OpenClaw | ZeroClaw |
+|---------|:--------:|:--------:|
+| **Multi-Provider** | ✅ | 🚧 |
+| **CLI Channel** | ✅ | 🚧 |
+| **Discord** | ✅ | ❌ |
+| **Custom Identity** | ✅ (SOUL.md) | ❌ |
+| **Integrations** | 🚧 | ❌ |
+| **Onboarding Wizard** | ✅ | 🚧 |
+
+## Choosing an Agent
+
+**Use OpenClaw when:**
+- You need Discord or multi-channel support
+- You want customizable identity/personality
+- You need integrations with external tools
+- You want a full-featured assistant
+
+**Use ZeroClaw when:**
+- You only need CLI interaction
+- You want minimal resource usage
+- You need quick automation scripts
+- You prefer simple, no-frills setup
+
+## Adding New Agents
+
+To request support for a new agent type or feature:
+
+1. Check the existing agent matrices for current capabilities
+2. Open an issue describing your use case
+3. Reference the relevant agent matrix in your request
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution guidelines.

--- a/website/docs/agent-support/integrations/confluence.md
+++ b/website/docs/agent-support/integrations/confluence.md
@@ -1,0 +1,112 @@
+# Confluence Integration
+
+**Status:** 📋 Not Currently Planned
+
+Atlassian Confluence integration for documentation and knowledge base access.
+
+---
+
+## Why Not Planned?
+
+Confluence integration is not currently on the Clawrium roadmap for the following reasons:
+
+1. **Scope:** Confluence is primarily a documentation/wiki tool, less relevant for agent workflows
+2. **Complexity:** Confluence API is complex for read operations
+3. **Use Case:** Agents typically don't need to write documentation
+4. **Priority:** Jira integration covers the more common Atlassian use case
+5. **Alternatives:** Notion integration (if requested) would serve similar needs
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need Confluence support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](../../issues/new?labels=enhancement,integration&title=Add+Confluence+integration+support)
+
+Include:
+- Your specific use case
+- Read-only vs read-write needs
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+We'd love your contribution! Implementation would involve:
+
+1. Confluence REST API client
+2. Authentication (API token or OAuth)
+3. Page search and retrieval
+4. Content parsing (handle Confluence markup)
+5. Optional: Page creation/updates
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+---
+
+## What Would Be Needed
+
+### Authentication
+
+- **API Token:** Personal access token
+- **Username + Token:** For server instances
+- **OAuth 2.0:** For app integrations
+
+### Use Cases
+
+If implemented, Confluence integration could:
+
+- **Search documentation:** Find relevant pages
+- **Answer questions:** Use docs as knowledge base
+- **Summarize content:** Extract key information
+- **Create pages:** Log agent activities
+- **Update docs:** Maintain runbooks
+
+### API Challenges
+
+Confluence API has some complexities:
+
+- Storage format is Confluence markup (not plain markdown)
+- Versioning requires handling
+- Space/page hierarchy navigation
+- Permission model is complex
+
+---
+
+## Alternatives
+
+### Use Jira Instead
+
+For many use cases, [Jira integration](jira.md) (when available) with issue descriptions may suffice.
+
+### Direct API Calls
+
+```bash
+curl -u email@example.com:$CONFLUENCE_TOKEN \
+     "https://your-domain.atlassian.net/wiki/rest/api/content?spaceKey=TEAM&expand=body.storage"
+```
+
+### RAG over Exported Docs
+
+Export Confluence pages and use RAG (Retrieval-Augmented Generation) via the agent's knowledge base.
+
+---
+
+## Related Integrations
+
+| Integration | Status | Use Case |
+|-------------|--------|----------|
+| **Jira** | 🚧 Q2 2026 | Issue tracking |
+| **Notion** | 📋 Not planned | Docs/notes (alternative) |
+| **Confluence** | 📋 Not planned | Wiki/docs |
+
+---
+
+## Vote for This Feature
+
+Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+
+---
+
+[Back to Integrations](index.md)

--- a/website/docs/agent-support/integrations/github.md
+++ b/website/docs/agent-support/integrations/github.md
@@ -1,0 +1,156 @@
+# GitHub Integration
+
+**Status:** 🚧 In Development
+
+GitHub integration allows agents to interact with repositories, pull requests, and issues.
+
+---
+
+## Planned Features
+
+- **PR Reviews:** Comment on pull requests
+- **Issue Management:** Read and create issues
+- **Code Search:** Search repositories
+- **Actions:** Trigger and monitor workflows
+- **Webhooks:** React to GitHub events
+- **Notifications:** Summarize activity
+
+## Timeline
+
+**Target:** Q2 2026
+
+**Milestone:** [SEA (Secondary Engagement & Automation)](../milestones)
+
+Track progress: [GitHub Issue #TBD](../../issues)
+
+---
+
+## Use Cases
+
+### Code Review Assistant
+
+```
+User: Review PR #123 in myorg/myrepo
+Agent: Analyzing PR #123...
+      
+      Summary:
+      - 5 files changed, 250 lines added
+      - No obvious security issues
+      - 2 suggestions:
+        1. Consider adding error handling on line 45
+        2. Missing docstring for new function
+```
+
+### Issue Triage
+
+```
+User: Summarize open issues from last week
+Agent: Found 12 new issues:
+      
+      Priority breakdown:
+      - 3 high priority (label: bug)
+      - 7 medium priority (label: enhancement)  
+      - 2 low priority (label: question)
+      
+      2 issues need more info (label: needs-repro)
+```
+
+### Release Notes
+
+```
+User: Draft release notes for v2.1.0
+Agent: Analyzing commits since v2.0.0...
+      
+      ## What's New
+      
+      ### Features
+      - Add OAuth support (#234)
+      - New dashboard widgets (#245)
+      
+      ### Bug Fixes
+      - Fix memory leak in worker (#240)
+      - Correct timezone handling (#238)
+```
+
+---
+
+## Preliminary Setup (Subject to Change)
+
+### 1. Create GitHub App
+
+1. Go to [GitHub Developer Settings](https://github.com/settings/apps)
+2. Click **New GitHub App**
+3. Configure:
+   - Name: `My Claw Agent`
+   - Homepage URL: Your URL
+   - Callback URL: Not needed for CLI
+4. Set permissions:
+   - Repository: Read & Write
+   - Pull requests: Read & Write
+   - Issues: Read & Write
+   - Actions: Read (optional)
+5. Create app and generate private key
+
+### 2. Install App
+
+1. Install the app on your repositories
+2. Note the installation ID
+
+### 3. Configure in Clawrium (When Available)
+
+```bash
+clm agent configure my-agent
+# Select GitHub integration when prompted
+```
+
+---
+
+## Authentication
+
+GitHub integration will support:
+
+- **GitHub App:** Recommended for organizations
+- **Personal Access Token:** For personal use
+- **Fine-grained PAT:** New GitHub feature
+
+---
+
+## Permissions Required
+
+| Feature | Permission | Level |
+|---------|------------|-------|
+| Read issues | Issues | Read |
+| Create issues | Issues | Write |
+| Read PRs | Pull requests | Read |
+| Comment on PRs | Pull requests | Write |
+| Trigger workflows | Actions | Write |
+
+---
+
+## Alternatives (Current Workaround)
+
+Until native integration is available:
+
+1. **CLI Tools:** Use `gh` CLI in agent scripts
+   ```bash
+   clm chat my-agent
+   # In chat: Run "gh issue list --repo myorg/myrepo"
+   ```
+
+2. **API via curl:** Make direct API calls
+   ```bash
+   curl -H "Authorization: token $GITHUB_TOKEN" \
+        https://api.github.com/repos/myorg/myrepo/issues
+   ```
+
+3. **MCP Tools:** (Coming Q2 2026) Use GitHub MCP server
+
+---
+
+## Vote for Priority
+
+Add a 👍 reaction to [the GitHub integration issue](../../issues) to help prioritize.
+
+---
+
+[Back to Integrations](index.md)

--- a/website/docs/agent-support/integrations/gitlab.md
+++ b/website/docs/agent-support/integrations/gitlab.md
@@ -1,0 +1,124 @@
+# GitLab Integration
+
+**Status:** 📋 Not Currently Planned
+
+GitLab integration for merge requests, issues, and CI/CD pipelines.
+
+---
+
+## Why Not Planned?
+
+GitLab integration is not currently on the Clawrium roadmap for the following reasons:
+
+1. **Overlap:** GitHub integration (in development) covers most Git hosting needs
+2. **Demand:** Lower community demand compared to GitHub
+3. **Priority:** Jira and GitHub prioritized first
+4. **Resources:** Limited development bandwidth
+5. **API Similarity:** GitLab API is similar enough to GitHub that adaptation would be straightforward if needed
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need GitLab support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](../../issues/new?labels=enhancement,integration&title=Add+GitLab+integration+support)
+
+Include:
+- Your use case (personal, enterprise, etc.)
+- Self-hosted vs GitLab.com
+- Which features you need most (MRs, issues, CI/CD, etc.)
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+We'd love your contribution! Implementation would be similar to [GitHub integration](github.md):
+
+1. GitLab API client (REST or GraphQL)
+2. OAuth or PAT authentication
+3. MR/issue operations
+4. CI/CD pipeline status
+5. Webhook handling
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+---
+
+## What Would Be Needed
+
+### Authentication
+
+- **Personal Access Token:** For GitLab.com or self-hosted
+- **OAuth 2.0:** For app-based authentication
+- **CI/CD Token:** For pipeline integration
+
+### API Scope
+
+```
+api (read, write)
+read_repository
+write_repository
+read_user
+```
+
+### Features to Implement
+
+- List/view merge requests
+- Create MR comments
+- Read/create issues
+- View pipeline status
+- Trigger pipeline runs
+- Search code
+
+---
+
+## Alternatives
+
+### Use GitHub Integration
+
+If you can mirror to GitHub:
+
+```bash
+# Mirror GitLab to GitHub
+git remote add github https://github.com/user/repo.git
+git push github main
+```
+
+Then use [GitHub integration](github.md) when available.
+
+### Direct API Calls
+
+Agents can use curl to call GitLab API directly:
+
+```bash
+curl -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+     https://gitlab.com/api/v4/projects/123/issues
+```
+
+### MCP Tools
+
+(Coming Q2 2026) Use generic HTTP MCP tools to interact with GitLab API.
+
+---
+
+## Comparison: GitHub vs GitLab
+
+| Feature | GitHub | GitLab |
+|---------|--------|--------|
+| **Market Share** | ~70% | ~20% |
+| **Self-hosted** | Enterprise only | Free option |
+| **CI/CD** | GitHub Actions | Built-in (stronger) |
+| **API** | REST + GraphQL | REST + GraphQL |
+| **Integration Priority** | 🚧 Q2 2026 | 📋 Not planned |
+
+---
+
+## Vote for This Feature
+
+Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+
+---
+
+[Back to Integrations](index.md)

--- a/website/docs/agent-support/integrations/index.md
+++ b/website/docs/agent-support/integrations/index.md
@@ -1,0 +1,62 @@
+# Integrations
+
+Integrations allow agents to interact with external tools and services, extending their capabilities beyond chat.
+
+## Available Integrations
+
+| Integration | Agents | Use Case |
+|-------------|--------|----------|
+| **[GitHub](github.md)** | OpenClaw (planned) | PR reviews, issues |
+| **[Jira](jira.md)** | OpenClaw (planned) | Issue tracking |
+| **[GitLab](gitlab.md)** | Not planned | Alternative to GitHub |
+| **[Confluence](confluence.md)** | Not planned | Documentation |
+| **[Linear](linear.md)** | Not planned | Issue tracking |
+| **[Notion](notion.md)** | Not planned | Knowledge base |
+
+## Integration vs Provider vs Channel
+
+| Component | Purpose | Example |
+|-----------|---------|---------|
+| **Provider** | AI model backend | OpenAI GPT-4 |
+| **Channel** | How users talk to agent | Discord, CLI |
+| **Integration** | What the agent can do | Read GitHub issues |
+
+## How Integrations Work
+
+Integrations typically:
+
+1. **Read data:** Fetch information from external services
+2. **Take actions:** Create/update items in external services
+3. **Receive events:** Webhooks for real-time updates
+4. **Use credentials:** API keys or OAuth tokens
+
+## Configuration
+
+Integrations will be configured during agent onboarding or separately:
+
+```bash
+# Future command (not yet available)
+clm agent configure <agent-name> --integrations
+```
+
+## Security
+
+- API tokens stored securely
+- Scoped permissions (least privilege)
+- Audit logging for actions
+- Per-integration credential isolation
+
+## Requesting New Integrations
+
+To request a new integration:
+
+1. Check if it exists in [📋 Not Planned](gitlab.md) section
+2. [Open an issue](../../issues/new) describing:
+   - The service (e.g., PagerDuty, Zendesk)
+   - Use case
+   - Required actions (read, write, both)
+3. Consider contributing a PR
+
+---
+
+See individual integration pages for detailed setup instructions.

--- a/website/docs/agent-support/integrations/jira.md
+++ b/website/docs/agent-support/integrations/jira.md
@@ -1,0 +1,147 @@
+# Jira Integration
+
+**Status:** 🚧 In Development
+
+Jira integration allows agents to interact with Jira issues, projects, and workflows.
+
+---
+
+## Planned Features
+
+- **Issue Management:** Read, create, and update issues
+- **Search:** JQL query support
+- **Comments:** Add and read comments
+- **Transitions:** Move issues through workflows
+- **Sprint Management:** View and update sprints
+- **Reporting:** Summarize project status
+
+## Timeline
+
+**Target:** Q2 2026
+
+**Milestone:** [SEA](https://github.com/ric03uec/clawrium/milestone/2)
+
+Track progress: [GitHub Issue #230](https://github.com/ric03uec/clawrium/issues/230)
+
+---
+
+## Use Cases
+
+### Daily Standup Summary
+
+```
+User: What's the status of PROJ sprint?
+Agent: Sprint "March 2026":
+      
+      Completed: 12/20 issues (60%)
+      In Progress: 5 issues
+      Blocked: 3 issues
+      
+      Blocked issues:
+      - PROJ-123: Waiting for API keys
+      - PROJ-124: Dependency on external team
+      - PROJ-125: Requirements unclear
+```
+
+### Issue Creation
+
+```
+User: Create a bug for the login issue
+Agent: Creating issue...
+      
+      Title: Login fails with 500 error
+      Type: Bug
+      Priority: High
+      
+      PROJ-456 created and assigned to you.
+```
+
+### Ticket Triage
+
+```
+User: Show me high priority bugs from this week
+Agent: Found 5 high priority bugs:
+      
+      1. PROJ-401: Memory leak (Created: 2 days ago)
+      2. PROJ-402: Database timeout (Created: 3 days ago)
+      3. PROJ-403: Race condition (Created: 4 days ago)
+      
+      2 issues are unassigned.
+```
+
+---
+
+## Preliminary Setup (Subject to Change)
+
+### 1. Create API Token
+
+1. Log in to Jira
+2. Go to **Account Settings** → **Security** → **API Tokens**
+3. Click **Create API Token**
+4. Name it (e.g., "Claw Agent")
+5. Copy the token
+
+### 2. Get Instance URL
+
+- Cloud: `https://your-domain.atlassian.net`
+- Server: `https://jira.yourcompany.com`
+
+### 3. Configure in Clawrium (When Available)
+
+```bash
+clm agent configure my-agent
+# Select Jira integration when prompted
+```
+
+---
+
+## Authentication
+
+Jira integration will support:
+
+- **API Token:** For Jira Cloud
+- **OAuth 2.0:** For enterprise SSO
+- **Basic Auth:** For Jira Server/Data Center (legacy)
+
+---
+
+## Permissions Required
+
+| Feature | Permission |
+|---------|------------|
+| Read issues | Browse Projects |
+| Create issues | Create Issues |
+| Update issues | Edit Issues |
+| Add comments | Add Comments |
+| Transition issues | Transition Issues |
+| View sprints | View Agile |
+
+---
+
+## Alternatives (Current Workaround)
+
+Until native integration is available:
+
+1. **Jira CLI:** Use command-line tools
+   ```bash
+   jira issue list --project PROJ --status "In Progress"
+   ```
+
+2. **API via curl:** Direct Jira REST API calls
+   ```bash
+   curl -u email@example.com:$JIRA_TOKEN \
+        https://your-domain.atlassian.net/rest/api/3/search \
+        -d '{"jql": "project = PROJ"}'
+   ```
+
+3. **MCP Tools:** (Coming Q2 2026) Use Jira MCP server
+
+---
+
+## Vote for Priority
+
+Add a 👍 reaction to [the Jira integration issue](../../issues) to help prioritize.
+
+---
+
+[Back to Integrations](index.md)

--- a/website/docs/agent-support/integrations/linear.md
+++ b/website/docs/agent-support/integrations/linear.md
@@ -1,0 +1,123 @@
+# Linear Integration
+
+**Status:** 📋 Not Currently Planned
+
+Linear integration for modern issue tracking.
+
+---
+
+## Why Not Planned?
+
+Linear integration is not currently on the Clawrium roadmap for the following reasons:
+
+1. **Niche:** Linear is popular in startup/tech circles but has smaller market share than Jira
+2. **Overlap:** Jira integration (in development) serves the primary issue tracking need
+3. **Priority:** GitHub and Jira cover most project management use cases
+4. **Resources:** Limited development bandwidth
+5. **API Maturity:** Linear's API is newer and still evolving
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need Linear support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](../../issues/new?labels=enhancement,integration&title=Add+Linear+integration+support)
+
+Include:
+- Your use case (team size, workflow)
+- Features you need most
+- Whether Linear is a hard requirement vs nice-to-have
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+We'd love your contribution! Linear has a well-designed GraphQL API:
+
+1. Linear GraphQL API client
+2. Personal API key authentication
+3. Issue CRUD operations
+4. Cycle/sprint management
+5. Real-time via webhooks
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+---
+
+## What Would Be Needed
+
+### Authentication
+
+- **Personal API Key:** Get from Linear Settings → API
+
+### API Capabilities
+
+Linear's GraphQL API supports:
+
+- Issues (create, read, update, delete)
+- Cycles (sprints)
+- Projects
+- Teams
+- Comments
+- Attachments
+- Webhooks
+
+### Use Cases
+
+If implemented, Linear integration could:
+
+- **Daily standups:** Summarize cycle progress
+- **Issue creation:** Create tickets from chat
+- **Triage:** Find unassigned/high priority issues
+- **Reporting:** Cycle velocity, burndown
+- **Git linking:** View linked PRs
+
+---
+
+## Alternatives
+
+### Use Jira Integration
+
+[Jira integration](jira.md) will be available Q2 2026 and serves similar needs.
+
+### Use GitHub Issues
+
+[GitHub integration](github.md) (Q2 2026) if you're using GitHub for code.
+
+### Notion Database
+
+If you use Notion, database integration (if requested) could track issues.
+
+### Direct API Calls
+
+```bash
+curl -H "Authorization: $LINEAR_API_KEY" \
+     -H "Content-Type: application/json" \
+     -X POST \
+     https://api.linear.app/graphql \
+     -d '{"query": "query { issues { nodes { id title state { name } } } }" }'
+```
+
+---
+
+## Comparison: Linear vs Jira
+
+| Feature | Linear | Jira |
+|---------|--------|------|
+| **Target** | Startups, modern teams | Enterprise, all sizes |
+| **Speed** | Fast, opinionated | Slower, customizable |
+| **Market Share** | ~5% | ~70% |
+| **API** | GraphQL, modern | REST + GraphQL |
+| **Integration Priority** | 📋 Not planned | 🚧 Q2 2026 |
+
+---
+
+## Vote for This Feature
+
+Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+
+---
+
+[Back to Integrations](index.md)

--- a/website/docs/agent-support/integrations/notion.md
+++ b/website/docs/agent-support/integrations/notion.md
@@ -1,0 +1,118 @@
+# Notion Integration
+
+**Status:** 📋 Not Currently Planned
+
+Notion integration for knowledge base, notes, and databases.
+
+---
+
+## Why Not Planned?
+
+Notion integration is not currently on the Clawrium roadmap for the following reasons:
+
+1. **Scope:** Notion serves more as a personal/team wiki than an agent integration target
+2. **Use Case:** Less clear how agents would productively interact with Notion
+3. **Priority:** GitHub and Jira cover the main workflow integrations
+4. **Resources:** Limited development bandwidth
+5. **Alternative:** Can be implemented via MCP tools when available
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need Notion support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](../../issues/new?labels=enhancement,integration&title=Add+Notion+integration+support)
+
+Include:
+- Your specific use case
+- Read-only (search) vs read-write needs
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+We'd love your contribution! Notion has a well-documented API:
+
+1. Notion API client
+2. Internal integration token authentication
+3. Page/database search
+4. Content retrieval
+5. Optional: Page creation/updates
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+---
+
+## What Would Be Needed
+
+### Authentication
+
+1. Go to [Notion Integrations](https://www.notion.so/my-integrations)
+2. Create new integration
+3. Copy the **Internal Integration Token**
+4. Share specific pages/databases with the integration
+
+### API Capabilities
+
+Notion API supports:
+
+- Search across pages and databases
+- Read page content (blocks)
+- Query databases
+- Create/update pages
+- Append blocks
+
+### Use Cases
+
+If implemented, Notion integration could:
+
+- **Knowledge base:** Search and retrieve documentation
+- **Meeting notes:** Find relevant past notes
+- **Project tracking:** Read project database
+- **Task management:** Update todo lists
+- **Content creation:** Draft blog posts, docs
+
+---
+
+## Alternatives
+
+### Use as Knowledge Base
+
+Export Notion content and use as agent knowledge base (RAG) instead of direct integration.
+
+### Direct API Calls
+
+```bash
+curl -H "Authorization: Bearer $NOTION_TOKEN" \
+     -H "Notion-Version: 2022-06-28" \
+     https://api.notion.com/v1/search \
+     -d '{"query": "meeting notes"}'
+```
+
+### MCP Tools (Coming Q2 2026)
+
+Use generic HTTP MCP tools or Notion-specific MCP server when available.
+
+---
+
+## Comparison: Notion vs Confluence
+
+| Feature | Notion | Confluence |
+|---------|--------|------------|
+| **Target** | Teams, individuals | Enterprise |
+| **Pricing** | Freemium | Paid (Atlassian) |
+| **API** | REST, good docs | REST, complex |
+| **Use Case** | Notes, docs, databases | Wiki, documentation |
+| **Integration Priority** | 📋 Not planned | 📋 Not planned |
+
+---
+
+## Vote for This Feature
+
+Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+
+---
+
+[Back to Integrations](index.md)

--- a/website/docs/agent-support/openclaw.md
+++ b/website/docs/agent-support/openclaw.md
@@ -1,0 +1,166 @@
+# OpenClaw Support Matrix
+
+OpenClaw is a full-featured agent supporting multiple LLM providers, communication channels, and third-party integrations.
+
+**Status:** ✅ Production Ready
+
+**Best for:** Discord bots, multi-channel assistants, complex workflows
+
+---
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Fully supported and tested |
+| 🚧 | In development / Planned |
+| ❌ | Not supported |
+| 📋 | Not planned (PRs welcome) |
+
+---
+
+## Provider Support
+
+OpenClaw supports all major LLM providers:
+
+| Provider | Status | Configuration | Models |
+|----------|:------:|---------------|--------|
+| **[OpenAI](providers/openai.md)** | ✅ | [Setup Guide](providers/openai.md) | GPT-4o, GPT-4, GPT-3.5, o1 |
+| **[Anthropic](providers/anthropic.md)** | ✅ | [Setup Guide](providers/anthropic.md) | Claude Opus, Sonnet, Haiku |
+| **[OpenRouter](providers/openrouter.md)** | ✅ | [Setup Guide](providers/openrouter.md) | Multi-provider gateway |
+| **[AWS Bedrock](providers/bedrock.md)** | ✅ | [Setup Guide](providers/bedrock.md) | Claude, Llama, Titan |
+| **[Google Vertex](providers/vertex.md)** | ✅ | [Setup Guide](providers/vertex.md) | Gemini series |
+| **[ZAI / BigModel](providers/zai.md)** | ✅ | [Setup Guide](providers/zai.md) | GLM series |
+| **[Ollama](providers/ollama.md)** | ✅ | [Setup Guide](providers/ollama.md) | Self-hosted models |
+| **[Azure OpenAI](providers/azure-openai.md)** | 📋 | [Not Planned](providers/azure-openai.md) | — |
+
+**Quick Setup:**
+```bash
+clm provider add <name> --type <provider-type>
+```
+
+---
+
+## Channel Support
+
+Channels define how users interact with the agent:
+
+| Channel | Status | Configuration | Notes |
+|---------|:------:|---------------|-------|
+| **[CLI](channels/cli.md)** | ✅ | [Setup Guide](channels/cli.md) | Interactive terminal chat |
+| **[Discord](channels/discord.md)** | ✅ | [Setup Guide](channels/discord.md) | Bot with allowlisting |
+| **[Slack](channels/slack.md)** | 🚧 | [Milestone SEA](channels/slack.md) | Coming Q2 2026 |
+| **[Web Interface](channels/web.md)** | 🚧 | [Milestone SEA](channels/web.md) | Browser-based chat |
+| **[WhatsApp](channels/whatsapp.md)** | 📋 | [Not Planned](channels/whatsapp.md) | PRs welcome |
+
+**During Onboarding:**
+```bash
+clm agent configure <agent-name>
+# Select channel during the channels stage
+```
+
+---
+
+## Integration Support
+
+Integrations allow the agent to interact with external tools and services:
+
+| Integration | Status | Configuration | Use Case |
+|-------------|:------:|---------------|----------|
+| **[GitHub](integrations/github.md)** | 🚧 | [Milestone SEA](integrations/github.md) | PR reviews, issues |
+| **[Jira](integrations/jira.md)** | 🚧 | [Milestone SEA](integrations/jira.md) | Issue tracking |
+| **[GitLab](integrations/gitlab.md)** | 📋 | [Not Planned](integrations/gitlab.md) | PRs welcome |
+| **[Confluence](integrations/confluence.md)** | 📋 | [Not Planned](integrations/confluence.md) | PRs welcome |
+| **[Linear](integrations/linear.md)** | 📋 | [Not Planned](integrations/linear.md) | PRs welcome |
+| **[Notion](integrations/notion.md)** | 📋 | [Not Planned](integrations/notion.md) | PRs welcome |
+
+---
+
+## Additional Features
+
+| Feature | Status | Notes |
+|---------|:------:|-------|
+| **Custom Identity** | ✅ | SOUL.md + IDENTITY.md |
+| **Multi-Provider** | ✅ | Switch providers per request |
+| **Secrets Management** | ✅ | Per-instance secret storage |
+| **Token Tracking** | 🚧 | Coming Q2 2026 |
+| **MCP Tools** | 🚧 | Coming Q2 2026 |
+| **Auto-Restart** | ✅ | Supervisor-managed |
+| **Log Streaming** | ✅ | Real-time log access |
+| **Onboarding Wizard** | ✅ | Guided 4-stage setup |
+
+---
+
+## Getting Started
+
+### 1. Install OpenClaw
+
+```bash
+clm agent install --type openclaw --host <host-alias> --name my-assistant
+```
+
+### 2. Configure the Agent
+
+```bash
+clm agent configure my-assistant
+```
+
+The wizard will guide you through:
+- Provider selection
+- Identity configuration (SOUL.md, IDENTITY.md)
+- Channel setup (CLI, Discord, etc.)
+- Validation
+
+### 3. Start the Agent
+
+```bash
+clm agent start my-assistant
+```
+
+### 4. Chat with the Agent
+
+```bash
+clm chat my-assistant
+```
+
+---
+
+## Troubleshooting
+
+<details>
+<summary><strong>"Discord bot token invalid"</strong></summary>
+
+1. Verify the bot token in Discord Developer Portal
+2. Re-run: `clm agent configure <name> --stage channels`
+3. Ensure the bot has proper server permissions
+</details>
+
+<details>
+<summary><strong>"Provider connectivity failed"</strong></summary>
+
+1. Check provider status: `clm provider status <provider-name>`
+2. Verify API key is set: `clm provider list`
+3. Test network connectivity from the host
+</details>
+
+<details>
+<summary><strong>"Onboarding incomplete"</strong></summary>
+
+Run the full onboarding wizard:
+```bash
+clm agent configure <agent-name>
+```
+
+Or configure a specific stage:
+```bash
+clm agent configure <agent-name> --stage <stage-name>
+```
+</details>
+
+---
+
+## Next Steps
+
+- [Agent Onboarding](../agent-onboarding.md) - Detailed onboarding guide
+- [CLI Reference](../reference/cli/agent.md) - Full command documentation
+- [Provider Configuration](../host-preparation.md) - Setting up inference providers

--- a/website/docs/agent-support/providers/anthropic.md
+++ b/website/docs/agent-support/providers/anthropic.md
@@ -1,0 +1,95 @@
+# Anthropic Provider
+
+**Status:** ✅ Supported
+
+Official Anthropic Claude API integration.
+
+## Supported Models
+
+- `claude-opus-4-20250514` - Most capable
+- `claude-sonnet-4-20250514` - Balanced performance
+- `claude-3-5-sonnet-20241022` - Previous generation
+- `claude-3-5-haiku-20241022` - Fast, cost-effective
+- `claude-3-opus-20240229` - Original Opus
+- `claude-3-sonnet-20240229` - Original Sonnet
+- `claude-3-haiku-20240307` - Original Haiku
+
+## Setup
+
+### 1. Get API Key
+
+1. Visit [Anthropic Console](https://console.anthropic.com/)
+2. Create or log in to your account
+3. Go to **API keys** → **Create Key**
+4. Copy the key (starts with `sk-ant-`)
+
+### 2. Add to Clawrium
+
+```bash
+clm provider add my-claude --type anthropic
+```
+
+You will be prompted to enter your API key securely.
+
+### 3. Select Model
+
+Choose a default model during setup:
+- `claude-opus-4-20250514` (best quality)
+- `claude-sonnet-4-20250514` (recommended balance)
+- `claude-3-5-haiku-20241022` (fastest)
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Change default model
+clm provider edit my-claude --model claude-sonnet-4-20250514
+
+# Update API key
+clm provider edit my-claude --update-key
+
+# Remove provider
+clm provider remove my-claude
+```
+
+## Pricing Considerations
+
+| Model | Input (per 1M tokens) | Output (per 1M tokens) |
+|-------|----------------------|------------------------|
+| Claude Opus 4 | $15.00 | $75.00 |
+| Claude Sonnet 4 | $3.00 | $15.00 |
+| Claude 3.5 Haiku | $0.25 | $1.25 |
+
+*Prices subject to change. Check [Anthropic pricing](https://www.anthropic.com/pricing) for current rates.*
+
+## Why Claude?
+
+- **Longer context:** Up to 200K tokens on some models
+- **Strong reasoning:** Excellent for complex tasks
+- **Constitutional AI:** Built-in safety measures
+- **Vision support:** Some models support image input
+
+## Usage in Agents
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+# Select my-claude when prompted for provider
+```
+
+## Troubleshooting
+
+**"Invalid API key"**
+- Verify the key starts with `sk-ant-`
+- Check your Anthropic console for active keys
+
+**"Rate limit exceeded"**
+- Check your Anthropic usage dashboard
+- Contact Anthropic for rate limit increases
+
+---
+
+[Back to Providers](index.md)

--- a/website/docs/agent-support/providers/azure-openai.md
+++ b/website/docs/agent-support/providers/azure-openai.md
@@ -1,0 +1,83 @@
+# Azure OpenAI Provider
+
+**Status:** 📋 Not Currently Planned
+
+Azure OpenAI Service provides OpenAI models through Microsoft Azure infrastructure.
+
+---
+
+## Why Not Planned?
+
+Azure OpenAI is not currently on the Clawrium roadmap for the following reasons:
+
+1. **Overlap:** Standard OpenAI provider already covers GPT models
+2. **Complexity:** Azure AD authentication adds setup friction
+3. **Priority:** Community demand has been low compared to other providers
+4. **Focus:** Development resources are focused on Ollama, Bedrock, and Vertex
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need Azure OpenAI support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](../../issues/new?labels=enhancement,provider&title=Add+Azure+OpenAI+provider+support)
+
+Include:
+- Your use case
+- Why existing providers don't meet your needs
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+We'd love your contribution! Implementation would involve:
+
+1. Add Azure provider type to `src/clawrium/core/providers.py`
+2. Handle Azure AD authentication (service principal or managed identity)
+3. Support Azure-specific endpoints and model deployment names
+4. Add tests and documentation
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+
+### Option 3: Use OpenRouter
+
+As a workaround, you can use [OpenRouter](openrouter.md) which may provide Azure-hosted models:
+
+```bash
+clm provider add my-router --type openrouter
+# Select Azure-hosted models if available
+```
+
+---
+
+## What Would Be Needed
+
+If implementing Azure OpenAI support, the following would be required:
+
+**Authentication Options:**
+- Service Principal (Client ID, Client Secret, Tenant ID)
+- Managed Identity (for Azure-hosted agents)
+- Azure CLI credentials (for development)
+
+**Configuration:**
+- Azure OpenAI Endpoint (e.g., `https://<resource>.openai.azure.com/`)
+- Deployment name (Azure uses custom deployment names, not model names)
+- API version
+
+**Differences from Standard OpenAI:**
+- Model access controlled by Azure
+- Different authentication flow
+- Custom deployment names instead of model names
+- Regional availability varies
+
+---
+
+## Vote for This Feature
+
+Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+
+---
+
+[Back to Providers](index.md)

--- a/website/docs/agent-support/providers/bedrock.md
+++ b/website/docs/agent-support/providers/bedrock.md
@@ -1,0 +1,117 @@
+# AWS Bedrock Provider
+
+**Status:** ✅ Supported
+
+Amazon Bedrock provides managed access to foundation models through AWS infrastructure.
+
+## Supported Models
+
+- `anthropic.claude-opus-4-20250514-v1:0` - Most capable Claude
+- `anthropic.claude-sonnet-4-20250514-v1:0` - Balanced Claude
+- `anthropic.claude-3-5-sonnet-20241022-v2:0` - Previous generation
+- `anthropic.claude-3-5-haiku-20241022-v1:0` - Fast Claude
+- `anthropic.claude-3-haiku-20240307-v1:0` - Original Haiku
+- `amazon.titan-text-express-v1` - Amazon Titan
+- `amazon.titan-text-lite-v1` - Lightweight Titan
+- `meta.llama3-70b-instruct-v1:0` - Meta Llama 3
+
+## Setup
+
+### 1. AWS Credentials
+
+You need AWS credentials with Bedrock access:
+
+1. Go to [AWS IAM Console](https://console.aws.amazon.com/iam/)
+2. Create or use an existing user
+3. Attach policy: `AmazonBedrockFullAccess`
+4. Create access key (Access Key ID + Secret Access Key)
+
+### 2. Enable Model Access
+
+1. Go to [Amazon Bedrock Console](https://console.aws.amazon.com/bedrock/)
+2. Navigate to **Model access**
+3. Request access for desired models (Claude, Llama, etc.)
+4. Wait for approval (usually instant)
+
+### 3. Add to Clawrium
+
+```bash
+clm provider add my-bedrock --type bedrock
+```
+
+You will be prompted to enter:
+- AWS Access Key ID
+- AWS Secret Access Key
+
+### 4. Select Model
+
+Choose a default model during setup:
+- `anthropic.claude-opus-4-20250514-v1:0` (best quality)
+- `anthropic.claude-sonnet-4-20250514-v1:0` (recommended)
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Change default model
+clm provider edit my-bedrock --model anthropic.claude-sonnet-4-20250514-v1:0
+
+# Update AWS credentials
+clm provider edit my-bedrock --update-key
+
+# Remove provider
+clm provider remove my-bedrock
+```
+
+## Pricing
+
+Bedrock uses on-demand pricing per 1K tokens. Check [AWS Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) for current rates.
+
+Example approximate costs:
+- Claude Sonnet 4: ~$3/1M input tokens, ~$15/1M output tokens
+- Llama 3 70B: ~$0.72/1M input tokens
+
+## Benefits
+
+- **AWS ecosystem:** Integrates with existing AWS infrastructure
+- **Compliance:** SOC 2, HIPAA, GDPR compliant
+- **Private connectivity:** VPC endpoints available
+- **No API keys:** Uses AWS IAM for authentication
+
+## Security
+
+- Credentials stored securely (not in plain text)
+- IAM policies control access
+- CloudTrail logs API calls
+- No data leaves your AWS account
+
+## Usage in Agents
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+# Select my-bedrock when prompted for provider
+```
+
+## Troubleshooting
+
+**"Access denied"**
+- Verify IAM user has `AmazonBedrockFullAccess`
+- Check model access is enabled in Bedrock console
+- Ensure credentials are correct
+
+**"Model not available"**
+- Request model access in Bedrock console
+- Some models require approval (can take 24-48 hours)
+- Check your AWS region supports the model
+
+**"Rate limit exceeded"**
+- Request quota increase in AWS Support Center
+- Consider using provisioned throughput
+
+---
+
+[Back to Providers](index.md)

--- a/website/docs/agent-support/providers/index.md
+++ b/website/docs/agent-support/providers/index.md
@@ -1,0 +1,82 @@
+# Providers
+
+LLM providers supply the AI models that power your agents. Clawrium supports multiple providers, allowing you to choose the best model for your use case.
+
+## Supported Providers
+
+| Provider | Type | Best For |
+|----------|------|----------|
+| **[OpenAI](openai.md)** | Cloud | GPT-4o, latest models |
+| **[Anthropic](anthropic.md)** | Cloud | Claude, long context |
+| **[OpenRouter](openrouter.md)** | Gateway | Multi-provider access |
+| **[AWS Bedrock](bedrock.md)** | Cloud | AWS ecosystem, compliance |
+| **[Google Vertex](vertex.md)** | Cloud | Gemini, Google Cloud |
+| **[ZAI / BigModel](zai.md)** | Cloud | GLM models, China region |
+| **[Ollama](ollama.md)** | Self-hosted | Local inference, privacy |
+
+## Provider Comparison
+
+| Feature | OpenAI | Anthropic | Ollama |
+|---------|--------|-----------|--------|
+| **Setup** | API key | API key | Server URL |
+| **Cost** | Pay per token | Pay per token | Hardware only |
+| **Latency** | Network | Network | Local/Network |
+| **Privacy** | Cloud | Cloud | On-premise |
+| **Model Choice** | Fixed list | Fixed list | Unlimited |
+
+## Quick Setup
+
+Add a provider in one command:
+
+```bash
+# Cloud provider (OpenAI, Anthropic, etc.)
+clm provider add my-openai --type openai
+
+# Self-hosted (Ollama)
+clm provider add local-llm --type ollama --url http://192.168.1.50:11434
+```
+
+Then assign it to an agent during onboarding:
+
+```bash
+clm agent configure <agent-name>
+# Select provider during the providers stage
+```
+
+## Managing Providers
+
+```bash
+# List all providers
+clm provider list
+
+# View available models
+clm provider models <provider-name>
+
+# Edit a provider
+clm provider edit <provider-name> --model <new-model>
+
+# Remove a provider
+clm provider remove <provider-name>
+```
+
+## Security
+
+- API keys are stored securely (not in plain text)
+- Keys are never logged or displayed in full
+- Per-provider isolation
+
+## Troubleshooting
+
+**"Provider connectivity failed"**
+- Verify API key is valid
+- Check network connectivity from the host
+- Ensure provider service is operational
+
+**"No models available"** (Ollama)
+- SSH to the Ollama host
+- Run: `ollama list` to verify models are pulled
+- Pull models: `ollama pull <model-name>`
+
+---
+
+See individual provider pages for detailed setup instructions.

--- a/website/docs/agent-support/providers/ollama.md
+++ b/website/docs/agent-support/providers/ollama.md
@@ -1,0 +1,140 @@
+# Ollama Provider
+
+**Status:** ✅ Supported
+
+Ollama lets you run open-source LLMs locally on your own hardware.
+
+## Supported Models
+
+Ollama supports 100+ models including:
+
+- `llama3.3` - Meta's Llama 3.3
+- `llama3.2` - Meta's Llama 3.2
+- `llama3.1` - Meta's Llama 3.1
+- `llama3` - Meta's Llama 3
+- `mistral` - Mistral AI
+- `mixtral` - Mixtral 8x7B
+- `gemma2` - Google Gemma 2
+- `qwen2.5` - Alibaba Qwen
+- `phi4` - Microsoft Phi-4
+- `deepseek-r1` - DeepSeek R1
+
+And many more at [ollama.com/library](https://ollama.com/library)
+
+## Setup
+
+### 1. Install Ollama
+
+On your target host (or any machine on your network):
+
+```bash
+# macOS/Linux
+curl -fsSL https://ollama.com/install.sh | sh
+
+# Or download from https://ollama.com/download
+```
+
+### 2. Pull Models
+
+```bash
+# Pull a model
+ollama pull llama3.2
+
+# List available models
+ollama list
+```
+
+### 3. Configure Server Access
+
+By default, Ollama only accepts local connections. To allow remote access:
+
+```bash
+# Set environment variable
+export OLLAMA_HOST=0.0.0.0:11434
+
+# Or edit systemd service
+sudo systemctl edit ollama.service
+```
+
+Add:
+```ini
+[Service]
+Environment="OLLAMA_HOST=0.0.0.0:11434"
+```
+
+Then restart:
+```bash
+sudo systemctl restart ollama
+```
+
+### 4. Add to Clawrium
+
+```bash
+clm provider add local-ollama --type ollama --url http://192.168.1.50:11434
+```
+
+Clawrium will:
+1. Connect to the Ollama server
+2. Fetch available models
+3. Let you select a default
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Refresh model list (after pulling new models)
+clm provider refresh local-ollama
+
+# Change default model
+clm provider edit local-ollama --model llama3.2
+
+# Update server URL
+clm provider edit local-ollama --url http://new-server:11434
+
+# Remove provider
+clm provider remove local-ollama
+```
+
+## Hardware Requirements
+
+| Model | RAM Required | GPU Recommended |
+|-------|--------------|-----------------|
+| llama3.2 (3B) | 8GB | Optional |
+| llama3.1 (8B) | 16GB | 8GB VRAM |
+| llama3.3 (70B) | 64GB | 40GB+ VRAM |
+| mixtral (47B) | 32GB | 24GB VRAM |
+
+## Benefits
+
+- **Privacy:** Data never leaves your network
+- **No API costs:** Pay only for hardware/electricity
+- **No rate limits:** Unlimited requests
+- **Offline capable:** Works without internet
+- **Model variety:** 100+ open-source models
+
+## Troubleshooting
+
+**"Connection refused"**
+- Verify Ollama is running: `ollama serve`
+- Check `OLLAMA_HOST` is set for remote access
+- Ensure firewall allows port 11434
+
+**"Model not found"**
+- Pull the model first: `ollama pull <model>`
+- Check available models: `ollama list`
+
+**"Out of memory"**
+- Use a smaller model (e.g., llama3.2 instead of llama3.1)
+- Add more RAM or VRAM
+- Use CPU-only mode (slower): `ollama run <model> --cpu`
+
+**"Slow responses"**
+- GPU acceleration significantly improves speed
+- Consider quantization (Q4, Q5, Q8)
+- Check GPU utilization with `nvidia-smi`
+
+---
+
+[Back to Providers](index.md)

--- a/website/docs/agent-support/providers/openai.md
+++ b/website/docs/agent-support/providers/openai.md
@@ -1,0 +1,103 @@
+# OpenAI Provider
+
+**Status:** ✅ Supported
+
+Official OpenAI API integration for GPT models.
+
+## Supported Models
+
+- `gpt-4o` - Latest flagship model
+- `gpt-4o-mini` - Fast, cost-effective
+- `gpt-4-turbo` - Previous generation
+- `gpt-4` - Original GPT-4
+- `gpt-3.5-turbo` - Cost-optimized
+- `o1` - Reasoning model
+- `o1-mini` - Fast reasoning
+- `o1-preview` - Reasoning preview
+
+## Setup
+
+### 1. Get API Key
+
+1. Visit [OpenAI Platform](https://platform.openai.com/)
+2. Create or log in to your account
+3. Go to **API keys** → **Create new secret key**
+4. Copy the key (starts with `sk-`)
+
+### 2. Add to Clawrium
+
+```bash
+clm provider add my-openai --type openai
+```
+
+You will be prompted to enter your API key securely.
+
+### 3. Select Model
+
+Choose a default model during setup:
+- `gpt-4o` (recommended for most use cases)
+- `gpt-4o-mini` (faster, cheaper)
+- `gpt-4-turbo` (if you need specific features)
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Change default model
+clm provider edit my-openai --model gpt-4o-mini
+
+# Update API key
+clm provider edit my-openai --update-key
+
+# Remove provider
+clm provider remove my-openai
+```
+
+## Pricing Considerations
+
+| Model | Input (per 1M tokens) | Output (per 1M tokens) |
+|-------|----------------------|------------------------|
+| gpt-4o | $5.00 | $15.00 |
+| gpt-4o-mini | $0.15 | $0.60 |
+| gpt-4-turbo | $10.00 | $30.00 |
+| gpt-3.5-turbo | $0.50 | $1.50 |
+
+*Prices subject to change. Check [OpenAI pricing](https://openai.com/pricing) for current rates.*
+
+## Usage in Agents
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+# Select my-openai when prompted for provider
+```
+
+Or change later:
+
+```bash
+clm agent configure my-agent --stage providers
+```
+
+## Troubleshooting
+
+**"Invalid API key"**
+- Verify the key starts with `sk-`
+- Ensure the key hasn't been revoked
+- Check your OpenAI account has available credits
+
+**"Rate limit exceeded"**
+- Check your OpenAI usage dashboard
+- Consider upgrading your account tier
+- Implement retry logic in your agent
+
+**"Model not found"**
+- Verify the model name is correct
+- Some models may require beta access
+- Check [OpenAI model documentation](https://platform.openai.com/docs/models)
+
+---
+
+[Back to Providers](index.md)

--- a/website/docs/agent-support/providers/openrouter.md
+++ b/website/docs/agent-support/providers/openrouter.md
@@ -1,0 +1,104 @@
+# OpenRouter Provider
+
+**Status:** ✅ Supported
+
+OpenRouter provides unified access to multiple AI models through a single API.
+
+## Supported Models
+
+OpenRouter supports 100+ models including:
+
+- `anthropic/claude-opus-4`
+- `anthropic/claude-sonnet-4`
+- `openai/gpt-4o`
+- `openai/o1`
+- `google/gemini-2.5-pro`
+- `meta-llama/llama-4-maverick`
+- `deepseek/deepseek-chat-v3`
+- `deepseek/deepseek-r1`
+- `qwen/qwen3-235b`
+
+## Setup
+
+### 1. Get API Key
+
+1. Visit [OpenRouter](https://openrouter.ai/)
+2. Create or log in to your account
+3. Go to **Keys** → **Create Key**
+4. Copy the key
+
+### 2. Add to Clawrium
+
+```bash
+clm provider add my-router --type openrouter
+```
+
+You will be prompted to enter your API key securely.
+
+### 3. Select Model
+
+Choose from OpenRouter's extensive model list:
+- `anthropic/claude-opus-4` (best quality)
+- `google/gemini-2.5-pro` (competitive pricing)
+- `openai/gpt-4o` (familiar API)
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Change default model
+clm provider edit my-router --model anthropic/claude-sonnet-4
+
+# Update API key
+clm provider edit my-router --update-key
+
+# Remove provider
+clm provider remove my-router
+```
+
+## Benefits
+
+- **Model fallback:** Automatically route to available models
+- **Unified billing:** One account for multiple providers
+- **Competitive pricing:** Often cheaper than direct provider access
+- **Model variety:** Access to open-source and proprietary models
+
+## Pricing
+
+OpenRouter adds a small fee on top of provider costs. Check [OpenRouter pricing](https://openrouter.ai/docs#pricing) for current rates.
+
+## Usage in Agents
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+# Select my-router when prompted for provider
+```
+
+## Model Routing
+
+You can switch models without changing providers:
+
+```bash
+clm provider edit my-router --model deepseek/deepseek-chat-v3
+```
+
+Then restart your agent to use the new model.
+
+## Troubleshooting
+
+**"Model not available"**
+- Check OpenRouter model status page
+- Some models may have temporary outages
+- Try a fallback model
+
+**"Credits exhausted"**
+- Add credits in OpenRouter dashboard
+- Set up auto-recharge for production use
+
+---
+
+[Back to Providers](index.md)

--- a/website/docs/agent-support/providers/vertex.md
+++ b/website/docs/agent-support/providers/vertex.md
@@ -1,0 +1,129 @@
+# Google Vertex AI Provider
+
+**Status:** ✅ Supported
+
+Google Cloud Vertex AI provides access to Gemini models.
+
+## Supported Models
+
+- `gemini-2.5-pro` - Latest flagship model
+- `gemini-2.5-flash` - Fast, efficient
+- `gemini-2.5-flash-lite` - Lightweight version
+- `gemini-2.0-flash` - Previous generation
+- `gemini-1.5-pro` - Earlier pro model
+- `gemini-1.5-flash` - Earlier flash model
+
+## Setup
+
+### 1. Google Cloud Setup
+
+1. Create or select a [Google Cloud project](https://console.cloud.google.com/)
+2. Enable the Vertex AI API:
+   ```bash
+   gcloud services enable aiplatform.googleapis.com
+   ```
+3. Ensure billing is enabled
+
+### 2. Authentication
+
+Clawrium uses Application Default Credentials (ADC). Set up authentication:
+
+```bash
+# Install gcloud CLI if not already installed
+# https://cloud.google.com/sdk/docs/install
+
+# Authenticate
+gcloud auth application-default login
+```
+
+Or use a service account:
+
+```bash
+# Create service account
+gcloud iam service-accounts create clawrium-provider \
+  --display-name="Clawrium Provider"
+
+# Grant Vertex AI User role
+gcloud projects add-iam-policy-binding PROJECT_ID \
+  --member="serviceAccount:clawrium-provider@PROJECT_ID.iam.gserviceaccount.com" \
+  --role="roles/aiplatform.user"
+
+# Create and download key
+gcloud iam service-accounts keys create key.json \
+  --iam-account=clawrium-provider@PROJECT_ID.iam.gserviceaccount.com
+
+# Set environment variable
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
+```
+
+### 3. Add to Clawrium
+
+```bash
+clm provider add my-vertex --type vertex
+```
+
+Note: Vertex AI uses Google Cloud authentication, not an API key.
+
+### 4. Select Model
+
+Choose a default model during setup:
+- `gemini-2.5-pro` (best quality)
+- `gemini-2.5-flash` (recommended balance)
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Change default model
+clm provider edit my-vertex --model gemini-2.5-flash
+
+# Remove provider
+clm provider remove my-vertex
+```
+
+## Pricing
+
+Vertex AI uses pay-per-use pricing. Check [Vertex AI pricing](https://cloud.google.com/vertex-ai/pricing) for current rates.
+
+Approximate costs:
+- Gemini 2.5 Pro: ~$1.25/1M input tokens, ~$10/1M output tokens
+- Gemini 2.5 Flash: ~$0.15/1M input tokens, ~$0.60/1M output tokens
+
+## Benefits
+
+- **Google Cloud integration:** Works with GCP services
+- **Enterprise features:** Fine-tuning, batch prediction
+- **Global infrastructure:** Low latency worldwide
+- **Gemini models:** Google's most capable models
+
+## Usage in Agents
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+# Select my-vertex when prompted for provider
+```
+
+## Troubleshooting
+
+**"Permission denied"**
+- Verify Vertex AI API is enabled
+- Check IAM permissions (needs `aiplatform.user`)
+- Ensure billing is enabled
+
+**"Authentication failed"**
+- Run `gcloud auth application-default login`
+- Check `GOOGLE_APPLICATION_CREDENTIALS` is set correctly
+- Verify service account has proper roles
+
+**"Model not found"**
+- Check your region supports the model
+- Verify the model name is correct
+- Some models may be in preview/limited availability
+
+---
+
+[Back to Providers](index.md)

--- a/website/docs/agent-support/providers/zai.md
+++ b/website/docs/agent-support/providers/zai.md
@@ -1,0 +1,96 @@
+# ZAI / BigModel Provider
+
+**Status:** ✅ Supported
+
+Zhipu AI (ZAI) BigModel platform provides access to GLM (General Language Model) series.
+
+## Supported Models
+
+- `glm-4` - General purpose
+- `glm-4-plus` - Enhanced capabilities
+- `glm-4-air` - Fast inference
+- `glm-4-airx` - Extended context
+- `glm-4-flash` - Ultra-fast
+- `glm-4-long` - Long context
+- `glm-4v` - Vision capable
+- `glm-4v-plus` - Enhanced vision
+
+## Setup
+
+### 1. Get API Key
+
+1. Visit [BigModel Platform](https://open.bigmodel.cn/)
+2. Create or log in to your account
+3. Go to **API Keys** → **Create API Key**
+4. Copy the key
+
+### 2. Add to Clawrium
+
+```bash
+clm provider add my-zai --type zai
+```
+
+You will be prompted to enter your API key securely.
+
+### 3. Select Model
+
+Choose a default model during setup:
+- `glm-4` (general purpose)
+- `glm-4-plus` (enhanced)
+- `glm-4-flash` (fastest)
+
+## Configuration
+
+```bash
+# View provider details
+clm provider list
+
+# Change default model
+clm provider edit my-zai --model glm-4-plus
+
+# Update API key
+clm provider edit my-zai --update-key
+
+# Remove provider
+clm provider remove my-zai
+```
+
+## Pricing
+
+ZAI offers competitive pricing, especially for the China region. Check [BigModel pricing](https://open.bigmodel.cn/pricing) for current rates.
+
+## Benefits
+
+- **China region:** Optimized for China-based deployments
+- **GLM models:** Strong Chinese language support
+- **Vision models:** GLM-4V supports image understanding
+- **Competitive pricing:** Often cheaper than western providers
+
+## Usage in Agents
+
+During agent onboarding:
+
+```bash
+clm agent configure my-agent
+# Select my-zai when prompted for provider
+```
+
+## Region Considerations
+
+- API endpoint: `https://open.bigmodel.cn/api/paas/v4`
+- Optimized for China region
+- May have higher latency from other regions
+
+## Troubleshooting
+
+**"Invalid API key"**
+- Verify the key is active in BigModel console
+- Check account has available credits
+
+**"High latency"**
+- Expected if connecting from outside China
+- Consider using a different provider for non-China deployments
+
+---
+
+[Back to Providers](index.md)

--- a/website/docs/agent-support/zeroclaw.md
+++ b/website/docs/agent-support/zeroclaw.md
@@ -1,0 +1,180 @@
+# ZeroClaw Support Matrix
+
+ZeroClaw is a minimal CLI-only agent designed for simple automation tasks and quick scripts.
+
+**Status:** 🚧 In Development
+
+**Best for:** CLI automation, minimal resource usage, quick tasks
+
+---
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Fully supported and tested |
+| 🚧 | In development / Planned |
+| ❌ | Not supported |
+| 📋 | Not planned (PRs welcome) |
+
+---
+
+## Provider Support
+
+ZeroClaw will support a limited set of providers focused on efficiency:
+
+| Provider | Status | Configuration | Models |
+|----------|:------:|---------------|--------|
+| **[OpenAI](providers/openai.md)** | 🚧 | [In Development](providers/openai.md) | GPT-4o-mini, GPT-3.5 |
+| **[Anthropic](providers/anthropic.md)** | 🚧 | [In Development](providers/anthropic.md) | Claude Haiku |
+| **[Ollama](providers/ollama.md)** | 🚧 | [In Development](providers/ollama.md) | Local models |
+| **[OpenRouter](providers/openrouter.md)** | ❌ | — | Not planned |
+| **[AWS Bedrock](providers/bedrock.md)** | ❌ | — | Not planned |
+| **[Google Vertex](providers/vertex.md)** | ❌ | — | Not planned |
+| **[ZAI / BigModel](providers/zai.md)** | ❌ | — | Not planned |
+| **[Azure OpenAI](providers/azure-openai.md)** | ❌ | — | Not planned |
+
+**Notes:**
+- ZeroClaw focuses on lightweight providers
+- Self-hosted (Ollama) is prioritized for cost efficiency
+- Complex providers (Bedrock, Vertex) are excluded by design
+
+---
+
+## Channel Support
+
+ZeroClaw is CLI-only by design:
+
+| Channel | Status | Configuration | Notes |
+|---------|:------:|---------------|-------|
+| **[CLI](channels/cli.md)** | 🚧 | [In Development](channels/cli.md) | Terminal-only |
+| **Discord** | ❌ | — | Not supported (use OpenClaw) |
+| **[Slack](channels/slack.md)** | ❌ | — | Not supported |
+| **[Web Interface](channels/web.md)** | ❌ | — | Not supported |
+| **[WhatsApp](channels/whatsapp.md)** | ❌ | — | Not supported |
+
+**Philosophy:**
+ZeroClaw intentionally excludes multi-channel support to maintain simplicity. For Discord or web interfaces, use [OpenClaw](openclaw.md).
+
+---
+
+## Integration Support
+
+ZeroClaw does not support external integrations by design:
+
+| Integration | Status | Configuration | Notes |
+|-------------|:------:|---------------|-------|
+| **GitHub** | ❌ | — | Not supported |
+| **Jira** | ❌ | — | Not supported |
+| **GitLab** | ❌ | — | Not supported |
+| **Confluence** | ❌ | — | Not supported |
+| **Linear** | ❌ | — | Not supported |
+| **Notion** | ❌ | — | Not supported |
+
+**Philosophy:**
+ZeroClaw is designed for simple, self-contained automation. It focuses on:
+- Quick CLI tasks
+- Local file operations
+- Simple API calls via curl/httpie
+- Scripting and piping
+
+For integrations with GitHub, Jira, etc., use [OpenClaw](openclaw.md).
+
+---
+
+## Feature Support
+
+| Feature | Status | Notes |
+|---------|:------:|-------|
+| **Custom Identity** | ❌ | Minimal identity only (no SOUL.md) |
+| **Multi-Provider** | 🚧 | Basic switching planned |
+| **Secrets Management** | 🚧 | Per-instance storage planned |
+| **Token Tracking** | ❌ | Not planned |
+| **MCP Tools** | ❌ | Not planned |
+| **Auto-Restart** | 🚧 | Supervisor-managed planned |
+| **Log Streaming** | 🚧 | Planned |
+| **Onboarding Wizard** | 🚧 | Simplified 2-stage setup |
+
+---
+
+## Comparison with OpenClaw
+
+| Aspect | ZeroClaw | OpenClaw |
+|--------|----------|----------|
+| **Setup Time** | 1-2 minutes | 3-5 minutes |
+| **Channels** | CLI only | CLI, Discord, Web |
+| **Identity** | Minimal | Fully customizable |
+| **Providers** | 3 (lightweight) | 7+ (all major) |
+| **Integrations** | None | GitHub, Jira, etc. |
+| **Resource Usage** | Low | Moderate |
+| **Use Case** | Automation | Assistants |
+
+---
+
+## Getting Started (When Available)
+
+### 1. Install ZeroClaw
+
+```bash
+clm agent install --type zeroclaw --host <host-alias> --name my-script
+```
+
+### 2. Configure (Minimal)
+
+```bash
+clm agent configure my-script
+# Auto-skips identity, configures CLI channel only
+```
+
+### 3. Start and Chat
+
+```bash
+clm agent start my-script
+clm chat my-script
+```
+
+---
+
+## Development Status
+
+ZeroClaw is currently in development. Expected features:
+
+- **v0.1.0** (Target: Q2 2026)
+  - CLI channel support
+  - OpenAI and Anthropic providers
+  - Basic onboarding
+  - Start/stop lifecycle
+
+- **v0.2.0** (Target: Q3 2026)
+  - Ollama support
+  - Log streaming
+  - Secrets management
+
+Track progress: [GitHub Milestone SEA](../milestones)
+
+---
+
+## When to Use ZeroClaw vs OpenClaw
+
+**Choose ZeroClaw when:**
+- ✅ You only need CLI interaction
+- ✅ You want minimal resource usage
+- ✅ You need quick automation scripts
+- ✅ You don't need custom identity
+- ✅ You don't need Discord or web interface
+- ✅ You want fast setup (1-2 minutes)
+
+**Choose OpenClaw when:**
+- ✅ You need Discord or web interface
+- ✅ You want customizable personality
+- ✅ You need external integrations (GitHub, Jira)
+- ✅ You need full feature set
+- ✅ You want multi-provider flexibility
+
+---
+
+## Next Steps
+
+- [OpenClaw Support Matrix](openclaw.md) - Full-featured alternative
+- [Agent Onboarding](../agent-onboarding.md) - Onboarding process overview
+- [CLI Reference](../reference/cli/agent.md) - Command documentation


### PR DESCRIPTION
## Summary

Move agent-support documentation from docs/ to website/docs/ so it gets built and deployed by Docusaurus.

## Problem

The agent support matrix was created in docs/agent-support/ but the deployment workflow only watches website/** paths. This meant the documentation wasn't being deployed to the website.

## Solution

Copy all agent-support documentation to website/docs/agent-support/ so it will be:
1. Built by Docusaurus
2. Deployed to GitHub Pages
3. Accessible at https://ric03uec.github.io/clawrium/docs/agent-support/

## Files Added

- website/docs/agent-support/index.md
- website/docs/agent-support/openclaw.md
- website/docs/agent-support/zeroclaw.md
- website/docs/agent-support/providers/*.md (8 files)
- website/docs/agent-support/channels/*.md (6 files)
- website/docs/agent-support/integrations/*.md (7 files)

## Testing

Once merged, verify at: https://ric03uec.github.io/clawrium/docs/agent-support/

## Related

Follow-up to #232 which added the documentation but in the wrong location.