### PR TITLE
docs(hermes): user guide + memory model + index update (#68 phase 5)

### DIFF
--- a/.itx/68/01_EXECUTION.md
+++ b/.itx/68/01_EXECUTION.md
@@ -494,4 +494,31 @@ E2E results on wolf-i (192.168.1.36) against provider `clm-openrouter`:
 - `clm agent configure hermes-test --yes --stage validate` (with service stopped) — **correctly failed**: "api_server /health did not return 200 for agent 'hermes-test' on host 'wolf-i'. The hermes service is not healthy. Inspect 'journalctl -u hermes-hermes-test.service'." Validate stage fails loudly when /health is down, exactly as intended.
 - `clm agent remove hermes-test --force` — cleaned up the agent user, systemd unit, `~/.hermes/`, binary symlink, and `hosts.json` record.
 
+---
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-10T20:30:00Z
+**Model**: claude-opus-4-7
+**Subtask**: #316 (Phase 5)
+**Branch**: `issue-68-phase-5-docs` (base: `main` @ 3cb2952)
+
+```prompt
+/itx:execute 316 (sub-agent invocation, Phase 5 — Docs + parent close-out)
+```
+
+Implementation outcomes:
+
+1. Published `docs/agent-support/hermes.md` — capability matrix (providers / channels / features), pinned version (`v2026.5.7`), install + configure walkthrough, local OpenAI-compatible API `curl` example with `jq` extraction of `HERMES_API_SERVER_KEY` from `secrets.json` (post-PR #318 location), SSH-tunnel recipe for off-host access, hermes-specific caveats (no `clm chat` linking #322; deferred gateways; identity auto-skip; bearer token storage path; memory size limits; atomic-write safety), troubleshooting (service won't start / `/health` non-200 / provider connectivity / oversize memory / `userdel` stuck), deferred-items section linking back to `.itx/68/00_PLAN.md`.
+
+2. Published `docs/agent-support/memory.md` — manifest-driven dispatch model (`features.memory` + `workspace.memory_path`), per-claw on-disk layouts (hermes two-file with hard caps; openclaw daily-files + top-level identity), atomic-write safety (stage-then-rename via `rename(2)`), explicit out-of-scope list (pluggable backends, `state.db`, identity-file editing, alt filesystem layouts).
+
+3. Updated `docs/agent-support/index.md` — added hermes row under "In Development", replaced the 2-column Quick Comparison with a 3-column matrix covering Status, Transport, `clm chat`, Multi-Provider, Memory, Identity, Messaging gateways, External integrations, Onboarding, Resource usage. Added a "Use Hermes when" guidance block.
+
+4. Updated `README.md` FAQ #2 — added a hermes paragraph noting `🚧 In Development` status, the local OpenAI-compatible API at `127.0.0.1:8642`, the gaps (no `clm chat`, no external gateways), and a link to the hermes docs page. The Quickstart section was inspected and intentionally left alone — it walks through OpenClaw only as the canonical first-time example, which is still the right onboarding path.
+
+5. `make lint` clean. `make test` → 1566 passed (no code touched).
+
+Documentation-blocking findings: none. One pre-existing nit observed but NOT fixed (out of scope for docs-only PR): `_run_validate_stage` description in the manifest still references the Phase 1 placeholder pipeline language in some comments; harmless but worth a follow-up cleanup pass.
+
 </details>

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Other Linux distributions may work, but they are not currently part of the test 
 
 [OpenClaw](https://github.com/openclaw/openclaw) is officially supported and tested end-to-end.
 
+[Hermes](https://github.com/NousResearch/hermes-agent) (Nous Research) is supported in `🚧 In Development` status — install, configure, and a local OpenAI-compatible HTTP API on `127.0.0.1:8642` are wired end-to-end. `clm chat` and external messaging gateways are not yet supported for hermes. See the [Hermes Support Matrix](https://ric03uec.github.io/clawrium/docs/agent-support/hermes) for details.
+
 Additional agent types are planned.
 
 ### 3. Is Claude subscription supported?

--- a/docs/agent-support/hermes.md
+++ b/docs/agent-support/hermes.md
@@ -79,7 +79,7 @@ Hermes is intentionally scoped to a single channel in this iteration: a loopback
 ### 1. Install Hermes
 
 ```bash
-clm agent install --type hermes --host <host-alias> --name <agent-name>
+clm agent install --type hermes --host <host> --name <agent-name>
 ```
 
 What happens:
@@ -147,7 +147,7 @@ Hermes deep-merges `config.yaml` with its built-in defaults at load time, so onl
 | `openai` | `openai` | (omitted; hermes default) | `OPENAI_API_KEY` |
 | `ollama` (or any custom OpenAI-compatible URL) | `custom` | `<provider.endpoint>/v1` (suffix `/v1` appended if missing) | (none — local endpoint) |
 
-After `.env` write, the restart handler enables and starts the systemd unit. The validate stage probes `http://127.0.0.1:8642/health` (10 retries / 3s). `/health` is unauthenticated; `/v1/*` requires the bearer header.
+After `.env` write, the restart handler enables and starts the systemd unit. The configure playbook probes `http://127.0.0.1:8642/health` with `retries: 20, delay: 3` (≈60s max). `/health` is unauthenticated; `/v1/*` requires the bearer header.
 
 ### 3. Use the local OpenAI-compatible API
 
@@ -175,7 +175,7 @@ curl -fsS http://127.0.0.1:8642/v1/chat/completions \
   }'
 ```
 
-Substitute the canonical instance key (`<host-alias>:hermes:<agent-name>` — single colons) for your fleet. The `model` field is always `hermes-agent` — hermes routes to whatever upstream model is configured in `config.yaml`.
+Substitute the canonical instance key (`<host>:hermes:<agent-name>` — single colons) for your fleet. The `model` field is always `hermes-agent` — hermes routes to whatever upstream model is configured in `config.yaml`.
 
 #### Off-host access (loopback constraint)
 
@@ -209,7 +209,7 @@ clm agent remove <agent-name>    # stop, remove unit, rm ~/.hermes/, userdel
 - **No `clm chat <hermes-name>`** in this iteration. `clm chat` only supports openclaw. Tracked as [#322](https://github.com/ric03uec/clawrium/issues/322). Use `curl` against the local API in the meantime.
 - **External messaging gateways are deferred.** Discord, Slack, Telegram, WhatsApp, Signal, email, Matrix, Mattermost, Teams, Google Chat — none are wired to hermes via clm. See [Deferred items](#deferred-items--follow-ups).
 - **Identity is hermes-managed.** clm does not push `SOUL.md` / `AGENTS.md` into `~/.hermes/`. The identity onboarding stage auto-skips. If you want custom identity, edit those files directly on the agent host via SSH.
-- **Bearer token lives in `secrets.json`, not `hosts.json`.** As of PR #318, the canonical store for `HERMES_API_SERVER_KEY` is `~/.config/clawrium/secrets.json` keyed by `<host-alias>::<agent-name>`.
+- **Bearer token lives in `secrets.json`, not `hosts.json`.** As of PR #318, the canonical store for `HERMES_API_SERVER_KEY` is `~/.config/clawrium/secrets.json` keyed by `<host>:hermes:<agent-name>` (single-colon, 3 components). Provider keys use a different schema (`provider:<provider-name>`) in the same file.
 - **Memory has hard size limits.** `MEMORY.md` ≤ 2200 chars, `USER.md` ≤ 1375 chars. Other filenames in `~/.hermes/memories/` are rejected by `clm agent memory edit`. See [memory.md](memory.md).
 - **Concurrent writes are visible-atomic.** Hermes' `memory_write.yaml` uses a stage-then-rename pattern (`rename(2)` within the same filesystem) so the running hermes daemon never observes a partial file. The pattern is visible-atomic, not crash-durable (no explicit `fsync`).
 
@@ -241,13 +241,13 @@ Full details: [memory.md](memory.md).
    sudo journalctl -u hermes-<agent-name>.service -n 100 --no-pager
    ```
 
-2. The most common Phase 1 carryover symptom is `Gateway service is not installed`. That means the unit was rendered with `ExecStart=... hermes gateway start` instead of `gateway run`. `configure` re-renders the unit with `gateway run`; if you skipped configure, re-run it.
-
-3. Check that `~/.hermes/.env` exists and has `API_SERVER_ENABLED=1` and `API_SERVER_KEY=...`:
+2. Check that `~/.hermes/.env` exists and has `API_SERVER_ENABLED=1` and `API_SERVER_KEY=...`:
 
    ```bash
-   sudo -u <agent-name> cat /home/<agent-name>/.hermes/.env
+   sudo cat /home/<agent-name>/.hermes/.env
    ```
+
+3. Confirm the unit's `ExecStart` references `hermes gateway run` (the foreground supervisor command — both `install.yaml` and `start.yaml` render this). If you see `gateway start` in the unit file, you're on a pre-PR #318 build; `clm agent remove` + reinstall to pick up the corrected unit.
 
 </details>
 

--- a/docs/agent-support/hermes.md
+++ b/docs/agent-support/hermes.md
@@ -1,0 +1,336 @@
+# Hermes Support Matrix
+
+Hermes is the [Nous Research self-improving AI agent](https://github.com/NousResearch/hermes-agent) — a Python daemon that exposes a local OpenAI-compatible HTTP API and is designed to maintain its own identity, memory, and skills over time.
+
+**Status:** 🚧 In Development
+
+**Best for:** Local-first agents that need an OpenAI-compatible HTTP endpoint, file-based memory, and self-managed identity. Particularly useful with self-hosted inference (Ollama, vLLM, llama.cpp) since the api_server platform turns any of those into a unified OpenAI-style backend.
+
+**Pinned version:** `v2026.5.7` (manifest entry, both Ubuntu 22.04 and 24.04 x86_64). The installer SHA256 is pinned in `src/clawrium/platform/registry/hermes/manifest.yaml`; every version bump requires re-pinning.
+
+---
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Fully supported and tested |
+| 🚧 | In development / Planned |
+| ❌ | Not supported (use a different claw) |
+| 📋 | Deferred — tracked as follow-up |
+
+---
+
+## Provider Support
+
+Hermes supports cloud providers via API keys and any OpenAI-compatible local endpoint via its `custom` provider (alias `ollama`):
+
+| Provider | Status | clm `provider.type` | Notes |
+|----------|:------:|---------------------|-------|
+| **[OpenRouter](providers/openrouter.md)** | ✅ | `openrouter` | Renders `OPENROUTER_API_KEY` + `model.base_url: https://openrouter.ai/api/v1` |
+| **[Anthropic](providers/anthropic.md)** | ✅ | `anthropic` | Renders `ANTHROPIC_API_KEY`; uses hermes default `base_url` |
+| **[OpenAI](providers/openai.md)** | ✅ | `openai` | Renders `OPENAI_API_KEY`; uses hermes default `base_url` |
+| **[Ollama / custom OpenAI-compatible](providers/ollama.md)** | ✅ | `ollama` | Renders `model.provider: custom` + `model.base_url: <endpoint>/v1`. No API key required for local endpoints. |
+| **AWS Bedrock** | 📋 | — | Deferred. Hermes upstream supports it; clm wiring not in this iteration. |
+| **Google Vertex** | 📋 | — | Deferred. |
+| **ZAI / BigModel** | 📋 | — | Deferred. |
+| **Azure OpenAI** | 📋 | — | Deferred. |
+
+The provider mapping is implemented in `src/clawrium/platform/registry/hermes/templates/` and walked through in [Configure the agent](#2-configure-the-agent).
+
+---
+
+## Channel Support
+
+Hermes is intentionally scoped to a single channel in this iteration: a loopback OpenAI-compatible HTTP API on `127.0.0.1:8642` (the api_server platform).
+
+| Channel | Status | Notes |
+|---------|:------:|-------|
+| **Local OpenAI-compatible HTTP API** (`POST /v1/chat/completions`, `GET /v1/models`, `GET /health`) | ✅ | Bound to loopback on the agent host. See [Use the local API](#3-use-the-local-openai-compatible-api). |
+| **clm `chat <hermes-name>`** | 🚧 | Not supported yet (only openclaw). Tracked as [#322](https://github.com/ric03uec/clawrium/issues/322). |
+| **Discord** | 📋 | Deferred — see [Deferred items](#deferred-items--follow-ups) |
+| **Slack** | 📋 | Deferred |
+| **Telegram / WhatsApp / Signal** | 📋 | Deferred |
+| **Email / Matrix / Mattermost / Teams / Google Chat** | 📋 | Deferred |
+
+---
+
+## Feature Support
+
+| Feature | Status | Notes |
+|---------|:------:|-------|
+| **Local API server** | ✅ | `API_SERVER_ENABLED=1` + `API_SERVER_KEY` in `~/.hermes/.env`, bound to `127.0.0.1:8642` |
+| **Multi-provider** | ✅ | openrouter, anthropic, openai, ollama / custom |
+| **Memory (Markdown backend)** | ✅ | Two-file model: `MEMORY.md` (≤ 2200 chars), `USER.md` (≤ 1375 chars). See [memory.md](memory.md). |
+| **Pluggable memory backends** (Holographic / Honcho / Hindsight / Mem0 / Byterover / OpenViking) | 📋 | Deferred. clm's `memory` CLI sees only the default markdown backend in this iteration. |
+| **Secrets management** | ✅ | `HERMES_API_SERVER_KEY` persisted in `~/.config/clawrium/secrets.json` (NOT `hosts.json`) under the canonical instance key. |
+| **Auto-restart** | ✅ | Supervisor-managed systemd unit `hermes-<agent_name>.service` |
+| **Log streaming** | ✅ | `journalctl -u hermes-<agent_name>.service` on the agent host |
+| **Onboarding wizard** | ✅ | 4 stages: `providers` (required) → `identity` (auto-skipped) → `channels` (cli only) → `validate` |
+| **Identity files (`SOUL.md` / `AGENTS.md`)** | 🚧 | Hermes manages these internally inside `~/.hermes/`. clm does not push identity files in this iteration — the identity onboarding stage auto-skips. |
+| **MCP server registration** | 📋 | Deferred |
+| **`~/.hermes/state.db` (session/transcript history)** | 📋 | Out of scope for memory CLI |
+| **OAuth / webhook secrets** | 📋 | Deferred |
+
+---
+
+## Getting Started
+
+### 1. Install Hermes
+
+```bash
+clm agent install --type hermes --host <host-alias> --name <agent-name>
+```
+
+What happens:
+
+1. Preflight checks that `ripgrep` and `ffmpeg` are installed system-wide on the host. If either is missing, the install aborts with a remediation message.
+2. The installer script is fetched from `https://raw.githubusercontent.com/NousResearch/hermes-agent/v2026.5.7/scripts/install.sh` and verified against the pinned SHA256.
+3. A dedicated Linux user (`<agent-name>`) is created with `/usr/sbin/nologin` shell.
+4. The installer runs non-interactively as that user:
+
+   ```bash
+   bash install.sh --skip-setup --branch v2026.5.7 \
+     --hermes-home /home/<agent-name>/.hermes \
+     --dir /home/<agent-name>/.hermes/code
+   ```
+
+5. `clm` creates `~/.hermes/` (mode 0700), `~/.hermes/.env` (mode 0600, empty), and `~/.hermes/memories/` (mode 0700) under the agent user.
+6. A systemd unit `hermes-<agent-name>.service` is dropped, **disabled and not started**. Step 2 (configure) starts it.
+7. A 64-char hex `HERMES_API_SERVER_KEY` is generated and persisted in `~/.config/clawrium/secrets.json` under the canonical instance key. Re-installing reuses the existing key.
+
+The full install takes about 10-12 minutes (uv venv, pip install, npm install, Playwright). Wrapped in an Ansible `async` poll so the SSH connection is reused per-poll.
+
+### 2. Configure the agent
+
+```bash
+clm agent configure <agent-name>
+```
+
+The wizard walks through:
+
+| Stage | Behavior |
+|-------|----------|
+| **providers** | Required. Pick from your registered clm providers; clm validates connectivity. |
+| **identity** | Auto-skipped. Hermes manages `SOUL.md` / `AGENTS.md` internally inside `~/.hermes/`. |
+| **channels** | Required. Only `cli` is offered (the api_server platform is the CLI-equivalent endpoint). |
+| **validate** | Required. Runs `hermes --version`, checks `~/.hermes/.env`, and probes `GET /health`. |
+
+Configure renders TWO files on the agent host:
+
+- `~/.hermes/.env` (mode 0600):
+
+  ```env
+  HERMES_INFERENCE_PROVIDER=<provider-name-or-custom>
+  OPENROUTER_API_KEY=<...>           # only the active provider's key
+  API_SERVER_ENABLED=1
+  API_SERVER_HOST=127.0.0.1
+  API_SERVER_PORT=8642
+  API_SERVER_KEY=<64-char-hex>       # from secrets.json
+  ```
+
+- `~/.hermes/config.yaml` (mode 0600):
+
+  ```yaml
+  model:
+    provider: openrouter             # or anthropic, openai, custom
+    base_url: https://openrouter.ai/api/v1   # omitted for anthropic/openai defaults
+    default: <model-id>
+  ```
+
+Hermes deep-merges `config.yaml` with its built-in defaults at load time, so only the `model:` block is rendered. Per-provider mapping:
+
+| clm `provider.type` | Rendered `model.provider` | Rendered `model.base_url` | Rendered `.env` key |
+|---------------------|---------------------------|----------------------------|---------------------|
+| `openrouter` | `openrouter` | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
+| `anthropic` | `anthropic` | (omitted; hermes default) | `ANTHROPIC_API_KEY` |
+| `openai` | `openai` | (omitted; hermes default) | `OPENAI_API_KEY` |
+| `ollama` (or any custom OpenAI-compatible URL) | `custom` | `<provider.endpoint>/v1` (suffix `/v1` appended if missing) | (none — local endpoint) |
+
+After `.env` write, the restart handler enables and starts the systemd unit. The validate stage probes `http://127.0.0.1:8642/health` (10 retries / 3s). `/health` is unauthenticated; `/v1/*` requires the bearer header.
+
+### 3. Use the local OpenAI-compatible API
+
+The api_server platform binds to `127.0.0.1:8642` on the agent host. From a shell on the same host:
+
+```bash
+# Pull the bearer token from clm's secrets store on your control machine, OR
+# read it from ~/.hermes/.env on the agent host. The two are byte-identical
+# (configure hydrates .env from secrets.json).
+KEY=$(jq -r '.["wolf-i::hermes-test"].HERMES_API_SERVER_KEY.value' \
+  ~/.config/clawrium/secrets.json)
+
+curl -fsS http://127.0.0.1:8642/v1/chat/completions \
+  -H "Authorization: Bearer $KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hermes-agent",
+    "messages": [{"role": "user", "content": "Say only the word OK."}],
+    "max_tokens": 16
+  }'
+```
+
+Substitute the canonical instance key (`<host-alias>::<agent-name>`) for your fleet. The `model` field is always `hermes-agent` — hermes routes to whatever upstream model is configured in `config.yaml`.
+
+#### Off-host access (loopback constraint)
+
+The api_server only binds to `127.0.0.1` by design. To reach it from your control machine, open an SSH tunnel:
+
+```bash
+ssh -L 8642:127.0.0.1:8642 <user>@<agent-host>
+# In another terminal on the control machine:
+curl -fsS http://127.0.0.1:8642/v1/models \
+  -H "Authorization: Bearer $KEY"
+```
+
+Exposing hermes on a non-loopback interface is not supported in this iteration. Doing so without a properly hardened reverse proxy would let any LAN client invoke the model with the bearer token in plaintext.
+
+### 4. Lifecycle
+
+```bash
+clm agent start <agent-name>     # systemctl start; waits for /health = 200
+clm agent stop <agent-name>      # systemctl stop + disable; preserves ~/.hermes/
+clm agent remove <agent-name>    # stop, remove unit, rm ~/.hermes/, userdel
+```
+
+`clm agent start` is gated by onboarding state — before `configure` runs, the agent is in PENDING state and `start` is correctly blocked with: _"Cannot start `<name>` - onboarding not started. Run 'clm agent configure `<name>`' to begin onboarding."_
+
+---
+
+## Important caveats
+
+- **No `clm chat <hermes-name>`** in this iteration. `clm chat` only supports openclaw. Tracked as [#322](https://github.com/ric03uec/clawrium/issues/322). Use `curl` against the local API in the meantime.
+- **External messaging gateways are deferred.** Discord, Slack, Telegram, WhatsApp, Signal, email, Matrix, Mattermost, Teams, Google Chat — none are wired to hermes via clm. See [Deferred items](#deferred-items--follow-ups).
+- **Identity is hermes-managed.** clm does not push `SOUL.md` / `AGENTS.md` into `~/.hermes/`. The identity onboarding stage auto-skips. If you want custom identity, edit those files directly on the agent host via SSH.
+- **Bearer token lives in `secrets.json`, not `hosts.json`.** As of PR #318, the canonical store for `HERMES_API_SERVER_KEY` is `~/.config/clawrium/secrets.json` keyed by `<host-alias>::<agent-name>`.
+- **Memory has hard size limits.** `MEMORY.md` ≤ 2200 chars, `USER.md` ≤ 1375 chars. Other filenames in `~/.hermes/memories/` are rejected by `clm agent <name> memory write`. See [memory.md](memory.md).
+- **Concurrent writes are race-safe.** `memory write` uses an atomic stage-then-rename pattern so the running hermes daemon never observes a partial file.
+
+---
+
+## Memory model
+
+Hermes ships a two-file Markdown memory backend at `~/.hermes/memories/`:
+
+| File | Limit | Purpose |
+|------|------:|---------|
+| `MEMORY.md` | 2200 chars | Agent notes / scratchpad |
+| `USER.md` | 1375 chars | User profile |
+
+Both are managed by `clm agent <hermes-name> memory show|read|write|edit|delete`. The dispatcher is driven by the agent's manifest (`workspace.memory_path` + `features.memory: true`), so the CLI surface is identical to openclaw.
+
+Full details: [memory.md](memory.md).
+
+---
+
+## Troubleshooting
+
+<details>
+<summary><strong>Service won't start (`clm agent start` hangs or exits)</strong></summary>
+
+1. SSH to the agent host and inspect the journal:
+
+   ```bash
+   sudo journalctl -u hermes-<agent-name>.service -n 100 --no-pager
+   ```
+
+2. The most common Phase 1 carryover symptom is `Gateway service is not installed`. That means the unit was rendered with `ExecStart=... hermes gateway start` instead of `gateway run`. `configure` re-renders the unit with `gateway run`; if you skipped configure, re-run it.
+
+3. Check that `~/.hermes/.env` exists and has `API_SERVER_ENABLED=1` and `API_SERVER_KEY=...`:
+
+   ```bash
+   sudo -u <agent-name> cat /home/<agent-name>/.hermes/.env
+   ```
+
+</details>
+
+<details>
+<summary><strong>`/health` returns non-200 or connection refused</strong></summary>
+
+1. Confirm the service is active:
+
+   ```bash
+   sudo systemctl status hermes-<agent-name>.service
+   ```
+
+2. From the agent host (not your control machine — loopback only):
+
+   ```bash
+   curl -v http://127.0.0.1:8642/health
+   ```
+
+3. If the service is active but the probe fails, the most likely cause is the api_server platform failing to register. That happens when `API_SERVER_KEY` is missing from `.env` (the configure stage should always write it). Re-run `clm agent configure <name> --stage providers`.
+
+4. From your control machine, you cannot reach `/health` directly — use SSH port-forwarding (see [Off-host access](#off-host-access-loopback-constraint)).
+
+</details>
+
+<details>
+<summary><strong>Provider connectivity failed during configure</strong></summary>
+
+1. Verify the provider is registered and has a key:
+
+   ```bash
+   clm provider list
+   ```
+
+2. Test the provider in isolation:
+
+   ```bash
+   clm provider test <provider-name>
+   ```
+
+3. For `ollama` / custom endpoints, ensure the agent host can reach the endpoint URL (not just your control machine):
+
+   ```bash
+   ssh <agent-host> "curl -fsS <endpoint>/v1/models"
+   ```
+
+4. Re-run `clm agent configure <name> --stage providers` after fixing.
+
+</details>
+
+<details>
+<summary><strong>`memory write USER.md ...` rejects with character limit</strong></summary>
+
+`USER.md` is hard-capped at 1375 chars, `MEMORY.md` at 2200. The limit is enforced client-side in `clm` before any Ansible dispatch, so you get an immediate error. Trim the content and retry. Other filenames are rejected with `"hermes memory accepts only MEMORY.md and USER.md"`.
+
+</details>
+
+<details>
+<summary><strong>`userdel` fails on `clm agent remove`</strong></summary>
+
+Hermes runs `loginctl enable-linger` on first start, which keeps a per-user systemd manager + dbus running even after the system unit stops. `remove.yaml` runs `loginctl disable-linger` + `pkill -KILL -u <user>` before `userdel`, but if you hit a stuck state, do it manually:
+
+```bash
+sudo loginctl disable-linger <agent-name>
+sudo pkill -KILL -u <agent-name>
+sudo userdel -r <agent-name>
+```
+
+Then re-run `clm agent remove <name> --force`.
+
+</details>
+
+---
+
+## Deferred items / follow-ups
+
+The following are explicitly out of scope for issue #68 and tracked as separate follow-ups (see `.itx/68/00_PLAN.md` → "Out of scope"):
+
+- Messaging gateway pairing: Discord, Slack, Telegram, WhatsApp, Signal, email, Teams, Google Chat, Matrix, Mattermost, QQBot, Feishu, DingTalk.
+- Pluggable memory backends: Holographic, Honcho, Hindsight, Mem0, Byterover, OpenViking. clm's `memory` CLI only sees the default markdown backend.
+- MCP server registration.
+- `~/.hermes/state.db` (session / transcript history) inspection via clm.
+- OAuth file (`HERMES_OAUTH_FILE`) and webhook secrets.
+- Installer-checksum refresh helper (manifest must be re-pinned every version bump — currently manual).
+- `clm chat <hermes-name>` ([#322](https://github.com/ric03uec/clawrium/issues/322)).
+
+---
+
+## Next Steps
+
+- [Memory model](memory.md) — manifest-driven memory CLI across claw types
+- [OpenClaw Support Matrix](openclaw.md) — full-featured alternative with multi-channel support
+- [Agent Onboarding](../agent-onboarding.md) — detailed onboarding wizard guide
+- [Host Preparation](../host-preparation.md) — installing provider credentials and host prereqs

--- a/docs/agent-support/hermes.md
+++ b/docs/agent-support/hermes.md
@@ -63,8 +63,8 @@ Hermes is intentionally scoped to a single channel in this iteration: a loopback
 | **Multi-provider** | ✅ | openrouter, anthropic, openai, ollama / custom |
 | **Memory (Markdown backend)** | ✅ | Two-file model: `MEMORY.md` (≤ 2200 chars), `USER.md` (≤ 1375 chars). See [memory.md](memory.md). |
 | **Pluggable memory backends** (Holographic / Honcho / Hindsight / Mem0 / Byterover / OpenViking) | 📋 | Deferred. clm's `memory` CLI sees only the default markdown backend in this iteration. |
-| **Secrets management** | ✅ | `HERMES_API_SERVER_KEY` persisted in `~/.config/clawrium/secrets.json` (NOT `hosts.json`) under the canonical instance key. |
-| **Auto-restart** | ✅ | Supervisor-managed systemd unit `hermes-<agent_name>.service` |
+| **Secrets management** | ✅ | `HERMES_API_SERVER_KEY` persisted in `~/.config/clawrium/secrets.json` (NOT `hosts.json`) under the canonical instance key `<host>:hermes:<agent-name>` (single-colon, 3 components). `secrets.json` is chmod 0600 on creation. Per-agent secrets are isolated by instance key. |
+| **Auto-restart** | ✅ | Systemd unit `hermes-<agent_name>.service` with `Restart=on-failure`; systemd is the supervisor (no separate process). |
 | **Log streaming** | ✅ | `journalctl -u hermes-<agent_name>.service` on the agent host |
 | **Onboarding wizard** | ✅ | 4 stages: `providers` (required) → `identity` (auto-skipped) → `channels` (cli only) → `validate` |
 | **Identity files (`SOUL.md` / `AGENTS.md`)** | 🚧 | Hermes manages these internally inside `~/.hermes/`. clm does not push identity files in this iteration — the identity onboarding stage auto-skips. |
@@ -97,7 +97,7 @@ What happens:
 
 5. `clm` creates `~/.hermes/` (mode 0700), `~/.hermes/.env` (mode 0600, empty), and `~/.hermes/memories/` (mode 0700) under the agent user.
 6. A systemd unit `hermes-<agent-name>.service` is dropped, **disabled and not started**. Step 2 (configure) starts it.
-7. A 64-char hex `HERMES_API_SERVER_KEY` is generated and persisted in `~/.config/clawrium/secrets.json` under the canonical instance key. Re-installing reuses the existing key.
+7. A 64-char lowercase-hex `HERMES_API_SERVER_KEY` is generated and persisted in `~/.config/clawrium/secrets.json` under the canonical instance key `<host>:hermes:<agent-name>` (single-colon, 3 components). Re-installing reuses the existing key. The 64-char-lowercase-hex format is validated on load; a hand-edit to an invalid format produces an error at next configure/start.
 
 The full install takes about 10-12 minutes (uv venv, pip install, npm install, Playwright). Wrapped in an Ansible `async` poll so the SSH connection is reused per-poll.
 
@@ -157,9 +157,14 @@ The api_server platform binds to `127.0.0.1:8642` on the agent host. From a shel
 # Pull the bearer token from clm's secrets store on your control machine, OR
 # read it from ~/.hermes/.env on the agent host. The two are byte-identical
 # (configure hydrates .env from secrets.json).
-KEY=$(jq -r '.["wolf-i::hermes-test"].HERMES_API_SERVER_KEY.value' \
+#
+# Instance key format: "<host>:<claw_type>:<claw_name>" — single-colon, 3
+# components. For host alias `wolf-i`, agent `hermes-test`:
+KEY=$(jq -r '.["wolf-i:hermes:hermes-test"].HERMES_API_SERVER_KEY.value' \
   ~/.config/clawrium/secrets.json)
 
+# Note: `127.0.0.1:8642` is the AGENT HOST's loopback. Run the curl below on
+# the agent host. For control-machine access, see "Off-host access" below.
 curl -fsS http://127.0.0.1:8642/v1/chat/completions \
   -H "Authorization: Bearer $KEY" \
   -H "Content-Type: application/json" \
@@ -170,7 +175,7 @@ curl -fsS http://127.0.0.1:8642/v1/chat/completions \
   }'
 ```
 
-Substitute the canonical instance key (`<host-alias>::<agent-name>`) for your fleet. The `model` field is always `hermes-agent` — hermes routes to whatever upstream model is configured in `config.yaml`.
+Substitute the canonical instance key (`<host-alias>:hermes:<agent-name>` — single colons) for your fleet. The `model` field is always `hermes-agent` — hermes routes to whatever upstream model is configured in `config.yaml`.
 
 #### Off-host access (loopback constraint)
 
@@ -188,12 +193,14 @@ Exposing hermes on a non-loopback interface is not supported in this iteration. 
 ### 4. Lifecycle
 
 ```bash
-clm agent start <agent-name>     # systemctl start; waits for /health = 200
+clm agent start <agent-name>     # systemctl start; waits for ActiveState ∈ {active, activating}
 clm agent stop <agent-name>      # systemctl stop + disable; preserves ~/.hermes/
 clm agent remove <agent-name>    # stop, remove unit, rm ~/.hermes/, userdel
 ```
 
-`clm agent start` is gated by onboarding state — before `configure` runs, the agent is in PENDING state and `start` is correctly blocked with: _"Cannot start `<name>` - onboarding not started. Run 'clm agent configure `<name>`' to begin onboarding."_
+`clm agent start` checks systemd's `ActiveState` after a 3-second settle window and fails loudly if the unit is not `active` or `activating`. The HTTP `/health` probe runs during the `validate` onboarding stage, NOT during `clm agent start`.
+
+`clm agent start` is gated by onboarding state — until `configure` completes and onboarding reaches READY, `start` is blocked with: _"Cannot start `<host:hermes:name>`: onboarding incomplete (state=`<current-state>`). Run 'clm agent configure `<agent-name>`' first."_ Use `--force` to override the gate (not recommended; bypasses provider/validate checks).
 
 ---
 
@@ -203,8 +210,8 @@ clm agent remove <agent-name>    # stop, remove unit, rm ~/.hermes/, userdel
 - **External messaging gateways are deferred.** Discord, Slack, Telegram, WhatsApp, Signal, email, Matrix, Mattermost, Teams, Google Chat — none are wired to hermes via clm. See [Deferred items](#deferred-items--follow-ups).
 - **Identity is hermes-managed.** clm does not push `SOUL.md` / `AGENTS.md` into `~/.hermes/`. The identity onboarding stage auto-skips. If you want custom identity, edit those files directly on the agent host via SSH.
 - **Bearer token lives in `secrets.json`, not `hosts.json`.** As of PR #318, the canonical store for `HERMES_API_SERVER_KEY` is `~/.config/clawrium/secrets.json` keyed by `<host-alias>::<agent-name>`.
-- **Memory has hard size limits.** `MEMORY.md` ≤ 2200 chars, `USER.md` ≤ 1375 chars. Other filenames in `~/.hermes/memories/` are rejected by `clm agent <name> memory write`. See [memory.md](memory.md).
-- **Concurrent writes are race-safe.** `memory write` uses an atomic stage-then-rename pattern so the running hermes daemon never observes a partial file.
+- **Memory has hard size limits.** `MEMORY.md` ≤ 2200 chars, `USER.md` ≤ 1375 chars. Other filenames in `~/.hermes/memories/` are rejected by `clm agent memory edit`. See [memory.md](memory.md).
+- **Concurrent writes are visible-atomic.** Hermes' `memory_write.yaml` uses a stage-then-rename pattern (`rename(2)` within the same filesystem) so the running hermes daemon never observes a partial file. The pattern is visible-atomic, not crash-durable (no explicit `fsync`).
 
 ---
 
@@ -217,7 +224,7 @@ Hermes ships a two-file Markdown memory backend at `~/.hermes/memories/`:
 | `MEMORY.md` | 2200 chars | Agent notes / scratchpad |
 | `USER.md` | 1375 chars | User profile |
 
-Both are managed by `clm agent <hermes-name> memory show|read|write|edit|delete`. The dispatcher is driven by the agent's manifest (`workspace.memory_path` + `features.memory: true`), so the CLI surface is identical to openclaw.
+Both are managed by `clm agent memory show|edit|delete <hermes-name>`. The dispatcher is driven by the agent's manifest (`workspace.memory_path` + `features.memory: true`), so the CLI surface is identical to openclaw. (Note: `read` and `write` are not separate CLI subcommands in this iteration — use `edit`.)
 
 Full details: [memory.md](memory.md).
 
@@ -274,26 +281,30 @@ Full details: [memory.md](memory.md).
    clm provider list
    ```
 
-2. Test the provider in isolation:
+2. Re-run the onboarding `providers` stage; clm runs `provider_test` connectivity validation as part of that stage:
 
    ```bash
-   clm provider test <provider-name>
+   clm agent configure <agent-name> --stage providers
    ```
 
-3. For `ollama` / custom endpoints, ensure the agent host can reach the endpoint URL (not just your control machine):
+3. For `ollama` / custom endpoints, ensure the **agent host** (not just your control machine) can reach the endpoint URL:
 
    ```bash
    ssh <agent-host> "curl -fsS <endpoint>/v1/models"
    ```
 
-4. Re-run `clm agent configure <name> --stage providers` after fixing.
+4. Inspect the agent's `~/.hermes/.env` and `~/.hermes/config.yaml` on the agent host to verify the rendered provider settings:
+
+   ```bash
+   ssh <agent-host> "sudo -u <agent-name> cat ~<agent-name>/.hermes/config.yaml"
+   ```
 
 </details>
 
 <details>
-<summary><strong>`memory write USER.md ...` rejects with character limit</strong></summary>
+<summary><strong>`memory edit USER.md` rejects on save with character limit</strong></summary>
 
-`USER.md` is hard-capped at 1375 chars, `MEMORY.md` at 2200. The limit is enforced client-side in `clm` before any Ansible dispatch, so you get an immediate error. Trim the content and retry. Other filenames are rejected with `"hermes memory accepts only MEMORY.md and USER.md"`.
+`USER.md` is hard-capped at 1375 chars, `MEMORY.md` at 2200. The limit is enforced client-side in `clm` before any Ansible dispatch, so you get an immediate error after `$EDITOR` exits. Trim the content and retry. Other filenames are rejected with `"hermes memory accepts only MEMORY.md and USER.md"`.
 
 </details>
 

--- a/docs/agent-support/index.md
+++ b/docs/agent-support/index.md
@@ -14,6 +14,7 @@ Clawrium supports multiple agent types, each designed for different use cases. T
 
 | Agent | Description | Status |
 |-------|-------------|--------|
+| **[Hermes](hermes.md)** | Nous Research self-improving agent — local OpenAI-compatible HTTP API, file-based memory | 🚧 In Development |
 | **[ZeroClaw](zeroclaw.md)** | Minimal CLI-only agent for simple automation | 🚧 In Development |
 
 ## Legend
@@ -23,28 +24,41 @@ Clawrium supports multiple agent types, each designed for different use cases. T
 | ✅ | Fully supported and tested |
 | 🚧 | In development / Planned |
 | ❌ | Not supported |
-| 📋 | Not planned (PRs welcome) |
+| 📋 | Not planned / Deferred (PRs welcome) |
 
 ## Quick Comparison
 
-| Feature | OpenClaw | ZeroClaw |
-|---------|:--------:|:--------:|
-| **Multi-Provider** | ✅ | 🚧 |
-| **CLI Channel** | ✅ | 🚧 |
-| **Discord** | ✅ | ❌ |
-| **Custom Identity** | ✅ (SOUL.md) | ❌ |
-| **Integrations** | 🚧 | ❌ |
-| **Onboarding Wizard** | ✅ | 🚧 |
+| Aspect | OpenClaw | Hermes | ZeroClaw |
+|--------|:--------:|:------:|:--------:|
+| **Status** | ✅ Production Ready | 🚧 In Development | 🚧 In Development |
+| **Transport** | Native daemon | Local OpenAI-compatible HTTP API (`127.0.0.1:8642`) | CLI process |
+| **`clm chat <name>` support** | ✅ | 🚧 ([#322](https://github.com/ric03uec/clawrium/issues/322)) | 🚧 |
+| **Multi-Provider** | ✅ (OpenAI, Anthropic, OpenRouter, Bedrock, Vertex, ZAI, Ollama) | ✅ (OpenRouter, Anthropic, OpenAI, Ollama / custom) | 🚧 (OpenAI, Anthropic, Ollama planned) |
+| **Memory model** | Daily files + identity files | Two fixed files: `MEMORY.md` (≤ 2200 chars), `USER.md` (≤ 1375 chars) | ❌ |
+| **Identity management** | clm-managed `SOUL.md` / `IDENTITY.md` | Hermes-managed inside `~/.hermes/` (clm does not push) | ❌ |
+| **Messaging gateways** | Discord ✅, Slack 🚧, Web 🚧 | 📋 All deferred (Discord/Slack/Telegram/WhatsApp/Signal/email/...) | ❌ |
+| **External integrations** | GitHub 🚧, Jira 🚧 | 📋 Deferred | ❌ |
+| **Onboarding wizard** | ✅ 4-stage | ✅ 4-stage (identity auto-skipped) | 🚧 2-stage |
+| **Resource usage** | Moderate | Moderate-to-high (uv venv + npm + playwright) | Low |
 
 ## Choosing an Agent
 
 **Use OpenClaw when:**
-- You need Discord or multi-channel support
-- You want customizable identity/personality
+
+- You need Discord, Slack, or multi-channel support
+- You want clm-managed customizable identity/personality
 - You need integrations with external tools
-- You want a full-featured assistant
+- You want a fully production-ready experience today
+
+**Use Hermes when:**
+
+- You want a local OpenAI-compatible HTTP API in front of your model
+- You want a self-managed-identity agent (hermes manages its own `SOUL.md` / `AGENTS.md`)
+- You're driving a local inference endpoint (Ollama, vLLM, llama.cpp) and want hermes to wrap it
+- You only need loopback access — `clm chat` and external gateways aren't required yet
 
 **Use ZeroClaw when:**
+
 - You only need CLI interaction
 - You want minimal resource usage
 - You need quick automation scripts

--- a/docs/agent-support/memory.md
+++ b/docs/agent-support/memory.md
@@ -3,12 +3,13 @@
 Clawrium's `memory` CLI inspects and edits the on-disk memory files of running agents. As of issue #68, the dispatcher is **manifest-driven**, so a single CLI surface works across openclaw, hermes, and any future claw type that opts in.
 
 ```bash
-clm agent <name> memory show
-clm agent <name> memory read <file>
-clm agent <name> memory write <file> [--content "..."]
-clm agent <name> memory edit <file>           # opens $EDITOR
-clm agent <name> memory delete <file>
+clm agent memory show <name>                     # list memory files + sizes
+clm agent memory edit <name> <file>              # opens $EDITOR; atomic-write on save
+clm agent memory delete <name> --file <file>     # delete one file
+clm agent memory delete <name> --all --force     # delete every memory file
 ```
+
+Note: in this iteration the CLI exposes `show`, `edit`, and `delete`. `read` and `write` are not separate subcommands — use `edit` for both (read = view in `$EDITOR`; write = save in `$EDITOR`). The underlying `read_memory_file` / `write_memory_file` primitives in `core/memory.py` are wired for future expansion.
 
 ---
 
@@ -69,28 +70,31 @@ Other filenames are rejected on `memory write` with `"hermes memory accepts only
 ### OpenClaw
 
 ```
-~/.openclaw/workspace/memory/
-├── SOUL.md          # Identity (top-level)
-├── IDENTITY.md      # Identity (top-level)
-├── USER.md          # User profile (top-level)
-├── TOOLS.md         # Tools (top-level)
+~/.openclaw/workspace/
+├── SOUL.md             # Identity (top-level)
+├── IDENTITY.md         # Identity (top-level)
+├── USER.md             # User profile (top-level)
+├── TOOLS.md            # Tools (top-level)
 └── memory/
-    └── YYYY-MM-DD.md  # Daily files (dynamic listing)
+    └── YYYY-MM-DD.md   # Daily files (dynamic listing)
 ```
 
-OpenClaw uses a daily-file model under `memory/`, plus a fixed set of top-level identity/profile files. There are no per-file character caps; the global cap is `MAX_MEMORY_CONTENT_BYTES = 5 MiB` (a transport safety bound, not a per-claw policy).
+OpenClaw uses a daily-file model under `memory/`, plus a fixed set of top-level identity/profile files at the workspace root. There are no per-file character caps; the global cap is `MAX_MEMORY_CONTENT_BYTES = 5 MiB` (a transport safety bound, not a per-claw policy).
 
 ---
 
-## Atomic-write safety
+## Write safety
 
-Both claws can be edited concurrently with the running daemon. Memory writes use a stage-then-rename pattern:
+The two claws use different write strategies:
+
+**Hermes** (`registry/hermes/playbooks/memory_write.yaml`) uses a stage-then-rename pattern:
 
 1. Write the new content to a sibling temp file in the same directory (`.<file>.tmp`).
-2. `fsync` the temp file.
-3. `rename(2)` the temp file over the target.
+2. `rename(2)` the temp file over the target (single `mv -f` within the same filesystem).
 
-Because `rename(2)` within a single filesystem is atomic on Linux, the daemon never observes a partial or torn file — it sees either the old content or the new content. This is implemented identically in `registry/hermes/playbooks/memory_write.yaml` and `registry/openclaw/playbooks/memory_write.yaml`.
+Because `rename(2)` within a single filesystem is visible-atomic on Linux, the hermes daemon never observes a partial or torn file — it sees either the old content or the new content. (Note: the playbook does not currently issue an explicit `fsync` before rename, so the new content is atomic from the daemon's perspective but not guaranteed durable across a hard-crash power loss until the kernel flushes the page cache. This is acceptable for the memory CLI's use case — content lost in a crash window can be re-written.)
+
+**OpenClaw** (`registry/openclaw/playbooks/memory_write.yaml`) uses `ansible.builtin.copy` directly — no staging file, no rename. Concurrent writes between the openclaw daemon and `clm memory write` are not protected against torn reads. In practice this has not been observed as a problem because openclaw's memory model is daily-files (write contention is rare); a follow-up may align openclaw's write playbook with the hermes stage-then-rename pattern for consistency.
 
 ---
 

--- a/docs/agent-support/memory.md
+++ b/docs/agent-support/memory.md
@@ -1,0 +1,112 @@
+# Memory Model
+
+Clawrium's `memory` CLI inspects and edits the on-disk memory files of running agents. As of issue #68, the dispatcher is **manifest-driven**, so a single CLI surface works across openclaw, hermes, and any future claw type that opts in.
+
+```bash
+clm agent <name> memory show
+clm agent <name> memory read <file>
+clm agent <name> memory write <file> [--content "..."]
+clm agent <name> memory edit <file>           # opens $EDITOR
+clm agent <name> memory delete <file>
+```
+
+---
+
+## How dispatch works
+
+1. **Resolve the claw type.** `clm` looks up the agent in `hosts.json` (or scans candidates by name across all hosts when the user typed an ambiguous identifier) and reads the recorded `type`.
+2. **Check the manifest.** `core/memory.py::claw_supports_memory(<type>)` loads `registry/<type>/manifest.yaml` and returns True iff `features.memory` is `true`.
+3. **Resolve the workspace path.** Used for display — read from `manifest.workspace.memory_path` and expanded against the agent user's home directory (`~`).
+4. **Dispatch the playbook.** The runner invokes `registry/<type>/playbooks/memory_<op>.yaml` (where `<op>` is `info`, `read`, `write`, or `delete`). Each claw ships its own playbooks targeting its own on-disk layout.
+
+If `features.memory` is missing or `false`, the CLI exits non-zero with:
+
+```
+memory operations not supported for agent type '<type>'
+```
+
+For example, `clm agent <zeroclaw-name> memory show` produces that error today, since the zeroclaw manifest does not declare `features.memory: true`.
+
+---
+
+## Manifest schema
+
+The relevant fields in `registry/<type>/manifest.yaml`:
+
+```yaml
+workspace:
+  memory_path: "~/.<agent_workspace>/memory"   # required to display the path
+
+features:
+  memory: true                                  # required to enable the memory CLI
+```
+
+Both fields are optional in the `AgentManifest` TypedDict — legacy claws (e.g. zeroclaw) continue to validate without either. Declaring `features.memory: true` is the opt-in for memory CLI support.
+
+---
+
+## Per-claw on-disk layouts
+
+The CLI surface is uniform, but each claw's on-disk model is different.
+
+### Hermes
+
+```
+~/.hermes/memories/
+├── MEMORY.md      # Agent notes / scratchpad     (≤ 2200 chars)
+└── USER.md        # User profile                  (≤ 1375 chars)
+```
+
+Hard limits:
+
+| File | Max chars |
+|------|----------:|
+| `MEMORY.md` | 2200 |
+| `USER.md` | 1375 |
+
+Other filenames are rejected on `memory write` with `"hermes memory accepts only MEMORY.md and USER.md"`. The limits are enforced **client-side in `core/memory.py`** (immediate, no Ansible roundtrip) AND defensively in `memory_write.yaml`. Identity files (`SOUL.md`, `AGENTS.md`) are explicitly excluded from memory by hermes itself and are not editable via the memory CLI.
+
+### OpenClaw
+
+```
+~/.openclaw/workspace/memory/
+├── SOUL.md          # Identity (top-level)
+├── IDENTITY.md      # Identity (top-level)
+├── USER.md          # User profile (top-level)
+├── TOOLS.md         # Tools (top-level)
+└── memory/
+    └── YYYY-MM-DD.md  # Daily files (dynamic listing)
+```
+
+OpenClaw uses a daily-file model under `memory/`, plus a fixed set of top-level identity/profile files. There are no per-file character caps; the global cap is `MAX_MEMORY_CONTENT_BYTES = 5 MiB` (a transport safety bound, not a per-claw policy).
+
+---
+
+## Atomic-write safety
+
+Both claws can be edited concurrently with the running daemon. Memory writes use a stage-then-rename pattern:
+
+1. Write the new content to a sibling temp file in the same directory (`.<file>.tmp`).
+2. `fsync` the temp file.
+3. `rename(2)` the temp file over the target.
+
+Because `rename(2)` within a single filesystem is atomic on Linux, the daemon never observes a partial or torn file — it sees either the old content or the new content. This is implemented identically in `registry/hermes/playbooks/memory_write.yaml` and `registry/openclaw/playbooks/memory_write.yaml`.
+
+---
+
+## What's NOT in scope
+
+The following are explicitly deferred for issue #68 and tracked as separate follow-ups (see `.itx/68/00_PLAN.md` → "Out of scope"):
+
+- **Pluggable memory backends.** Hermes upstream supports Holographic, Honcho, Hindsight, Mem0, Byterover, and OpenViking. clm's `memory` CLI only sees the default markdown backend in this iteration.
+- **Session / transcript history (`~/.hermes/state.db`).** This is intentionally not exposed via `memory` — hermes treats `state.db` as transcript history, not memory.
+- **Identity-file editing for hermes.** clm does not push `SOUL.md` / `AGENTS.md` into `~/.hermes/`; hermes manages them internally. Edit those files directly via SSH if needed.
+- **Pluggable filesystem layouts.** The current schema assumes flat markdown files. Future backends (sqlite-backed, encrypted, network-mounted) would require a backend abstraction in `core/memory.py`.
+
+---
+
+## See also
+
+- [Hermes Support Matrix](hermes.md) — full hermes user guide
+- [OpenClaw Support Matrix](openclaw.md) — full openclaw user guide
+- [Agent Onboarding](../agent-onboarding.md) — how stages interact with manifest


### PR DESCRIPTION
## Summary

- Final phase (Phase 5) of issue #68. Publishes hermes user-facing documentation, formalises the manifest-driven memory model now that it spans claw types, and closes out the parent issue.
- New: `docs/agent-support/hermes.md` (capability matrix, install/configure walkthrough, local OpenAI-compatible API curl example, SSH-tunnel recipe, caveats, troubleshooting, deferred-items list).
- New: `docs/agent-support/memory.md` (manifest-driven dispatch, per-claw on-disk layouts, write-safety differences between hermes and openclaw).
- Modified: `docs/agent-support/index.md` (add hermes row + 3-column Quick Comparison matrix; status `🚧 In Development`).
- Modified: `README.md` FAQ #2 (add hermes paragraph linking to support matrix). Quickstart intentionally left alone — openclaw remains the canonical first-time example.
- Docs-only PR. Zero source/test changes. `make test` 1566 passed; `make lint` clean.

## Files

| File | Change |
|------|--------|
| `docs/agent-support/hermes.md` | Create |
| `docs/agent-support/memory.md` | Create |
| `docs/agent-support/index.md` | Modify |
| `README.md` | Modify (FAQ #2 only) |
| `.itx/68/01_EXECUTION.md` | Append Phase 5 execution log entry |

## ATX Review Summary

**Final Review: Rating 3/5**
**Total Cost: $6.40 | Total Time: ~16m**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1, B2, B3, B4 | All fixed | $3.38 | 8m30s | leader, test-coverage, lifecycle-state, cli-ux, ansible-playbook, secrets-provider |
| 2 | 3/5 | B1 (regression at line 212) | Fixed in iter-2 commit (post-review) | $3.02 | ~8m | leader, test-coverage, lifecycle-state, cli-ux, ansible-playbook, secrets-provider |

> **Note**: ATX does not expose model information per agent. Iter 2 surfaced one stale double-colon instance key at hermes.md:212 (a regression from the iter 1 fix that missed one location). The fix landed in the iter 2 commit; the rating snapshot of 3/5 predates the iter 2 commit. Per the 2-iteration cap policy this PR is handed back to the orchestrator at this rating.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `hermes.md` (multiple) | Instance key format wrong (`host::name`, double-colon) | Fixed — `<host>:hermes:<agent-name>` (single colon, 3 components) per `secrets.py::get_instance_key()` |
| B2 | `hermes.md:280` | Phantom `clm provider test <name>` (no such command) | Fixed — replaced with `clm agent configure <name> --stage providers` + direct ssh curl for ollama |
| B3 | `memory.md:93` | False parity claim — openclaw not atomic | Fixed — split into per-claw subsections; openclaw uses plain `copy`, hermes uses stage-then-rename |
| B4 | `memory.md:88-91` | Documented fsync that never happens | Fixed — removed fsync step; documented as visible-atomic via rename(2) only |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `hermes.md:191` | `clm agent start` health-check claim wrong (no `/health` probe) | Fixed — describes `ActiveState ∈ {active, activating}` check |
| W2 | `hermes.md:196` | Quoted onboarding-gate error doesn't match `lifecycle.py:353` | Fixed — exact message used |
| W3 | `hermes.md` | "Supervisor-managed" misleading | Fixed — "systemd is the supervisor (`Restart=on-failure`)" |
| W4 | `memory.md` | Openclaw memory tree root wrong | Fixed — `~/.openclaw/workspace/` root with `memory/` for dailies |
| W5 | `hermes.md` | Memory CLI surface uncertain | Verified against `cli/agent.py:2239-2310` — only show/edit/delete; updated docs |
| W6 | `hermes.md` | configure.yaml `no_log: true` audit | Acknowledged — out of scope for docs PR |
| W7 | `hermes.md` | Key validation format (64-char lowercase hex) undocumented | Fixed — noted in install walkthrough |
| W8 | `hermes.md` | `secrets.json` 0600 perms undocumented | Fixed — noted in feature matrix |
| W9 | tests | Atomic-write test coverage missing | Acknowledged — code follow-up |
| W10 | tests | Per-agent secrets isolation untested | Acknowledged — code follow-up |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `hermes.md:212` | One stale `host::name` reference (iter 1 fix missed it) | Fixed in iter-2 commit |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `hermes.md:~150` | Retry count "10 retries / 3s" wrong | Fixed — "20 retries / 3s delay (≈60s max)" per `configure.yaml:173-174` |
| W2 | `hermes.md:244` | Obsolete "gateway start vs gateway run" troubleshooting | Fixed — replaced with positive note + pre-PR-#318 remediation |
| W3 | `memory.md:6-9` | Inconsistent `edit <file>` vs `delete --file <file>` | Acknowledged — reflects actual CLI surface |
| W4 | `memory.md:6-9` | Positional `<name>` vs `--name` convention | Acknowledged — reflects actual CLI surface |
| W5 | `hermes.md` | `<host>` vs `<host-alias>` inconsistency | Fixed — standardised to `<host>` |
| W6 | `hermes.md:66,125-129` | Provider key schema in `secrets.json` undocumented | Fixed — one-line note at bearer-token caveat |

**Suggestions (deferred to follow-ups):**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | `agent_name` regex validation in stop/remove playbooks | Code follow-up — out of scope |
| S2 | `--all` + `--force` interaction clarification | Code follow-up |
| S3 | `.itx/68/00_PLAN.md` fsync mention | Plan file is historical record — preserved as-is |
| S4 | Stop playbook `ignore_errors` comments | Code follow-up |
| S5 | Doc-assertion tests for documented constants | Tooling follow-up |

</details>

## Acceptance Criteria (Issue #68, full close-out)

The parent issue's acceptance criteria from `.itx/68/00_PLAN.md` are reproduced here with verification source for each.

- [x] `clm claw list` shows `hermes` — verified Phase 1 (`tests/test_registry_hermes.py::test_hermes_listed_in_registry`)
- [x] `clm agent install --type hermes --host <host> --name <name>` succeeds; service unit dropped, disabled, not started — verified Phase 1 E2E on wolf-i
- [x] `clm agent configure <name> --provider openrouter --model <m> --api-key <KEY>` succeeds and brings the service up; `/health` returns 200 — verified Phase 2 E2E
- [x] `clm agent start | stop | remove <name>` all succeed — verified Phase 2 + Phase 4 E2E
- [x] `curl http://127.0.0.1:8642/v1/models` returns `hermes-agent` — verified Phase 2 E2E
- [x] `clm agent memory show <hermes-name>` lists `MEMORY.md` + `USER.md` — verified Phase 3 E2E
- [x] `clm agent memory edit <hermes-name> USER.md` rejects content > 1375 chars — verified Phase 3 client-side validation in `core/memory.py`
- [x] `clm agent memory show <openclaw-name>` continues to behave identically to pre-change — verified Phase 3 (byte-for-byte; openclaw test suite unchanged)
- [x] `clm agent memory show <zeroclaw-name>` returns `"memory operations not supported for agent type 'zeroclaw'"` — verified Phase 3 (`tests/test_core_memory.py`)
- [x] `docs/agent-support/hermes.md` published; index updated — this PR

### Phase 5 exit criteria (subtask #316)

- [x] `make lint` green
- [x] `make test` 1566 passed (no code touched)
- [x] `docs/agent-support/hermes.md` published — capability matrix + walkthrough accurate (verified against `registry/hermes/manifest.yaml`, `playbooks/*`, `core/install.py`, `core/secrets.py`)
- [x] `docs/agent-support/index.md` updated — hermes row + 3-column Quick Comparison matrix; status `🚧 In Development`
- [x] `docs/agent-support/memory.md` published — manifest-driven dispatch documented
- [x] `README.md` FAQ updated
- [x] Review attempted with two ATX iterations per AGENTS.md `<atx-review-requirements>`; final rating 3/5 — handing back to orchestrator per 2-iteration cap

Closes #316
ref #68

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>