### PR TITLE
chore: bring stranded Phase 2 commits to main (#68)

### DIFF
--- a/.itx/68/01_EXECUTION.md
+++ b/.itx/68/01_EXECUTION.md
@@ -37,6 +37,45 @@ Implementation notes (research during Phase 2 worktree work):
 - `tests/test_hermes_configure.py` adds `ollama`/custom branch coverage.
 - Phase 2 acceptance criteria (`01_EXECUTION.md` + subtask #313 body) get an additional row: "ollama provider drives `.env` correctly; service comes up; `/v1/models` returns hermes-agent identity using local-inx model".
 
+### Hermes env-var research (pinned before coding, tag v2026.5.7)
+
+Sources read:
+- `gateway/config.py` — only the API_SERVER_* gateway/platform env vars, not provider/model selection.
+- `hermes_cli/config.py` — hermes runtime config layout: TWO files in `~/.hermes/`:
+  - `config.yaml` — `model.provider`, `model.default`, `model.base_url` (the canonical model selection).
+  - `.env` — API keys (`OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) + platform vars (`API_SERVER_*`).
+- `hermes_cli/runtime_provider.py` — provider resolution precedence:
+  1. explicit `--provider` flag (CLI only, not relevant for daemon)
+  2. `model.provider` in `config.yaml`
+  3. `HERMES_INFERENCE_PROVIDER` env var (read but lower-priority than config.yaml)
+  4. `"auto"` (auto-detect from credentials present in env).
+- `hermes_cli/providers.py` — provider catalogue.
+- `cli-config.yaml.example` — default config.yaml shipped at install time.
+- `plugins/model-providers/custom/__init__.py` — `custom` is the provider that backs local Ollama / vLLM / llama.cpp / any user-OpenAI-compatible URL. The aliases `ollama`, `local`, `vllm`, `llamacpp`, `llama.cpp`, `llama-cpp` all map to `custom`. `env_vars=()` (no fixed key — base_url + optional api_key come from `model.base_url` in `config.yaml`).
+
+Findings:
+
+| Need | Mechanism |
+|------|-----------|
+| Cloud provider selection | `model.provider: openrouter` (or `anthropic`, `openai`, `auto`) in `config.yaml`. Equivalent override `HERMES_INFERENCE_PROVIDER=<name>` in `.env` is honored but lower-precedence than config.yaml. |
+| Model selection | `model.default: <id>` in `config.yaml`. `HERMES_INFERENCE_MODEL` is NOT honored (the env-var fallback in `runtime_provider.py` only looks at `HERMES_INFERENCE_PROVIDER`); plan's mention of `HERMES_INFERENCE_MODEL` was incorrect — model must be in `config.yaml`. |
+| Cloud API key | `OPENROUTER_API_KEY` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` in `.env` (matches plan). |
+| Custom OpenAI-compatible endpoint (local Ollama, vLLM, etc.) | `model.provider: custom` (alias `ollama` works) + `model.base_url: http://host:port/v1` + `model.default: <model_id>` in `config.yaml`. No required env var. The `custom` provider's `env_vars=()` means hermes does NOT need any API key to call a local endpoint — it sends `Authorization: Bearer ` (empty) which Ollama accepts. |
+| Gateway daemon (local OpenAI-compatible API on 127.0.0.1:8642) | `API_SERVER_ENABLED=1` + `API_SERVER_KEY=<token>` in `.env` (matches plan). Optional `API_SERVER_HOST=127.0.0.1`, `API_SERVER_PORT=8642`. The `/health` endpoint does NOT require the bearer header (verified during Phase 2 E2E; `/v1/*` endpoints DO). |
+
+Decision: Phase 2 renders BOTH files:
+1. `~/.hermes/.env` (mode 0600) — cloud provider API keys + `API_SERVER_*` block. `HERMES_INFERENCE_PROVIDER` ALSO emitted as a redundant safety net (low-priority anyway).
+2. `~/.hermes/config.yaml` (mode 0600) — partial config containing only the `model:` block. Hermes deep-merges this with `DEFAULT_CONFIG` at load time, so omitted top-level keys retain hermes defaults. The installer's previously-written `config.yaml` is safe to overwrite (it was the example template).
+
+Per-provider mapping:
+
+| clm `provider.type` | rendered `model.provider` | rendered `model.base_url` | rendered `.env` key |
+|---------------------|---------------------------|----------------------------|---------------------|
+| `openrouter` | `openrouter` | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
+| `anthropic` | `anthropic` | (omitted; hermes default) | `ANTHROPIC_API_KEY` |
+| `openai` | `openai` | (omitted; hermes default) | `OPENAI_API_KEY` |
+| `ollama` | `custom` | `<provider.endpoint>/v1` (suffix `/v1` appended if missing) | (none) |
+
 
 
 **Rationale**: Plan (`.itx/68/00_PLAN.md`) explicitly enumerates 5 independent PRs with one strict ordering edge: Phase 1 (installation primitives + manifest schema) must land before any other phase compiles meaningfully. Phase 3 (memory generalization) depends on Phase 1's manifest fields (`workspace.memory_path`, `features.memory`). Phase 2 (configuration), Phase 4 (onboarding metadata), Phase 5 (docs) depend only on Phase 1. Phases 2/3 may run in parallel after Phase 1 lands; phases 4/5 may run in parallel after their respective deps. Splitting reduces review surface (each PR ≤ ~600 LOC) and bounds blast radius — a regression in memory generalization (Phase 3) cannot block hermes lifecycle (Phases 1+2).

--- a/.itx/68/01_EXECUTION.md
+++ b/.itx/68/01_EXECUTION.md
@@ -375,4 +375,45 @@ E2E findings worth carrying into Phase 2:
 
 6. Per-host start/stop via `clm agent <name>` is gated by onboarding state (`pending_onboard`). Phase 1 leaves the agent in PENDING state by design (no `onboarding.stages` declared yet); Phase 2 / Phase 4 unblock the start path. Direct `systemctl start hermes-<name>.service` confirms the documented "service exits immediately, status 1, log says 'Gateway service is not installed'" behavior.
 
+---
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-10T18:30:00Z
+**Model**: claude-opus-4-7
+**Subtask**: #313 (Phase 2)
+**Branch**: `issue-68-phase-2-configuration` (stacked on `issue-68-phase-1-installation`)
+
+```prompt
+/itx:execute 313 (sub-agent invocation)
+```
+
+Implementation outcomes:
+
+1. Hermes uses TWO config files (research finding pinned above): `config.yaml` for `model.provider` / `model.default` / `model.base_url`, and `.env` for API keys + `API_SERVER_*`. Phase 2 renders both. `HERMES_INFERENCE_MODEL` is NOT a recognized env var (the plan mentioned it incorrectly) — model selection happens via `model.default` in `config.yaml` only.
+
+2. `model.provider: custom` with `model.base_url: <endpoint>/v1` drives the local Ollama / vLLM / llama.cpp / any OpenAI-compatible endpoint. clm `provider.type=ollama` maps to it. The hermes `custom` provider has `env_vars=()` so no API key is required for local endpoints.
+
+3. **Phase 1 carryover bug discovered during E2E and fixed in Phase 2**: Phase 1's install.yaml dropped a systemd unit with `ExecStart=... hermes gateway start`, but `hermes gateway start` delegates to a per-user systemd unit installed via `hermes gateway install` (which we don't run). It exits 1 with "Gateway service is not installed". The correct foreground-supervisor command is `hermes gateway run`. Phase 2's `configure.yaml` re-renders the unit with `gateway run` before the restart handler fires. Phase 1's unit file remains as a placeholder until configure runs (which is the expected lifecycle: install → configure → ready). Filing a follow-up suggestion to update Phase 1's `install.yaml` and `start.yaml` to use `gateway run` directly is recommended; tracked in PR description.
+
+4. Configure timeout in `core/lifecycle.py` was 60s — too short for hermes (service restart + 20×3s `/health` retries). Bumped to 240s for `resolved_type == "hermes"`.
+
+5. `lineinfile` in `check_mode` does NOT correctly verify a credential is present — it always reports `changed=true` when the regexp matches a value-bearing line that differs from the placeholder. (This pattern is also broken in openclaw's `configure.yaml`; out-of-scope to fix here.) Phase 2 uses `command: grep -q '^KEY='` instead, which gives a clean rc=0/1 contract.
+
+6. `/health` endpoint on the hermes API server is **unauthenticated** (verified during E2E: `curl http://127.0.0.1:8642/health` returns 200 without bearer header). `/v1/*` endpoints DO require `Authorization: Bearer $API_SERVER_KEY`.
+
+7. `API_SERVER_KEY` generation moved to `core/install.py` (not `core/lifecycle.py::configure_agent` as one reading of the plan suggested). This mirrors openclaw's gateway-token pattern: install generates the secret, persists it in `hosts.json`, and configure reuses it. Idempotency comes from re-using the persisted key when an existing 64-char hex value is found in the agent record at install time (covers re-install scenarios) and from `configure_agent` hydrating from `hosts.json` on every reconfigure.
+
+E2E results on wolf-i (192.168.1.36) against `local-inx` provider (Ollama @ 192.168.1.17:11434, model `qwen3-coder:30b-128k`):
+
+- `clm agent install --type hermes --host wolf-i --name hermes-test` succeeded; `API_SERVER_KEY` persisted in `hosts.json`.
+- `clm agent configure hermes-test --stage providers` (with `local-inx` selected) succeeded; service active+running.
+- `~/.hermes/.env` rendered 0600, contains `API_SERVER_KEY` + `HERMES_INFERENCE_PROVIDER=custom`.
+- `~/.hermes/config.yaml` rendered 0600 with `model: {provider: custom, base_url: http://192.168.1.17:11434/v1, default: qwen3-coder:30b-128k}`.
+- `curl http://127.0.0.1:8642/health` → `{"status": "ok", "platform": "hermes-agent"}` (200, no auth).
+- `curl http://127.0.0.1:8642/v1/models -H "Authorization: Bearer ..."` → `[{"id": "hermes-agent", ...}]`.
+- `curl -X POST http://127.0.0.1:8642/v1/chat/completions -H "Authorization: Bearer ..." -d '{"model":"hermes-agent","messages":[{"role":"user","content":"Say only the word OK and nothing else."}],"max_tokens":16}'` → `{"choices":[{"message":{"role":"assistant","content":"OK"}}], ...}`. Full hermes-via-clm-via-ollama-via-DGX-Spark roundtrip works.
+- Reconfigure with `local-inx.default_model` rotated to `gpt-oss:20b-128k` succeeded; `API_SERVER_KEY` byte-identical across reconfigures (idempotency contract verified); `model.default` rotated; service still active.
+- `clm agent remove hermes-test --force` cleaned up: user removed, `~/.hermes/` deleted, systemd unit removed, `~/.local/bin/hermes` symlink removed, `hosts.json` agent record (with `api_server.key`) removed.
+
 </details>

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -333,6 +333,12 @@ def _sync_provider_config(
     if "channels" in existing_config:
         config_data["channels"] = existing_config["channels"]
 
+    # Preserve existing api_server block (Hermes loopback gateway auth).
+    # configure_agent re-hydrates this from hosts.json too, but carrying it
+    # through here keeps the persisted record consistent across rotations.
+    if "api_server" in existing_config:
+        config_data["api_server"] = existing_config["api_server"]
+
     # Call configure_agent to apply configuration via Ansible
     success, error = configure_agent(
         host,

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -55,6 +55,18 @@ from clawrium.core.onboarding import initialize_onboarding
 logger = logging.getLogger(__name__)
 
 
+def _is_valid_hermes_api_server_key(value: object) -> bool:
+    """Return True if `value` is a well-formed 64-char lowercase hex string.
+
+    Used by both install.py (existing-key reuse on idempotent install) and
+    lifecycle.configure_agent() (hydration from secrets.json) so a corrupted
+    secrets.json can't silently propagate a broken bearer token to Ansible.
+    """
+    if not isinstance(value, str) or len(value) != 64:
+        return False
+    return all(c in "0123456789abcdef" for c in value)
+
+
 class InstallationError(Exception):
     """Raised when installation fails."""
 
@@ -523,15 +535,15 @@ def run_installation(
             "HERMES_API_SERVER_KEY"
         )
         existing_key = existing_entry["value"] if existing_entry else None
-        # Validate well-formed 64-char lowercase hex so a corrupted secrets.json
-        # doesn't silently propagate a broken token.
-        if (
-            isinstance(existing_key, str)
-            and len(existing_key) == 64
-            and all(c in "0123456789abcdef" for c in existing_key)
-        ):
+        if _is_valid_hermes_api_server_key(existing_key):
             hermes_api_server_key = existing_key
         else:
+            if existing_key is not None:
+                logger.warning(
+                    "Existing HERMES_API_SERVER_KEY for %s is corrupted "
+                    "(not 64-char lowercase hex); regenerating.",
+                    instance_key,
+                )
             hermes_api_server_key = secrets.token_hex(32)  # 64-char hex token
             set_instance_secret(
                 instance_key,

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -48,6 +48,7 @@ from clawrium.core.registry import (
 from clawrium.core.secrets import (
     get_instance_key,
     get_instance_secrets,
+    set_instance_secret,
 )
 from clawrium.core.onboarding import initialize_onboarding
 
@@ -508,23 +509,33 @@ def run_installation(
     # Hermes: generate (or reuse) the API_SERVER_KEY that gates the local
     # OpenAI-compatible gateway on 127.0.0.1:8642. Generated once on first
     # install so reconfigure flows can rely on the same token across runs.
-    # Idempotency: if a previous install record already has the key, reuse it
-    # so existing API consumers don't break on a re-install.
+    # Persisted in secrets.json under the canonical instance key so
+    # remove_instance_secrets() cleans it up alongside provider keys when the
+    # agent is removed; hosts.json only carries the non-sensitive shape
+    # (enabled / host / port).
     hermes_api_server_key = None
     if claw_name == "hermes":
-        existing_host = get_host(hostname)
-        existing_key = (
-            (existing_host or {})
-            .get("agents", {})
-            .get(agent_name, {})
-            .get("config", {})
-            .get("api_server", {})
-            .get("key")
+        instance_key = get_instance_key(hostname, claw_name, agent_name)
+        existing_entry = get_instance_secrets(instance_key).get(
+            "HERMES_API_SERVER_KEY"
         )
-        if isinstance(existing_key, str) and len(existing_key) == 64:
+        existing_key = existing_entry["value"] if existing_entry else None
+        # Validate well-formed 64-char lowercase hex so a corrupted secrets.json
+        # doesn't silently propagate a broken token.
+        if (
+            isinstance(existing_key, str)
+            and len(existing_key) == 64
+            and all(c in "0123456789abcdef" for c in existing_key)
+        ):
             hermes_api_server_key = existing_key
         else:
             hermes_api_server_key = secrets.token_hex(32)  # 64-char hex token
+            set_instance_secret(
+                instance_key,
+                "HERMES_API_SERVER_KEY",
+                hermes_api_server_key,
+                description="Bearer token for hermes local OpenAI-compatible API gateway (loopback only).",
+            )
         config["api_server"] = {
             "enabled": True,
             "host": "127.0.0.1",
@@ -811,8 +822,10 @@ def run_installation(
                             "privateKey": device_private_key,
                         }
 
-                # Persist Hermes API_SERVER_KEY (loopback gateway auth) so
-                # reconfigure flows can reuse it without rotating the token.
+                # Persist non-sensitive hermes api_server shape (enabled / host
+                # / port) into hosts.json. The bearer token itself lives in
+                # secrets.json (see HERMES_API_SERVER_KEY persistence above) so
+                # remove_instance_secrets() cleans it up on agent removal.
                 if claw_name == "hermes" and hermes_api_server_key:
                     if "config" not in h["agents"][agent_name]:
                         h["agents"][agent_name]["config"] = {}
@@ -820,7 +833,6 @@ def run_installation(
                         "enabled": True,
                         "host": "127.0.0.1",
                         "port": 8642,
-                        "key": hermes_api_server_key,
                     }
             return h
 

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -505,6 +505,33 @@ def run_installation(
         }
     }
 
+    # Hermes: generate (or reuse) the API_SERVER_KEY that gates the local
+    # OpenAI-compatible gateway on 127.0.0.1:8642. Generated once on first
+    # install so reconfigure flows can rely on the same token across runs.
+    # Idempotency: if a previous install record already has the key, reuse it
+    # so existing API consumers don't break on a re-install.
+    hermes_api_server_key = None
+    if claw_name == "hermes":
+        existing_host = get_host(hostname)
+        existing_key = (
+            (existing_host or {})
+            .get("agents", {})
+            .get(agent_name, {})
+            .get("config", {})
+            .get("api_server", {})
+            .get("key")
+        )
+        if isinstance(existing_key, str) and len(existing_key) == 64:
+            hermes_api_server_key = existing_key
+        else:
+            hermes_api_server_key = secrets.token_hex(32)  # 64-char hex token
+        config["api_server"] = {
+            "enabled": True,
+            "host": "127.0.0.1",
+            "port": 8642,
+            "key": hermes_api_server_key,
+        }
+
     inventory = {
         "all": {
             "hosts": {
@@ -783,6 +810,18 @@ def run_installation(
                             "token": device_token,
                             "privateKey": device_private_key,
                         }
+
+                # Persist Hermes API_SERVER_KEY (loopback gateway auth) so
+                # reconfigure flows can reuse it without rotating the token.
+                if claw_name == "hermes" and hermes_api_server_key:
+                    if "config" not in h["agents"][agent_name]:
+                        h["agents"][agent_name]["config"] = {}
+                    h["agents"][agent_name]["config"]["api_server"] = {
+                        "enabled": True,
+                        "host": "127.0.0.1",
+                        "port": 8642,
+                        "key": hermes_api_server_key,
+                    }
             return h
 
         update_host(host["hostname"], set_installed)

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -515,7 +515,10 @@ def run_installation(
     # (enabled / host / port).
     hermes_api_server_key = None
     if claw_name == "hermes":
-        instance_key = get_instance_key(hostname, claw_name, agent_name)
+        # Use canonical hostname (not the alias passed by the CLI) so the
+        # instance_key matches what lifecycle.configure_agent() will look up.
+        canonical_hostname = host["hostname"]
+        instance_key = get_instance_key(canonical_hostname, claw_name, agent_name)
         existing_entry = get_instance_secrets(instance_key).get(
             "HERMES_API_SERVER_KEY"
         )

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -726,26 +726,40 @@ def configure_agent(
     # Use inner agent_name (Unix username) if available, otherwise fall back to dict key
     unix_agent_name = agent_record.get("agent_name") or agent_key
 
-    # Hermes: hydrate persisted api_server block (generated at install time)
-    # into config_data so the configure playbook can render API_SERVER_KEY into
-    # ~/.hermes/.env. Reconfigure flows reuse the persisted token verbatim
-    # (idempotency contract — clients reading the gateway don't see rotation).
+    # Hermes: hydrate the persisted api_server block (non-sensitive shape from
+    # hosts.json) PLUS the bearer token from secrets.json into config_data so
+    # the configure playbook can render API_SERVER_KEY into ~/.hermes/.env.
+    # Reconfigure flows reuse the persisted token verbatim (idempotency
+    # contract — clients reading the gateway don't see rotation).
     if resolved_type == "hermes":
         persisted_api_server = agent_record.get("config", {}).get("api_server")
-        if isinstance(persisted_api_server, dict) and persisted_api_server.get("key"):
+        instance_key = get_instance_key(hostname, resolved_type, unix_agent_name)
+        secret_entry = get_instance_secrets(instance_key).get("HERMES_API_SERVER_KEY")
+        api_server_key = secret_entry["value"] if secret_entry else None
+
+        if not (isinstance(api_server_key, str) and len(api_server_key) == 64):
+            return (
+                False,
+                "Hermes agent missing HERMES_API_SERVER_KEY in secrets.json. "
+                "Re-run 'clm agent install --type hermes ...' to generate one.",
+            )
+
+        if isinstance(persisted_api_server, dict):
             existing_api_server = config_data.get("api_server") or {}
             if not isinstance(existing_api_server, dict):
                 existing_api_server = {}
-            # Persisted values are authoritative for key/host/port; user-supplied
-            # config_data may carry transient fields we want to preserve.
             merged_api_server = {**existing_api_server, **persisted_api_server}
+            merged_api_server["key"] = api_server_key
             config_data["api_server"] = merged_api_server
         else:
-            return (
-                False,
-                "Hermes agent missing api_server.key in hosts.json. "
-                "Re-run 'clm agent install --type hermes ...' to generate one.",
-            )
+            # hosts.json shape missing (legacy/corrupted); reconstruct defaults
+            # alongside the token from secrets.json so the playbook can run.
+            config_data["api_server"] = {
+                "enabled": True,
+                "host": "127.0.0.1",
+                "port": 8642,
+                "key": api_server_key,
+            }
 
     # Validate config data before running Ansible
     # Validate required provider fields (must check dict type first)

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -732,15 +732,24 @@ def configure_agent(
     # Reconfigure flows reuse the persisted token verbatim (idempotency
     # contract — clients reading the gateway don't see rotation).
     if resolved_type == "hermes":
+        from clawrium.core.install import _is_valid_hermes_api_server_key
+
         persisted_api_server = agent_record.get("config", {}).get("api_server")
-        instance_key = get_instance_key(hostname, resolved_type, unix_agent_name)
+        # Use canonical hostname (host['hostname']) instead of the raw hostname
+        # parameter so the lookup matches install.py's instance_key even when
+        # callers pass an alias. CLI paths today always resolve canonical, but
+        # programmatic callers may not.
+        instance_key = get_instance_key(
+            host["hostname"], resolved_type, unix_agent_name
+        )
         secret_entry = get_instance_secrets(instance_key).get("HERMES_API_SERVER_KEY")
         api_server_key = secret_entry["value"] if secret_entry else None
 
-        if not (isinstance(api_server_key, str) and len(api_server_key) == 64):
+        if not _is_valid_hermes_api_server_key(api_server_key):
             return (
                 False,
-                "Hermes agent missing HERMES_API_SERVER_KEY in secrets.json. "
+                "Hermes agent missing or invalid HERMES_API_SERVER_KEY in "
+                "secrets.json (expected 64-char lowercase hex). "
                 "Re-run 'clm agent install --type hermes ...' to generate one.",
             )
 
@@ -1004,7 +1013,18 @@ def configure_agent(
             existing_gateway = existing_config.get("gateway", {})
             device_creds = existing_gateway.get("device")
 
-            h["agents"][agent_key]["config"] = config_data
+            # Strip the hermes bearer token before persisting to hosts.json.
+            # The token was hydrated into config_data['api_server']['key']
+            # earlier in this call (line ~752) so the ansible playbook could
+            # render it, but the canonical store is secrets.json. Keeping it
+            # in hosts.json after configure would defeat the B3 migration.
+            persisted_config = dict(config_data)
+            if resolved_type == "hermes" and "api_server" in persisted_config:
+                api_server_persisted = dict(persisted_config["api_server"])
+                api_server_persisted.pop("key", None)
+                persisted_config["api_server"] = api_server_persisted
+
+            h["agents"][agent_key]["config"] = persisted_config
 
             # Restore device credentials if they existed
             if device_creds:

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -726,6 +726,27 @@ def configure_agent(
     # Use inner agent_name (Unix username) if available, otherwise fall back to dict key
     unix_agent_name = agent_record.get("agent_name") or agent_key
 
+    # Hermes: hydrate persisted api_server block (generated at install time)
+    # into config_data so the configure playbook can render API_SERVER_KEY into
+    # ~/.hermes/.env. Reconfigure flows reuse the persisted token verbatim
+    # (idempotency contract — clients reading the gateway don't see rotation).
+    if resolved_type == "hermes":
+        persisted_api_server = agent_record.get("config", {}).get("api_server")
+        if isinstance(persisted_api_server, dict) and persisted_api_server.get("key"):
+            existing_api_server = config_data.get("api_server") or {}
+            if not isinstance(existing_api_server, dict):
+                existing_api_server = {}
+            # Persisted values are authoritative for key/host/port; user-supplied
+            # config_data may carry transient fields we want to preserve.
+            merged_api_server = {**existing_api_server, **persisted_api_server}
+            config_data["api_server"] = merged_api_server
+        else:
+            return (
+                False,
+                "Hermes agent missing api_server.key in hosts.json. "
+                "Re-run 'clm agent install --type hermes ...' to generate one.",
+            )
+
     # Validate config data before running Ansible
     # Validate required provider fields (must check dict type first)
     required_provider_fields = ["name", "type", "default_model"]
@@ -923,13 +944,18 @@ def configure_agent(
 
     emit("configure", "Running Ansible playbook...")
 
+    # Hermes' configure flow restarts the service and probes /health with up
+    # to 20×3s retries (60s) — leave generous headroom for slow first-startup
+    # path that loads the agent venv. Other claws keep the legacy 60s budget.
+    configure_timeout = 240 if resolved_type == "hermes" else 60
+
     try:
         result = ansible_runner.run(
             private_data_dir=str(operation_log_dir),
             inventory=inventory,
             playbook=str(playbook_path),
             quiet=True,
-            timeout=60,
+            timeout=configure_timeout,
         )
 
         if result.status == "timeout":

--- a/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
@@ -1,0 +1,198 @@
+---
+- hosts: all
+  become: yes
+  tasks:
+    - name: Check if agent user exists
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ agent_name }}"
+      failed_when: false
+      register: user_check
+
+    - name: Fail if hermes not installed
+      ansible.builtin.fail:
+        msg: "Agent user '{{ agent_name }}' not found. Run 'clm agent install --type hermes ...' first."
+      when: user_check.msg is defined
+
+    - name: Verify API_SERVER_KEY is present in config
+      ansible.builtin.fail:
+        msg: |
+          api_server.key is missing for agent '{{ agent_name }}'.
+          Re-run 'clm agent install --type hermes --host <h> --name {{ agent_name }}' to regenerate.
+      when: config.api_server is not defined or not config.api_server.key
+
+    - name: Ensure ~/.hermes config directory exists
+      ansible.builtin.file:
+        path: "/home/{{ agent_name }}/.hermes"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0700"
+
+    # Re-render the systemd unit to use `hermes gateway run` (foreground,
+    # supervisor-friendly) instead of `hermes gateway start` (which delegates
+    # to a pre-installed per-user systemd unit and exits 1 if that unit isn't
+    # there — see `hermes gateway --help`). Phase 1's install.yaml dropped the
+    # initial unit; configure.yaml owns the runtime ExecStart.
+    - name: Sync hermes systemd unit (Phase 2 ExecStart)
+      ansible.builtin.copy:
+        dest: "/etc/systemd/system/{{ agent_type }}-{{ agent_name }}.service"
+        content: |
+          [Unit]
+          Description=Hermes AI Agent ({{ agent_name }})
+          After=network.target
+
+          [Service]
+          Type=simple
+          User={{ agent_name }}
+          WorkingDirectory=/home/{{ agent_name }}/.hermes
+          EnvironmentFile=/home/{{ agent_name }}/.hermes/.env
+          ExecStart=/home/{{ agent_name }}/.local/bin/hermes gateway run
+          Restart=on-failure
+          RestartSec=5
+
+          [Install]
+          WantedBy=multi-user.target
+        mode: "0644"
+      notify: Reload systemd and restart hermes service
+
+    # Render ~/.hermes/.env (provider API key + API_SERVER_* + low-priority
+    # provider/model env-var fallback). force: yes overwrites the populated
+    # template .env that hermes' upstream installer drops.
+    - name: Render ~/.hermes/.env from template
+      ansible.builtin.template:
+        src: "{{ template_path }}/.env.j2"
+        dest: "/home/{{ agent_name }}/.hermes/.env"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0600"
+        force: yes
+      no_log: true
+      notify: Restart hermes service
+
+    # Render ~/.hermes/config.yaml (model.provider, model.default,
+    # model.base_url). Hermes deep-merges with DEFAULT_CONFIG so omitted
+    # top-level keys keep their hermes defaults.
+    - name: Render ~/.hermes/config.yaml from template
+      ansible.builtin.template:
+        src: "{{ template_path }}/config.yaml.j2"
+        dest: "/home/{{ agent_name }}/.hermes/config.yaml"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0600"
+        force: yes
+      notify: Restart hermes service
+
+    # Per-provider credential verification — uses `grep -q` so we get a clean
+    # zero/non-zero exit status without leaking the rendered key into logs.
+    - name: Verify .env credentials for OpenRouter provider
+      ansible.builtin.command:
+        cmd: grep -q '^OPENROUTER_API_KEY=' "/home/{{ agent_name }}/.hermes/.env"
+      register: openrouter_check
+      changed_when: false
+      failed_when: openrouter_check.rc != 0
+      no_log: true
+      when:
+        - config.provider is defined
+        - config.provider.type == 'openrouter'
+        - provider_api_key | default('') | length > 0
+
+    - name: Verify .env credentials for Anthropic provider
+      ansible.builtin.command:
+        cmd: grep -q '^ANTHROPIC_API_KEY=' "/home/{{ agent_name }}/.hermes/.env"
+      register: anthropic_check
+      changed_when: false
+      failed_when: anthropic_check.rc != 0
+      no_log: true
+      when:
+        - config.provider is defined
+        - config.provider.type == 'anthropic'
+        - provider_api_key | default('') | length > 0
+
+    - name: Verify .env credentials for OpenAI provider
+      ansible.builtin.command:
+        cmd: grep -q '^OPENAI_API_KEY=' "/home/{{ agent_name }}/.hermes/.env"
+      register: openai_check
+      changed_when: false
+      failed_when: openai_check.rc != 0
+      no_log: true
+      when:
+        - config.provider is defined
+        - config.provider.type == 'openai'
+        - provider_api_key | default('') | length > 0
+
+    # Ollama / custom OpenAI-compatible endpoint: no API key, but the
+    # config.yaml must declare model.provider: custom and model.base_url.
+    - name: Verify config.yaml declares custom provider for Ollama
+      ansible.builtin.command:
+        cmd: grep -qE '^\s*provider:\s*"custom"' "/home/{{ agent_name }}/.hermes/config.yaml"
+      register: custom_provider_check
+      changed_when: false
+      failed_when: custom_provider_check.rc != 0
+      when:
+        - config.provider is defined
+        - config.provider.type == 'ollama'
+
+    - name: Verify config.yaml declares base_url for Ollama provider
+      ansible.builtin.command:
+        cmd: grep -qE '^\s*base_url:\s+' "/home/{{ agent_name }}/.hermes/config.yaml"
+      register: base_url_check
+      changed_when: false
+      failed_when: base_url_check.rc != 0
+      when:
+        - config.provider is defined
+        - config.provider.type == 'ollama'
+
+    # Verify the API_SERVER block always renders, regardless of provider.
+    # Use grep -q rather than lineinfile check_mode because the latter reports
+    # `changed: true` whenever the matched line differs from the placeholder
+    # (i.e., always — the real key never equals our placeholder).
+    - name: Verify .env contains API_SERVER_KEY
+      ansible.builtin.command:
+        cmd: grep -q '^API_SERVER_KEY=' "/home/{{ agent_name }}/.hermes/.env"
+      register: api_server_key_check
+      changed_when: false
+      failed_when: api_server_key_check.rc != 0
+      no_log: true
+      no_log: true
+
+    # Force the restart handler to fire NOW so probes below run against the
+    # newly-rendered config.
+    - name: Apply pending restart before probing
+      ansible.builtin.meta: flush_handlers
+
+    # Wait for the gateway to come up. /health is unauthenticated (verified
+    # against gateway/platforms/api_server.py at v2026.5.7), so we don't pass
+    # the bearer token here.
+    - name: Probe hermes /health endpoint
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ config.api_server.port | default(8642) | int }}/health"
+        method: GET
+        status_code: 200
+        timeout: 5
+      register: health_probe
+      retries: 20
+      delay: 3
+      until: health_probe.status == 200
+
+    - name: Display configure success
+      ansible.builtin.debug:
+        msg: |
+          Hermes agent '{{ agent_name }}' configured for provider '{{ config.provider.type | default('auto') }}'.
+          Local OpenAI-compatible API: http://127.0.0.1:{{ config.api_server.port | default(8642) | int }}
+          Service: hermes-{{ agent_name }}.service (active)
+
+  handlers:
+    - name: Restart hermes service
+      ansible.builtin.systemd:
+        name: "{{ agent_type }}-{{ agent_name }}"
+        state: restarted
+        enabled: yes
+        daemon_reload: yes
+
+    - name: Reload systemd and restart hermes service
+      ansible.builtin.systemd:
+        name: "{{ agent_type }}-{{ agent_name }}"
+        state: restarted
+        enabled: yes
+        daemon_reload: yes

--- a/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
@@ -54,7 +54,7 @@
           [Install]
           WantedBy=multi-user.target
         mode: "0644"
-      notify: Reload systemd and restart hermes service
+      notify: Restart hermes service
 
     # Render ~/.hermes/.env (provider API key + API_SERVER_* + low-priority
     # provider/model env-var fallback). force: yes overwrites the populated
@@ -154,7 +154,6 @@
       changed_when: false
       failed_when: api_server_key_check.rc != 0
       no_log: true
-      no_log: true
 
     # Force the restart handler to fire NOW so probes below run against the
     # newly-rendered config.
@@ -183,14 +182,11 @@
           Service: hermes-{{ agent_name }}.service (active)
 
   handlers:
+    # Single canonical restart handler. Always does daemon_reload so it covers
+    # both unit-file changes (from install.yaml) and pure env changes (from
+    # the template/config tasks above). All `notify` directives above point at
+    # this handler so first-configure restarts the service exactly once.
     - name: Restart hermes service
-      ansible.builtin.systemd:
-        name: "{{ agent_type }}-{{ agent_name }}"
-        state: restarted
-        enabled: yes
-        daemon_reload: yes
-
-    - name: Reload systemd and restart hermes service
       ansible.builtin.systemd:
         name: "{{ agent_type }}-{{ agent_name }}"
         state: restarted

--- a/src/clawrium/platform/registry/hermes/templates/.env.j2
+++ b/src/clawrium/platform/registry/hermes/templates/.env.j2
@@ -1,0 +1,29 @@
+# Managed by clawrium (clm). Do not edit by hand — re-render with
+# `clm agent configure {{ agent_name }}`.
+#
+# Provider API keys (only the active provider's key is populated; others are
+# omitted entirely so hermes does not pick a stale credential).
+{% if config.provider is defined and config.provider.type == 'openrouter' and provider_api_key | default('') | length > 0 %}
+OPENROUTER_API_KEY={{ provider_api_key }}
+{% elif config.provider is defined and config.provider.type == 'anthropic' and provider_api_key | default('') | length > 0 %}
+ANTHROPIC_API_KEY={{ provider_api_key }}
+{% elif config.provider is defined and config.provider.type == 'openai' and provider_api_key | default('') | length > 0 %}
+OPENAI_API_KEY={{ provider_api_key }}
+{% endif %}
+
+# Provider/model selection. config.yaml's `model:` block is the canonical
+# source — these env vars are emitted as a low-priority fallback.
+{% if config.provider is defined and config.provider.type %}
+{% if config.provider.type == 'ollama' %}
+HERMES_INFERENCE_PROVIDER=custom
+{% else %}
+HERMES_INFERENCE_PROVIDER={{ config.provider.type }}
+{% endif %}
+{% endif %}
+
+# API server (local OpenAI-compatible gateway on 127.0.0.1:8642).
+{% set api_server = config.api_server | default({}) %}
+API_SERVER_ENABLED=1
+API_SERVER_HOST={{ api_server.host | default('127.0.0.1') }}
+API_SERVER_PORT={{ api_server.port | default(8642) | int }}
+API_SERVER_KEY={{ api_server.key }}

--- a/src/clawrium/platform/registry/hermes/templates/config.yaml.j2
+++ b/src/clawrium/platform/registry/hermes/templates/config.yaml.j2
@@ -1,0 +1,34 @@
+# Managed by clawrium (clm). Do not edit by hand — re-render with
+# `clm agent configure {{ agent_name }}`.
+#
+# Hermes deep-merges this file with its DEFAULT_CONFIG at load time, so any
+# top-level keys not listed here retain their hermes defaults.
+{% set provider = config.provider | default({}) %}
+{% set provider_type = provider.type | default('') %}
+{% set model_id = provider.default_model | default('') %}
+{% set endpoint = provider.endpoint | default('') %}
+
+model:
+{% if provider_type == 'openrouter' %}
+  provider: "openrouter"
+  base_url: "https://openrouter.ai/api/v1"
+{% elif provider_type == 'anthropic' %}
+  provider: "anthropic"
+{% elif provider_type == 'openai' %}
+  provider: "openai"
+{% elif provider_type == 'ollama' %}
+  provider: "custom"
+{# Hermes' custom provider expects an OpenAI-compatible /v1 root. Append /v1
+   when the clm provider endpoint omits it (e.g. raw Ollama base URL). #}
+{% set endpoint_clean = endpoint.rstrip('/') %}
+{% if endpoint_clean and endpoint_clean.endswith('/v1') %}
+  base_url: "{{ endpoint_clean }}"
+{% elif endpoint_clean %}
+  base_url: "{{ endpoint_clean }}/v1"
+{% endif %}
+{% else %}
+  provider: "auto"
+{% endif %}
+{% if model_id %}
+  default: "{{ model_id }}"
+{% endif %}

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -302,7 +302,7 @@ class TestConfigureAgentApiServerKey:
     """configure_agent() must enforce + reuse the persisted api_server.key for hermes."""
 
     def test_hermes_without_persisted_key_returns_error(self):
-        """Reject configure when hermes agent record has no api_server.key."""
+        """Reject configure when secrets.json has no HERMES_API_SERVER_KEY."""
         host = {
             "hostname": "test-host",
             "key_id": "test",
@@ -310,7 +310,7 @@ class TestConfigureAgentApiServerKey:
                 "hermes-test": {
                     "type": "hermes",
                     "agent_name": "hermes-test",
-                    "config": {},  # no api_server block
+                    "config": {},
                 }
             },
         }
@@ -323,15 +323,22 @@ class TestConfigureAgentApiServerKey:
             },
         }
         with patch("clawrium.core.lifecycle.get_host", return_value=host):
-            success, error = configure_agent(
-                "test-host", "hermes", config_data, agent_name="hermes-test"
-            )
+            # Empty secrets.json for this instance — should trigger the
+            # "missing HERMES_API_SERVER_KEY" branch.
+            with patch(
+                "clawrium.core.lifecycle.get_instance_secrets", return_value={}
+            ):
+                success, error = configure_agent(
+                    "test-host", "hermes", config_data, agent_name="hermes-test"
+                )
         assert success is False
-        assert "api_server.key" in error
+        assert "HERMES_API_SERVER_KEY" in error
         assert "install" in error  # remediation pointer
 
     def test_hermes_with_persisted_key_passes_to_ansible(self, tmp_path: Path):
-        """When a key is persisted, configure_agent merges it into the ansible config var."""
+        """When the bearer token is persisted in secrets.json, configure_agent
+        hydrates it into the ansible config var alongside the non-sensitive
+        shape from hosts.json."""
         persisted_key = "b" * 64
         host = {
             "hostname": "test-host",
@@ -345,7 +352,6 @@ class TestConfigureAgentApiServerKey:
                             "enabled": True,
                             "host": "127.0.0.1",
                             "port": 8642,
-                            "key": persisted_key,
                         }
                     },
                 }
@@ -385,13 +391,26 @@ class TestConfigureAgentApiServerKey:
             ),
             patch("clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run),
             patch("clawrium.core.lifecycle.update_host", return_value=True),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                return_value={
+                    "HERMES_API_SERVER_KEY": {
+                        "key": "HERMES_API_SERVER_KEY",
+                        "value": persisted_key,
+                        "created_at": "2026-05-10T00:00:00+00:00",
+                        "updated_at": "2026-05-10T00:00:00+00:00",
+                        "description": "",
+                    }
+                },
+            ),
         ):
             success, error = configure_agent(
                 "test-host", "hermes", config_data, agent_name="hermes-test"
             )
 
         assert success is True, error
-        # api_server.key must reach the playbook unchanged (idempotency contract).
+        # api_server.key must reach the playbook (idempotency contract);
+        # value is now sourced from secrets.json, not hosts.json.
         sent_config = captured["inventory"]["all"]["vars"]["config"]
         assert sent_config["api_server"]["key"] == persisted_key
         assert sent_config["api_server"]["host"] == "127.0.0.1"
@@ -399,7 +418,7 @@ class TestConfigureAgentApiServerKey:
 
     def test_hermes_reconfigure_does_not_rotate_persisted_key(self, tmp_path: Path):
         """A second configure call with the same persisted record must use the same key
-        (idempotency: keys never rotate on reconfigure)."""
+        (idempotency: keys never rotate on reconfigure). Key lives in secrets.json."""
         persisted_key = "c" * 64
         host = {
             "hostname": "test-host",
@@ -413,14 +432,14 @@ class TestConfigureAgentApiServerKey:
                             "enabled": True,
                             "host": "127.0.0.1",
                             "port": 8642,
-                            "key": persisted_key,
                         }
                     },
                 }
             },
         }
-        # Caller passes config_data WITHOUT api_server (simulates _sync_provider_config
-        # forgetting to carry it through). configure_agent must hydrate from hosts.json.
+        # Caller passes config_data WITHOUT api_server (simulates
+        # _sync_provider_config not carrying it through). configure_agent must
+        # hydrate the shape from hosts.json and the bearer token from secrets.json.
         config_data = {
             "gateway": {"host": "127.0.0.1", "port": 8642},
             "provider": {"name": "p", "type": "ollama", "default_model": "x", "endpoint": "http://h:1/v1"},
@@ -430,6 +449,16 @@ class TestConfigureAgentApiServerKey:
         key_path.write_text("k")
         playbook = tmp_path / "configure.yaml"
         playbook.write_text("---\n")
+
+        secret_entry = {
+            "HERMES_API_SERVER_KEY": {
+                "key": "HERMES_API_SERVER_KEY",
+                "value": persisted_key,
+                "created_at": "2026-05-10T00:00:00+00:00",
+                "updated_at": "2026-05-10T00:00:00+00:00",
+                "description": "",
+            }
+        }
 
         seen_keys = []
 
@@ -457,6 +486,10 @@ class TestConfigureAgentApiServerKey:
                     "clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run
                 ),
                 patch("clawrium.core.lifecycle.update_host", return_value=True),
+                patch(
+                    "clawrium.core.lifecycle.get_instance_secrets",
+                    return_value=secret_entry,
+                ),
             ):
                 success, error = configure_agent(
                     "test-host", "hermes", dict(config_data), agent_name="hermes-test"

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -1,0 +1,467 @@
+"""Tests for the Hermes configure playbook + template + API_SERVER_KEY persistence.
+
+These cover:
+- `.env.j2` rendering across openrouter / anthropic / openai / ollama branches
+- `config.yaml.j2` rendering for ollama (model.provider=custom, base_url with /v1)
+- `configure.yaml` playbook structure: handler triggers, /health probe, credential
+  verification, missing-API_SERVER_KEY guard
+- `configure_agent()` rejects hermes agents missing api_server.key in hosts.json
+- `configure_agent()` reuses persisted api_server.key across reconfigures
+  (idempotency contract)
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+from clawrium.core.lifecycle import configure_agent
+
+HERMES_TEMPLATES = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "clawrium"
+    / "platform"
+    / "registry"
+    / "hermes"
+    / "templates"
+)
+HERMES_PLAYBOOKS = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "clawrium"
+    / "platform"
+    / "registry"
+    / "hermes"
+    / "playbooks"
+)
+
+
+def _render_env(config: dict, provider_api_key: str = "", agent_name: str = "h") -> str:
+    env = Environment(
+        loader=FileSystemLoader(str(HERMES_TEMPLATES)),
+        keep_trailing_newline=True,
+    )
+    template = env.get_template(".env.j2")
+    return template.render(
+        config=config, provider_api_key=provider_api_key, agent_name=agent_name
+    )
+
+
+def _render_config_yaml(config: dict, agent_name: str = "h") -> str:
+    env = Environment(
+        loader=FileSystemLoader(str(HERMES_TEMPLATES)),
+        keep_trailing_newline=True,
+    )
+    template = env.get_template("config.yaml.j2")
+    return template.render(config=config, agent_name=agent_name)
+
+
+# ---------------------------------------------------------------------------
+# .env.j2 rendering — provider branches
+# ---------------------------------------------------------------------------
+
+
+class TestEnvTemplateProviderBranches:
+    """Verify each provider branch emits the right credential line and only that one."""
+
+    def _api_server(self) -> dict:
+        return {"key": "a" * 64, "host": "127.0.0.1", "port": 8642, "enabled": True}
+
+    def test_openrouter_branch_emits_only_openrouter_key(self):
+        rendered = _render_env(
+            {
+                "provider": {
+                    "type": "openrouter",
+                    "default_model": "anthropic/claude-opus-4.6",
+                },
+                "api_server": self._api_server(),
+            },
+            provider_api_key="sk-or-test-123",
+        )
+        assert "OPENROUTER_API_KEY=sk-or-test-123" in rendered
+        assert "ANTHROPIC_API_KEY=" not in rendered
+        assert "OPENAI_API_KEY=" not in rendered
+        assert "HERMES_INFERENCE_PROVIDER=openrouter" in rendered
+
+    def test_anthropic_branch_emits_only_anthropic_key(self):
+        rendered = _render_env(
+            {
+                "provider": {"type": "anthropic", "default_model": "claude-opus-4.6"},
+                "api_server": self._api_server(),
+            },
+            provider_api_key="sk-ant-test-456",
+        )
+        assert "ANTHROPIC_API_KEY=sk-ant-test-456" in rendered
+        assert "OPENROUTER_API_KEY=" not in rendered
+        assert "OPENAI_API_KEY=" not in rendered
+        assert "HERMES_INFERENCE_PROVIDER=anthropic" in rendered
+
+    def test_openai_branch_emits_only_openai_key(self):
+        rendered = _render_env(
+            {
+                "provider": {"type": "openai", "default_model": "gpt-4o"},
+                "api_server": self._api_server(),
+            },
+            provider_api_key="sk-openai-test-789",
+        )
+        assert "OPENAI_API_KEY=sk-openai-test-789" in rendered
+        assert "OPENROUTER_API_KEY=" not in rendered
+        assert "ANTHROPIC_API_KEY=" not in rendered
+        assert "HERMES_INFERENCE_PROVIDER=openai" in rendered
+
+    def test_ollama_branch_emits_no_provider_api_key_and_custom_provider(self):
+        """Ollama / custom local endpoint: no API key required; provider maps to 'custom'."""
+        rendered = _render_env(
+            {
+                "provider": {
+                    "type": "ollama",
+                    "endpoint": "http://192.168.1.17:11434",
+                    "default_model": "qwen3-coder:30b-128k",
+                },
+                "api_server": self._api_server(),
+            },
+            provider_api_key="",  # no key for local endpoints
+        )
+        assert "OPENAI_API_KEY=" not in rendered
+        assert "ANTHROPIC_API_KEY=" not in rendered
+        assert "OPENROUTER_API_KEY=" not in rendered
+        # HERMES_INFERENCE_PROVIDER is the alias 'custom', not 'ollama' (matches
+        # hermes_cli/providers.py CUSTOM_ALIASES at v2026.5.7).
+        assert "HERMES_INFERENCE_PROVIDER=custom" in rendered
+
+    def test_api_server_block_always_rendered(self):
+        rendered = _render_env(
+            {
+                "provider": {"type": "openrouter", "default_model": "x"},
+                "api_server": self._api_server(),
+            },
+            provider_api_key="k",
+        )
+        assert "API_SERVER_ENABLED=1" in rendered
+        assert "API_SERVER_HOST=127.0.0.1" in rendered
+        assert "API_SERVER_PORT=8642" in rendered
+        assert "API_SERVER_KEY=" + ("a" * 64) in rendered
+
+    def test_no_provider_api_key_omits_credential_line(self):
+        """If provider_api_key is empty, the cloud-provider line is omitted entirely."""
+        rendered = _render_env(
+            {
+                "provider": {"type": "openrouter", "default_model": "x"},
+                "api_server": self._api_server(),
+            },
+            provider_api_key="",
+        )
+        assert "OPENROUTER_API_KEY=" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# config.yaml.j2 rendering
+# ---------------------------------------------------------------------------
+
+
+class TestConfigYamlTemplate:
+    """The model: block is the canonical source of truth for provider / base_url / default."""
+
+    def test_ollama_renders_custom_provider_with_v1_suffix_appended(self):
+        rendered = _render_config_yaml(
+            {
+                "provider": {
+                    "type": "ollama",
+                    "endpoint": "http://192.168.1.17:11434",
+                    "default_model": "qwen3-coder:30b-128k",
+                }
+            }
+        )
+        parsed = yaml.safe_load(rendered)
+        assert parsed["model"]["provider"] == "custom"
+        assert parsed["model"]["base_url"] == "http://192.168.1.17:11434/v1"
+        assert parsed["model"]["default"] == "qwen3-coder:30b-128k"
+
+    def test_ollama_endpoint_already_has_v1_suffix_not_doubled(self):
+        rendered = _render_config_yaml(
+            {
+                "provider": {
+                    "type": "ollama",
+                    "endpoint": "http://10.0.0.5:8000/v1",
+                    "default_model": "any",
+                }
+            }
+        )
+        parsed = yaml.safe_load(rendered)
+        assert parsed["model"]["base_url"] == "http://10.0.0.5:8000/v1"
+
+    def test_openrouter_renders_provider_and_base_url(self):
+        rendered = _render_config_yaml(
+            {
+                "provider": {
+                    "type": "openrouter",
+                    "default_model": "anthropic/claude-opus-4.6",
+                }
+            }
+        )
+        parsed = yaml.safe_load(rendered)
+        assert parsed["model"]["provider"] == "openrouter"
+        assert parsed["model"]["base_url"] == "https://openrouter.ai/api/v1"
+        assert parsed["model"]["default"] == "anthropic/claude-opus-4.6"
+
+    def test_anthropic_omits_base_url(self):
+        rendered = _render_config_yaml(
+            {"provider": {"type": "anthropic", "default_model": "claude-opus-4.6"}}
+        )
+        parsed = yaml.safe_load(rendered)
+        assert parsed["model"]["provider"] == "anthropic"
+        assert "base_url" not in parsed["model"]
+
+    def test_openai_omits_base_url(self):
+        rendered = _render_config_yaml(
+            {"provider": {"type": "openai", "default_model": "gpt-4o"}}
+        )
+        parsed = yaml.safe_load(rendered)
+        assert parsed["model"]["provider"] == "openai"
+        assert "base_url" not in parsed["model"]
+
+
+# ---------------------------------------------------------------------------
+# configure.yaml playbook shape
+# ---------------------------------------------------------------------------
+
+
+class TestConfigurePlaybookShape:
+    """Static checks on the configure playbook contract."""
+
+    def _load_playbook(self) -> dict:
+        return yaml.safe_load((HERMES_PLAYBOOKS / "configure.yaml").read_text())[0]
+
+    def test_playbook_renders_env_and_config_yaml(self):
+        play = self._load_playbook()
+        names = [t.get("name", "") for t in play["tasks"]]
+        assert any("Render ~/.hermes/.env" in n for n in names)
+        assert any("Render ~/.hermes/config.yaml" in n for n in names)
+
+    def test_playbook_guards_missing_api_server_key(self):
+        play = self._load_playbook()
+        names = [t.get("name", "") for t in play["tasks"]]
+        assert any("Verify API_SERVER_KEY is present in config" == n for n in names)
+
+    def test_playbook_has_health_probe(self):
+        play = self._load_playbook()
+        names = [t.get("name", "") for t in play["tasks"]]
+        assert any("Probe hermes /health endpoint" in n for n in names)
+
+    def test_playbook_restart_handler_triggers_systemd(self):
+        play = self._load_playbook()
+        handlers = play.get("handlers", [])
+        restart = [
+            h for h in handlers if "Restart hermes service" in h.get("name", "")
+        ]
+        assert restart, "configure.yaml must declare a Restart hermes service handler"
+        sysd = restart[0]["ansible.builtin.systemd"]
+        assert sysd["state"] == "restarted"
+        assert sysd["enabled"] is True
+
+    def test_env_template_is_referenced_by_render_task(self):
+        play = self._load_playbook()
+        tasks = play["tasks"]
+        env_render = next(
+            (t for t in tasks if "Render ~/.hermes/.env" in t.get("name", "")), None
+        )
+        assert env_render is not None
+        tpl = env_render["ansible.builtin.template"]
+        assert tpl["src"].endswith(".env.j2")
+        assert tpl["dest"] == "/home/{{ agent_name }}/.hermes/.env"
+        assert tpl["mode"] == "0600"
+        assert tpl["force"] is True
+
+    def test_ollama_branch_verifies_config_yaml_provider_and_base_url(self):
+        """The ollama branch must verify both `provider: custom` and a base_url line."""
+        play = self._load_playbook()
+        names = [t.get("name", "") for t in play["tasks"]]
+        assert any("custom provider for Ollama" in n for n in names)
+        assert any("base_url for Ollama" in n for n in names)
+
+    def test_systemd_unit_uses_gateway_run_not_start(self):
+        """The Phase 2 unit MUST use `hermes gateway run` — `gateway start`
+        delegates to a per-user systemd unit that does not exist in our setup."""
+        content = (HERMES_PLAYBOOKS / "configure.yaml").read_text()
+        assert "ExecStart=/home/{{ agent_name }}/.local/bin/hermes gateway run" in content
+        # Ensure the broken `gateway start` form is NOT what configure.yaml writes.
+        # (Phase 1's install.yaml dropped a placeholder using `gateway start`;
+        # configure.yaml owns the runtime ExecStart.)
+        configure_content = content.split("hermes systemd unit")[1] if "hermes systemd unit" in content else ""
+        assert "gateway start" not in configure_content
+
+
+# ---------------------------------------------------------------------------
+# configure_agent() — api_server.key persistence + idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureAgentApiServerKey:
+    """configure_agent() must enforce + reuse the persisted api_server.key for hermes."""
+
+    def test_hermes_without_persisted_key_returns_error(self):
+        """Reject configure when hermes agent record has no api_server.key."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {},  # no api_server block
+                }
+            },
+        }
+        config_data = {
+            "gateway": {"host": "127.0.0.1", "port": 8642},
+            "provider": {
+                "name": "p",
+                "type": "openrouter",
+                "default_model": "x",
+            },
+        }
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            success, error = configure_agent(
+                "test-host", "hermes", config_data, agent_name="hermes-test"
+            )
+        assert success is False
+        assert "api_server.key" in error
+        assert "install" in error  # remediation pointer
+
+    def test_hermes_with_persisted_key_passes_to_ansible(self, tmp_path: Path):
+        """When a key is persisted, configure_agent merges it into the ansible config var."""
+        persisted_key = "b" * 64
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {
+                        "api_server": {
+                            "enabled": True,
+                            "host": "127.0.0.1",
+                            "port": 8642,
+                            "key": persisted_key,
+                        }
+                    },
+                }
+            },
+        }
+        config_data = {
+            "gateway": {"host": "127.0.0.1", "port": 8642},
+            "provider": {
+                "name": "p",
+                "type": "openrouter",
+                "default_model": "x",
+            },
+        }
+
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        captured = {}
+
+        def fake_run(**kwargs):
+            captured["inventory"] = kwargs["inventory"]
+            mock = MagicMock()
+            mock.status = "successful"
+            mock.events = []
+            return mock
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ),
+            patch("clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run),
+            patch("clawrium.core.lifecycle.update_host", return_value=True),
+        ):
+            success, error = configure_agent(
+                "test-host", "hermes", config_data, agent_name="hermes-test"
+            )
+
+        assert success is True, error
+        # api_server.key must reach the playbook unchanged (idempotency contract).
+        sent_config = captured["inventory"]["all"]["vars"]["config"]
+        assert sent_config["api_server"]["key"] == persisted_key
+        assert sent_config["api_server"]["host"] == "127.0.0.1"
+        assert sent_config["api_server"]["port"] == 8642
+
+    def test_hermes_reconfigure_does_not_rotate_persisted_key(self, tmp_path: Path):
+        """A second configure call with the same persisted record must use the same key
+        (idempotency: keys never rotate on reconfigure)."""
+        persisted_key = "c" * 64
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {
+                        "api_server": {
+                            "enabled": True,
+                            "host": "127.0.0.1",
+                            "port": 8642,
+                            "key": persisted_key,
+                        }
+                    },
+                }
+            },
+        }
+        # Caller passes config_data WITHOUT api_server (simulates _sync_provider_config
+        # forgetting to carry it through). configure_agent must hydrate from hosts.json.
+        config_data = {
+            "gateway": {"host": "127.0.0.1", "port": 8642},
+            "provider": {"name": "p", "type": "ollama", "default_model": "x", "endpoint": "http://h:1/v1"},
+        }
+
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        seen_keys = []
+
+        def fake_run(**kwargs):
+            seen_keys.append(
+                kwargs["inventory"]["all"]["vars"]["config"]["api_server"]["key"]
+            )
+            mock = MagicMock()
+            mock.status = "successful"
+            mock.events = []
+            return mock
+
+        for _ in range(2):
+            with (
+                patch("clawrium.core.lifecycle.get_host", return_value=host),
+                patch(
+                    "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                    return_value=playbook,
+                ),
+                patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ),
+                patch(
+                    "clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run
+                ),
+                patch("clawrium.core.lifecycle.update_host", return_value=True),
+            ):
+                success, error = configure_agent(
+                    "test-host", "hermes", dict(config_data), agent_name="hermes-test"
+                )
+                assert success is True, error
+
+        assert len(seen_keys) == 2
+        assert seen_keys[0] == seen_keys[1] == persisted_key

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -498,3 +498,248 @@ class TestConfigureAgentApiServerKey:
 
         assert len(seen_keys) == 2
         assert seen_keys[0] == seen_keys[1] == persisted_key
+
+
+class TestHermesApiServerKeySecretsHygiene:
+    """Regression guards for the B3 migration and its iter-2 follow-ups."""
+
+    def test_is_valid_hermes_api_server_key_accepts_canonical(self):
+        """64-char lowercase hex is accepted."""
+        from clawrium.core.install import _is_valid_hermes_api_server_key
+
+        assert _is_valid_hermes_api_server_key("a" * 64) is True
+        assert _is_valid_hermes_api_server_key("0123456789abcdef" * 4) is True
+
+    def test_is_valid_hermes_api_server_key_rejects_invalid(self):
+        """Anything non-64-lowercase-hex is rejected."""
+        from clawrium.core.install import _is_valid_hermes_api_server_key
+
+        assert _is_valid_hermes_api_server_key("a" * 63) is False  # short
+        assert _is_valid_hermes_api_server_key("a" * 65) is False  # long
+        assert _is_valid_hermes_api_server_key("A" * 64) is False  # uppercase
+        assert _is_valid_hermes_api_server_key("g" * 64) is False  # non-hex
+        assert _is_valid_hermes_api_server_key(None) is False
+        assert _is_valid_hermes_api_server_key(123) is False
+        assert _is_valid_hermes_api_server_key("") is False
+
+    def test_configure_strips_api_server_key_from_persisted_hosts_json(
+        self, tmp_path: Path
+    ):
+        """B3 invariant: the bearer token must NOT land in hosts.json after configure.
+
+        The hydration path puts it on config_data['api_server']['key'] for
+        Ansible, but the updater closure must strip it before persisting.
+        """
+        persisted_key = "d" * 64
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {
+                        "api_server": {
+                            "enabled": True,
+                            "host": "127.0.0.1",
+                            "port": 8642,
+                        }
+                    },
+                }
+            },
+        }
+        config_data = {
+            "gateway": {"host": "127.0.0.1", "port": 8642},
+            "provider": {
+                "name": "p",
+                "type": "openrouter",
+                "default_model": "x",
+            },
+        }
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        captured_updater_arg = {}
+
+        def fake_update_host(hostname_arg, updater):
+            # Run the updater on a copy of the host fixture to capture what
+            # configure_agent intends to persist.
+            updated = updater({"agents": dict(host["agents"])})
+            captured_updater_arg["agents"] = updated["agents"]
+            return True
+
+        secrets_fixture = {
+            "HERMES_API_SERVER_KEY": {
+                "key": "HERMES_API_SERVER_KEY",
+                "value": persisted_key,
+                "created_at": "2026-05-10T00:00:00+00:00",
+                "updated_at": "2026-05-10T00:00:00+00:00",
+                "description": "",
+            }
+        }
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch("clawrium.core.lifecycle.get_host_private_key", return_value=key_path),
+            patch(
+                "clawrium.core.lifecycle.ansible_runner.run",
+                return_value=MagicMock(status="successful", events=[]),
+            ),
+            patch(
+                "clawrium.core.lifecycle.update_host", side_effect=fake_update_host
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                return_value=secrets_fixture,
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host", "hermes", config_data, agent_name="hermes-test"
+            )
+
+        assert success is True, error
+        persisted_api_server = (
+            captured_updater_arg["agents"]["hermes-test"]
+            .get("config", {})
+            .get("api_server", {})
+        )
+        # B3 invariant — the bearer token must not be persisted to hosts.json.
+        assert "key" not in persisted_api_server, (
+            "hermes bearer token leaked into hosts.json: " f"{persisted_api_server}"
+        )
+        # Non-sensitive shape is preserved.
+        assert persisted_api_server.get("enabled") is True
+        assert persisted_api_server.get("host") == "127.0.0.1"
+        assert persisted_api_server.get("port") == 8642
+
+    def test_configure_rejects_invalid_hex_key_in_secrets(self, tmp_path: Path):
+        """A corrupted (non-hex / wrong length) HERMES_API_SERVER_KEY is rejected
+        before reaching the Ansible playbook."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {"api_server": {"enabled": True, "host": "127.0.0.1", "port": 8642}},
+                }
+            },
+        }
+        bad_secrets = {
+            "HERMES_API_SERVER_KEY": {
+                "key": "HERMES_API_SERVER_KEY",
+                "value": "G" * 64,  # uppercase / non-hex
+                "created_at": "2026-05-10T00:00:00+00:00",
+                "updated_at": "2026-05-10T00:00:00+00:00",
+                "description": "",
+            }
+        }
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                return_value=bad_secrets,
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host",
+                "hermes",
+                {"provider": {"name": "p", "type": "openrouter", "default_model": "x"}},
+                agent_name="hermes-test",
+            )
+        assert success is False
+        assert "invalid" in error.lower()
+        assert "HERMES_API_SERVER_KEY" in error
+
+    def test_configure_uses_canonical_hostname_for_instance_key(self, tmp_path: Path):
+        """Regression guard for commit 27d1ea8 + W1 from ATX iter 2: instance_key
+        must derive from host['hostname'], not the alias passed by the CLI."""
+        persisted_key = "e" * 64
+        host = {
+            "hostname": "192.168.1.100",  # canonical
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {"api_server": {"enabled": True, "host": "127.0.0.1", "port": 8642}},
+                }
+            },
+        }
+        secrets_fixture = {
+            "HERMES_API_SERVER_KEY": {
+                "key": "HERMES_API_SERVER_KEY",
+                "value": persisted_key,
+                "created_at": "2026-05-10T00:00:00+00:00",
+                "updated_at": "2026-05-10T00:00:00+00:00",
+                "description": "",
+            }
+        }
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+        get_secrets_mock = MagicMock(return_value=secrets_fixture)
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch("clawrium.core.lifecycle.get_host_private_key", return_value=key_path),
+            patch(
+                "clawrium.core.lifecycle.ansible_runner.run",
+                return_value=MagicMock(status="successful", events=[]),
+            ),
+            patch("clawrium.core.lifecycle.update_host", return_value=True),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                side_effect=get_secrets_mock,
+            ),
+        ):
+            # Caller passes the ALIAS form. Internally configure_agent must
+            # resolve via host['hostname'] (canonical) for the instance_key.
+            success, _ = configure_agent(
+                "wolf-i",
+                "hermes",
+                {"provider": {"name": "p", "type": "openrouter", "default_model": "x"}},
+                agent_name="hermes-test",
+            )
+        assert success is True
+        # instance_key passed to get_instance_secrets must be the canonical form.
+        # Ignore additional calls (lifecycle queries secrets for other purposes).
+        called_keys = [args[0] for args, _ in get_secrets_mock.call_args_list]
+        assert "192.168.1.100:hermes:hermes-test" in called_keys, called_keys
+        assert "wolf-i:hermes:hermes-test" not in called_keys, called_keys
+
+
+class TestConfigureYamlHandlerShape:
+    """B1 (iter 1) regression guard: configure.yaml must have exactly one
+    restart handler — having two caused a double restart on first configure."""
+
+    def test_configure_playbook_has_single_restart_handler(self):
+        playbook_path = (
+            Path(__file__).parent.parent
+            / "src/clawrium/platform/registry/hermes/playbooks/configure.yaml"
+        )
+        data = yaml.safe_load(playbook_path.read_text())
+        assert isinstance(data, list) and len(data) == 1
+        play = data[0]
+        handlers = play.get("handlers", [])
+        # All handlers must be restarts (no daemon-only handlers).
+        restart_handlers = [
+            h for h in handlers if "Restart" in h.get("name", "")
+        ]
+        assert len(handlers) == len(restart_handlers) == 1, (
+            f"expected exactly 1 restart handler, got {len(handlers)} total / "
+            f"{len(restart_handlers)} restart: "
+            f"{[h.get('name') for h in handlers]}"
+        )


### PR DESCRIPTION
## Why

When PR #318 (Phase 2) was merged, its base was still `issue-68-phase-1-installation` rather than `main`. GitHub doesn't auto-retarget a stacked PR's base after the parent merges, so the Phase 2 merge commit landed on the Phase 1 branch and never reached `main`.

This PR brings those 6 stranded commits over so `main` actually contains Phase 2.

## Stranded commits

\`\`\`
ff11b95 Merge pull request #318 from ric03uec/issue-68-phase-2-configuration
49d2fc3 fix(hermes): address ATX review 2 blocker + warnings on PR #318
27d1ea8 fix(hermes): use canonical hostname for HERMES_API_SERVER_KEY instance_key
85bb089 fix(hermes): address ATX review 1 blockers B1, B2, B3 on PR #318
1126048 feat(registry): hermes-agent configuration + api_server gateway (#68 phase 2)
e1e2095 docs(itx): pin Hermes env-var research for #68 Phase 2
\`\`\`

## Review

No new code — these are the exact commits already reviewed and approved in PR #318 (ATX trajectory 3.5/5 → 3.5/5 → 4/5, fully detailed in the #318 PR body). Re-merging here just propagates them to \`main\`.

## Process note (for future stacked PRs)

Before merging the second PR in a stack, retarget its base from the parent branch to \`main\` (after the parent has merged). The "Edit" button on the PR page lets you change the base; otherwise the merge lands on the parent branch, not main.

Refs #68