### PR TITLE
docs: add OS support section with Ubuntu versions and macOS placeholder

### DIFF
--- a/docs/os-support/macos.md
+++ b/docs/os-support/macos.md
@@ -1,0 +1,28 @@
+# macOS
+
+## Status
+
+TBD.
+
+macOS support is not documented yet.
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need macOS support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](https://github.com/ric03uec/clawrium/issues/new?labels=enhancement,documentation&title=Add+macOS+OS+support+docs)
+
+Include:
+- macOS version needed
+- Host architecture (for example, Apple Silicon or Intel)
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+Add the macOS support page details and compatibility notes in `docs/os-support/macos.md`.
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.

--- a/docs/os-support/ubuntu/24-04.md
+++ b/docs/os-support/ubuntu/24-04.md
@@ -1,0 +1,42 @@
+# Ubuntu 24.04
+
+## Status
+
+Tested and supported.
+
+## Architecture
+
+- `x86_64`
+
+## System Packages Installed by Ansible
+
+Source: `src/clawrium/platform/playbooks/base.yaml`
+
+- `curl`
+- `ca-certificates`
+- `gnupg`
+- `nodejs`
+- `build-essential`
+- `git`
+- `gh`
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need another Ubuntu version:
+
+### Option 1: Open an Issue
+
+[Create a feature request](https://github.com/ric03uec/clawrium/issues/new?labels=enhancement,documentation&title=Add+Ubuntu+OS+version+support+docs)
+
+Include:
+- Ubuntu version needed
+- Host architecture (for example, `x86_64` or `aarch64`)
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+Add the requested Ubuntu version page under `docs/os-support/ubuntu/`.
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.

--- a/website/docs/os-support/macos.md
+++ b/website/docs/os-support/macos.md
@@ -1,0 +1,34 @@
+---
+title: macOS
+description: OS support details for macOS.
+keywords: [os support, macos]
+---
+
+# macOS
+
+## Status
+
+TBD.
+
+macOS support is not documented yet.
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need macOS support:
+
+### Option 1: Open an Issue
+
+[Create a feature request](https://github.com/ric03uec/clawrium/issues/new?labels=enhancement,documentation&title=Add+macOS+OS+support+docs)
+
+Include:
+- macOS version needed
+- Host architecture (for example, Apple Silicon or Intel)
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+Add the macOS support page details and compatibility notes in `website/docs/os-support/macos.md`.
+
+See [CONTRIBUTING.md](/docs/contributing) for guidelines.

--- a/website/docs/os-support/ubuntu/24-04.md
+++ b/website/docs/os-support/ubuntu/24-04.md
@@ -1,0 +1,48 @@
+---
+title: Ubuntu 24.04
+description: OS support details for Ubuntu 24.04.
+keywords: [os support, ubuntu 24.04, architecture, ansible]
+---
+
+# Ubuntu 24.04
+
+## Status
+
+Tested and supported.
+
+## Architecture
+
+- `x86_64`
+
+## System Packages Installed by Ansible
+
+Source: `src/clawrium/platform/playbooks/base.yaml`
+
+- `curl`
+- `ca-certificates`
+- `gnupg`
+- `nodejs`
+- `build-essential`
+- `git`
+- `gh`
+
+---
+
+## Want This Feature?
+
+We welcome community contributions! If you need another Ubuntu version:
+
+### Option 1: Open an Issue
+
+[Create a feature request](https://github.com/ric03uec/clawrium/issues/new?labels=enhancement,documentation&title=Add+Ubuntu+OS+version+support+docs)
+
+Include:
+- Ubuntu version needed
+- Host architecture (for example, `x86_64` or `aarch64`)
+- Whether you can contribute a PR
+
+### Option 2: Submit a PR
+
+Add the requested Ubuntu version page under `website/docs/os-support/ubuntu/` and update the sidebar entry.
+
+See [CONTRIBUTING.md](/docs/contributing) for guidelines.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -24,6 +24,22 @@ const sidebars: SidebarsConfig = {
     'architecture',
     {
       type: 'category',
+      label: 'OS Support',
+      collapsed: false,
+      items: [
+        {
+          type: 'category',
+          label: 'Ubuntu',
+          collapsed: false,
+          items: [
+            'os-support/ubuntu/24-04',
+          ],
+        },
+        'os-support/macos',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Agent Support',
       link: {
         type: 'doc',


### PR DESCRIPTION
## Summary
- Add a new **OS Support** section in the docs sidebar after Architecture.
- Add `OS Support > Ubuntu > 24-04` with architecture and system-level Ansible package details.
- Add `OS Support > macOS` placeholder page marked TBD, using the same feature-request format as integration pages.
- Mirror OS support pages in both `website/docs` and `docs` trees.

## Testing
- `npm run build` (in `website/`)
- `npm run start -- --host 127.0.0.1 --port 3001 --no-open` (local preview)