### PR TITLE
feat(onboarding): real hermes onboarding pipeline (#68 phase 4)

### DIFF
--- a/.itx/68/01_EXECUTION.md
+++ b/.itx/68/01_EXECUTION.md
@@ -447,4 +447,51 @@ Implementation outcomes:
 
 E2E results on wolf-i (192.168.1.36) — captured after the next "E2E" log entry below.
 
+---
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-10T19:00:00Z
+**Model**: claude-opus-4-7
+**Subtask**: #315 (Phase 4)
+**Branch**: `issue-68-phase-4-onboarding` (base: `main` @ 2cb086d)
+
+```prompt
+/itx:execute 315 (sub-agent invocation, Phase 4 — Onboarding metadata)
+```
+
+Implementation outcomes:
+
+1. Replaced hermes Phase 1 placeholder onboarding (all four stages `auto_skip: true`) with the real pipeline:
+   - `providers` — required, two canonical tasks (`provider_select` + `provider_test`) identical in shape to openclaw.
+   - `identity` — `auto_skip: true` with descriptive text. Hermes manages SOUL.md/AGENTS.md internally inside `~/.hermes/` on the agent host; clm does not push identity files in this iteration.
+   - `channels` — required, single confirm task. The CLI runner forces `channels = ["cli"]` for `claw_type == "hermes"` so the user is never offered Discord/Slack — those gateways are out of scope and deferred.
+   - `validate` — three composite tasks (`binary_check`, `env_check`, `health_check`), executed in code by the new `validate_hermes_health()` helper.
+
+2. New `validate_hermes_health()` in `core/validation.py` runs three checks on the agent host via Ansible: `hermes --version`, `test -f ~/.hermes/.env`, and `curl -fsS http://127.0.0.1:8642/health`. Because the api_server platform binds to loopback on the agent host by design, the probe MUST execute there rather than from the clm machine. Three implementation gotchas surfaced during E2E:
+   - The hermes agent user ships with `/usr/sbin/nologin` as its login shell (Phase 1 design). `sudo -u <user> -i bash` therefore fails with "This account is currently not available." Fix: use `sudo -u <user> bash -c '…'` (non-login) with explicit `HOME` and `PATH` env vars so `hermes` from `~/.local/bin` resolves.
+   - Ansible's `shell` module defaults to `/bin/sh` (dash), which does NOT support `set -o pipefail`. Removed the `pipefail` prefix; each check captures its own rc into a sentinel line instead.
+   - `curl -w "%{http_code}"` with `-o /dev/null` writes the status code with NO trailing newline. Added `\n` to the format string so the parser can read the line cleanly.
+
+3. Added per-stage `auto_skip:true` handling to `can_skip_stage()` in `core/onboarding.py`. Previously the function only honored a top-level `skip_stages: [...]` list; now it also returns True when `onboarding.stages.<stage>.auto_skip is True`. This wires up hermes' identity stage to be silently skipped by the configure wizard.
+
+4. Extended `_run_validate_stage` with a hermes branch that calls `validate_hermes_health` instead of openclaw's `validate_openclaw_gateway`. Also skips the SOUL.md check for hermes (since identity is auto_skipped, there is no local SOUL.md to validate). Step numbering is now computed from `total_checks` instead of hardcoded indices.
+
+5. The `initialize_onboarding` auto_skip → READY short-circuit is left intact. Hermes Phase 4 no longer triggers it (because `providers` is now real), but the contract MUST keep working for future agent types that declare every stage as auto_skip. New test `test_initialize_all_auto_skip_short_circuits_to_ready` exercises the short-circuit via a manifest mock to lock the behavior in independent of any specific shipping manifest.
+
+6. Test surface:
+   - New `tests/test_hermes_onboarding.py` — 14 tests covering manifest shape, `can_skip_stage` behavior, and four `validate_hermes_health` scenarios (all pass / health fail / env missing / binary missing) plus an agent-not-found guard. ansible_runner is mocked.
+   - Updated `tests/test_registry_hermes.py::test_hermes_manifest_onboarding_all_auto_skip` → `_real_pipeline` to assert the new shape.
+   - Updated `tests/test_onboarding.py::test_initialize_hermes_auto_skips_to_ready` → `_starts_pending_after_phase_4`, plus the new `_all_auto_skip_short_circuits_to_ready` regression test.
+
+E2E results on wolf-i (192.168.1.36) against provider `clm-openrouter`:
+
+- `clm agent install --type hermes --host wolf-i --name hermes-test --yes` — succeeded (~2 min, install + clone + python venv).
+- `clm agent start hermes-test` (no --force, before configure) — **correctly blocked**: "Cannot start hermes-test - onboarding not started. Run 'clm agent configure hermes-test' to begin onboarding." This is the new contract: hermes no longer fast-paths to READY at install time.
+- `clm agent configure hermes-test --yes` — walked through PROVIDERS (clm-openrouter selected) → IDENTITY (silently auto-skipped, no header printed) → CHANNELS (only `cli` offered, single recommended option auto-selected) → VALIDATE (4 checks: install, provider config, provider connectivity, hermes health). Onboarding ended in READY.
+- `clm agent start hermes-test` (no --force, after configure) — succeeded.
+- `clm agent stop hermes-test` — succeeded.
+- `clm agent configure hermes-test --yes --stage validate` (with service stopped) — **correctly failed**: "api_server /health did not return 200 for agent 'hermes-test' on host 'wolf-i'. The hermes service is not healthy. Inspect 'journalctl -u hermes-hermes-test.service'." Validate stage fails loudly when /health is down, exactly as intended.
+- `clm agent remove hermes-test --force` — cleaned up the agent user, systemd unit, `~/.hermes/`, binary symlink, and `hosts.json` record.
+
 </details>

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -1384,7 +1384,7 @@ def configure(
     skip_health: bool = typer.Option(
         False,
         "--skip-health",
-        help="Skip OpenClaw gateway health verification during validate",
+        help="Skip agent health verification during validate (openclaw gateway probe or hermes /health probe)",
     ),
     file: Optional[list[Path]] = typer.Option(
         None,
@@ -1599,6 +1599,12 @@ def configure(
                 continue
 
             if can_skip_stage(claw_type, stage_name):
+                # Print a one-line breadcrumb so the user sees that a stage
+                # was deliberately skipped rather than silently swallowed.
+                console.print(
+                    f"[dim]Stage {i + 1}/{total_stages}: "
+                    f"{stage_name.upper()} — auto-skipped[/dim]"
+                )
                 try:
                     complete_stage(
                         hostname, installed_name, stage_name, StageStatus.SKIPPED
@@ -1608,6 +1614,20 @@ def configure(
                         f"[red]Error:[/red] Failed to skip stage: {rich_escape(str(e))}"
                     )
                     raise typer.Exit(code=1)
+                # Also advance the state pointer so the next required stage's
+                # `transition_state(PENDING → providers/identity/...)` does not
+                # InvalidTransitionError when 2+ consecutive stages auto-skip.
+                next_state = STAGE_TO_NEXT_STATE.get(stage_name)
+                if next_state is not None:
+                    current_st = get_onboarding_state(hostname, installed_name)
+                    # Only advance forward; don't revert e.g. validate→ready loop.
+                    if current_st.value != next_state.value:
+                        try:
+                            transition_state(hostname, installed_name, next_state)
+                        except InvalidTransitionError:
+                            # Either the state already advanced past us or the
+                            # caller is re-running. Either way, drop through.
+                            pass
                 continue
 
             _stage_header(
@@ -1703,10 +1723,13 @@ def _show_start_blocked_error(
 
     total_stages = len(STAGES)
 
+    # Treat both "complete" and "skipped" as resolved — a skipped stage (e.g.
+    # hermes' identity stage in Phase 4) is not something the user needs to
+    # come back to.
     incomplete_stages = [
         (name, desc)
         for name, desc in STAGES
-        if stages_data.get(name, {}).get("status") != "complete"
+        if stages_data.get(name, {}).get("status") not in ("complete", "skipped")
     ]
 
     console.print()

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -708,7 +708,13 @@ def _run_channels_stage(
     """
     from clawrium.core.secrets import get_instance_key, set_instance_secret
 
-    channels = ["cli", "discord", "slack"]
+    # Hermes ships with only the loopback api_server platform in this iteration.
+    # External messaging gateways (Discord/Slack/Telegram/etc.) are tracked as
+    # a separate follow-up issue; offering them here would mislead the user.
+    if claw_type == "hermes":
+        channels = ["cli"]
+    else:
+        channels = ["cli", "discord", "slack"]
 
     console.print("[bold]Select default channel:[/bold]")
     for i, ch in enumerate(channels, 1):
@@ -717,7 +723,7 @@ def _run_channels_stage(
 
     console.print()
 
-    if yes:
+    if yes or len(channels) == 1:
         choice = 1
     else:
         choice = typer.prompt("Select", type=int, default=1)
@@ -955,14 +961,29 @@ def _run_validate_stage(
         verify_provider_connectivity,
         validate_agent_installation,
         validate_openclaw_gateway,
+        validate_hermes_health,
     )
 
     all_errors = []
     all_warnings = []
 
-    total_checks = 5 if claw_type == "openclaw" else 4
+    # Hermes manages SOUL.md/AGENTS.md internally inside ~/.hermes/ on the
+    # agent host — clm does not push identity files for hermes (identity stage
+    # auto_skips). So we skip the SOUL.md check for hermes and replace
+    # openclaw's gateway health probe with the hermes-specific /health check.
+    skip_soul_check = claw_type == "hermes"
 
-    console.print(f"[1/{total_checks}] Validating agent installation...")
+    total_checks = 5
+    if skip_soul_check:
+        total_checks -= 1
+    if claw_type not in ("openclaw", "hermes"):
+        # Generic claws (zeroclaw, future agents) have no gateway/health step.
+        total_checks -= 1
+
+    step_idx = 0
+
+    step_idx += 1
+    console.print(f"[{step_idx}/{total_checks}] Validating agent installation...")
     agent_name = installed_name or claw_type
     install_result = validate_agent_installation(host, agent_name)
     if install_result.passed:
@@ -973,20 +994,25 @@ def _run_validate_stage(
             console.print(f"    [red]Error:[/red] {rich_escape(error)}")
         all_errors.extend(install_result.errors)
 
-    console.print(f"[2/{total_checks}] Validating personality file (SOUL.md)...")
-    soul_result = validate_soul_md(claw_type)
-    if soul_result.passed:
-        console.print("  [green]✓[/green] SOUL.md exists and readable")
-        for warning in soul_result.warnings:
-            console.print(f"    [yellow]Warning:[/yellow] {rich_escape(warning)}")
-            all_warnings.append(warning)
-    else:
-        console.print("  [red]✗[/red] SOUL.md validation failed")
-        for error in soul_result.errors:
-            console.print(f"    [red]Error:[/red] {rich_escape(error)}")
-        all_errors.extend(soul_result.errors)
+    if not skip_soul_check:
+        step_idx += 1
+        console.print(
+            f"[{step_idx}/{total_checks}] Validating personality file (SOUL.md)..."
+        )
+        soul_result = validate_soul_md(claw_type)
+        if soul_result.passed:
+            console.print("  [green]✓[/green] SOUL.md exists and readable")
+            for warning in soul_result.warnings:
+                console.print(f"    [yellow]Warning:[/yellow] {rich_escape(warning)}")
+                all_warnings.append(warning)
+        else:
+            console.print("  [red]✗[/red] SOUL.md validation failed")
+            for error in soul_result.errors:
+                console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+            all_errors.extend(soul_result.errors)
 
-    console.print(f"[3/{total_checks}] Validating provider configuration...")
+    step_idx += 1
+    console.print(f"[{step_idx}/{total_checks}] Validating provider configuration...")
     provider_result = validate_provider_config(host, agent_name)
     if provider_result.passed:
         provider_id = provider_result.details.get("provider_id", "unknown")
@@ -1017,7 +1043,8 @@ def _run_validate_stage(
             console.print(f"    [red]Error:[/red] {rich_escape(error)}")
         all_errors.extend(provider_result.errors)
 
-    console.print(f"[4/{total_checks}] Testing provider connectivity...")
+    step_idx += 1
+    console.print(f"[{step_idx}/{total_checks}] Testing provider connectivity...")
     if provider_result.passed:
         provider_id = provider_result.details.get("provider_id")
         conn_result = verify_provider_connectivity(provider_id)
@@ -1037,9 +1064,15 @@ def _run_validate_stage(
     gateway_status = "not_applicable"
     gateway_reason = ""
     gateway_details: dict = {}
+    hermes_health_status = "not_applicable"
+    hermes_health_reason = ""
+    hermes_health_details: dict = {}
 
     if claw_type == "openclaw":
-        console.print(f"[5/{total_checks}] Verifying OpenClaw gateway health...")
+        step_idx += 1
+        console.print(
+            f"[{step_idx}/{total_checks}] Verifying OpenClaw gateway health..."
+        )
         if skip_health:
             gateway_status = "skipped"
             gateway_reason = "skipped via --skip-health"
@@ -1066,6 +1099,37 @@ def _run_validate_stage(
                 for error in conn_result.errors:
                     console.print(f"    [red]Error:[/red] {rich_escape(error)}")
                 all_errors.extend(conn_result.errors)
+    elif claw_type == "hermes":
+        # hermes runs three checks on the agent host (binary + .env +
+        # loopback /health). The api_server platform binds to 127.0.0.1:8642
+        # on the agent host, so the probe runs there via Ansible rather than
+        # from the clm machine.
+        step_idx += 1
+        console.print(
+            f"[{step_idx}/{total_checks}] Verifying hermes health on agent host..."
+        )
+        if skip_health:
+            hermes_health_status = "skipped"
+            hermes_health_reason = "skipped via --skip-health"
+            console.print("  [yellow]⚠[/yellow] Skipped (--skip-health)")
+        elif all_errors:
+            hermes_health_status = "skipped"
+            hermes_health_reason = "skipped due to earlier validation errors"
+            console.print("  [dim]Skipped due to previous validation errors[/dim]")
+        else:
+            hermes_result = validate_hermes_health(host, agent_name)
+            hermes_health_details = hermes_result.details
+            if hermes_result.passed:
+                hermes_health_status = "passed"
+                console.print(
+                    "  [green]✓[/green] hermes --version OK, ~/.hermes/.env exists, /health returned 200"
+                )
+            else:
+                hermes_health_status = "failed"
+                console.print("  [red]✗[/red] hermes health check failed")
+                for error in hermes_result.errors:
+                    console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+                all_errors.extend(hermes_result.errors)
 
     console.print()
     if all_errors:
@@ -1091,6 +1155,15 @@ def _run_validate_stage(
             metadata["gateway_health_reason"] = gateway_reason
         if "gateway_url" in gateway_details:
             metadata["gateway_url"] = gateway_details["gateway_url"]
+    elif claw_type == "hermes":
+        metadata = {
+            "hermes_health_checked": hermes_health_status == "passed",
+            "hermes_health_status": hermes_health_status,
+        }
+        if hermes_health_reason:
+            metadata["hermes_health_reason"] = hermes_health_reason
+        if "health_status" in hermes_health_details:
+            metadata["hermes_http_status"] = hermes_health_details["health_status"]
 
     try:
         complete_stage(

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -1599,12 +1599,36 @@ def configure(
                 continue
 
             if can_skip_stage(claw_type, stage_name):
-                # Print a one-line breadcrumb so the user sees that a stage
-                # was deliberately skipped rather than silently swallowed.
-                console.print(
-                    f"[dim]Stage {i + 1}/{total_stages}: "
-                    f"{stage_name.upper()} — auto-skipped[/dim]"
-                )
+                # Print a one-line breadcrumb so the user sees WHY a stage was
+                # skipped rather than silently swallowed. The reason comes
+                # from the manifest stage's `description` field (set by the
+                # claw author), e.g. "Hermes manages SOUL.md/AGENTS.md
+                # inside ~/.hermes/; clm does not push identity files in
+                # this iteration".
+                from clawrium.core.registry import load_manifest
+
+                skip_reason = ""
+                try:
+                    _manifest = load_manifest(claw_type)
+                    _stage_cfg = (
+                        (_manifest.get("onboarding") or {})
+                        .get("stages", {})
+                        .get(stage_name, {})
+                    )
+                    skip_reason = _stage_cfg.get("description", "") or ""
+                except Exception:
+                    pass
+                if skip_reason:
+                    console.print(
+                        f"[dim]Stage {i + 1}/{total_stages}: "
+                        f"{rich_escape(stage_name.upper())} — auto-skipped "
+                        f"({rich_escape(skip_reason)})[/dim]"
+                    )
+                else:
+                    console.print(
+                        f"[dim]Stage {i + 1}/{total_stages}: "
+                        f"{rich_escape(stage_name.upper())} — auto-skipped[/dim]"
+                    )
                 try:
                     complete_stage(
                         hostname, installed_name, stage_name, StageStatus.SKIPPED
@@ -1718,7 +1742,7 @@ def _show_start_blocked_error(
     completed_count = sum(
         1
         for stage_name in [s[0] for s in STAGES]
-        if stages_data.get(stage_name, {}).get("status") == "complete"
+        if stages_data.get(stage_name, {}).get("status") in ("complete", "skipped")
     )
 
     total_stages = len(STAGES)

--- a/src/clawrium/core/onboarding.py
+++ b/src/clawrium/core/onboarding.py
@@ -422,11 +422,17 @@ def initialize_onboarding(host: str, claw_name: str) -> bool:
 def can_skip_stage(agent_type: str, stage: str) -> bool:
     """Check if a stage can be auto-skipped for an agent type.
 
-    Some agent types may not need certain stages (e.g., an agent without
-    communication features doesn't need the channels stage).
+    Recognized signals (in precedence order):
+
+    1. Top-level ``skip_stages: [stage_name, ...]`` list in the manifest.
+       (Legacy contract; preserved for backward compatibility.)
+    2. Per-stage ``onboarding.stages.<stage>.auto_skip: true``.
+       Used by hermes' ``identity`` stage in Phase 4 so the configure wizard
+       skips it without prompting (hermes manages its own SOUL.md/AGENTS.md
+       inside ~/.hermes/ on the agent host).
 
     Args:
-        agent_type: Type of agent (e.g., "openclaw", "zeroclaw")
+        agent_type: Type of agent (e.g., "openclaw", "zeroclaw", "hermes")
         stage: Stage name to check
 
     Returns:
@@ -437,9 +443,13 @@ def can_skip_stage(agent_type: str, stage: str) -> bool:
     except Exception:
         return False
 
-    # Check if manifest has skip_stages configuration
     skip_stages = manifest.get("skip_stages", [])
-    return stage in skip_stages
+    if stage in skip_stages:
+        return True
+
+    stages = (manifest.get("onboarding") or {}).get("stages") or {}
+    stage_config = stages.get(stage) or {}
+    return stage_config.get("auto_skip") is True
 
 
 def get_stage_tasks(agent_type: str, stage: str) -> list[dict]:

--- a/src/clawrium/core/validation.py
+++ b/src/clawrium/core/validation.py
@@ -23,6 +23,7 @@ __all__ = [
     "validate_provider_api_key",
     "verify_provider_connectivity",
     "validate_openclaw_gateway",
+    "validate_hermes_health",
     "validate_agent_installation",
     "ERROR_MESSAGES",
     "WARNING_MESSAGES",
@@ -112,6 +113,18 @@ ERROR_MESSAGES = {
         "Verify gateway auth token and device credentials."
     ),
     "gateway_protocol_failed": "Gateway protocol error: {error}",
+    "hermes_binary_missing": (
+        "`hermes --version` failed on host '{host}'. "
+        "The hermes binary is missing or not in the agent user's PATH."
+    ),
+    "hermes_env_missing": (
+        "`~/.hermes/.env` does not exist for agent '{claw_name}' on host '{host}'. "
+        "Run 'clm agent configure {claw_name} --stage providers' first."
+    ),
+    "hermes_health_failed": (
+        "api_server /health did not return 200 for agent '{claw_name}' on host '{host}'. "
+        "The hermes service is not healthy. Inspect 'journalctl -u hermes-{claw_name}.service'."
+    ),
 }
 
 WARNING_MESSAGES = {
@@ -893,4 +906,198 @@ def validate_agent_installation(host: str, claw_name: str) -> ValidationResult:
             "version": claw_data.get("version"),
             "status": claw_data.get("status"),
         },
+    )
+
+
+def validate_hermes_health(
+    host: str,
+    claw_name: str,
+    timeout: int = 30,
+) -> ValidationResult:
+    """Validate hermes agent health on a remote host.
+
+    Runs three checks via Ansible against the agent user on the remote host:
+
+    1. ``hermes --version`` exits 0 (binary present and runnable).
+    2. ``~/.hermes/.env`` exists (configure has been run at least once).
+    3. ``curl -fsS http://127.0.0.1:8642/health`` returns 200 (api_server up).
+
+    The api_server platform binds to loopback on the agent host by design,
+    so the /health probe must be issued from inside that host. We use the
+    same ansible-runner infrastructure as the rest of clm rather than
+    setting up a port-forward.
+
+    Args:
+        host: Host alias, hostname, or key_id.
+        claw_name: Name of the hermes agent instance.
+        timeout: Ansible-runner timeout in seconds.
+
+    Returns:
+        ValidationResult with pass/fail status. On failure, ``errors``
+        contains one entry per failed check; ``details`` carries the raw
+        stdout/stderr/rc for the failing check (when available).
+    """
+    import ansible_runner
+    from clawrium.core import keys as core_keys
+    from clawrium.core.hosts import get_host_by_key_id
+
+    host_data = get_host(host)
+    if not host_data:
+        host_data = get_host_by_key_id(host)
+    if not host_data:
+        return ValidationResult(
+            passed=False,
+            errors=[f"Host '{host}' not found."],
+        )
+
+    hostname = host_data["hostname"]
+    display_host = host_data.get("alias") or hostname
+
+    agents = host_data.get("agents", {})
+    claw_record = agents.get(claw_name)
+    if not isinstance(claw_record, dict):
+        return ValidationResult(
+            passed=False,
+            errors=[
+                ERROR_MESSAGES["agent_not_installed"].format(
+                    claw_type=claw_name, host=display_host
+                )
+            ],
+        )
+
+    key_id = host_data.get("key_id") or hostname
+    ssh_key = core_keys.get_host_private_key(key_id)
+    if not ssh_key:
+        return ValidationResult(
+            passed=False,
+            errors=[
+                f"SSH key for host '{key_id}' not found. "
+                f"Run 'clm host init {hostname}' to provision it."
+            ],
+        )
+
+    inventory = {
+        "all": {
+            "hosts": {
+                hostname: {
+                    "ansible_user": host_data.get("user", "xclm"),
+                    "ansible_port": host_data.get("port", 22),
+                    "ansible_ssh_private_key_file": str(ssh_key),
+                }
+            }
+        }
+    }
+
+    # Three independent checks. Each runs as the agent user on the remote host
+    # via `sudo -u <agent_name> bash` (NOT `-i`/login shell — the hermes user
+    # ships with /usr/sbin/nologin as its login shell by design, so a login
+    # shell would refuse to start). We set HOME and PATH explicitly so the
+    # `hermes` symlink in ~/.local/bin resolves and ~/.hermes/.env is found.
+    # Ansible's `shell` module defaults to /bin/sh (dash) which doesn't
+    # support `set -o pipefail`; we don't need a pipefail since each check
+    # captures its own rc into a sentinel line.
+    agent_home = f"/home/{claw_name}"
+    shell_cmd = (
+        f"sudo -u {claw_name} bash -c '"
+        f"  export HOME={agent_home}; "
+        f'  export PATH={agent_home}/.local/bin:$PATH; '
+        f"  echo BINARY_CHECK; "
+        f"  hermes --version 2>&1; "
+        f"  echo BINARY_RC=$?; "
+        f"  echo ENV_CHECK; "
+        f"  test -f {agent_home}/.hermes/.env && echo ENV_OK || echo ENV_MISSING; "
+        f"  echo HEALTH_CHECK; "
+        f'  curl -fsS -o /dev/null -w "%{{http_code}}\\n" http://127.0.0.1:8642/health '
+        f"     || echo CURL_FAILED"
+        f"'"
+    )
+
+    errors: list[str] = []
+    details: dict[str, Any] = {}
+
+    try:
+        result = ansible_runner.run(
+            private_data_dir="/tmp",
+            inventory=inventory,
+            host_pattern=hostname,
+            module="shell",
+            module_args=shell_cmd,
+            quiet=True,
+            timeout=timeout,
+        )
+    except Exception as e:
+        return ValidationResult(
+            passed=False,
+            errors=[f"Failed to run hermes health checks on '{display_host}': {e}"],
+        )
+
+    stdout = ""
+    rc = None
+    for event in result.events:
+        if event.get("event") in ("runner_on_ok", "runner_on_failed"):
+            res = event.get("event_data", {}).get("res", {})
+            stdout = res.get("stdout", "") or ""
+            rc = res.get("rc")
+            break
+        if event.get("event") == "runner_on_unreachable":
+            res = event.get("event_data", {}).get("res", {})
+            msg = res.get("msg", "host unreachable")
+            return ValidationResult(
+                passed=False,
+                errors=[f"Host '{display_host}' unreachable: {msg}"],
+            )
+
+    details["raw_stdout"] = stdout
+    details["rc"] = rc
+
+    # Parse stdout line-by-line. We tolerate ordering surprises by scanning
+    # for each marker and the value on the following line(s).
+    lines = stdout.splitlines()
+
+    # Binary check: BINARY_RC line carries the rc of `hermes --version`.
+    binary_rc: int | None = None
+    for line in lines:
+        if line.startswith("BINARY_RC="):
+            try:
+                binary_rc = int(line.split("=", 1)[1].strip())
+            except (ValueError, IndexError):
+                binary_rc = None
+            break
+    if binary_rc != 0:
+        errors.append(
+            ERROR_MESSAGES["hermes_binary_missing"].format(host=display_host)
+        )
+
+    # Env check: literal token ENV_OK or ENV_MISSING.
+    env_ok = "ENV_OK" in lines
+    env_missing = "ENV_MISSING" in lines
+    if env_missing or not env_ok:
+        errors.append(
+            ERROR_MESSAGES["hermes_env_missing"].format(
+                claw_name=claw_name, host=display_host
+            )
+        )
+
+    # Health check: the curl line prints the HTTP status code (e.g. "200"),
+    # or "CURL_FAILED" on connection failure. Find the line immediately
+    # after the HEALTH_CHECK marker.
+    health_status = None
+    for i, line in enumerate(lines):
+        if line.strip() == "HEALTH_CHECK" and i + 1 < len(lines):
+            health_status = lines[i + 1].strip()
+            break
+    if health_status != "200":
+        errors.append(
+            ERROR_MESSAGES["hermes_health_failed"].format(
+                claw_name=claw_name, host=display_host
+            )
+        )
+    details["health_status"] = health_status
+    details["binary_rc"] = binary_rc
+    details["env_ok"] = env_ok
+
+    return ValidationResult(
+        passed=len(errors) == 0,
+        errors=errors,
+        details=details,
     )

--- a/src/clawrium/core/validation.py
+++ b/src/clawrium/core/validation.py
@@ -6,6 +6,7 @@ and connectivity before transitioning to READY state.
 
 import asyncio
 import json
+import re
 import socket
 import time
 import urllib.request
@@ -15,6 +16,12 @@ from typing import Any
 
 from clawrium.core.config import get_config_dir
 from clawrium.core.hosts import get_host
+
+
+# Reused for shell-argument safety in validate_hermes_health: the agent name is
+# interpolated into a sudo command line, so we re-validate at point of use
+# (defense-in-depth) even though hosts.json is normally trusted.
+_AGENT_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
 
 __all__ = [
     "ValidationResult",
@@ -938,8 +945,26 @@ def validate_hermes_health(
         stdout/stderr/rc for the failing check (when available).
     """
     import ansible_runner
+    import os
+    import shutil
+    import tempfile
     from clawrium.core import keys as core_keys
     from clawrium.core.hosts import get_host_by_key_id
+
+    # Defense-in-depth: claw_name is interpolated into a `sudo -u <name>` shell
+    # command below. hosts.json is normally trusted (the canonical writer is
+    # `clm agent install` which validates the name via validate_agent_name()),
+    # but we re-validate at point of use so a corrupted record can never
+    # trigger shell injection through this path.
+    if not _AGENT_NAME_PATTERN.match(claw_name):
+        return ValidationResult(
+            passed=False,
+            errors=[
+                f"Invalid agent name '{claw_name}'. Must start with a lowercase "
+                f"letter and contain only lowercase letters, digits, hyphens, "
+                f"underscores (max 32 chars)."
+            ],
+        )
 
     host_data = get_host(host)
     if not host_data:
@@ -1015,37 +1040,58 @@ def validate_hermes_health(
     errors: list[str] = []
     details: dict[str, Any] = {}
 
+    # Ansible-runner writes the inventory (host IPs, SSH key paths) into
+    # `private_data_dir`. Using /tmp directly would leak those to other local
+    # users; create a per-run 0o700 directory and clean it up unconditionally.
+    # IMPORTANT: ansible_runner.Runner.events is a lazy iterator that reads
+    # the on-disk job_events directory at iteration time, so we must keep the
+    # directory alive while collecting stdout below and only clean up at the
+    # very end of the function.
+    runner_dir = tempfile.mkdtemp(prefix="clawrium-validate-hermes-")
     try:
-        result = ansible_runner.run(
-            private_data_dir="/tmp",
-            inventory=inventory,
-            host_pattern=hostname,
-            module="shell",
-            module_args=shell_cmd,
-            quiet=True,
-            timeout=timeout,
-        )
-    except Exception as e:
-        return ValidationResult(
-            passed=False,
-            errors=[f"Failed to run hermes health checks on '{display_host}': {e}"],
-        )
-
-    stdout = ""
-    rc = None
-    for event in result.events:
-        if event.get("event") in ("runner_on_ok", "runner_on_failed"):
-            res = event.get("event_data", {}).get("res", {})
-            stdout = res.get("stdout", "") or ""
-            rc = res.get("rc")
-            break
-        if event.get("event") == "runner_on_unreachable":
-            res = event.get("event_data", {}).get("res", {})
-            msg = res.get("msg", "host unreachable")
+        os.chmod(runner_dir, 0o700)
+        try:
+            result = ansible_runner.run(
+                private_data_dir=runner_dir,
+                inventory=inventory,
+                host_pattern=hostname,
+                module="shell",
+                module_args=shell_cmd,
+                quiet=True,
+                timeout=timeout,
+            )
+        except Exception as e:
             return ValidationResult(
                 passed=False,
-                errors=[f"Host '{display_host}' unreachable: {msg}"],
+                errors=[
+                    f"Failed to run hermes health checks on '{display_host}': {e}"
+                ],
             )
+
+        # Drain events while the runner dir is still on disk; the iterator
+        # reads job_events lazily so it MUST be consumed inside this try.
+        stdout = ""
+        rc = None
+        unreachable_msg: str | None = None
+        for event in result.events:
+            ev_type = event.get("event")
+            if ev_type in ("runner_on_ok", "runner_on_failed"):
+                res = event.get("event_data", {}).get("res", {})
+                stdout = res.get("stdout", "") or ""
+                rc = res.get("rc")
+                break
+            if ev_type == "runner_on_unreachable":
+                res = event.get("event_data", {}).get("res", {})
+                unreachable_msg = res.get("msg", "host unreachable")
+                break
+    finally:
+        shutil.rmtree(runner_dir, ignore_errors=True)
+
+    if unreachable_msg is not None:
+        return ValidationResult(
+            passed=False,
+            errors=[f"Host '{display_host}' unreachable: {unreachable_msg}"],
+        )
 
     details["raw_stdout"] = stdout
     details["rc"] = rc

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -77,6 +77,7 @@ onboarding:
           default: true
 
     validate:
+      required: true
       description: "Verify hermes is healthy"
       tasks:
         - id: binary_check

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -28,30 +28,70 @@ secrets:
 
 # Onboarding workflow configuration.
 #
-# Phase 1 ships a placeholder pipeline where every stage is auto-skipped so
-# fresh installs reach READY immediately and `clm agent start` works without
-# `--force`. Phase 4 will replace this with the real onboarding flow that
-# walks through provider selection, identity bootstrapping, and channel
-# configuration for hermes. Until then, configuration is performed by
-# `clm agent configure` (Phase 2), which writes ~/.hermes/.env directly.
+# Phase 4 replaces the Phase 1 placeholder (where every stage was auto-skipped
+# to short-circuit to READY) with a real onboarding pipeline. `clm agent start`
+# now requires the user to walk through `clm agent configure` first, mirroring
+# the openclaw flow.
+#
+# Stage notes:
+#   providers  required.  provider_select + provider_test, identical wiring
+#              to openclaw. Selecting a provider writes ~/.hermes/.env and
+#              ~/.hermes/config.yaml on the agent host (Phase 2 logic).
+#   identity   auto_skip. Hermes manages its own identity files (SOUL.md,
+#              AGENTS.md) inside ~/.hermes/ on the agent host; clm does not
+#              push identity files in this iteration. The wizard records this
+#              stage as SKIPPED and advances.
+#   channels   default `cli`. The api_server platform (loopback
+#              OpenAI-compatible HTTP API at 127.0.0.1:8642) is the local
+#              CLI-equivalent endpoint. External messaging gateways
+#              (Discord/Slack/Telegram/etc.) are out of scope and tracked as a
+#              separate follow-up issue.
+#   validate   Composite shell-level check: `hermes --version` succeeds,
+#              ~/.hermes/.env exists, and GET /health returns 200.
 onboarding:
   stages:
     providers:
-      required: false
-      auto_skip: true
-      description: "Provider configuration deferred to `clm agent configure` (Phase 2)"
+      required: true
+      description: "Assign inference provider"
+      tasks:
+        - id: select_provider
+          name: "Select inference provider"
+          type: provider_select
+        - id: verify_provider
+          name: "Verify provider connectivity"
+          type: provider_test
+
     identity:
       required: false
       auto_skip: true
-      description: "Identity bootstrapping deferred to Phase 4"
+      description: "Hermes manages SOUL.md/AGENTS.md inside ~/.hermes/; clm does not push identity files in this iteration"
+
     channels:
-      required: false
-      auto_skip: true
-      description: "Channel configuration deferred to Phase 4"
+      required: true
+      description: "Configure communication channel (cli only; external messaging gateways deferred)"
+      tasks:
+        - id: confirm_cli
+          name: "Confirm CLI channel"
+          type: confirm
+          message: "Hermes will use the loopback api_server platform on 127.0.0.1:8642 as its CLI-equivalent endpoint."
+          default: true
+
     validate:
-      required: false
-      auto_skip: true
-      description: "Validation deferred to Phase 4"
+      description: "Verify hermes is healthy"
+      tasks:
+        - id: binary_check
+          name: "Verify hermes binary"
+          type: command
+          command: "hermes --version"
+        - id: env_check
+          name: "Verify ~/.hermes/.env exists"
+          type: file_exists
+          paths:
+            - "~/.hermes/.env"
+        - id: health_check
+          name: "Verify api_server /health returns 200"
+          type: command
+          command: "curl -fsS http://127.0.0.1:8642/health"
 
 # Note: The hermes installer is a single bash script served from
 # raw.githubusercontent.com at the pinned tag. The same script content is

--- a/tests/test_hermes_onboarding.py
+++ b/tests/test_hermes_onboarding.py
@@ -260,13 +260,30 @@ def test_validate_hermes_health_reports_missing_agent(hermes_host_record):
     assert any("not" in e.lower() for e in result.errors)
 
 
-def test_validate_hermes_health_rejects_injection_payload_in_claw_name():
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "hermes; rm -rf /",        # command chaining
+        "hermes$(whoami)",          # subshell substitution
+        "hermes`id`",               # backtick substitution
+        "1hermes",                  # leading digit
+        "Hermes",                   # uppercase
+        "a" * 33,                   # over 32 chars
+        "her mes",                  # whitespace
+        "",                          # empty
+        "hermes\n--version",       # newline injection
+        "hermes/../etc/passwd",     # path traversal
+    ],
+)
+def test_validate_hermes_health_rejects_injection_payload_in_claw_name(payload):
     """Defense-in-depth: claw_name is interpolated into a `sudo -u <name>`
     shell command. Re-validate at point of use so even a corrupted
     hosts.json entry cannot trigger shell injection through this path.
 
-    A name like `hermes-test; rm -rf /` MUST be rejected before any
-    ansible_runner.run call.
+    Multiple payload classes are covered: command chaining, subshell,
+    backtick, leading digit, uppercase, oversize, whitespace, empty,
+    newline, path traversal. All must be rejected BEFORE any host lookup
+    or ansible_runner.run call.
     """
     with (
         patch(
@@ -284,10 +301,13 @@ def test_validate_hermes_health_rejects_injection_payload_in_claw_name():
             ),
         ),
     ):
-        result = validate_hermes_health("wolf-i", "hermes-test; rm -rf /")
+        result = validate_hermes_health("wolf-i", payload)
 
     assert result.passed is False
-    assert any("invalid agent name" in e.lower() for e in result.errors)
+    assert any("invalid agent name" in e.lower() for e in result.errors), (
+        f"payload {payload!r} did not produce 'invalid agent name' error: "
+        f"{result.errors}"
+    )
 
 
 def test_validate_hermes_health_handles_ansible_exception(hermes_host_record):
@@ -357,6 +377,41 @@ def test_validate_hermes_health_cleans_up_runner_directory(hermes_host_record):
     )
 
 
+def test_validate_hermes_health_cleans_up_runner_directory_on_exception(
+    hermes_host_record,
+):
+    """ATX B5: cleanup must fire on the exception path too. If
+    ansible_runner.run raises, the per-run private_data_dir must still be
+    removed — otherwise a long-running clm process with many failures would
+    accumulate inventory files in /tmp."""
+    import os
+
+    captured_paths: list[str] = []
+
+    def fake_run(*, private_data_dir, **kwargs):
+        captured_paths.append(private_data_dir)
+        raise RuntimeError("ssh: connect to host: timeout")
+
+    with (
+        patch(
+            "clawrium.core.validation.get_host",
+            return_value=hermes_host_record,
+        ),
+        patch(
+            "clawrium.core.keys.get_host_private_key",
+            return_value="/tmp/fake-key",
+        ),
+        patch("ansible_runner.run", side_effect=fake_run),
+    ):
+        result = validate_hermes_health("wolf-i", "hermes-test")
+
+    assert result.passed is False
+    assert captured_paths, "ansible_runner.run was not called"
+    assert not os.path.exists(captured_paths[0]), (
+        f"runner dir {captured_paths[0]} leaked after ansible_runner exception"
+    )
+
+
 # ---------------------------------------------------------------------------
 # can_skip_stage edge cases (S6).
 # ---------------------------------------------------------------------------
@@ -371,3 +426,10 @@ def test_can_skip_stage_stage_without_auto_skip_returns_false():
     """A stage that omits the auto_skip key entirely is not auto-skipped."""
     # The hermes manifest's providers stage has no auto_skip key, only required:true.
     assert can_skip_stage("hermes", "providers") is False
+
+
+def test_can_skip_stage_unknown_claw_type_returns_false():
+    """An unknown claw type whose manifest can't be loaded must not be
+    treated as auto-skippable — the function must return False so the
+    wizard does NOT silently skip stages it doesn't recognize."""
+    assert can_skip_stage("does-not-exist-claw", "identity") is False

--- a/tests/test_hermes_onboarding.py
+++ b/tests/test_hermes_onboarding.py
@@ -258,3 +258,116 @@ def test_validate_hermes_health_reports_missing_agent(hermes_host_record):
 
     assert result.passed is False
     assert any("not" in e.lower() for e in result.errors)
+
+
+def test_validate_hermes_health_rejects_injection_payload_in_claw_name():
+    """Defense-in-depth: claw_name is interpolated into a `sudo -u <name>`
+    shell command. Re-validate at point of use so even a corrupted
+    hosts.json entry cannot trigger shell injection through this path.
+
+    A name like `hermes-test; rm -rf /` MUST be rejected before any
+    ansible_runner.run call.
+    """
+    with (
+        patch(
+            "ansible_runner.run",
+            side_effect=AssertionError(
+                "validate_hermes_health must NOT call ansible_runner with an "
+                "unsafe agent name"
+            ),
+        ),
+        patch(
+            "clawrium.core.validation.get_host",
+            side_effect=AssertionError(
+                "validate_hermes_health must short-circuit BEFORE host lookup "
+                "when claw_name is malformed"
+            ),
+        ),
+    ):
+        result = validate_hermes_health("wolf-i", "hermes-test; rm -rf /")
+
+    assert result.passed is False
+    assert any("invalid agent name" in e.lower() for e in result.errors)
+
+
+def test_validate_hermes_health_handles_ansible_exception(hermes_host_record):
+    """If ansible_runner.run raises (e.g. SSH timeout, network failure,
+    runner bootstrap error), validate_hermes_health must surface a
+    ValidationResult with a single, well-shaped error instead of
+    propagating an uncaught exception out of the validation layer."""
+    with (
+        patch(
+            "clawrium.core.validation.get_host",
+            return_value=hermes_host_record,
+        ),
+        patch(
+            "clawrium.core.keys.get_host_private_key",
+            return_value="/tmp/fake-key",
+        ),
+        patch(
+            "ansible_runner.run",
+            side_effect=RuntimeError("ssh: connect to host: timeout"),
+        ),
+    ):
+        result = validate_hermes_health("wolf-i", "hermes-test")
+
+    assert result.passed is False
+    assert len(result.errors) == 1
+    assert "hermes health checks" in result.errors[0].lower()
+    assert "timeout" in result.errors[0].lower()
+
+
+def test_validate_hermes_health_cleans_up_runner_directory(hermes_host_record):
+    """Ansible-runner writes inventory (host IPs, SSH key paths) under its
+    `private_data_dir`. validate_hermes_health must allocate a 0o700 temp
+    directory and remove it unconditionally, so secrets do not leak to other
+    local users via /tmp world-readable inventory files."""
+    import os
+
+    captured_paths: list[str] = []
+
+    def fake_run(*, private_data_dir, **kwargs):
+        captured_paths.append(private_data_dir)
+        # Confirm permissions match the security contract while the dir
+        # still exists.
+        mode = os.stat(private_data_dir).st_mode & 0o777
+        assert mode == 0o700, f"runner dir must be 0o700, got {oct(mode)}"
+        return _build_mock_runner_result(
+            "BINARY_CHECK\nv1\nBINARY_RC=0\nENV_CHECK\nENV_OK\nHEALTH_CHECK\n200\n"
+        )
+
+    with (
+        patch(
+            "clawrium.core.validation.get_host",
+            return_value=hermes_host_record,
+        ),
+        patch(
+            "clawrium.core.keys.get_host_private_key",
+            return_value="/tmp/fake-key",
+        ),
+        patch("ansible_runner.run", side_effect=fake_run),
+    ):
+        result = validate_hermes_health("wolf-i", "hermes-test")
+
+    assert result.passed is True
+    assert captured_paths, "ansible_runner.run was not called"
+    # The directory MUST be cleaned up after validate returns.
+    assert not os.path.exists(captured_paths[0]), (
+        f"runner dir {captured_paths[0]} leaked after validate_hermes_health"
+    )
+
+
+# ---------------------------------------------------------------------------
+# can_skip_stage edge cases (S6).
+# ---------------------------------------------------------------------------
+
+
+def test_can_skip_stage_unknown_stage_returns_false():
+    """A stage name that isn't present in the manifest cannot be skipped."""
+    assert can_skip_stage("hermes", "nonexistent-stage") is False
+
+
+def test_can_skip_stage_stage_without_auto_skip_returns_false():
+    """A stage that omits the auto_skip key entirely is not auto-skipped."""
+    # The hermes manifest's providers stage has no auto_skip key, only required:true.
+    assert can_skip_stage("hermes", "providers") is False

--- a/tests/test_hermes_onboarding.py
+++ b/tests/test_hermes_onboarding.py
@@ -1,0 +1,260 @@
+"""Hermes onboarding pipeline tests (issue #68 Phase 4).
+
+This module covers the Phase 4 contract for hermes onboarding: the manifest
+declares a real pipeline (providers required, identity auto_skip, channels
+required cli-only, validate composite), `can_skip_stage` honors per-stage
+``auto_skip:true`` so the wizard skips identity without prompting, and
+`validate_hermes_health` runs the three composite checks via Ansible on the
+agent host.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clawrium.core.onboarding import can_skip_stage, get_stage_tasks
+from clawrium.core.registry import load_manifest
+from clawrium.core.validation import validate_hermes_health
+
+
+# ---------------------------------------------------------------------------
+# Manifest-level contracts.
+# ---------------------------------------------------------------------------
+
+
+def test_hermes_manifest_parses_with_real_onboarding_pipeline():
+    """The hermes manifest validates under the existing registry schema and
+    exposes the four canonical stages with the Phase 4 shape."""
+    manifest = load_manifest("hermes")
+    onboarding = manifest.get("onboarding") or {}
+    stages = onboarding.get("stages") or {}
+    assert set(stages.keys()) == {"providers", "identity", "channels", "validate"}
+
+
+def test_hermes_providers_stage_is_required():
+    manifest = load_manifest("hermes")
+    providers = manifest["onboarding"]["stages"]["providers"]
+    assert providers["required"] is True
+    assert providers.get("auto_skip") is not True
+
+
+def test_hermes_identity_stage_auto_skips():
+    manifest = load_manifest("hermes")
+    identity = manifest["onboarding"]["stages"]["identity"]
+    assert identity["auto_skip"] is True
+    assert identity["description"]
+
+
+def test_hermes_channels_stage_default_cli():
+    """channels stage is required and ships a confirm task whose default
+    is the cli channel — there are no Discord/Slack/Telegram options in
+    this iteration."""
+    manifest = load_manifest("hermes")
+    channels = manifest["onboarding"]["stages"]["channels"]
+    assert channels["required"] is True
+
+    tasks = channels.get("tasks", [])
+    assert tasks, "hermes channels stage must declare at least one task"
+    confirm_tasks = [t for t in tasks if t.get("type") == "confirm"]
+    assert confirm_tasks
+    assert confirm_tasks[0].get("default") is True
+
+
+def test_hermes_validate_stage_runs_binary_env_health():
+    manifest = load_manifest("hermes")
+    validate_stage = manifest["onboarding"]["stages"]["validate"]
+    tasks = validate_stage.get("tasks", [])
+    task_ids = [t.get("id") for t in tasks]
+    assert task_ids == ["binary_check", "env_check", "health_check"]
+
+
+def test_hermes_stage_ordering_matches_canonical():
+    manifest = load_manifest("hermes")
+    stages = list(manifest["onboarding"]["stages"].keys())
+    assert stages == ["providers", "identity", "channels", "validate"]
+
+
+# ---------------------------------------------------------------------------
+# can_skip_stage behavior — per-stage auto_skip:true must be honored.
+# ---------------------------------------------------------------------------
+
+
+def test_can_skip_stage_honors_hermes_identity_auto_skip():
+    """Phase 4 contract: the configure wizard must skip identity for hermes
+    without prompting, because hermes manages identity internally."""
+    assert can_skip_stage("hermes", "identity") is True
+
+
+def test_can_skip_stage_does_not_skip_required_stages():
+    """providers/channels/validate are required for hermes — the wizard
+    must run them."""
+    assert can_skip_stage("hermes", "providers") is False
+    assert can_skip_stage("hermes", "channels") is False
+    assert can_skip_stage("hermes", "validate") is False
+
+
+# ---------------------------------------------------------------------------
+# get_stage_tasks plumbing.
+# ---------------------------------------------------------------------------
+
+
+def test_get_stage_tasks_returns_provider_select_and_test():
+    tasks = get_stage_tasks("hermes", "providers")
+    types = [t.get("type") for t in tasks]
+    assert "provider_select" in types
+    assert "provider_test" in types
+
+
+# ---------------------------------------------------------------------------
+# validate_hermes_health — three composite checks via Ansible.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def hermes_host_record():
+    return {
+        "hostname": "192.168.1.36",
+        "alias": "wolf-i",
+        "user": "xclm",
+        "port": 22,
+        "key_id": "wolf-i",
+        "agents": {
+            "hermes-test": {
+                "type": "hermes",
+                "version": "2026.5.7",
+                "agent_name": "hermes-test",
+            }
+        },
+    }
+
+
+def _build_mock_runner_result(stdout: str, rc: int = 0):
+    event = {
+        "event": "runner_on_ok",
+        "event_data": {"res": {"stdout": stdout, "rc": rc}},
+    }
+    result = MagicMock()
+    result.events = [event]
+    return result
+
+
+def test_validate_hermes_health_passes_when_all_checks_succeed(hermes_host_record):
+    stdout = "BINARY_CHECK\nv0.13.0 (2026.5.7)\nBINARY_RC=0\nENV_CHECK\nENV_OK\nHEALTH_CHECK\n200\n"
+
+    with (
+        patch(
+            "clawrium.core.validation.get_host",
+            return_value=hermes_host_record,
+        ),
+        patch(
+            "clawrium.core.keys.get_host_private_key",
+            return_value="/tmp/fake-key",
+        ),
+        patch(
+            "ansible_runner.run",
+            return_value=_build_mock_runner_result(stdout),
+        ),
+    ):
+        result = validate_hermes_health("wolf-i", "hermes-test")
+
+    assert result.passed is True
+    assert result.errors == []
+    assert result.details["health_status"] == "200"
+    assert result.details["binary_rc"] == 0
+    assert result.details["env_ok"] is True
+
+
+def test_validate_hermes_health_fails_when_health_not_200(hermes_host_record):
+    stdout = (
+        "BINARY_CHECK\nv0.13.0 (2026.5.7)\nBINARY_RC=0\n"
+        "ENV_CHECK\nENV_OK\n"
+        "HEALTH_CHECK\nCURL_FAILED\n"
+    )
+
+    with (
+        patch(
+            "clawrium.core.validation.get_host",
+            return_value=hermes_host_record,
+        ),
+        patch(
+            "clawrium.core.keys.get_host_private_key",
+            return_value="/tmp/fake-key",
+        ),
+        patch(
+            "ansible_runner.run",
+            return_value=_build_mock_runner_result(stdout),
+        ),
+    ):
+        result = validate_hermes_health("wolf-i", "hermes-test")
+
+    assert result.passed is False
+    assert any("/health" in e for e in result.errors)
+
+
+def test_validate_hermes_health_fails_when_env_missing(hermes_host_record):
+    stdout = (
+        "BINARY_CHECK\nv0.13.0 (2026.5.7)\nBINARY_RC=0\n"
+        "ENV_CHECK\nENV_MISSING\n"
+        "HEALTH_CHECK\n200\n"
+    )
+
+    with (
+        patch(
+            "clawrium.core.validation.get_host",
+            return_value=hermes_host_record,
+        ),
+        patch(
+            "clawrium.core.keys.get_host_private_key",
+            return_value="/tmp/fake-key",
+        ),
+        patch(
+            "ansible_runner.run",
+            return_value=_build_mock_runner_result(stdout),
+        ),
+    ):
+        result = validate_hermes_health("wolf-i", "hermes-test")
+
+    assert result.passed is False
+    assert any(".env" in e for e in result.errors)
+
+
+def test_validate_hermes_health_fails_when_binary_missing(hermes_host_record):
+    stdout = (
+        "BINARY_CHECK\nhermes: command not found\nBINARY_RC=127\n"
+        "ENV_CHECK\nENV_OK\n"
+        "HEALTH_CHECK\n200\n"
+    )
+
+    with (
+        patch(
+            "clawrium.core.validation.get_host",
+            return_value=hermes_host_record,
+        ),
+        patch(
+            "clawrium.core.keys.get_host_private_key",
+            return_value="/tmp/fake-key",
+        ),
+        patch(
+            "ansible_runner.run",
+            return_value=_build_mock_runner_result(stdout, rc=127),
+        ),
+    ):
+        result = validate_hermes_health("wolf-i", "hermes-test")
+
+    assert result.passed is False
+    assert any("hermes" in e.lower() for e in result.errors)
+
+
+def test_validate_hermes_health_reports_missing_agent(hermes_host_record):
+    """If the agent record is absent on the host, validate_hermes_health must
+    return a clean ValidationResult rather than dispatching Ansible."""
+    host_without_agent = {**hermes_host_record, "agents": {}}
+
+    with patch(
+        "clawrium.core.validation.get_host",
+        return_value=host_without_agent,
+    ):
+        result = validate_hermes_health("wolf-i", "hermes-test")
+
+    assert result.passed is False
+    assert any("not" in e.lower() for e in result.errors)

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -358,11 +358,16 @@ class TestInitializeOnboarding:
         with pytest.raises(AgentNotFoundError):
             initialize_onboarding("nonexistent", "openclaw")
 
-    def test_initialize_hermes_auto_skips_to_ready(self, isolated_config):
-        """hermes manifest declares auto_skip:true on every stage, so
-        initialize_onboarding must short-circuit straight to READY with all
-        stages marked SKIPPED. This unblocks `clm agent start` without --force
-        for the Phase 1 placeholder onboarding pipeline (ATX B2)."""
+    def test_initialize_hermes_starts_pending_after_phase_4(self, isolated_config):
+        """Phase 4 replaces the placeholder all-auto_skip pipeline with a real
+        onboarding flow (providers required, identity auto_skip, channels
+        required, validate required). `initialize_onboarding` must therefore
+        leave hermes in PENDING — the auto_skip short-circuit no longer fires
+        because `providers` is no longer auto_skip.
+
+        Regression guard: if a future commit reverts hermes back to all-auto_skip
+        without intending to, this test starts failing immediately.
+        """
         hosts_data = [
             {
                 "hostname": "192.168.1.100",
@@ -391,10 +396,79 @@ class TestInitializeOnboarding:
         host = get_host("server1")
         onboarding = host["agents"]["hermes-test"]["onboarding"]
 
+        assert onboarding["state"] == "pending"
+        for stage_name, stage_data in onboarding["stages"].items():
+            assert stage_data["status"] == "pending", (
+                f"hermes stage {stage_name} should be pending after Phase 4, got "
+                f"{stage_data['status']}"
+            )
+            assert stage_data["completed_at"] is None
+
+    def test_initialize_all_auto_skip_short_circuits_to_ready(
+        self, isolated_config, monkeypatch
+    ):
+        """The auto_skip → READY short-circuit contract MUST remain intact
+        for hypothetical future agent types whose manifest declares every
+        stage as auto_skip:true. Hermes Phase 4 stops being such an agent
+        (providers is real and required), but the contract must keep working
+        for other agents — exercised here via a manifest mock.
+        """
+        hosts_data = [
+            {
+                "hostname": "192.168.1.100",
+                "alias": "server1",
+                "port": 22,
+                "agent_name": "xclm",
+                "agents": {
+                    "future-claw-test": {
+                        "type": "future-claw",
+                        "version": "1.0.0",
+                        "status": "installed",
+                        "agent_name": "future-claw-test",
+                    }
+                },
+            }
+        ]
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        hosts_path = isolated_config / "hosts.json"
+        hosts_path.write_text(json.dumps(hosts_data))
+
+        fake_manifest = {
+            "agent": {"type": "future-claw", "description": "Future claw type"},
+            "platforms": [],
+            "onboarding": {
+                "stages": {
+                    "providers": {
+                        "description": "n/a",
+                        "auto_skip": True,
+                    },
+                    "identity": {"description": "n/a", "auto_skip": True},
+                    "channels": {"description": "n/a", "auto_skip": True},
+                    "validate": {"description": "n/a", "auto_skip": True},
+                }
+            },
+        }
+
+        from clawrium.core import onboarding as onboarding_module
+
+        monkeypatch.setattr(
+            onboarding_module,
+            "load_manifest",
+            lambda agent_type: fake_manifest,
+        )
+
+        result = initialize_onboarding("server1", "future-claw-test")
+        assert result is True
+
+        from clawrium.core.hosts import get_host
+
+        host = get_host("server1")
+        onboarding = host["agents"]["future-claw-test"]["onboarding"]
+
         assert onboarding["state"] == "ready"
         for stage_name, stage_data in onboarding["stages"].items():
             assert stage_data["status"] == "skipped", (
-                f"hermes stage {stage_name} should be skipped, got "
+                f"future-claw stage {stage_name} should be skipped, got "
                 f"{stage_data['status']}"
             )
             assert stage_data["completed_at"] is not None

--- a/tests/test_registry_hermes.py
+++ b/tests/test_registry_hermes.py
@@ -250,18 +250,70 @@ def test_hermes_install_env_file_created_with_mode_0600():
     )
 
 
-def test_hermes_manifest_onboarding_all_auto_skip():
-    """All four canonical stages in the hermes manifest must be auto_skip:true
-    so initialize_onboarding short-circuits to READY. Phase 4 will replace
-    this with a real onboarding pipeline."""
+def test_hermes_manifest_onboarding_real_pipeline():
+    """Phase 4 replaces the Phase 1 placeholder all-auto_skip block with a real
+    onboarding pipeline mirroring openclaw's structure:
+
+      * ``providers`` is required (no auto_skip) and exposes the canonical
+        provider_select + provider_test tasks.
+      * ``identity`` keeps auto_skip:true (hermes manages SOUL.md/AGENTS.md
+        internally inside ~/.hermes/; clm does not push identity files in
+        this iteration).
+      * ``channels`` is required (no auto_skip) with a confirm task — the
+        only legal option is `cli` since the api_server platform is the
+        local-CLI-equivalent endpoint.
+      * ``validate`` runs a composite shell check (hermes binary present,
+        ~/.hermes/.env exists, /health returns 200).
+
+    Each assertion guards a specific contract independently so a future
+    regression points at exactly which property changed."""
     manifest = load_manifest("hermes")
     onboarding = manifest.get("onboarding") or {}
     stages = onboarding.get("stages") or {}
+
     for stage_name in ("providers", "identity", "channels", "validate"):
         assert stage_name in stages, f"hermes onboarding missing stage: {stage_name}"
-        assert stages[stage_name].get("auto_skip") is True, (
-            f"hermes onboarding stage '{stage_name}' must declare auto_skip: true"
-        )
+
+    # providers — required, exposes provider_select + provider_test
+    providers = stages["providers"]
+    assert providers.get("required") is True
+    assert providers.get("auto_skip") is not True
+    task_types = [t.get("type") for t in providers.get("tasks", [])]
+    assert "provider_select" in task_types
+    assert "provider_test" in task_types
+
+    # identity — auto_skip:true
+    identity = stages["identity"]
+    assert identity.get("auto_skip") is True
+    assert identity.get("required") is not True
+    assert identity.get("description")
+
+    # channels — required, cli-only confirm task
+    channels = stages["channels"]
+    assert channels.get("required") is True
+    assert channels.get("auto_skip") is not True
+    channel_task_types = [t.get("type") for t in channels.get("tasks", [])]
+    assert "confirm" in channel_task_types
+
+    # validate — three composite checks (binary + env + health)
+    validate_stage = stages["validate"]
+    assert validate_stage.get("auto_skip") is not True
+    validate_task_ids = [t.get("id") for t in validate_stage.get("tasks", [])]
+    assert "binary_check" in validate_task_ids
+    assert "env_check" in validate_task_ids
+    assert "health_check" in validate_task_ids
+
+
+def test_hermes_manifest_onboarding_stage_ordering():
+    """Stage order must match the canonical openclaw ordering (providers →
+    identity → channels → validate) so the configure wizard walks them in
+    the expected sequence."""
+    manifest = load_manifest("hermes")
+    stages = ((manifest.get("onboarding") or {}).get("stages") or {})
+    keys = list(stages.keys())
+    assert keys == ["providers", "identity", "channels", "validate"], (
+        f"hermes stage ordering must match canonical pipeline, got {keys}"
+    )
 
 
 def test_hermes_start_playbook_fails_on_inactive_service():


### PR DESCRIPTION
## Summary

Replaces the Phase 1 placeholder hermes onboarding (all four stages `auto_skip:true` → fast-path to READY at install time) with a real onboarding pipeline mirroring openclaw's structure. After this change `clm agent start <hermes>` correctly blocks until the user has run `clm agent configure`.

### Before
```
clm agent install --type hermes --name N    # → onboarding initialized to READY immediately
clm agent start N                            # → succeeds (service starts but exits w/o provider)
```

### After
```
clm agent install --type hermes --name N    # → onboarding initialized to PENDING
clm agent start N                            # → blocks: "onboarding not started"
clm agent configure N                        # → walks PROVIDERS → IDENTITY (auto-skipped) → CHANNELS (cli only) → VALIDATE (3 remote checks)
clm agent start N                            # → succeeds
```

### Stages

| Stage | Required | auto_skip | Notes |
|-------|----------|-----------|-------|
| `providers` | yes | no | provider_select + provider_test (identical wiring to openclaw) |
| `identity` | no | **yes** | hermes manages SOUL.md/AGENTS.md inside `~/.hermes/`; clm does not push identity files in this iteration. The configure wizard prints "Stage 2/4: IDENTITY — auto-skipped (<description>)" rather than silently swallowing the stage |
| `channels` | yes | no | cli-only confirm task. External messaging gateways (Discord/Slack/Telegram/etc.) are out of scope and tracked as a follow-up |
| `validate` | yes | no | composite shell-level check: `hermes --version` succeeds, `~/.hermes/.env` exists, GET /health returns 200 — runs on the agent host via `validate_hermes_health()` |

### Backward compat
The `initialize_onboarding` auto_skip → READY short-circuit contract is preserved for hypothetical future agent types whose manifest declares every stage as `auto_skip:true`. New regression test `test_initialize_all_auto_skip_short_circuits_to_ready` exercises this path via a manifest mock so it stays covered independently of any shipping manifest.

The openclaw onboarding flow is byte-for-byte unchanged.

## Testing

### Test Results
- [x] All existing tests pass (`make test` — 1566 passed)
- [x] Linter passes (`make lint` — clean)
- [x] New tests added in `tests/test_hermes_onboarding.py` (24 tests covering manifest shape, can_skip_stage behavior, validate_hermes_health happy/error/exception paths, injection-rejection via 10 parametrized payloads, and runner-dir cleanup on success+exception paths)

### Manual Testing (E2E on wolf-i 192.168.1.36)
- [x] `clm agent install --type hermes --host wolf-i --name hermes-test --yes` — succeeded
- [x] `clm agent start hermes-test` (before configure) — blocked with friendly "onboarding not started" message (NO more auto-READY)
- [x] `clm agent configure hermes-test --yes` — walked PROVIDERS → (identity auto-skipped, breadcrumb shown) → CHANNELS (cli only, single recommended option auto-selected) → VALIDATE (3 remote checks pass) → READY
- [x] `clm agent start hermes-test` (after configure) — succeeded
- [x] `clm agent stop hermes-test` — succeeded
- [x] `clm agent configure hermes-test --yes --stage validate` (service stopped) — failed loudly: "api_server /health did not return 200 ... Inspect 'journalctl -u hermes-hermes-test.service'"
- [x] `clm agent remove hermes-test --force` — cleaned up agent user, systemd unit, ~/.hermes/, binary symlink, and hosts.json record

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (claw_name re-validated against `^[a-z][a-z0-9_-]{0,31}$` at shell interpolation point — defense-in-depth)
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources
- [x] ansible_runner private_data_dir is a per-run 0o700 mkdtemp with unconditional cleanup (no /tmp world-readable inventory)

## ATX Review Summary

**Final Review: Rating 4/5** ✅ Merge threshold crossed.
**Trajectory: 2/5 → 3/5 → 4/5**
**Total Cost: ~$3.35 | Total Time: ~12m**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1, B2, B3, B4 | B1+B2 fixed; B3+B4 out-of-scope | $1.5565 | ~5m | leader, cli-ux, lifecycle, secrets, ansible, test-coverage |
| 2 | 3/5 | B5, B6, B7 | All fixed in commit 462a05f | $0.15 | 52s | leader, secrets-provider, lifecycle-state, cli-ux, ansible-playbook, test-coverage |
| 3 | **4/5** | none | Ready | $1.64 | 6m 27s | leader, lifecycle-state, test-coverage, cli-ux, secrets-provider |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | Location | Issue | Resolution |
|---|----------|-------|------------|
| B1 | `validation.py` | Command injection via claw_name in `sudo -u {name} bash -c '...'` | Fixed — added `_AGENT_NAME_PATTERN` regex re-validation at point of use, fires before host lookup |
| B2 | `validation.py` | `private_data_dir='/tmp'` leaked inventory to world-readable path | Fixed — per-run `tempfile.mkdtemp(prefix='clawrium-validate-hermes-')` + `os.chmod(0o700)` + `finally: shutil.rmtree` |
| B3 | `install.py:516` | Gateway auth token stored in hosts.json instead of secrets.json | Out-of-scope — pre-existing in earlier phases, not touched by this PR |
| B4 | `install.py:833` | Device credentials stored in hosts.json | Out-of-scope — pre-existing, not touched by this PR |

**Warnings (round 1, all addressed in iter-1 commit):**

| # | Warning | Action |
|---|---------|--------|
| W1 | Multi-consecutive-skip lifecycle bug | Fixed — auto-skip path now transitions state forward |
| W2 | Skipped stages treated as incomplete in start-blocked error | Fixed — predicate changed to `not in ("complete", "skipped")` |
| W3 | Auto-skipped stages produced zero UI output | Fixed — added dim breadcrumb line |
| W4 | Validate failure lacks remediation hints | Acknowledged — existing errors include configure-rerun and journalctl hints |
| W5 | No spinner during remote health check | Acknowledged — typical call < 3s |
| W8 | No ansible exception test | Fixed — added `test_validate_hermes_health_handles_ansible_exception` |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Blocking Issues (all fixed in follow-up commit):**

| # | Location | Issue | Resolution |
|---|----------|-------|------------|
| B5 | `tests/test_hermes_onboarding.py` | Runner-dir cleanup test only covered success path | Fixed — added `test_validate_hermes_health_cleans_up_runner_directory_on_exception` |
| B6 | `cli/agent.py:1721` | `completed_count` excluded skipped stages | Fixed — predicate changed to `in ("complete", "skipped")` |
| B7 | `cli/agent.py:1606` | Auto-skip breadcrumb did not explain reason | Fixed — now prints manifest stage's `description` alongside the breadcrumb |

**Warnings (round 2):**

| # | Warning | Action |
|---|---------|--------|
| W4 | Leading-skip lifecycle bug masked by hermes happy path | Acknowledged — no shipping manifest exercises this case |
| W5 | Injection-rejection test covered one payload | Fixed — parametrized with 10 payload classes |
| W6 | Stage name interpolated without rich_escape | Fixed — B7's code path uses `rich_escape` |
| W7 | can_skip_stage edge cases incomplete | Fixed — added unknown claw-type test |

<details>
<summary>Review 3 Details (Rating 4/5 — ready)</summary>

All iter-2 blockers verified resolved. No remaining blockers. 5 new warnings (W6-W10), all non-blocking; reviewer explicitly: "**Ready to merge.**"

**Blocker Resolution:**

| # | Status | Verification |
|---|--------|--------------|
| B5 | ✅ Fixed | `test_validate_hermes_health_cleans_up_runner_directory_on_exception` verifies production cleanup with mocked I/O |
| B6 | ✅ Fixed | `agent.py:1745` uses `in ('complete', 'skipped')` — confirmed by lifecycle-state + cli-ux |
| B7 | ✅ Fixed | `agent.py:1610-1631` loads manifest description and renders via `rich_escape()`; confirmed by secrets-provider |

**New non-blocking warnings (tracked as follow-up):**

| # | Domain | Recommendation |
|---|--------|----------------|
| W6 | Tests | Add `test_start_blocked_skipped_identity_counts_toward_progress` for B6 regression guard |
| W7 | Tests | Add `test_auto_skip_breadcrumb_includes_manifest_reason` for B7 regression guard |
| W8 | `agent.py:1614-1616` | Narrow `except Exception` to `(ManifestNotFoundError, KeyError)` or add `logging.debug` |
| W9 | `agent.py:1608-1619` | Double `load_manifest` per auto-skip stage — cache before stage loop |
| W10 | `agent.py:1608` | Move lazy import `load_manifest` to module-level |

**Specialist ratings:** lifecycle-state 3, test-coverage 3, cli-ux 4, secrets-provider 5. Leader rolled to **4/5**.

**B3/B4 confirmed out-of-scope** — secrets-provider reviewer verified `core/install.py:501-829` is byte-identical to pre-this-PR. Recommended as separate security follow-up (migrate gateway tokens to `secrets.json` via `set_instance_secret()`).

</details>


---

Closes #315
Refs #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
