### PR TITLE
fix(website): add category config files for agent-support sections

### DIFF
--- a/website/docs/agent-support/_category_.json
+++ b/website/docs/agent-support/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Agent Support",
+  "position": 2,
+  "link": {
+    "type": "doc",
+    "id": "agent-support/index"
+  }
+}

--- a/website/docs/agent-support/channels/_category_.json
+++ b/website/docs/agent-support/channels/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Channels",
+  "position": 2,
+  "link": {
+    "type": "doc",
+    "id": "agent-support/channels/index"
+  }
+}

--- a/website/docs/agent-support/channels/slack.md
+++ b/website/docs/agent-support/channels/slack.md
@@ -74,7 +74,7 @@ clm agent configure my-agent
 
 ## Vote for Priority
 
-Add a 👍 reaction to [the Slack channel issue](../../issues) to help prioritize.
+Add a 👍 reaction to [the Slack channel issue](https://github.com/ric03uec/clawrium/issues) to help prioritize.
 
 ---
 

--- a/website/docs/agent-support/channels/web.md
+++ b/website/docs/agent-support/channels/web.md
@@ -20,9 +20,9 @@ A browser-based chat interface for interacting with agents.
 
 **Target:** Q2 2026
 
-**Milestone:** [SEA (Secondary Engagement & Automation)](../milestones)
+**Milestone:** [SEA (Secondary Engagement & Automation)](https://github.com/ric03uec/clawrium/milestones)
 
-Track progress: [GitHub Issue #TBD](../../issues)
+Track progress: [GitHub Issue #TBD](https://github.com/ric03uec/clawrium/issues)
 
 ---
 
@@ -75,7 +75,7 @@ Access will require:
 
 ## Vote for Priority
 
-Add a 👍 reaction to [the web channel issue](../../issues) to help prioritize.
+Add a 👍 reaction to [the web channel issue](https://github.com/ric03uec/clawrium/issues) to help prioritize.
 
 ---
 

--- a/website/docs/agent-support/channels/whatsapp.md
+++ b/website/docs/agent-support/channels/whatsapp.md
@@ -24,7 +24,7 @@ We welcome community contributions! If you need WhatsApp support:
 
 ### Option 1: Open an Issue
 
-[Create a feature request](../../issues/new?labels=enhancement,channel&title=Add+WhatsApp+channel+support)
+[Create a feature request](https://github.com/ric03uec/clawrium/issues/new?labels=enhancement,channel&title=Add+WhatsApp+channel+support)
 
 Include:
 - Your use case (personal, business, etc.)
@@ -41,7 +41,7 @@ We'd love your contribution! Implementation would involve:
 4. Rate limiting and conversation tracking
 5. Business verification documentation
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](/docs/contributing) for guidelines.
 
 ---
 
@@ -92,7 +92,7 @@ If you need mobile messaging:
 
 ## Vote for This Feature
 
-Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+Add a 👍 reaction to [this issue](https://github.com/ric03uec/clawrium/issues) to help us prioritize.
 
 ---
 

--- a/website/docs/agent-support/index.md
+++ b/website/docs/agent-support/index.md
@@ -58,4 +58,4 @@ To request support for a new agent type or feature:
 2. Open an issue describing your use case
 3. Reference the relevant agent matrix in your request
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution guidelines.
+See [CONTRIBUTING.md](/docs/contributing) for contribution guidelines.

--- a/website/docs/agent-support/integrations/_category_.json
+++ b/website/docs/agent-support/integrations/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Integrations",
+  "position": 3,
+  "link": {
+    "type": "doc",
+    "id": "agent-support/integrations/index"
+  }
+}

--- a/website/docs/agent-support/integrations/confluence.md
+++ b/website/docs/agent-support/integrations/confluence.md
@@ -24,7 +24,7 @@ We welcome community contributions! If you need Confluence support:
 
 ### Option 1: Open an Issue
 
-[Create a feature request](../../issues/new?labels=enhancement,integration&title=Add+Confluence+integration+support)
+[Create a feature request](https://github.com/ric03uec/clawrium/issues/new?labels=enhancement,integration&title=Add+Confluence+integration+support)
 
 Include:
 - Your specific use case
@@ -41,7 +41,7 @@ We'd love your contribution! Implementation would involve:
 4. Content parsing (handle Confluence markup)
 5. Optional: Page creation/updates
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](/docs/contributing) for guidelines.
 
 ---
 
@@ -105,7 +105,7 @@ Export Confluence pages and use RAG (Retrieval-Augmented Generation) via the age
 
 ## Vote for This Feature
 
-Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+Add a 👍 reaction to [this issue](https://github.com/ric03uec/clawrium/issues) to help us prioritize.
 
 ---
 

--- a/website/docs/agent-support/integrations/github.md
+++ b/website/docs/agent-support/integrations/github.md
@@ -19,9 +19,9 @@ GitHub integration allows agents to interact with repositories, pull requests, a
 
 **Target:** Q2 2026
 
-**Milestone:** [SEA (Secondary Engagement & Automation)](../milestones)
+**Milestone:** [SEA (Secondary Engagement & Automation)](https://github.com/ric03uec/clawrium/milestones)
 
-Track progress: [GitHub Issue #TBD](../../issues)
+Track progress: [GitHub Issue #TBD](https://github.com/ric03uec/clawrium/issues)
 
 ---
 
@@ -149,7 +149,7 @@ Until native integration is available:
 
 ## Vote for Priority
 
-Add a 👍 reaction to [the GitHub integration issue](../../issues) to help prioritize.
+Add a 👍 reaction to [the GitHub integration issue](https://github.com/ric03uec/clawrium/issues) to help prioritize.
 
 ---
 

--- a/website/docs/agent-support/integrations/gitlab.md
+++ b/website/docs/agent-support/integrations/gitlab.md
@@ -24,7 +24,7 @@ We welcome community contributions! If you need GitLab support:
 
 ### Option 1: Open an Issue
 
-[Create a feature request](../../issues/new?labels=enhancement,integration&title=Add+GitLab+integration+support)
+[Create a feature request](https://github.com/ric03uec/clawrium/issues/new?labels=enhancement,integration&title=Add+GitLab+integration+support)
 
 Include:
 - Your use case (personal, enterprise, etc.)
@@ -42,7 +42,7 @@ We'd love your contribution! Implementation would be similar to [GitHub integrat
 4. CI/CD pipeline status
 5. Webhook handling
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](/docs/contributing) for guidelines.
 
 ---
 
@@ -117,7 +117,7 @@ curl -H "PRIVATE-TOKEN: $GITLAB_TOKEN" \
 
 ## Vote for This Feature
 
-Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+Add a 👍 reaction to [this issue](https://github.com/ric03uec/clawrium/issues) to help us prioritize.
 
 ---
 

--- a/website/docs/agent-support/integrations/index.md
+++ b/website/docs/agent-support/integrations/index.md
@@ -51,7 +51,7 @@ clm agent configure <agent-name> --integrations
 To request a new integration:
 
 1. Check if it exists in [📋 Not Planned](gitlab.md) section
-2. [Open an issue](../../issues/new) describing:
+2. [Open an issue](https://github.com/ric03uec/clawrium/issues/new) describing:
    - The service (e.g., PagerDuty, Zendesk)
    - Use case
    - Required actions (read, write, both)

--- a/website/docs/agent-support/integrations/jira.md
+++ b/website/docs/agent-support/integrations/jira.md
@@ -140,7 +140,7 @@ Until native integration is available:
 
 ## Vote for Priority
 
-Add a 👍 reaction to [the Jira integration issue](../../issues) to help prioritize.
+Add a 👍 reaction to [the Jira integration issue](https://github.com/ric03uec/clawrium/issues) to help prioritize.
 
 ---
 

--- a/website/docs/agent-support/integrations/linear.md
+++ b/website/docs/agent-support/integrations/linear.md
@@ -24,7 +24,7 @@ We welcome community contributions! If you need Linear support:
 
 ### Option 1: Open an Issue
 
-[Create a feature request](../../issues/new?labels=enhancement,integration&title=Add+Linear+integration+support)
+[Create a feature request](https://github.com/ric03uec/clawrium/issues/new?labels=enhancement,integration&title=Add+Linear+integration+support)
 
 Include:
 - Your use case (team size, workflow)
@@ -42,7 +42,7 @@ We'd love your contribution! Linear has a well-designed GraphQL API:
 4. Cycle/sprint management
 5. Real-time via webhooks
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](/docs/contributing) for guidelines.
 
 ---
 
@@ -116,7 +116,7 @@ curl -H "Authorization: $LINEAR_API_KEY" \
 
 ## Vote for This Feature
 
-Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+Add a 👍 reaction to [this issue](https://github.com/ric03uec/clawrium/issues) to help us prioritize.
 
 ---
 

--- a/website/docs/agent-support/integrations/notion.md
+++ b/website/docs/agent-support/integrations/notion.md
@@ -24,7 +24,7 @@ We welcome community contributions! If you need Notion support:
 
 ### Option 1: Open an Issue
 
-[Create a feature request](../../issues/new?labels=enhancement,integration&title=Add+Notion+integration+support)
+[Create a feature request](https://github.com/ric03uec/clawrium/issues/new?labels=enhancement,integration&title=Add+Notion+integration+support)
 
 Include:
 - Your specific use case
@@ -41,7 +41,7 @@ We'd love your contribution! Notion has a well-documented API:
 4. Content retrieval
 5. Optional: Page creation/updates
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](/docs/contributing) for guidelines.
 
 ---
 
@@ -111,7 +111,7 @@ Use generic HTTP MCP tools or Notion-specific MCP server when available.
 
 ## Vote for This Feature
 
-Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+Add a 👍 reaction to [this issue](https://github.com/ric03uec/clawrium/issues) to help us prioritize.
 
 ---
 

--- a/website/docs/agent-support/openclaw.md
+++ b/website/docs/agent-support/openclaw.md
@@ -161,6 +161,6 @@ clm agent configure <agent-name> --stage <stage-name>
 
 ## Next Steps
 
-- [Agent Onboarding](../agent-onboarding.md) - Detailed onboarding guide
-- [CLI Reference](../reference/cli/agent.md) - Full command documentation
-- [Provider Configuration](../host-preparation.md) - Setting up inference providers
+- [Agent Onboarding](/docs/guides/agent-onboarding) - Detailed onboarding guide
+- [CLI Reference](/docs/reference/cli/agent) - Full command documentation
+- [Provider Configuration](/docs/guides/host-setup) - Setting up inference providers

--- a/website/docs/agent-support/providers/_category_.json
+++ b/website/docs/agent-support/providers/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Providers",
+  "position": 1,
+  "link": {
+    "type": "doc",
+    "id": "agent-support/providers/index"
+  }
+}

--- a/website/docs/agent-support/providers/azure-openai.md
+++ b/website/docs/agent-support/providers/azure-openai.md
@@ -23,7 +23,7 @@ We welcome community contributions! If you need Azure OpenAI support:
 
 ### Option 1: Open an Issue
 
-[Create a feature request](../../issues/new?labels=enhancement,provider&title=Add+Azure+OpenAI+provider+support)
+[Create a feature request](https://github.com/ric03uec/clawrium/issues/new?labels=enhancement,provider&title=Add+Azure+OpenAI+provider+support)
 
 Include:
 - Your use case
@@ -39,7 +39,7 @@ We'd love your contribution! Implementation would involve:
 3. Support Azure-specific endpoints and model deployment names
 4. Add tests and documentation
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](/docs/contributing) for guidelines.
 
 ### Option 3: Use OpenRouter
 
@@ -76,7 +76,7 @@ If implementing Azure OpenAI support, the following would be required:
 
 ## Vote for This Feature
 
-Add a 👍 reaction to [this issue](../../issues) to help us prioritize.
+Add a 👍 reaction to [this issue](https://github.com/ric03uec/clawrium/issues) to help us prioritize.
 
 ---
 

--- a/website/docs/agent-support/zeroclaw.md
+++ b/website/docs/agent-support/zeroclaw.md
@@ -150,7 +150,7 @@ ZeroClaw is currently in development. Expected features:
   - Log streaming
   - Secrets management
 
-Track progress: [GitHub Milestone SEA](../milestones)
+Track progress: [GitHub Milestone SEA](https://github.com/ric03uec/clawrium/milestones)
 
 ---
 
@@ -176,5 +176,5 @@ Track progress: [GitHub Milestone SEA](../milestones)
 ## Next Steps
 
 - [OpenClaw Support Matrix](openclaw.md) - Full-featured alternative
-- [Agent Onboarding](../agent-onboarding.md) - Onboarding process overview
-- [CLI Reference](../reference/cli/agent.md) - Command documentation
+- [Agent Onboarding](/docs/guides/agent-onboarding) - Onboarding process overview
+- [CLI Reference](/docs/reference/cli/agent) - Command documentation


### PR DESCRIPTION
## Summary

Add _category_.json configuration files to enable proper Docusaurus sidebar navigation for agent-support sections.

## Problem

The channels, providers, and integrations subdirectories weren't showing up in the sidebar because Docusaurus requires _category_.json files to properly organize documentation sections.

## Solution

Added _category_.json files with:
- Proper labels for each section
- Position ordering (Providers: 1, Channels: 2, Integrations: 3)
- Links to index pages

## Files Added

- website/docs/agent-support/_category_.json
- website/docs/agent-support/providers/_category_.json
- website/docs/agent-support/channels/_category_.json
- website/docs/agent-support/integrations/_category_.json

## Testing

Once deployed, verify:
- Sidebar shows Agent Support section
- Providers, Channels, Integrations appear as sub-items
- All pages are accessible

## Related

Follow-up to #234