### PR TITLE
feat(memory): clm agent <name> memory edit <file>

### DIFF
--- a/.itx/308/00_PLAN.md
+++ b/.itx/308/00_PLAN.md
@@ -1,0 +1,282 @@
+# Issue #308 — `clm agent memory edit` (CLI)
+
+## Overview
+
+Add a `clm agent <name> memory edit <file>` command that fetches a memory file
+from a remote openclaw agent, opens it in `$EDITOR`, and on a successful save
+syncs the content back and (optionally) restarts the agent. This is the
+CLI-only first iteration of the Phase 4 "edit" capability from #210; the TUI
+flow tracked under #210 will later wrap the same primitives.
+
+All core primitives already exist:
+
+- `clawrium.core.memory.read_memory_file` (issue #307)
+- `clawrium.core.memory.write_memory_file` (issue #307)
+- `clawrium.core.lifecycle.restart_agent`
+
+The work is **glue + UX**: a new CLI handler in `src/clawrium/cli/memory.py`,
+wiring in `src/clawrium/cli/agent.py`, and a comprehensive test pass in
+`tests/test_cli_memory.py`. No new core module surface, no new playbook.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/clawrium/cli/memory.py` | Add `edit_cmd(...)` handler + `_resolve_editor()` + `_run_editor()` helpers. Reuse existing `_resolve_openclaw_for_cli`, `_stdin_is_tty`. Export `edit_cmd` in `__all__`. |
+| `src/clawrium/cli/agent.py` | Add `@memory_app.command(name="edit")` wrapper that delegates to `edit_cmd`. Mirrors existing `memory_show` / `memory_delete` pattern at lines 2113-2146. |
+| `tests/test_cli_memory.py` | Add tests covering every acceptance-criteria scenario. |
+
+No new files. No changes to `src/clawrium/core/memory.py` or `lifecycle.py`.
+
+## Implementation Steps
+
+### Step 1 — Editor resolution helper (`cli/memory.py`)
+
+```python
+def _resolve_editor(explicit: str | None) -> list[str]:
+    """Resolve editor command to argv list.
+
+    Precedence: --editor > $VISUAL > $EDITOR > 'vi'.
+    Returned as a list so subprocess.run(...) can be invoked without shell=True.
+    Uses shlex.split so users may set 'EDITOR=code --wait' and have it parsed
+    safely (still no shell expansion).
+    """
+```
+
+- Precedence matches git's editor resolution as called out in the issue's
+  Implementation Notes.
+- `shlex.split` lets users pass flags (e.g. `code --wait`, `nvim -p`) without
+  introducing shell injection.
+- Final fallback is `["vi"]`. Do **not** silently default to anything that
+  could exist as an unexpected binary on PATH.
+
+### Step 2 — Editor invocation helper
+
+```python
+def _run_editor(editor_argv: list[str], file_path: str) -> int:
+    """Spawn editor as a child process. Returns exit code.
+
+    Wrapped so tests can monkey-patch a single function rather than each
+    subprocess.run call site.
+    """
+    return subprocess.run([*editor_argv, file_path], check=False).returncode
+```
+
+`shell=False` is implicit (default). Issue's acceptance criterion explicitly
+forbids `shell=True`.
+
+### Step 3 — Main `edit_cmd` handler
+
+Signature:
+
+```python
+def edit_cmd(
+    claw_name: str,
+    file: str,
+    editor: Optional[str] = None,
+    no_restart: bool = False,
+    force: bool = False,
+) -> None:
+```
+
+Flow (mirrors the issue's "Flow" section verbatim — the issue is the spec):
+
+1. `hostname, agent_name = _resolve_openclaw_for_cli(claw_name)` — reuses
+   existing non-openclaw / not-found rejection.
+2. `original = read_memory_file(hostname, agent_name, file)`. If `None`,
+   print **the same** "Memory unavailable" pair of lines as `show_cmd` and
+   `raise typer.Exit(code=1)`. Use the existing wording so error messaging
+   is consistent across `show`/`delete`/`edit`.
+3. `original_hash = hashlib.sha256(original.encode("utf-8")).digest()` —
+   used both for change-detection (step 6) and for conflict detection
+   (step 7).
+4. Create a temp file:
+   - Use `tempfile.NamedTemporaryFile(delete=False, mode="w",
+     encoding="utf-8", suffix=Path(file).suffix)` so editors get correct
+     syntax highlighting from the suffix.
+   - Prefer `dir=os.environ.get("XDG_RUNTIME_DIR")` when that var is set
+     and the directory exists; otherwise default tempfile location.
+   - Immediately `os.chmod(path, 0o600)` after creation.
+   - Wrap the entire post-creation flow in `try` / `finally`; the `finally`
+     unconditionally `os.unlink`s the temp path (suppress
+     `FileNotFoundError` if the editor deleted it).
+5. Write `original` to the temp file, flush, close handle.
+6. `exit_code = _run_editor(_resolve_editor(editor), tmp_path)`.
+7. Post-edit checks (in order — first-match short-circuits):
+   - **Editor exit non-zero** → print `"Editor exited non-zero ({code}). No
+     changes."` and `Exit(code=0)`. Non-zero from the editor is a user
+     cancellation, not a clm error — exit 0 to match the "no-op" semantics.
+   - **Temp file gone** (`FileNotFoundError` on read) → print `"Edit
+     cancelled (temp file removed)."` and `Exit(code=0)`.
+   - **Content unchanged** (sha256 of new == `original_hash`) → print
+     `"No changes."` and `Exit(code=0)`.
+8. `new_content = tmp_path.read_text(encoding="utf-8")`.
+   `len(new_content.encode("utf-8")) > MAX_MEMORY_CONTENT_BYTES` → print
+   `"Error: edit exceeds maximum size (... bytes). Aborted; remote file
+   unchanged."` and `Exit(code=1)`. Don't even attempt the write — keep
+   the agent's copy of the file pristine.
+9. `ok, err = write_memory_file(hostname, agent_name, file, new_content)`.
+   On `not ok`, print `f"[red]Error:[/red] {rich_escape(str(err))}"` and
+   `Exit(code=1)` — same surface as `delete_cmd`. **No conflict
+   detection** — last writer wins. Trade-off explicitly accepted to keep
+   the first iteration simple; revisit if it becomes a real problem in
+   practice.
+10. Restart logic:
+    - If `no_restart`: print `f"[green]Saved '{file}' to '{claw_name}'.
+      Skipping restart (--no-restart).[/green]"` and return.
+    - If `force`: skip prompt, restart immediately.
+    - Else: gate on `_stdin_is_tty()`. Non-TTY without `--force` → print
+      `"Error: restart requires either --force or an interactive TTY.
+      File saved; agent NOT restarted."` and `Exit(code=1)`. (Mirrors the
+      `delete_cmd --all` TTY gate. Saving is fine; silently restarting a
+      live agent on piped input is not.)
+    - On TTY, prompt `typer.confirm(f"Restart agent '{claw_name}' to apply
+      changes?", default=False)`. If declined, print `"Saved. Agent not
+      restarted; new memory takes effect on next restart."` and exit 0.
+11. On confirmed restart, call `restart_agent(hostname, "openclaw",
+    agent_name=agent_name)` (`_resolve_openclaw_for_cli` already
+    guaranteed the type is openclaw). Surface result['success'] / error
+    in the standard `[green]/[red]` style.
+
+### Step 4 — Wire into Typer (`cli/agent.py`)
+
+Add immediately after `memory_delete` (line ~2146), before
+`agent_app.add_typer(memory_app, name="memory")` at line 2149:
+
+```python
+@memory_app.command(name="edit")
+def memory_edit(
+    claw_name: str = typer.Argument(..., help="Agent instance name"),
+    file: str = typer.Argument(..., help="Workspace-relative file (e.g., SOUL.md or memory/2026-05-09.md)."),
+    editor: Optional[str] = typer.Option(
+        None, "--editor",
+        help="Editor command. Defaults to $VISUAL, then $EDITOR, then 'vi'.",
+    ),
+    no_restart: bool = typer.Option(
+        False, "--no-restart",
+        help="Save the edit but skip restarting the agent.",
+    ),
+    force: bool = typer.Option(
+        False, "--force", "-f",
+        help="Skip the restart confirmation prompt.",
+    ),
+) -> None:
+    """Edit a memory file in $EDITOR; sync changes back and restart agent."""
+    from clawrium.cli.memory import edit_cmd
+
+    edit_cmd(
+        claw_name=claw_name,
+        file=file,
+        editor=editor,
+        no_restart=no_restart,
+        force=force,
+    )
+```
+
+### Step 5 — Tests (`tests/test_cli_memory.py`)
+
+Add a class `TestMemoryEdit` (or a flat test block) with these cases. Use
+the same `hosts_with_installed_claw` fixture used by existing memory
+tests. Patch `clawrium.cli.memory._run_editor` to simulate editor
+behaviour without spawning a real subprocess.
+
+Required tests (one per acceptance-criteria scenario):
+
+| # | Test | What it asserts |
+|---|------|-----------------|
+| 1 | `test_edit_happy_path_writes_and_restarts` | TTY=on, `_run_editor` mutates the temp file → confirm prompt accepted → `write_memory_file` called with new content → `restart_agent` called → exit 0, "Saved" + "Restarted" output. |
+| 2 | `test_edit_unchanged_does_not_write_or_restart` | `_run_editor` returns 0 without changing the file → "No changes." printed → `write_memory_file` and `restart_agent` NOT called → exit 0. |
+| 3 | `test_edit_editor_nonzero_exit_does_not_write` | `_run_editor` returns 1 → "Editor exited non-zero" message → no write/restart → exit 0. |
+| 4 | `test_edit_temp_file_deleted_does_not_write` | `_run_editor` deletes the temp file → "Edit cancelled (temp file removed)." → no write/restart → exit 0. |
+| 5 | `test_edit_oversized_content_aborts_before_write` | `_run_editor` writes content > `MAX_MEMORY_CONTENT_BYTES`. → exceeds-size error → no write/restart → exit 1. |
+| 6 | `test_edit_unreachable_on_initial_read` | `read_memory_file` returns None → "Memory unavailable" → editor never spawned → exit 1. |
+| 7 | `test_edit_write_failure_surfaces_error` | `write_memory_file` returns `(False, "playbook failed")` → red error printed → restart NOT called → exit 1. |
+| 8 | `test_edit_restart_confirmation_declined` | TTY=on, edit succeeds, prompt input is "n" → write happens, restart NOT called → exit 0. |
+| 9 | `test_edit_no_restart_flag_skips_restart` | `--no-restart` → write happens, restart NOT called, no prompt shown → exit 0. |
+| 10 | `test_edit_force_skips_confirmation` | `--force`, write succeeds → restart called without prompt → exit 0. |
+| 11 | `test_edit_non_tty_without_force_refuses_restart` | Patch `_stdin_is_tty` False, no `--force` → write succeeds, restart refused, error message, exit 1. |
+| 12 | `test_edit_temp_file_always_cleaned_up` | After a write failure, assert the temp file path no longer exists. Also assert mode 0o600 while it does exist (capture in the patched `_run_editor`). |
+| 13 | `test_edit_rejects_path_traversal` | `<file>=../../../etc/passwd`. Re-uses `_validate_memory_filename` via `read_memory_file` returning None → "Memory unavailable" exit. (Lighter than re-asserting the validator; the gate is enforced inside the core primitive.) |
+| 14 | `test_edit_rejects_non_openclaw_agent` | Mirror of `test_show_rejects_non_openclaw_agent`. |
+| 15 | `test_edit_no_shell_invocation` | Patch `subprocess.run` directly, assert `shell` not in kwargs OR explicitly False, and that argv is a list. |
+
+Tests 1, 8, 10, 11 require a TTY mock — patch
+`clawrium.cli.memory._stdin_is_tty` per the established pattern (see
+`test_delete_all_force_refuses_when_stdin_not_tty`).
+
+### Step 6 — Verification
+
+```bash
+make format
+make lint
+make test
+```
+
+All must pass. Then update `AGENTS.md` only if there is a CLI surface
+catalogue (there is not — skip).
+
+## Test Strategy
+
+- **Unit tests** above cover every acceptance-criteria bullet. The
+  `_run_editor` seam is the key to keeping tests fast (no subprocess).
+- **Manual smoke** (recommended before commit, not gated):
+  1. Install an openclaw on a test host.
+  2. `clm agent memory edit <agent> SOUL.md` → modify in `vi` → `:wq` →
+     observe restart.
+  3. Repeat with `EDITOR='code --wait'` to confirm `shlex.split` parses
+     the flag correctly.
+  4. `--no-restart`: edit, exit, confirm no restart line in output.
+  5. Pipe `yes ""` into `clm agent memory edit ...` (no `--force`) →
+     should refuse with the TTY error.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| User sets `$EDITOR` to a non-blocking GUI editor (`code` without `--wait`, `subl` without `-w`). Editor returns immediately, content unchanged → silently treated as no-op. | Document in `--help`: "GUI editors must be invoked with their wait flag (e.g., `--editor 'code --wait'`)." Out of scope to detect. |
+| Editor preserves an unrelated trailing newline policy that hash-flips the file → spurious write/restart. | Acceptable. Hash compares raw bytes; if the editor changed the file, it changed the file. |
+| `XDG_RUNTIME_DIR` exists but is unwritable. | `tempfile.NamedTemporaryFile` raises `OSError` → caught at top level, surfaced as red error, exit 1. Fallback to default tempfile dir if `XDG_RUNTIME_DIR` is unset. |
+| Concurrent-edit race: agent writes to `memory/<today>.md` while user is editing → user's save clobbers the agent's interim writes (or vice versa). | **Accepted** for the first iteration. Last writer wins. Keeps the implementation simple; revisit only if it bites in practice. Diverges from the issue's "Concurrent-edit safety" section — captured below in *Deviations from issue*. |
+
+## Deviations from issue
+
+The issue's "Concurrent-edit safety" section mandates a re-read + hash
+compare before write, with a special-case allowlist for identity files.
+This plan **drops conflict detection entirely**. Last writer wins.
+
+Rationale: the safety net is partial anyway (race window remains between
+re-read and write), the implementation cost is non-trivial (extra
+round-trip + branching error paths + 2 extra tests), and the surface
+where it actually matters (`memory/<today>.md` while the agent is live)
+is narrow. Defer until there's evidence it's needed.
+
+The corresponding acceptance-criterion bullet ("Conflict detection:
+re-read before write…") is not satisfied by this plan. Confirm with
+issue owner before merging if this matters.
+
+## Subtasks
+
+None — single task execution. Two-file change with a contained test pass.
+
+## Out of Scope (per issue)
+
+- TUI edit flow (Phase 4 of #210).
+- 3-way merge / conflict resolution UI.
+- Diff preview before write.
+- Multi-file edit in one invocation.
+
+---
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: planning
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-05-09T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-plan-create 308
+```
+
+</details>

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -2146,6 +2146,42 @@ def memory_delete(
     delete_cmd(claw_name=claw_name, file=file, all_files=all_files, force=force)
 
 
+@memory_app.command(name="edit")
+def memory_edit(
+    claw_name: str = typer.Argument(..., help="Agent instance name"),
+    file: str = typer.Argument(
+        ...,
+        help="Workspace-relative file (e.g., SOUL.md or memory/2026-05-09.md).",
+    ),
+    editor: Optional[str] = typer.Option(
+        None,
+        "--editor",
+        help="Editor command. Defaults to $VISUAL, then $EDITOR, then 'vi'.",
+    ),
+    no_restart: bool = typer.Option(
+        False,
+        "--no-restart",
+        help="Save the edit but skip restarting the agent.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Skip the restart confirmation prompt.",
+    ),
+) -> None:
+    """Edit a memory file in $EDITOR; sync changes back and restart agent."""
+    from clawrium.cli.memory import edit_cmd
+
+    edit_cmd(
+        claw_name=claw_name,
+        file=file,
+        editor=editor,
+        no_restart=no_restart,
+        force=force,
+    )
+
+
 agent_app.add_typer(memory_app, name="memory")
 
 

--- a/src/clawrium/cli/memory.py
+++ b/src/clawrium/cli/memory.py
@@ -1,13 +1,19 @@
 """Memory management commands for openclaw agents.
 
-Surfaces ``clm agent <name> memory show|delete`` (registered by
+Surfaces ``clm agent <name> memory show|delete|edit`` (registered by
 ``clawrium.cli.agent``). Thin layer over ``clawrium.core.memory`` —
 argument parsing, confirmation flows, and human-readable rendering.
 """
 
 from __future__ import annotations
 
+import hashlib
+import os
+import shlex
+import subprocess
 import sys
+import tempfile
+from pathlib import Path
 from typing import Optional
 
 import typer
@@ -16,16 +22,20 @@ from rich.markup import escape as rich_escape
 from rich.table import Table
 
 from clawrium.core.hosts import get_host
+from clawrium.core.lifecycle import LifecycleError, restart_agent
 from clawrium.core.memory import (
+    MAX_MEMORY_CONTENT_BYTES,
     delete_memory_files,
     get_memory_info,
+    read_memory_file,
+    write_memory_file,
 )
 from clawrium.core.secrets import (
     AgentNotFoundError,
     get_installed_claw,
 )
 
-__all__ = ["show_cmd", "delete_cmd"]
+__all__ = ["show_cmd", "delete_cmd", "edit_cmd"]
 
 console = Console()
 
@@ -106,9 +116,7 @@ def show_cmd(
         raise typer.Exit(code=1)
 
     console.print(f"\n[bold]Agent:[/bold] {safe_claw} ({safe_host})")
-    console.print(
-        f"[bold]Workspace:[/bold] {rich_escape(info['workspace_path'])}"
-    )
+    console.print(f"[bold]Workspace:[/bold] {rich_escape(info['workspace_path'])}")
     console.print(f"[bold]Total size:[/bold] {_human_size(info['total_bytes'])}\n")
 
     table = Table(show_header=True, box=None)
@@ -166,14 +174,10 @@ def delete_cmd(
     silently bypass the safeguard.
     """
     if not file and not all_files:
-        console.print(
-            "[red]Error:[/red] specify either --file <name> or --all."
-        )
+        console.print("[red]Error:[/red] specify either --file <name> or --all.")
         raise typer.Exit(code=1)
     if file and all_files:
-        console.print(
-            "[red]Error:[/red] --file and --all are mutually exclusive."
-        )
+        console.print("[red]Error:[/red] --file and --all are mutually exclusive.")
         raise typer.Exit(code=1)
 
     hostname, agent_name = _resolve_openclaw_for_cli(claw_name)
@@ -240,10 +244,213 @@ def delete_cmd(
 
     if all_files:
         console.print(
-            f"[green]Deleted {len(targets)} memory file(s) from "
-            f"'{safe_claw}'.[/green]"
+            f"[green]Deleted {len(targets)} memory file(s) from '{safe_claw}'.[/green]"
         )
     else:
         console.print(
             f"[green]Deleted '{rich_escape(file)}' from '{safe_claw}'.[/green]"
         )
+
+
+def _resolve_editor(explicit: str | None) -> list[str]:
+    """Resolve editor command to argv list.
+
+    Precedence: explicit (--editor) > $VISUAL > $EDITOR > 'vi'. Parsed
+    via shlex.split so flags (e.g. 'code --wait') are preserved without
+    invoking a shell.
+    """
+    raw = explicit or os.environ.get("VISUAL") or os.environ.get("EDITOR") or "vi"
+    parts = shlex.split(raw)
+    return parts or ["vi"]
+
+
+def _run_editor(editor_argv: list[str], file_path: str) -> int:
+    """Spawn editor as a child process. Returns exit code.
+
+    Wrapped so tests can patch a single function rather than every
+    subprocess.run call site. shell is left at the default (False).
+    """
+    return subprocess.run([*editor_argv, file_path], check=False).returncode
+
+
+def _temp_file_dir() -> str | None:
+    """Prefer XDG_RUNTIME_DIR when set and writable; else fall back to None.
+
+    Returning None lets tempfile use its platform default.
+    """
+    xdg = os.environ.get("XDG_RUNTIME_DIR")
+    if xdg and os.path.isdir(xdg) and os.access(xdg, os.W_OK):
+        return xdg
+    return None
+
+
+def _agent_runtime_status(hostname: str, agent_name: str) -> str:
+    """Return 'running' / 'stopped' / 'unknown' for an installed agent.
+
+    Reads runtime.status from the local host record. The agents dict may
+    be keyed by agent name OR by claw type depending on schema version,
+    so fall back to scanning records by their agent_name field.
+    """
+    host = get_host(hostname)
+    if not host:
+        return "unknown"
+    agents = host.get("agents", {})
+    record = agents.get(agent_name)
+    if not isinstance(record, dict) or not record:
+        for r in agents.values():
+            if isinstance(r, dict) and r.get("agent_name") == agent_name:
+                record = r
+                break
+    if not isinstance(record, dict):
+        return "unknown"
+    runtime = record.get("runtime") or {}
+    status = runtime.get("status")
+    return status if isinstance(status, str) else "stopped"
+
+
+def edit_cmd(
+    claw_name: str = typer.Argument(..., help="Agent instance name"),
+    file: str = typer.Argument(
+        ...,
+        help="Workspace-relative file (e.g., SOUL.md or memory/2026-05-09.md).",
+    ),
+    editor: Optional[str] = typer.Option(
+        None,
+        "--editor",
+        help="Editor command. Defaults to $VISUAL, then $EDITOR, then 'vi'.",
+    ),
+    no_restart: bool = typer.Option(
+        False,
+        "--no-restart",
+        help="Save the edit but skip restarting the agent.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Skip the restart confirmation prompt.",
+    ),
+) -> None:
+    """Edit a memory file in $EDITOR; sync changes back and restart agent."""
+    hostname, agent_name = _resolve_openclaw_for_cli(claw_name)
+    safe_claw = rich_escape(claw_name)
+    safe_host = rich_escape(hostname)
+    safe_file = rich_escape(file)
+
+    original = read_memory_file(hostname, agent_name, file)
+    if original is None:
+        console.print(
+            f"[yellow]Memory unavailable for '{safe_claw}' on '{safe_host}'.[/yellow]"
+        )
+        console.print(
+            "[dim]The agent may be unreachable, still installing, or in a "
+            "failed state. Run 'clm ps' to check status.[/dim]"
+        )
+        raise typer.Exit(code=1)
+
+    original_hash = hashlib.sha256(original.encode("utf-8")).digest()
+
+    suffix = Path(file).suffix
+    # mkstemp creates files with mode 0o600 by default on POSIX.
+    fd, tmp_path = tempfile.mkstemp(suffix=suffix, dir=_temp_file_dir())
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(original)
+
+        exit_code = _run_editor(_resolve_editor(editor), tmp_path)
+
+        if exit_code != 0:
+            console.print(f"Editor exited non-zero ({exit_code}). No changes.")
+            return
+
+        try:
+            new_content = Path(tmp_path).read_text(encoding="utf-8")
+        except FileNotFoundError:
+            console.print("Edit cancelled (temp file removed).")
+            return
+
+        if hashlib.sha256(new_content.encode("utf-8")).digest() == original_hash:
+            console.print("No changes.")
+            return
+
+        encoded_size = len(new_content.encode("utf-8"))
+        if encoded_size > MAX_MEMORY_CONTENT_BYTES:
+            console.print(
+                f"[red]Error:[/red] edit exceeds maximum size "
+                f"({encoded_size} > {MAX_MEMORY_CONTENT_BYTES} bytes). "
+                f"Aborted; remote file unchanged."
+            )
+            raise typer.Exit(code=1)
+
+        ok, err = write_memory_file(hostname, agent_name, file, new_content)
+        if not ok:
+            console.print(f"[red]Error:[/red] {rich_escape(str(err))}")
+            raise typer.Exit(code=1)
+
+        if no_restart:
+            console.print(
+                f"[green]Saved '{safe_file}' to '{safe_claw}'. "
+                f"Skipping restart (--no-restart).[/green]"
+            )
+            return
+
+        # Skip restart if the agent isn't running. Calling restart_agent
+        # here would unintentionally start a stopped agent, since
+        # restart = stop (idempotent) + start.
+        runtime_status = _agent_runtime_status(hostname, agent_name)
+        if runtime_status != "running":
+            console.print(
+                f"[green]Saved '{safe_file}' to '{safe_claw}'.[/green] "
+                f"Agent is {rich_escape(runtime_status)}; new memory takes "
+                f"effect on next start."
+            )
+            return
+
+        if not force:
+            if not _stdin_is_tty():
+                console.print(
+                    "[red]Error:[/red] restart requires either --force or an "
+                    "interactive TTY. File saved; agent NOT restarted."
+                )
+                raise typer.Exit(code=1)
+
+            confirmed = typer.confirm(
+                f"Restart agent '{safe_claw}' to apply changes?",
+                default=False,
+            )
+            if not confirmed:
+                console.print(
+                    f"[green]Saved '{safe_file}' to '{safe_claw}'.[/green] "
+                    "Agent not restarted; new memory takes effect on next restart."
+                )
+                return
+
+        try:
+            result = restart_agent(hostname, "openclaw", agent_name=agent_name)
+        except LifecycleError as e:
+            console.print(f"[green]Saved '{safe_file}' to '{safe_claw}'.[/green]")
+            console.print(
+                f"[red]Error:[/red] restart failed: {rich_escape(str(e))}. "
+                f"The agent may now be stopped. Run 'clm agent start "
+                f"{safe_claw}' to bring it back up."
+            )
+            raise typer.Exit(code=1)
+
+        if not result.get("success"):
+            console.print(f"[green]Saved '{safe_file}' to '{safe_claw}'.[/green]")
+            console.print(
+                f"[red]Error:[/red] restart failed: "
+                f"{rich_escape(str(result.get('error') or 'unknown'))}. "
+                f"The agent may now be stopped. Run 'clm agent start "
+                f"{safe_claw}' to bring it back up."
+            )
+            raise typer.Exit(code=1)
+
+        console.print(
+            f"[green]Saved '{safe_file}' to '{safe_claw}' and restarted agent.[/green]"
+        )
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass

--- a/tests/test_cli_memory.py
+++ b/tests/test_cli_memory.py
@@ -1,11 +1,14 @@
-"""Tests for CLI memory commands (clm agent <name> memory show|delete)."""
+"""Tests for CLI memory commands (clm agent <name> memory show|delete|edit)."""
 
 import os
 import contextlib
+import stat
+from pathlib import Path
 from typer.testing import CliRunner
 from unittest.mock import patch
 
 from clawrium.cli.main import app
+from clawrium.core.memory import MAX_MEMORY_CONTENT_BYTES
 
 runner = CliRunner()
 
@@ -57,9 +60,7 @@ def test_show_renders_table_when_info_available(hosts_with_installed_claw):
         ],
     }
     with patch("clawrium.cli.memory.get_memory_info", return_value=info):
-        result = runner.invoke(
-            app, ["agent", "memory", "show", "work"], env=os.environ
-        )
+        result = runner.invoke(app, ["agent", "memory", "show", "work"], env=os.environ)
     assert result.exit_code == 0, result.output
     assert "SOUL.md" in result.output
     assert "USER.md" in result.output
@@ -69,9 +70,7 @@ def test_show_renders_table_when_info_available(hosts_with_installed_claw):
 
 
 def test_show_exits_nonzero_when_agent_not_found(hosts_with_installed_claw):
-    result = runner.invoke(
-        app, ["agent", "memory", "show", "ghost"], env=os.environ
-    )
+    result = runner.invoke(app, ["agent", "memory", "show", "ghost"], env=os.environ)
     assert result.exit_code != 0
     assert "not found" in result.output.lower()
 
@@ -80,9 +79,7 @@ def test_show_exits_with_unavailable_message_on_offline_host(
     hosts_with_installed_claw,
 ):
     with patch("clawrium.cli.memory.get_memory_info", return_value=None):
-        result = runner.invoke(
-            app, ["agent", "memory", "show", "work"], env=os.environ
-        )
+        result = runner.invoke(app, ["agent", "memory", "show", "work"], env=os.environ)
     assert result.exit_code != 0
     assert "unavailable" in result.output.lower()
 
@@ -91,9 +88,7 @@ def test_show_exits_with_unavailable_message_on_offline_host(
 
 
 def test_delete_requires_file_or_all(hosts_with_installed_claw):
-    result = runner.invoke(
-        app, ["agent", "memory", "delete", "work"], env=os.environ
-    )
+    result = runner.invoke(app, ["agent", "memory", "delete", "work"], env=os.environ)
     assert result.exit_code != 0
     assert "either --file" in result.output
 
@@ -224,11 +219,13 @@ def test_delete_all_force_requires_typed_confirmation(
             },
         ],
     }
-    with _fake_tty(), patch(
-        "clawrium.cli.memory.get_memory_info", return_value=info
-    ), patch(
-        "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
-    ) as mock_delete:
+    with (
+        _fake_tty(),
+        patch("clawrium.cli.memory.get_memory_info", return_value=info),
+        patch(
+            "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
+        ) as mock_delete,
+    ):
         # Wrong typed name → cancelled.
         result = runner.invoke(
             app,
@@ -268,11 +265,13 @@ def test_delete_all_force_with_correct_name_proceeds(
             },
         ],
     }
-    with _fake_tty(), patch(
-        "clawrium.cli.memory.get_memory_info", return_value=info
-    ), patch(
-        "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
-    ) as mock_delete:
+    with (
+        _fake_tty(),
+        patch("clawrium.cli.memory.get_memory_info", return_value=info),
+        patch(
+            "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
+        ) as mock_delete,
+    ):
         result = runner.invoke(
             app,
             ["agent", "memory", "delete", "work", "--all", "--force"],
@@ -292,11 +291,13 @@ def test_delete_all_force_when_no_files(hosts_with_installed_claw):
         "total_bytes": 0,
         "files": [],
     }
-    with _fake_tty(), patch(
-        "clawrium.cli.memory.get_memory_info", return_value=info
-    ), patch(
-        "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
-    ) as mock_delete:
+    with (
+        _fake_tty(),
+        patch("clawrium.cli.memory.get_memory_info", return_value=info),
+        patch(
+            "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
+        ) as mock_delete,
+    ):
         result = runner.invoke(
             app,
             ["agent", "memory", "delete", "work", "--all", "--force"],
@@ -308,11 +309,13 @@ def test_delete_all_force_when_no_files(hosts_with_installed_claw):
 
 
 def test_delete_all_force_offline_host(hosts_with_installed_claw):
-    with _fake_tty(), patch(
-        "clawrium.cli.memory.get_memory_info", return_value=None
-    ), patch(
-        "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
-    ) as mock_delete:
+    with (
+        _fake_tty(),
+        patch("clawrium.cli.memory.get_memory_info", return_value=None),
+        patch(
+            "clawrium.cli.memory.delete_memory_files", return_value=(True, None)
+        ) as mock_delete,
+    ):
         result = runner.invoke(
             app,
             ["agent", "memory", "delete", "work", "--all", "--force"],
@@ -328,11 +331,10 @@ def test_delete_all_force_refuses_when_stdin_not_tty(hosts_with_installed_claw):
 
     The CliRunner default already provides a non-TTY stdin, so we just
     invoke without _fake_tty and confirm the early refusal fires."""
-    with patch(
-        "clawrium.cli.memory.get_memory_info"
-    ) as mock_info, patch(
-        "clawrium.cli.memory.delete_memory_files"
-    ) as mock_delete:
+    with (
+        patch("clawrium.cli.memory.get_memory_info") as mock_info,
+        patch("clawrium.cli.memory.delete_memory_files") as mock_delete,
+    ):
         result = runner.invoke(
             app,
             ["agent", "memory", "delete", "work", "--all", "--force"],
@@ -375,9 +377,7 @@ def test_show_rejects_non_openclaw_agent(isolated_config):
         )
     )
 
-    result = runner.invoke(
-        app, ["agent", "memory", "show", "zerowork"], env=os.environ
-    )
+    result = runner.invoke(app, ["agent", "memory", "show", "zerowork"], env=os.environ)
     assert result.exit_code != 0
     assert "openclaw" in result.output.lower()
     assert "zeroclaw" in result.output.lower()
@@ -409,11 +409,13 @@ def test_delete_all_surfaces_core_failure(hosts_with_installed_claw):
             }
         ],
     }
-    with _fake_tty(), patch(
-        "clawrium.cli.memory.get_memory_info", return_value=info
-    ), patch(
-        "clawrium.cli.memory.delete_memory_files",
-        return_value=(False, "Host unreachable: timed out"),
+    with (
+        _fake_tty(),
+        patch("clawrium.cli.memory.get_memory_info", return_value=info),
+        patch(
+            "clawrium.cli.memory.delete_memory_files",
+            return_value=(False, "Host unreachable: timed out"),
+        ),
     ):
         result = runner.invoke(
             app,
@@ -423,3 +425,539 @@ def test_delete_all_surfaces_core_failure(hosts_with_installed_claw):
         )
     assert result.exit_code != 0
     assert "Host unreachable" in result.output
+
+
+# ----- edit -----------------------------------------------------------------
+
+
+def _make_editor(new_content=None, *, exit_code=0, delete_temp=False, observer=None):
+    """Build a fake _run_editor that simulates editor side effects.
+
+    new_content: str written to the temp file (None = leave file untouched)
+    exit_code: editor return code
+    delete_temp: if True, unlink the temp file before returning
+    observer: optional callable(path) invoked while file still exists,
+              useful for asserting file mode / contents mid-flight
+    """
+
+    def _editor(argv, file_path):
+        if observer is not None:
+            observer(file_path)
+        if delete_temp:
+            os.unlink(file_path)
+        elif new_content is not None:
+            Path(file_path).write_text(new_content, encoding="utf-8")
+        return exit_code
+
+    return _editor
+
+
+def _restart_ok(*_args, **_kwargs):
+    return {
+        "success": True,
+        "agent": "opc-work",
+        "host": "192.168.1.100",
+        "operation": "restart",
+        "pid": 1234,
+        "started_at": "2026-05-09T00:00:00Z",
+        "error": None,
+    }
+
+
+@contextlib.contextmanager
+def _running_agent():
+    """Make _agent_runtime_status return 'running' so the restart path fires.
+
+    The conftest fixture installs the agent without runtime.status, which
+    defaults to 'stopped' under the new pre-flight check. Tests that need
+    to exercise the restart code path opt in via this helper.
+    """
+    with patch(
+        "clawrium.cli.memory._agent_runtime_status", return_value="running"
+    ):
+        yield
+
+
+def test_edit_happy_path_writes_and_restarts(hosts_with_installed_claw):
+    with (
+        _fake_tty(),
+        _running_agent(),
+        patch("clawrium.cli.memory.read_memory_file", return_value="old\n"),
+        patch(
+            "clawrium.cli.memory._run_editor",
+            side_effect=_make_editor(new_content="new\n"),
+        ),
+        patch(
+            "clawrium.cli.memory.write_memory_file", return_value=(True, None)
+        ) as mock_write,
+        patch(
+            "clawrium.cli.memory.restart_agent", side_effect=_restart_ok
+        ) as mock_restart,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md"],
+            input="y\n",
+            env=os.environ,
+        )
+    assert result.exit_code == 0, result.output
+    args, _kwargs = mock_write.call_args
+    assert args[2] == "SOUL.md"
+    assert args[3] == "new\n"
+    mock_restart.assert_called_once()
+    assert "restarted agent" in result.output.lower()
+
+
+def test_edit_unchanged_does_not_write(hosts_with_installed_claw):
+    with (
+        patch("clawrium.cli.memory.read_memory_file", return_value="same\n"),
+        patch("clawrium.cli.memory._run_editor", side_effect=_make_editor()),
+        patch(
+            "clawrium.cli.memory.write_memory_file", return_value=(True, None)
+        ) as mock_write,
+        patch(
+            "clawrium.cli.memory.restart_agent", side_effect=_restart_ok
+        ) as mock_restart,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md"],
+            env=os.environ,
+        )
+    assert result.exit_code == 0, result.output
+    assert "No changes" in result.output
+    mock_write.assert_not_called()
+    mock_restart.assert_not_called()
+
+
+def test_edit_editor_nonzero_exit_does_not_write(hosts_with_installed_claw):
+    with (
+        patch("clawrium.cli.memory.read_memory_file", return_value="x\n"),
+        patch(
+            "clawrium.cli.memory._run_editor",
+            side_effect=_make_editor(new_content="changed\n", exit_code=1),
+        ),
+        patch(
+            "clawrium.cli.memory.write_memory_file", return_value=(True, None)
+        ) as mock_write,
+        patch(
+            "clawrium.cli.memory.restart_agent", side_effect=_restart_ok
+        ) as mock_restart,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md"],
+            env=os.environ,
+        )
+    assert result.exit_code == 0
+    assert "non-zero" in result.output
+    mock_write.assert_not_called()
+    mock_restart.assert_not_called()
+
+
+def test_edit_temp_file_deleted_does_not_write(hosts_with_installed_claw):
+    with (
+        patch("clawrium.cli.memory.read_memory_file", return_value="x\n"),
+        patch(
+            "clawrium.cli.memory._run_editor",
+            side_effect=_make_editor(delete_temp=True),
+        ),
+        patch(
+            "clawrium.cli.memory.write_memory_file", return_value=(True, None)
+        ) as mock_write,
+        patch(
+            "clawrium.cli.memory.restart_agent", side_effect=_restart_ok
+        ) as mock_restart,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md"],
+            env=os.environ,
+        )
+    assert result.exit_code == 0
+    assert "cancelled" in result.output.lower()
+    mock_write.assert_not_called()
+    mock_restart.assert_not_called()
+
+
+def test_edit_oversized_content_aborts_before_write(hosts_with_installed_claw):
+    huge = "x" * (MAX_MEMORY_CONTENT_BYTES + 1)
+    with (
+        patch("clawrium.cli.memory.read_memory_file", return_value="small\n"),
+        patch(
+            "clawrium.cli.memory._run_editor",
+            side_effect=_make_editor(new_content=huge),
+        ),
+        patch(
+            "clawrium.cli.memory.write_memory_file", return_value=(True, None)
+        ) as mock_write,
+        patch(
+            "clawrium.cli.memory.restart_agent", side_effect=_restart_ok
+        ) as mock_restart,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md"],
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    assert "exceeds maximum size" in result.output
+    mock_write.assert_not_called()
+    mock_restart.assert_not_called()
+
+
+def test_edit_unreachable_on_initial_read(hosts_with_installed_claw):
+    with (
+        patch("clawrium.cli.memory.read_memory_file", return_value=None),
+        patch("clawrium.cli.memory._run_editor") as mock_editor,
+        patch(
+            "clawrium.cli.memory.write_memory_file", return_value=(True, None)
+        ) as mock_write,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md"],
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    assert "unavailable" in result.output.lower()
+    mock_editor.assert_not_called()
+    mock_write.assert_not_called()
+
+
+def test_edit_write_failure_surfaces_error(hosts_with_installed_claw):
+    with (
+        _fake_tty(),
+        patch("clawrium.cli.memory.read_memory_file", return_value="old\n"),
+        patch(
+            "clawrium.cli.memory._run_editor",
+            side_effect=_make_editor(new_content="new\n"),
+        ),
+        patch(
+            "clawrium.cli.memory.write_memory_file",
+            return_value=(False, "playbook failed"),
+        ),
+        patch(
+            "clawrium.cli.memory.restart_agent", side_effect=_restart_ok
+        ) as mock_restart,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md"],
+            input="y\n",
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    assert "playbook failed" in result.output
+    mock_restart.assert_not_called()
+
+
+def test_edit_restart_confirmation_declined(hosts_with_installed_claw):
+    with (
+        _fake_tty(),
+        _running_agent(),
+        patch("clawrium.cli.memory.read_memory_file", return_value="old\n"),
+        patch(
+            "clawrium.cli.memory._run_editor",
+            side_effect=_make_editor(new_content="new\n"),
+        ),
+        patch(
+            "clawrium.cli.memory.write_memory_file", return_value=(True, None)
+        ) as mock_write,
+        patch(
+            "clawrium.cli.memory.restart_agent", side_effect=_restart_ok
+        ) as mock_restart,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md"],
+            input="n\n",
+            env=os.environ,
+        )
+    assert result.exit_code == 0, result.output
+    mock_write.assert_called_once()
+    mock_restart.assert_not_called()
+    assert "not restarted" in result.output.lower()
+
+
+def test_edit_no_restart_flag_skips_restart(hosts_with_installed_claw):
+    with (
+        patch("clawrium.cli.memory.read_memory_file", return_value="old\n"),
+        patch(
+            "clawrium.cli.memory._run_editor",
+            side_effect=_make_editor(new_content="new\n"),
+        ),
+        patch(
+            "clawrium.cli.memory.write_memory_file", return_value=(True, None)
+        ) as mock_write,
+        patch(
+            "clawrium.cli.memory.restart_agent", side_effect=_restart_ok
+        ) as mock_restart,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md", "--no-restart"],
+            env=os.environ,
+        )
+    assert result.exit_code == 0, result.output
+    mock_write.assert_called_once()
+    mock_restart.assert_not_called()
+    assert "skipping restart" in result.output.lower()
+
+
+def test_edit_force_skips_confirmation(hosts_with_installed_claw):
+    with (
+        _running_agent(),
+        patch("clawrium.cli.memory.read_memory_file", return_value="old\n"),
+        patch(
+            "clawrium.cli.memory._run_editor",
+            side_effect=_make_editor(new_content="new\n"),
+        ),
+        patch("clawrium.cli.memory.write_memory_file", return_value=(True, None)),
+        patch(
+            "clawrium.cli.memory.restart_agent", side_effect=_restart_ok
+        ) as mock_restart,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md", "--force"],
+            env=os.environ,
+        )
+    assert result.exit_code == 0, result.output
+    mock_restart.assert_called_once()
+
+
+def test_edit_non_tty_without_force_refuses_restart(hosts_with_installed_claw):
+    # Default _stdin_is_tty() under CliRunner is False. No --force, no
+    # --no-restart → must refuse the restart but the file is still saved.
+    with (
+        _running_agent(),
+        patch("clawrium.cli.memory.read_memory_file", return_value="old\n"),
+        patch(
+            "clawrium.cli.memory._run_editor",
+            side_effect=_make_editor(new_content="new\n"),
+        ),
+        patch(
+            "clawrium.cli.memory.write_memory_file", return_value=(True, None)
+        ) as mock_write,
+        patch(
+            "clawrium.cli.memory.restart_agent", side_effect=_restart_ok
+        ) as mock_restart,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md"],
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    assert "TTY" in result.output
+    mock_write.assert_called_once()
+    mock_restart.assert_not_called()
+
+
+def test_edit_temp_file_always_cleaned_up(hosts_with_installed_claw):
+    captured = {}
+
+    def _observe(path):
+        captured["path"] = path
+        captured["mode"] = stat.S_IMODE(os.stat(path).st_mode)
+
+    with (
+        patch("clawrium.cli.memory.read_memory_file", return_value="old\n"),
+        patch(
+            "clawrium.cli.memory._run_editor",
+            side_effect=_make_editor(new_content="new\n", observer=_observe),
+        ),
+        patch(
+            "clawrium.cli.memory.write_memory_file",
+            return_value=(False, "boom"),
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md", "--force"],
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    assert captured.get("mode") == 0o600
+    assert not os.path.exists(captured["path"])
+
+
+def test_edit_rejects_path_traversal(hosts_with_installed_claw):
+    # The path validator lives in core; the CLI surfaces the same
+    # "unavailable" path when read_memory_file rejects the input.
+    with patch("clawrium.cli.memory._run_editor") as mock_editor:
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "../../../etc/passwd"],
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    mock_editor.assert_not_called()
+
+
+def test_edit_rejects_non_openclaw_agent(isolated_config):
+    import json
+
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    (isolated_config / "hosts.json").write_text(
+        json.dumps(
+            [
+                {
+                    "hostname": "192.168.1.100",
+                    "alias": "server1",
+                    "port": 22,
+                    "agent_name": "xclm",
+                    "agents": {
+                        "zerowork": {
+                            "type": "zeroclaw",
+                            "agent_name": "zerowork",
+                            "name": "zerowork",
+                        }
+                    },
+                }
+            ]
+        )
+    )
+
+    result = runner.invoke(
+        app,
+        ["agent", "memory", "edit", "zerowork", "SOUL.md"],
+        env=os.environ,
+    )
+    assert result.exit_code != 0
+    assert "openclaw" in result.output.lower()
+
+
+def test_edit_restart_returns_failure_surfaces_error(hosts_with_installed_claw):
+    """When restart_agent returns success=False, we must print Saved + the
+    restart error, then exit 1."""
+    failure = {
+        "success": False,
+        "agent": "opc-work",
+        "host": "192.168.1.100",
+        "operation": "restart",
+        "pid": None,
+        "started_at": None,
+        "error": "Stop failed: timed out",
+    }
+    with (
+        _running_agent(),
+        patch("clawrium.cli.memory.read_memory_file", return_value="old\n"),
+        patch(
+            "clawrium.cli.memory._run_editor",
+            side_effect=_make_editor(new_content="new\n"),
+        ),
+        patch("clawrium.cli.memory.write_memory_file", return_value=(True, None)),
+        patch(
+            "clawrium.cli.memory.restart_agent", return_value=failure
+        ) as mock_restart,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md", "--force"],
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    assert "Saved" in result.output
+    assert "timed out" in result.output
+    # Rich may wrap the phrase across lines; check the unwrapped output.
+    assert "may now be stopped" in " ".join(result.output.split())
+    mock_restart.assert_called_once()
+
+
+def test_edit_restart_raises_lifecycle_error_surfaces_error(
+    hosts_with_installed_claw,
+):
+    """If restart_agent raises LifecycleError, we must surface it cleanly
+    rather than letting a traceback leak. The user must still see that the
+    file was saved before the restart attempt failed."""
+    from clawrium.core.lifecycle import LifecycleError
+
+    with (
+        _running_agent(),
+        patch("clawrium.cli.memory.read_memory_file", return_value="old\n"),
+        patch(
+            "clawrium.cli.memory._run_editor",
+            side_effect=_make_editor(new_content="new\n"),
+        ),
+        patch("clawrium.cli.memory.write_memory_file", return_value=(True, None)),
+        patch(
+            "clawrium.cli.memory.restart_agent",
+            side_effect=LifecycleError("Host '192.168.1.100' not found"),
+        ) as mock_restart,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md", "--force"],
+            env=os.environ,
+        )
+    assert result.exit_code != 0
+    assert "Saved" in result.output
+    assert "not found" in result.output
+    # Rich may wrap the phrase across lines; check the unwrapped output.
+    assert "may now be stopped" in " ".join(result.output.split())
+    mock_restart.assert_called_once()
+    # No raw Python traceback in the output.
+    assert "Traceback" not in result.output
+
+
+def test_edit_skips_restart_when_agent_not_running(hosts_with_installed_claw):
+    """If the agent is stopped, edit must not call restart_agent — that
+    would unintentionally start a stopped agent (since restart = stop +
+    start, and stop is idempotent)."""
+    with (
+        patch(
+            "clawrium.cli.memory._agent_runtime_status", return_value="stopped"
+        ),
+        patch("clawrium.cli.memory.read_memory_file", return_value="old\n"),
+        patch(
+            "clawrium.cli.memory._run_editor",
+            side_effect=_make_editor(new_content="new\n"),
+        ),
+        patch("clawrium.cli.memory.write_memory_file", return_value=(True, None)),
+        patch(
+            "clawrium.cli.memory.restart_agent", side_effect=_restart_ok
+        ) as mock_restart,
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md", "--force"],
+            env=os.environ,
+        )
+    assert result.exit_code == 0, result.output
+    mock_restart.assert_not_called()
+    flat = " ".join(result.output.split()).lower()
+    assert "stopped" in flat
+    assert "next start" in flat
+
+
+def test_edit_no_shell_invocation(hosts_with_installed_claw):
+    """Editor must be spawned with shell=False (default) and an argv list,
+    so user-controlled $EDITOR can never be interpreted as a shell command.
+    """
+    captured_kwargs = {}
+    captured_args = {}
+
+    class _Result:
+        returncode = 0
+
+    def _fake_run(*args, **kwargs):
+        captured_args["args"] = args
+        captured_kwargs.update(kwargs)
+        return _Result()
+
+    with (
+        patch("clawrium.cli.memory.read_memory_file", return_value="x\n"),
+        patch("clawrium.cli.memory.subprocess.run", side_effect=_fake_run),
+    ):
+        runner.invoke(
+            app,
+            ["agent", "memory", "edit", "work", "SOUL.md", "--no-restart"],
+            env=os.environ,
+        )
+    # subprocess.run was called with a list as the first positional arg
+    # and shell is either absent (default False) or explicitly False.
+    argv = captured_args["args"][0]
+    assert isinstance(argv, list)
+    assert captured_kwargs.get("shell", False) is False


### PR DESCRIPTION
## Summary

- New `clm agent <name> memory edit <file>` command: fetches a memory file, opens it in `$EDITOR`, syncs the saved content back to the agent, and (if running) restarts it.
- All core primitives already existed (`read_memory_file`, `write_memory_file`, `restart_agent`); this PR is glue + UX in the CLI layer.
- 18 new tests covering happy path, no-op/cancel paths, security guards, restart logic, and stopped-agent safety.

CLI-only first iteration of Phase 4 from #210. The TUI flow tracked under #210 will later wrap the same primitives.

## Files Changed

- `src/clawrium/cli/memory.py` — `edit_cmd` + `_resolve_editor` / `_run_editor` / `_temp_file_dir` / `_agent_runtime_status` helpers
- `src/clawrium/cli/agent.py` — Typer wiring for `memory edit`
- `tests/test_cli_memory.py` — 18 new tests (35 → 53 in this file; full suite 1424 → 1442 passing)
- `.itx/308/00_PLAN.md` — implementation plan with documented "Deviations from issue" (conflict detection deliberately omitted)

## Testing

### Test Results
- [x] All existing tests pass (`make test` → 1442 passed)
- [x] Linter passes (`make lint`)
- [x] New tests added for new functionality (18 new edit tests)

### Test Coverage
- New tests: happy path, unchanged-no-op, non-zero editor exit, deleted temp file, oversized content, unreachable on initial read, write failure, restart confirmation declined, `--no-restart`, `--force`, non-TTY refusal, temp-file cleanup with mode 0o600 assertion, path traversal, non-openclaw rejection, restart returns failure, restart raises `LifecycleError`, stopped-agent skip, `shell=False` subprocess invocation.

### Manual Testing

Not run in this environment (no live host). Recommended pre-merge smoke:
1. `clm agent memory edit <agent> SOUL.md` → modify in vi → `:wq` → observe restart prompt + restart.
2. `EDITOR='code --wait' clm agent memory edit <agent> SOUL.md` → confirm `shlex.split` parses the flag correctly.
3. `clm agent memory edit <agent> SOUL.md --no-restart` → confirm no restart line in output.
4. Pipe `yes` into the command without `--force` → should refuse with the TTY error.
5. Stop the agent, then run edit → should print "Agent is stopped; new memory takes effect on next start" and not restart.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation: filename validated by `_MEMORY_FILENAME_PATTERN` in core (path traversal rejected at `read_memory_file`/`write_memory_file`); CLI surfaces "Memory unavailable" on rejection. Test `test_edit_rejects_path_traversal` covers this.
- [x] No SQL/XSS risk. Editor invocation uses `subprocess.run([..., file_path], shell=False)` with argv parsed via `shlex.split` → no shell interpolation of `$EDITOR`. Test `test_edit_no_shell_invocation` enforces this.
- [x] Temp file created via `tempfile.mkstemp` (mode `0o600` on POSIX), cleaned up in `finally`. Test `test_edit_temp_file_always_cleaned_up` enforces both.
- [x] All user-controlled strings in console output are passed through `rich_escape` to prevent Rich markup injection.
- [x] Same `MAX_MEMORY_CONTENT_BYTES` limit enforced as `write_memory_file` — bounded memory.

## ATX Review Summary

**Final Review: Rating 4/5** · No blocking issues
**Total Cost: \$10.03 | Total Time: ~38m**

| Review | Rating | Blocking Issues | Status | Cost | Time |
|--------|--------|-----------------|--------|------|------|
| 1 | 2/5 | B1, B2, B3 | B1 out-of-scope (issue spec); B2, B3 fixed | \$2.47 | 10m32s |
| 2 | 3/5 | B1 | Fixed (`_agent_runtime_status` pre-flight) | \$2.81 | 9m53s |
| 3 | 3/5 | B1 | Out-of-scope (cites pre-existing PR #307 code) | \$2.87 | 10m56s |
| 4 | 4/5 | None | Ready | \$1.84 | 7m5s |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `cli/agent.py:2154-2157` | `file` positional in edit, `--file` option in delete | Out-of-scope: issue #308 explicitly specifies `<file>` as positional. delete uses `--file` because it has a mutually-exclusive `--all` flag; edit has only one file argument. |
| B2 | `cli/memory.py:381` | Rich markup injection: raw `claw_name` in `typer.confirm` | Fixed — switched to `safe_claw`. |
| B3 | `cli/memory.py:392` | `restart_agent` can raise `LifecycleError`, no `try/except` | Fixed — wrapped in try/except, prints "Saved" then "Restart failed", exits 1. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W3 | `memory.py:332` | Redundant `os.chmod` (mkstemp gives 0o600) | Fixed — removed. |
| W4 | `memory.py:287-292` | Tempfile permissions depend on umask | Acknowledged — non-issue: `mkstemp` enforces 0o600 on POSIX. |
| W5 | `tests/test_cli_memory.py` | No test for restart failure | Fixed — added `test_edit_restart_returns_failure_surfaces_error` and `test_edit_restart_raises_lifecycle_error_surfaces_error`. |
| W6 | `tests/test_cli_memory.py` | No test for missing `$EDITOR`/`$VISUAL` | Acknowledged — non-issue: `_resolve_editor` falls back to `vi` and never raises. |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `memory.py:392-405` | `edit_cmd` calls `restart_agent` without checking runtime status — could unintentionally start a stopped agent (restart = stop + start, stop is idempotent) | Fixed — added `_agent_runtime_status` helper; restart only fires when status == "running"; new test `test_edit_skips_restart_when_agent_not_running`. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `memory.py:394-405` | Restart-failure paths don't tell user agent is now stopped | Fixed — both paths now print "agent may now be stopped, run `clm agent start <name>` to bring it back up". |
| W2 | `tests/test_cli_memory.py` | No `mock_restart.assert_called_once()` in W5 tests | Fixed — added to both restart-failure tests. |

</details>

<details>
<summary>Review 3 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `core/memory.py:204-210` | `no_log` removed from Ansible tasks handling `memory_content_b64` | Out-of-scope — `core/memory.py` is **not** modified by this PR (verified via `git diff --name-only main`). The hardening belongs in a separate issue against PR #307's code. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `memory.py:287-308` | Stale local `hosts.json` runtime state | Out-of-scope — system-wide CLM design choice; every CLI command trusts local state. |
| W2 | `memory.py:78 vs 294` | TOCTOU on double `get_host()` | Acknowledged — refactoring `_resolve_openclaw_for_cli` to share the host record affects show/delete; deferred. |
| W4 | `memory.py:365` | `print('Opening editor...')` bypasses `console.print` | Hallucination — no such call exists in `cli/memory.py` (verified via `grep`). |
| W7,W8 | `memory.py` | Helper functions lack unit tests | Acknowledged — integration tests through `edit_cmd` cover the externally-observable behaviour. |

</details>

<details>
<summary>Review 4 Details (Rating 4/5 — Final)</summary>

No blocking issues. Three non-blocking warnings remain:

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `cli/memory.py:232` (delete_cmd) | Rich markup injection in `typer.confirm` | Out-of-scope — pre-existing code from PR #307. |
| W2 | `cli/memory.py:220` (delete_cmd) | Rich markup injection in `typer.prompt` | Out-of-scope — pre-existing code from PR #307. |
| W3 | `cli/memory.py:410-415` | Non-TTY exit code 1 when file was saved | Acknowledged — defensible: user did not pass `--no-restart`, so they wanted the restart and the system could not do it. Exit 1 conveys partial failure. |

</details>

Closes #308

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>