### PR TITLE
feat(cli): add --version flag to show CLI version

### DIFF
--- a/src/clawrium/__init__.py
+++ b/src/clawrium/__init__.py
@@ -1,3 +1,8 @@
 """Clawrium - CLI tool for managing AI assistant fleets."""
 
-__version__ = "0.1.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("clawrium")
+except PackageNotFoundError:
+    __version__ = "0.0.0"

--- a/src/clawrium/cli/main.py
+++ b/src/clawrium/cli/main.py
@@ -15,6 +15,7 @@ from typing import Optional
 import typer
 from rich.console import Console
 
+from clawrium import __version__
 from clawrium.cli.init import init as init_command
 from clawrium.cli.agent import agent_app
 from clawrium.cli.chat import chat as chat_command
@@ -36,8 +37,16 @@ app = typer.Typer(
 
 
 @app.callback(invoke_without_command=True)
-def main(ctx: typer.Context) -> None:
+def main(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        False, "--version", help="Show version and exit"
+    ),
+) -> None:
     """Clawrium CLI main entry point."""
+    if version:
+        console.print(f"clm {__version__}")
+        raise typer.Exit(code=0)
     # If no command was provided, show help (handled by no_args_is_help)
     if ctx.invoked_subcommand is None:
         pass

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,56 @@
+"""Tests for clm --version command."""
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from clawrium import __version__
+from clawrium.cli.main import app
+
+runner = CliRunner()
+
+
+class TestCliVersion:
+    """Tests for the --version flag."""
+
+    def test_version_flag_shows_version(self) -> None:
+        """Running clm --version should show the version."""
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert __version__ in result.output
+
+    def test_version_output_format(self) -> None:
+        """Version output should be in 'clm <version>' format."""
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert f"clm {__version__}" in result.output
+
+    def test_version_works_without_config(self, isolated_config: Path) -> None:
+        """Version should work even without configuration."""
+        assert not isolated_config.exists()
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert "clm" in result.output
+
+    def test_version_is_valid_semver(self) -> None:
+        """Version should be a valid semver-like string."""
+        # Version should have at least major.minor format
+        parts = __version__.split(".")
+        assert len(parts) >= 2
+        # First two parts should be numeric
+        assert parts[0].isdigit()
+        assert parts[1].isdigit()
+
+    def test_short_v_flag_not_version(self) -> None:
+        """-v should NOT trigger --version (reserved for verbose on ps)."""
+        result = runner.invoke(app, ["-v"])
+        # -v at top level without a command should fail or show help, not version
+        # because -v is not registered as a --version alias
+        assert "clm" not in result.output or result.exit_code != 0
+
+    def test_ps_verbose_still_works(self) -> None:
+        """ps -v should trigger verbose mode, not version."""
+        result = runner.invoke(app, ["ps", "-v"])
+        # Should work (verbose output or no agents found message)
+        # Should NOT show version string
+        assert f"clm {__version__}" not in result.output


### PR DESCRIPTION
## Summary
- Add `--version` flag to `clm` CLI to show current version
- Uses `importlib.metadata` to read version from `pyproject.toml` (single source of truth)
- No `-v` alias to avoid collision with `ps -v` (verbose)

## Test plan
- [x] `clm --version` shows version and exits with code 0
- [x] Output format is `clm <version>`
- [x] Works without configuration present
- [x] `-v` does NOT trigger version (reserved for verbose)
- [x] `ps -v` still works for verbose mode

## ATX Review Summary

**Final Review: Rating 3/5**
**Total Cost: $1.68 | Agents: leader, cli-ux, test-coverage**

| Review | Rating | Blocking Issues | Status | Cost |
|--------|--------|-----------------|--------|------|
| 1 | 1/5 | B1 (flag collision), B2 (exit code) | All fixed | $1.00 |
| 2 | 2/5 | B1-B4 (test gaps) | Fixed or out-of-scope | $0.68 |

<details>
<summary>Review 1 Details (Rating 1/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `main.py:42-44` | -v alias collides with ps -v verbose | Fixed - removed -v alias |
| B2 | `main.py:49` | typer.Exit() missing explicit code | Fixed - changed to code=0 |

</details>

<details>
<summary>Review 2 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | tests | No negative test for -v | Fixed - added test_short_v_flag_not_version |
| B2 | tests | No exit code assertion | N/A - already in test_version_flag_shows_version |
| B3 | tests | No PackageNotFoundError test | Out-of-scope - standard library behavior |
| B4 | tests | No malformed version tests | Out-of-scope - version from pyproject.toml |

**Warnings:**

| # | Warning | Action |
|---|---------|--------|
| W1 | No config-independent test | Fixed - test_version_works_without_config |
| W2 | Output format not asserted | Fixed - test_version_output_format |
| W3 | ps -v regression test | Fixed - test_ps_verbose_still_works |

</details>

Closes #263

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>