### PR TITLE
fix(tui): preserve gateway scheme and consolidate chat event loop

### DIFF
--- a/src/clawrium/cli/tui/data.py
+++ b/src/clawrium/cli/tui/data.py
@@ -6,6 +6,7 @@ import logging
 import re
 from datetime import datetime, timezone
 from typing import TypedDict
+from urllib.parse import urlparse
 
 from clawrium.core.health import ClawStatus, HealthResult, check_claw_health
 from clawrium.core.hosts import HostsFileCorruptedError, load_hosts
@@ -74,6 +75,19 @@ def calculate_uptime(started_at: str | None) -> str:
         return "-"
 
 
+def _gateway_scheme(stored_url: object) -> str:
+    """Return the scheme from a stored gateway URL, defaulting to ws.
+
+    The gateway serves plain WebSocket; using wss by default would break
+    connections to gateways that aren't fronted by TLS.
+    """
+    if isinstance(stored_url, str) and stored_url:
+        parsed_scheme = urlparse(stored_url).scheme
+        if parsed_scheme in {"ws", "wss"}:
+            return parsed_scheme
+    return "ws"
+
+
 def get_fleet_data(
     host_filter: str | None = None,
 ) -> tuple[list[AgentViewModel], FleetSummary]:
@@ -130,10 +144,10 @@ def get_fleet_data(
                     auth_val = gateway_cfg.get("auth")
                     if isinstance(auth_val, str) and auth_val.strip():
                         gateway_auth = auth_val
-                    # Reconstruct gateway URL using host's current address and port
-                    # Use wss:// by default, ws:// only for localhost
+                    # Reconstruct gateway URL using host's current address and port,
+                    # preserving the scheme stored at install/configure time.
                     if gateway_port is not None:
-                        scheme = "ws" if hostname in ("localhost", "127.0.0.1") else "wss"
+                        scheme = _gateway_scheme(gateway_cfg.get("url"))
                         gateway_url = f"{scheme}://{hostname}:{gateway_port}"
                     # Extract device credentials for operator.write scope
                     device_cfg = gateway_cfg.get("device")
@@ -265,10 +279,10 @@ def get_agent_detail(agent_key: str, host_identifier: str) -> AgentViewModel | N
                 auth_val = gateway_cfg.get("auth")
                 if isinstance(auth_val, str) and auth_val.strip():
                     gateway_auth = auth_val
-                # Reconstruct gateway URL using host's current address and port
-                # Use wss:// by default, ws:// only for localhost
+                # Reconstruct gateway URL using host's current address and port,
+                # preserving the scheme stored at install/configure time.
                 if gateway_port is not None:
-                    scheme = "ws" if hostname in ("localhost", "127.0.0.1") else "wss"
+                    scheme = _gateway_scheme(gateway_cfg.get("url"))
                     gateway_url = f"{scheme}://{hostname}:{gateway_port}"
                 # Extract device credentials for operator.write scope
                 device_cfg = gateway_cfg.get("device")

--- a/src/clawrium/cli/tui/widgets/chat_panel.py
+++ b/src/clawrium/cli/tui/widgets/chat_panel.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from rich.markup import escape
@@ -13,7 +12,6 @@ from textual.containers import Vertical
 from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Input, RichLog
-from textual.worker import get_current_worker
 
 from clawrium.core.chat import (
     ChatAuthenticationError,
@@ -124,11 +122,9 @@ class ChatPanel(Widget):
         color = {"error": "red", "warning": "yellow", "info": "dim"}.get(severity, "dim")
         log.write(f"[{color}]{escape(message)}[/{color}]")
 
-    @work(thread=True)
-    def _connect_async(self) -> None:
-        worker = get_current_worker()
-
-        async def _connect() -> None:
+    @work(exclusive=True, group="chat-connect")
+    async def _connect_async(self) -> None:
+        try:
             self._client = OpenClawChatClient(
                 gateway_url=self._gateway_url,
                 auth_token=SecretStr(self._gateway_auth),
@@ -137,52 +133,24 @@ class ChatPanel(Widget):
                 timeout_seconds=30.0,
             )
             await self._client.connect()
-
-        try:
-            asyncio.run(_connect())
-            if worker.is_cancelled:
-                return
             self._connected = True
-            self.app.call_from_thread(
-                self._add_system_message, "Connected to agent", "info"
-            )
+            self._add_system_message("Connected to agent", "info")
         except ChatAuthenticationError:
-            if worker.is_cancelled:
-                return
-            self.app.call_from_thread(
-                self._add_system_message, "Authentication failed", "error"
-            )
-            self.app.call_from_thread(
-                self.post_message, self.ChatError("Authentication failed")
-            )
+            self._add_system_message("Authentication failed", "error")
+            self.post_message(self.ChatError("Authentication failed"))
         except ChatConnectionError:
-            if worker.is_cancelled:
-                return
-            self.app.call_from_thread(
-                self._add_system_message,
-                "Connection failed - check agent status",
-                "error",
+            self._add_system_message(
+                "Connection failed - check agent status", "error"
             )
-            self.app.call_from_thread(
-                self.post_message, self.ChatError("Connection failed")
-            )
+            self.post_message(self.ChatError("Connection failed"))
         except Exception:
-            if worker.is_cancelled:
-                return
-            self.app.call_from_thread(
-                self._add_system_message, "Connection error", "error"
-            )
-            self.app.call_from_thread(
-                self.post_message, self.ChatError("Connection error")
-            )
+            self._add_system_message("Connection error", "error")
+            self.post_message(self.ChatError("Connection error"))
 
-    @work(thread=True)
-    def _send_message_async(self, message: str) -> None:
-        worker = get_current_worker()
+    @work(group="chat-send")
+    async def _send_message_async(self, message: str) -> None:
         if not self._connected or self._client is None:
-            self.app.call_from_thread(
-                self._add_system_message, "Not connected to agent", "warning"
-            )
+            self._add_system_message("Not connected to agent", "warning")
             return
 
         response_chunks: list[str] = []
@@ -192,62 +160,39 @@ class ChatPanel(Widget):
             nonlocal first_chunk
             response_chunks.append(delta)
             if first_chunk:
-                self.app.call_from_thread(self._add_agent_delta, delta, True)
+                self._add_agent_delta(delta, True)
                 first_chunk = False
 
-        async def _send() -> str:
-            if self._client is None:
-                raise ChatConnectionError("Client not initialized")
-            return await self._client.send_message(
+        try:
+            final_response = await self._client.send_message(
                 message=message,
                 session_key=self._session_key,
                 on_delta=on_delta,
                 response_timeout_seconds=120.0,
             )
-
-        try:
-            final_response = asyncio.run(_send())
-            if worker.is_cancelled:
-                return
-            # If we didn't get any deltas, show the full response
             if not response_chunks:
-                self.app.call_from_thread(self._add_agent_message, final_response)
+                self._add_agent_message(final_response)
             else:
-                # Store the complete response
                 self._messages.append(("agent", final_response))
-        except ChatProtocolError:
-            if worker.is_cancelled:
-                return
-            self.app.call_from_thread(
-                self._add_system_message, "Message failed - protocol error", "error"
+        except ChatProtocolError as exc:
+            self._add_system_message(
+                f"Message failed - protocol error: {exc}", "error"
             )
-        except ChatConnectionError:
-            if worker.is_cancelled:
-                return
-            self.app.call_from_thread(
-                self._add_system_message, "Connection lost", "error"
-            )
+        except ChatConnectionError as exc:
+            self._add_system_message(f"Connection lost: {exc}", "error")
             self._connected = False
-        except Exception:
-            if worker.is_cancelled:
-                return
-            self.app.call_from_thread(
-                self._add_system_message, "Message failed", "error"
-            )
+        except Exception as exc:
+            self._add_system_message(f"Message failed: {exc}", "error")
 
     def on_unmount(self) -> None:
         if self._client is not None:
-            # Close the client connection in a background task
             self._close_client_async()
 
-    @work(thread=True)
-    def _close_client_async(self) -> None:
-        async def _close() -> None:
+    @work(group="chat-close")
+    async def _close_client_async(self) -> None:
+        try:
             if self._client is not None:
                 await self._client.close()
-
-        try:
-            asyncio.run(_close())
         except Exception:
             pass
         finally:

--- a/tests/test_tui/test_tui_data.py
+++ b/tests/test_tui/test_tui_data.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 
 from clawrium.cli.tui.data import (
+    _gateway_scheme,
     calculate_uptime,
     get_fleet_data,
     get_agent_detail,
@@ -49,6 +50,30 @@ class TestCalculateUptime:
         naive = now.replace(tzinfo=None)
         result = calculate_uptime(naive.isoformat())
         assert "1h" in result
+
+
+class TestGatewayScheme:
+    def test_stored_ws_returns_ws(self):
+        assert _gateway_scheme("ws://192.168.1.36:40198") == "ws"
+
+    def test_stored_wss_returns_wss(self):
+        assert _gateway_scheme("wss://gateway.example.com:443") == "wss"
+
+    def test_none_returns_default_ws(self):
+        assert _gateway_scheme(None) == "ws"
+
+    def test_empty_string_returns_default_ws(self):
+        assert _gateway_scheme("") == "ws"
+
+    def test_non_string_returns_default_ws(self):
+        assert _gateway_scheme(12345) == "ws"
+
+    def test_no_scheme_returns_default_ws(self):
+        assert _gateway_scheme("192.168.1.36:40198") == "ws"
+
+    def test_unsupported_scheme_returns_default_ws(self):
+        assert _gateway_scheme("http://192.168.1.36:40198") == "ws"
+        assert _gateway_scheme("https://gateway.example.com") == "ws"
 
 
 class TestLoadHostsSafe:
@@ -478,6 +503,132 @@ class TestGetFleetData:
 
         assert agents[0]["gateway_port"] is None
 
+    def test_gateway_url_preserves_stored_ws_scheme(self, isolated_config):
+        """Gateway URL should preserve ws:// from stored config (matches CLI)."""
+        import json
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts = [
+            {
+                "hostname": "192.168.1.100",
+                "agents": {
+                    "openclaw": {
+                        "type": "openclaw",
+                        "agent_name": "opc-test",
+                        "config": {
+                            "gateway": {
+                                "port": 40123,
+                                "url": "ws://192.168.1.100:40123",
+                            },
+                        },
+                    }
+                },
+            }
+        ]
+        (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+
+        mock_result = {
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.RUNNING,
+            "user": None,
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+            "cpu_count": 4,
+            "memory_total_mb": 8192,
+        }
+
+        with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
+            agents, _ = get_fleet_data()
+
+        assert agents[0]["gateway_url"] == "ws://192.168.1.100:40123"
+
+    def test_gateway_url_preserves_stored_wss_scheme(self, isolated_config):
+        """Gateway URL should preserve wss:// from stored config."""
+        import json
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts = [
+            {
+                "hostname": "gateway.example.com",
+                "agents": {
+                    "openclaw": {
+                        "type": "openclaw",
+                        "agent_name": "opc-test",
+                        "config": {
+                            "gateway": {
+                                "port": 443,
+                                "url": "wss://gateway.example.com:443",
+                            },
+                        },
+                    }
+                },
+            }
+        ]
+        (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+
+        mock_result = {
+            "agent": "openclaw",
+            "host": "gateway.example.com",
+            "status": ClawStatus.RUNNING,
+            "user": None,
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+            "cpu_count": 4,
+            "memory_total_mb": 8192,
+        }
+
+        with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
+            agents, _ = get_fleet_data()
+
+        assert agents[0]["gateway_url"] == "wss://gateway.example.com:443"
+
+    def test_gateway_url_defaults_to_ws_when_no_stored_url(self, isolated_config):
+        """Gateway URL falls back to ws:// when stored URL is missing."""
+        import json
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts = [
+            {
+                "hostname": "192.168.1.100",
+                "agents": {
+                    "openclaw": {
+                        "type": "openclaw",
+                        "agent_name": "opc-test",
+                        "config": {
+                            "gateway": {"port": 40123},
+                        },
+                    }
+                },
+            }
+        ]
+        (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+
+        mock_result = {
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.RUNNING,
+            "user": None,
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+            "cpu_count": 4,
+            "memory_total_mb": 8192,
+        }
+
+        with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
+            agents, _ = get_fleet_data()
+
+        assert agents[0]["gateway_url"] == "ws://192.168.1.100:40123"
+
 
 class TestGetAgentDetail:
     def test_found(self, isolated_config):
@@ -574,3 +725,95 @@ class TestGetAgentDetail:
 
         assert detail is not None
         assert detail["gateway_port"] == 40456
+
+    def test_gateway_url_preserves_stored_ws_scheme(self, isolated_config):
+        """get_agent_detail should preserve ws:// from stored config."""
+        import json
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts = [
+            {
+                "hostname": "192.168.1.100",
+                "alias": "myhost",
+                "agents": {
+                    "openclaw": {
+                        "type": "openclaw",
+                        "agent_name": "opc-test",
+                        "version": "1.0.0",
+                        "config": {
+                            "gateway": {
+                                "port": 40456,
+                                "url": "ws://192.168.1.100:40456",
+                            },
+                        },
+                    }
+                },
+            }
+        ]
+        (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+
+        mock_result = {
+            "agent": "openclaw",
+            "host": "192.168.1.100",
+            "status": ClawStatus.RUNNING,
+            "user": None,
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+            "cpu_count": 4,
+            "memory_total_mb": 8192,
+        }
+
+        with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
+            detail = get_agent_detail("openclaw", "192.168.1.100")
+
+        assert detail is not None
+        assert detail["gateway_url"] == "ws://192.168.1.100:40456"
+
+    def test_gateway_url_preserves_stored_wss_scheme(self, isolated_config):
+        """get_agent_detail should preserve wss:// from stored config."""
+        import json
+
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts = [
+            {
+                "hostname": "gateway.example.com",
+                "alias": "remote",
+                "agents": {
+                    "openclaw": {
+                        "type": "openclaw",
+                        "agent_name": "opc-test",
+                        "version": "1.0.0",
+                        "config": {
+                            "gateway": {
+                                "port": 443,
+                                "url": "wss://gateway.example.com:443",
+                            },
+                        },
+                    }
+                },
+            }
+        ]
+        (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+
+        mock_result = {
+            "agent": "openclaw",
+            "host": "gateway.example.com",
+            "status": ClawStatus.RUNNING,
+            "user": None,
+            "error": None,
+            "missing_secrets": None,
+            "onboarding_step": None,
+            "process_running": True,
+            "onboarding_stages": None,
+            "cpu_count": 4,
+            "memory_total_mb": 8192,
+        }
+
+        with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
+            detail = get_agent_detail("openclaw", "gateway.example.com")
+
+        assert detail is not None
+        assert detail["gateway_url"] == "wss://gateway.example.com:443"


### PR DESCRIPTION
## Summary

- Stop hardcoding `wss://` for non-localhost hosts in the TUI; preserve the scheme stored at install/configure time, matching what `clm agent chat` already does. Without this, the TUI fails to connect to any gateway that serves plain WebSocket.
- Convert `ChatPanel` workers from `@work(thread=True)` + `asyncio.run()` to native async Textual workers so connect/send/close share one event loop. The previous design created a fresh loop per worker call, leaving the websocket bound to a dead loop and surfacing every send as a generic "Message failed".
- Surface the underlying exception text in chat error messages instead of swallowing it.

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — 1297 passed (was 1285)
- [x] Linter passes (`make lint`)
- [x] New tests added for `_gateway_scheme()` and end-to-end scheme preservation

### Test Coverage
- Files changed: `src/clawrium/cli/tui/data.py`, `src/clawrium/cli/tui/widgets/chat_panel.py`, `tests/test_tui/test_tui_data.py`
- New tests: `TestGatewayScheme` (7 cases) + 5 end-to-end scheme assertions on `get_fleet_data` / `get_agent_detail`
- Coverage impact: increased

### Manual Testing
- Reproduced original failure: TUI chat showed "Connection failed - check agent status" against `ws://192.168.1.36:40198`.
- After fix 1: TUI connects to gateway successfully.
- Reproduced original failure: typing "hello" produced "Message failed".
- After fix 2: messages send through the gateway. The next error surfaced from upstream (`Message failed - protocol error: The security token included in the request is invalid`) is an AWS Bedrock credential issue on the agent host, not a TUI issue — confirming end-to-end delivery.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation: `_gateway_scheme()` rejects non-ws/wss schemes; `core/chat.py:148` already validates the URL before connecting
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources

## ATX Review Summary

**Review 1: Rating 2/5** (test-coverage reviewer)
**Cost / time / agents**: not reported in --format text output

| Review | Rating | Blocking Issues | Status | Notes |
|--------|--------|-----------------|--------|-------|
| 1 | 2/5 | B1, B2, B3, B4, B5, B6 | B4 fixed; B1/B2/B3 out-of-scope; B5/B6 deferred | See details |

<details>
<summary>Review 1 Details</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `data.py` | Stored `ws://` silently used for remote hosts; auth token transmitted in cleartext | Out-of-scope — the openclaw gateway only serves plain WebSocket today. The previous `wss://` enforcement was non-functional and *caused* this bug. Whether clawrium should require TLS is a separate architecture decision; this PR aligns the TUI with the CLI's existing behavior. |
| B2 | `validation.py:757` | Fallback URL defaults to `ws://` for all hosts | Out-of-scope — pre-existing code path, untouched by this PR. Ties to the same B1 architecture question. |
| B3 | `data.py` | Localhost check misses `127.0.0.1`, `::1` | Not applicable — this PR *removed* the localhost check entirely. Comment reflects a stale reading. |
| B4 | `test_tui_data.py` | `_gateway_scheme()` had zero tests | Fixed — added `TestGatewayScheme` (7 cases) + 5 end-to-end assertions verifying scheme preservation through `get_fleet_data` / `get_agent_detail`. |
| B5 | `test_tui_chat.py` | Worker lifecycle (connect/send/close) has zero tests | Deferred — testing native Textual async workers requires `app.run_test()` pilot harness not yet established in this codebase; would expand scope significantly. Verified manually end-to-end against a live agent. |
| B6 | `test_tui_chat.py` | Event-loop consolidation unverified | Deferred — verified manually by sending messages successfully. Were the loops still split, send would raise; we now see legitimate upstream errors instead. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `install.py` | `hosts.json` URL not integrity-protected | Acknowledged — ties to B1 architecture question |
| W2 | `data.py` | No early scheme validation before WebSocket use | Acknowledged — `core/chat.py:148` already validates ws/wss before connecting |
| W3 | `chat_panel.py` | Error message content not tested | Acknowledged — deferred with B5 |
| W4 | `test_tui_chat.py` | No Textual worker test pattern established | Acknowledged — deferred with B5 |

</details>

## Reviewer Notes

The B1/B2 architectural question (should clawrium enforce WSS for remote gateways?) is worth addressing in a follow-up issue, but solving it requires either:
- Making the openclaw gateway terminate TLS (server-side change), or
- Adding an explicit `--allow-insecure-gateway` opt-in (CLI/TUI change).

Either path is larger than this bugfix and out of scope here.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>