### PR TITLE
feat(tui): display gateway port in agent details page

### DIFF
--- a/src/clawrium/cli/tui/data.py
+++ b/src/clawrium/cli/tui/data.py
@@ -34,6 +34,7 @@ class AgentViewModel(TypedDict):
     provider_type: str | None
     cpu_count: int | None
     memory_total_mb: int | None
+    gateway_port: int | None
 
 
 class FleetSummary(TypedDict):
@@ -106,12 +107,18 @@ def get_fleet_data(
             model = "-"
             provider_name = None
             provider_type = None
+            gateway_port = None
             if isinstance(config, dict):
                 provider_cfg = config.get("provider")
                 if isinstance(provider_cfg, dict):
                     model = provider_cfg.get("default_model", "-")
                     provider_name = provider_cfg.get("name") or provider_cfg.get("type")
                     provider_type = provider_cfg.get("type")
+                gateway_cfg = config.get("gateway")
+                if isinstance(gateway_cfg, dict):
+                    port_val = gateway_cfg.get("port")
+                    if isinstance(port_val, int):
+                        gateway_port = port_val
 
             started_at = None
             runtime = claw_record.get("runtime", {})
@@ -145,6 +152,7 @@ def get_fleet_data(
                     provider_type=provider_type,
                     cpu_count=result.get("cpu_count"),
                     memory_total_mb=result.get("memory_total_mb"),
+                    gateway_port=gateway_port,
                 )
             )
 
@@ -209,12 +217,18 @@ def get_agent_detail(agent_key: str, host_identifier: str) -> AgentViewModel | N
         model = "-"
         provider_name = None
         provider_type = None
+        gateway_port = None
         if isinstance(config, dict):
             provider_cfg = config.get("provider")
             if isinstance(provider_cfg, dict):
                 model = provider_cfg.get("default_model", "-")
                 provider_name = provider_cfg.get("name") or provider_cfg.get("type")
                 provider_type = provider_cfg.get("type")
+            gateway_cfg = config.get("gateway")
+            if isinstance(gateway_cfg, dict):
+                port_val = gateway_cfg.get("port")
+                if isinstance(port_val, int):
+                    gateway_port = port_val
 
         started_at = None
         runtime = claw_record.get("runtime", {})
@@ -242,5 +256,6 @@ def get_agent_detail(agent_key: str, host_identifier: str) -> AgentViewModel | N
             provider_type=provider_type,
             cpu_count=result.get("cpu_count"),
             memory_total_mb=result.get("memory_total_mb"),
+            gateway_port=gateway_port,
         )
     return None

--- a/src/clawrium/cli/tui/widgets/detail_cards.py
+++ b/src/clawrium/cli/tui/widgets/detail_cards.py
@@ -125,10 +125,15 @@ class DetailCards(Grid):
         if agent.get("missing_secrets"):
             secrets_status = f"missing: {len(agent['missing_secrets'])} key(s)"
 
+        gateway_port = agent.get("gateway_port")
+        gateway_port_display = (
+            str(gateway_port) if gateway_port is not None else "not configured"
+        )
+
         config_rows = [
             ("provider", agent.get("provider") or "not configured"),
             ("provider type", agent.get("provider_type") or "not configured"),
-            ("gateway port", "N/A"),
+            ("gateway port", gateway_port_display),
             ("secrets", secrets_status),
         ]
 

--- a/tests/test_tui/test_tui_data.py
+++ b/tests/test_tui/test_tui_data.py
@@ -319,6 +319,165 @@ class TestGetFleetData:
         assert agents[0]["provider"] == "anthropic"
         assert agents[0]["provider_type"] == "anthropic"
 
+    def test_gateway_port_extracted_from_config(self, isolated_config):
+        """Gateway port should be extracted from config.gateway.port."""
+        import json
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts = [
+            {
+                "hostname": "192.168.1.100",
+                "alias": "testhost",
+                "agents": {
+                    "openclaw": {
+                        "type": "openclaw",
+                        "agent_name": "opc-test",
+                        "config": {
+                            "gateway": {"port": 40123},
+                        },
+                    }
+                },
+            }
+        ]
+        (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+
+        mock_result = {
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.RUNNING,
+            "user": None,
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+            "cpu_count": 4,
+            "memory_total_mb": 8192,
+        }
+
+        with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
+            agents, _ = get_fleet_data()
+
+        assert agents[0]["gateway_port"] == 40123
+
+    def test_gateway_port_none_when_not_configured(self, isolated_config):
+        """Gateway port should be None when not configured."""
+        import json
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts = [
+            {
+                "hostname": "192.168.1.100",
+                "agents": {
+                    "zeroclaw": {
+                        "type": "zeroclaw",
+                        "agent_name": "zc-test",
+                    }
+                },
+            }
+        ]
+        (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+
+        mock_result = {
+            "agent": "zeroclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.RUNNING,
+            "user": None,
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+            "cpu_count": 2,
+            "memory_total_mb": 4096,
+        }
+
+        with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
+            agents, _ = get_fleet_data()
+
+        assert agents[0]["gateway_port"] is None
+
+    def test_gateway_port_string_value_ignored(self, isolated_config):
+        """String port value should be ignored (type validation)."""
+        import json
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts = [
+            {
+                "hostname": "192.168.1.100",
+                "agents": {
+                    "openclaw": {
+                        "type": "openclaw",
+                        "agent_name": "opc-test",
+                        "config": {
+                            "gateway": {"port": "40123"},  # String instead of int
+                        },
+                    }
+                },
+            }
+        ]
+        (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+
+        mock_result = {
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.RUNNING,
+            "user": None,
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+            "cpu_count": 4,
+            "memory_total_mb": 8192,
+        }
+
+        with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
+            agents, _ = get_fleet_data()
+
+        # String port value should be rejected, resulting in None
+        assert agents[0]["gateway_port"] is None
+
+    def test_gateway_port_empty_gateway_config(self, isolated_config):
+        """Empty gateway config should result in None port."""
+        import json
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts = [
+            {
+                "hostname": "192.168.1.100",
+                "agents": {
+                    "openclaw": {
+                        "type": "openclaw",
+                        "agent_name": "opc-test",
+                        "config": {
+                            "gateway": {},  # Empty gateway config
+                        },
+                    }
+                },
+            }
+        ]
+        (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+
+        mock_result = {
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.RUNNING,
+            "user": None,
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+            "cpu_count": 4,
+            "memory_total_mb": 8192,
+        }
+
+        with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
+            agents, _ = get_fleet_data()
+
+        assert agents[0]["gateway_port"] is None
+
 
 class TestGetAgentDetail:
     def test_found(self, isolated_config):
@@ -372,3 +531,46 @@ class TestGetAgentDetail:
     def test_invalid_agent_key_rejected(self):
         result = get_agent_detail("../../../etc/passwd", "somehost")
         assert result is None
+
+    def test_gateway_port_extracted(self, isolated_config):
+        """Gateway port should be extracted in get_agent_detail."""
+        import json
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts = [
+            {
+                "hostname": "192.168.1.100",
+                "alias": "myhost",
+                "agents": {
+                    "openclaw": {
+                        "type": "openclaw",
+                        "agent_name": "opc-test",
+                        "version": "1.0.0",
+                        "config": {
+                            "gateway": {"port": 40456},
+                        },
+                    }
+                },
+            }
+        ]
+        (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+
+        mock_result = {
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.RUNNING,
+            "user": None,
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+            "cpu_count": 4,
+            "memory_total_mb": 8192,
+        }
+
+        with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
+            detail = get_agent_detail("openclaw", "192.168.1.100")
+
+        assert detail is not None
+        assert detail["gateway_port"] == 40456

--- a/tests/test_tui/test_tui_screens.py
+++ b/tests/test_tui/test_tui_screens.py
@@ -36,6 +36,7 @@ SAMPLE_AGENT = AgentViewModel(
     provider_type="openai",
     cpu_count=4,
     memory_total_mb=16384,
+    gateway_port=40123,
 )
 
 
@@ -159,6 +160,7 @@ class TestDetailCards:
             provider_type="openai",
             cpu_count=4,
             memory_total_mb=8192,
+            gateway_port=40000,
         )
         cards = DetailCards(agent=agent)
         built = cards._build_cards(agent)
@@ -196,6 +198,7 @@ class TestDetailCards:
             provider_type=None,
             cpu_count=None,
             memory_total_mb=None,
+            gateway_port=None,
         )
         cards = DetailCards(agent=agent)
         built = cards._build_cards(agent)
@@ -308,6 +311,33 @@ class TestDetailCards:
         config_card = built[2]
         provider_type_row = [r for r in config_card._rows if r[0] == "provider type"][0]
         assert provider_type_row[1] == "not configured"
+
+    def test_gateway_port_displayed(self):
+        """Gateway port should be displayed in config card."""
+        agent = AgentViewModel(**{**SAMPLE_AGENT, "gateway_port": 40789})
+        cards = DetailCards(agent=agent)
+        built = cards._build_cards(agent)
+        config_card = built[2]
+        gateway_port_row = [r for r in config_card._rows if r[0] == "gateway port"][0]
+        assert gateway_port_row[1] == "40789"
+
+    def test_gateway_port_none_shows_not_configured(self):
+        """None gateway port should show 'not configured'."""
+        agent = AgentViewModel(**{**SAMPLE_AGENT, "gateway_port": None})
+        cards = DetailCards(agent=agent)
+        built = cards._build_cards(agent)
+        config_card = built[2]
+        gateway_port_row = [r for r in config_card._rows if r[0] == "gateway port"][0]
+        assert gateway_port_row[1] == "not configured"
+
+    def test_gateway_port_zero_displays_correctly(self):
+        """Port 0 should display as '0' (edge case for explicit is not None check)."""
+        agent = AgentViewModel(**{**SAMPLE_AGENT, "gateway_port": 0})
+        cards = DetailCards(agent=agent)
+        built = cards._build_cards(agent)
+        config_card = built[2]
+        gateway_port_row = [r for r in config_card._rows if r[0] == "gateway port"][0]
+        assert gateway_port_row[1] == "0"
 
 
 class TestConfirmModal:


### PR DESCRIPTION
## Summary
- Extract `gateway_port` from agent config (`config.gateway.port`) and display in TUI Configuration card
- Show actual port value when configured, or "not configured" when absent
- Add type validation with `isinstance(int)` guard to reject non-integer values

## Test plan
- [x] `make test` passes (1275 tests)
- [x] `make lint` passes
- [x] ATX review passes (4/5 rating)
- [x] Gateway port displays correctly when configured
- [x] "not configured" shows when port is missing
- [x] Edge cases: string port values ignored, empty gateway config handled, port=0 displays correctly

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $1.82 | Total Time: 97s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3/5 | B1, B2 (out-of-scope), W1, W2 | Fixed W1, W2 | $1.39 | 65s | leader, cli-ux-reviewer, test-coverage |
| 2 | 4/5 | None | Ready | $0.43 | 32s | leader, cli-ux-reviewer, test-coverage |

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `README.md`, `intro.md`, `quickstart.md` | Pre-existing doc drift - `clm ps` output format outdated | Out-of-scope - not part of this changeset |
| B2 | `quickstart.md` | Pre-existing reference to undocumented `clm agent status` | Out-of-scope - not part of this changeset |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `test_tui_data.py` | Missing edge case tests for invalid port types | Fixed - added tests for string port and empty gateway config |
| W2 | `data.py` | No type validation for gateway_port | Fixed - added `isinstance(port_val, int)` guard |

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**No blocking issues.** All previous warnings addressed.

**Suggestions (optional):**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Extract `_extract_gateway_port()` helper (DRY) | Deferred - minor, out of scope |
| S2 | Add `not isinstance(port_val, bool)` guard | Deferred - edge case unlikely from JSON config |

</details>

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>