### PR TITLE
feat(memory): clm agent <name> memory show|delete (Phase 2 of #210)

### DIFF
--- a/.itx/210/02_PHASE2_PLAN.md
+++ b/.itx/210/02_PHASE2_PLAN.md
@@ -1,0 +1,39 @@
+# Issue #210 — Phase 2 Plan
+
+CLI surface for openclaw memory operations. Builds on the Phase 1 core
+module shipped in #306.
+
+## Scope
+
+Two commands, mounted under `clm agent <name> memory`:
+
+| Command | Purpose |
+|---------|---------|
+| `clm agent <name> memory show` | Display total size, workspace path, per-file size table |
+| `clm agent <name> memory delete --file <f>` | Delete a single memory file (confirmation unless `--force`) |
+| `clm agent <name> memory delete --all` | Delete every existing memory file (refused without `--force`; `--force` still requires typed agent-name confirmation per Gap #6) |
+
+## New files
+
+- `src/clawrium/cli/memory.py` — command implementations
+- `tests/test_cli_memory.py` — CliRunner-based tests
+
+## Modified files
+
+- `src/clawrium/cli/agent.py` — register `memory_app` subcommand following the `secret_app` pattern
+
+## UX invariants
+
+- **Resolution**: `get_installed_claw` looks up the agent in hosts.json; an unknown name exits 1 with a clear error.
+- **Offline degradation**: `show` distinguishes "agent not found" from "core returned None" (host unreachable, status=installing) so users debugging a still-installing agent do not chase a red herring.
+- **Delete safety (Gap #6)**:
+  - `--file <f>` deletes one file; prompts unless `--force`.
+  - `--all` without `--force` refuses outright.
+  - `--all --force` still requires a typed confirmation matching the agent name. This mirrors how cloud consoles gate destructive bulk operations.
+- **Size formatting**: bytes → human-readable (B / KB / MB).
+
+## Out of scope (Phase 3+)
+
+- TUI MEMORY card (Phase 3)
+- TUI edit → sync → restart (Phase 4)
+- Compaction/truncation (separate follow-up issue)

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -2102,6 +2102,53 @@ def secret_import(
 agent_app.add_typer(secret_app, name="secret")
 
 
+# Memory inspection and management for agents
+memory_app = typer.Typer(
+    name="memory",
+    help="Inspect and manage memory for openclaw agents",
+    no_args_is_help=True,
+)
+
+
+@memory_app.command(name="show")
+def memory_show(
+    claw_name: str = typer.Argument(..., help="Agent instance name"),
+) -> None:
+    """Show memory file paths and sizes for an openclaw agent."""
+    from clawrium.cli.memory import show_cmd
+
+    show_cmd(claw_name=claw_name)
+
+
+@memory_app.command(name="delete")
+def memory_delete(
+    claw_name: str = typer.Argument(..., help="Agent instance name"),
+    file: Optional[str] = typer.Option(
+        None,
+        "--file",
+        "-f",
+        help="Single memory file to delete (e.g., SOUL.md or memory/2026-05-09.md).",
+    ),
+    all_files: bool = typer.Option(
+        False,
+        "--all",
+        help="Delete every memory file. Requires --force and a typed confirmation.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Skip the per-file confirmation prompt. Required for --all.",
+    ),
+) -> None:
+    """Delete one memory file or every memory file for the agent."""
+    from clawrium.cli.memory import delete_cmd
+
+    delete_cmd(claw_name=claw_name, file=file, all_files=all_files, force=force)
+
+
+agent_app.add_typer(memory_app, name="memory")
+
+
 # Integration management for agents
 integration_app = typer.Typer(
     name="integration",

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -2126,7 +2126,6 @@ def memory_delete(
     file: Optional[str] = typer.Option(
         None,
         "--file",
-        "-f",
         help="Single memory file to delete (e.g., SOUL.md or memory/2026-05-09.md).",
     ),
     all_files: bool = typer.Option(
@@ -2137,7 +2136,8 @@ def memory_delete(
     force: bool = typer.Option(
         False,
         "--force",
-        help="Skip the per-file confirmation prompt. Required for --all.",
+        "-f",
+        help="Skip the per-file confirmation prompt; required gate for --all.",
     ),
 ) -> None:
     """Delete one memory file or every memory file for the agent."""

--- a/src/clawrium/cli/memory.py
+++ b/src/clawrium/cli/memory.py
@@ -1,0 +1,220 @@
+"""Memory management commands for openclaw agents.
+
+Surfaces ``clm agent <name> memory show|delete``. Thin layer over
+``clawrium.core.memory`` — argument parsing, confirmation flows, and
+human-readable rendering.
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from clawrium.core.memory import (
+    delete_memory_files,
+    get_memory_info,
+)
+from clawrium.core.hosts import get_host
+from clawrium.core.secrets import (
+    AgentNotFoundError,
+    get_installed_claw,
+)
+
+__all__ = ["memory_app", "show_cmd", "delete_cmd"]
+
+console = Console()
+
+memory_app = typer.Typer(
+    name="memory",
+    help="Inspect and manage memory for openclaw agents",
+    no_args_is_help=True,
+)
+
+
+def _human_size(num_bytes: int) -> str:
+    """Render an integer byte count as B / KB / MB. One decimal place."""
+    if num_bytes < 1024:
+        return f"{num_bytes} B"
+    if num_bytes < 1024 * 1024:
+        return f"{num_bytes / 1024:.1f} KB"
+    return f"{num_bytes / (1024 * 1024):.1f} MB"
+
+
+def _resolve_openclaw_for_cli(claw_name: str) -> tuple[str, str]:
+    """Resolve agent name to (hostname, unix_agent_name) or exit 1.
+
+    Restricts memory ops to openclaw agents — other types are not
+    supported in this iteration. Returns the unix-level ``agent_name``
+    the core module needs.
+    """
+    try:
+        hostname, agent_key, name = get_installed_claw(claw_name)
+    except AgentNotFoundError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+    # get_installed_claw returns the agents-dict key as the second element,
+    # which under the current schema is the agent name rather than the claw
+    # type. Read the inner type field from the host record to validate.
+    host = get_host(hostname)
+    record = (host or {}).get("agents", {}).get(agent_key, {})
+    actual_type = record.get("type") if isinstance(record, dict) else None
+
+    if actual_type != "openclaw":
+        console.print(
+            f"[red]Error:[/red] memory is only supported for openclaw agents "
+            f"(got '{actual_type or 'unknown'}')."
+        )
+        raise typer.Exit(code=1)
+
+    return hostname, name
+
+
+@memory_app.command(name="show")
+def show_cmd(
+    claw_name: str = typer.Argument(..., help="Agent instance name"),
+) -> None:
+    """Show memory file paths and sizes for an openclaw agent."""
+    hostname, agent_name = _resolve_openclaw_for_cli(claw_name)
+
+    info = get_memory_info(hostname, agent_name)
+    if info is None:
+        console.print(
+            f"[yellow]Memory unavailable for '{claw_name}' on '{hostname}'.[/yellow]"
+        )
+        console.print(
+            "[dim]The agent may be unreachable, still installing, or in a "
+            "failed state. Run 'clm ps' to check status.[/dim]"
+        )
+        raise typer.Exit(code=1)
+
+    console.print(f"\n[bold]Agent:[/bold] {claw_name} ({hostname})")
+    console.print(f"[bold]Workspace:[/bold] {info['workspace_path']}")
+    console.print(f"[bold]Total size:[/bold] {_human_size(info['total_bytes'])}\n")
+
+    table = Table(show_header=True, box=None)
+    table.add_column("File", style="cyan")
+    table.add_column("Status")
+    table.add_column("Size", justify="right")
+
+    if not info["files"]:
+        console.print("  No memory files.")
+        return
+
+    for entry in info["files"]:
+        if entry["exists"]:
+            status = "[green]present[/green]"
+            size = _human_size(entry["size_bytes"])
+        else:
+            status = "[dim]missing[/dim]"
+            size = "-"
+        table.add_row(entry["relative_path"], status, size)
+
+    console.print(table)
+
+
+def _existing_files(hostname: str, agent_name: str) -> list[str] | None:
+    """Return relative paths of all existing memory files, or None on miss."""
+    info = get_memory_info(hostname, agent_name)
+    if info is None:
+        return None
+    return [f["relative_path"] for f in info["files"] if f["exists"]]
+
+
+@memory_app.command(name="delete")
+def delete_cmd(
+    claw_name: str = typer.Argument(..., help="Agent instance name"),
+    file: str | None = typer.Option(
+        None,
+        "--file",
+        "-f",
+        help="Single memory file to delete (e.g., SOUL.md or memory/2026-05-09.md).",
+    ),
+    all_files: bool = typer.Option(
+        False,
+        "--all",
+        help="Delete every memory file. Requires --force and a typed confirmation.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Skip the per-file confirmation prompt. Required for --all.",
+    ),
+) -> None:
+    """Delete one memory file or every memory file for the agent.
+
+    --all is gated by --force AND a typed agent-name confirmation so a
+    bulk wipe cannot happen by accident or by piped input.
+    """
+    if not file and not all_files:
+        console.print(
+            "[red]Error:[/red] specify either --file <name> or --all."
+        )
+        raise typer.Exit(code=1)
+    if file and all_files:
+        console.print(
+            "[red]Error:[/red] --file and --all are mutually exclusive."
+        )
+        raise typer.Exit(code=1)
+
+    hostname, agent_name = _resolve_openclaw_for_cli(claw_name)
+
+    if all_files:
+        if not force:
+            console.print(
+                "[red]Error:[/red] --all requires --force to acknowledge "
+                "the bulk delete."
+            )
+            raise typer.Exit(code=1)
+
+        targets = _existing_files(hostname, agent_name)
+        if targets is None:
+            console.print(
+                f"[yellow]Memory unavailable for '{claw_name}'.[/yellow] "
+                "Cannot enumerate files to delete."
+            )
+            raise typer.Exit(code=1)
+        if not targets:
+            console.print("No memory files to delete.")
+            raise typer.Exit(code=0)
+
+        console.print(
+            f"[yellow]About to delete {len(targets)} memory file(s) "
+            f"from '{claw_name}'.[/yellow]"
+        )
+        for path in targets:
+            console.print(f"  - {path}")
+
+        typed = typer.prompt(
+            f"Type the agent name '{claw_name}' to confirm",
+            default="",
+            show_default=False,
+        )
+        if typed.strip() != claw_name:
+            console.print("Cancelled.")
+            raise typer.Exit(code=1)
+
+        ok, err = delete_memory_files(hostname, agent_name, targets)
+    else:
+        if not force:
+            confirmed = typer.confirm(
+                f"Delete '{file}' from '{claw_name}'? This cannot be undone."
+            )
+            if not confirmed:
+                console.print("Cancelled.")
+                raise typer.Exit(code=0)
+
+        ok, err = delete_memory_files(hostname, agent_name, [file])
+
+    if not ok:
+        console.print(f"[red]Error:[/red] {err}")
+        raise typer.Exit(code=1)
+
+    if all_files:
+        console.print(
+            f"[green]Deleted {len(targets)} memory file(s) from "
+            f"'{claw_name}'.[/green]"
+        )
+    else:
+        console.print(f"[green]Deleted '{file}' from '{claw_name}'.[/green]")

--- a/src/clawrium/cli/memory.py
+++ b/src/clawrium/cli/memory.py
@@ -1,35 +1,43 @@
 """Memory management commands for openclaw agents.
 
-Surfaces ``clm agent <name> memory show|delete``. Thin layer over
-``clawrium.core.memory`` — argument parsing, confirmation flows, and
-human-readable rendering.
+Surfaces ``clm agent <name> memory show|delete`` (registered by
+``clawrium.cli.agent``). Thin layer over ``clawrium.core.memory`` —
+argument parsing, confirmation flows, and human-readable rendering.
 """
 
 from __future__ import annotations
 
+import sys
+from typing import Optional
+
 import typer
 from rich.console import Console
+from rich.markup import escape as rich_escape
 from rich.table import Table
 
+from clawrium.core.hosts import get_host
 from clawrium.core.memory import (
     delete_memory_files,
     get_memory_info,
 )
-from clawrium.core.hosts import get_host
 from clawrium.core.secrets import (
     AgentNotFoundError,
     get_installed_claw,
 )
 
-__all__ = ["memory_app", "show_cmd", "delete_cmd"]
+__all__ = ["show_cmd", "delete_cmd"]
 
 console = Console()
 
-memory_app = typer.Typer(
-    name="memory",
-    help="Inspect and manage memory for openclaw agents",
-    no_args_is_help=True,
-)
+
+def _stdin_is_tty() -> bool:
+    """Return True if stdin is connected to a terminal.
+
+    Wrapped in a module-level helper so tests can monkey-patch the TTY
+    check directly — CliRunner swaps ``sys.stdin`` per-invocation, so
+    patching ``sys.stdin.isatty`` does not stick across runner.invoke().
+    """
+    return sys.stdin.isatty()
 
 
 def _human_size(num_bytes: int) -> str:
@@ -51,37 +59,45 @@ def _resolve_openclaw_for_cli(claw_name: str) -> tuple[str, str]:
     try:
         hostname, agent_key, name = get_installed_claw(claw_name)
     except AgentNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
         raise typer.Exit(code=1)
 
     # get_installed_claw returns the agents-dict key as the second element,
     # which under the current schema is the agent name rather than the claw
     # type. Read the inner type field from the host record to validate.
     host = get_host(hostname)
-    record = (host or {}).get("agents", {}).get(agent_key, {})
+    if host is None:
+        console.print(
+            f"[red]Error:[/red] host '{rich_escape(hostname)}' not found "
+            f"in local config."
+        )
+        raise typer.Exit(code=1)
+
+    record = host.get("agents", {}).get(agent_key, {})
     actual_type = record.get("type") if isinstance(record, dict) else None
 
     if actual_type != "openclaw":
         console.print(
             f"[red]Error:[/red] memory is only supported for openclaw agents "
-            f"(got '{actual_type or 'unknown'}')."
+            f"(got '{rich_escape(actual_type or 'unknown')}')."
         )
         raise typer.Exit(code=1)
 
     return hostname, name
 
 
-@memory_app.command(name="show")
 def show_cmd(
     claw_name: str = typer.Argument(..., help="Agent instance name"),
 ) -> None:
     """Show memory file paths and sizes for an openclaw agent."""
     hostname, agent_name = _resolve_openclaw_for_cli(claw_name)
+    safe_claw = rich_escape(claw_name)
+    safe_host = rich_escape(hostname)
 
     info = get_memory_info(hostname, agent_name)
     if info is None:
         console.print(
-            f"[yellow]Memory unavailable for '{claw_name}' on '{hostname}'.[/yellow]"
+            f"[yellow]Memory unavailable for '{safe_claw}' on '{safe_host}'.[/yellow]"
         )
         console.print(
             "[dim]The agent may be unreachable, still installing, or in a "
@@ -89,8 +105,10 @@ def show_cmd(
         )
         raise typer.Exit(code=1)
 
-    console.print(f"\n[bold]Agent:[/bold] {claw_name} ({hostname})")
-    console.print(f"[bold]Workspace:[/bold] {info['workspace_path']}")
+    console.print(f"\n[bold]Agent:[/bold] {safe_claw} ({safe_host})")
+    console.print(
+        f"[bold]Workspace:[/bold] {rich_escape(info['workspace_path'])}"
+    )
     console.print(f"[bold]Total size:[/bold] {_human_size(info['total_bytes'])}\n")
 
     table = Table(show_header=True, box=None)
@@ -109,7 +127,7 @@ def show_cmd(
         else:
             status = "[dim]missing[/dim]"
             size = "-"
-        table.add_row(entry["relative_path"], status, size)
+        table.add_row(rich_escape(entry["relative_path"]), status, size)
 
     console.print(table)
 
@@ -122,13 +140,11 @@ def _existing_files(hostname: str, agent_name: str) -> list[str] | None:
     return [f["relative_path"] for f in info["files"] if f["exists"]]
 
 
-@memory_app.command(name="delete")
 def delete_cmd(
     claw_name: str = typer.Argument(..., help="Agent instance name"),
-    file: str | None = typer.Option(
+    file: Optional[str] = typer.Option(
         None,
         "--file",
-        "-f",
         help="Single memory file to delete (e.g., SOUL.md or memory/2026-05-09.md).",
     ),
     all_files: bool = typer.Option(
@@ -139,13 +155,15 @@ def delete_cmd(
     force: bool = typer.Option(
         False,
         "--force",
-        help="Skip the per-file confirmation prompt. Required for --all.",
+        "-f",
+        help="Skip the per-file confirmation prompt; required gate for --all.",
     ),
 ) -> None:
     """Delete one memory file or every memory file for the agent.
 
-    --all is gated by --force AND a typed agent-name confirmation so a
-    bulk wipe cannot happen by accident or by piped input.
+    --all is gated by --force AND a typed agent-name confirmation. The
+    typed confirmation is also TTY-gated so a piped 'yes <name>' cannot
+    silently bypass the safeguard.
     """
     if not file and not all_files:
         console.print(
@@ -159,6 +177,7 @@ def delete_cmd(
         raise typer.Exit(code=1)
 
     hostname, agent_name = _resolve_openclaw_for_cli(claw_name)
+    safe_claw = rich_escape(claw_name)
 
     if all_files:
         if not force:
@@ -168,10 +187,18 @@ def delete_cmd(
             )
             raise typer.Exit(code=1)
 
+        if not _stdin_is_tty():
+            console.print(
+                "[red]Error:[/red] --all --force requires an interactive "
+                "TTY for the typed confirmation. Refusing to proceed with "
+                "piped input."
+            )
+            raise typer.Exit(code=1)
+
         targets = _existing_files(hostname, agent_name)
         if targets is None:
             console.print(
-                f"[yellow]Memory unavailable for '{claw_name}'.[/yellow] "
+                f"[yellow]Memory unavailable for '{safe_claw}'.[/yellow] "
                 "Cannot enumerate files to delete."
             )
             raise typer.Exit(code=1)
@@ -181,10 +208,10 @@ def delete_cmd(
 
         console.print(
             f"[yellow]About to delete {len(targets)} memory file(s) "
-            f"from '{claw_name}'.[/yellow]"
+            f"from '{safe_claw}'.[/yellow]"
         )
         for path in targets:
-            console.print(f"  - {path}")
+            console.print(f"  - {rich_escape(path)}")
 
         typed = typer.prompt(
             f"Type the agent name '{claw_name}' to confirm",
@@ -208,13 +235,15 @@ def delete_cmd(
         ok, err = delete_memory_files(hostname, agent_name, [file])
 
     if not ok:
-        console.print(f"[red]Error:[/red] {err}")
+        console.print(f"[red]Error:[/red] {rich_escape(str(err))}")
         raise typer.Exit(code=1)
 
     if all_files:
         console.print(
             f"[green]Deleted {len(targets)} memory file(s) from "
-            f"'{claw_name}'.[/green]"
+            f"'{safe_claw}'.[/green]"
         )
     else:
-        console.print(f"[green]Deleted '{file}' from '{claw_name}'.[/green]")
+        console.print(
+            f"[green]Deleted '{rich_escape(file)}' from '{safe_claw}'.[/green]"
+        )

--- a/src/clawrium/core/memory.py
+++ b/src/clawrium/core/memory.py
@@ -288,6 +288,16 @@ def _run_memory_playbook(
 
 
 def _extract_failure_message(result, default: str) -> str:
+    # SSH/network failures land as runner_on_unreachable, not runner_on_failed.
+    # Prefer that signal so the user sees "Host unreachable: <reason>" rather
+    # than the generic playbook status string.
+    for event in result.events:
+        if event.get("event") == "runner_on_unreachable":
+            res = event.get("event_data", {}).get("res", {})
+            msg = res.get("msg")
+            if msg:
+                return f"Host unreachable: {msg}"
+            return "Host unreachable"
     for event in result.events:
         if event.get("event") == "runner_on_failed":
             res = event.get("event_data", {}).get("res", {})
@@ -496,10 +506,15 @@ def write_memory_file(
     except MemoryOpError as e:
         return False, str(e)
 
+    # Pass content as base64 so user-supplied bytes are never interpreted
+    # as Jinja2 by the playbook. Pairs with the b64decode filter in
+    # memory_write.yaml.
     extra_vars = {
         "agent_name": unix_name,
         "memory_filename": filename,
-        "memory_content": content,
+        "memory_content_b64": base64.b64encode(
+            content.encode("utf-8")
+        ).decode("ascii"),
     }
     result, log_dir, setup_error = _run_memory_playbook(
         host, "memory_write", extra_vars, timeout=60

--- a/src/clawrium/core/memory.py
+++ b/src/clawrium/core/memory.py
@@ -204,9 +204,13 @@ def _cleanup_artifacts(operation_log_dir: Path) -> None:
     """Remove ansible-runner artifacts that may contain inventory secrets.
 
     Mirrors the cleanup used in lifecycle._cleanup_ansible_artifacts so memory
-    operations do not leak SSH key paths or inventory contents on disk.
+    operations do not leak SSH key paths, extravars, or inventory contents on
+    disk. ``inventory/`` is included alongside ``artifacts/`` and ``env/``
+    because ansible-runner writes ``memory_content_b64`` and other extravars
+    there; without this, the security justification for removing ``no_log``
+    from the read playbook would only hold partway.
     """
-    for sub in ("artifacts", "env"):
+    for sub in ("artifacts", "env", "inventory"):
         target = operation_log_dir / sub
         if target.exists():
             try:

--- a/src/clawrium/core/memory.py
+++ b/src/clawrium/core/memory.py
@@ -362,11 +362,13 @@ def get_memory_info(hostname: str, agent_name: str) -> MemoryStats | None:
             return None
 
         # The memory_info playbook emits structured lines via the debug
-        # module (one msg per runner_on_ok event). Concatenate every msg
-        # value and parse the combined buffer.
+        # module. Standalone debug tasks surface as runner_on_ok events;
+        # debug tasks under a loop surface as runner_item_on_ok per
+        # iteration (the runner_on_ok aggregate just says "All items
+        # completed"). Collect msg from both.
         lines: list[str] = []
         for event in result.events:
-            if event.get("event") != "runner_on_ok":
+            if event.get("event") not in {"runner_on_ok", "runner_item_on_ok"}:
                 continue
             res = event.get("event_data", {}).get("res", {})
             msg = res.get("msg")

--- a/src/clawrium/platform/registry/openclaw/playbooks/memory_read.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/memory_read.yaml
@@ -30,7 +30,11 @@
       when: not memory_stat.stat.exists
 
     - name: Read memory file content
+      # no_log is intentionally NOT set: it would censor the runner event
+      # to {"censored": ...} and Python would never see the file content.
+      # The slurp result is base64-encoded and the runner's private data
+      # directory is 0700 with auto-cleanup of artifacts/ and env/ via
+      # _cleanup_artifacts, so this is acceptable for memory data.
       ansible.builtin.slurp:
         src: "{{ memory_target }}"
       register: memory_content
-      no_log: true

--- a/src/clawrium/platform/registry/openclaw/playbooks/memory_write.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/memory_write.yaml
@@ -33,10 +33,13 @@
       when: memory_filename is match('^memory/.*$')
 
     - name: Write memory file content
+      # Content is passed as base64 from Python so user-supplied bytes are
+      # never interpreted as Jinja2. Decoding via the b64decode filter
+      # produces the literal payload without re-templating.
       ansible.builtin.copy:
-        content: "{{ memory_content }}"
+        content: "{{ memory_content_b64 | b64decode }}"
         dest: "/home/{{ agent_name }}/.openclaw/workspace/{{ memory_filename }}"
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
-        mode: "0644"
+        mode: "0600"
       no_log: true

--- a/tests/test_cli_memory.py
+++ b/tests/test_cli_memory.py
@@ -1,12 +1,26 @@
 """Tests for CLI memory commands (clm agent <name> memory show|delete)."""
 
 import os
+import contextlib
 from typer.testing import CliRunner
 from unittest.mock import patch
 
 from clawrium.cli.main import app
 
 runner = CliRunner()
+
+
+@contextlib.contextmanager
+def _fake_tty():
+    """Make the CLI's TTY check return True for the duration of the block.
+
+    The CliRunner-injected stdin is a non-TTY pipe, which the --all --force
+    path correctly rejects. Tests that exercise the typed-confirmation
+    flow opt in to a TTY-like environment by patching the small helper
+    that wraps the isatty call.
+    """
+    with patch("clawrium.cli.memory._stdin_is_tty", return_value=True):
+        yield
 
 
 # `hosts_with_installed_claw` (defined in conftest.py) registers a single
@@ -210,7 +224,7 @@ def test_delete_all_force_requires_typed_confirmation(
             },
         ],
     }
-    with patch(
+    with _fake_tty(), patch(
         "clawrium.cli.memory.get_memory_info", return_value=info
     ), patch(
         "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
@@ -254,7 +268,7 @@ def test_delete_all_force_with_correct_name_proceeds(
             },
         ],
     }
-    with patch(
+    with _fake_tty(), patch(
         "clawrium.cli.memory.get_memory_info", return_value=info
     ), patch(
         "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
@@ -278,7 +292,7 @@ def test_delete_all_force_when_no_files(hosts_with_installed_claw):
         "total_bytes": 0,
         "files": [],
     }
-    with patch(
+    with _fake_tty(), patch(
         "clawrium.cli.memory.get_memory_info", return_value=info
     ), patch(
         "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
@@ -294,7 +308,7 @@ def test_delete_all_force_when_no_files(hosts_with_installed_claw):
 
 
 def test_delete_all_force_offline_host(hosts_with_installed_claw):
-    with patch(
+    with _fake_tty(), patch(
         "clawrium.cli.memory.get_memory_info", return_value=None
     ), patch(
         "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
@@ -307,3 +321,105 @@ def test_delete_all_force_offline_host(hosts_with_installed_claw):
     assert result.exit_code != 0
     assert "unavailable" in result.output.lower()
     mock_delete.assert_not_called()
+
+
+def test_delete_all_force_refuses_when_stdin_not_tty(hosts_with_installed_claw):
+    """B4: piped input must not be able to satisfy the typed confirmation.
+
+    The CliRunner default already provides a non-TTY stdin, so we just
+    invoke without _fake_tty and confirm the early refusal fires."""
+    with patch(
+        "clawrium.cli.memory.get_memory_info"
+    ) as mock_info, patch(
+        "clawrium.cli.memory.delete_memory_files"
+    ) as mock_delete:
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "delete", "work", "--all", "--force"],
+            input="work\n",
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    assert "TTY" in result.output
+    # The TTY guard fires before either core call.
+    mock_info.assert_not_called()
+    mock_delete.assert_not_called()
+
+
+# ----- routing fix coverage (B7) -------------------------------------------
+
+
+def test_show_rejects_non_openclaw_agent(isolated_config):
+    """Routing fix: agents with type != openclaw must be rejected with a
+    clear message rather than running memory ops against them."""
+    import json
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    (isolated_config / "hosts.json").write_text(
+        json.dumps(
+            [
+                {
+                    "hostname": "192.168.1.100",
+                    "alias": "server1",
+                    "port": 22,
+                    "agent_name": "xclm",
+                    "agents": {
+                        "zerowork": {
+                            "type": "zeroclaw",
+                            "agent_name": "zerowork",
+                            "name": "zerowork",
+                        }
+                    },
+                }
+            ]
+        )
+    )
+
+    result = runner.invoke(
+        app, ["agent", "memory", "show", "zerowork"], env=os.environ
+    )
+    assert result.exit_code != 0
+    assert "openclaw" in result.output.lower()
+    assert "zeroclaw" in result.output.lower()
+
+
+def test_delete_rejects_nonexistent_agent(hosts_with_installed_claw):
+    result = runner.invoke(
+        app,
+        ["agent", "memory", "delete", "ghost", "--file", "SOUL.md", "--force"],
+        env=os.environ,
+    )
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+
+
+def test_delete_all_surfaces_core_failure(hosts_with_installed_claw):
+    """When the underlying delete_memory_files returns (False, error) on the
+    --all path, the CLI must surface that error and exit non-zero rather
+    than printing a misleading success line."""
+    info = {
+        "workspace_path": "/home/opc-work/.openclaw/workspace",
+        "total_bytes": 50,
+        "files": [
+            {
+                "name": "SOUL.md",
+                "exists": True,
+                "size_bytes": 50,
+                "relative_path": "SOUL.md",
+            }
+        ],
+    }
+    with _fake_tty(), patch(
+        "clawrium.cli.memory.get_memory_info", return_value=info
+    ), patch(
+        "clawrium.cli.memory.delete_memory_files",
+        return_value=(False, "Host unreachable: timed out"),
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "delete", "work", "--all", "--force"],
+            input="work\n",
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    assert "Host unreachable" in result.output

--- a/tests/test_cli_memory.py
+++ b/tests/test_cli_memory.py
@@ -1,0 +1,309 @@
+"""Tests for CLI memory commands (clm agent <name> memory show|delete)."""
+
+import os
+from typer.testing import CliRunner
+from unittest.mock import patch
+
+from clawrium.cli.main import app
+
+runner = CliRunner()
+
+
+# `hosts_with_installed_claw` (defined in conftest.py) registers a single
+# openclaw agent — hostname=192.168.1.100, claw_type=openclaw, name=work,
+# unix agent_name=opc-work. All tests below use that fixture.
+
+
+# ----- show -----------------------------------------------------------------
+
+
+def test_show_renders_table_when_info_available(hosts_with_installed_claw):
+    info = {
+        "workspace_path": "/home/opc-work/.openclaw/workspace",
+        "total_bytes": 2048,
+        "files": [
+            {
+                "name": "SOUL.md",
+                "exists": True,
+                "size_bytes": 1024,
+                "relative_path": "SOUL.md",
+            },
+            {
+                "name": "USER.md",
+                "exists": False,
+                "size_bytes": 0,
+                "relative_path": "USER.md",
+            },
+            {
+                "name": "2026-05-09.md",
+                "exists": True,
+                "size_bytes": 1024,
+                "relative_path": "memory/2026-05-09.md",
+            },
+        ],
+    }
+    with patch("clawrium.cli.memory.get_memory_info", return_value=info):
+        result = runner.invoke(
+            app, ["agent", "memory", "show", "work"], env=os.environ
+        )
+    assert result.exit_code == 0, result.output
+    assert "SOUL.md" in result.output
+    assert "USER.md" in result.output
+    assert "memory/2026-05-09.md" in result.output
+    # Total rendered as human-readable.
+    assert "2.0 KB" in result.output
+
+
+def test_show_exits_nonzero_when_agent_not_found(hosts_with_installed_claw):
+    result = runner.invoke(
+        app, ["agent", "memory", "show", "ghost"], env=os.environ
+    )
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+
+
+def test_show_exits_with_unavailable_message_on_offline_host(
+    hosts_with_installed_claw,
+):
+    with patch("clawrium.cli.memory.get_memory_info", return_value=None):
+        result = runner.invoke(
+            app, ["agent", "memory", "show", "work"], env=os.environ
+        )
+    assert result.exit_code != 0
+    assert "unavailable" in result.output.lower()
+
+
+# ----- delete: argument validation -----------------------------------------
+
+
+def test_delete_requires_file_or_all(hosts_with_installed_claw):
+    result = runner.invoke(
+        app, ["agent", "memory", "delete", "work"], env=os.environ
+    )
+    assert result.exit_code != 0
+    assert "either --file" in result.output
+
+
+def test_delete_rejects_file_and_all_together(hosts_with_installed_claw):
+    result = runner.invoke(
+        app,
+        ["agent", "memory", "delete", "work", "--file", "SOUL.md", "--all"],
+        env=os.environ,
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+# ----- delete: single file --------------------------------------------------
+
+
+def test_delete_single_file_with_confirmation(hosts_with_installed_claw):
+    with patch(
+        "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
+    ) as mock_delete:
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "delete", "work", "--file", "SOUL.md"],
+            input="y\n",
+            env=os.environ,
+        )
+    assert result.exit_code == 0, result.output
+    assert "Deleted 'SOUL.md'" in result.output
+    args, _kwargs = mock_delete.call_args
+    assert args[2] == ["SOUL.md"]
+
+
+def test_delete_single_file_cancelled(hosts_with_installed_claw):
+    with patch(
+        "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
+    ) as mock_delete:
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "delete", "work", "--file", "SOUL.md"],
+            input="n\n",
+            env=os.environ,
+        )
+    assert result.exit_code == 0
+    assert "Cancelled" in result.output
+    mock_delete.assert_not_called()
+
+
+def test_delete_single_file_with_force_skips_prompt(hosts_with_installed_claw):
+    with patch(
+        "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
+    ) as mock_delete:
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "memory",
+                "delete",
+                "work",
+                "--file",
+                "memory/2026-05-09.md",
+                "--force",
+            ],
+            env=os.environ,
+        )
+    assert result.exit_code == 0, result.output
+    assert "Deleted 'memory/2026-05-09.md'" in result.output
+    mock_delete.assert_called_once()
+
+
+def test_delete_single_file_surfaces_core_error(hosts_with_installed_claw):
+    with patch(
+        "clawrium.cli.memory.delete_memory_files",
+        return_value=(False, "agent unreachable"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "memory",
+                "delete",
+                "work",
+                "--file",
+                "SOUL.md",
+                "--force",
+            ],
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    assert "agent unreachable" in result.output
+
+
+# ----- delete --all gating --------------------------------------------------
+
+
+def test_delete_all_without_force_refuses(hosts_with_installed_claw):
+    with patch(
+        "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
+    ) as mock_delete:
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "delete", "work", "--all"],
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    assert "--force" in result.output
+    mock_delete.assert_not_called()
+
+
+def test_delete_all_force_requires_typed_confirmation(
+    hosts_with_installed_claw,
+):
+    info = {
+        "workspace_path": "/home/opc-work/.openclaw/workspace",
+        "total_bytes": 100,
+        "files": [
+            {
+                "name": "SOUL.md",
+                "exists": True,
+                "size_bytes": 50,
+                "relative_path": "SOUL.md",
+            },
+            {
+                "name": "USER.md",
+                "exists": True,
+                "size_bytes": 50,
+                "relative_path": "USER.md",
+            },
+        ],
+    }
+    with patch(
+        "clawrium.cli.memory.get_memory_info", return_value=info
+    ), patch(
+        "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
+    ) as mock_delete:
+        # Wrong typed name → cancelled.
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "delete", "work", "--all", "--force"],
+            input="not-the-name\n",
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    assert "Cancelled" in result.output
+    mock_delete.assert_not_called()
+
+
+def test_delete_all_force_with_correct_name_proceeds(
+    hosts_with_installed_claw,
+):
+    info = {
+        "workspace_path": "/home/opc-work/.openclaw/workspace",
+        "total_bytes": 100,
+        "files": [
+            {
+                "name": "SOUL.md",
+                "exists": True,
+                "size_bytes": 50,
+                "relative_path": "SOUL.md",
+            },
+            {
+                "name": "USER.md",
+                "exists": False,
+                "size_bytes": 0,
+                "relative_path": "USER.md",
+            },
+            {
+                "name": "2026-05-09.md",
+                "exists": True,
+                "size_bytes": 50,
+                "relative_path": "memory/2026-05-09.md",
+            },
+        ],
+    }
+    with patch(
+        "clawrium.cli.memory.get_memory_info", return_value=info
+    ), patch(
+        "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
+    ) as mock_delete:
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "delete", "work", "--all", "--force"],
+            input="work\n",
+            env=os.environ,
+        )
+    assert result.exit_code == 0, result.output
+    # Only existing files are deleted; USER.md (missing) is excluded.
+    args, _kwargs = mock_delete.call_args
+    assert sorted(args[2]) == ["SOUL.md", "memory/2026-05-09.md"]
+    assert "Deleted 2 memory file(s)" in result.output
+
+
+def test_delete_all_force_when_no_files(hosts_with_installed_claw):
+    info = {
+        "workspace_path": "/home/opc-work/.openclaw/workspace",
+        "total_bytes": 0,
+        "files": [],
+    }
+    with patch(
+        "clawrium.cli.memory.get_memory_info", return_value=info
+    ), patch(
+        "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
+    ) as mock_delete:
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "delete", "work", "--all", "--force"],
+            env=os.environ,
+        )
+    assert result.exit_code == 0
+    assert "No memory files" in result.output
+    mock_delete.assert_not_called()
+
+
+def test_delete_all_force_offline_host(hosts_with_installed_claw):
+    with patch(
+        "clawrium.cli.memory.get_memory_info", return_value=None
+    ), patch(
+        "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
+    ) as mock_delete:
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "delete", "work", "--all", "--force"],
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    assert "unavailable" in result.output.lower()
+    mock_delete.assert_not_called()


### PR DESCRIPTION
## Summary

Phase 2 of #210 — the user-facing CLI for openclaw memory, built on top of the Phase 1 core module merged in #306.

```
clm agent <name> memory show
clm agent <name> memory delete --file <f> [--force]
clm agent <name> memory delete --all --force   # + typed confirmation, TTY-only
```

## Commands

### `show`

Resolves the agent, fetches `MemoryStats`, and prints workspace path, total size, and a per-file table (status + human-readable size).

```
$ clm agent memory show wolf-i

Agent: wolf-i (192.168.1.36)
Workspace: /home/wolf-i/.openclaw/workspace
Total size: 6.5 KB

 File                  Status     Size 
 SOUL.md               present  1.1 KB 
 IDENTITY.md           present   775 B 
 USER.md               present   477 B 
 TOOLS.md              present  1.2 KB 
 memory/2026-04-17.md  present  1.8 KB 
 memory/2026-05-09.md  present  1.2 KB
```

If the host is unreachable / the agent is still installing, exits 1 with `Memory unavailable for '<name>' on '<host>'.` and a hint to run `clm ps`.

### `delete --file <f>`

Deletes a single workspace-relative path (`SOUL.md`, `memory/YYYY-MM-DD.md`, …). Prompts for confirmation unless `--force`.

### `delete --all --force` (Gap #6)

Bulk delete every existing memory file. Layered safety:

1. `--all` without `--force` is refused outright.
2. `--all --force` requires an interactive TTY — piped input is refused before any prompt.
3. Lists every file that will be removed, then requires the user to type the agent name verbatim. Anything else cancels with exit 1.

## Routing fix

`get_installed_claw` returns `(hostname, claw_type, claw_name)` — but its second element is the agents-dict key, which under the current schema is the agent name, not the claw type. The CLI reads the inner `type` field from the host record to validate `openclaw` rather than trusting the misnamed return slot. This avoids breaking secrets/integrations consumers that already rely on the existing return shape. Renaming the API slot is tracked as an out-of-scope follow-up.

## Core parser fix included

The Phase 1 `memory_info` playbook emits per-file data via `debug` inside a loop. Ansible surfaces those iterations as `runner_item_on_ok` events; the standalone debug task surfaces as `runner_on_ok`. The parser in `get_memory_info` now consumes both event types so the file list and totals are non-empty against real hosts. (Caught during live testing — unit tests had been mocking the easier event path.)

## Bonus core fix included

`memory_read.yaml`'s slurp had `no_log: true`, which censored the runner event to `{"censored": ...}` and silently broke `read_memory_file` in real (non-mocked) use. Phase 1 unit tests mocked the `content` field directly so they passed despite the defect. Caught during ATX-Round-1 live verification of the new base64 write path; the slurp result is base64-encoded and the runner private data dir is 0700 with auto-cleanup of `artifacts/`, `env/`, **and `inventory/`** (the latter added in Round 2 to fully back the no-`no_log` rationale).

## Testing

### Test Results

- [x] All existing tests pass — 1409 tests
- [x] Linter passes — `make lint` clean
- [x] 18 new tests in `tests/test_cli_memory.py`
- [x] All 4 playbooks parse — `ansible-playbook --syntax-check`

### Manual Testing (live, against real openclaw on `wolf-i`)

- `clm agent memory show wolf-i` → renders 6 files / 6.5 KB
- `clm agent memory show maurice` → renders 4 files / 2.8 KB
- `write_memory_file → show (file present) → delete --file <f> → show (file gone)` round-trip on `e2e-roundtrip.md`
- `delete --file ... ` with interactive `n` → cancelled, file still present
- `delete --all` (no `--force`) → refuses with `--all requires --force`
- `delete --all --force` with wrong typed name → cancelled
- `echo "wolf-i" | clm ... delete --all --force` → refused by TTY guard before any prompt
- `write_memory_file` with content containing `{{ lookup("file", "/etc/passwd") }}` round-trips byte-for-byte (B1 verified — content not re-templated by Ansible)

### Security Checklist

- [x] No hardcoded secrets or credentials
- [x] Path traversal validation deferred to Phase 1 core (`.`/`..` rejection at both Python and Ansible layers)
- [x] Rich markup injection mitigated via `rich_escape` on all user-controlled strings
- [x] Jinja2 template injection mitigated via base64-encoded `memory_content_b64` + `b64decode` filter
- [x] `--all --force` typed confirmation is TTY-gated (cannot be satisfied via piped input)
- [x] Memory files written with mode `0600`
- [x] ansible-runner working directory (`artifacts/`, `env/`, `inventory/`) wiped after every operation

## ATX Review Summary

**Final Review (Round 2): Rating 4/5 — no blocking issues**
**Total Cost: ~$2.10 | Total Time: ~25 min across 2 rounds**

| Review | Rating | Blocking Issues | Status | Cost | Time |
|--------|--------|-----------------|--------|------|------|
| 1 | 2/5 | B1, B2, B3, B4, B5, B6, B7 | All fixed except B5 (out-of-scope) | $1.95 | ~10m |
| 2 | 4/5 | None | Ready (W1 inventory cleanup also addressed in `9d4c822`) | ~$0.15 | ~15m |

> One Round 2 specialist flagged a B1 about `Panel()` rendering memory file content unescaped — false positive, no `Panel()` usage exists in `cli/memory.py`. The leader-level verdict was "No blocking issues remain. The code is ready to merge." All other specialists agreed.

<details>
<summary>Round 1 — Rating 2/5</summary>

**Specialist ratings:** cli-ux 2/5, lifecycle-state 3/5, test-coverage 2/5, secrets-provider 3/5, ansible-playbook 2/5

**Blocking issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `core/memory.py:499`, `memory_write.yaml:37` | Jinja2 template injection: `content: "{{ memory_content }}"` evaluates user-supplied bytes if they contain `{{ ... }}`; also serializes plaintext to `env/extravars` on disk | Fixed in `fac0cf3` — base64-encode `memory_content_b64` from Python; `memory_write.yaml` decodes via `b64decode` filter. Live-verified content like `{{ lookup("file", "/etc/passwd") }}` round-trips literally. |
| B2 | `cli/memory.py:43` | `--file` claimed `-f`, colliding with the established `-f` for `--force` across other `clm` commands | Fixed in `fac0cf3` — removed `-f` short from `--file`; `-f` now binds to `--force`. |
| B3 | `cli/memory.py` (8 sites) | Rich markup injection: `claw_name`, `hostname`, `file`, `err` interpolated raw into Rich strings | Fixed in `fac0cf3` — `rich_escape()` applied to every user-controlled value, matching the `agent.py` pattern. |
| B4 | `cli/memory.py:195` | Typed-name confirmation bypassable via `echo 'name' | clm ... delete --all --force`. Module docstring claimed to prevent piped-input bypass; implementation didn't enforce it. | Fixed in `fac0cf3` — `_stdin_is_tty()` helper guard refuses non-TTY stdin before any prompt. Live-verified rejecting piped `echo "wolf-i" | ...`. |
| B5 | `core/secrets.py:268-275` | `get_installed_claw` returns the agents-dict key as `claw_type`, but under the current schema that's the agent name. All `secret.py` callers consume the misidentified value. | Out-of-scope — tracked as a follow-up. Phase 2 works around it by reading `type` from the host record. Renaming the API slot would refactor every existing caller. |
| B6 | `core/memory.py:528-540` | `_extract_failure_message` only handled `runner_on_failed`; SSH/network failures land as `runner_on_unreachable` and were swallowed | Fixed in `fac0cf3` — now reads `runner_on_unreachable` first and surfaces `Host unreachable: <reason>`. |
| B7 | `tests/test_cli_memory.py` | Missing tests: non-openclaw rejection, delete on nonexistent agent, `--all` core-failure path | Fixed in `fac0cf3` — 3 new tests added; `--all` without `--force` refusal was already covered. |

**Warnings (Round 1):** W2 (dead `memory_app` Typer) and W5 (file mode 0644 → 0600) fixed in `fac0cf3`. Other warnings (W1, W3, W4, W6, W7, W8) acknowledged or out-of-scope.

**Bonus fix in `fac0cf3`:** removed `no_log: true` from `memory_read.yaml`'s slurp — was censoring runner events to `{"censored": ...}` and silently breaking `read_memory_file` in real use. Phase 1 unit tests had mocked the `content` field directly so the defect shipped to main.

</details>

<details>
<summary>Round 2 — Rating 4/5 (Final)</summary>

**Specialist ratings:** cli-ux, ansible-playbook, secrets-provider, lifecycle-state, test-coverage all confirmed Round 1 fixes verified.

**Round 1 fix verification (all confirmed):**

| R1 # | Status |
|------|--------|
| B1 (b64) | Fixed — encode/decode chain correct, Jinja content preserved literally |
| B2 (-f) | Fixed — no flag collisions remain |
| B3 (rich_escape) | Fixed — applied to all user-controlled strings |
| B4 (TTY guard) | Fixed — non-TTY rejected with clear message |
| B5 (rename) | Acceptable deferral — no inconsistency introduced |
| B6 (unreachable) | Fixed — both event types handled |
| B7 (tests) | Fixed — all 4 tests well-structured |
| W2 (dead Typer) | Fixed — removed cleanly |
| W5 (0600) | Fixed — enforced in playbook |
| Bonus (`no_log` removal) | Justified |

**No blocking issues remain.**

**Round 2 warnings:**

| # | Status | Issue |
|---|--------|-------|
| W1 (inventory cleanup gap) | Fixed in `9d4c822` — `_cleanup_artifacts` now wipes `inventory/` alongside `artifacts/` and `env/`, fully backing the no-`no_log` rationale |
| W2 (`hosts_with_installed_claw` keys agents by type, not name) | Acknowledged — pre-existing fixture; tracked as follow-up since fixing it would touch many existing tests |
| W3 (`agent.py` has 24 unescaped `console.print` sites) | Acknowledged — broader refactor; tracked as follow-up |
| W4 (missing test for empty `show` files list, status-column rendering, `mock_delete.call_args` verification) | Acknowledged — minor coverage gap; tracked as follow-up |

**False positive:** one specialist flagged a B1 about `Panel()` rendering memory file content unescaped. No `Panel()` usage exists in `cli/memory.py` — the CLI doesn't render file content (that's deferred to Phase 4 TUI edit). Discounted.

</details>

## What's deferred

- Phase 3: TUI MEMORY card with size and paths
- Phase 4: TUI edit → sync → restart (incl. Gap #3 restart confirm + Gap #4 concurrent-edit safety + onboarding-state guard for writes)
- Phase 5: docs
- Follow-ups tracked: rename `get_installed_claw` second slot (B5), `hosts_with_installed_claw` fixture key migration (Round 2 W2), `agent.py` rich_escape sweep (Round 2 W3)

## Reviewer Notes

Does **not** close #210 — the issue-level acceptance for "CLI supports `clm agent <name> memory show|delete`" gets satisfied here. The remaining checkboxes will close as Phases 3–5 merge.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>