### PR TITLE
docs: remove redundant integration wording

### DIFF
--- a/docs/agent-support/integrations/confluence.md
+++ b/docs/agent-support/integrations/confluence.md
@@ -1,4 +1,4 @@
-# Confluence Integration
+# Confluence
 
 **Status:** 📋 Not Currently Planned
 

--- a/docs/agent-support/integrations/github.md
+++ b/docs/agent-support/integrations/github.md
@@ -1,4 +1,4 @@
-# GitHub Integration
+# GitHub
 
 **Status:** 🚧 In Development
 

--- a/docs/agent-support/integrations/gitlab.md
+++ b/docs/agent-support/integrations/gitlab.md
@@ -1,4 +1,4 @@
-# GitLab Integration
+# GitLab
 
 **Status:** 📋 Not Currently Planned
 
@@ -76,7 +76,7 @@ read_user
 
 ## Alternatives
 
-### Use GitHub Integration
+### Use GitHub
 
 If you can mirror to GitHub:
 

--- a/docs/agent-support/integrations/jira.md
+++ b/docs/agent-support/integrations/jira.md
@@ -1,4 +1,4 @@
-# Jira Integration
+# Jira
 
 **Status:** 🚧 In Development
 

--- a/docs/agent-support/integrations/linear.md
+++ b/docs/agent-support/integrations/linear.md
@@ -1,4 +1,4 @@
-# Linear Integration
+# Linear
 
 **Status:** 📋 Not Currently Planned
 
@@ -78,7 +78,7 @@ If implemented, Linear integration could:
 
 ## Alternatives
 
-### Use Jira Integration
+### Use Jira
 
 [Jira integration](jira.md) will be available Q2 2026 and serves similar needs.
 

--- a/docs/agent-support/integrations/notion.md
+++ b/docs/agent-support/integrations/notion.md
@@ -1,4 +1,4 @@
-# Notion Integration
+# Notion
 
 **Status:** 📋 Not Currently Planned
 

--- a/website/docs/agent-support/integrations/confluence.md
+++ b/website/docs/agent-support/integrations/confluence.md
@@ -1,4 +1,4 @@
-# Confluence Integration
+# Confluence
 
 **Status:** 📋 Not Currently Planned
 

--- a/website/docs/agent-support/integrations/github.md
+++ b/website/docs/agent-support/integrations/github.md
@@ -1,4 +1,4 @@
-# GitHub Integration
+# GitHub
 
 **Status:** 🚧 In Development
 

--- a/website/docs/agent-support/integrations/gitlab.md
+++ b/website/docs/agent-support/integrations/gitlab.md
@@ -1,4 +1,4 @@
-# GitLab Integration
+# GitLab
 
 **Status:** 📋 Not Currently Planned
 
@@ -76,7 +76,7 @@ read_user
 
 ## Alternatives
 
-### Use GitHub Integration
+### Use GitHub
 
 If you can mirror to GitHub:
 

--- a/website/docs/agent-support/integrations/jira.md
+++ b/website/docs/agent-support/integrations/jira.md
@@ -1,4 +1,4 @@
-# Jira Integration
+# Jira
 
 **Status:** 🚧 In Development
 

--- a/website/docs/agent-support/integrations/linear.md
+++ b/website/docs/agent-support/integrations/linear.md
@@ -1,4 +1,4 @@
-# Linear Integration
+# Linear
 
 **Status:** 📋 Not Currently Planned
 
@@ -78,7 +78,7 @@ If implemented, Linear integration could:
 
 ## Alternatives
 
-### Use Jira Integration
+### Use Jira
 
 [Jira integration](jira.md) will be available Q2 2026 and serves similar needs.
 

--- a/website/docs/agent-support/integrations/notion.md
+++ b/website/docs/agent-support/integrations/notion.md
@@ -1,4 +1,4 @@
-# Notion Integration
+# Notion
 
 **Status:** 📋 Not Currently Planned
 


### PR DESCRIPTION
## Summary
- Remove the redundant word "Integration" from integration page H1 titles in both docs trees.
- Update related subheadings (for example, "Use GitHub Integration" -> "Use GitHub") for consistency.

## Testing
- `npm run build` (in `website/`)