### PR TITLE
docs: sync documentation across /docs/ and /website/docs/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ clm ps
 
 - Repository: https://github.com/ric03uec/clawrium
 - Project Board: https://github.com/users/ric03uec/projects/1
-- Version: 26.04.03
+- Version: 26.4.5
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ No. Clawrium supports API keys only, by design.
 
 ### 4. Which channels are supported?
 
-[Discord](https://ric03uec.github.io/clawrium/docs/channels/discord) is supported right now.
+[Discord](https://ric03uec.github.io/clawrium/docs/agent-support/channels/discord) and [Slack](https://ric03uec.github.io/clawrium/docs/agent-support/channels/slack) are supported for OpenClaw.
 
 Additional channels are planned.
 

--- a/docs/agent-support/channels/index.md
+++ b/docs/agent-support/channels/index.md
@@ -8,7 +8,7 @@ Channels define how users interact with your agents. Different agents support di
 |---------|--------|----------|
 | **[CLI](cli.md)** | All | Terminal-based interaction |
 | **[Discord](discord.md)** | OpenClaw | Discord server bot |
-| **[Slack](slack.md)** | OpenClaw (planned) | Slack workspace bot |
+| **[Slack](slack.md)** | OpenClaw | Slack workspace bot |
 | **[Web](web.md)** | OpenClaw (planned) | Browser-based chat |
 | **[WhatsApp](whatsapp.md)** | Not planned | Mobile messaging |
 
@@ -18,9 +18,11 @@ Channels define how users interact with your agents. Different agents support di
 |---------|-----|---------|-------|-----|
 | **Setup Complexity** | Low | Medium | Medium | High |
 | **Multi-user** | No | Yes | Yes | Yes |
-| **Access Control** | OS-level | Roles | Permissions | Auth |
+| **Access Control** | OS-level | Roles | Policies | Auth |
 | **Rich Media** | Limited | Yes | Yes | Yes |
 | **Mobile Support** | SSH app | Discord app | Slack app | Browser |
+| **Connection** | Local | Gateway | Socket Mode | HTTP |
+| **Required Tokens** | None | 1 (bot) | 2 (bot + app) | Varies |
 
 ## Channel vs Provider
 

--- a/docs/agent-support/integrations/github.md
+++ b/docs/agent-support/integrations/github.md
@@ -19,9 +19,9 @@ GitHub integration allows agents to interact with repositories, pull requests, a
 
 **Target:** Q2 2026
 
-**Milestone:** [SEA (Secondary Engagement & Automation)](../milestones)
+**Milestone:** [SEA (Secondary Engagement & Automation)](https://github.com/ric03uec/clawrium/milestones)
 
-Track progress: [GitHub Issue #TBD](../../issues)
+Track progress: [GitHub Issue #TBD](https://github.com/ric03uec/clawrium/issues)
 
 ---
 
@@ -131,7 +131,7 @@ Until native integration is available:
 
 ## Vote for Priority
 
-Add a 👍 reaction to [the GitHub integration issue](../../issues) to help prioritize.
+Add a 👍 reaction to [the GitHub integration issue](https://github.com/ric03uec/clawrium/issues) to help prioritize.
 
 ---
 

--- a/website/docs/guides/agent-onboarding.md
+++ b/website/docs/guides/agent-onboarding.md
@@ -91,8 +91,9 @@ Create IDENTITY.md? (defines role and context) [Y/n]: y
 Select default communication channel:
   1. cli (recommended)
   2. discord
+  3. slack
 
-Select [1-2]: 1
+Select [1-3]: 1
 ✓ Default channel: cli
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -249,6 +250,24 @@ This is useful for:
 - Automated deployments
 - CI/CD pipelines
 - Bulk agent configuration
+
+### Edit Config Directly
+
+For advanced users, edit the agent's config file directly:
+
+```bash
+# Open in default editor (uses VISUAL, EDITOR, or vi)
+clm agent configure opc-work --edit-config
+
+# Use a specific editor
+clm agent configure opc-work --edit-config --editor nano
+```
+
+After saving, Clawrium validates the config and offers to restart the agent if it's running.
+
+:::warning
+Direct editing bypasses the wizard's validation. Make sure you understand the config format before making changes.
+:::
 
 ### Resume Onboarding
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -20,11 +20,12 @@ A **claw** is a general-purpose AI assistant that runs on a machine in your netw
 - Help with writing, brainstorming, and planning
 - Connect to external services (GitHub, Jira, etc.)
 
-**Currently supported claws:**
-- [**OpenClaw**](https://github.com/opencode-ai/opencode) - Full-featured assistant with multi-provider and multi-channel support
+**Currently supported:**
+- [**OpenClaw**](https://github.com/openclaw/openclaw) - Full-featured assistant with multi-provider and multi-channel support
 
 **Planned:**
 - **ZeroClaw** - Lightweight assistant for resource-constrained devices
+- **IronClaw** - High-performance assistant for demanding workloads
 
 ## Why Clawrium?
 
@@ -150,7 +151,7 @@ No. API keys are required by design - Clawrium manages API credentials, not subs
 
 ### Which communication channels are supported?
 
-Discord and CLI are supported today. Slack and web interfaces are planned.
+Discord, Slack, and CLI are supported today. Web interface is planned.
 
 ### Do I need to be online?
 

--- a/website/docs/reference/cli/agent.md
+++ b/website/docs/reference/cli/agent.md
@@ -80,9 +80,12 @@ clm agent configure <agent-name> [options]
 - `agent-name` - Name of the agent to configure
 
 **Options:**
-- `--stage <stage>` - Configure specific stage only (providers, identity, channels, validate)
-- `--yes` - Accept defaults and skip confirmations
-- `--provider <id>` - Pre-select provider (skips provider selection prompt)
+- `--stage <stage>` / `-s` - Configure specific stage only (providers, identity, channels, validate)
+- `--yes` / `-y` - Accept defaults and skip confirmations
+- `--file <path>` / `-f` - Import identity file (SOUL.md, AGENTS.md, TOOLS.md, IDENTITY.md). Repeatable. Only valid with `--stage identity`
+- `--skip-health` - Skip OpenClaw gateway health verification during validate stage
+- `--edit-config` - Open agent config file in editor for direct editing. Cannot be combined with `--stage`, `--file`, or `--skip-health`
+- `--editor <command>` - Editor command for `--edit-config` (e.g., vim, nano). Falls back to VISUAL, then EDITOR, then vi
 
 **Examples:**
 
@@ -97,8 +100,14 @@ clm agent configure opc-work --stage identity
 # Non-interactive (use defaults)
 clm agent configure opc-work --yes
 
-# Pre-select provider
-clm agent configure opc-work --provider openai-prod --yes
+# Import identity file
+clm agent configure opc-work --stage identity --file ~/SOUL.md
+
+# Edit config directly in default editor
+clm agent configure opc-work --edit-config
+
+# Edit config with specific editor
+clm agent configure opc-work --edit-config --editor nano
 ```
 
 **Stages:**

--- a/website/docs/reference/cli/integration.md
+++ b/website/docs/reference/cli/integration.md
@@ -1,0 +1,268 @@
+# Integration Commands
+
+Manage external service integrations (GitHub, Jira, etc.) for agents.
+
+```bash
+clm integration <command> [options]
+```
+
+Integrations connect your agents to external services like GitHub, Jira, and Confluence. Credentials are stored securely in `~/.config/clawrium/secrets.yml`.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| [`clm integration types`](#clm-integration-types) | List supported integration types |
+| [`clm integration list`](#clm-integration-list) | List all configured integrations |
+| [`clm integration add`](#clm-integration-add) | Add a new integration |
+| [`clm integration show`](#clm-integration-show) | Show details of a configured integration |
+| [`clm integration remove`](#clm-integration-remove) | Remove an integration |
+| [`clm integration credentials`](#clm-integration-credentials) | View or update credentials |
+
+---
+
+## clm integration types
+
+List supported integration types.
+
+```bash
+clm integration types
+```
+
+### Example
+
+```bash
+$ clm integration types
+Supported integration types:
+
+  github      - GitHub repositories, issues, and PRs
+  gitlab      - GitLab repositories and merge requests
+  jira        - Jira issues and projects
+  confluence  - Confluence pages and spaces
+  linear      - Linear issues and projects
+  notion      - Notion pages and databases
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Types listed successfully |
+
+---
+
+## clm integration list
+
+List all configured integrations.
+
+```bash
+clm integration list
+```
+
+### Example
+
+```bash
+$ clm integration list
+                    Configured Integrations
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Name         ┃ Type     ┃ Credential          ┃ Added      ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ my-github    │ github   │ ghp_...abc          │ 2026-04-01 │
+│ work-jira    │ jira     │ https://...         │ 2026-04-02 │
+└──────────────┴──────────┴─────────────────────┴────────────┘
+```
+
+No integrations configured:
+
+```bash
+$ clm integration list
+No integrations configured. Use 'clm integration add' to add one.
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Integrations listed successfully |
+| 1 | Configuration file corrupted |
+
+---
+
+## clm integration add
+
+Add a new external service integration.
+
+```bash
+clm integration add <name> --type <type>
+```
+
+Credentials are collected securely via interactive prompts.
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `name` | Unique name for this integration |
+
+### Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--type` | `-t` | Integration type (required): github, gitlab, jira, confluence, linear, notion |
+
+### Examples
+
+Add a GitHub integration:
+
+```bash
+$ clm integration add my-github --type github
+Enter GitHub personal access token: ********
+Integration 'my-github' added successfully!
+```
+
+Add a Jira integration:
+
+```bash
+$ clm integration add work-jira --type jira
+Enter Jira instance URL: https://mycompany.atlassian.net
+Enter Jira email: user@company.com
+Enter Jira API token: ********
+Integration 'work-jira' added successfully!
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Integration added successfully |
+| 1 | Invalid name, invalid type, or duplicate integration |
+
+---
+
+## clm integration show
+
+Show details of a configured integration.
+
+```bash
+clm integration show <name>
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `name` | Integration name to show |
+
+### Example
+
+```bash
+$ clm integration show my-github
+Integration: my-github
+Type: github
+Added: 2026-04-01T10:30:00Z
+Credential: ghp_...abc (masked)
+
+Used by agents:
+  - opc-work
+  - opc-home
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Integration details shown |
+| 1 | Integration not found |
+
+---
+
+## clm integration remove
+
+Remove an integration configuration.
+
+```bash
+clm integration remove <name> [--force]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `name` | Integration name to remove |
+
+### Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--force` | `-f` | Skip confirmation prompt |
+
+### Examples
+
+```bash
+$ clm integration remove old-github
+Remove integration 'old-github'? This cannot be undone. [y/N]: y
+Integration 'old-github' removed successfully.
+```
+
+Force removal:
+
+```bash
+$ clm integration remove old-github --force
+Integration 'old-github' removed successfully.
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Integration removed successfully or operation cancelled |
+| 1 | Integration not found or removal failed |
+
+---
+
+## clm integration credentials
+
+View or update credentials for an integration.
+
+```bash
+clm integration credentials <name> [--update]
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `name` | Integration name |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--update` | Update credentials (will prompt for new values) |
+
+### Examples
+
+View credentials (masked):
+
+```bash
+$ clm integration credentials my-github
+Integration: my-github
+Type: github
+Credential: ghp_...abc (masked)
+Last updated: 2026-04-01T10:30:00Z
+```
+
+Update credentials:
+
+```bash
+$ clm integration credentials my-github --update
+Enter new GitHub personal access token: ********
+Credentials updated for 'my-github'.
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Credentials shown or updated |
+| 1 | Integration not found or update failed |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -115,6 +115,7 @@ const sidebars: SidebarsConfig = {
             'reference/cli/host',
             'reference/cli/agent',
             'reference/cli/provider',
+            'reference/cli/integration',
             'reference/cli/secret',
             'reference/cli/registry',
           ],


### PR DESCRIPTION
## Summary

Audit and fix inconsistencies between `/docs/` and `/website/docs/` directories, plus align documentation with features added in the last 48 hours.

**Changes:**
- Update Slack channel status from "planned" to "supported" in `/docs/agent-support/channels/index.md`
- Fix README FAQ to include Slack as supported channel (also fixed broken link path)
- Fix website intro FAQ to show Slack as supported, not planned
- Add missing CLI options to agent reference (`--edit-config`, `--editor`, `--file`, `--skip-health`)
- Update onboarding guide with Slack in channel examples and new "Edit Config Directly" section
- Fix AGENTS.md version number (26.04.03 → 26.4.5)
- Create new `/website/docs/reference/cli/integration.md` page for `clm integration` commands
- Fix GitHub integration broken relative links in `/docs/`
- Align agent types between README and website intro (added IronClaw to planned list)

## Test plan

- [x] `make test` passes (1205 tests)
- [x] `make lint` passes
- [x] `npm run build` in website/ succeeds
- [x] All internal links resolve

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>