### PR TITLE
feat(cli): add host alias and tag management commands

### DIFF
--- a/src/clawrium/cli/host.py
+++ b/src/clawrium/cli/host.py
@@ -13,6 +13,7 @@ from rich.table import Table
 
 from clawrium.core.hosts import (
     add_host,
+    alias_exists,
     get_host,
     get_host_by_key_id,
     load_hosts,
@@ -487,6 +488,137 @@ def remove(
             console.print(f"[dim]Keypair for '{key_id}' deleted.[/dim]")
     else:
         console.print("[red]Error:[/red] Failed to remove host")
+        raise typer.Exit(code=1)
+
+
+@host_app.command(name="alias")
+def alias_cmd(
+    host: str = typer.Argument(..., help="Host hostname or alias"),
+    set_alias: str = typer.Option(..., "--set", "-s", help="New alias for the host"),
+) -> None:
+    """Update the alias for a host.
+
+    Target can be specified by hostname or current alias.
+    """
+    # Find host by hostname or alias
+    try:
+        host_record = get_host(host)
+    except HostsFileCorruptedError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    if not host_record:
+        console.print(f"[red]Error:[/red] Host '{host}' not found")
+        raise typer.Exit(code=1)
+
+    hostname = host_record["hostname"]
+    old_alias = host_record.get("alias")
+
+    # Validate new alias doesn't conflict
+    exists, conflicting_host = alias_exists(set_alias, exclude_hostname=hostname)
+    if exists:
+        # Determine if conflict is with hostname or alias
+        if conflicting_host == set_alias:
+            console.print(
+                f"[red]Error:[/red] Alias '{set_alias}' conflicts with existing hostname"
+            )
+        else:
+            console.print(
+                f"[red]Error:[/red] Alias '{set_alias}' already in use by host '{conflicting_host}'"
+            )
+        raise typer.Exit(code=1)
+
+    # Update alias atomically
+    def apply_alias_update(h: dict) -> dict:
+        h["alias"] = set_alias
+        return h
+
+    if update_host(hostname, apply_alias_update):
+        old_display = old_alias or hostname
+        console.print(f"Host alias updated: {old_display} -> {set_alias}")
+    else:
+        console.print("[red]Error:[/red] Failed to update host alias")
+        raise typer.Exit(code=1)
+
+
+@host_app.command()
+def tag(
+    host: str = typer.Argument(..., help="Host hostname or alias"),
+    add: Optional[list[str]] = typer.Option(None, "--add", help="Add tag(s)"),
+    remove: Optional[list[str]] = typer.Option(None, "--remove", help="Remove tag(s)"),
+    set_tags: Optional[str] = typer.Option(
+        None, "--set", help="Replace all tags (comma-separated)"
+    ),
+) -> None:
+    """Manage tags for a host.
+
+    Add, remove, or replace tags. Use --set "" to clear all tags.
+    """
+    # Validate mutually exclusive options
+    if set_tags is not None and (add or remove):
+        console.print("[red]Error:[/red] --set cannot be combined with --add or --remove")
+        raise typer.Exit(code=1)
+
+    # Require at least one operation
+    if set_tags is None and not add and not remove:
+        console.print("[red]Error:[/red] Specify --add, --remove, or --set")
+        raise typer.Exit(code=1)
+
+    # Find host by hostname or alias
+    try:
+        host_record = get_host(host)
+    except HostsFileCorruptedError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    if not host_record:
+        console.print(f"[red]Error:[/red] Host '{host}' not found")
+        raise typer.Exit(code=1)
+
+    hostname = host_record["hostname"]
+    display_name = host_record.get("alias") or hostname
+
+    # Build updater function based on operation
+    def apply_tag_update(h: dict) -> dict:
+        if "metadata" not in h:
+            h["metadata"] = {}
+        current_tags = list(h["metadata"].get("tags", []))
+
+        if set_tags is not None:
+            # Replace all tags
+            if set_tags == "":
+                new_tags = []
+            else:
+                new_tags = [t.strip() for t in set_tags.split(",") if t.strip()]
+        else:
+            # Add tags (deduplicate)
+            if add:
+                for t in add:
+                    tag_clean = t.strip()
+                    if tag_clean and tag_clean not in current_tags:
+                        current_tags.append(tag_clean)
+            # Remove tags
+            if remove:
+                for t in remove:
+                    tag_clean = t.strip()
+                    if tag_clean in current_tags:
+                        current_tags.remove(tag_clean)
+            new_tags = current_tags
+
+        h["metadata"]["tags"] = new_tags
+        return h
+
+    if update_host(hostname, apply_tag_update):
+        # Reload to show final state
+        updated_host = get_host(hostname)
+        final_tags = updated_host.get("metadata", {}).get("tags", []) if updated_host else []
+
+        if final_tags:
+            console.print(f"Tags updated for '{display_name}': {', '.join(final_tags)}")
+        else:
+            console.print(f"Tags cleared for '{display_name}'")
+    else:
+        console.print("[red]Error:[/red] Failed to update host tags")
         raise typer.Exit(code=1)
 
 

--- a/src/clawrium/core/hosts.py
+++ b/src/clawrium/core/hosts.py
@@ -19,6 +19,7 @@ __all__ = [
     "update_host",
     "remove_agent_from_host",
     "get_agent_by_name",
+    "alias_exists",
     "HOSTS_FILE",
     "HostsFileCorruptedError",
     "DuplicateHostError",
@@ -286,6 +287,38 @@ def get_host_by_key_id(key_id: str) -> dict | None:
         if host.get("key_id") == key_id:
             return host
     return None
+
+
+def alias_exists(alias: str, exclude_hostname: str | None = None) -> tuple[bool, str | None]:
+    """Check if alias is already in use by another host.
+
+    Checks against both hostname and alias fields of all hosts.
+
+    Args:
+        alias: The alias to check for conflicts.
+        exclude_hostname: Optionally exclude this hostname from the check (for self-reference).
+
+    Returns:
+        Tuple of (exists, conflicting_hostname).
+        - (True, hostname) if alias conflicts with another host's hostname or alias.
+        - (False, None) if alias is available.
+    """
+    hosts = load_hosts()
+    for host in hosts:
+        host_hostname = host.get("hostname")
+        # Skip the excluded host
+        if exclude_hostname and host_hostname == exclude_hostname:
+            continue
+
+        # Check if alias matches this host's hostname
+        if host_hostname == alias:
+            return (True, host_hostname)
+
+        # Check if alias matches this host's alias
+        if host.get("alias") == alias:
+            return (True, host_hostname)
+
+    return (False, None)
 
 
 def remove_agent_from_host(hostname: str, agent_identifier: str) -> bool:

--- a/tests/test_cli_host.py
+++ b/tests/test_cli_host.py
@@ -531,3 +531,305 @@ def test_host_init_existing_keypair_not_regenerated(isolated_config: Path):
 
             # Key should not be regenerated
             assert private_key.read_text() == "existing-key-content"
+
+
+# Tests for clm host alias command
+
+
+def test_host_alias_set(isolated_config: Path, sample_host_data: dict):
+    """clm host alias --set updates alias successfully."""
+    import json
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    hosts_file = isolated_config / "hosts.json"
+    hosts_file.write_text(json.dumps([sample_host_data]))
+
+    result = runner.invoke(
+        app, ["host", "alias", "192.168.1.100", "--set", "new-alias"], env=os.environ
+    )
+
+    assert result.exit_code == 0
+    assert "new-alias" in result.output
+
+    # Verify persisted
+    hosts = json.loads(hosts_file.read_text())
+    assert hosts[0].get("alias") == "new-alias"
+
+
+def test_host_alias_by_current_alias(isolated_config: Path, sample_host_data: dict):
+    """clm host alias can target host by current alias."""
+    import json
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    # Host with existing alias - use copy to avoid fixture mutation
+    host_data = sample_host_data.copy()
+    host_data["alias"] = "old-alias"
+    hosts_file = isolated_config / "hosts.json"
+    hosts_file.write_text(json.dumps([host_data]))
+
+    result = runner.invoke(
+        app, ["host", "alias", "old-alias", "--set", "new-alias"], env=os.environ
+    )
+
+    assert result.exit_code == 0
+    assert "new-alias" in result.output
+
+    # Verify persisted
+    hosts = json.loads(hosts_file.read_text())
+    assert hosts[0].get("alias") == "new-alias"
+
+
+def test_host_alias_duplicate_rejected(isolated_config: Path, sample_host_data: dict):
+    """clm host alias rejects duplicate alias."""
+    import json
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    # Two hosts, one with alias
+    host1 = sample_host_data.copy()
+    host2 = {
+        "hostname": "192.168.1.101",
+        "alias": "existing-alias",
+        "port": 22,
+        "user": "xclm",
+        "auth_method": "key",
+        "hardware": {},
+        "metadata": {"added_at": "2026-03-21", "last_seen": "2026-03-21", "tags": []},
+    }
+    hosts_file = isolated_config / "hosts.json"
+    hosts_file.write_text(json.dumps([host1, host2]))
+
+    result = runner.invoke(
+        app,
+        ["host", "alias", "192.168.1.100", "--set", "existing-alias"],
+        env=os.environ,
+    )
+
+    assert result.exit_code == 1
+    assert "already in use" in result.output.lower()
+
+
+def test_host_alias_hostname_conflict(isolated_config: Path, sample_host_data: dict):
+    """clm host alias rejects alias that matches existing hostname."""
+    import json
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    # Two hosts
+    host1 = sample_host_data.copy()
+    host2 = {
+        "hostname": "192.168.1.101",
+        "port": 22,
+        "user": "xclm",
+        "auth_method": "key",
+        "hardware": {},
+        "metadata": {"added_at": "2026-03-21", "last_seen": "2026-03-21", "tags": []},
+    }
+    hosts_file = isolated_config / "hosts.json"
+    hosts_file.write_text(json.dumps([host1, host2]))
+
+    # Try to set alias to existing hostname
+    result = runner.invoke(
+        app, ["host", "alias", "192.168.1.100", "--set", "192.168.1.101"], env=os.environ
+    )
+
+    assert result.exit_code == 1
+    assert "conflicts" in result.output.lower()
+
+
+def test_host_alias_not_found(isolated_config: Path):
+    """clm host alias shows error when host not found."""
+    isolated_config.mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(
+        app, ["host", "alias", "nonexistent", "--set", "new-alias"], env=os.environ
+    )
+
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()
+
+
+# Tests for clm host tag command
+
+
+def test_host_tag_add(isolated_config: Path, sample_host_data: dict):
+    """clm host tag --add adds single tag."""
+    import json
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    hosts_file = isolated_config / "hosts.json"
+    hosts_file.write_text(json.dumps([sample_host_data]))
+
+    result = runner.invoke(
+        app, ["host", "tag", "192.168.1.100", "--add", "production"], env=os.environ
+    )
+
+    assert result.exit_code == 0
+    assert "production" in result.output
+
+    # Verify persisted
+    hosts = json.loads(hosts_file.read_text())
+    assert "production" in hosts[0]["metadata"]["tags"]
+
+
+def test_host_tag_add_multiple(isolated_config: Path, sample_host_data: dict):
+    """clm host tag --add adds multiple tags."""
+    import json
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    hosts_file = isolated_config / "hosts.json"
+    hosts_file.write_text(json.dumps([sample_host_data]))
+
+    result = runner.invoke(
+        app,
+        ["host", "tag", "192.168.1.100", "--add", "web", "--add", "api"],
+        env=os.environ,
+    )
+
+    assert result.exit_code == 0
+    assert "web" in result.output
+    assert "api" in result.output
+
+    # Verify persisted
+    hosts = json.loads(hosts_file.read_text())
+    assert "web" in hosts[0]["metadata"]["tags"]
+    assert "api" in hosts[0]["metadata"]["tags"]
+
+
+def test_host_tag_remove(isolated_config: Path, sample_host_data: dict):
+    """clm host tag --remove removes existing tag."""
+    import json
+    import copy
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    # Add initial tags - use deep copy to avoid fixture mutation
+    host_data = copy.deepcopy(sample_host_data)
+    host_data["metadata"]["tags"] = ["production", "web", "api"]
+    hosts_file = isolated_config / "hosts.json"
+    hosts_file.write_text(json.dumps([host_data]))
+
+    result = runner.invoke(
+        app, ["host", "tag", "192.168.1.100", "--remove", "web"], env=os.environ
+    )
+
+    assert result.exit_code == 0
+
+    # Verify persisted
+    hosts = json.loads(hosts_file.read_text())
+    assert "web" not in hosts[0]["metadata"]["tags"]
+    assert "production" in hosts[0]["metadata"]["tags"]
+    assert "api" in hosts[0]["metadata"]["tags"]
+
+
+def test_host_tag_remove_nonexistent(isolated_config: Path, sample_host_data: dict):
+    """clm host tag --remove gracefully handles missing tag."""
+    import json
+    import copy
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    host_data = copy.deepcopy(sample_host_data)
+    host_data["metadata"]["tags"] = ["production"]
+    hosts_file = isolated_config / "hosts.json"
+    hosts_file.write_text(json.dumps([host_data]))
+
+    result = runner.invoke(
+        app, ["host", "tag", "192.168.1.100", "--remove", "nonexistent"], env=os.environ
+    )
+
+    # Should succeed (graceful handling)
+    assert result.exit_code == 0
+
+    # Original tag preserved
+    hosts = json.loads(hosts_file.read_text())
+    assert "production" in hosts[0]["metadata"]["tags"]
+
+
+def test_host_tag_set(isolated_config: Path, sample_host_data: dict):
+    """clm host tag --set replaces all tags."""
+    import json
+    import copy
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    host_data = copy.deepcopy(sample_host_data)
+    host_data["metadata"]["tags"] = ["old-tag"]
+    hosts_file = isolated_config / "hosts.json"
+    hosts_file.write_text(json.dumps([host_data]))
+
+    result = runner.invoke(
+        app, ["host", "tag", "192.168.1.100", "--set", "staging,backend"], env=os.environ
+    )
+
+    assert result.exit_code == 0
+    assert "staging" in result.output
+    assert "backend" in result.output
+
+    # Verify persisted
+    hosts = json.loads(hosts_file.read_text())
+    assert hosts[0]["metadata"]["tags"] == ["staging", "backend"]
+
+
+def test_host_tag_set_empty(isolated_config: Path, sample_host_data: dict):
+    """clm host tag --set '' clears all tags."""
+    import json
+    import copy
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    host_data = copy.deepcopy(sample_host_data)
+    host_data["metadata"]["tags"] = ["production", "web"]
+    hosts_file = isolated_config / "hosts.json"
+    hosts_file.write_text(json.dumps([host_data]))
+
+    result = runner.invoke(
+        app, ["host", "tag", "192.168.1.100", "--set", ""], env=os.environ
+    )
+
+    assert result.exit_code == 0
+    assert "cleared" in result.output.lower()
+
+    # Verify persisted
+    hosts = json.loads(hosts_file.read_text())
+    assert hosts[0]["metadata"]["tags"] == []
+
+
+def test_host_tag_mutually_exclusive(isolated_config: Path, sample_host_data: dict):
+    """clm host tag rejects --set combined with --add/--remove."""
+    import json
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    hosts_file = isolated_config / "hosts.json"
+    hosts_file.write_text(json.dumps([sample_host_data]))
+
+    result = runner.invoke(
+        app,
+        ["host", "tag", "192.168.1.100", "--set", "new-tag", "--add", "another"],
+        env=os.environ,
+    )
+
+    assert result.exit_code == 1
+    assert "--set cannot be combined" in result.output
+
+
+def test_host_tag_no_operation(isolated_config: Path, sample_host_data: dict):
+    """clm host tag without operation shows error."""
+    import json
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    hosts_file = isolated_config / "hosts.json"
+    hosts_file.write_text(json.dumps([sample_host_data]))
+
+    result = runner.invoke(
+        app, ["host", "tag", "192.168.1.100"], env=os.environ
+    )
+
+    assert result.exit_code == 1
+    assert "specify" in result.output.lower()
+
+
+def test_host_tag_not_found(isolated_config: Path):
+    """clm host tag shows error when host not found."""
+    isolated_config.mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(
+        app, ["host", "tag", "nonexistent", "--add", "test"], env=os.environ
+    )
+
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()


### PR DESCRIPTION
## Summary

- Add `clm host alias` command to update host alias with validation
- Add `clm host tag` command to manage tags (add/remove/set)
- Add `alias_exists()` helper for conflict detection
- Comprehensive test coverage (13 new tests)

## Test plan

- [x] `make test` - All 1219 tests pass
- [x] `make lint` - No issues
- [x] ATX review - Rating 4/5, no blocking issues

## ATX Review Summary

**Final Review: Rating 4/5**

| Review | Rating | Blocking Issues | Status | Agents |
|--------|--------|-----------------|--------|--------|
| 1 | 4/5 | None | Ready | leader, cli-ux, test-coverage |

<details>
<summary>Review 1 Details (Rating 4/5)</summary>

**Suggestions Addressed:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Add -s short flag to --set | Fixed |
| S2 | Rename remove_tags -> remove | Fixed |
| S4 | Replace Unicode arrow with ASCII | Fixed |
| S9 | Fix fixture mutation in tests | Fixed |

**Suggestions Deferred:**

| # | Suggestion | Reason |
|---|------------|--------|
| S3 | Improve error message | Current message is clear |
| S5-S8, S10 | Additional test cases | Enhancement for follow-up |

</details>

Closes #265

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>