### PR TITLE
fix(secrets): remove mandatory OPENAI_API_KEY from openclaw

### DIFF
--- a/src/clawrium/core/health.py
+++ b/src/clawrium/core/health.py
@@ -141,6 +141,10 @@ def get_missing_secrets(claw_type: str, host: dict, claw_record: dict) -> list[s
     Returns:
         List of missing required secret keys
     """
+    # Cannot check secrets without a valid claw type
+    if not claw_type:
+        return []
+
     # Use canonical instance name.
     # For current installs this is stored in `user`; `name` is supported as fallback.
     claw_name = claw_record.get("agent_name") or claw_record.get("name", "")
@@ -360,7 +364,8 @@ def check_claw_health(
 
         if process_running:
             try:
-                missing = get_missing_secrets(claw_name, host, claw_record)
+                claw_type = claw_record.get("type", "")
+                missing = get_missing_secrets(claw_type, host, claw_record)
             except SecretsFileCorruptedError as e:
                 return {
                     "agent": claw_name,

--- a/src/clawrium/platform/registry/openclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/openclaw/manifest.yaml
@@ -2,16 +2,14 @@ agent:
   type: openclaw
   description: "Open-source AI assistant framework"
 
-# Secrets required for this agent (installation fails when missing)
+# Secrets configuration
+# Note: Provider-specific API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
+# are managed through provider configuration, not as standalone secrets.
 secrets:
-  required:
-    - key: OPENAI_API_KEY
-      description: "OpenAI API key for LLM requests"
+  required: []
 
   # Optional secrets (agent still runs without them)
   optional:
-    - key: ANTHROPIC_API_KEY
-      description: "Anthropic API key for Claude models"
     - key: DISCORD_BOT_TOKEN
       description: "Discord bot token for Discord channel"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,6 +193,7 @@ def hosts_with_installed_claw(isolated_config):
             "agent_name": "xclm",
             "agents": {
                 "openclaw": {
+                    "type": "openclaw",
                     "version": "0.1.0",
                     "status": "installed",
                     "name": "work",

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -47,10 +47,9 @@ def test_registry_show_openclaw():
     assert result.exit_code == 0
     assert "openclaw" in result.output.lower()
     assert "Supported Platforms" in result.output
-    assert "Required Secrets" in result.output
-    assert "OPENAI_API_KEY" in result.output
+    # openclaw has no required secrets (provider credentials managed separately)
     assert "Optional Secrets" in result.output
-    assert "ANTHROPIC_API_KEY" in result.output
+    assert "DISCORD_BOT_TOKEN" in result.output
     assert "ubuntu" in result.output.lower()
 
 

--- a/tests/test_cli_secret.py
+++ b/tests/test_cli_secret.py
@@ -283,30 +283,34 @@ def test_secret_list_shows_keys_not_values(hosts_with_installed_claw: Path):
 
 
 def test_secret_list_shows_missing_required_secrets(hosts_with_installed_claw: Path):
-    """clm secret list shows missing required secrets per claw instance."""
+    """clm secret list shows missing required secrets per claw instance.
+
+    Note: openclaw has no required secrets (provider credentials managed separately).
+    This test verifies the command runs successfully with no missing secrets shown.
+    """
     result = runner.invoke(app, ["agent", "secret", "list", "work"], env=os.environ)
 
     assert result.exit_code == 0
-    # Should show claw and missing secrets
+    # Should show claw name
     assert "work" in result.output
-    assert "OPENAI_API_KEY" in result.output
-    assert "Missing" in result.output or "missing" in result.output
+    # openclaw has no required secrets, so no missing section
+    assert "Missing:" not in result.output
 
 
 def test_secret_list_no_missing_when_all_set(hosts_with_installed_claw: Path):
     """clm secret list does not show missing section when all required secrets set."""
-    # Set all required secrets for openclaw
-    with patch("clawrium.cli.secret.getpass.getpass", return_value="sk-test"):
+    # Set an optional secret for openclaw
+    with patch("clawrium.cli.secret.getpass.getpass", return_value="test-token"):
         runner.invoke(
-            app, ["agent", "secret", "set", "work", "OPENAI_API_KEY"], env=os.environ
+            app, ["agent", "secret", "set", "work", "DISCORD_BOT_TOKEN"], env=os.environ
         )
 
     result = runner.invoke(app, ["agent", "secret", "list", "work"], env=os.environ)
 
     assert result.exit_code == 0
     # Should show the stored secret
-    assert "OPENAI_API_KEY" in result.output
-    # Should NOT show missing section
+    assert "DISCORD_BOT_TOKEN" in result.output
+    # Should NOT show missing section (no required secrets for openclaw)
     assert "Missing:" not in result.output
 
 
@@ -554,7 +558,11 @@ def test_secret_list_per_claw(isolated_config: Path):
 
 
 def test_secret_list_shows_missing_required(isolated_config: Path):
-    """clm secret list shows missing required secrets per claw instance."""
+    """clm secret list shows missing required secrets per claw instance.
+
+    Note: openclaw has no required secrets (provider credentials managed separately).
+    This test verifies the command runs successfully with no missing secrets shown.
+    """
     _create_hosts_json(
         isolated_config,
         [
@@ -563,6 +571,7 @@ def test_secret_list_shows_missing_required(isolated_config: Path):
                 "alias": "wolf",
                 "agents": {
                     "openclaw": {
+                        "type": "openclaw",
                         "status": "installed",
                         "agent_name": "opc-work",
                     }
@@ -576,9 +585,8 @@ def test_secret_list_shows_missing_required(isolated_config: Path):
     assert result.exit_code == 0
     # Should show claw
     assert "opc-work" in result.output
-    # Should show missing required secrets
-    assert "Missing" in result.output or "missing" in result.output
-    assert "OPENAI_API_KEY" in result.output
+    # openclaw has no required secrets, so no missing section
+    assert "Missing:" not in result.output
 
 
 def test_secret_list_claw_not_found(isolated_config: Path):

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -448,14 +448,15 @@ def test_status_hosts_file_corrupted():
 
 def test_status_shows_degraded_with_missing_secrets(mock_hosts_with_claws):
     """Degraded status shows missing secret keys."""
+    # Use zeroclaw secrets since openclaw has no required secrets
     mock_health = MagicMock(
         return_value={
-            "agent": "openclaw",
+            "agent": "zeroclaw",
             "host": "192.168.1.100",
             "status": ClawStatus.DEGRADED,
-            "agent_name": "opc-server1",
+            "agent_name": "zc-server1",
             "error": None,
-            "missing_secrets": ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
+            "missing_secrets": ["LLM_PROVIDER_URL", "LLM_MODEL"],
             "onboarding_step": None,
             "process_running": True,
             "onboarding_stages": None,
@@ -468,8 +469,8 @@ def test_status_shows_degraded_with_missing_secrets(mock_hosts_with_claws):
 
     assert result.exit_code == 0
     assert "degraded" in result.output
-    assert "OPENAI_API_KEY" in result.output
-    assert "ANTHROPIC_API_KEY" in result.output
+    assert "LLM_PROVIDER_URL" in result.output
+    assert "LLM_MODEL" in result.output
 
 
 def test_status_degraded_truncates_long_list(mock_hosts_with_claws):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -25,6 +25,7 @@ def mock_host():
         "key_id": "testhost",
         "agents": {
             "openclaw": {
+                "type": "openclaw",
                 "version": "0.1.0",
                 "status": "installed",
                 "agent_name": "opc-testhost",
@@ -408,6 +409,49 @@ def test_check_claw_health_corrupted_secrets_file(mock_host):
     assert "corrupted" in result["error"].lower()
 
 
+def test_check_claw_health_uses_type_not_key_for_secrets():
+    """Regression test: secrets lookup uses agent type, not agent key.
+
+    When the agent key (e.g., 'wolf-i') differs from the agent type (e.g., 'openclaw'),
+    get_required_secrets must receive the type, not the key. Otherwise, it would fail
+    with ManifestNotFoundError because there's no 'wolf-i' manifest.
+    """
+    # Host with agent key 'wolf-i' but type 'openclaw'
+    host = {
+        "hostname": "192.168.1.100",
+        "port": 22,
+        "key_id": "testhost",
+        "agents": {
+            "wolf-i": {  # Key differs from type
+                "type": "openclaw",  # Actual agent type
+                "version": "2026.4.2",
+                "status": "installed",
+                "agent_name": "wolf-i",
+            }
+        },
+    }
+
+    mock_runner = MagicMock()
+    mock_runner.status = "successful"
+    mock_runner.events = [{"event": "runner_on_ok", "event_data": {"res": {"rc": 0}}}]
+
+    with patch("clawrium.core.health.get_host_private_key", return_value="/fake/key"):
+        with patch("clawrium.core.health.ansible_runner.run", return_value=mock_runner):
+            with patch(
+                "clawrium.core.health.get_instance_secrets", return_value={}
+            ) as mock_secrets:
+                with patch(
+                    "clawrium.core.health.get_required_secrets", return_value=[]
+                ) as mock_required:
+                    result = check_claw_health("wolf-i", host)
+
+    # Should call get_required_secrets with 'openclaw' (the type), not 'wolf-i' (the key)
+    mock_required.assert_called_once_with("openclaw")
+
+    # Should succeed without ManifestNotFoundError
+    assert result["status"] == ClawStatus.RUNNING
+
+
 def test_missing_secrets_none_for_non_running_status(mock_host):
     """Non-running status has missing_secrets as None."""
     mock_runner = MagicMock()
@@ -728,6 +772,7 @@ class TestHealthCheckOnboardingIntegration:
             "key_id": "testhost",
             "agents": {
                 "openclaw": {
+                    "type": "openclaw",
                     "version": "0.1.0",
                     "status": "installed",
                     "agent_name": "opc-testhost",
@@ -957,6 +1002,7 @@ class TestProcessRunningField:
             "key_id": "testhost",
             "agents": {
                 "openclaw": {
+                    "type": "openclaw",
                     "version": "0.1.0",
                     "status": "installed",
                     "agent_name": "opc-testhost",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -588,8 +588,13 @@ def test_get_required_secrets_returns_list():
     """Test get_required_secrets returns list of SecretDefinition dicts."""
     from clawrium.core.registry import get_required_secrets
 
+    # openclaw has no required secrets (provider credentials managed separately)
     secrets = get_required_secrets("openclaw")
+    assert isinstance(secrets, list)
+    assert len(secrets) == 0
 
+    # zeroclaw has required secrets
+    secrets = get_required_secrets("zeroclaw")
     assert isinstance(secrets, list)
     assert len(secrets) > 0
     # Each secret should have key and description


### PR DESCRIPTION
## Summary

- Remove `OPENAI_API_KEY` from openclaw required secrets - provider-specific API keys are now managed through provider configuration
- Fix bug in `health.py` where `claw_name` was passed instead of `claw_type` to `get_missing_secrets()`
- Add guard for empty `claw_type` to prevent `InvalidAgentTypeError`
- Update test fixtures to include `type` field in agent records

## Test plan

- [x] `make test` passes (1040 tests)
- [x] `clm ps` shows `running` status instead of `degraded (missing: OPENAI_API_KEY)`
- [x] Regression test added for agent key != type scenario

## ATX Review Summary

**Final Review: Rating 3/5**

| Review | Rating | Blocking Issues | Status | Agents |
|--------|--------|-----------------|--------|--------|
| 1 | 3/5 | None | Warnings fixed | lifecycle-state-reviewer, ansible-playbook-reviewer, test-coverage, secrets-provider-reviewer |

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Warnings:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| W1 | `core/health.py:361-364` | Empty claw_type causes InvalidAgentTypeError | Fixed - added early return for empty claw_type |
| W5 | `test_cli_status.py:458-472` | Stale mock references ANTHROPIC_API_KEY | Fixed - updated to zeroclaw secrets |
| W6/W7 | `tests/test_cli_secret.py` | Test fixtures missing type field | Fixed - added type to all fixtures |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S5 | Add regression test for agent key != type bug | Added `test_check_claw_health_uses_type_not_key_for_secrets()` |

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>