### PR TITLE
feat(openclaw): enforce headless browser policy and exec approvals

### DIFF
--- a/docs/agent-support/integrations/github.md
+++ b/docs/agent-support/integrations/github.md
@@ -74,56 +74,38 @@ Agent: Analyzing commits since v2.0.0...
 
 ---
 
-## Preliminary Setup (Subject to Change)
+## Create Fine-Grained Token for One Repo
 
-### 1. Create GitHub App
-
-1. Go to [GitHub Developer Settings](https://github.com/settings/apps)
-2. Click **New GitHub App**
+1. Go to GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens
+   - Direct link: https://github.com/settings/tokens?type=beta
+2. Click **Generate new token**
 3. Configure:
-   - Name: `My Claw Agent`
-   - Homepage URL: Your URL
-   - Callback URL: Not needed for CLI
-4. Set permissions:
-   - Repository: Read & Write
-   - Pull requests: Read & Write
-   - Issues: Read & Write
-   - Actions: Read (optional)
-5. Create app and generate private key
+   - Token name: Descriptive name (for example, `clawrium-myrepo`)
+   - Expiration: Set as needed
+   - Repository access: Select **Only select repositories** and pick your single repo
+4. Set permissions based on what you need:
 
-### 2. Install App
+| Use Case | Permission | Level |
+|----------|------------|-------|
+| Read code | Contents | Read |
+| Push code | Contents | Read & Write |
+| Read issues | Issues | Read |
+| Create/comment issues | Issues | Read & Write |
+| Read PRs | Pull requests | Read |
+| Create/review PRs | Pull requests | Read & Write |
 
-1. Install the app on your repositories
-2. Note the installation ID
+5. Click **Generate token** and copy it immediately.
 
-### 3. Configure in Clawrium (When Available)
+## Use with Clawrium
+
+When configuring your agent:
 
 ```bash
 clm agent configure my-agent
-# Select GitHub integration when prompted
+# Enter the fine-grained token when prompted for GitHub credentials
 ```
 
----
-
-## Authentication
-
-GitHub integration will support:
-
-- **GitHub App:** Recommended for organizations
-- **Personal Access Token:** For personal use
-- **Fine-grained PAT:** New GitHub feature
-
----
-
-## Permissions Required
-
-| Feature | Permission | Level |
-|---------|------------|-------|
-| Read issues | Issues | Read |
-| Create issues | Issues | Write |
-| Read PRs | Pull requests | Read |
-| Comment on PRs | Pull requests | Write |
-| Trigger workflows | Actions | Write |
+The key difference from classic tokens: fine-grained tokens let you scope to specific repos and grant minimal permissions per resource type.
 
 ---
 

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -95,6 +95,22 @@
       when: config.provider is defined and config.provider.default_model is defined
       notify: Restart openclaw service
 
+    - name: Write exec approvals policy from template
+      ansible.builtin.template:
+        src: "{{ template_path }}/exec-approvals.json.j2"
+        dest: "/home/{{ agent_name }}/.openclaw/exec-approvals.json"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0600"
+        backup: yes
+      no_log: true
+      notify: Restart openclaw service
+
+    - name: Verify exec approvals JSON is valid
+      ansible.builtin.command:
+        cmd: python3 -m json.tool /home/{{ agent_name }}/.openclaw/exec-approvals.json
+      changed_when: false
+
     # B1/B2/B3 fix: Wrap verification in block/always for cleanup; use command not script
     - name: Config verification block
       when: config.provider is defined and config.provider.default_model is defined

--- a/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
@@ -100,6 +100,21 @@
         group: "{{ agent_name }}"
         mode: "0600"
 
+    - name: Write exec approvals policy from template
+      ansible.builtin.template:
+        src: "{{ template_path }}/exec-approvals.json.j2"
+        dest: "/home/{{ agent_name }}/.openclaw/exec-approvals.json"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0600"
+        backup: yes
+      no_log: true
+
+    - name: Verify exec approvals JSON is valid
+      ansible.builtin.command:
+        cmd: python3 -m json.tool /home/{{ agent_name }}/.openclaw/exec-approvals.json
+      changed_when: false
+
     - name: Create environment file for agent
       ansible.builtin.copy:
         dest: "/home/{{ agent_name }}/.openclaw/env"

--- a/src/clawrium/platform/registry/openclaw/templates/TOOLS.md.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/TOOLS.md.j2
@@ -17,9 +17,14 @@ The agent has access to the following tool categories:
 - Manage processes
 
 ### Web Access
-- Fetch web pages
-- Search the web
-- Access APIs
+- Search the web with `web_search`
+- Fetch specific URLs with `web_fetch`
+- Access APIs over HTTP tools
+
+### Browser Automation
+- Browser tool is disabled in this deployment
+- Do not call `browser` tool in this environment
+- Prefer `web_search` + `web_fetch` for research tasks
 
 ## Tool Usage Guidelines
 
@@ -45,6 +50,14 @@ The following operations require explicit user confirmation:
 - System configuration changes
 - Network operations to unknown hosts
 - Installation of packages or dependencies
+
+The following tool is unavailable in this host mode:
+- `browser` (headless server deployment)
+
+Alternatives when browser automation is requested:
+- `web_search` for discovery and ranking
+- `web_fetch` for content extraction from known URLs
+- `exec` with `curl`/`wget` only when HTTP tools are insufficient
 
 ## Custom Tool Configuration
 

--- a/src/clawrium/platform/registry/openclaw/templates/exec-approvals.json.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/exec-approvals.json.j2
@@ -1,0 +1,13 @@
+{% set tools = config.tools | default({}) %}
+{% set tools_exec = tools.exec | default({}) %}
+{% set approvals = config.exec_approvals | default({}) %}
+{% set defaults = approvals.defaults | default({}) %}
+{
+  "version": {{ approvals.version | default(1) | int }},
+  "defaults": {
+    "security": {{ defaults.security | default(tools_exec.security | default('full')) | tojson }},
+    "ask": {{ defaults.ask | default(tools_exec.ask | default('off')) | tojson }},
+    "askFallback": {{ defaults.askFallback | default('full') | tojson }},
+    "autoAllowSkills": {{ defaults.autoAllowSkills | default(false) | tojson }}
+  }
+}

--- a/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
@@ -133,12 +133,29 @@
 {% endif %}
 {% set tools = config.tools | default({}) %}
 {% set tools_exec = tools.exec | default({}) %}
+{% set tools_deny = tools.deny | default([]) %}
+{% set browser_denied = 'browser' in tools_deny %}
   "tools": {
     "exec": {
-      "host": {{ tools_exec.host | default('gateway') | tojson }}
+      "host": {{ tools_exec.host | default('gateway') | tojson }},
+      "security": {{ tools_exec.security | default('full') | tojson }},
+      "ask": {{ tools_exec.ask | default('off') | tojson }}
+{% if tools_exec.strictInlineEval is defined %}
+      ,"strictInlineEval": {{ tools_exec.strictInlineEval | tojson }}
+{% endif %}
+{% if tools_exec.safeBins is defined %}
+      ,"safeBins": {{ tools_exec.safeBins | tojson }}
+{% endif %}
+{% if tools_exec.safeBinTrustedDirs is defined %}
+      ,"safeBinTrustedDirs": {{ tools_exec.safeBinTrustedDirs | tojson }}
+{% endif %}
+{% if tools_exec.safeBinProfiles is defined %}
+      ,"safeBinProfiles": {{ tools_exec.safeBinProfiles | tojson }}
+{% endif %}
     }
+    ,"deny": {{ (tools_deny if browser_denied else tools_deny + ['browser']) | tojson }}
 {% if tools | length > 0 %}
-    {% for key, value in tools.items() if key != 'exec' %}
+    {% for key, value in tools.items() if key != 'exec' and key != 'deny' %}
     ,"{{ key }}": {{ value | tojson }}
     {% endfor %}
 {% endif %}
@@ -155,9 +172,13 @@
 {% if config.channels is defined and config.channels %}
   "channels": {{ config.channels | tojson }},
 {% endif %}
-{% if config.browser is defined %}
-  "browser": {{ config.browser | tojson }},
-{% endif %}
+{% set browser_cfg = config.browser | default({}) %}
+  "browser": {
+    "enabled": false
+{% for key, value in browser_cfg.items() if key != 'enabled' %}
+    ,"{{ key }}": {{ value | tojson }}
+{% endfor %}
+  },
 {% if config.audio is defined %}
   "audio": {{ config.audio | tojson }},
 {% endif %}

--- a/tests/test_configure_claw.py
+++ b/tests/test_configure_claw.py
@@ -362,6 +362,9 @@ class TestOpenClawTemplate:
         assert result["agents"]["defaults"]["maxConcurrent"] == 4
         assert result["gateway"]["port"] == 18789
         assert result["gateway"]["bind"] == "lan"
+        assert "browser" in result["tools"]["deny"]
+        assert result["browser"]["enabled"] is False
+        assert "plugins" not in result
 
     def test_template_renders_full_config(self):
         """Test template renders with all optional fields."""
@@ -389,12 +392,43 @@ class TestOpenClawTemplate:
         assert result["gateway"]["port"] == 40123
         assert result["gateway"]["bind"] == "loopback"
         assert result["gateway"]["auth"]["token"] == "secret"
+        assert result["tools"]["exec"]["security"] == "full"
+        assert result["tools"]["exec"]["ask"] == "off"
         assert result["session"]["dmScope"] == "per-peer"
         assert result["session"]["reset"]["atHour"] == 6
         assert result["session"]["reset"]["idleMinutes"] == 60
         # Verify channels rendered correctly
         assert "channels" in result
         assert result["channels"]["telegram"]["enabled"] is True
+
+    def test_template_enforces_browser_disabled(self):
+        """Headless profile always disables browser even when config sets enabled=true."""
+        config = {
+            "provider": {"default_model": "openai/gpt-5.4"},
+            "browser": {"enabled": True, "headless": True},
+            "plugins": {"entries": {"browser": {"enabled": True}}},
+            "tools": {"deny": ["exec"]},
+        }
+
+        result = self._render_template(config)
+
+        assert result["browser"]["enabled"] is False
+        assert result["browser"]["headless"] is True
+        assert result["plugins"]["entries"]["browser"]["enabled"] is True
+        assert "exec" in result["tools"]["deny"]
+        assert "browser" in result["tools"]["deny"]
+
+    def test_template_preserves_web_tools_when_browser_disabled(self):
+        """Browser deny list should not block web_search/web_fetch alternatives."""
+        config = {
+            "provider": {"default_model": "openai/gpt-5.4"},
+        }
+
+        result = self._render_template(config)
+
+        assert "browser" in result["tools"]["deny"]
+        assert "web_search" not in result["tools"]["deny"]
+        assert "web_fetch" not in result["tools"]["deny"]
 
     def test_template_defaults_match_openclaw_docs(self):
         """Test that defaults match OpenClaw official documentation."""
@@ -566,6 +600,132 @@ class TestOpenClawTemplate:
         assert success is True, f"Configuration failed: {error}"
         assert error is None
 
+    def test_configure_openclaw_with_headless_enforces_browser_deny(
+        self, tmp_path: Path
+    ):
+        """configure_agent pipeline should render browser-disabled config for headless hosts."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {"ocl-test": {"type": "openclaw"}},
+        }
+        config_data = {
+            "provider": {
+                "name": "test-provider",
+                "type": "openrouter",
+                "default_model": "deepseek/deepseek-chat-v3",
+            },
+            "browser": {"enabled": True, "headless": True},
+            "tools": {"deny": ["exec"]},
+        }
+
+        key_path = tmp_path / "key"
+        key_path.write_text("key")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        return_value=mock_runner,
+                    ) as mock_ansible:
+                        with patch("clawrium.core.lifecycle.update_host"):
+                            with patch(
+                                "clawrium.core.providers.get_provider_api_key",
+                                return_value="sk-or-test",
+                            ):
+                                success, error = configure_agent(
+                                    "test-host", "openclaw", config_data
+                                )
+
+                                assert success is True
+                                assert error is None
+
+                                ansible_vars = mock_ansible.call_args.kwargs[
+                                    "inventory"
+                                ]["all"]["vars"]
+                                rendered = self._render_template(ansible_vars["config"])
+
+                                assert "browser" in rendered["tools"]["deny"]
+                                assert "web_search" not in rendered["tools"]["deny"]
+                                assert "web_fetch" not in rendered["tools"]["deny"]
+                                assert rendered["browser"]["enabled"] is False
+
+    def test_configure_openclaw_template_path_and_config_vars(self, tmp_path: Path):
+        """configure_agent should pass template path and config vars to ansible."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {"ocl-test": {"type": "openclaw"}},
+        }
+        config_data = {
+            "provider": {
+                "name": "test-provider",
+                "type": "openrouter",
+                "default_model": "deepseek/deepseek-chat-v3",
+            }
+        }
+
+        key_path = tmp_path / "key"
+        key_path.write_text("key")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        return_value=mock_runner,
+                    ) as mock_ansible:
+                        with patch("clawrium.core.lifecycle.update_host"):
+                            with patch(
+                                "clawrium.core.providers.get_provider_api_key",
+                                return_value="sk-or-test",
+                            ):
+                                success, error = configure_agent(
+                                    "test-host", "openclaw", config_data
+                                )
+
+                                assert success is True
+                                assert error is None
+
+                                ansible_vars = mock_ansible.call_args.kwargs[
+                                    "inventory"
+                                ]["all"]["vars"]
+                                assert "openclaw/templates" in str(
+                                    ansible_vars["template_path"]
+                                )
+                                assert ansible_vars["config"]["provider"][
+                                    "default_model"
+                                ] == ("deepseek/deepseek-chat-v3")
+
     def test_template_ollama_renders_models_block(self):
         """Test that ollama provider generates models.providers.ollama block."""
         config = {
@@ -649,6 +809,113 @@ class TestOpenClawTemplate:
         result = self._render_template(config)
 
         assert result["agents"]["defaults"]["model"]["primary"] == "ollama/llama3.1:8b"
+
+    def test_template_exec_defaults_to_yolo_policy(self):
+        """Test tools.exec defaults to no-prompt host execution policy."""
+        config = {
+            "provider": {
+                "default_model": "anthropic/claude-sonnet-4-6",
+            }
+        }
+        result = self._render_template(config)
+
+        assert result["tools"]["exec"]["host"] == "gateway"
+        assert result["tools"]["exec"]["security"] == "full"
+        assert result["tools"]["exec"]["ask"] == "off"
+
+    def test_template_exec_renders_custom_policy_fields(self):
+        """Test tools.exec includes security/ask and optional policy knobs."""
+        config = {
+            "provider": {
+                "default_model": "anthropic/claude-sonnet-4-6",
+            },
+            "tools": {
+                "exec": {
+                    "host": "node",
+                    "security": "allowlist",
+                    "ask": "always",
+                    "strictInlineEval": True,
+                    "safeBins": ["head", "tail"],
+                    "safeBinTrustedDirs": ["/usr/bin"],
+                    "safeBinProfiles": {"head": {"maxPositional": 0}},
+                }
+            },
+        }
+        result = self._render_template(config)
+
+        assert result["tools"]["exec"]["host"] == "node"
+        assert result["tools"]["exec"]["security"] == "allowlist"
+        assert result["tools"]["exec"]["ask"] == "always"
+        assert result["tools"]["exec"]["strictInlineEval"] is True
+        assert result["tools"]["exec"]["safeBins"] == ["head", "tail"]
+        assert result["tools"]["exec"]["safeBinTrustedDirs"] == ["/usr/bin"]
+        assert result["tools"]["exec"]["safeBinProfiles"]["head"]["maxPositional"] == 0
+
+
+class TestExecApprovalsTemplate:
+    """Tests for OpenClaw exec-approvals.json.j2 template rendering."""
+
+    def _render_template(self, config):
+        template_dir = (
+            Path(__file__).parent.parent
+            / "src/clawrium/platform/registry/openclaw/templates"
+        )
+        env = Environment(loader=FileSystemLoader(str(template_dir)))
+        template = env.get_template("exec-approvals.json.j2")
+        rendered = template.render(config=config)
+        return json.loads(rendered)
+
+    def test_exec_approvals_defaults_to_no_prompt_policy(self):
+        config = {}
+        result = self._render_template(config)
+
+        assert result["version"] == 1
+        assert result["defaults"]["security"] == "full"
+        assert result["defaults"]["ask"] == "off"
+        assert result["defaults"]["askFallback"] == "full"
+        assert result["defaults"]["autoAllowSkills"] is False
+
+    def test_exec_approvals_follows_tools_exec_fallbacks(self):
+        config = {
+            "tools": {
+                "exec": {
+                    "security": "allowlist",
+                    "ask": "on-miss",
+                }
+            }
+        }
+        result = self._render_template(config)
+
+        assert result["defaults"]["security"] == "allowlist"
+        assert result["defaults"]["ask"] == "on-miss"
+        assert result["defaults"]["askFallback"] == "full"
+        assert result["defaults"]["autoAllowSkills"] is False
+
+    def test_exec_approvals_honors_explicit_overrides(self):
+        config = {
+            "tools": {
+                "exec": {
+                    "security": "allowlist",
+                    "ask": "on-miss",
+                }
+            },
+            "exec_approvals": {
+                "version": 2,
+                "defaults": {
+                    "security": "full",
+                    "ask": "off",
+                    "askFallback": "allowlist",
+                    "autoAllowSkills": True,
+                },
+            },
+        }
+        result = self._render_template(config)
+
+        assert result["version"] == 2
+        assert result["defaults"]["security"] == "full"
+        assert result["defaults"]["ask"] == "off"
+        assert result["defaults"]["askFallback"] == "allowlist"
+        assert result["defaults"]["autoAllowSkills"] is True
 
 
 class TestEnvTemplate:

--- a/tests/test_playbooks.py
+++ b/tests/test_playbooks.py
@@ -107,11 +107,28 @@ def test_openclaw_install_playbook_structure():
         "Should allow startup before interactive setup is completed"
     )
     assert "EnvironmentFile=" in content, "Should load environment file in service"
+    assert "exec-approvals.json" in content, (
+        "Should write host exec approvals policy file"
+    )
 
     # Parse YAML to ensure it's valid
     data = yaml.safe_load(content)
     assert isinstance(data, list), "Playbook should be a list of plays"
     assert len(data) > 0, "Playbook should have at least one play"
+    tasks = data[0].get("tasks", [])
+    exec_approvals_task = next(
+        t for t in tasks if t.get("name") == "Write exec approvals policy from template"
+    )
+    template_cfg = exec_approvals_task["ansible.builtin.template"]
+    assert template_cfg["src"] == "{{ template_path }}/exec-approvals.json.j2"
+    assert (
+        template_cfg["dest"] == "/home/{{ agent_name }}/.openclaw/exec-approvals.json"
+    )
+    assert template_cfg["backup"] is True
+    assert exec_approvals_task["no_log"] is True
+    assert any(t.get("name") == "Verify exec approvals JSON is valid" for t in tasks), (
+        "Should validate exec-approvals JSON after rendering"
+    )
 
 
 def test_openclaw_configure_playbook_exists():
@@ -140,13 +157,28 @@ def test_openclaw_configure_playbook_structure():
         "Should include configuration validation task"
     )
     # B2 fix: Now uses external script instead of embedded Python
-    assert "verify_config.py" in content, (
-        "Should use external verify_config.py script"
+    assert "verify_config.py" in content, "Should use external verify_config.py script"
+    assert "Write exec approvals policy from template" in content, (
+        "Should include task to manage host exec approvals policy"
     )
 
     data = yaml.safe_load(content)
     assert isinstance(data, list), "Playbook should be a list of plays"
     assert len(data) > 0, "Playbook should have at least one play"
+    tasks = data[0].get("tasks", [])
+    exec_approvals_task = next(
+        t for t in tasks if t.get("name") == "Write exec approvals policy from template"
+    )
+    template_cfg = exec_approvals_task["ansible.builtin.template"]
+    assert template_cfg["src"] == "{{ template_path }}/exec-approvals.json.j2"
+    assert (
+        template_cfg["dest"] == "/home/{{ agent_name }}/.openclaw/exec-approvals.json"
+    )
+    assert template_cfg["backup"] is True
+    assert exec_approvals_task["no_log"] is True
+    assert any(t.get("name") == "Verify exec approvals JSON is valid" for t in tasks), (
+        "Should validate exec-approvals JSON after rendering"
+    )
 
 
 def test_openclaw_start_playbook_uses_openclaw_process_check():
@@ -227,9 +259,16 @@ def test_identity_templates_exist():
     template_dir = openclaw_package / "templates"
 
     # Verify templates exist
-    assert (template_dir / "AGENTS.md.j2").is_file(), "AGENTS.md.j2 template should exist"
+    assert (template_dir / "AGENTS.md.j2").is_file(), (
+        "AGENTS.md.j2 template should exist"
+    )
     assert (template_dir / "TOOLS.md.j2").is_file(), "TOOLS.md.j2 template should exist"
-    assert (template_dir / "IDENTITY.md.j2").is_file(), "IDENTITY.md.j2 template should exist"
+    assert (template_dir / "IDENTITY.md.j2").is_file(), (
+        "IDENTITY.md.j2 template should exist"
+    )
+    assert (template_dir / "exec-approvals.json.j2").is_file(), (
+        "exec-approvals.json.j2 template should exist"
+    )
 
 
 def test_verify_config_script_exists():

--- a/website/docs/agent-support/integrations/github.md
+++ b/website/docs/agent-support/integrations/github.md
@@ -74,56 +74,38 @@ Agent: Analyzing commits since v2.0.0...
 
 ---
 
-## Preliminary Setup (Subject to Change)
+## Create Fine-Grained Token for One Repo
 
-### 1. Create GitHub App
-
-1. Go to [GitHub Developer Settings](https://github.com/settings/apps)
-2. Click **New GitHub App**
+1. Go to GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens
+   - Direct link: https://github.com/settings/tokens?type=beta
+2. Click **Generate new token**
 3. Configure:
-   - Name: `My Claw Agent`
-   - Homepage URL: Your URL
-   - Callback URL: Not needed for CLI
-4. Set permissions:
-   - Repository: Read & Write
-   - Pull requests: Read & Write
-   - Issues: Read & Write
-   - Actions: Read (optional)
-5. Create app and generate private key
+   - Token name: Descriptive name (for example, `clawrium-myrepo`)
+   - Expiration: Set as needed
+   - Repository access: Select **Only select repositories** and pick your single repo
+4. Set permissions based on what you need:
 
-### 2. Install App
+| Use Case | Permission | Level |
+|----------|------------|-------|
+| Read code | Contents | Read |
+| Push code | Contents | Read & Write |
+| Read issues | Issues | Read |
+| Create/comment issues | Issues | Read & Write |
+| Read PRs | Pull requests | Read |
+| Create/review PRs | Pull requests | Read & Write |
 
-1. Install the app on your repositories
-2. Note the installation ID
+5. Click **Generate token** and copy it immediately.
 
-### 3. Configure in Clawrium (When Available)
+## Use with Clawrium
+
+When configuring your agent:
 
 ```bash
 clm agent configure my-agent
-# Select GitHub integration when prompted
+# Enter the fine-grained token when prompted for GitHub credentials
 ```
 
----
-
-## Authentication
-
-GitHub integration will support:
-
-- **GitHub App:** Recommended for organizations
-- **Personal Access Token:** For personal use
-- **Fine-grained PAT:** New GitHub feature
-
----
-
-## Permissions Required
-
-| Feature | Permission | Level |
-|---------|------------|-------|
-| Read issues | Issues | Read |
-| Create issues | Issues | Write |
-| Read PRs | Pull requests | Read |
-| Comment on PRs | Pull requests | Write |
-| Trigger workflows | Actions | Write |
+The key difference from classic tokens: fine-grained tokens let you scope to specific repos and grant minimal permissions per resource type.
 
 ---
 


### PR DESCRIPTION
## Summary
- enforce headless-safe OpenClaw defaults by forcing `browser.enabled=false` and ensuring `tools.deny` always contains `browser`
- add host-level exec approvals policy management by templating `~/.openclaw/exec-approvals.json` during both install and configure
- update OpenClaw tool guidance for headless mode and add coverage for template behavior, playbook task wiring, and configure-agent integration path

## Testing
- `make test`
- `uv run pytest tests/test_configure_claw.py tests/test_playbooks.py`
- `clm agent sync maurice`

## ATX Review Summary

**Final Review: Skipped per user request**
**Total Cost: $2.11 | Total Time: N/A**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2.5/5 | B1-B7 | Addressed in follow-up changes where in scope | $0.93 | N/A | leader + specialists |
| 2 | 2/5 | test-coverage focused | Additional hardening and integration tests added | $1.17 | N/A | leader + specialists |
| 3 | Skipped | N/A | Skipped per explicit user instruction | $0.00 | N/A | N/A |

> **Note**: Final ATX pass was intentionally skipped per explicit user instruction in this session.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>