### PR TITLE
feat(ssh): add push_file_to_remote() helper for SFTP uploads

### DIFF
--- a/src/clawrium/core/ssh_connection.py
+++ b/src/clawrium/core/ssh_connection.py
@@ -10,6 +10,7 @@ __all__ = [
     "get_ssh_config",
     "test_ssh_connection",
     "accept_host_key",
+    "push_file_to_remote",
     "HostKeyVerificationRequired",
 ]
 
@@ -244,3 +245,102 @@ def accept_host_key(
             os.umask(old_umask)
 
     return policy.key_accepted
+
+
+def push_file_to_remote(
+    hostname: str,
+    port: int,
+    username: str,
+    private_key_path: str,
+    local_path: str | Path,
+    remote_path: str,
+    permissions: int | None = None,
+) -> tuple[bool, str | None]:
+    """Push a local file to a remote host via SFTP.
+
+    Transfers a file from the local filesystem to a remote host using SFTP.
+    Uses the same SSH connection patterns as other functions in this module.
+
+    Args:
+        hostname: Remote host to connect to.
+        port: SSH port.
+        username: SSH username.
+        private_key_path: Path to private key file for authentication.
+        local_path: Local file to upload.
+        remote_path: Destination path on remote host.
+        permissions: Optional file mode to set (e.g., 0o600).
+
+    Returns:
+        Tuple of (success, error_message). On success, error_message is None.
+        On failure, error_message contains actionable user-facing error.
+
+    Raises:
+        HostKeyVerificationRequired: If host key not in known_hosts (TOFU).
+    """
+    local_path = Path(local_path)
+
+    # Validate local file exists before attempting connection
+    if not local_path.exists():
+        return (False, f"Local file not found: {local_path}")
+    if not local_path.is_file():
+        return (False, f"Path is not a file: {local_path}")
+
+    client = paramiko.SSHClient()
+    client.load_system_host_keys()
+    client.set_missing_host_key_policy(StrictHostKeyPolicy())
+
+    sftp = None
+    try:
+        client.connect(
+            hostname=hostname,
+            port=port,
+            username=username,
+            key_filename=private_key_path,
+            timeout=10,
+        )
+
+        sftp = client.open_sftp()
+        sftp.put(str(local_path), remote_path)
+
+        if permissions is not None:
+            sftp.chmod(remote_path, permissions)
+
+        return (True, None)
+
+    except HostKeyVerificationRequired:
+        raise
+    except paramiko.BadHostKeyException:
+        return (
+            False,
+            "Host key verification failed - host key changed since last connection",
+        )
+    except paramiko.AuthenticationException:
+        return (False, f"Authentication failed for {username}@{hostname}")
+    except paramiko.SFTPError as e:
+        # SFTP protocol errors
+        logger.debug("SFTP error during file transfer: %s", e)
+        error_msg = str(e)
+        if "Permission denied" in error_msg:
+            return (False, f"Permission denied writing to {remote_path}")
+        if "No such file" in error_msg:
+            return (False, f"Remote directory does not exist: {remote_path}")
+        return (False, f"File transfer failed: {error_msg}")
+    except paramiko.SSHException as e:
+        logger.debug("SSH error during file transfer to %s:%d: %s", hostname, port, e)
+        return (False, "SSH connection failed - check host availability and SSH configuration")
+    except socket.error as e:
+        logger.debug("Socket error during file transfer to %s:%d: %s", hostname, port, e)
+        return (False, f"Network error: could not reach {hostname}:{port}")
+    except OSError as e:
+        # File system errors during SFTP operations (IOError is OSError in Python 3)
+        logger.debug("OS error during file transfer: %s", e)
+        error_msg = str(e)
+        if "Permission denied" in error_msg:
+            return (False, f"Permission denied writing to {remote_path}")
+        if "No such file" in error_msg:
+            return (False, f"Remote directory does not exist: {remote_path}")
+        return (False, f"File transfer failed: {error_msg}")
+    finally:
+        if sftp is not None:
+            sftp.close()
+        client.close()

--- a/tests/test_ssh_push_file.py
+++ b/tests/test_ssh_push_file.py
@@ -1,0 +1,424 @@
+"""Tests for SFTP file push functionality."""
+
+import pytest
+from pathlib import Path
+from unittest.mock import Mock, patch
+import paramiko
+import socket
+
+from clawrium.core.ssh_connection import (
+    push_file_to_remote,
+    HostKeyVerificationRequired,
+    StrictHostKeyPolicy,
+)
+
+
+class TestPushFileToRemote:
+    """Tests for push_file_to_remote function."""
+
+    def test_success_path(self, tmp_path):
+        """push_file_to_remote returns (True, None) on successful transfer."""
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+        mock_sftp = Mock()
+        mock_client.open_sftp.return_value = mock_sftp
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            success, error = push_file_to_remote(
+                hostname="testhost",
+                port=22,
+                username="xclm",
+                private_key_path="/path/to/key",
+                local_path=local_file,
+                remote_path="/home/xclm/.openclaw/openclaw.json",
+            )
+
+            assert success is True
+            assert error is None
+
+            # B2: Verify StrictHostKeyPolicy is set
+            mock_client.set_missing_host_key_policy.assert_called_once()
+            policy_arg = mock_client.set_missing_host_key_policy.call_args[0][0]
+            assert isinstance(policy_arg, StrictHostKeyPolicy)
+
+            # B3: Verify load_system_host_keys is called
+            mock_client.load_system_host_keys.assert_called_once()
+
+            # B3: Verify connection parameters include timeout
+            connect_kwargs = mock_client.connect.call_args.kwargs
+            assert connect_kwargs.get("timeout") == 10
+
+            mock_client.connect.assert_called_once()
+            mock_sftp.put.assert_called_once_with(
+                str(local_file), "/home/xclm/.openclaw/openclaw.json"
+            )
+            mock_sftp.close.assert_called_once()
+            mock_client.close.assert_called_once()
+
+    def test_success_with_permissions(self, tmp_path):
+        """push_file_to_remote sets file permissions when specified."""
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+        mock_sftp = Mock()
+        mock_client.open_sftp.return_value = mock_sftp
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            success, error = push_file_to_remote(
+                hostname="testhost",
+                port=22,
+                username="xclm",
+                private_key_path="/path/to/key",
+                local_path=local_file,
+                remote_path="/home/xclm/.openclaw/openclaw.json",
+                permissions=0o600,
+            )
+
+            assert success is True
+            assert error is None
+            mock_sftp.chmod.assert_called_once_with(
+                "/home/xclm/.openclaw/openclaw.json", 0o600
+            )
+
+    def test_chmod_failure_after_successful_put(self, tmp_path):
+        """push_file_to_remote returns error when chmod fails after successful put.
+
+        B1: This is a security-critical test - a chmod failure after put would
+        leave a secret file world-readable.
+        """
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+        mock_sftp = Mock()
+        mock_client.open_sftp.return_value = mock_sftp
+        # put() succeeds, chmod() fails
+        mock_sftp.chmod.side_effect = paramiko.SFTPError("Permission denied")
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            success, error = push_file_to_remote(
+                hostname="testhost",
+                port=22,
+                username="xclm",
+                private_key_path="/path/to/key",
+                local_path=local_file,
+                remote_path="/home/xclm/.openclaw/openclaw.json",
+                permissions=0o600,
+            )
+
+            assert success is False
+            assert "Permission denied" in error
+            # W3: Verify SFTP flow was initiated
+            mock_client.open_sftp.assert_called_once()
+            # Verify put was called (file was uploaded)
+            mock_sftp.put.assert_called_once()
+            # Verify chmod was attempted
+            mock_sftp.chmod.assert_called_once()
+            # Verify cleanup happened
+            mock_sftp.close.assert_called_once()
+            mock_client.close.assert_called_once()
+
+    def test_local_file_not_found(self, tmp_path):
+        """push_file_to_remote returns error when local file doesn't exist."""
+        nonexistent = tmp_path / "nonexistent.json"
+
+        success, error = push_file_to_remote(
+            hostname="testhost",
+            port=22,
+            username="xclm",
+            private_key_path="/path/to/key",
+            local_path=nonexistent,
+            remote_path="/home/xclm/.openclaw/openclaw.json",
+        )
+
+        assert success is False
+        assert "Local file not found" in error
+
+    def test_local_path_is_directory(self, tmp_path):
+        """push_file_to_remote returns error when local path is a directory."""
+        success, error = push_file_to_remote(
+            hostname="testhost",
+            port=22,
+            username="xclm",
+            private_key_path="/path/to/key",
+            local_path=tmp_path,  # directory, not file
+            remote_path="/home/xclm/.openclaw/openclaw.json",
+        )
+
+        assert success is False
+        assert "not a file" in error
+
+    def test_network_error(self, tmp_path):
+        """push_file_to_remote returns error on network failure."""
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+        mock_client.connect.side_effect = socket.error("Connection refused")
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            success, error = push_file_to_remote(
+                hostname="testhost",
+                port=22,
+                username="xclm",
+                private_key_path="/path/to/key",
+                local_path=local_file,
+                remote_path="/home/xclm/.openclaw/openclaw.json",
+            )
+
+            assert success is False
+            assert "Network error" in error
+            assert "testhost:22" in error
+            mock_client.close.assert_called_once()
+
+    def test_auth_failure(self, tmp_path):
+        """push_file_to_remote returns error on authentication failure."""
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+        mock_client.connect.side_effect = paramiko.AuthenticationException("Auth failed")
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            success, error = push_file_to_remote(
+                hostname="testhost",
+                port=22,
+                username="xclm",
+                private_key_path="/path/to/key",
+                local_path=local_file,
+                remote_path="/home/xclm/.openclaw/openclaw.json",
+            )
+
+            assert success is False
+            assert "Authentication failed" in error
+            assert "xclm@testhost" in error
+            mock_client.close.assert_called_once()
+
+    def test_bad_host_key(self, tmp_path):
+        """push_file_to_remote returns error on host key mismatch."""
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+        mock_key = Mock()
+        mock_key.get_base64.return_value = "AAAA"
+        mock_client.connect.side_effect = paramiko.BadHostKeyException(
+            "testhost", mock_key, mock_key
+        )
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            success, error = push_file_to_remote(
+                hostname="testhost",
+                port=22,
+                username="xclm",
+                private_key_path="/path/to/key",
+                local_path=local_file,
+                remote_path="/home/xclm/.openclaw/openclaw.json",
+            )
+
+            assert success is False
+            assert "Host key" in error
+            assert "changed" in error
+            mock_client.close.assert_called_once()
+
+    def test_raises_host_key_verification_required(self, tmp_path):
+        """push_file_to_remote propagates HostKeyVerificationRequired for TOFU flow."""
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+
+        def raise_verification(*args, **kwargs):
+            raise HostKeyVerificationRequired("testhost", "ssh-rsa", "aa:bb:cc:dd")
+
+        mock_client.connect.side_effect = raise_verification
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            with pytest.raises(HostKeyVerificationRequired) as exc_info:
+                push_file_to_remote(
+                    hostname="testhost",
+                    port=22,
+                    username="xclm",
+                    private_key_path="/path/to/key",
+                    local_path=local_file,
+                    remote_path="/home/xclm/.openclaw/openclaw.json",
+                )
+
+            assert exc_info.value.hostname == "testhost"
+            assert exc_info.value.key_type == "ssh-rsa"
+            assert exc_info.value.fingerprint == "aa:bb:cc:dd"
+            mock_client.close.assert_called_once()
+
+    def test_ssh_exception(self, tmp_path):
+        """push_file_to_remote returns error on generic SSH exception."""
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+        mock_client.connect.side_effect = paramiko.SSHException("Protocol error")
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            success, error = push_file_to_remote(
+                hostname="testhost",
+                port=22,
+                username="xclm",
+                private_key_path="/path/to/key",
+                local_path=local_file,
+                remote_path="/home/xclm/.openclaw/openclaw.json",
+            )
+
+            assert success is False
+            assert "SSH connection failed" in error
+            mock_client.close.assert_called_once()
+
+    def test_remote_permission_denied(self, tmp_path):
+        """push_file_to_remote returns error when remote write is denied."""
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+        mock_sftp = Mock()
+        mock_client.open_sftp.return_value = mock_sftp
+        mock_sftp.put.side_effect = paramiko.SFTPError("Permission denied")
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            success, error = push_file_to_remote(
+                hostname="testhost",
+                port=22,
+                username="xclm",
+                private_key_path="/path/to/key",
+                local_path=local_file,
+                remote_path="/root/forbidden/openclaw.json",
+            )
+
+            assert success is False
+            assert "Permission denied" in error
+            mock_sftp.close.assert_called_once()
+            mock_client.close.assert_called_once()
+
+    def test_remote_directory_not_found(self, tmp_path):
+        """push_file_to_remote returns error when remote directory doesn't exist."""
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+        mock_sftp = Mock()
+        mock_client.open_sftp.return_value = mock_sftp
+        mock_sftp.put.side_effect = paramiko.SFTPError("No such file or directory")
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            success, error = push_file_to_remote(
+                hostname="testhost",
+                port=22,
+                username="xclm",
+                private_key_path="/path/to/key",
+                local_path=local_file,
+                remote_path="/nonexistent/dir/openclaw.json",
+            )
+
+            assert success is False
+            assert "Remote directory does not exist" in error
+            mock_sftp.close.assert_called_once()
+            mock_client.close.assert_called_once()
+
+    def test_sftp_generic_error(self, tmp_path):
+        """push_file_to_remote returns error message for generic SFTP errors."""
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+        mock_sftp = Mock()
+        mock_client.open_sftp.return_value = mock_sftp
+        mock_sftp.put.side_effect = paramiko.SFTPError("Disk full")
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            success, error = push_file_to_remote(
+                hostname="testhost",
+                port=22,
+                username="xclm",
+                private_key_path="/path/to/key",
+                local_path=local_file,
+                remote_path="/home/xclm/.openclaw/openclaw.json",
+            )
+
+            assert success is False
+            assert "File transfer failed" in error
+            assert "Disk full" in error
+            mock_sftp.close.assert_called_once()
+            mock_client.close.assert_called_once()
+
+    def test_cleanup_on_sftp_open_failure(self, tmp_path):
+        """push_file_to_remote cleans up SSH client when SFTP open fails.
+
+        S1: Also verifies that sftp.close() is NOT called when SFTP was never opened,
+        ensuring the None guard in the finally block is exercised.
+        """
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+        mock_sftp = Mock()  # Create mock to verify it's NOT closed
+        mock_client.open_sftp.side_effect = paramiko.SSHException("SFTP not available")
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            success, error = push_file_to_remote(
+                hostname="testhost",
+                port=22,
+                username="xclm",
+                private_key_path="/path/to/key",
+                local_path=local_file,
+                remote_path="/home/xclm/.openclaw/openclaw.json",
+            )
+
+            assert success is False
+            # SSH client cleanup still happens
+            mock_client.close.assert_called_once()
+            # S1: SFTP close should NOT be called since open_sftp raised
+            assert mock_sftp.close.call_count == 0
+
+    def test_accepts_path_object(self, tmp_path):
+        """push_file_to_remote accepts Path objects for local_path."""
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+        mock_sftp = Mock()
+        mock_client.open_sftp.return_value = mock_sftp
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            success, error = push_file_to_remote(
+                hostname="testhost",
+                port=22,
+                username="xclm",
+                private_key_path="/path/to/key",
+                local_path=Path(local_file),  # Explicitly use Path
+                remote_path="/home/xclm/.openclaw/openclaw.json",
+            )
+
+            assert success is True
+            assert error is None
+
+    def test_accepts_string_path(self, tmp_path):
+        """push_file_to_remote accepts string paths for local_path."""
+        local_file = tmp_path / "test.json"
+        local_file.write_text('{"key": "value"}')
+
+        mock_client = Mock(spec=paramiko.SSHClient)
+        mock_sftp = Mock()
+        mock_client.open_sftp.return_value = mock_sftp
+
+        with patch("clawrium.core.ssh_connection.paramiko.SSHClient", return_value=mock_client):
+            success, error = push_file_to_remote(
+                hostname="testhost",
+                port=22,
+                username="xclm",
+                private_key_path="/path/to/key",
+                local_path=str(local_file),  # String path
+                remote_path="/home/xclm/.openclaw/openclaw.json",
+            )
+
+            assert success is True
+            assert error is None


### PR DESCRIPTION
## Summary
- Add `push_file_to_remote()` function to `ssh_connection.py` for unidirectional local→remote config sync
- Uses existing SSH patterns (TOFU, StrictHostKeyPolicy)
- Returns `(success, error_message)` tuple with actionable errors
- Handles network, auth, SFTP permission, and path errors
- Sets file permissions via `sftp.chmod()` when specified

## Test plan
- [x] `make test` passes (1065 tests)
- [x] `make lint` passes
- [x] Unit tests cover success paths, error conditions, and cleanup

## ATX Review Summary

**Final Review: Rating 3/5**
**Total Cost: $1.52 | Total Time: ~2m**

| Review | Rating | Blocking Issues | Status | Cost | Agents |
|--------|--------|-----------------|--------|------|--------|
| 1 | 3/5 | B1, B2, B3 | All fixed | $0.72 | leader, test-coverage, secrets-provider |
| 2 | 3/5 | B1 | Fixed | $0.80 | leader, test-coverage, secrets-provider |

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `test_ssh_push_file.py` | chmod failure after put not tested | Fixed - added test_chmod_failure_after_successful_put |
| B2 | `test_ssh_push_file.py` | StrictHostKeyPolicy not verified | Fixed - added assertion |
| B3 | `test_ssh_push_file.py` | Connection params not asserted | Fixed - added timeout and load_system_host_keys checks |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W3 | `ssh_connection.py` | FileTransferError unused | Fixed - removed dead code |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `test_ssh_push_file.py` | Incorrect patch target | Fixed - changed to module import location |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `ssh_connection.py` | Auth error includes username@hostname | Acknowledged - follows existing pattern |
| W2 | `ssh_connection.py` | remote_path not validated | Out-of-scope - caller responsibility |
| W3 | `test_ssh_push_file.py` | open_sftp not verified in chmod test | Fixed |

</details>

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>