### PR TITLE
feat(cli): add Port column to agent ps command

### DIFF
--- a/src/clawrium/cli/status.py
+++ b/src/clawrium/cli/status.py
@@ -144,6 +144,7 @@ def status(
     table.add_column("Name", style="cyan bold")
     table.add_column("Agent Type", style="dim")
     table.add_column("Host", style="white")
+    table.add_column("Port", style="dim")
     table.add_column("Version", style="green")
     table.add_column("Status", no_wrap=True)
     table.add_column("Installed", style="dim")
@@ -164,6 +165,9 @@ def status(
             if installed_at and installed_at != "-":
                 # Format as date only for readability
                 installed_at = installed_at.split("T")[0]
+
+            port = claw_record.get("config", {}).get("gateway", {}).get("port")
+            port_display = str(port) if port else "-"
 
             # Get live status with color coding
             result = health_results.get((claw_name, h["hostname"]))
@@ -250,6 +254,7 @@ def status(
                 escape(full_name),
                 escape(agent_type),
                 escape(display_host),
+                port_display,
                 version,
                 status_display,
                 installed_at,

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -905,3 +905,126 @@ def test_status_verbose_short_alias(mock_hosts_with_claws):
 
     assert result.exit_code == 0
     assert "providers" in result.output
+
+
+# Tests for port column - Issue #253
+
+
+def test_status_shows_port_when_configured():
+    """Port column displays gateway port when configured."""
+    hosts = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "server1",
+            "agents": {
+                "openclaw": {
+                    "version": "0.1.0",
+                    "status": "installed",
+                    "installed_at": "2026-03-21T10:00:00Z",
+                    "agent_name": "opc-server1",
+                    "config": {"gateway": {"port": 40123}},
+                }
+            },
+        }
+    ]
+
+    mock_health = MagicMock(
+        return_value={
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.RUNNING,
+            "agent_name": "opc-server1",
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+        }
+    )
+
+    with patch("clawrium.cli.status.load_hosts", return_value=hosts):
+        with patch("clawrium.cli.status.check_claw_health", mock_health):
+            result = runner.invoke(app, ["ps"])
+
+    assert result.exit_code == 0
+    assert "40123" in result.output
+
+
+def test_status_shows_dash_when_port_missing():
+    """Port column displays '-' when port not configured."""
+    hosts = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "server1",
+            "agents": {
+                "openclaw": {
+                    "version": "0.1.0",
+                    "status": "installed",
+                    "installed_at": "2026-03-21T10:00:00Z",
+                    "agent_name": "opc-server1",
+                }
+            },
+        }
+    ]
+
+    mock_health = MagicMock(
+        return_value={
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.RUNNING,
+            "agent_name": "opc-server1",
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+        }
+    )
+
+    with patch("clawrium.cli.status.load_hosts", return_value=hosts):
+        with patch("clawrium.cli.status.check_claw_health", mock_health):
+            result = runner.invoke(app, ["ps"])
+
+    assert result.exit_code == 0
+    # Table should have Port column header
+    assert "Port" in result.output
+
+
+def test_status_shows_dash_when_config_empty():
+    """Port column displays '-' when config exists but gateway missing."""
+    hosts = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "server1",
+            "agents": {
+                "openclaw": {
+                    "version": "0.1.0",
+                    "status": "installed",
+                    "installed_at": "2026-03-21T10:00:00Z",
+                    "agent_name": "opc-server1",
+                    "config": {},
+                }
+            },
+        }
+    ]
+
+    mock_health = MagicMock(
+        return_value={
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.RUNNING,
+            "agent_name": "opc-server1",
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+        }
+    )
+
+    with patch("clawrium.cli.status.load_hosts", return_value=hosts):
+        with patch("clawrium.cli.status.check_claw_health", mock_health):
+            result = runner.invoke(app, ["ps"])
+
+    assert result.exit_code == 0
+    assert "Port" in result.output


### PR DESCRIPTION
## Summary
- Add Port column to `clm ps` / `clm agent ps` output table
- Port extracted from `agent_record["config"]["gateway"]["port"]`
- Shows "-" when port not configured

## Output

```
Agent Fleet Status                            
┏━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Name   ┃ Agent Type ┃ Host   ┃ Port  ┃ Version  ┃ Status  ┃ Installed  ┃
┡━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━┩
│ wolf-i │ openclaw   │ wolf-i │ 40198 │ 2026.4.2 │ running │ 2026-04-11 │
└────────┴────────────┴────────┴───────┴──────────┴─────────┴────────────┘
```

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (1066 tests, 3 new)
- [x] Manual test: `clm ps` shows port column

🤖 Generated with [Claude Code](https://claude.com/claude-code)