### PR TITLE
feat(cli): add --edit-config and --editor options to configure command

### DIFF
--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -967,6 +967,41 @@ def _run_validate_stage(
         return False
 
 
+def _run_edit_config(
+    hostname: str,
+    host_data: dict,
+    claw_type: str,
+    installed_name: str,
+    display_host: str,
+    editor: Optional[str] = None,
+) -> None:
+    """Run the edit-config workflow for direct config file editing.
+
+    Opens the agent's config file in an editor, validates changes,
+    syncs to the remote host, and optionally restarts the agent.
+
+    Args:
+        hostname: Remote host hostname
+        host_data: Host configuration data
+        claw_type: Type of agent (e.g., "openclaw")
+        installed_name: Agent instance name
+        display_host: Display name for the host
+        editor: Optional editor override (else uses VISUAL/EDITOR/vi)
+    """
+    # Edit-config workflow is not yet implemented
+    # This will be implemented in a follow-up subtask of #167
+    console.print(
+        f"[red]Error:[/red] Edit-config workflow for '{rich_escape(installed_name)}' "
+        f"on '{rich_escape(display_host)}' is not yet implemented."
+    )
+    console.print(
+        "\nThis feature will be available in a future release. "
+        "Use the onboarding wizard instead:"
+    )
+    console.print(f"  clm agent configure {rich_escape(installed_name)}")
+    raise typer.Exit(code=1)
+
+
 # Allowed identity file names for --file option
 IDENTITY_FILE_ALLOWLIST = {"SOUL.md", "AGENTS.md", "TOOLS.md", "IDENTITY.md"}
 
@@ -996,18 +1031,59 @@ def configure(
         exists=True,
         readable=True,
     ),
+    edit_config: bool = typer.Option(
+        False,
+        "--edit-config",
+        help="Open agent config file in editor for direct editing. Cannot be combined with --stage, --file, or --skip-health.",
+    ),
+    editor: Optional[str] = typer.Option(
+        None,
+        "--editor",
+        help="Editor command for --edit-config (e.g., vim, nano). If not specified, uses VISUAL, then EDITOR, then vi.",
+    ),
 ) -> None:
     """Configure agent settings through an interactive wizard.
 
     Runs through onboarding stages: providers, identity, channels, validate.
     Use --stage to run a specific stage only.
+    Use --edit-config to directly edit the agent's config file.
 
     Examples:
         clm agent configure wise-hypatia
         clm agent configure clever-einstein --stage providers
         clm agent configure work-assistant --yes
         clm agent configure wolf-i --stage identity --file ~/SOUL.md
+        clm agent configure wolf-i --edit-config
+        clm agent configure wolf-i --edit-config --editor nano
     """
+    # Validate --edit-config incompatible options
+    if edit_config:
+        if stage:
+            console.print(
+                "[red]Error:[/red] --edit-config cannot be used with --stage. "
+                "Use --edit-config alone to edit the config file."
+            )
+            raise typer.Exit(code=1)
+        if file:
+            console.print(
+                "[red]Error:[/red] --edit-config cannot be used with --file. "
+                "Use --edit-config alone to edit the config file."
+            )
+            raise typer.Exit(code=1)
+        if skip_health:
+            console.print(
+                "[red]Error:[/red] --edit-config cannot be used with --skip-health. "
+                "Use --edit-config alone to edit the config file."
+            )
+            raise typer.Exit(code=1)
+
+    # Validate --editor requires --edit-config
+    if editor and not edit_config:
+        console.print(
+            "[red]Error:[/red] --editor can only be used with --edit-config"
+        )
+        raise typer.Exit(code=1)
+
     # Validate --file is only used with --stage identity
     if file and stage != "identity":
         console.print("[red]Error:[/red] --file can only be used with --stage identity")
@@ -1049,6 +1125,18 @@ def configure(
         raise typer.Exit(code=1)
 
     display_host = host_data.get("alias") or host_data["hostname"]
+
+    # Route to edit-config flow if requested
+    if edit_config:
+        _run_edit_config(
+            hostname=hostname,
+            host_data=host_data,
+            claw_type=claw_type,
+            installed_name=installed_name,
+            display_host=display_host,
+            editor=editor,
+        )
+        raise typer.Exit(code=0)
 
     try:
         current_state = get_onboarding_state(hostname, installed_name)

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -1547,3 +1547,140 @@ class TestConfigurePreservesGatewayAuth:
 
         # Verify channels key was not added
         assert "channels" not in captured_config[0]
+
+
+class TestEditConfigOptions:
+    """Tests for --edit-config and --editor CLI options."""
+
+    def test_edit_config_routes_to_edit_flow(self, isolated_config: Path):
+        """--edit-config flag routes to _run_edit_config with correct parameters."""
+        create_host_with_claw(isolated_config, onboarding_state="ready")
+        create_test_keypair(isolated_config, "work")
+
+        with patch("clawrium.cli.agent._run_edit_config") as mock_edit:
+            result = runner.invoke(
+                app, ["agent", "configure", "assistant", "--edit-config"]
+            )
+
+        # Verify _run_edit_config was called
+        mock_edit.assert_called_once()
+        call_kwargs = mock_edit.call_args.kwargs
+        assert call_kwargs["hostname"] == "192.168.1.100"
+        assert call_kwargs["installed_name"] == "assistant"
+        assert call_kwargs["claw_type"] == "openclaw"
+        assert call_kwargs["editor"] is None
+        assert result.exit_code == 0
+
+    def test_edit_config_passes_editor_option(self, isolated_config: Path):
+        """--editor option is passed to _run_edit_config."""
+        create_host_with_claw(isolated_config, onboarding_state="ready")
+        create_test_keypair(isolated_config, "work")
+
+        with patch("clawrium.cli.agent._run_edit_config") as mock_edit:
+            result = runner.invoke(
+                app,
+                ["agent", "configure", "assistant", "--edit-config", "--editor", "nano"],
+            )
+
+        mock_edit.assert_called_once()
+        assert mock_edit.call_args.kwargs["editor"] == "nano"
+        assert result.exit_code == 0
+
+    def test_edit_config_not_yet_implemented(self, isolated_config: Path):
+        """--edit-config shows not implemented error and exits with code 1."""
+        create_host_with_claw(isolated_config, onboarding_state="ready")
+        create_test_keypair(isolated_config, "work")
+
+        result = runner.invoke(app, ["agent", "configure", "assistant", "--edit-config"])
+
+        assert result.exit_code == 1
+        assert "not yet implemented" in result.output
+        assert "clm agent configure assistant" in result.output
+
+    def test_edit_config_with_stage_fails(self, isolated_config: Path):
+        """--edit-config with --stage fails with actionable error."""
+        create_host_with_claw(isolated_config, onboarding_state="ready")
+        create_test_keypair(isolated_config, "work")
+
+        result = runner.invoke(
+            app,
+            ["agent", "configure", "assistant", "--edit-config", "--stage", "providers"],
+        )
+
+        assert result.exit_code == 1
+        assert "--edit-config cannot be used with --stage" in result.output
+
+    def test_edit_config_with_file_fails(self, isolated_config: Path):
+        """--edit-config with --file fails with actionable error."""
+        create_host_with_claw(isolated_config, onboarding_state="ready")
+        create_test_keypair(isolated_config, "work")
+
+        # Create a dummy file
+        dummy_file = isolated_config / "SOUL.md"
+        dummy_file.write_text("# Test Soul")
+
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "configure",
+                "assistant",
+                "--edit-config",
+                "--file",
+                str(dummy_file),
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "--edit-config cannot be used with --file" in result.output
+
+    def test_edit_config_with_skip_health_fails(self, isolated_config: Path):
+        """--edit-config with --skip-health fails with actionable error."""
+        create_host_with_claw(isolated_config, onboarding_state="ready")
+        create_test_keypair(isolated_config, "work")
+
+        result = runner.invoke(
+            app,
+            ["agent", "configure", "assistant", "--edit-config", "--skip-health"],
+        )
+
+        assert result.exit_code == 1
+        assert "--edit-config cannot be used with --skip-health" in result.output
+
+    def test_editor_without_edit_config_fails(self, isolated_config: Path):
+        """--editor without --edit-config fails with actionable error."""
+        create_host_with_claw(isolated_config, onboarding_state="ready")
+        create_test_keypair(isolated_config, "work")
+
+        result = runner.invoke(
+            app, ["agent", "configure", "assistant", "--editor", "vim"]
+        )
+
+        assert result.exit_code == 1
+        assert "--editor can only be used with --edit-config" in result.output
+
+    def test_edit_config_does_not_run_onboarding(self, isolated_config: Path):
+        """--edit-config routes to edit flow, not onboarding wizard."""
+        create_host_with_claw(isolated_config, onboarding_state="pending")
+        create_test_keypair(isolated_config, "work")
+
+        with patch("clawrium.cli.agent._run_edit_config"):
+            result = runner.invoke(
+                app, ["agent", "configure", "assistant", "--edit-config"]
+            )
+
+        # Should NOT show onboarding flow
+        assert "Starting onboarding" not in result.output
+        assert "Stage 1" not in result.output
+
+    def test_edit_config_agent_not_found(self, isolated_config: Path):
+        """--edit-config with non-existent agent fails with error."""
+        create_host_with_claw(isolated_config, onboarding_state="ready")
+        create_test_keypair(isolated_config, "work")
+
+        result = runner.invoke(
+            app, ["agent", "configure", "nonexistent", "--edit-config"]
+        )
+
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -439,7 +439,7 @@ def test_check_claw_health_uses_type_not_key_for_secrets():
         with patch("clawrium.core.health.ansible_runner.run", return_value=mock_runner):
             with patch(
                 "clawrium.core.health.get_instance_secrets", return_value={}
-            ) as mock_secrets:
+            ):
                 with patch(
                     "clawrium.core.health.get_required_secrets", return_value=[]
                 ) as mock_required:


### PR DESCRIPTION
## Summary

- Add `--edit-config` flag to enter direct config editing mode
- Add `--editor` option to specify editor (fallback: VISUAL > EDITOR > vi)
- Validate incompatible flag combinations with actionable error messages
- Placeholder implementation exits with code 1 until full workflow is implemented

Part of #167 - Phase 4

## Test plan

- [x] `make test` passes (1049 tests)
- [x] `make lint` passes
- [x] `--edit-config` routes to edit flow (not onboarding)
- [x] `--editor` option is passed through correctly
- [x] Invalid flag combinations show clear errors

## ATX Review Summary

**Final Review: Rating 3/5**

| Review | Rating | Blocking Issues | Status | Cost | Agents |
|--------|--------|-----------------|--------|------|--------|
| 1 | 3/5 | B1, B2 | All fixed | $0.84 | leader, test-coverage, cli-ux-reviewer |

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `cli/agent.py` | Placeholder exited with code 0 | Fixed - exits with code 1 |
| B2 | `tests/test_cli_agent_configure.py` | Tests asserted on output strings | Fixed - mock _run_edit_config |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `cli/agent.py` | --editor help text missing fallback chain | Fixed |
| W2 | `cli/agent.py` | --edit-config help text missing --skip-health | Fixed |
| W4 | `test_health.py` | Pre-existing lint issue | Fixed |

</details>

Closes #243

Co-Authored-By: Claude <noreply@anthropic.com>