### PR TITLE
feat(memory): openclaw memory core module + ansible playbooks (Phase 1 of #210)

### DIFF
--- a/.itx/210/00_PLAN.md
+++ b/.itx/210/00_PLAN.md
@@ -1,0 +1,73 @@
+# Issue #210 — Implementation Plan
+
+User can configure basic memory for openclaw agents.
+
+Source of truth: GitHub issue #210, including the implementation plan and
+plan-reconciliation comments.
+
+## Phasing strategy
+
+The five phases below ship as **independent PRs** to keep reviews small.
+Each PR closes only the phase milestone; the issue stays open until Phase 5.
+
+| Phase | Branch | PR closes |
+|-------|--------|-----------|
+| 1 | `issue-210-phase-1-memory-core` | core memory module + ansible playbooks + tests |
+| 2 | `issue-210-phase-2-cli` | `clm agent <name> memory show\|delete` |
+| 3 | `issue-210-phase-3-tui-display` | TUI MEMORY card with size and paths |
+| 4 | `issue-210-phase-4-tui-edit` | TUI edit → sync → restart flow |
+| 5 | `issue-210-phase-5-docs` | docs + README updates |
+
+Compaction/truncation (acceptance criteria items 6 and 7) is explicitly
+deferred to a follow-up issue per the plan-reconciliation comment.
+
+## Workspace layout assumed by all phases
+
+`/home/<agent_name>/.openclaw/workspace/` contains:
+
+- `SOUL.md` — agent personality
+- `IDENTITY.md` — agent identity
+- `USER.md` — user context
+- `TOOLS.md` — available tools
+- `memory/` — daily files (`YYYY-MM-DD.md`)
+
+## Phase 1 scope (this PR)
+
+**New files**
+
+- `src/clawrium/platform/registry/openclaw/playbooks/memory_info.yaml`
+- `src/clawrium/platform/registry/openclaw/playbooks/memory_read.yaml`
+- `src/clawrium/platform/registry/openclaw/playbooks/memory_write.yaml`
+- `src/clawrium/platform/registry/openclaw/playbooks/memory_delete.yaml`
+- `src/clawrium/core/memory.py`
+- `tests/test_core_memory.py`
+
+**Modified**
+
+- `tests/conftest.py` — mock workspace fixture (Gap #5)
+
+**Public API**
+
+```python
+def get_memory_info(hostname: str, agent_name: str) -> MemoryStats | None
+def read_memory_file(hostname: str, agent_name: str, filename: str) -> str | None
+def write_memory_file(hostname: str, agent_name: str, filename: str, content: str) -> tuple[bool, str | None]
+def delete_memory_files(hostname: str, agent_name: str, files: list[str]) -> tuple[bool, str | None]
+```
+
+**Gaps addressed in Phase 1**
+
+- Gap #1 (offline graceful failure): functions catch ansible-runner failures
+  and return `None` / `(False, error)` rather than raising.
+- Gap #2 (file ownership on writes): `memory_write` and `memory_delete`
+  playbooks set `owner`/`group` to `{{ agent_name }}` and run with `become`.
+- Gap #5 (mock workspace fixture): added to `tests/conftest.py`.
+
+Gaps #3, #4, #6 are surfaced in later phases (TUI / CLI safety prompts).
+
+## Acceptance for this PR
+
+- [ ] `make test` green
+- [ ] `make lint` green
+- [ ] ATX review > 3/5 with no blocking issues
+- [ ] PR opened against `main`

--- a/src/clawrium/core/memory.py
+++ b/src/clawrium/core/memory.py
@@ -121,22 +121,22 @@ def _validate_memory_filename(filename: str) -> None:
 
 def _resolve_openclaw_agent(
     hostname: str, agent_name: str
-) -> tuple[dict, str] | None:
+) -> tuple[dict, str] | tuple[None, str]:
     """Resolve agent identifier to (host_record, unix_agent_name).
 
-    Looks up the host, then finds an installed openclaw agent matching
-    ``agent_name`` against either the dict key, the inner ``agent_name``
-    field, or the ``name`` field. Returns ``None`` on any miss so callers
-    can present a degraded "unavailable" state instead of raising.
+    On miss, returns ``(None, reason)`` so callers can distinguish
+    "not found" from "not ready" and emit accurate messages — a user
+    debugging a visible agent that's still installing should not see
+    "agent not found".
     """
     host = get_host(hostname)
     if not host:
         logger.warning("Memory op: host '%s' not found", hostname)
-        return None
+        return None, f"host '{hostname}' not found"
 
     agents = host.get("agents", {})
     if not isinstance(agents, dict):
-        return None
+        return None, f"host '{hostname}' has no agents registry"
 
     matches: list[str] = []
     direct = agents.get(agent_name)
@@ -157,7 +157,7 @@ def _resolve_openclaw_agent(
         logger.warning(
             "Memory op: openclaw agent '%s' not found on '%s'", agent_name, hostname
         )
-        return None
+        return None, f"openclaw agent '{agent_name}' not found on '{hostname}'"
     if len(matches) > 1:
         logger.warning(
             "Memory op: multiple openclaw agents match '%s' on '%s': %s",
@@ -165,22 +165,30 @@ def _resolve_openclaw_agent(
             hostname,
             matches,
         )
-        return None
+        return None, (
+            f"multiple openclaw agents match '{agent_name}' on '{hostname}': "
+            f"{', '.join(matches)}"
+        )
 
     record = agents[matches[0]]
-    # Reject explicitly non-installed records ("installing" / "failed").
-    # Records without a status field are treated as legacy/installed because
-    # older host entries predate the status convention. install.py sets
-    # "installed" once provisioning succeeds.
+    # Allowlist: only records with status='installed' or no status field run
+    # memory ops. install.py writes status='installing' before Ansible runs and
+    # 'installed' on success — None means a pre-convention legacy record, not
+    # a partial new install. Treating None as installed keeps backward compat
+    # while a future status (e.g. 'removing') is rejected by default rather
+    # than silently passing through a blocklist gap.
     status = record.get("status")
-    if status in {"installing", "failed"}:
+    if status is not None and status != "installed":
         logger.warning(
             "Memory op: agent '%s' on '%s' has status '%s' (must be 'installed')",
             agent_name,
             hostname,
             status,
         )
-        return None
+        return None, (
+            f"agent '{agent_name}' on '{hostname}' is not ready "
+            f"(status='{status}', expected 'installed')"
+        )
 
     unix_name = record.get("agent_name") or matches[0]
     return host, unix_name
@@ -322,10 +330,9 @@ def _parse_memory_info_stdout(stdout: str) -> dict:
 
 def get_memory_info(hostname: str, agent_name: str) -> MemoryStats | None:
     """Return memory stats for the openclaw agent or None if unavailable."""
-    resolved = _resolve_openclaw_agent(hostname, agent_name)
-    if not resolved:
+    host, unix_name = _resolve_openclaw_agent(hostname, agent_name)
+    if host is None:
         return None
-    host, unix_name = resolved
 
     try:
         _validate_agent_name(unix_name)
@@ -416,10 +423,9 @@ def read_memory_file(
         logger.warning("Memory read: %s", e)
         return None
 
-    resolved = _resolve_openclaw_agent(hostname, agent_name)
-    if not resolved:
+    host, unix_name = _resolve_openclaw_agent(hostname, agent_name)
+    if host is None:
         return None
-    host, unix_name = resolved
 
     try:
         _validate_agent_name(unix_name)
@@ -479,10 +485,9 @@ def write_memory_file(
             f"({encoded_size} > {MAX_MEMORY_CONTENT_BYTES} bytes)"
         )
 
-    resolved = _resolve_openclaw_agent(hostname, agent_name)
-    if not resolved:
-        return False, f"openclaw agent '{agent_name}' not found on '{hostname}'"
-    host, unix_name = resolved
+    host, unix_name = _resolve_openclaw_agent(hostname, agent_name)
+    if host is None:
+        return False, unix_name
 
     try:
         _validate_agent_name(unix_name)
@@ -529,10 +534,9 @@ def delete_memory_files(
         except MemoryOpError as e:
             return False, str(e)
 
-    resolved = _resolve_openclaw_agent(hostname, agent_name)
-    if not resolved:
-        return False, f"openclaw agent '{agent_name}' not found on '{hostname}'"
-    host, unix_name = resolved
+    host, unix_name = _resolve_openclaw_agent(hostname, agent_name)
+    if host is None:
+        return False, unix_name
 
     try:
         _validate_agent_name(unix_name)

--- a/src/clawrium/core/memory.py
+++ b/src/clawrium/core/memory.py
@@ -1,0 +1,559 @@
+"""Agent memory inspection and management for openclaw agents.
+
+Operations target the openclaw workspace at
+``/home/<agent_name>/.openclaw/workspace/`` and run via ansible-runner.
+
+Public functions:
+    - get_memory_info(hostname, agent_name) -> MemoryStats | None
+    - read_memory_file(hostname, agent_name, filename) -> str | None
+    - write_memory_file(hostname, agent_name, filename, content) -> tuple[bool, str | None]
+    - delete_memory_files(hostname, agent_name, files) -> tuple[bool, str | None]
+
+All operations degrade gracefully on transport errors: read/info return
+``None`` and write/delete return ``(False, error_message)`` so callers can
+present an "unavailable" state instead of raising.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import re
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import TypedDict
+
+import ansible_runner
+
+from clawrium.core import keys as core_keys
+from clawrium.core.config import get_config_dir
+from clawrium.core.hosts import get_host
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "MAX_MEMORY_CONTENT_BYTES",
+    "MEMORY_TOP_LEVEL_FILES",
+    "MemoryFileInfo",
+    "MemoryStats",
+    "MemoryOpError",
+    "get_memory_info",
+    "read_memory_file",
+    "write_memory_file",
+    "delete_memory_files",
+]
+
+# Maximum bytes accepted by write_memory_file. Memory files are intended for
+# short-form context (soul, identity, daily notes), and Ansible extravars are
+# loaded entirely into memory on both ends — bound the input to prevent a
+# bogus megabytes-of-content write from exhausting the runner.
+MAX_MEMORY_CONTENT_BYTES = 5 * 1024 * 1024  # 5 MiB
+
+# Top-level workspace files surfaced to the user.
+# Daily files under ``memory/`` are discovered dynamically by get_memory_info.
+MEMORY_TOP_LEVEL_FILES: tuple[str, ...] = (
+    "SOUL.md",
+    "IDENTITY.md",
+    "USER.md",
+    "TOOLS.md",
+)
+
+# Workspace-relative path validation: filename or memory/<filename>.
+# Mirrors the pattern enforced in the playbooks.
+_MEMORY_FILENAME_PATTERN = re.compile(r"^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)?$")
+
+# Agent-name validation matches the rule used elsewhere in lifecycle.py.
+_AGENT_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
+
+_PLAYBOOK_DIR = (
+    Path(__file__).parent.parent
+    / "platform"
+    / "registry"
+    / "openclaw"
+    / "playbooks"
+)
+
+
+class MemoryFileInfo(TypedDict):
+    name: str
+    exists: bool
+    size_bytes: int
+    relative_path: str  # workspace-relative, e.g. "SOUL.md" or "memory/2026-05-09.md"
+
+
+class MemoryStats(TypedDict):
+    workspace_path: str
+    total_bytes: int
+    files: list[MemoryFileInfo]
+
+
+class MemoryOpError(Exception):
+    """Raised when memory operation arguments are invalid."""
+
+
+def _validate_agent_name(agent_name: str) -> None:
+    if not _AGENT_NAME_PATTERN.match(agent_name):
+        raise MemoryOpError(
+            f"Invalid agent_name format: '{agent_name}'. Must start with "
+            "lowercase letter and contain only lowercase letters, digits, "
+            "hyphens, underscores (max 32 chars)."
+        )
+
+
+def _validate_memory_filename(filename: str) -> None:
+    safe_repr = repr(filename)[:64]
+    if not _MEMORY_FILENAME_PATTERN.match(filename):
+        raise MemoryOpError(
+            f"Invalid memory filename: {safe_repr}. Allowed: <name> or "
+            "memory/<name> with [A-Za-z0-9._-] components."
+        )
+    # The pattern alone allows '..' (any sequence of dot/dash/underscore/
+    # alphanumeric). Reject path-traversal components explicitly.
+    for component in filename.split("/"):
+        if component in {"", ".", ".."}:
+            raise MemoryOpError(
+                f"Invalid memory filename: {safe_repr}. Path traversal "
+                "components ('.', '..') are not allowed."
+            )
+
+
+def _resolve_openclaw_agent(
+    hostname: str, agent_name: str
+) -> tuple[dict, str] | None:
+    """Resolve agent identifier to (host_record, unix_agent_name).
+
+    Looks up the host, then finds an installed openclaw agent matching
+    ``agent_name`` against either the dict key, the inner ``agent_name``
+    field, or the ``name`` field. Returns ``None`` on any miss so callers
+    can present a degraded "unavailable" state instead of raising.
+    """
+    host = get_host(hostname)
+    if not host:
+        logger.warning("Memory op: host '%s' not found", hostname)
+        return None
+
+    agents = host.get("agents", {})
+    if not isinstance(agents, dict):
+        return None
+
+    matches: list[str] = []
+    direct = agents.get(agent_name)
+    if isinstance(direct, dict) and direct.get("type") == "openclaw":
+        matches.append(agent_name)
+    else:
+        for key, record in agents.items():
+            if not isinstance(record, dict) or record.get("type") != "openclaw":
+                continue
+            if (
+                key == agent_name
+                or record.get("agent_name") == agent_name
+                or record.get("name") == agent_name
+            ):
+                matches.append(key)
+
+    if not matches:
+        logger.warning(
+            "Memory op: openclaw agent '%s' not found on '%s'", agent_name, hostname
+        )
+        return None
+    if len(matches) > 1:
+        logger.warning(
+            "Memory op: multiple openclaw agents match '%s' on '%s': %s",
+            agent_name,
+            hostname,
+            matches,
+        )
+        return None
+
+    record = agents[matches[0]]
+    # Reject explicitly non-installed records ("installing" / "failed").
+    # Records without a status field are treated as legacy/installed because
+    # older host entries predate the status convention. install.py sets
+    # "installed" once provisioning succeeds.
+    status = record.get("status")
+    if status in {"installing", "failed"}:
+        logger.warning(
+            "Memory op: agent '%s' on '%s' has status '%s' (must be 'installed')",
+            agent_name,
+            hostname,
+            status,
+        )
+        return None
+
+    unix_name = record.get("agent_name") or matches[0]
+    return host, unix_name
+
+
+def _get_logs_dir() -> Path:
+    logs_dir = get_config_dir() / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    return logs_dir
+
+
+def _cleanup_artifacts(operation_log_dir: Path) -> None:
+    """Remove ansible-runner artifacts that may contain inventory secrets.
+
+    Mirrors the cleanup used in lifecycle._cleanup_ansible_artifacts so memory
+    operations do not leak SSH key paths or inventory contents on disk.
+    """
+    for sub in ("artifacts", "env"):
+        target = operation_log_dir / sub
+        if target.exists():
+            try:
+                shutil.rmtree(target)
+            except OSError as e:
+                logger.warning("Failed to clean up %s: %s", target, e)
+
+
+def _build_inventory(
+    host: dict, ssh_key: Path, extra_vars: dict
+) -> dict:
+    return {
+        "all": {
+            "hosts": {
+                host["hostname"]: {
+                    "ansible_user": host.get("user", "xclm"),
+                    "ansible_port": host.get("port", 22),
+                    "ansible_ssh_private_key_file": str(ssh_key),
+                }
+            },
+            "vars": extra_vars,
+        }
+    }
+
+
+def _run_memory_playbook(
+    host: dict,
+    operation: str,
+    extra_vars: dict,
+    timeout: int = 30,
+):
+    """Run a memory-* playbook and return the ansible-runner result.
+
+    Returns ``(result, log_dir, error)``. On any setup failure the result
+    is ``None`` and ``error`` is populated. Callers own artifact cleanup
+    via their ``finally`` block — this function never calls
+    ``_cleanup_artifacts`` to avoid double-fire on exception paths.
+    """
+    playbook_path = _PLAYBOOK_DIR / f"{operation}.yaml"
+    if not playbook_path.exists():
+        return None, None, f"Playbook not found: {playbook_path}"
+
+    key_id = host.get("key_id") or host["hostname"]
+    ssh_key = core_keys.get_host_private_key(key_id)
+    if not ssh_key:
+        return None, None, (
+            f"SSH key for host '{key_id}' not found. "
+            f"Run 'clm host init {host['hostname']}' to provision it."
+        )
+
+    # Pre-flight setup must also degrade gracefully: a malformed XDG_CONFIG_HOME
+    # or read-only logs/ dir would otherwise raise OSError out of the public
+    # function, breaking the offline-tolerant contract.
+    try:
+        inventory = _build_inventory(host, ssh_key, extra_vars)
+        logs_dir = _get_logs_dir()
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        host_display = host.get("alias") or host.get("key_id") or host["hostname"]
+        log_dir = logs_dir / f"{operation}-openclaw-{host_display}-{timestamp}"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        os.chmod(log_dir, 0o700)
+    except OSError as e:
+        return None, None, f"Failed to set up runner workdir: {e}"
+
+    try:
+        result = ansible_runner.run(
+            private_data_dir=str(log_dir),
+            inventory=inventory,
+            playbook=str(playbook_path),
+            quiet=True,
+            timeout=timeout,
+        )
+        return result, log_dir, None
+    except Exception as e:
+        # Do NOT cleanup here — caller's finally block owns cleanup. We
+        # still surface the log_dir so the caller can clean it up exactly
+        # once.
+        return None, log_dir, str(e)
+
+
+def _extract_failure_message(result, default: str) -> str:
+    for event in result.events:
+        if event.get("event") == "runner_on_failed":
+            res = event.get("event_data", {}).get("res", {})
+            if "msg" in res:
+                return res["msg"]
+            if "stderr" in res:
+                return res["stderr"]
+    return default
+
+
+def _parse_memory_info_stdout(stdout: str) -> dict:
+    """Parse the WORKSPACE_PATH / TOP / DAILY lines from memory_info playbook."""
+    workspace_path = ""
+    top: list[tuple[str, int]] = []
+    daily: list[tuple[str, int]] = []
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("WORKSPACE_PATH="):
+            workspace_path = line.split("=", 1)[1]
+        elif line.startswith("TOP "):
+            parts = line.split(None, 2)
+            if len(parts) == 3:
+                _, name, size_str = parts
+                try:
+                    top.append((name, int(size_str)))
+                except ValueError:
+                    continue
+        elif line.startswith("DAILY "):
+            parts = line.split(None, 2)
+            if len(parts) == 3:
+                _, name, size_str = parts
+                try:
+                    daily.append((name, int(size_str)))
+                except ValueError:
+                    continue
+    return {"workspace_path": workspace_path, "top": top, "daily": daily}
+
+
+def get_memory_info(hostname: str, agent_name: str) -> MemoryStats | None:
+    """Return memory stats for the openclaw agent or None if unavailable."""
+    resolved = _resolve_openclaw_agent(hostname, agent_name)
+    if not resolved:
+        return None
+    host, unix_name = resolved
+
+    try:
+        _validate_agent_name(unix_name)
+    except MemoryOpError as e:
+        logger.warning("Memory info: %s", e)
+        return None
+
+    extra_vars = {"agent_name": unix_name}
+    result, log_dir, setup_error = _run_memory_playbook(
+        host, "memory_info", extra_vars, timeout=30
+    )
+    if log_dir is None and setup_error:
+        logger.warning("Memory info setup error: %s", setup_error)
+        return None
+
+    try:
+        if setup_error:
+            return None
+        if result.status == "timeout":
+            logger.warning("Memory info timed out for %s", unix_name)
+            return None
+        if result.status != "successful":
+            logger.warning(
+                "Memory info playbook failed: %s",
+                _extract_failure_message(result, result.status),
+            )
+            return None
+
+        # The memory_info playbook emits structured lines via the debug
+        # module (one msg per runner_on_ok event). Concatenate every msg
+        # value and parse the combined buffer.
+        lines: list[str] = []
+        for event in result.events:
+            if event.get("event") != "runner_on_ok":
+                continue
+            res = event.get("event_data", {}).get("res", {})
+            msg = res.get("msg")
+            if isinstance(msg, str):
+                lines.append(msg)
+            elif isinstance(msg, list):
+                for item in msg:
+                    if isinstance(item, str):
+                        lines.append(item)
+
+        parsed = _parse_memory_info_stdout("\n".join(lines))
+
+        files: list[MemoryFileInfo] = []
+        total = 0
+        for name, size in parsed["top"]:
+            exists = size >= 0
+            entry: MemoryFileInfo = {
+                "name": name,
+                "exists": exists,
+                "size_bytes": size if exists else 0,
+                "relative_path": name,
+            }
+            files.append(entry)
+            if exists:
+                total += size
+        for name, size in parsed["daily"]:
+            entry = {
+                "name": name,
+                "exists": True,
+                "size_bytes": size,
+                "relative_path": f"memory/{name}",
+            }
+            files.append(entry)
+            total += size
+
+        return {
+            "workspace_path": parsed["workspace_path"]
+            or f"/home/{unix_name}/.openclaw/workspace",
+            "total_bytes": total,
+            "files": files,
+        }
+    finally:
+        if log_dir is not None:
+            _cleanup_artifacts(log_dir)
+
+
+def read_memory_file(
+    hostname: str, agent_name: str, filename: str
+) -> str | None:
+    """Read content of a single memory file. Returns None if unavailable."""
+    try:
+        _validate_memory_filename(filename)
+    except MemoryOpError as e:
+        logger.warning("Memory read: %s", e)
+        return None
+
+    resolved = _resolve_openclaw_agent(hostname, agent_name)
+    if not resolved:
+        return None
+    host, unix_name = resolved
+
+    try:
+        _validate_agent_name(unix_name)
+    except MemoryOpError:
+        return None
+
+    extra_vars = {"agent_name": unix_name, "memory_filename": filename}
+    result, log_dir, setup_error = _run_memory_playbook(
+        host, "memory_read", extra_vars, timeout=30
+    )
+    if log_dir is None and setup_error:
+        logger.warning("Memory read setup error: %s", setup_error)
+        return None
+
+    try:
+        if setup_error:
+            return None
+        if result.status == "timeout":
+            logger.warning("Memory read timed out for %s", filename)
+            return None
+        if result.status != "successful":
+            logger.warning(
+                "Memory read playbook failed: %s",
+                _extract_failure_message(result, result.status),
+            )
+            return None
+
+        for event in result.events:
+            if event.get("event") == "runner_on_ok":
+                res = event.get("event_data", {}).get("res", {})
+                content_b64 = res.get("content")
+                if content_b64:
+                    try:
+                        return base64.b64decode(content_b64).decode("utf-8")
+                    except (ValueError, UnicodeDecodeError) as e:
+                        logger.warning("Failed to decode memory content: %s", e)
+                        return None
+        return None
+    finally:
+        if log_dir is not None:
+            _cleanup_artifacts(log_dir)
+
+
+def write_memory_file(
+    hostname: str, agent_name: str, filename: str, content: str
+) -> tuple[bool, str | None]:
+    """Write content to a memory file. Returns (success, error)."""
+    try:
+        _validate_memory_filename(filename)
+    except MemoryOpError as e:
+        return False, str(e)
+
+    encoded_size = len(content.encode("utf-8"))
+    if encoded_size > MAX_MEMORY_CONTENT_BYTES:
+        return False, (
+            f"Memory content exceeds maximum size "
+            f"({encoded_size} > {MAX_MEMORY_CONTENT_BYTES} bytes)"
+        )
+
+    resolved = _resolve_openclaw_agent(hostname, agent_name)
+    if not resolved:
+        return False, f"openclaw agent '{agent_name}' not found on '{hostname}'"
+    host, unix_name = resolved
+
+    try:
+        _validate_agent_name(unix_name)
+    except MemoryOpError as e:
+        return False, str(e)
+
+    extra_vars = {
+        "agent_name": unix_name,
+        "memory_filename": filename,
+        "memory_content": content,
+    }
+    result, log_dir, setup_error = _run_memory_playbook(
+        host, "memory_write", extra_vars, timeout=60
+    )
+    if log_dir is None and setup_error:
+        return False, setup_error
+
+    try:
+        if setup_error:
+            return False, setup_error
+        if result.status == "timeout":
+            return False, "Memory write timed out"
+        if result.status != "successful":
+            return False, _extract_failure_message(result, result.status)
+        return True, None
+    finally:
+        if log_dir is not None:
+            _cleanup_artifacts(log_dir)
+
+
+def delete_memory_files(
+    hostname: str, agent_name: str, files: list[str]
+) -> tuple[bool, str | None]:
+    """Delete a list of memory files. Returns (success, error).
+
+    Each file is workspace-relative (e.g. "SOUL.md" or "memory/2026-05-09.md").
+    """
+    if not files:
+        return True, None
+
+    for f in files:
+        try:
+            _validate_memory_filename(f)
+        except MemoryOpError as e:
+            return False, str(e)
+
+    resolved = _resolve_openclaw_agent(hostname, agent_name)
+    if not resolved:
+        return False, f"openclaw agent '{agent_name}' not found on '{hostname}'"
+    host, unix_name = resolved
+
+    try:
+        _validate_agent_name(unix_name)
+    except MemoryOpError as e:
+        return False, str(e)
+
+    extra_vars = {"agent_name": unix_name, "memory_files": list(files)}
+    result, log_dir, setup_error = _run_memory_playbook(
+        host, "memory_delete", extra_vars, timeout=30
+    )
+    if log_dir is None and setup_error:
+        return False, setup_error
+
+    try:
+        if setup_error:
+            return False, setup_error
+        if result.status == "timeout":
+            return False, "Memory delete timed out"
+        if result.status != "successful":
+            return False, _extract_failure_message(result, result.status)
+        return True, None
+    finally:
+        if log_dir is not None:
+            _cleanup_artifacts(log_dir)

--- a/src/clawrium/platform/registry/openclaw/playbooks/memory_delete.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/memory_delete.yaml
@@ -1,0 +1,24 @@
+---
+- hosts: all
+  become: yes
+  gather_facts: false
+  tasks:
+    - name: Validate memory filenames pattern
+      ansible.builtin.fail:
+        msg: "Invalid memory filename"
+      loop: "{{ memory_files }}"
+      when:
+        - item is not match('^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)?$')
+
+    - name: Reject path-traversal components in filenames
+      ansible.builtin.fail:
+        msg: "Invalid memory filename: traversal components not allowed"
+      loop: "{{ memory_files }}"
+      when:
+        - item.split('/') | intersect(['', '.', '..']) | length > 0
+
+    - name: Delete memory files
+      ansible.builtin.file:
+        path: "/home/{{ agent_name }}/.openclaw/workspace/{{ item }}"
+        state: absent
+      loop: "{{ memory_files }}"

--- a/src/clawrium/platform/registry/openclaw/playbooks/memory_info.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/memory_info.yaml
@@ -1,0 +1,48 @@
+---
+- hosts: all
+  become: yes
+  gather_facts: false
+  vars:
+    memory_top_level_files:
+      - SOUL.md
+      - IDENTITY.md
+      - USER.md
+      - TOOLS.md
+  tasks:
+    - name: Set workspace path
+      ansible.builtin.set_fact:
+        memory_workspace_path: "/home/{{ agent_name }}/.openclaw/workspace"
+
+    - name: Stat top-level workspace files
+      ansible.builtin.stat:
+        path: "{{ memory_workspace_path }}/{{ item }}"
+      register: top_level_stats
+      loop: "{{ memory_top_level_files }}"
+
+    - name: Find daily memory files
+      ansible.builtin.find:
+        paths: "{{ memory_workspace_path }}/memory"
+        patterns: "*.md"
+        file_type: file
+      register: daily_files
+      failed_when: false
+
+    - name: Emit workspace path
+      ansible.builtin.debug:
+        msg: "WORKSPACE_PATH={{ memory_workspace_path }}"
+
+    - name: Emit top-level file stats
+      ansible.builtin.debug:
+        msg: >-
+          TOP {{ item.item }}
+          {{ (item.stat.size | default(-1)) if item.stat.exists else -1 }}
+      loop: "{{ top_level_stats.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Emit daily file stats
+      ansible.builtin.debug:
+        msg: "DAILY {{ item.path | basename }} {{ item.size }}"
+      loop: "{{ daily_files.files | default([]) }}"
+      loop_control:
+        label: "{{ item.path | basename }}"

--- a/src/clawrium/platform/registry/openclaw/playbooks/memory_read.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/memory_read.yaml
@@ -1,0 +1,36 @@
+---
+- hosts: all
+  become: yes
+  gather_facts: false
+  tasks:
+    - name: Validate memory filename pattern
+      ansible.builtin.fail:
+        msg: "Invalid memory filename"
+      when:
+        - memory_filename is not match('^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)?$')
+
+    - name: Reject path-traversal components
+      ansible.builtin.fail:
+        msg: "Invalid memory filename: traversal components not allowed"
+      when:
+        - memory_filename.split('/') | intersect(['', '.', '..']) | length > 0
+
+    - name: Resolve memory file path
+      ansible.builtin.set_fact:
+        memory_target: "/home/{{ agent_name }}/.openclaw/workspace/{{ memory_filename }}"
+
+    - name: Verify file exists
+      ansible.builtin.stat:
+        path: "{{ memory_target }}"
+      register: memory_stat
+
+    - name: Fail if file does not exist
+      ansible.builtin.fail:
+        msg: "Memory file not found: {{ memory_filename }}"
+      when: not memory_stat.stat.exists
+
+    - name: Read memory file content
+      ansible.builtin.slurp:
+        src: "{{ memory_target }}"
+      register: memory_content
+      no_log: true

--- a/src/clawrium/platform/registry/openclaw/playbooks/memory_write.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/memory_write.yaml
@@ -1,0 +1,42 @@
+---
+- hosts: all
+  become: yes
+  gather_facts: false
+  tasks:
+    - name: Validate memory filename pattern
+      ansible.builtin.fail:
+        msg: "Invalid memory filename"
+      when:
+        - memory_filename is not match('^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)?$')
+
+    - name: Reject path-traversal components
+      ansible.builtin.fail:
+        msg: "Invalid memory filename: traversal components not allowed"
+      when:
+        - memory_filename.split('/') | intersect(['', '.', '..']) | length > 0
+
+    - name: Ensure workspace directory exists
+      ansible.builtin.file:
+        path: "/home/{{ agent_name }}/.openclaw/workspace"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0700"
+
+    - name: Ensure memory subdirectory exists when needed
+      ansible.builtin.file:
+        path: "/home/{{ agent_name }}/.openclaw/workspace/memory"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0700"
+      when: memory_filename is match('^memory/.*$')
+
+    - name: Write memory file content
+      ansible.builtin.copy:
+        content: "{{ memory_content }}"
+        dest: "/home/{{ agent_name }}/.openclaw/workspace/{{ memory_filename }}"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0644"
+      no_log: true

--- a/tests/test_core_memory.py
+++ b/tests/test_core_memory.py
@@ -118,12 +118,16 @@ def _host(agents: dict) -> dict:
 class TestResolveOpenclawAgent:
     def test_returns_none_when_host_missing(self):
         with patch("clawrium.core.memory.get_host", return_value=None):
-            assert _resolve_openclaw_agent("nope", "anything") is None
+            host, reason = _resolve_openclaw_agent("nope", "anything")
+        assert host is None
+        assert "host 'nope' not found" in reason
 
     def test_returns_none_when_agents_field_invalid(self):
         host = {"hostname": "192.168.1.100", "agents": []}
         with patch("clawrium.core.memory.get_host", return_value=host):
-            assert _resolve_openclaw_agent("192.168.1.100", "x") is None
+            h, reason = _resolve_openclaw_agent("192.168.1.100", "x")
+        assert h is None
+        assert "no agents registry" in reason
 
     def test_resolves_by_dict_key(self):
         host = _host(
@@ -137,7 +141,7 @@ class TestResolveOpenclawAgent:
         )
         with patch("clawrium.core.memory.get_host", return_value=host):
             result = _resolve_openclaw_agent("192.168.1.100", "opc-work")
-        assert result is not None
+        assert result[0] is not None
         assert result[1] == "opc-work"
 
     def test_resolves_by_short_name(self):
@@ -152,20 +156,23 @@ class TestResolveOpenclawAgent:
         )
         with patch("clawrium.core.memory.get_host", return_value=host):
             result = _resolve_openclaw_agent("192.168.1.100", "work")
-        assert result is not None
+        assert result[0] is not None
         assert result[1] == "opc-work"
 
     def test_returns_none_when_agent_missing(self):
         host = _host({})
         with patch("clawrium.core.memory.get_host", return_value=host):
-            assert _resolve_openclaw_agent("192.168.1.100", "ghost") is None
+            h, reason = _resolve_openclaw_agent("192.168.1.100", "ghost")
+        assert h is None
+        assert "not found" in reason
 
     def test_returns_none_when_agent_is_wrong_type(self):
         host = _host(
             {"zeroclaw": {"type": "zeroclaw", "agent_name": "zc", "name": "zc"}}
         )
         with patch("clawrium.core.memory.get_host", return_value=host):
-            assert _resolve_openclaw_agent("192.168.1.100", "zeroclaw") is None
+            h, _ = _resolve_openclaw_agent("192.168.1.100", "zeroclaw")
+        assert h is None
 
     def test_returns_none_when_multiple_matches(self):
         host = _host(
@@ -175,7 +182,9 @@ class TestResolveOpenclawAgent:
             }
         )
         with patch("clawrium.core.memory.get_host", return_value=host):
-            assert _resolve_openclaw_agent("192.168.1.100", "shared") is None
+            h, reason = _resolve_openclaw_agent("192.168.1.100", "shared")
+        assert h is None
+        assert "multiple openclaw agents" in reason
 
     @pytest.mark.parametrize("status", ["installing", "failed"])
     def test_rejects_non_installed_status(self, status: str):
@@ -189,7 +198,30 @@ class TestResolveOpenclawAgent:
             }
         )
         with patch("clawrium.core.memory.get_host", return_value=host):
-            assert _resolve_openclaw_agent("192.168.1.100", "opc-work") is None
+            h, reason = _resolve_openclaw_agent("192.168.1.100", "opc-work")
+        assert h is None
+        # Reason must distinguish "not ready" from "not found" so users
+        # debugging a still-installing agent don't chase a red herring.
+        assert "not ready" in reason
+        assert status in reason
+
+    def test_rejects_unknown_future_status(self):
+        # Allowlist behavior: any non-'installed' status is rejected even
+        # if it isn't 'installing' or 'failed'. Guards against future
+        # status additions silently passing through.
+        host = _host(
+            {
+                "opc-work": {
+                    "type": "openclaw",
+                    "agent_name": "opc-work",
+                    "status": "removing",
+                }
+            }
+        )
+        with patch("clawrium.core.memory.get_host", return_value=host):
+            h, reason = _resolve_openclaw_agent("192.168.1.100", "opc-work")
+        assert h is None
+        assert "removing" in reason
 
     def test_accepts_explicitly_installed_status(self):
         host = _host(
@@ -203,7 +235,7 @@ class TestResolveOpenclawAgent:
         )
         with patch("clawrium.core.memory.get_host", return_value=host):
             result = _resolve_openclaw_agent("192.168.1.100", "opc-work")
-        assert result is not None and result[1] == "opc-work"
+        assert result[0] is not None and result[1] == "opc-work"
 
     def test_accepts_record_without_status_field(self):
         # Legacy/test records without status are treated as installed.
@@ -212,7 +244,7 @@ class TestResolveOpenclawAgent:
         )
         with patch("clawrium.core.memory.get_host", return_value=host):
             result = _resolve_openclaw_agent("192.168.1.100", "opc-work")
-        assert result is not None
+        assert result[0] is not None
 
 
 # ----- _parse_memory_info_stdout -------------------------------------------
@@ -326,7 +358,7 @@ def _setup_playbook_env(tmp_path: Path, operation: str) -> tuple[Path, Path]:
 
 class TestGetMemoryInfo:
     def test_returns_none_when_agent_unresolved(self):
-        with patch("clawrium.core.memory._resolve_openclaw_agent", return_value=None):
+        with patch("clawrium.core.memory._resolve_openclaw_agent", return_value=(None, "test-reason")):
             assert get_memory_info("192.168.1.100", "x") is None
 
     def test_returns_none_on_missing_playbook(self, tmp_path: Path):
@@ -459,7 +491,7 @@ class TestReadMemoryFile:
         assert read_memory_file("h", "a", "../bad") is None
 
     def test_returns_none_when_unresolved(self):
-        with patch("clawrium.core.memory._resolve_openclaw_agent", return_value=None):
+        with patch("clawrium.core.memory._resolve_openclaw_agent", return_value=(None, "test-reason")):
             assert read_memory_file("h", "a", "SOUL.md") is None
 
     def test_returns_decoded_content_on_success(self, tmp_path: Path):
@@ -598,7 +630,7 @@ class TestWriteMemoryFile:
         assert err is not None and "Invalid" in err
 
     def test_returns_false_when_unresolved(self):
-        with patch("clawrium.core.memory._resolve_openclaw_agent", return_value=None):
+        with patch("clawrium.core.memory._resolve_openclaw_agent", return_value=(None, "test-reason")):
             ok, err = write_memory_file("h", "a", "SOUL.md", "x")
         assert ok is False
         assert err is not None
@@ -759,7 +791,7 @@ class TestDeleteMemoryFiles:
         assert err is not None
 
     def test_returns_false_when_unresolved(self):
-        with patch("clawrium.core.memory._resolve_openclaw_agent", return_value=None):
+        with patch("clawrium.core.memory._resolve_openclaw_agent", return_value=(None, "test-reason")):
             ok, err = delete_memory_files("h", "a", ["SOUL.md"])
         assert ok is False
 
@@ -988,6 +1020,41 @@ class TestCleanupArtifacts:
             "clawrium.core.memory.core_keys.get_host_private_key", return_value=None
         ):
             assert expect_falsy(call())
+
+    @pytest.mark.parametrize(
+        "operation,call",
+        [
+            (
+                "memory_write",
+                lambda: write_memory_file("h", "opc-work", "SOUL.md", "x"),
+            ),
+            (
+                "memory_delete",
+                lambda: delete_memory_files("h", "opc-work", ["SOUL.md"]),
+            ),
+        ],
+    )
+    def test_ssh_key_missing_error_includes_remediation_command(
+        self, tmp_path: Path, operation: str, call
+    ):
+        # write/delete surface the structured error string back to the user;
+        # confirm the actionable 'clm host init' guidance is present so the
+        # CLI/TUI message stays useful if someone refactors the error text.
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, _ = _setup_playbook_env(tmp_path, operation)
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=None
+        ):
+            ok, err = call()
+        assert ok is False
+        assert err is not None
+        assert "clm host init" in err
 
     def test_cleanup_swallows_permission_error(self, tmp_path: Path):
         # Real cleanup uses shutil.rmtree which can raise PermissionError on

--- a/tests/test_core_memory.py
+++ b/tests/test_core_memory.py
@@ -1,0 +1,1007 @@
+"""Tests for openclaw memory operations."""
+
+import base64
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clawrium.core.memory import (
+    MAX_MEMORY_CONTENT_BYTES,
+    MEMORY_TOP_LEVEL_FILES,
+    MemoryOpError,
+    _cleanup_artifacts,
+    _extract_failure_message,
+    _parse_memory_info_stdout,
+    _resolve_openclaw_agent,
+    _validate_agent_name,
+    _validate_memory_filename,
+    delete_memory_files,
+    get_memory_info,
+    read_memory_file,
+    write_memory_file,
+)
+
+
+# ----- validation -----------------------------------------------------------
+
+
+class TestValidation:
+    def test_agent_name_accepts_typical_unix_user(self):
+        _validate_agent_name("opc-work")
+
+    def test_agent_name_rejects_uppercase(self):
+        with pytest.raises(MemoryOpError):
+            _validate_agent_name("OPC-Work")
+
+    def test_agent_name_rejects_path_traversal(self):
+        with pytest.raises(MemoryOpError):
+            _validate_agent_name("../etc")
+
+    def test_filename_accepts_top_level(self):
+        _validate_memory_filename("SOUL.md")
+
+    def test_filename_accepts_daily(self):
+        _validate_memory_filename("memory/2026-05-09.md")
+
+    def test_filename_rejects_traversal(self):
+        with pytest.raises(MemoryOpError):
+            _validate_memory_filename("../../../etc/passwd")
+
+    def test_filename_rejects_nested_path(self):
+        with pytest.raises(MemoryOpError):
+            _validate_memory_filename("a/b/c.md")
+
+    def test_filename_rejects_absolute_path(self):
+        with pytest.raises(MemoryOpError):
+            _validate_memory_filename("/etc/hosts")
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "..",
+            "../etc",
+            "memory/..",
+            "../memory",
+            ".",
+            "./SOUL.md",
+            "",
+            "SOUL\x00.md",  # null byte
+            "..\\etc",  # backslash separator (regex rejects)
+            "%2e%2e/etc",  # url-encoded (regex rejects '%')
+            "memory/SOUL.md/extra",  # too-deep path (regex rejects)
+        ],
+    )
+    def test_filename_rejects_traversal_components(self, name: str):
+        with pytest.raises(MemoryOpError):
+            _validate_memory_filename(name)
+
+    def test_agent_name_rejects_empty(self):
+        with pytest.raises(MemoryOpError):
+            _validate_agent_name("")
+
+    def test_agent_name_accepts_max_length(self):
+        # 32 chars: 1 letter + 31 trailing
+        _validate_agent_name("a" + "0" * 31)
+
+    def test_agent_name_rejects_over_max_length(self):
+        with pytest.raises(MemoryOpError):
+            _validate_agent_name("a" + "0" * 32)
+
+
+# ----- top-level constants --------------------------------------------------
+
+
+class TestConstants:
+    def test_top_level_files_match_workspace_layout(self):
+        assert set(MEMORY_TOP_LEVEL_FILES) == {
+            "SOUL.md",
+            "IDENTITY.md",
+            "USER.md",
+            "TOOLS.md",
+        }
+
+
+# ----- _resolve_openclaw_agent ---------------------------------------------
+
+
+def _host(agents: dict) -> dict:
+    return {
+        "hostname": "192.168.1.100",
+        "key_id": "test",
+        "port": 22,
+        "user": "xclm",
+        "agents": agents,
+    }
+
+
+class TestResolveOpenclawAgent:
+    def test_returns_none_when_host_missing(self):
+        with patch("clawrium.core.memory.get_host", return_value=None):
+            assert _resolve_openclaw_agent("nope", "anything") is None
+
+    def test_returns_none_when_agents_field_invalid(self):
+        host = {"hostname": "192.168.1.100", "agents": []}
+        with patch("clawrium.core.memory.get_host", return_value=host):
+            assert _resolve_openclaw_agent("192.168.1.100", "x") is None
+
+    def test_resolves_by_dict_key(self):
+        host = _host(
+            {
+                "opc-work": {
+                    "type": "openclaw",
+                    "agent_name": "opc-work",
+                    "name": "work",
+                }
+            }
+        )
+        with patch("clawrium.core.memory.get_host", return_value=host):
+            result = _resolve_openclaw_agent("192.168.1.100", "opc-work")
+        assert result is not None
+        assert result[1] == "opc-work"
+
+    def test_resolves_by_short_name(self):
+        host = _host(
+            {
+                "opc-work": {
+                    "type": "openclaw",
+                    "agent_name": "opc-work",
+                    "name": "work",
+                }
+            }
+        )
+        with patch("clawrium.core.memory.get_host", return_value=host):
+            result = _resolve_openclaw_agent("192.168.1.100", "work")
+        assert result is not None
+        assert result[1] == "opc-work"
+
+    def test_returns_none_when_agent_missing(self):
+        host = _host({})
+        with patch("clawrium.core.memory.get_host", return_value=host):
+            assert _resolve_openclaw_agent("192.168.1.100", "ghost") is None
+
+    def test_returns_none_when_agent_is_wrong_type(self):
+        host = _host(
+            {"zeroclaw": {"type": "zeroclaw", "agent_name": "zc", "name": "zc"}}
+        )
+        with patch("clawrium.core.memory.get_host", return_value=host):
+            assert _resolve_openclaw_agent("192.168.1.100", "zeroclaw") is None
+
+    def test_returns_none_when_multiple_matches(self):
+        host = _host(
+            {
+                "opc-a": {"type": "openclaw", "agent_name": "opc-a", "name": "shared"},
+                "opc-b": {"type": "openclaw", "agent_name": "opc-b", "name": "shared"},
+            }
+        )
+        with patch("clawrium.core.memory.get_host", return_value=host):
+            assert _resolve_openclaw_agent("192.168.1.100", "shared") is None
+
+    @pytest.mark.parametrize("status", ["installing", "failed"])
+    def test_rejects_non_installed_status(self, status: str):
+        host = _host(
+            {
+                "opc-work": {
+                    "type": "openclaw",
+                    "agent_name": "opc-work",
+                    "status": status,
+                }
+            }
+        )
+        with patch("clawrium.core.memory.get_host", return_value=host):
+            assert _resolve_openclaw_agent("192.168.1.100", "opc-work") is None
+
+    def test_accepts_explicitly_installed_status(self):
+        host = _host(
+            {
+                "opc-work": {
+                    "type": "openclaw",
+                    "agent_name": "opc-work",
+                    "status": "installed",
+                }
+            }
+        )
+        with patch("clawrium.core.memory.get_host", return_value=host):
+            result = _resolve_openclaw_agent("192.168.1.100", "opc-work")
+        assert result is not None and result[1] == "opc-work"
+
+    def test_accepts_record_without_status_field(self):
+        # Legacy/test records without status are treated as installed.
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        with patch("clawrium.core.memory.get_host", return_value=host):
+            result = _resolve_openclaw_agent("192.168.1.100", "opc-work")
+        assert result is not None
+
+
+# ----- _parse_memory_info_stdout -------------------------------------------
+
+
+class TestParseMemoryInfoStdout:
+    def test_parses_workspace_path_and_top(self):
+        stdout = (
+            "WORKSPACE_PATH=/home/opc-work/.openclaw/workspace\n"
+            "TOP SOUL.md 100\n"
+            "TOP IDENTITY.md 50\n"
+            "TOP USER.md -1\n"
+            "TOP TOOLS.md 200\n"
+            "DAILY 2026-05-09.md 300\n"
+        )
+        parsed = _parse_memory_info_stdout(stdout)
+        assert parsed["workspace_path"] == "/home/opc-work/.openclaw/workspace"
+        assert parsed["top"] == [
+            ("SOUL.md", 100),
+            ("IDENTITY.md", 50),
+            ("USER.md", -1),
+            ("TOOLS.md", 200),
+        ]
+        assert parsed["daily"] == [("2026-05-09.md", 300)]
+
+    def test_handles_empty_stdout(self):
+        parsed = _parse_memory_info_stdout("")
+        assert parsed == {"workspace_path": "", "top": [], "daily": []}
+
+    def test_skips_malformed_lines(self):
+        stdout = "TOP\nDAILY only-name\nTOP weird notanumber\n"
+        parsed = _parse_memory_info_stdout(stdout)
+        assert parsed["top"] == []
+        assert parsed["daily"] == []
+
+
+# ----- _extract_failure_message --------------------------------------------
+
+
+class TestExtractFailureMessage:
+    def test_returns_default_when_no_failed_events(self):
+        result = MagicMock()
+        result.events = [
+            {"event": "runner_on_ok", "event_data": {"res": {"msg": "ignored"}}}
+        ]
+        assert _extract_failure_message(result, "fallback") == "fallback"
+
+    def test_returns_msg_field_when_present(self):
+        result = MagicMock()
+        result.events = [
+            {
+                "event": "runner_on_failed",
+                "event_data": {"res": {"msg": "boom", "stderr": "extra"}},
+            }
+        ]
+        assert _extract_failure_message(result, "fallback") == "boom"
+
+    def test_falls_back_to_stderr_when_msg_missing(self):
+        result = MagicMock()
+        result.events = [
+            {
+                "event": "runner_on_failed",
+                "event_data": {"res": {"stderr": "stderr-value"}},
+            }
+        ]
+        assert _extract_failure_message(result, "fallback") == "stderr-value"
+
+    def test_returns_first_failed_when_multiple(self):
+        result = MagicMock()
+        result.events = [
+            {
+                "event": "runner_on_failed",
+                "event_data": {"res": {"msg": "first"}},
+            },
+            {
+                "event": "runner_on_failed",
+                "event_data": {"res": {"msg": "second"}},
+            },
+        ]
+        assert _extract_failure_message(result, "fallback") == "first"
+
+    def test_returns_default_when_failed_event_has_no_message(self):
+        result = MagicMock()
+        result.events = [
+            {"event": "runner_on_failed", "event_data": {"res": {}}}
+        ]
+        assert _extract_failure_message(result, "fallback") == "fallback"
+
+
+# ----- get_memory_info ------------------------------------------------------
+
+
+def _runner_result(status: str, events: list) -> MagicMock:
+    r = MagicMock()
+    r.status = status
+    r.events = events
+    r.rc = 0 if status == "successful" else 1
+    return r
+
+
+def _setup_playbook_env(tmp_path: Path, operation: str) -> tuple[Path, Path]:
+    """Return (playbook_dir, ssh_key) populated with the given operation."""
+    playbook_dir = tmp_path / "pb"
+    playbook_dir.mkdir(exist_ok=True)
+    (playbook_dir / f"{operation}.yaml").write_text("---\n")
+    ssh_key = tmp_path / "id_rsa"
+    if not ssh_key.exists():
+        ssh_key.write_text("key")
+    return playbook_dir, ssh_key
+
+
+class TestGetMemoryInfo:
+    def test_returns_none_when_agent_unresolved(self):
+        with patch("clawrium.core.memory._resolve_openclaw_agent", return_value=None):
+            assert get_memory_info("192.168.1.100", "x") is None
+
+    def test_returns_none_on_missing_playbook(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch(
+            "clawrium.core.memory._PLAYBOOK_DIR", tmp_path / "missing"
+        ):
+            assert get_memory_info("192.168.1.100", "opc-work") is None
+
+    def test_returns_none_when_ssh_key_missing(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        # Point _PLAYBOOK_DIR at a tmp dir containing the playbook so the
+        # missing-playbook check passes and we exercise the SSH key path.
+        playbook_dir = tmp_path / "pb"
+        playbook_dir.mkdir()
+        (playbook_dir / "memory_info.yaml").write_text("---\n")
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=None
+        ):
+            assert get_memory_info("192.168.1.100", "opc-work") is None
+
+    def test_extracts_stats_from_successful_run(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir = tmp_path / "pb"
+        playbook_dir.mkdir()
+        (playbook_dir / "memory_info.yaml").write_text("---\n")
+
+        ssh_key = tmp_path / "id_rsa"
+        ssh_key.write_text("key")
+
+        # The memory_info playbook emits one debug msg per line; each
+        # arrives as its own runner_on_ok event with res.msg populated.
+        msgs = [
+            "WORKSPACE_PATH=/home/opc-work/.openclaw/workspace",
+            "TOP SOUL.md 10",
+            "TOP IDENTITY.md 20",
+            "TOP USER.md -1",
+            "TOP TOOLS.md 30",
+            "DAILY 2026-05-09.md 40",
+        ]
+        events = [
+            {"event": "runner_on_ok", "event_data": {"res": {"msg": m}}}
+            for m in msgs
+        ]
+        result = _runner_result("successful", events)
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run", return_value=result
+        ):
+            stats = get_memory_info("192.168.1.100", "opc-work")
+
+        assert stats is not None
+        assert stats["workspace_path"] == "/home/opc-work/.openclaw/workspace"
+        # 10 + 20 + 30 + 40 = 100; missing USER.md contributes 0
+        assert stats["total_bytes"] == 100
+        files_by_name = {f["name"]: f for f in stats["files"]}
+        assert files_by_name["USER.md"]["exists"] is False
+        assert files_by_name["USER.md"]["size_bytes"] == 0
+        daily = files_by_name["2026-05-09.md"]
+        assert daily["relative_path"] == "memory/2026-05-09.md"
+        assert daily["size_bytes"] == 40
+
+    def test_returns_none_on_timeout(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir = tmp_path / "pb"
+        playbook_dir.mkdir()
+        (playbook_dir / "memory_info.yaml").write_text("---\n")
+        ssh_key = tmp_path / "id_rsa"
+        ssh_key.write_text("key")
+
+        result = _runner_result("timeout", [])
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run", return_value=result
+        ):
+            assert get_memory_info("192.168.1.100", "opc-work") is None
+
+    def test_returns_none_on_runner_exception_offline(self, tmp_path: Path):
+        """Gap #1: offline / unreachable agent must degrade gracefully."""
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir = tmp_path / "pb"
+        playbook_dir.mkdir()
+        (playbook_dir / "memory_info.yaml").write_text("---\n")
+        ssh_key = tmp_path / "id_rsa"
+        ssh_key.write_text("key")
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run",
+            side_effect=ConnectionError("host unreachable"),
+        ):
+            assert get_memory_info("192.168.1.100", "opc-work") is None
+
+
+# ----- read_memory_file -----------------------------------------------------
+
+
+class TestReadMemoryFile:
+    def test_returns_none_on_invalid_filename(self):
+        assert read_memory_file("h", "a", "../bad") is None
+
+    def test_returns_none_when_unresolved(self):
+        with patch("clawrium.core.memory._resolve_openclaw_agent", return_value=None):
+            assert read_memory_file("h", "a", "SOUL.md") is None
+
+    def test_returns_decoded_content_on_success(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir = tmp_path / "pb"
+        playbook_dir.mkdir()
+        (playbook_dir / "memory_read.yaml").write_text("---\n")
+        ssh_key = tmp_path / "id_rsa"
+        ssh_key.write_text("key")
+
+        encoded = base64.b64encode(b"hello world").decode("ascii")
+        events = [
+            {"event": "runner_on_ok", "event_data": {"res": {"content": encoded}}}
+        ]
+        result = _runner_result("successful", events)
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run", return_value=result
+        ):
+            assert read_memory_file("h", "opc-work", "SOUL.md") == "hello world"
+
+    def test_returns_none_when_playbook_fails(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, "memory_read")
+
+        result = _runner_result("failed", [])
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run", return_value=result
+        ):
+            assert read_memory_file("h", "opc-work", "SOUL.md") is None
+
+    def test_returns_none_on_runner_exception_offline(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, "memory_read")
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run",
+            side_effect=ConnectionError("host unreachable"),
+        ):
+            assert read_memory_file("h", "opc-work", "SOUL.md") is None
+
+    def test_returns_none_on_timeout(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, "memory_read")
+        result = _runner_result("timeout", [])
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run", return_value=result
+        ):
+            assert read_memory_file("h", "opc-work", "SOUL.md") is None
+
+    def test_returns_none_on_invalid_base64(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, "memory_read")
+        events = [
+            {
+                "event": "runner_on_ok",
+                "event_data": {"res": {"content": "not-valid-base64!!!"}},
+            }
+        ]
+        result = _runner_result("successful", events)
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run", return_value=result
+        ):
+            assert read_memory_file("h", "opc-work", "SOUL.md") is None
+
+    def test_returns_none_on_non_utf8_bytes(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, "memory_read")
+        encoded = base64.b64encode(b"\xff\xfe\xfd").decode("ascii")
+        events = [
+            {
+                "event": "runner_on_ok",
+                "event_data": {"res": {"content": encoded}},
+            }
+        ]
+        result = _runner_result("successful", events)
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run", return_value=result
+        ):
+            assert read_memory_file("h", "opc-work", "SOUL.md") is None
+
+
+# ----- write_memory_file ----------------------------------------------------
+
+
+class TestWriteMemoryFile:
+    def test_validation_error_returns_false(self):
+        ok, err = write_memory_file("h", "a", "../etc/passwd", "x")
+        assert ok is False
+        assert err is not None and "Invalid" in err
+
+    def test_returns_false_when_unresolved(self):
+        with patch("clawrium.core.memory._resolve_openclaw_agent", return_value=None):
+            ok, err = write_memory_file("h", "a", "SOUL.md", "x")
+        assert ok is False
+        assert err is not None
+
+    def test_returns_true_on_successful_run(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir = tmp_path / "pb"
+        playbook_dir.mkdir()
+        (playbook_dir / "memory_write.yaml").write_text("---\n")
+        ssh_key = tmp_path / "id_rsa"
+        ssh_key.write_text("key")
+
+        result = _runner_result("successful", [])
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run", return_value=result
+        ):
+            ok, err = write_memory_file("h", "opc-work", "SOUL.md", "content")
+        assert ok is True
+        assert err is None
+
+    def test_returns_failure_message_from_events(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, "memory_write")
+
+        events = [
+            {
+                "event": "runner_on_failed",
+                "event_data": {"res": {"msg": "permission denied"}},
+            }
+        ]
+        result = _runner_result("failed", events)
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run", return_value=result
+        ):
+            ok, err = write_memory_file("h", "opc-work", "SOUL.md", "content")
+        assert ok is False
+        assert err == "permission denied"
+
+    def test_returns_false_on_timeout(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, "memory_write")
+
+        result = _runner_result("timeout", [])
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run", return_value=result
+        ):
+            ok, err = write_memory_file("h", "opc-work", "SOUL.md", "content")
+        assert ok is False
+        assert err is not None and "timed out" in err
+
+    def test_returns_false_on_runner_exception_offline(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, "memory_write")
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run",
+            side_effect=ConnectionError("host unreachable"),
+        ):
+            ok, err = write_memory_file("h", "opc-work", "SOUL.md", "content")
+        assert ok is False
+        assert err is not None and "unreachable" in err
+
+    def test_rejects_oversize_content(self):
+        # Build content one byte over the limit.
+        oversize = "a" * (MAX_MEMORY_CONTENT_BYTES + 1)
+        ok, err = write_memory_file("h", "opc-work", "SOUL.md", oversize)
+        assert ok is False
+        assert err is not None and "exceeds maximum size" in err
+
+    def test_accepts_content_at_size_limit(self, tmp_path: Path):
+        # Exact-limit and one-byte-under should both pass the size check
+        # (and proceed to the host resolution step which we mock).
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, "memory_write")
+        result = _runner_result("successful", [])
+
+        for size in (MAX_MEMORY_CONTENT_BYTES - 1, MAX_MEMORY_CONTENT_BYTES):
+            with patch(
+                "clawrium.core.memory._resolve_openclaw_agent",
+                return_value=(host, "opc-work"),
+            ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+                "clawrium.core.memory.core_keys.get_host_private_key",
+                return_value=ssh_key,
+            ), patch(
+                "clawrium.core.memory.ansible_runner.run", return_value=result
+            ):
+                ok, err = write_memory_file(
+                    "h", "opc-work", "SOUL.md", "a" * size
+                )
+            assert ok is True, f"size {size} should be accepted"
+            assert err is None
+
+    def test_returns_false_on_pre_flight_oserror(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, "memory_write")
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory._get_logs_dir",
+            side_effect=OSError("read-only filesystem"),
+        ):
+            ok, err = write_memory_file("h", "opc-work", "SOUL.md", "x")
+        assert ok is False
+        assert err is not None and "read-only filesystem" in err
+
+
+# ----- delete_memory_files --------------------------------------------------
+
+
+class TestDeleteMemoryFiles:
+    def test_empty_list_is_noop(self):
+        ok, err = delete_memory_files("h", "a", [])
+        assert ok is True
+        assert err is None
+
+    def test_validation_failure(self):
+        ok, err = delete_memory_files("h", "a", ["../bad"])
+        assert ok is False
+        assert err is not None
+
+    def test_returns_false_when_unresolved(self):
+        with patch("clawrium.core.memory._resolve_openclaw_agent", return_value=None):
+            ok, err = delete_memory_files("h", "a", ["SOUL.md"])
+        assert ok is False
+
+    def test_passes_files_list_through_to_playbook(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, "memory_delete")
+
+        result = _runner_result("successful", [])
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run", return_value=result
+        ) as mock_run:
+            ok, err = delete_memory_files(
+                "h", "opc-work", ["SOUL.md", "memory/2026-05-09.md"]
+            )
+
+        assert ok is True
+        assert err is None
+        kwargs = mock_run.call_args.kwargs
+        inventory = kwargs["inventory"]
+        assert inventory["all"]["vars"]["memory_files"] == [
+            "SOUL.md",
+            "memory/2026-05-09.md",
+        ]
+
+    def test_returns_false_on_timeout(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, "memory_delete")
+
+        result = _runner_result("timeout", [])
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run", return_value=result
+        ):
+            ok, err = delete_memory_files("h", "opc-work", ["SOUL.md"])
+        assert ok is False
+        assert err is not None and "timed out" in err
+
+    def test_returns_false_on_runner_exception_offline(self, tmp_path: Path):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, "memory_delete")
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run",
+            side_effect=ConnectionError("host unreachable"),
+        ):
+            ok, err = delete_memory_files("h", "opc-work", ["SOUL.md"])
+        assert ok is False
+        assert err is not None and "unreachable" in err
+
+
+# ----- _cleanup_artifacts ---------------------------------------------------
+
+
+class TestCleanupArtifacts:
+    def test_removes_known_subdirs(self, tmp_path: Path):
+        artifacts = tmp_path / "artifacts"
+        artifacts.mkdir()
+        (artifacts / "f").write_text("x")
+        env = tmp_path / "env"
+        env.mkdir()
+        (env / "f").write_text("x")
+
+        _cleanup_artifacts(tmp_path)
+
+        assert not artifacts.exists()
+        assert not env.exists()
+
+    def test_silently_ignores_missing_dirs(self, tmp_path: Path):
+        # No exception should be raised if subdirs do not exist.
+        _cleanup_artifacts(tmp_path)
+
+    @pytest.mark.parametrize(
+        "operation,call",
+        [
+            (
+                "memory_read",
+                lambda: read_memory_file("h", "opc-work", "SOUL.md"),
+            ),
+            (
+                "memory_write",
+                lambda: write_memory_file("h", "opc-work", "SOUL.md", "x"),
+            ),
+            (
+                "memory_delete",
+                lambda: delete_memory_files("h", "opc-work", ["SOUL.md"]),
+            ),
+            (
+                "memory_info",
+                lambda: get_memory_info("h", "opc-work"),
+            ),
+        ],
+    )
+    def test_cleanup_called_on_success_for_all_operations(
+        self, tmp_path: Path, operation: str, call
+    ):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, operation)
+        result = _runner_result(
+            "successful",
+            [
+                {
+                    "event": "runner_on_ok",
+                    "event_data": {"res": {"stdout": "", "content": ""}},
+                }
+            ],
+        )
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run", return_value=result
+        ), patch(
+            "clawrium.core.memory._cleanup_artifacts"
+        ) as cleanup:
+            call()
+        # Success path cleans up exactly once via the caller's finally block.
+        assert cleanup.call_count == 1
+
+    @pytest.mark.parametrize(
+        "operation,call",
+        [
+            (
+                "memory_read",
+                lambda: read_memory_file("h", "opc-work", "SOUL.md"),
+            ),
+            (
+                "memory_write",
+                lambda: write_memory_file("h", "opc-work", "SOUL.md", "x"),
+            ),
+            (
+                "memory_delete",
+                lambda: delete_memory_files("h", "opc-work", ["SOUL.md"]),
+            ),
+            (
+                "memory_info",
+                lambda: get_memory_info("h", "opc-work"),
+            ),
+        ],
+    )
+    def test_cleanup_called_on_runner_exception_for_all_operations(
+        self, tmp_path: Path, operation: str, call
+    ):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, ssh_key = _setup_playbook_env(tmp_path, operation)
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=ssh_key
+        ), patch(
+            "clawrium.core.memory.ansible_runner.run",
+            side_effect=ConnectionError("offline"),
+        ), patch(
+            "clawrium.core.memory._cleanup_artifacts"
+        ) as cleanup:
+            call()
+        assert cleanup.call_count == 1
+
+    @pytest.mark.parametrize(
+        "operation,call,expect_falsy",
+        [
+            (
+                "memory_info",
+                lambda: get_memory_info("h", "opc-work"),
+                lambda r: r is None,
+            ),
+            (
+                "memory_read",
+                lambda: read_memory_file("h", "opc-work", "SOUL.md"),
+                lambda r: r is None,
+            ),
+            (
+                "memory_write",
+                lambda: write_memory_file("h", "opc-work", "SOUL.md", "x"),
+                lambda r: r[0] is False and r[1] is not None,
+            ),
+            (
+                "memory_delete",
+                lambda: delete_memory_files("h", "opc-work", ["SOUL.md"]),
+                lambda r: r[0] is False and r[1] is not None,
+            ),
+        ],
+    )
+    def test_ssh_key_missing_degrades_for_all_operations(
+        self, tmp_path: Path, operation: str, call, expect_falsy
+    ):
+        host = _host(
+            {"opc-work": {"type": "openclaw", "agent_name": "opc-work"}}
+        )
+        playbook_dir, _ = _setup_playbook_env(tmp_path, operation)
+
+        with patch(
+            "clawrium.core.memory._resolve_openclaw_agent",
+            return_value=(host, "opc-work"),
+        ), patch("clawrium.core.memory._PLAYBOOK_DIR", playbook_dir), patch(
+            "clawrium.core.memory.core_keys.get_host_private_key", return_value=None
+        ):
+            assert expect_falsy(call())
+
+    def test_cleanup_swallows_permission_error(self, tmp_path: Path):
+        # Real cleanup uses shutil.rmtree which can raise PermissionError on
+        # locked-down FS. The function must not propagate it because callers
+        # invoke it from finally blocks where a raised exception would mask
+        # the original error.
+        artifacts = tmp_path / "artifacts"
+        artifacts.mkdir()
+        (artifacts / "f").write_text("x")
+
+        with patch(
+            "clawrium.core.memory.shutil.rmtree",
+            side_effect=PermissionError("locked"),
+        ):
+            _cleanup_artifacts(tmp_path)  # must not raise
+
+


### PR DESCRIPTION
## Summary

Phase 1 of #210. Implements the Python core for openclaw memory operations and the four backing Ansible playbooks. CLI/TUI surfaces and docs ship in subsequent phases per `.itx/210/00_PLAN.md`.

## Public API

`src/clawrium/core/memory.py`:

- `get_memory_info(hostname, agent_name) -> MemoryStats | None`
- `read_memory_file(hostname, agent_name, filename) -> str | None`
- `write_memory_file(hostname, agent_name, filename, content) -> tuple[bool, str | None]`
- `delete_memory_files(hostname, agent_name, files) -> tuple[bool, str | None]`

Read/info return `None` and write/delete return `(False, error)` on transport failure so callers can present an "unavailable" state instead of raising.

## Playbooks

Under `src/clawrium/platform/registry/openclaw/playbooks/`:

- `memory_info.yaml` — native stat/find/debug; emits structured `msg` lines per file
- `memory_read.yaml` — slurp with `no_log` on content
- `memory_write.yaml` — copy, owner/group set to agent user, mode 0644
- `memory_delete.yaml` — `file state=absent`

## Security posture

- Defense-in-depth filename validation: Python regex + explicit `.`/`..` component rejection, mirrored by `split+intersect` rejection in each playbook so the workspace boundary holds even if a playbook is invoked directly.
- `write_memory_file` enforces a 5 MiB content cap before encoding to prevent runner exhaustion.
- `_resolve_openclaw_agent` rejects records with `status='installing'` or `'failed'`.
- `_cleanup_artifacts` removes both `artifacts/` and `env/` so SSH keys and `extravars` plaintext don't persist on disk.

## Issue #210 plan-reconciliation gaps

- Gap #1 (offline graceful failure) — covered
- Gap #2 (workspace ownership preservation) — playbooks set owner/group to agent user
- Gap #5 (test fixtures) — inline `_host` helper

Gap #3 (TUI restart confirmation), #4 (concurrent-edit), #6 (`delete --all` safety) live in Phase 4/2.

## Testing

### Test Results

- [x] All existing tests pass — 1388 tests (was 1342 baseline)
- [x] Linter passes — `make lint` clean
- [x] All 4 playbooks parse — `ansible-playbook --syntax-check`
- [x] 86 new tests in `tests/test_core_memory.py`

### Coverage

- Files changed: 7 (all new)
- New tests: `tests/test_core_memory.py` (86 cases)
- Coverage impact: increased

## ATX Review Summary

**Final Review: Rating 4/5** — no blocking issues
**Total Cost: \$7.02 | Total Time: ~37m across 5 rounds**

| Review | Rating | Blocking Issues | Status | Cost | Time |
|--------|--------|-----------------|--------|------|------|
| 1 | 2/5 | B1, B2, B3 | All fixed | \$0.47 | 4m43s |
| 2 | 3/5 | B1, B2 | B1 out-of-scope, B2 fixed | \$1.64 | 6m58s |
| 3 | 2/5 | B1, B2 | All fixed | \$1.64 | 7m |
| 4 | 3/5 | B1, B2 | All fixed | \$1.96 | 10m49s |
| 5 | 4/5 | None | Ready | \$1.30 | 7m10s |

> **Note**: Review 1 had three of four specialists fail with API errors; iteration 2 onwards had full coverage.

<details>
<summary>Review 1 — Rating 2/5</summary>

**Blocking:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_core_memory.py` | No timeout test for `write_memory_file` | Added |
| B2 | `tests/test_core_memory.py` | No timeout test for `delete_memory_files` | Added |
| B3 | `tests/test_core_memory.py` | `_extract_failure_message` had no direct unit tests | Added `TestExtractFailureMessage` (5 cases) |

</details>

<details>
<summary>Review 2 — Rating 3/5</summary>

**Blocking:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/conftest.py` | Pre-existing `hosts_with_installed_claw` fixture keyed by claw type, not agent_name | Out-of-scope — not consumed by Phase 1 tests; track in Phase 2 |
| B2 | `tests/test_core_memory.py` | Cleanup coverage incomplete | Added parametrized success/exception cleanup tests across all 4 ops with `call_count` assertions |

**Warnings handled:**
- W1 (unused `mock_openclaw_workspace` fixture) — Removed
- W3 (status guard) — Deferred for consistency with `lifecycle.py`

</details>

<details>
<summary>Review 3 — Rating 2/5</summary>

**Blocking:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `memory.py` | Path traversal: regex `[A-Za-z0-9._-]+` matches `..`, so `../etc` passed | Added explicit `.`/`..` component rejection + parametrized traversal tests |
| B2 | `memory_info.yaml` | Shell module + `stat -c%s` / `find -printf` raised both injection and BSD/macOS portability concerns | Rewrote using native `ansible.builtin.stat` + `find` + `debug`; updated python parser to read `msg` fields |

**Warnings handled:** W2 double-cleanup removed; W3 SSH-key-missing parametrized; W4 base64 decode failure tests; W5 pre-flight `OSError` guarded; W7 read-timeout branch; W8 5 MiB content cap.

</details>

<details>
<summary>Review 4 — Rating 3/5</summary>

**Blocking:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | playbooks | Ansible-side regex still accepted `..` — defense-in-depth gap | Added `split+intersect(['', '.', '..'])` rejection task to read/write/delete playbooks |
| B2 | `memory.py` | No agent status guard — `installing`/`failed` agents silently matched | `_resolve_openclaw_agent` rejects non-installed status (records without status treated as legacy/installed) |

**Warnings handled:**
- W1 SSH key error → actionable with `clm host init {hostname}`
- W3 traversal tests → null byte, empty string, backslash, URL-encoded, deep-path
- W4 cleanup parametrize → `memory_info` added to both success and exception lists
- W5 size boundary → exact-`MAX_BYTES` accepted
- W6 onboarding state guard → deferred to Phase 4 TUI-edit
- W7 extravars on disk → mitigated by existing `_cleanup_artifacts` removing `env/`

</details>

<details>
<summary>Review 5 — Rating 4/5 (Final)</summary>

**Blocking:** None

**Warnings remaining (acknowledged, tracked as follow-ups):**

| # | Issue | Status |
|---|-------|--------|
| W1 | "not found" message when status-rejected misleads users debugging visible agents | Acknowledged — track follow-up |
| W2 | Status guard uses blocklist; future statuses (e.g., `removing`) silently pass | Acknowledged — track follow-up |
| W3 | Cleanup not crash-safe between `run()` and cleanup call | Acknowledged — `atexit` or tmpfs follow-up |
| W4 | SSH key guidance text not test-asserted | Acknowledged — minor test gap |
| W5 | `MAX_BYTES-1` not separately parametrized | Acknowledged — minor |
| W6 | Read-path size enforcement not tested | Acknowledged — read currently uncapped by design |

</details>

## What's deferred to later phases

- Phase 2: `clm agent <name> memory show|delete` (consumes this module)
- Phase 3: TUI MEMORY card with size and paths
- Phase 4: TUI edit → sync → restart (incl. Gap #3 restart confirm + Gap #4 concurrent-edit safety + W6 onboarding-state guard)
- Phase 5: docs

Compaction/truncation is deferred to a follow-up issue per the issue #210 reconciliation comment.

## Reviewer Notes

This PR does **not** close #210 — only the issue-level acceptance criteria are checked off as each phase merges.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>