### PR TITLE
fix(chat): reconstruct gateway URL using current host address

### DIFF
--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -82,7 +82,7 @@ def chat(
         raise typer.Exit(code=1)
 
     try:
-        gateway = _extract_gateway_config(agent_record)
+        gateway = _extract_gateway_config(agent_record, host_record)
     except ValueError as exc:
         console.print(f"[red]Error:[/red] {rich_escape(str(exc))}")
         raise typer.Exit(code=1)
@@ -217,7 +217,9 @@ async def _read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
         raise
 
 
-def _extract_gateway_config(agent_record: dict[str, Any]) -> GatewayConfig:
+def _extract_gateway_config(
+    agent_record: dict[str, Any], host_record: dict[str, Any]
+) -> GatewayConfig:
     config = agent_record.get("config")
     if not isinstance(config, dict):
         raise ValueError("Agent config missing. Re-run agent configure/install.")
@@ -226,8 +228,8 @@ def _extract_gateway_config(agent_record: dict[str, Any]) -> GatewayConfig:
     if not isinstance(gateway, dict):
         raise ValueError("Gateway config missing. Re-run agent configure/install.")
 
-    gateway_url = gateway.get("url")
-    if not isinstance(gateway_url, str) or not gateway_url.strip():
+    stored_url = gateway.get("url")
+    if not isinstance(stored_url, str) or not stored_url.strip():
         raise ValueError(
             "Gateway URL is missing. Re-run install/configure to capture gateway URL."
         )
@@ -237,6 +239,10 @@ def _extract_gateway_config(agent_record: dict[str, Any]) -> GatewayConfig:
         raise ValueError(
             "Gateway auth token is missing. Re-run install/configure to refresh pairing token."
         )
+
+    # Reconstruct gateway URL using current primary address from host record.
+    # This ensures connectivity regardless of which network interface is used.
+    gateway_url = _reconstruct_gateway_url(stored_url, gateway, host_record)
 
     result: GatewayConfig = {"url": gateway_url, "auth": auth_token}
 
@@ -251,6 +257,46 @@ def _extract_gateway_config(agent_record: dict[str, Any]) -> GatewayConfig:
             result["device_private_key"] = device_private_key
 
     return result
+
+
+def _reconstruct_gateway_url(
+    stored_url: str, gateway: dict[str, Any], host_record: dict[str, Any]
+) -> str:
+    """Reconstruct gateway URL using host's current primary address.
+
+    The stored URL may contain an IP that's no longer reachable (e.g., LAN IP
+    when connecting via Tailscale). This function rebuilds the URL using the
+    host's current primary address while preserving the scheme and port.
+
+    Args:
+        stored_url: The originally stored gateway URL (e.g., ws://192.168.1.36:40317)
+        gateway: Gateway config dict that may contain explicit port
+        host_record: Host record containing current primary address in 'hostname'
+
+    Returns:
+        Reconstructed gateway URL using current primary address
+    """
+    from urllib.parse import urlparse
+
+    parsed = urlparse(stored_url)
+    scheme = parsed.scheme or "ws"
+
+    # Get port from gateway config or parse from stored URL
+    port = gateway.get("port")
+    if not port and parsed.port:
+        port = parsed.port
+
+    if not port:
+        raise ValueError(
+            "Gateway port not found. Re-run install/configure to capture gateway config."
+        )
+
+    # Use current primary address from host record
+    current_host = host_record.get("hostname")
+    if not current_host:
+        raise ValueError("Host primary address not found.")
+
+    return f"{scheme}://{current_host}:{port}"
 
 
 def _validate_session_key(session_key: str) -> None:

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -40,6 +40,181 @@ def test_chat_missing_gateway_token(monkeypatch):
     assert "token is missing" in result.output.lower()
 
 
+def test_chat_reconstructs_gateway_url_from_current_host(monkeypatch):
+    """Verify gateway URL is reconstructed using host's current primary address.
+
+    When the stored URL has a different IP than the host's current primary address
+    (e.g., LAN IP vs Tailscale IP), the URL should be rebuilt using the current
+    primary address to ensure connectivity across networks.
+    """
+    # Host's current primary address is Tailscale IP, but stored URL has LAN IP
+    host = {"hostname": "100.79.149.29", "alias": "wolf-i"}
+    agent = {
+        "agent_name": "maurice",
+        "config": {
+            "gateway": {
+                "url": "ws://192.168.1.36:40317",  # Old LAN IP
+                "auth": "test-token",
+                "port": 40317,
+            }
+        },
+    }
+    monkeypatch.setattr(
+        "clawrium.cli.chat.get_agent_by_name", lambda _name: (host, "openclaw", agent)
+    )
+
+    captured_args: dict[str, object] = {}
+
+    async def mock_chat_loop(gateway_url, **kwargs):
+        captured_args["gateway_url"] = gateway_url
+
+    monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
+
+    result = runner.invoke(app, ["chat", "maurice"])
+
+    assert result.exit_code == 0
+    # Verify URL was reconstructed with current host address, not stored IP
+    assert captured_args["gateway_url"] == "ws://100.79.149.29:40317"
+
+
+def test_chat_reconstructs_gateway_url_preserves_wss_scheme(monkeypatch):
+    """Verify wss:// scheme is preserved when reconstructing gateway URL."""
+    host = {"hostname": "secure.example.com", "alias": "secure-host"}
+    agent = {
+        "agent_name": "secure-agent",
+        "config": {
+            "gateway": {
+                "url": "wss://old-ip:40443",
+                "auth": "test-token",
+                "port": 40443,
+            }
+        },
+    }
+    monkeypatch.setattr(
+        "clawrium.cli.chat.get_agent_by_name", lambda _name: (host, "openclaw", agent)
+    )
+
+    captured_args: dict[str, object] = {}
+
+    async def mock_chat_loop(gateway_url, **kwargs):
+        captured_args["gateway_url"] = gateway_url
+
+    monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
+
+    result = runner.invoke(app, ["chat", "secure-agent"])
+
+    assert result.exit_code == 0
+    assert captured_args["gateway_url"] == "wss://secure.example.com:40443"
+
+
+def test_chat_extracts_port_from_url_when_not_in_config(monkeypatch):
+    """Verify port is extracted from stored URL when not in gateway config."""
+    host = {"hostname": "new-host.local", "alias": "host1"}
+    agent = {
+        "agent_name": "agent1",
+        "config": {
+            "gateway": {
+                "url": "ws://old-host:12345",  # Port only in URL, not config
+                "auth": "test-token",
+                # No explicit 'port' key
+            }
+        },
+    }
+    monkeypatch.setattr(
+        "clawrium.cli.chat.get_agent_by_name", lambda _name: (host, "openclaw", agent)
+    )
+
+    captured_args: dict[str, object] = {}
+
+    async def mock_chat_loop(gateway_url, **kwargs):
+        captured_args["gateway_url"] = gateway_url
+
+    monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
+
+    result = runner.invoke(app, ["chat", "agent1"])
+
+    assert result.exit_code == 0
+    # Port 12345 should be extracted from URL
+    assert captured_args["gateway_url"] == "ws://new-host.local:12345"
+
+
+def test_chat_gateway_url_reconstruction_missing_port(monkeypatch):
+    """Verify error when port cannot be extracted from URL or config."""
+    host = {"hostname": "example.com", "alias": "host1"}
+    agent = {
+        "agent_name": "agent1",
+        "config": {
+            "gateway": {
+                "url": "ws://old-host/",  # No port in URL
+                "auth": "test-token",
+                # No explicit 'port' key in config either
+            }
+        },
+    }
+    monkeypatch.setattr(
+        "clawrium.cli.chat.get_agent_by_name", lambda _name: (host, "openclaw", agent)
+    )
+
+    result = runner.invoke(app, ["chat", "agent1"])
+
+    assert result.exit_code == 1
+    assert "gateway port not found" in result.output.lower()
+
+
+def test_chat_gateway_url_reconstruction_missing_hostname(monkeypatch):
+    """Verify error when host record has no hostname."""
+    host = {"alias": "host1"}  # No 'hostname' key
+    agent = {
+        "agent_name": "agent1",
+        "config": {
+            "gateway": {
+                "url": "ws://old-host:40317",
+                "auth": "test-token",
+                "port": 40317,
+            }
+        },
+    }
+    monkeypatch.setattr(
+        "clawrium.cli.chat.get_agent_by_name", lambda _name: (host, "openclaw", agent)
+    )
+
+    result = runner.invoke(app, ["chat", "agent1"])
+
+    assert result.exit_code == 1
+    assert "host primary address not found" in result.output.lower()
+
+
+def test_chat_gateway_url_reconstruction_defaults_scheme_to_ws(monkeypatch):
+    """Verify schemeless URL defaults to ws:// scheme."""
+    host = {"hostname": "example.com", "alias": "host1"}
+    agent = {
+        "agent_name": "agent1",
+        "config": {
+            "gateway": {
+                "url": "//old-host:40317",  # Schemeless URL
+                "auth": "test-token",
+                "port": 40317,
+            }
+        },
+    }
+    monkeypatch.setattr(
+        "clawrium.cli.chat.get_agent_by_name", lambda _name: (host, "openclaw", agent)
+    )
+
+    captured_args: dict[str, object] = {}
+
+    async def mock_chat_loop(gateway_url, **kwargs):
+        captured_args["gateway_url"] = gateway_url
+
+    monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
+
+    result = runner.invoke(app, ["chat", "agent1"])
+
+    assert result.exit_code == 0
+    # Should default to ws:// scheme
+    assert captured_args["gateway_url"] == "ws://example.com:40317"
+
+
 def test_chat_handles_hosts_file_corrupted(monkeypatch):
     def fake_get_agent_by_name(_name: str):
         raise HostsFileCorruptedError("hosts file is corrupted")


### PR DESCRIPTION
## Summary
- Reconstruct gateway URL at chat time using host's current primary address
- Preserves scheme (ws/wss) and port from stored configuration
- Ensures chat connectivity regardless of which network interface is used

Closes #290

## Test plan
- [x] Unit tests for URL reconstruction with different host address
- [x] Unit tests for scheme preservation (ws/wss)
- [x] Unit tests for port extraction from URL when not in config
- [x] Unit tests for error paths (missing port, missing hostname, schemeless URL)
- [x] All 1260 tests pass
- [x] Lint passes

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $1.63 | Total Time: ~2m**

| Review | Rating | Blocking Issues | Status | Cost | Agents |
|--------|--------|-----------------|--------|------|--------|
| 1 | 2/5 | B1, B2, B3, B4 | All fixed | $0.81 | leader, cli-ux, test-coverage, secrets-provider |
| 2 | 4/5 | None | Ready | $0.82 | leader, cli-ux, test-coverage, secrets-provider |

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_cli_chat.py:43-79` | Coroutine frame inspection is brittle | Fixed - replaced with `_chat_loop` mock |
| B2 | `src/clawrium/cli/chat.py:289-292` | Missing port error path untested | Fixed - added `test_chat_gateway_url_reconstruction_missing_port` |
| B3 | `src/clawrium/cli/chat.py:295-297` | Missing hostname error path untested | Fixed - added `test_chat_gateway_url_reconstruction_missing_hostname` |
| B4 | `src/clawrium/cli/chat.py:282` | Schemeless URL not tested | Fixed - added `test_chat_gateway_url_reconstruction_defaults_scheme_to_ws` |

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**Blocking Issues:** None ✅

**Warnings:** W1, W2 relate to uncommitted changes in other files (health.py, data.py) - not part of this PR.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>