### PR TITLE
feat(agent): validate OpenClaw gateway during configure validate stage

### DIFF
--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -563,12 +563,18 @@ def _run_identity_stage(
         else:
             console.print("[red]✗[/red]")
             console.print(f"  [yellow]Warning:[/yellow] Workspace sync failed: {error}")
-            console.print("  [dim]Identity files saved locally. Sync later with 'clm agent sync'[/dim]")
+            console.print(
+                "  [dim]Identity files saved locally. Sync later with 'clm agent sync'[/dim]"
+            )
             # Don't fail the stage - local files are saved
     except Exception as e:
         console.print("[red]✗[/red]")
-        console.print(f"  [yellow]Warning:[/yellow] Workspace sync failed: {rich_escape(str(e))}")
-        console.print("  [dim]Identity files saved locally. Sync later with 'clm agent sync'[/dim]")
+        console.print(
+            f"  [yellow]Warning:[/yellow] Workspace sync failed: {rich_escape(str(e))}"
+        )
+        console.print(
+            "  [dim]Identity files saved locally. Sync later with 'clm agent sync'[/dim]"
+        )
         # Don't fail the stage - local files are saved
 
     # Only call complete_stage if we're actually in the identity state
@@ -578,9 +584,7 @@ def _run_identity_stage(
 
     if current_state == "identity":
         try:
-            complete_stage(
-                host, agent_name, "identity", StageStatus.COMPLETE
-            )
+            complete_stage(host, agent_name, "identity", StageStatus.COMPLETE)
         except Exception as e:
             console.print(
                 f"[red]Error:[/red] Failed to save identity stage: {rich_escape(str(e))}"
@@ -785,6 +789,7 @@ def _run_validate_stage(
     claw_type: str,
     yes: bool,
     installed_name: str | None = None,
+    skip_health: bool = False,
 ) -> bool:
     """Run the VALIDATE onboarding stage.
 
@@ -808,12 +813,15 @@ def _run_validate_stage(
         validate_provider_api_key,
         verify_provider_connectivity,
         validate_agent_installation,
+        validate_openclaw_gateway,
     )
 
     all_errors = []
     all_warnings = []
 
-    console.print("[1/4] Validating agent installation...")
+    total_checks = 5 if claw_type == "openclaw" else 4
+
+    console.print(f"[1/{total_checks}] Validating agent installation...")
     agent_name = installed_name or claw_type
     install_result = validate_agent_installation(host, agent_name)
     if install_result.passed:
@@ -824,7 +832,7 @@ def _run_validate_stage(
             console.print(f"    [red]Error:[/red] {rich_escape(error)}")
         all_errors.extend(install_result.errors)
 
-    console.print("[2/4] Validating personality file (SOUL.md)...")
+    console.print(f"[2/{total_checks}] Validating personality file (SOUL.md)...")
     soul_result = validate_soul_md(claw_type)
     if soul_result.passed:
         console.print("  [green]✓[/green] SOUL.md exists and readable")
@@ -837,7 +845,7 @@ def _run_validate_stage(
             console.print(f"    [red]Error:[/red] {rich_escape(error)}")
         all_errors.extend(soul_result.errors)
 
-    console.print("[3/4] Validating provider configuration...")
+    console.print(f"[3/{total_checks}] Validating provider configuration...")
     provider_result = validate_provider_config(host, claw_type)
     if provider_result.passed:
         provider_id = provider_result.details.get("provider_id", "unknown")
@@ -868,7 +876,7 @@ def _run_validate_stage(
             console.print(f"    [red]Error:[/red] {rich_escape(error)}")
         all_errors.extend(provider_result.errors)
 
-    console.print("[4/4] Testing provider connectivity...")
+    console.print(f"[4/{total_checks}] Testing provider connectivity...")
     if provider_result.passed:
         provider_id = provider_result.details.get("provider_id")
         conn_result = verify_provider_connectivity(provider_id)
@@ -885,6 +893,39 @@ def _run_validate_stage(
     else:
         console.print("  [dim]Skipped (no provider configured)[/dim]")
 
+    gateway_status = "not_applicable"
+    gateway_reason = ""
+    gateway_details: dict = {}
+
+    if claw_type == "openclaw":
+        console.print(f"[5/{total_checks}] Verifying OpenClaw gateway health...")
+        if skip_health:
+            gateway_status = "skipped"
+            gateway_reason = "skipped via --skip-health"
+            console.print("  [yellow]⚠[/yellow] Skipped (--skip-health)")
+        elif all_errors:
+            gateway_status = "skipped"
+            gateway_reason = "skipped due to earlier validation errors"
+            console.print("  [dim]Skipped due to previous validation errors[/dim]")
+        else:
+            conn_result = validate_openclaw_gateway(host, agent_name)
+            gateway_details = conn_result.details
+            if conn_result.passed:
+                gateway_status = "passed"
+                endpoint = conn_result.details.get("gateway_url")
+                if endpoint:
+                    console.print(
+                        f"  [green]✓[/green] Gateway reachable: {rich_escape(str(endpoint))}"
+                    )
+                else:
+                    console.print("  [green]✓[/green] Gateway connectivity OK")
+            else:
+                gateway_status = "failed"
+                console.print("  [red]✗[/red] Gateway health check failed")
+                for error in conn_result.errors:
+                    console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+                all_errors.extend(conn_result.errors)
+
     console.print()
     if all_errors:
         console.print(f"[red]Validation failed with {len(all_errors)} error(s)[/red]")
@@ -899,9 +940,24 @@ def _run_validate_stage(
     else:
         console.print("[green]Validation passed[/green]")
 
+    metadata = None
+    if claw_type == "openclaw":
+        metadata = {
+            "gateway_health_checked": gateway_status == "passed",
+            "gateway_health_status": gateway_status,
+        }
+        if gateway_reason:
+            metadata["gateway_health_reason"] = gateway_reason
+        if "gateway_url" in gateway_details:
+            metadata["gateway_url"] = gateway_details["gateway_url"]
+
     try:
         complete_stage(
-            host, installed_name or claw_type, "validate", StageStatus.COMPLETE
+            host,
+            installed_name or claw_type,
+            "validate",
+            StageStatus.COMPLETE,
+            metadata,
         )
         return True
     except Exception as e:
@@ -927,6 +983,11 @@ def configure(
         help="Run single stage (providers, identity, channels, validate)",
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip prompts, use defaults"),
+    skip_health: bool = typer.Option(
+        False,
+        "--skip-health",
+        help="Skip OpenClaw gateway health verification during validate",
+    ),
     file: Optional[list[Path]] = typer.Option(
         None,
         "--file",
@@ -949,8 +1010,12 @@ def configure(
     """
     # Validate --file is only used with --stage identity
     if file and stage != "identity":
+        console.print("[red]Error:[/red] --file can only be used with --stage identity")
+        raise typer.Exit(code=1)
+
+    if skip_health and stage and stage != "validate":
         console.print(
-            "[red]Error:[/red] --file can only be used with --stage identity"
+            "[red]Error:[/red] --skip-health can only be used with --stage validate or full onboarding"
         )
         raise typer.Exit(code=1)
 
@@ -1037,6 +1102,14 @@ def configure(
         try:
             if stage == "identity":
                 success = stage_func(hostname, claw_type, yes, installed_name, file)
+            elif stage == "validate":
+                success = stage_func(
+                    hostname,
+                    claw_type,
+                    yes,
+                    installed_name,
+                    skip_health,
+                )
             else:
                 success = stage_func(hostname, claw_type, yes, installed_name)
         except KeyboardInterrupt:
@@ -1102,9 +1175,18 @@ def configure(
                     console.print(f"[red]Error:[/red] {e}")
                     raise typer.Exit(code=1)
 
-            success = stage_functions[stage_name](
-                hostname, claw_type, yes, installed_name
-            )
+            if stage_name == "validate":
+                success = stage_functions[stage_name](
+                    hostname,
+                    claw_type,
+                    yes,
+                    installed_name,
+                    skip_health,
+                )
+            else:
+                success = stage_functions[stage_name](
+                    hostname, claw_type, yes, installed_name
+                )
 
             if not success:
                 console.print(

--- a/src/clawrium/core/validation.py
+++ b/src/clawrium/core/validation.py
@@ -4,6 +4,7 @@ This module provides validation functions to verify agent configuration
 and connectivity before transitioning to READY state.
 """
 
+import asyncio
 import json
 import socket
 import urllib.request
@@ -20,6 +21,7 @@ __all__ = [
     "validate_provider_config",
     "validate_provider_api_key",
     "verify_provider_connectivity",
+    "validate_openclaw_gateway",
     "validate_agent_installation",
     "ERROR_MESSAGES",
     "WARNING_MESSAGES",
@@ -92,6 +94,23 @@ ERROR_MESSAGES = {
         "Agent binary has incorrect permissions. Expected {expected}, found {actual}."
     ),
     "onboarding_not_found": "Onboarding record not found for {claw_name} on {host}.",
+    "gateway_not_configured": (
+        "Gateway endpoint not configured for this agent. "
+        "Re-run 'clm agent configure <claw> --stage providers' to sync config."
+    ),
+    "gateway_auth_missing": (
+        "Gateway auth token not configured for this agent. "
+        "Re-run 'clm agent install' or 'clm agent configure <claw> --stage providers'."
+    ),
+    "gateway_unreachable": (
+        "Could not connect to OpenClaw gateway at {endpoint}. "
+        "Check host, port, and network connectivity."
+    ),
+    "gateway_auth_failed": (
+        "Gateway authentication failed. "
+        "Verify gateway auth token and device credentials."
+    ),
+    "gateway_protocol_failed": "Gateway protocol error: {error}",
 }
 
 WARNING_MESSAGES = {
@@ -117,7 +136,9 @@ def validate_soul_md(claw_type: str, agent_name: str | None = None) -> Validatio
     # Check new agent-specific path first (if agent_name provided)
     # New path: agents/<type>/<agent-name>/identity/SOUL.md
     if agent_name:
-        new_path = config_dir / "agents" / claw_type / agent_name / "identity" / "SOUL.md"
+        new_path = (
+            config_dir / "agents" / claw_type / agent_name / "identity" / "SOUL.md"
+        )
         if new_path.exists():
             soul_path = new_path
         else:
@@ -648,6 +669,149 @@ def _test_vertex_connectivity(provider: dict, timeout: int) -> ValidationResult:
         passed=False,
         errors=[ERROR_MESSAGES["vertex_credentials"]],
     )
+
+
+async def _probe_openclaw_gateway(
+    gateway_url: str,
+    auth_token: str,
+    timeout: int,
+    device_id: str | None,
+    device_private_key: str | None,
+) -> None:
+    """Open and close an authenticated gateway connection."""
+    from clawrium.core.chat import OpenClawChatClient
+
+    client = OpenClawChatClient(
+        gateway_url=gateway_url,
+        auth_token=auth_token,
+        device_id=device_id,
+        device_private_key=device_private_key,
+        timeout_seconds=float(timeout),
+    )
+    try:
+        await client.connect()
+    finally:
+        await client.close()
+
+
+def validate_openclaw_gateway(
+    host: str, claw_name: str, timeout: int = 10
+) -> ValidationResult:
+    """Validate OpenClaw gateway reachability and authentication.
+
+    Args:
+        host: Host alias, hostname, or key_id.
+        claw_name: Name of the claw instance.
+        timeout: Connection timeout in seconds.
+
+    Returns:
+        ValidationResult with gateway health verification status.
+    """
+    from clawrium.core.chat import (
+        ChatAuthenticationError,
+        ChatConnectionError,
+        ChatProtocolError,
+    )
+    from clawrium.core.hosts import get_host_by_key_id
+    from clawrium.core.onboarding import _get_claw_record
+
+    host_data = get_host(host)
+    if not host_data:
+        host_data = get_host_by_key_id(host)
+    if not host_data:
+        return ValidationResult(
+            passed=False,
+            errors=[f"Host '{host}' not found."],
+        )
+
+    # Resolve claw from canonical hostname/alias to avoid key_id lookup gaps.
+    claw_record = _get_claw_record(host_data["hostname"], claw_name)
+    if claw_record is None:
+        return ValidationResult(
+            passed=False,
+            errors=[
+                ERROR_MESSAGES["onboarding_not_found"].format(
+                    claw_name=claw_name, host=host
+                )
+            ],
+        )
+
+    config = claw_record.get("config", {})
+    gateway = config.get("gateway", {})
+
+    gateway_url = gateway.get("url")
+    if not gateway_url:
+        port = gateway.get("port")
+        if not port:
+            return ValidationResult(
+                passed=False,
+                errors=[ERROR_MESSAGES["gateway_not_configured"]],
+            )
+        gateway_url = f"ws://{host_data['hostname']}:{port}"
+
+    auth = gateway.get("auth")
+    auth_token = ""
+    if isinstance(auth, str):
+        auth_token = auth
+    elif isinstance(auth, dict):
+        maybe_token = auth.get("token")
+        if isinstance(maybe_token, str):
+            auth_token = maybe_token
+
+    auth_token = auth_token.strip()
+    if not auth_token:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["gateway_auth_missing"]],
+            details={"gateway_url": gateway_url},
+        )
+
+    device = gateway.get("device", {})
+    device_id = device.get("id") if isinstance(device, dict) else None
+    device_private_key = device.get("privateKey") if isinstance(device, dict) else None
+
+    try:
+        asyncio.run(
+            _probe_openclaw_gateway(
+                gateway_url,
+                auth_token,
+                timeout,
+                device_id,
+                device_private_key,
+            )
+        )
+        return ValidationResult(
+            passed=True,
+            details={
+                "gateway_url": gateway_url,
+                "timeout": timeout,
+                "device_auth": bool(device_id and device_private_key),
+            },
+        )
+    except ChatConnectionError as e:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["gateway_unreachable"].format(endpoint=gateway_url)],
+            details={"error": str(e), "gateway_url": gateway_url},
+        )
+    except ChatAuthenticationError as e:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["gateway_auth_failed"]],
+            details={"error": str(e), "gateway_url": gateway_url},
+        )
+    except ChatProtocolError as e:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["gateway_protocol_failed"].format(error=str(e))],
+            details={"gateway_url": gateway_url},
+        )
+    except Exception as e:
+        return ValidationResult(
+            passed=False,
+            errors=[ERROR_MESSAGES["gateway_protocol_failed"].format(error=str(e))],
+            details={"gateway_url": gateway_url},
+        )
 
 
 def validate_agent_installation(host: str, claw_name: str) -> ValidationResult:

--- a/src/clawrium/core/validation.py
+++ b/src/clawrium/core/validation.py
@@ -7,6 +7,7 @@ and connectivity before transitioning to READY state.
 import asyncio
 import json
 import socket
+import time
 import urllib.request
 import urllib.error
 from dataclasses import dataclass, field
@@ -695,7 +696,11 @@ async def _probe_openclaw_gateway(
 
 
 def validate_openclaw_gateway(
-    host: str, claw_name: str, timeout: int = 10
+    host: str,
+    claw_name: str,
+    timeout: int = 10,
+    retries: int = 3,
+    retry_delay: float = 1.0,
 ) -> ValidationResult:
     """Validate OpenClaw gateway reachability and authentication.
 
@@ -703,6 +708,8 @@ def validate_openclaw_gateway(
         host: Host alias, hostname, or key_id.
         claw_name: Name of the claw instance.
         timeout: Connection timeout in seconds.
+        retries: Number of connection attempts on transient connection errors.
+        retry_delay: Delay between retries in seconds.
 
     Returns:
         ValidationResult with gateway health verification status.
@@ -770,48 +777,72 @@ def validate_openclaw_gateway(
     device_id = device.get("id") if isinstance(device, dict) else None
     device_private_key = device.get("privateKey") if isinstance(device, dict) else None
 
-    try:
-        asyncio.run(
-            _probe_openclaw_gateway(
-                gateway_url,
-                auth_token,
-                timeout,
-                device_id,
-                device_private_key,
+    retries = max(1, int(retries))
+    last_connection_error: ChatConnectionError | None = None
+
+    for attempt in range(1, retries + 1):
+        try:
+            asyncio.run(
+                _probe_openclaw_gateway(
+                    gateway_url,
+                    auth_token,
+                    timeout,
+                    device_id,
+                    device_private_key,
+                )
             )
-        )
-        return ValidationResult(
-            passed=True,
-            details={
-                "gateway_url": gateway_url,
-                "timeout": timeout,
-                "device_auth": bool(device_id and device_private_key),
-            },
-        )
-    except ChatConnectionError as e:
+            return ValidationResult(
+                passed=True,
+                details={
+                    "gateway_url": gateway_url,
+                    "timeout": timeout,
+                    "device_auth": bool(device_id and device_private_key),
+                    "attempts": attempt,
+                },
+            )
+        except ChatConnectionError as e:
+            last_connection_error = e
+            if attempt < retries:
+                time.sleep(retry_delay)
+                continue
+            break
+        except ChatAuthenticationError as e:
+            return ValidationResult(
+                passed=False,
+                errors=[ERROR_MESSAGES["gateway_auth_failed"]],
+                details={"error": str(e), "gateway_url": gateway_url},
+            )
+        except ChatProtocolError as e:
+            return ValidationResult(
+                passed=False,
+                errors=[ERROR_MESSAGES["gateway_protocol_failed"].format(error=str(e))],
+                details={"gateway_url": gateway_url},
+            )
+        except Exception as e:
+            return ValidationResult(
+                passed=False,
+                errors=[ERROR_MESSAGES["gateway_protocol_failed"].format(error=str(e))],
+                details={"gateway_url": gateway_url},
+            )
+
+    if last_connection_error is not None:
         return ValidationResult(
             passed=False,
             errors=[ERROR_MESSAGES["gateway_unreachable"].format(endpoint=gateway_url)],
-            details={"error": str(e), "gateway_url": gateway_url},
+            details={
+                "error": str(last_connection_error),
+                "gateway_url": gateway_url,
+                "attempts": retries,
+            },
         )
-    except ChatAuthenticationError as e:
-        return ValidationResult(
-            passed=False,
-            errors=[ERROR_MESSAGES["gateway_auth_failed"]],
-            details={"error": str(e), "gateway_url": gateway_url},
-        )
-    except ChatProtocolError as e:
-        return ValidationResult(
-            passed=False,
-            errors=[ERROR_MESSAGES["gateway_protocol_failed"].format(error=str(e))],
-            details={"gateway_url": gateway_url},
-        )
-    except Exception as e:
-        return ValidationResult(
-            passed=False,
-            errors=[ERROR_MESSAGES["gateway_protocol_failed"].format(error=str(e))],
-            details={"gateway_url": gateway_url},
-        )
+
+    return ValidationResult(
+        passed=False,
+        errors=[
+            ERROR_MESSAGES["gateway_protocol_failed"].format(error="Unknown error")
+        ],
+        details={"gateway_url": gateway_url},
+    )
 
 
 def validate_agent_installation(host: str, claw_name: str) -> ValidationResult:

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -9,6 +9,7 @@ import pytest
 from typer.testing import CliRunner
 
 from clawrium.cli.main import app
+from clawrium.core.validation import ValidationResult
 
 runner = CliRunner()
 
@@ -242,10 +243,37 @@ class TestAgentConfigureSingleStage:
                 mock_run.assert_called_once_with(
                     "192.168.1.100", "openclaw", True, "assistant", None
                 )
+            elif stage_name == "validate":
+                mock_run.assert_called_once_with(
+                    "192.168.1.100", "openclaw", True, "assistant", False
+                )
             else:
                 mock_run.assert_called_once_with(
                     "192.168.1.100", "openclaw", True, "assistant"
                 )
+
+    def test_skip_health_rejected_for_non_validate_single_stage(
+        self, isolated_config: Path
+    ):
+        """Rejects --skip-health with non-validate single stage."""
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(isolated_config)
+
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "configure",
+                "assistant",
+                "--stage",
+                "providers",
+                "--skip-health",
+            ],
+            env=os.environ,
+        )
+
+        assert result.exit_code == 1
+        assert "skip-health" in result.output.lower()
 
     def test_single_stage_failure(self, isolated_config: Path):
         """Stage failure exits with code 1."""
@@ -466,14 +494,19 @@ class TestRunIdentityStage:
 
         with patch("clawrium.cli.agent.complete_stage"):
             with patch("clawrium.cli.agent.get_host", return_value=mock_host):
-                with patch(
-                    "clawrium.core.lifecycle.configure_agent", mock_configure
-                ):
+                with patch("clawrium.core.lifecycle.configure_agent", mock_configure):
                     result = _run_identity_stage("work", "openclaw", True)
 
         assert result is True
         # New path: agents/<type>/<agent-name>/identity/SOUL.md
-        soul_path = isolated_config / "agents" / "openclaw" / "openclaw" / "identity" / "SOUL.md"
+        soul_path = (
+            isolated_config
+            / "agents"
+            / "openclaw"
+            / "openclaw"
+            / "identity"
+            / "SOUL.md"
+        )
         assert soul_path.exists()
 
         # Verify configure_agent was called with identity_files in extra_vars
@@ -942,6 +975,10 @@ class TestRunValidateStage:
             patch(
                 "clawrium.core.validation._make_request", return_value=(200, {}, None)
             ),
+            patch(
+                "clawrium.core.validation.validate_openclaw_gateway",
+                return_value=ValidationResult(passed=True),
+            ),
             patch("clawrium.cli.agent.complete_stage", side_effect=Exception("failed")),
         ):
             result = _run_validate_stage("work", "openclaw", True)
@@ -1008,6 +1045,13 @@ class TestRunValidateStage:
             patch(
                 "clawrium.core.validation._make_request", return_value=(200, {}, None)
             ),
+            patch(
+                "clawrium.core.validation.validate_openclaw_gateway",
+                return_value=ValidationResult(
+                    passed=True,
+                    details={"gateway_url": "ws://192.168.1.100:40123"},
+                ),
+            ),
             patch("clawrium.cli.agent.complete_stage"),
         ):
             result = _run_validate_stage("work", "openclaw", True)
@@ -1052,6 +1096,125 @@ class TestRunValidateStage:
             result = _run_validate_stage("work", "openclaw", True)
 
         assert result is False
+
+    def test_skip_health_marks_validate_metadata(self, isolated_config: Path):
+        """Stores skip metadata when validate runs with --skip-health."""
+        from clawrium.cli.agent import _run_validate_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(isolated_config, onboarding_state="validate")
+        create_provider(isolated_config)
+
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = json.loads(hosts_file.read_text())
+        hosts_data[0]["agents"]["openclaw"]["onboarding"]["stages"]["providers"][
+            "provider_id"
+        ] = "test-openai"
+        hosts_data[0]["agents"]["openclaw"]["config"] = {
+            "gateway": {
+                "url": "ws://192.168.1.100:40123",
+                "auth": "token-123",
+                "port": 40123,
+            }
+        }
+        hosts_file.write_text(json.dumps(hosts_data, indent=2))
+
+        soul_dir = isolated_config / "agents" / "openclaw"
+        soul_dir.mkdir(parents=True)
+        (soul_dir / "SOUL.md").write_text("Test personality")
+
+        secrets_file = isolated_config / "secrets.json"
+        secrets_file.write_text(
+            json.dumps(
+                {
+                    "provider:test-openai": {
+                        "API_KEY": {
+                            "key": "API_KEY",
+                            "value": "sk-test-key",
+                            "created_at": "2026-01-01T00:00:00Z",
+                            "updated_at": "2026-01-01T00:00:00Z",
+                            "description": "",
+                        }
+                    }
+                }
+            )
+        )
+
+        with (
+            patch(
+                "clawrium.core.validation._make_request", return_value=(200, {}, None)
+            ),
+            patch("clawrium.core.validation.validate_openclaw_gateway") as mock_gateway,
+            patch("clawrium.cli.agent.complete_stage") as mock_complete,
+        ):
+            result = _run_validate_stage("work", "openclaw", True, skip_health=True)
+
+        assert result is True
+        mock_gateway.assert_not_called()
+        args = mock_complete.call_args[0]
+        metadata = args[4]
+        assert metadata["gateway_health_checked"] is False
+        assert metadata["gateway_health_status"] == "skipped"
+
+    def test_gateway_health_failure_blocks_validate(self, isolated_config: Path):
+        """Validate fails when OpenClaw gateway health check fails."""
+        from clawrium.cli.agent import _run_validate_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(isolated_config, onboarding_state="validate")
+        create_provider(isolated_config)
+
+        hosts_file = isolated_config / "hosts.json"
+        hosts_data = json.loads(hosts_file.read_text())
+        hosts_data[0]["agents"]["openclaw"]["onboarding"]["stages"]["providers"][
+            "provider_id"
+        ] = "test-openai"
+        hosts_data[0]["agents"]["openclaw"]["config"] = {
+            "gateway": {
+                "url": "ws://192.168.1.100:40123",
+                "auth": "token-123",
+                "port": 40123,
+            }
+        }
+        hosts_file.write_text(json.dumps(hosts_data, indent=2))
+
+        soul_dir = isolated_config / "agents" / "openclaw"
+        soul_dir.mkdir(parents=True)
+        (soul_dir / "SOUL.md").write_text("Test personality")
+
+        secrets_file = isolated_config / "secrets.json"
+        secrets_file.write_text(
+            json.dumps(
+                {
+                    "provider:test-openai": {
+                        "API_KEY": {
+                            "key": "API_KEY",
+                            "value": "sk-test-key",
+                            "created_at": "2026-01-01T00:00:00Z",
+                            "updated_at": "2026-01-01T00:00:00Z",
+                            "description": "",
+                        }
+                    }
+                }
+            )
+        )
+
+        with (
+            patch(
+                "clawrium.core.validation._make_request", return_value=(200, {}, None)
+            ),
+            patch(
+                "clawrium.core.validation.validate_openclaw_gateway",
+                return_value=ValidationResult(
+                    passed=False, errors=["Could not connect to OpenClaw gateway"]
+                ),
+            ),
+            patch("clawrium.cli.agent.complete_stage") as mock_complete,
+        ):
+            result = _run_validate_stage("work", "openclaw", True)
+
+        assert result is False
+        mock_complete.assert_not_called()
 
 
 class TestHostsFileCorruptedError:

--- a/tests/test_core_validation.py
+++ b/tests/test_core_validation.py
@@ -645,6 +645,108 @@ class TestValidateOpenClawGateway:
         assert result.passed is False
         assert "authentication failed" in result.errors[0].lower()
 
+    @patch("clawrium.core.validation._probe_openclaw_gateway")
+    def test_gateway_probe_retries_and_recovers(
+        self, mock_probe, isolated_config: Path
+    ):
+        """Retries transient connection failures and succeeds on a later attempt."""
+        from clawrium.core.chat import ChatConnectionError
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "hostname": "192.168.1.100",
+                        "agents": {
+                            "assistant": {
+                                "type": "openclaw",
+                                "onboarding": {
+                                    "state": "validate",
+                                    "stages": {
+                                        "providers": {
+                                            "status": "complete",
+                                            "provider_id": "test-openai",
+                                        },
+                                        "identity": {"status": "complete"},
+                                        "channels": {"status": "complete"},
+                                        "validate": {"status": "pending"},
+                                    },
+                                },
+                                "config": {
+                                    "gateway": {
+                                        "url": "ws://192.168.1.100:40123",
+                                        "auth": "token-123",
+                                        "port": 40123,
+                                    }
+                                },
+                            }
+                        },
+                    }
+                ]
+            )
+        )
+        mock_probe.side_effect = [ChatConnectionError("timeout"), None]
+
+        result = validate_openclaw_gateway(
+            "192.168.1.100", "assistant", retries=3, retry_delay=0
+        )
+
+        assert result.passed is True
+        assert result.details.get("attempts") == 2
+        assert mock_probe.call_count == 2
+
+    @patch("clawrium.core.validation._probe_openclaw_gateway")
+    def test_gateway_probe_retries_exhausted(self, mock_probe, isolated_config: Path):
+        """Fails after exhausting connection retry attempts."""
+        from clawrium.core.chat import ChatConnectionError
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "hostname": "192.168.1.100",
+                        "agents": {
+                            "assistant": {
+                                "type": "openclaw",
+                                "onboarding": {
+                                    "state": "validate",
+                                    "stages": {
+                                        "providers": {
+                                            "status": "complete",
+                                            "provider_id": "test-openai",
+                                        },
+                                        "identity": {"status": "complete"},
+                                        "channels": {"status": "complete"},
+                                        "validate": {"status": "pending"},
+                                    },
+                                },
+                                "config": {
+                                    "gateway": {
+                                        "url": "ws://192.168.1.100:40123",
+                                        "auth": "token-123",
+                                        "port": 40123,
+                                    }
+                                },
+                            }
+                        },
+                    }
+                ]
+            )
+        )
+        mock_probe.side_effect = ChatConnectionError("timeout")
+
+        result = validate_openclaw_gateway(
+            "192.168.1.100", "assistant", retries=3, retry_delay=0
+        )
+
+        assert result.passed is False
+        assert result.details.get("attempts") == 3
+        assert mock_probe.call_count == 3
+
 
 class TestValidateAgentInstallation:
     """Tests for validate_agent_installation function."""

--- a/tests/test_core_validation.py
+++ b/tests/test_core_validation.py
@@ -10,6 +10,7 @@ from clawrium.core.validation import (
     validate_provider_config,
     validate_provider_api_key,
     verify_provider_connectivity,
+    validate_openclaw_gateway,
     validate_agent_installation,
     ERROR_MESSAGES,
     WARNING_MESSAGES,
@@ -469,6 +470,180 @@ class TestTestOllamaConnectivity:
             assert result.passed is True
             assert len(result.warnings) == 1
             assert "no models" in result.warnings[0].lower()
+
+
+class TestValidateOpenClawGateway:
+    """Tests for validate_openclaw_gateway function."""
+
+    def test_missing_gateway_config_fails(self, isolated_config: Path):
+        """Returns failure when gateway endpoint is not configured."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "hostname": "192.168.1.100",
+                        "agents": {
+                            "assistant": {
+                                "type": "openclaw",
+                                "onboarding": {
+                                    "state": "validate",
+                                    "stages": {
+                                        "providers": {
+                                            "status": "complete",
+                                            "provider_id": "test-openai",
+                                        },
+                                        "identity": {"status": "complete"},
+                                        "channels": {"status": "complete"},
+                                        "validate": {"status": "pending"},
+                                    },
+                                },
+                                "config": {"gateway": {}},
+                            }
+                        },
+                    }
+                ]
+            )
+        )
+
+        result = validate_openclaw_gateway("192.168.1.100", "assistant")
+
+        assert result.passed is False
+        assert "gateway endpoint not configured" in result.errors[0].lower()
+
+    def test_missing_gateway_auth_fails(self, isolated_config: Path):
+        """Returns failure when gateway auth token is missing."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "hostname": "192.168.1.100",
+                        "agents": {
+                            "assistant": {
+                                "type": "openclaw",
+                                "onboarding": {
+                                    "state": "validate",
+                                    "stages": {
+                                        "providers": {
+                                            "status": "complete",
+                                            "provider_id": "test-openai",
+                                        },
+                                        "identity": {"status": "complete"},
+                                        "channels": {"status": "complete"},
+                                        "validate": {"status": "pending"},
+                                    },
+                                },
+                                "config": {
+                                    "gateway": {
+                                        "url": "ws://192.168.1.100:40123",
+                                        "port": 40123,
+                                    }
+                                },
+                            }
+                        },
+                    }
+                ]
+            )
+        )
+
+        result = validate_openclaw_gateway("192.168.1.100", "assistant")
+
+        assert result.passed is False
+        assert "auth token not configured" in result.errors[0].lower()
+
+    @patch("clawrium.core.validation._probe_openclaw_gateway")
+    def test_gateway_probe_success(self, mock_probe, isolated_config: Path):
+        """Returns success when gateway probe connects and authenticates."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "hostname": "192.168.1.100",
+                        "agents": {
+                            "assistant": {
+                                "type": "openclaw",
+                                "onboarding": {
+                                    "state": "validate",
+                                    "stages": {
+                                        "providers": {
+                                            "status": "complete",
+                                            "provider_id": "test-openai",
+                                        },
+                                        "identity": {"status": "complete"},
+                                        "channels": {"status": "complete"},
+                                        "validate": {"status": "pending"},
+                                    },
+                                },
+                                "config": {
+                                    "gateway": {
+                                        "url": "ws://192.168.1.100:40123",
+                                        "auth": {"token": "test-token"},
+                                        "port": 40123,
+                                    }
+                                },
+                            }
+                        },
+                    }
+                ]
+            )
+        )
+
+        result = validate_openclaw_gateway("192.168.1.100", "assistant")
+
+        assert result.passed is True
+        assert result.details.get("gateway_url") == "ws://192.168.1.100:40123"
+
+    @patch("clawrium.core.validation._probe_openclaw_gateway")
+    def test_gateway_probe_auth_failure(self, mock_probe, isolated_config: Path):
+        """Returns auth failure when gateway rejects credentials."""
+        from clawrium.core.chat import ChatAuthenticationError
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_file = isolated_config / "hosts.json"
+        hosts_file.write_text(
+            json.dumps(
+                [
+                    {
+                        "hostname": "192.168.1.100",
+                        "agents": {
+                            "assistant": {
+                                "type": "openclaw",
+                                "onboarding": {
+                                    "state": "validate",
+                                    "stages": {
+                                        "providers": {
+                                            "status": "complete",
+                                            "provider_id": "test-openai",
+                                        },
+                                        "identity": {"status": "complete"},
+                                        "channels": {"status": "complete"},
+                                        "validate": {"status": "pending"},
+                                    },
+                                },
+                                "config": {
+                                    "gateway": {
+                                        "url": "ws://192.168.1.100:40123",
+                                        "auth": "bad-token",
+                                        "port": 40123,
+                                    }
+                                },
+                            }
+                        },
+                    }
+                ]
+            )
+        )
+        mock_probe.side_effect = ChatAuthenticationError("unauthorized")
+
+        result = validate_openclaw_gateway("192.168.1.100", "assistant")
+
+        assert result.passed is False
+        assert "authentication failed" in result.errors[0].lower()
 
 
 class TestValidateAgentInstallation:


### PR DESCRIPTION
Closes #166

## What changed
- Added OpenClaw gateway connectivity and auth verification inside the existing validate stage (no new onboarding state).
- Added skip-health option to clm agent configure to bypass only gateway verification during validate.
- Persist validate-stage metadata for gateway health outcomes (passed or skipped).
- Hardened gateway verification with retry handling for transient connection errors while keeping auth/protocol failures fail-fast.
- Added and updated tests for runtime behavior, skip-flag rules, gateway validation paths, and retry recovery/exhaustion.

## Testing
- uv run pytest tests/test_cli_agent_configure.py tests/test_core_validation.py
- make test
- make lint
- Manual command checks:
  - uv run clm agent configure --help
  - uv run clm agent configure assistant --stage providers --skip-health
  - uv run clm agent configure assistant --stage validate --skip-health
  - uv run clm agent configure wolf-i --stage validate --yes (run 3 times; all passed)

## Notes
- Per issue discussion, onboarding states remain unchanged: pending -> providers -> identity -> channels -> validate -> ready.
- Gateway verification is implemented inside validate only.