### PR TITLE
docs: add Discord community links to README and website intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  <a href="https://ric03uec.github.io/clawrium/">Documentation</a> · <a href="https://github.com/ric03uec/clawrium/issues">Issues</a> · <a href="https://github.com/users/ric03uec/projects/1">Roadmap</a>
+  <a href="https://ric03uec.github.io/clawrium/">Documentation</a> · <a href="https://github.com/ric03uec/clawrium/issues">Issues</a> · <a href="https://github.com/users/ric03uec/projects/1">Roadmap</a> · <a href="https://discord.gg/KzPuSxgQ98">Discord</a>
 </p>
 
 ---

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -9,6 +9,8 @@ keywords: [clawrium, AI assistant, fleet management, CLI tool, multi-host, agent
 
 **Clawrium is a CLI to manage all your AI assistants.** Point it at any machine on your network and deploy agents like [OpenClaw](https://github.com/openclaw/openclaw) with a single command.
 
+[Documentation](https://ric03uec.github.io/clawrium/) · [Issues](https://github.com/ric03uec/clawrium/issues) · [Roadmap](https://github.com/users/ric03uec/projects/1) · [Discord](https://discord.gg/KzPuSxgQ98)
+
 ## What is a Claw?
 
 A **claw** is a general-purpose AI assistant that runs on a machine in your network. Unlike coding-specific tools, claws are versatile assistants that can:


### PR DESCRIPTION
## Summary
- Add the community Discord invite link (`https://discord.gg/KzPuSxgQ98`) to the GitHub README top link row.
- Add the same Discord link to the website docs intro quick links so website and README stay consistent.
- Keep link formatting aligned with ZeroClaw-style inline `A · B · C · Discord` links.

## Testing
- `npm ci` (website)
- `npm run build` (website) -> fails due pre-existing broken links in `website/docs/guides/agent-onboarding.md` (`./channels/channels.md`, `./channels/discord.md`)
- `npm run start -- --host 127.0.0.1 --port 3001 --no-open` -> dev server starts and compiles successfully

## Notes
- ATX review was skipped per explicit maintainer request in chat.