### PR TITLE
feat(cli): add Address column to fleet status table

### DIFF
--- a/src/clawrium/cli/status.py
+++ b/src/clawrium/cli/status.py
@@ -144,6 +144,7 @@ def status(
     table.add_column("Name", style="cyan bold")
     table.add_column("Agent Type", style="dim")
     table.add_column("Host", style="white")
+    table.add_column("Address", style="dim")
     table.add_column("Port", style="dim")
     table.add_column("Version", style="green")
     table.add_column("Status", no_wrap=True)
@@ -157,6 +158,7 @@ def status(
 
         for h, claw_record in instances:
             display_host = h.get("alias") or h["hostname"]
+            address = h["hostname"]
             full_name = (
                 claw_record.get("agent_name") or claw_record.get("name") or claw_name
             )
@@ -254,6 +256,7 @@ def status(
                 escape(full_name),
                 escape(agent_type),
                 escape(display_host),
+                escape(address),
                 port_display,
                 version,
                 status_display,

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -86,7 +86,7 @@ def test_status_shows_claw_table(mock_hosts_with_claws):
 
     with patch("clawrium.cli.status.load_hosts", return_value=mock_hosts_with_claws):
         with patch("clawrium.cli.status.check_claw_health", mock_health):
-            result = runner.invoke(app, ["ps"])
+            result = runner.invoke(app, ["ps"], env={"COLUMNS": "200"})
 
     assert result.exit_code == 0
     assert "openclaw" in result.output
@@ -248,7 +248,7 @@ def test_status_shows_failed_install_truncates_long_error():
 
     with patch("clawrium.cli.status.load_hosts", return_value=hosts):
         with patch("clawrium.cli.status.check_claw_health", mock_health):
-            result = runner.invoke(app, ["ps"])
+            result = runner.invoke(app, ["ps"], env={"COLUMNS": "200"})
 
     assert "install failed" in result.output
     assert "A" * 50 + "..." in result.output


### PR DESCRIPTION
## Summary

- Add "Address" column to `clm ps` output showing the host's primary address
- Users can now see both alias and actual IP/hostname in fleet status
- Updated tests to handle wider table output

**Before:**
```
┃ Name    ┃ Agent Type ┃ Host   ┃ Port  ┃ Version  ┃ Status ┃ Installed  ┃
│ maurice │ openclaw   │ wolf-i │ 40317 │ 2026.4.2 │ ...    │ 2026-04-16 │
```

**After:**
```
┃ Name    ┃ Agent Type ┃ Host   ┃ Address       ┃ Port  ┃ Version  ┃ Status ┃ Installed  ┃
│ maurice │ openclaw   │ wolf-i │ 192.168.1.100 │ 40317 │ 2026.4.2 │ ...    │ 2026-04-16 │
```

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (1247 tests)
- [ ] Manual test: `clm ps` displays new Address column

## ATX Review Summary

**Final Review: Rating 4/5**

| Review | Rating | Blocking Issues | Status | Agents |
|--------|--------|-----------------|--------|--------|
| 1 | 4/5 | None | Ready | cli-ux-reviewer, test-coverage |

> **Note**: lifecycle-state-reviewer failed due to agent infrastructure issue (unrelated to PR)

<details>
<summary>Review 1 Details (Rating 4/5)</summary>

**Warnings (non-blocking):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `test_cli_status.py:73-140` | Health result mock duplicated ~40×, extract fixture | Deferred - test refactoring |
| W2 | `test_cli_status.py:119-139` | No test for `check_claw_health()` exception | Deferred - edge case |
| W3 | `test_cli_status.py:451-502` | Missing DEGRADED with empty missing_secrets | Deferred - edge case |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1-S4 (status.py) | Minor doc/comment improvements | Deferred |
| S1-S4 (tests) | Test organization improvements | Deferred |

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>