### PR TITLE
User can see complete agent information at a glance in TUI

### DIFF
--- a/src/clawrium/cli/tui/data.py
+++ b/src/clawrium/cli/tui/data.py
@@ -29,6 +29,10 @@ class AgentViewModel(TypedDict):
     onboarding_step: str | None
     process_running: bool | None
     health_error: str | None
+    addresses: list[dict]
+    provider: str | None
+    cpu_count: int | None
+    memory_total_mb: int | None
 
 
 class FleetSummary(TypedDict):
@@ -99,10 +103,12 @@ def get_fleet_data(
             version = claw_record.get("version", "?")
             config = claw_record.get("config", {})
             model = "-"
+            provider_name = None
             if isinstance(config, dict):
-                provider = config.get("provider")
-                if isinstance(provider, dict):
-                    model = provider.get("default_model", "-")
+                provider_cfg = config.get("provider")
+                if isinstance(provider_cfg, dict):
+                    model = provider_cfg.get("default_model", "-")
+                    provider_name = provider_cfg.get("name") or provider_cfg.get("type")
 
             started_at = None
             runtime = claw_record.get("runtime", {})
@@ -131,6 +137,10 @@ def get_fleet_data(
                     onboarding_step=result.get("onboarding_step"),
                     process_running=result.get("process_running"),
                     health_error=result.get("error"),
+                    addresses=h.get("addresses", []),
+                    provider=provider_name,
+                    cpu_count=result.get("cpu_count"),
+                    memory_total_mb=result.get("memory_total_mb"),
                 )
             )
 
@@ -165,6 +175,8 @@ def check_claw_health_safe(claw_name: str, host: dict) -> HealthResult:
             onboarding_step=None,
             process_running=None,
             onboarding_stages=None,
+            cpu_count=None,
+            memory_total_mb=None,
         )
 
 
@@ -191,10 +203,12 @@ def get_agent_detail(agent_key: str, host_identifier: str) -> AgentViewModel | N
         version = claw_record.get("version", "?")
         config = claw_record.get("config", {})
         model = "-"
+        provider_name = None
         if isinstance(config, dict):
-            provider = config.get("provider")
-            if isinstance(provider, dict):
-                model = provider.get("default_model", "-")
+            provider_cfg = config.get("provider")
+            if isinstance(provider_cfg, dict):
+                model = provider_cfg.get("default_model", "-")
+                provider_name = provider_cfg.get("name") or provider_cfg.get("type")
 
         started_at = None
         runtime = claw_record.get("runtime", {})
@@ -217,5 +231,9 @@ def get_agent_detail(agent_key: str, host_identifier: str) -> AgentViewModel | N
             onboarding_step=result.get("onboarding_step"),
             process_running=result.get("process_running"),
             health_error=result.get("error"),
+            addresses=h.get("addresses", []),
+            provider=provider_name,
+            cpu_count=result.get("cpu_count"),
+            memory_total_mb=result.get("memory_total_mb"),
         )
     return None

--- a/src/clawrium/cli/tui/widgets/agent_table.py
+++ b/src/clawrium/cli/tui/widgets/agent_table.py
@@ -10,7 +10,7 @@ from textual.widgets import DataTable
 from clawrium.cli.tui.data import AgentViewModel
 from clawrium.core.health import ClawStatus
 
-COLUMNS = ("", "Role", "Type", "Model", "Host", "Uptime", "Status")
+COLUMNS = ("", "Agent", "Type", "Model", "Host", "Uptime", "Status")
 logger = logging.getLogger(__name__)
 
 

--- a/src/clawrium/cli/tui/widgets/detail_cards.py
+++ b/src/clawrium/cli/tui/widgets/detail_cards.py
@@ -13,6 +13,15 @@ from clawrium.cli.tui.data import AgentViewModel
 from clawrium.core.health import ClawStatus
 
 
+def _format_memory(mb: int | None) -> str:
+    """Format memory in MB to human-readable string."""
+    if mb is None or mb == 0:
+        return "N/A"
+    if mb >= 1024:
+        return f"{mb // 1024} GB"
+    return f"{mb} MB"
+
+
 class DetailCard(Widget):
     DEFAULT_CSS = """
     DetailCard {
@@ -75,7 +84,7 @@ class DetailCards(Grid):
         }.get(status, "unknown")
 
         identity_rows = [
-            ("role", agent["agent_name"]),
+            ("agent", agent["agent_name"]),
             ("type", agent["agent_type"]),
             ("version", agent["version"]),
             (
@@ -87,6 +96,22 @@ class DetailCards(Grid):
             ("status", status_text),
             ("uptime", agent["uptime"]),
         ]
+
+        # Add all configured addresses
+        addresses = agent.get("addresses", [])
+        if not isinstance(addresses, list):
+            addresses = []
+        for addr in addresses:
+            if not isinstance(addr, dict):
+                continue
+            addr_value = escape(addr.get("address", "N/A"))
+            if addr.get("is_primary"):
+                label = "address (primary)"
+            elif addr.get("label"):
+                label = f"address ({escape(str(addr['label']))})"
+            else:
+                label = "address"
+            identity_rows.append((label, addr_value))
 
         model_cost_rows = [
             ("model", agent["model"]),
@@ -101,14 +126,16 @@ class DetailCards(Grid):
             secrets_status = f"missing: {len(agent['missing_secrets'])} key(s)"
 
         config_rows = [
-            ("provider", "N/A"),
+            ("provider", agent.get("provider") or "not configured"),
             ("gateway port", "N/A"),
             ("secrets", secrets_status),
         ]
 
+        cpu_count = agent.get("cpu_count")
+        mem_mb = agent.get("memory_total_mb")
         health_rows = [
-            ("cpu", "N/A"),
-            ("memory", "N/A"),
+            ("cpu cores", str(cpu_count) if cpu_count else "N/A"),
+            ("memory", _format_memory(mem_mb)),
             ("errors / 24h", "N/A"),
         ]
 

--- a/src/clawrium/core/health.py
+++ b/src/clawrium/core/health.py
@@ -28,6 +28,55 @@ logger = logging.getLogger(__name__)
 # lowercase letters, digits, underscores, or hyphens. Max 32 chars total.
 VALID_USERNAME_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
 
+
+def _collect_system_info(
+    inventory: dict,
+    hostname: str,
+    tmpdir: str,
+) -> tuple[int | None, int | None]:
+    """Collect CPU count and total memory from remote host.
+
+    Runs nproc and reads /proc/meminfo to get system specifications.
+
+    Args:
+        inventory: Ansible inventory dict
+        hostname: Target host
+        tmpdir: Temporary directory for ansible_runner
+
+    Returns:
+        Tuple of (cpu_count, memory_total_mb), both may be None on failure.
+    """
+    # Run nproc and grep MemTotal in a single shell command
+    cmd = "nproc && grep MemTotal /proc/meminfo | awk '{print $2}'"
+
+    result = ansible_runner.run(
+        private_data_dir=tmpdir,
+        inventory=inventory,
+        host_pattern=hostname,
+        module="shell",
+        module_args=cmd,
+        quiet=True,
+        timeout=10,
+    )
+
+    cpu_count = None
+    memory_total_mb = None
+
+    for event in result.events:
+        if event.get("event") == "runner_on_ok":
+            stdout = event.get("event_data", {}).get("res", {}).get("stdout", "")
+            lines = stdout.strip().split("\n")
+            if len(lines) >= 2:
+                try:
+                    cpu_count = int(lines[0])
+                    mem_kb = int(lines[1])
+                    memory_total_mb = mem_kb // 1024
+                except (ValueError, IndexError):
+                    pass
+            break
+
+    return cpu_count, memory_total_mb
+
 # Onboarding state to step mapping for display
 ONBOARDING_STEP_MAP: dict[str, str] = {
     "providers": "1/4",
@@ -62,6 +111,8 @@ class HealthResult(TypedDict):
     onboarding_step: str | None
     process_running: bool | None
     onboarding_stages: dict[str, dict[str, str | None]] | None
+    cpu_count: int | None
+    memory_total_mb: int | None
 
 
 def get_onboarding_status(claw_record: dict) -> tuple[ClawStatus, str | None]:
@@ -201,6 +252,8 @@ def check_claw_health(
             "onboarding_step": None,
             "process_running": None,
             "onboarding_stages": None,
+            "cpu_count": None,
+            "memory_total_mb": None,
         }
 
     port = host.get("port", 22)
@@ -221,6 +274,8 @@ def check_claw_health(
             "onboarding_step": None,
             "process_running": None,
             "onboarding_stages": None,
+            "cpu_count": None,
+            "memory_total_mb": None,
         }
 
     claw_user = claw_record.get("agent_name") or claw_record.get("name")
@@ -235,6 +290,8 @@ def check_claw_health(
             "onboarding_step": None,
             "process_running": None,
             "onboarding_stages": None,
+            "cpu_count": None,
+            "memory_total_mb": None,
         }
 
     if not VALID_USERNAME_PATTERN.match(claw_user):
@@ -248,6 +305,8 @@ def check_claw_health(
             "onboarding_step": None,
             "process_running": None,
             "onboarding_stages": None,
+            "cpu_count": None,
+            "memory_total_mb": None,
         }
 
     key_id = host.get("key_id") or hostname
@@ -263,6 +322,8 @@ def check_claw_health(
             "onboarding_step": None,
             "process_running": None,
             "onboarding_stages": None,
+            "cpu_count": None,
+            "memory_total_mb": None,
         }
 
     # Build inventory
@@ -313,6 +374,8 @@ def check_claw_health(
                 "onboarding_step": None,
                 "process_running": None,
                 "onboarding_stages": None,
+                "cpu_count": None,
+                "memory_total_mb": None,
             }
 
         # Parse events to determine process state.
@@ -337,6 +400,8 @@ def check_claw_health(
                     "onboarding_step": None,
                     "process_running": None,
                     "onboarding_stages": None,
+                    "cpu_count": None,
+                    "memory_total_mb": None,
                 }
             if event_type == "runner_on_ok":
                 process_running = True
@@ -349,6 +414,15 @@ def check_claw_health(
                     error_msg = f"Unexpected exit code: {rc}"
                 break
 
+        # Collect system info (CPU count, total memory) if we successfully
+        # connected to the host (process_running is not None)
+        cpu_count = None
+        memory_total_mb = None
+        if process_running is not None:
+            cpu_count, memory_total_mb = _collect_system_info(
+                inventory, hostname, tmpdir
+            )
+
         if process_running is None:
             return {
                 "agent": claw_name,
@@ -360,6 +434,8 @@ def check_claw_health(
                 "onboarding_step": None,
                 "process_running": None,
                 "onboarding_stages": None,
+                "cpu_count": None,
+                "memory_total_mb": None,
             }
 
         if process_running:
@@ -377,6 +453,8 @@ def check_claw_health(
                     "onboarding_step": None,
                     "process_running": True,
                     "onboarding_stages": None,
+                    "cpu_count": cpu_count,
+                    "memory_total_mb": memory_total_mb,
                 }
 
             if missing:
@@ -390,6 +468,8 @@ def check_claw_health(
                     "onboarding_step": None,
                     "process_running": True,
                     "onboarding_stages": None,
+                    "cpu_count": cpu_count,
+                    "memory_total_mb": memory_total_mb,
                 }
             else:
                 return {
@@ -402,6 +482,8 @@ def check_claw_health(
                     "onboarding_step": None,
                     "process_running": True,
                     "onboarding_stages": None,
+                    "cpu_count": cpu_count,
+                    "memory_total_mb": memory_total_mb,
                 }
         else:
             status, step = get_onboarding_status(claw_record)
@@ -423,6 +505,8 @@ def check_claw_health(
                 "onboarding_step": step,
                 "process_running": False,
                 "onboarding_stages": onboarding_stages,
+                "cpu_count": cpu_count,
+                "memory_total_mb": memory_total_mb,
             }
 
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1351,10 +1351,11 @@ class TestProcessNameByAgentType:
                 with patch("clawrium.core.health.get_required_secrets", return_value=[]):
                     check_claw_health("my-openclaw", host)
 
-        # Verify pgrep uses 'openclaw' process name
-        call_args = mock_run.call_args
-        assert call_args is not None
-        module_args = call_args.kwargs.get("module_args", "")
+        # Verify first call (pgrep) uses 'openclaw' process name
+        # Second call is for system info (cpu/memory)
+        assert len(mock_run.call_args_list) >= 1
+        first_call = mock_run.call_args_list[0]
+        module_args = first_call.kwargs.get("module_args", "")
         assert "pgrep -u wolf-i openclaw" == module_args
 
     def test_zeroclaw_uses_node_process_name(self):
@@ -1382,10 +1383,11 @@ class TestProcessNameByAgentType:
                 with patch("clawrium.core.health.get_required_secrets", return_value=[]):
                     check_claw_health("my-zeroclaw", host)
 
-        # Verify pgrep uses 'node' process name
-        call_args = mock_run.call_args
-        assert call_args is not None
-        module_args = call_args.kwargs.get("module_args", "")
+        # Verify first call (pgrep) uses 'node' process name
+        # Second call is for system info (cpu/memory)
+        assert len(mock_run.call_args_list) >= 1
+        first_call = mock_run.call_args_list[0]
+        module_args = first_call.kwargs.get("module_args", "")
         assert "pgrep -u zc-edge node" == module_args
 
     def test_missing_type_defaults_to_node(self):
@@ -1413,10 +1415,11 @@ class TestProcessNameByAgentType:
                 with patch("clawrium.core.health.get_required_secrets", return_value=[]):
                     check_claw_health("legacy-agent", host)
 
-        # Verify pgrep defaults to 'node' process name
-        call_args = mock_run.call_args
-        assert call_args is not None
-        module_args = call_args.kwargs.get("module_args", "")
+        # Verify first call (pgrep) defaults to 'node' process name
+        # Second call is for system info (cpu/memory)
+        assert len(mock_run.call_args_list) >= 1
+        first_call = mock_run.call_args_list[0]
+        module_args = first_call.kwargs.get("module_args", "")
         assert "pgrep -u legacy-user node" == module_args
 
     def test_empty_type_defaults_to_node(self):
@@ -1444,8 +1447,9 @@ class TestProcessNameByAgentType:
                 with patch("clawrium.core.health.get_required_secrets", return_value=[]):
                     check_claw_health("empty-type-agent", host)
 
-        # Verify pgrep defaults to 'node' process name
-        call_args = mock_run.call_args
-        assert call_args is not None
-        module_args = call_args.kwargs.get("module_args", "")
+        # Verify first call (pgrep) defaults to 'node' process name
+        # Second call is for system info (cpu/memory)
+        assert len(mock_run.call_args_list) >= 1
+        first_call = mock_run.call_args_list[0]
+        module_args = first_call.kwargs.get("module_args", "")
         assert "pgrep -u empty-user node" == module_args

--- a/tests/test_tui/test_tui_data.py
+++ b/tests/test_tui/test_tui_data.py
@@ -124,6 +124,8 @@ class TestGetFleetData:
             "onboarding_step": None,
             "process_running": True,
             "onboarding_stages": None,
+            "cpu_count": 8,
+            "memory_total_mb": 32768,
         }
 
         with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
@@ -133,6 +135,8 @@ class TestGetFleetData:
         assert agents[0]["agent_name"] == "opc-testhost"
         assert agents[0]["status"] == ClawStatus.RUNNING
         assert agents[0]["model"] == "gpt-4o"
+        assert agents[0]["cpu_count"] == 8
+        assert agents[0]["memory_total_mb"] == 32768
         assert summary["total"] == 1
         assert summary["running"] == 1
         assert summary["hosts"] == 1
@@ -178,6 +182,8 @@ class TestGetFleetData:
             "onboarding_step": "2/4",
             "process_running": False,
             "onboarding_stages": None,
+            "cpu_count": None,
+            "memory_total_mb": None,
         }
 
         with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
@@ -212,12 +218,15 @@ class TestGetFleetData:
             "onboarding_step": None,
             "process_running": True,
             "onboarding_stages": None,
+            "cpu_count": 2,
+            "memory_total_mb": 4096,
         }
 
         with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
             agents, _ = get_fleet_data()
 
         assert agents[0]["model"] == "-"
+        assert agents[0]["provider"] is None
 
 
 class TestGetAgentDetail:
@@ -250,6 +259,8 @@ class TestGetAgentDetail:
             "onboarding_step": None,
             "process_running": True,
             "onboarding_stages": None,
+            "cpu_count": 4,
+            "memory_total_mb": 8192,
         }
 
         with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
@@ -258,6 +269,8 @@ class TestGetAgentDetail:
         assert detail is not None
         assert detail["agent_key"] == "openclaw"
         assert detail["version"] == "1.0.0"
+        assert detail["cpu_count"] == 4
+        assert detail["memory_total_mb"] == 8192
 
     def test_not_found(self, isolated_config):
         isolated_config.mkdir(parents=True, exist_ok=True)

--- a/tests/test_tui/test_tui_screens.py
+++ b/tests/test_tui/test_tui_screens.py
@@ -31,6 +31,10 @@ SAMPLE_AGENT = AgentViewModel(
     onboarding_step=None,
     process_running=True,
     health_error=None,
+    addresses=[{"address": "192.168.1.100", "is_primary": True, "label": None}],
+    provider="openai",
+    cpu_count=4,
+    memory_total_mb=16384,
 )
 
 
@@ -149,6 +153,10 @@ class TestDetailCards:
             onboarding_step=None,
             process_running=True,
             health_error=None,
+            addresses=[],
+            provider="openai",
+            cpu_count=4,
+            memory_total_mb=8192,
         )
         cards = DetailCards(agent=agent)
         built = cards._build_cards(agent)
@@ -181,6 +189,10 @@ class TestDetailCards:
             onboarding_step=None,
             process_running=False,
             health_error="Host [red]unreachable[/red]",
+            addresses=[],
+            provider=None,
+            cpu_count=None,
+            memory_total_mb=None,
         )
         cards = DetailCards(agent=agent)
         built = cards._build_cards(agent)
@@ -194,6 +206,87 @@ class TestDetailCards:
             str(item.renderable) for item in rendered_items if isinstance(item, Static)
         ]
         assert any("\\[" in value for value in static_values)
+
+    def test_memory_under_1gb_shows_mb(self):
+        """Memory less than 1024 MB should display in MB."""
+        agent = AgentViewModel(
+            **{**SAMPLE_AGENT, "memory_total_mb": 512, "cpu_count": 2}
+        )
+        cards = DetailCards(agent=agent)
+        built = cards._build_cards(agent)
+        health_card = built[3]
+        memory_row = [r for r in health_card._rows if r[0] == "memory"][0]
+        assert memory_row[1] == "512 MB"
+
+    def test_memory_1gb_shows_gb(self):
+        """Memory >= 1024 MB should display in GB."""
+        agent = AgentViewModel(
+            **{**SAMPLE_AGENT, "memory_total_mb": 1024, "cpu_count": 4}
+        )
+        cards = DetailCards(agent=agent)
+        built = cards._build_cards(agent)
+        health_card = built[3]
+        memory_row = [r for r in health_card._rows if r[0] == "memory"][0]
+        assert memory_row[1] == "1 GB"
+
+    def test_memory_none_shows_na(self):
+        """None memory should show N/A."""
+        agent = AgentViewModel(
+            **{**SAMPLE_AGENT, "memory_total_mb": None, "cpu_count": None}
+        )
+        cards = DetailCards(agent=agent)
+        built = cards._build_cards(agent)
+        health_card = built[3]
+        memory_row = [r for r in health_card._rows if r[0] == "memory"][0]
+        cpu_row = [r for r in health_card._rows if r[0] == "cpu cores"][0]
+        assert memory_row[1] == "N/A"
+        assert cpu_row[1] == "N/A"
+
+    def test_multiple_addresses_rendered(self):
+        """All addresses should be rendered in identity card."""
+        agent = AgentViewModel(
+            **{
+                **SAMPLE_AGENT,
+                "addresses": [
+                    {"address": "192.168.1.100", "is_primary": True, "label": None},
+                    {"address": "10.0.0.50", "is_primary": False, "label": "vpn"},
+                ],
+            }
+        )
+        cards = DetailCards(agent=agent)
+        built = cards._build_cards(agent)
+        identity_card = built[0]
+        addr_rows = [r for r in identity_card._rows if r[0].startswith("address")]
+        assert len(addr_rows) == 2
+        assert any("primary" in r[0] for r in addr_rows)
+        assert any("vpn" in r[0] for r in addr_rows)
+
+    def test_empty_addresses_no_crash(self):
+        """Empty addresses list should not crash."""
+        agent = AgentViewModel(**{**SAMPLE_AGENT, "addresses": []})
+        cards = DetailCards(agent=agent)
+        built = cards._build_cards(agent)
+        identity_card = built[0]
+        addr_rows = [r for r in identity_card._rows if r[0].startswith("address")]
+        assert len(addr_rows) == 0
+
+    def test_provider_displayed(self):
+        """Provider name should be displayed in config card."""
+        agent = AgentViewModel(**{**SAMPLE_AGENT, "provider": "anthropic"})
+        cards = DetailCards(agent=agent)
+        built = cards._build_cards(agent)
+        config_card = built[2]
+        provider_row = [r for r in config_card._rows if r[0] == "provider"][0]
+        assert provider_row[1] == "anthropic"
+
+    def test_provider_none_shows_not_configured(self):
+        """None provider should show 'not configured'."""
+        agent = AgentViewModel(**{**SAMPLE_AGENT, "provider": None})
+        cards = DetailCards(agent=agent)
+        built = cards._build_cards(agent)
+        config_card = built[2]
+        provider_row = [r for r in config_card._rows if r[0] == "provider"][0]
+        assert provider_row[1] == "not configured"
 
 
 class TestConfirmModal:


### PR DESCRIPTION
## Summary
- Rename "Role" column to "Agent" in agent table for clarity
- Display all configured addresses (primary + labeled) in agent details
- Show provider name in configuration card
- Add CPU cores and total memory to health card via SSH collection

## Test plan
- [x] All 1257 tests pass
- [x] Lint passes
- [x] Manual TUI verification
- [ ] Verify address display with multiple addresses
- [ ] Verify memory formatting (MB vs GB)

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $1.58 | Agents: leader, cli-ux-reviewer, test-coverage**

| Review | Rating | Blocking Issues | Status | Cost | Agents |
|--------|--------|-----------------|--------|------|--------|
| 1 | 2/5 | B1, B2, B3, B4 | All fixed | $0.78 | leader, cli-ux-reviewer, test-coverage |
| 2 | 4/5 | None | Approved | $0.80 | leader, cli-ux-reviewer, test-coverage |

> **Note**: lifecycle-state-reviewer failed due to API error in both reviews.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `health.py` (all return paths) | `cpu_count` and `memory_total_mb` never populated - hardcoded to None | Fixed - implemented `_collect_system_info()` helper |
| B2 | `test_tui_data.py:95-139` | Mock HealthResult missing `cpu_count`/`memory_total_mb` fields | Fixed - updated all mock dicts |
| B3 | `data.py:140-143` | No tests for empty addresses or None provider edge cases | Fixed - added edge case tests |
| B4 | `test_tui_screens.py:122-167` | No tests for memory/CPU rendering, boundaries, N/A fallback | Fixed - added formatting tests |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `detail_cards.py:93-101` | addr_value not explicitly escaped | Fixed - added `escape()` |
| W2 | `detail_cards.py:121-129` | Nested ternary hard to read | Fixed - extracted `_format_memory()` |
| W3 | `test_tui_data.py` | All mock results incomplete | Fixed - updated with new fields |
| W4 | `detail_cards.py:92-101` | No type guard on addresses | Fixed - added `isinstance` check |

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**Blocking Issues:** None ✅

**Confirmed Fixes:**
- Rich markup escaping (`escape()`) on all user-facing address values
- Agent key pattern validation before lookup (injection prevention)
- Memory formatting extracted to `_format_memory()` helper
- Secrets shown as count, not raw values
- `HealthResult` mock updated with `cpu_count`/`memory_total_mb` fields
- `SAMPLE_AGENT` fixture updated with addresses, provider, cpu/memory
- Test assertions now use `call_args_list[0]` (handles multi-call cases)

**Warnings (Non-blocking, acknowledged):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `health.py:_collect_system_info()` | Called even when `process_running=False` | Acknowledged - minor perf impact |
| W2 | `data.py` | No logging when system info returns None | Acknowledged - will address in follow-up |
| W3 | `HealthResult` | `cpu_count`/`memory_total_mb` accept negative values | Acknowledged - edge case |

**Suggestions (Deferred):**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | `_format_memory(0)` returns N/A - add clarifying comment | Deferred |
| S2 | `AGENT_KEY_PATTERN` defined in two places | Deferred |
| S3 | Test zero memory edge case | Deferred |
| S4 | Test address robustness (non-string, markup injection) | Deferred |

</details>

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>