### PR TITLE
docs: collapse OS support sidebar by default

### DIFF
--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -25,12 +25,12 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'OS Support',
-      collapsed: false,
+      collapsed: true,
       items: [
         {
           type: 'category',
           label: 'Ubuntu',
-          collapsed: false,
+          collapsed: true,
           items: [
             'os-support/ubuntu/24-04',
           ],


### PR DESCRIPTION
## Summary
- Set **OS Support** category to collapsed by default.
- Set nested **Ubuntu** category to collapsed by default.
- Keep all OS support pages and ordering unchanged.

## Testing
- `npm run build` (in `website/`)