### PR TITLE
feat(openclaw): add gh CLI auth during configure

### DIFF
--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -84,6 +84,32 @@
       no_log: true
       notify: Restart openclaw service
 
+    # GitHub CLI authentication block
+    # Authenticates gh CLI for each github integration if gh is installed
+    # This enables openclaw's bundled github skill automatically
+    - name: GitHub CLI authentication block
+      when: integrations is defined
+      block:
+        - name: Check if gh CLI is installed
+          ansible.builtin.command: which gh
+          register: gh_check
+          changed_when: false
+          failed_when: false
+
+        - name: Authenticate gh CLI for each github integration
+          ansible.builtin.shell: |
+            echo "{{ item.value.GITHUB_TOKEN }}" | {{ gh_check.stdout }} auth login --with-token
+          become: yes
+          become_user: "{{ agent_name }}"
+          no_log: true
+          when:
+            - gh_check.rc == 0
+            - item.value.type == 'github'
+            - item.value.GITHUB_TOKEN is defined
+          loop: "{{ integrations | dict2items }}"
+          loop_control:
+            label: "{{ item.key }}"
+
     - name: Write openclaw config from template
       ansible.builtin.template:
         src: "{{ template_path }}/openclaw.json.j2"

--- a/src/clawrium/platform/registry/openclaw/templates/TOOLS.md.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/TOOLS.md.j2
@@ -16,6 +16,32 @@ The agent has access to the following tool categories:
 - Run scripts and build tools
 - Manage processes
 
+{% if integrations is defined %}
+{% set has_github = integrations.values() | selectattr('type', 'equalto', 'github') | list | length > 0 %}
+{% if has_github %}
+### GitHub CLI (gh)
+The `gh` CLI is installed and authenticated. Use it for GitHub operations:
+
+**Issues:**
+- `gh issue create --repo OWNER/REPO --title "Title" --body "Description"`
+- `gh issue list --repo OWNER/REPO`
+- `gh issue view NUMBER --repo OWNER/REPO`
+- `gh issue comment NUMBER --repo OWNER/REPO --body "Comment"`
+
+**Pull Requests:**
+- `gh pr create --repo OWNER/REPO --title "Title" --body "Description"`
+- `gh pr list --repo OWNER/REPO`
+- `gh pr view NUMBER --repo OWNER/REPO`
+- `gh pr review NUMBER --repo OWNER/REPO --approve`
+
+**Repositories:**
+- `gh repo view OWNER/REPO`
+- `gh repo clone OWNER/REPO`
+
+Always use the `exec` tool to run `gh` commands. The CLI is pre-authenticated.
+{% endif %}
+{% endif %}
+
 ### Web Access
 - Search the web with `web_search`
 - Fetch specific URLs with `web_fetch`


### PR DESCRIPTION
## Summary
- Authenticate `gh` CLI for each GitHub integration during agent configure so OpenClaw's bundled GitHub skill works automatically
- Add `gh` command reference to TOOLS.md template when GitHub integration is present

Closes #221

## Testing
- `make test` (1075 passed)
- Manual: `clm agent sync maurice` verified clean restart