### PR TITLE
feat(channels): native Discord support for hermes (#324)

### DIFF
--- a/.itx/324/00_PLAN.md
+++ b/.itx/324/00_PLAN.md
@@ -399,4 +399,21 @@ If implementation surfaces a chunk that wants to land separately (e.g. the `conf
 
 Context: triggered after #324 was filed by the orchestrator. Plan-create explores the codebase (which already has Discord wiring for openclaw/zeroclaw) and narrows the scope significantly — Phase 6 is mostly removing the hermes guard + translating the existing config shape into hermes' env-var contract + a B3-pattern token persistence path.
 
+---
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-10T20:55:00Z
+**Model**: claude-opus-4-7
+
+Implementation completed in a single sub-agent pass. Key deviations from the plan during execution:
+
+1. **Token persistence order had to flip for hermes.** Original plan: store secret AFTER successful sync (W4 invariant inherited from openclaw). Reality: hermes' `configure_agent` reads `DISCORD_BOT_TOKEN` from `secrets.json` during hydration BEFORE running the playbook (the playbook needs the token rendered into `.env`). For openclaw the order stays "sync first, then secret"; for hermes it's "secret first, then sync." Branched on `claw_type` in `_run_channels_stage`.
+
+2. **`.env.j2` had to switch from attribute-access to `dict.get()`.** Ansible 2.20's strict Jinja mode errors on undefined attribute access against dicts (`discord.allow_all_users` → `'dict' object has no attribute 'allow_all_users'`). All Discord-block accesses changed to `discord.get('key')` form.
+
+3. **Channels list for hermes is `[cli, discord]`** (not the openclaw `[cli, discord, slack]` — slack isn't wired for hermes yet).
+
+E2E on wolf-i / espresso: snapshot captured, channels stage migrated to clm-managed wiring, `.env` re-rendered with manual comment stripped, service auto-restarted, /health 200, ESTAB Discord connection preserved, idempotent re-run produces byte-identical `.env` (md5 match). Test suite: 1566 → 1589 (+23 new). Lint clean.
+
 </details>

--- a/docs/agent-support/hermes.md
+++ b/docs/agent-support/hermes.md
@@ -42,13 +42,13 @@ The provider mapping is implemented in `src/clawrium/platform/registry/hermes/te
 
 ## Channel Support
 
-Hermes is intentionally scoped to a single channel in this iteration: a loopback OpenAI-compatible HTTP API on `127.0.0.1:8642` (the api_server platform).
+Hermes supports two channels managed by clm: a loopback OpenAI-compatible HTTP API (always on) and Discord (opt-in via the channels onboarding stage).
 
 | Channel | Status | Notes |
 |---------|:------:|-------|
 | **Local OpenAI-compatible HTTP API** (`POST /v1/chat/completions`, `GET /v1/models`, `GET /health`) | ✅ | Bound to loopback on the agent host. See [Use the local API](#3-use-the-local-openai-compatible-api). |
+| **Discord** | ✅ | clm-managed via `clm agent configure <name> --stage channels`. Token in `secrets.json` (B3 invariant); non-sensitive config in `hosts.json`. See [Discord walkthrough](#discord-walkthrough). |
 | **clm `chat <hermes-name>`** | 🚧 | Not supported yet (only openclaw). Tracked as [#322](https://github.com/ric03uec/clawrium/issues/322). |
-| **Discord** | 📋 | Deferred — see [Deferred items](#deferred-items--follow-ups) |
 | **Slack** | 📋 | Deferred |
 | **Telegram / WhatsApp / Signal** | 📋 | Deferred |
 | **Email / Matrix / Mattermost / Teams / Google Chat** | 📋 | Deferred |
@@ -207,11 +207,108 @@ clm agent remove <agent-name>    # stop, remove unit, rm ~/.hermes/, userdel
 ## Important caveats
 
 - **No `clm chat <hermes-name>`** in this iteration. `clm chat` only supports openclaw. Tracked as [#322](https://github.com/ric03uec/clawrium/issues/322). Use `curl` against the local API in the meantime.
-- **External messaging gateways are deferred.** Discord, Slack, Telegram, WhatsApp, Signal, email, Matrix, Mattermost, Teams, Google Chat — none are wired to hermes via clm. See [Deferred items](#deferred-items--follow-ups).
+- **Discord is the only clm-managed messaging gateway today.** Slack, Telegram, WhatsApp, Signal, email, Matrix, Mattermost, Teams, Google Chat are tracked as separate follow-ups. Discord is fully wired — see [Discord walkthrough](#discord-walkthrough).
 - **Identity is hermes-managed.** clm does not push `SOUL.md` / `AGENTS.md` into `~/.hermes/`. The identity onboarding stage auto-skips. If you want custom identity, edit those files directly on the agent host via SSH.
 - **Bearer token lives in `secrets.json`, not `hosts.json`.** As of PR #318, the canonical store for `HERMES_API_SERVER_KEY` is `~/.config/clawrium/secrets.json` keyed by `<host>:hermes:<agent-name>` (single-colon, 3 components). Provider keys use a different schema (`provider:<provider-name>`) in the same file.
 - **Memory has hard size limits.** `MEMORY.md` ≤ 2200 chars, `USER.md` ≤ 1375 chars. Other filenames in `~/.hermes/memories/` are rejected by `clm agent memory edit`. See [memory.md](memory.md).
 - **Concurrent writes are visible-atomic.** Hermes' `memory_write.yaml` uses a stage-then-rename pattern (`rename(2)` within the same filesystem) so the running hermes daemon never observes a partial file. The pattern is visible-atomic, not crash-durable (no explicit `fsync`).
+
+---
+
+## Discord walkthrough
+
+Discord is opt-in. You'll need a Discord bot already installed in your server (token from the [Discord developer portal](https://discord.com/developers/applications)) and at least one allowed Discord user ID.
+
+### Interactive setup
+
+```bash
+clm agent configure <hermes-name> --stage channels
+```
+
+The wizard offers `cli` and `discord`. Pick `discord` and the CLI prompts for:
+
+| Prompt | Stored where | Required | Notes |
+|--------|--------------|:--------:|-------|
+| Discord bot token | `secrets.json` as `DISCORD_BOT_TOKEN` | yes | Masked input. Bearer token for the Discord gateway. |
+| Allowed Discord user IDs | `hosts.json` `channels.discord.allowed_users` | yes (or `all`) | Comma-separated IDs (17–19 digits). Use the literal string `all` to allow any user — you'll get a security warning + confirm prompt. |
+| Discord home channel ID | `hosts.json` `channels.discord.home_channel` | optional | Without this, hermes will nudge users to run `/sethome` on every cold start. |
+| Discord home channel name | `hosts.json` `channels.discord.home_channel_name` | optional | Defaults to `Home`. Display name only. |
+| Allowed channel IDs | `hosts.json` `channels.discord.allowed_channels` | optional | Restrict the bot to specific channels (comma-separated). Empty = any channel the bot is invited to. |
+| Require `@mention` to respond? | `hosts.json` `channels.discord.require_mention` | optional | Defaults to true. DMs always work regardless. |
+
+`clm` then runs the configure playbook which re-renders `~/.hermes/.env` with the `DISCORD_*` block and restarts `hermes-<name>.service`. Verification tasks confirm the token + an allowlist landed in the env file before the playbook reports success.
+
+### Resulting on-disk shape
+
+`hosts.json` (non-sensitive only):
+
+```json
+"config": {
+  "api_server": {"enabled": true, "host": "127.0.0.1", "port": 8642},
+  "provider": {...},
+  "channels": {
+    "discord": {
+      "enabled": true,
+      "allowed_users": ["740723459344302120"],
+      "allow_all_users": false,
+      "home_channel": "1503238729962356777",
+      "home_channel_name": "Home",
+      "require_mention": true
+    }
+  }
+}
+```
+
+`secrets.json`:
+
+```json
+"192.168.1.36:hermes:<name>": {
+  "HERMES_API_SERVER_KEY": {...},
+  "DISCORD_BOT_TOKEN": {"value": "<token>", "description": "Discord bot token", ...}
+}
+```
+
+The bot token **never** lands in `hosts.json` — the configure flow strips it from `config.channels.discord` before persisting (B3 invariant, mirrored from the `api_server.key` strip). Re-running `clm agent configure --stage channels` with the same token reuses it byte-identical (idempotency contract).
+
+### Removal
+
+`clm agent remove <name> --force` purges the entire instance entry from `secrets.json`, including `DISCORD_BOT_TOKEN`. There is no separate "rotate Discord token" command — re-run the channels stage with a new token to overwrite.
+
+### Troubleshooting
+
+<details>
+<summary><strong>Bot is online but doesn't respond in the test channel</strong></summary>
+
+1. Confirm your Discord user ID is in `hosts.json` `channels.discord.allowed_users` (or `allow_all_users: true`). Hermes silently drops messages from non-allowlisted users.
+2. If `require_mention` is true (default), the bot only responds to messages that `@mention` it directly in a guild channel. DMs always work.
+3. Confirm the bot has the right Discord permissions in the guild: Send Messages, Read Message History, Use Slash Commands.
+4. If `allowed_channels` is non-empty, the bot only responds in those channel IDs.
+
+</details>
+
+<details>
+<summary><strong>Service is active but Discord init silently fails</strong></summary>
+
+Hermes' default log level is WARNING, and Discord-init success/failure logs at INFO. The `/health` endpoint returns 200 even if the Discord platform failed to register. To check:
+
+```bash
+ssh <agent-host> "sudo journalctl -u hermes-<name>.service -n 200 --no-pager | grep -iE 'discord|platform'"
+```
+
+If you see nothing, temporarily bump `LOG_LEVEL=INFO` in `~/.hermes/.env` (manual edit — note the override will be wiped on next `clm agent configure`) and restart the service. The Discord init line will read `INFO  hermes.platforms.discord: connected as <bot-name>#<discriminator>`.
+
+</details>
+
+<details>
+<summary><strong>`DISCORD_ALLOW_ALL_USERS=true` is set and I want to lock it down</strong></summary>
+
+Re-run `clm agent configure <name> --stage channels`, pick `discord` again, and pass specific user IDs (not `all`) at the allowlist prompt. The new value overwrites the previous `channels.discord` block in `hosts.json`, and the next `~/.hermes/.env` render drops `DISCORD_ALLOW_ALL_USERS` entirely.
+
+</details>
+
+### Non-interactive flags
+
+Planned for a follow-up — interactive is the supported path in this release. For automation today, drive `clm agent configure --stage channels` via expect/pexpect, or set the values directly in `hosts.json` + `secrets.json` and re-run the stage to trigger a re-render.
 
 ---
 
@@ -329,7 +426,7 @@ Then re-run `clm agent remove <name> --force`.
 
 The following are explicitly out of scope for issue #68 and tracked as separate follow-ups (see `.itx/68/00_PLAN.md` → "Out of scope"):
 
-- Messaging gateway pairing: Discord, Slack, Telegram, WhatsApp, Signal, email, Teams, Google Chat, Matrix, Mattermost, QQBot, Feishu, DingTalk.
+- Messaging gateway pairing: Slack, Telegram, WhatsApp, Signal, email, Teams, Google Chat, Matrix, Mattermost, QQBot, Feishu, DingTalk. (Discord shipped — see [Discord walkthrough](#discord-walkthrough).)
 - Pluggable memory backends: Holographic, Honcho, Hindsight, Mem0, Byterover, OpenViking. clm's `memory` CLI only sees the default markdown backend.
 - MCP server registration.
 - `~/.hermes/state.db` (session / transcript history) inspection via clm.

--- a/docs/agent-support/index.md
+++ b/docs/agent-support/index.md
@@ -36,7 +36,7 @@ Clawrium supports multiple agent types, each designed for different use cases. T
 | **Multi-Provider** | ✅ (OpenAI, Anthropic, OpenRouter, Bedrock, Vertex, ZAI, Ollama) | ✅ (OpenRouter, Anthropic, OpenAI, Ollama / custom) | 🚧 (OpenAI, Anthropic, Ollama planned) |
 | **Memory model** | Daily files + identity files | Two fixed files: `MEMORY.md` (≤ 2200 chars), `USER.md` (≤ 1375 chars) | ❌ |
 | **Identity management** | clm-managed `SOUL.md` / `IDENTITY.md` | Hermes-managed inside `~/.hermes/` (clm does not push) | ❌ |
-| **Messaging gateways** | Discord ✅, Slack 🚧, Web 🚧 | 📋 All deferred (Discord/Slack/Telegram/WhatsApp/Signal/email/...) | ❌ |
+| **Messaging gateways** | Discord ✅, Slack 🚧, Web 🚧 | Discord ✅, Slack/Telegram/WhatsApp/Signal/email/... 📋 deferred | ❌ |
 | **External integrations** | GitHub 🚧, Jira 🚧 | 📋 Deferred | ❌ |
 | **Onboarding wizard** | ✅ 4-stage | ✅ 4-stage (identity auto-skipped) | 🚧 2-stage |
 | **Resource usage** | Moderate | Moderate-to-high (uv venv + npm + playwright) | Low |
@@ -45,7 +45,7 @@ Clawrium supports multiple agent types, each designed for different use cases. T
 
 **Use OpenClaw when:**
 
-- You need Discord, Slack, or multi-channel support
+- You need Slack or multi-channel (Discord + Slack + Web) support
 - You want clm-managed customizable identity/personality
 - You need integrations with external tools
 - You want a fully production-ready experience today
@@ -53,9 +53,9 @@ Clawrium supports multiple agent types, each designed for different use cases. T
 **Use Hermes when:**
 
 - You want a local OpenAI-compatible HTTP API in front of your model
+- You want Discord support backed by a local inference endpoint
 - You want a self-managed-identity agent (hermes manages its own `SOUL.md` / `AGENTS.md`)
 - You're driving a local inference endpoint (Ollama, vLLM, llama.cpp) and want hermes to wrap it
-- You only need loopback access — `clm chat` and external gateways aren't required yet
 
 **Use ZeroClaw when:**
 

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -708,11 +708,11 @@ def _run_channels_stage(
     """
     from clawrium.core.secrets import get_instance_key, set_instance_secret
 
-    # Hermes ships with only the loopback api_server platform in this iteration.
-    # External messaging gateways (Discord/Slack/Telegram/etc.) are tracked as
-    # a separate follow-up issue; offering them here would mislead the user.
+    # Hermes supports cli (loopback api_server) and discord. Slack is not
+    # wired for hermes yet (separate follow-up). openclaw/zeroclaw still get
+    # the full cli/discord/slack list.
     if claw_type == "hermes":
-        channels = ["cli"]
+        channels = ["cli", "discord"]
     else:
         channels = ["cli", "discord", "slack"]
 
@@ -754,44 +754,166 @@ def _run_channels_stage(
             console.print("[red]Error:[/red] Invalid bot token format")
             return False
 
-        # Prompt for guild ID with validation
-        guild_id = typer.prompt("Discord server (guild) ID")
-        if not re.match(r"^\d{17,19}$", guild_id):
-            console.print("[red]Error:[/red] Invalid guild ID format (17-19 digits)")
-            return False
+        if claw_type == "hermes":
+            # Hermes shape: env-var-driven, no guild/channel routing. Prompt
+            # for an allowed-user allowlist (comma-separated IDs or 'all'),
+            # optional home channel, optional allowed-channels allowlist,
+            # require-mention toggle.
+            allowed_users_raw = typer.prompt(
+                "Allowed Discord user IDs (comma-separated, or 'all' for open access)"
+            )
+            allowed_users_raw = (allowed_users_raw or "").strip()
+            allow_all_users = False
+            allowed_users: list[str] = []
+            if allowed_users_raw.lower() == "all":
+                console.print(
+                    "[red]WARNING:[/red] 'all' allows ANY Discord user who can see the "
+                    "bot to invoke it. This is an open bot."
+                )
+                confirm = typer.confirm(
+                    "Are you sure you want to allow ALL users?", default=False
+                )
+                if not confirm:
+                    console.print("[yellow]Aborted.[/yellow] Re-run and pass user IDs.")
+                    return False
+                allow_all_users = True
+            else:
+                ids = [s.strip() for s in allowed_users_raw.split(",") if s.strip()]
+                if not ids:
+                    console.print(
+                        "[red]Error:[/red] At least one allowed user ID required (or 'all')."
+                    )
+                    return False
+                for uid in ids:
+                    if not re.match(r"^\d{17,19}$", uid):
+                        console.print(
+                            f"[red]Error:[/red] Invalid user ID '{uid}' (17-19 digits required)"
+                        )
+                        return False
+                allowed_users = ids
 
-        # Prompt for channel ID with validation
-        channel_id = typer.prompt("Discord channel ID")
-        if not re.match(r"^\d{17,19}$", channel_id):
-            console.print("[red]Error:[/red] Invalid channel ID format (17-19 digits)")
-            return False
+            home_channel_raw = typer.prompt(
+                "Discord home channel ID (Enter to skip)", default="", show_default=False
+            ).strip()
+            if home_channel_raw and not re.match(r"^\d{17,19}$", home_channel_raw):
+                console.print(
+                    "[red]Error:[/red] Invalid home channel ID format (17-19 digits)"
+                )
+                return False
+            if not home_channel_raw:
+                console.print(
+                    "[yellow]Note:[/yellow] without DISCORD_HOME_CHANNEL, hermes will "
+                    "nudge users to run /sethome on every cold start. Set it later via "
+                    "'clm agent configure <name> --stage channels'."
+                )
 
-        # Prompt for user ID(s) to allowlist
-        user_id = typer.prompt("Your Discord user ID (for auto-approve)")
-        if not re.match(r"^\d{17,19}$", user_id):
-            console.print("[red]Error:[/red] Invalid user ID format (17-19 digits)")
-            return False
+            home_channel_name = "Home"
+            if home_channel_raw:
+                home_channel_name = typer.prompt(
+                    "Discord home channel name", default="Home"
+                ).strip() or "Home"
 
-        channels_config = {
-            "discord": {
+            allowed_channels_raw = typer.prompt(
+                "Allowed Discord channel IDs (comma-separated, Enter for any channel)",
+                default="",
+                show_default=False,
+            ).strip()
+            allowed_channels: list[str] = []
+            if allowed_channels_raw:
+                for cid in (
+                    s.strip() for s in allowed_channels_raw.split(",") if s.strip()
+                ):
+                    if not re.match(r"^\d{17,19}$", cid):
+                        console.print(
+                            f"[red]Error:[/red] Invalid channel ID '{cid}' (17-19 digits required)"
+                        )
+                        return False
+                    allowed_channels.append(cid)
+
+            require_mention = typer.confirm(
+                "Require @mention to respond?", default=True
+            )
+
+            discord_cfg: dict = {
                 "enabled": True,
-                "token": {
-                    "source": "env",
-                    "provider": "default",
-                    "id": "DISCORD_BOT_TOKEN",
-                },
-                "allowFrom": [user_id],
-                "groupPolicy": "allowlist",
-                "guilds": {
-                    guild_id: {
-                        "users": [user_id],
-                        "channels": {channel_id: {"allow": True}},
-                    }
-                },
+                "allowed_users": allowed_users,
+                "allow_all_users": allow_all_users,
+                "require_mention": require_mention,
             }
-        }
+            if home_channel_raw:
+                discord_cfg["home_channel"] = home_channel_raw
+                discord_cfg["home_channel_name"] = home_channel_name
+            if allowed_channels:
+                discord_cfg["allowed_channels"] = allowed_channels
 
-        # Sync channel config to agent first
+            channels_config = {"discord": discord_cfg}
+        else:
+            # Prompt for guild ID with validation
+            guild_id = typer.prompt("Discord server (guild) ID")
+            if not re.match(r"^\d{17,19}$", guild_id):
+                console.print(
+                    "[red]Error:[/red] Invalid guild ID format (17-19 digits)"
+                )
+                return False
+
+            # Prompt for channel ID with validation
+            channel_id = typer.prompt("Discord channel ID")
+            if not re.match(r"^\d{17,19}$", channel_id):
+                console.print(
+                    "[red]Error:[/red] Invalid channel ID format (17-19 digits)"
+                )
+                return False
+
+            # Prompt for user ID(s) to allowlist
+            user_id = typer.prompt("Your Discord user ID (for auto-approve)")
+            if not re.match(r"^\d{17,19}$", user_id):
+                console.print(
+                    "[red]Error:[/red] Invalid user ID format (17-19 digits)"
+                )
+                return False
+
+            channels_config = {
+                "discord": {
+                    "enabled": True,
+                    "token": {
+                        "source": "env",
+                        "provider": "default",
+                        "id": "DISCORD_BOT_TOKEN",
+                    },
+                    "allowFrom": [user_id],
+                    "groupPolicy": "allowlist",
+                    "guilds": {
+                        guild_id: {
+                            "users": [user_id],
+                            "channels": {channel_id: {"allow": True}},
+                        }
+                    },
+                }
+            }
+
+        # Resolve canonical instance_key up-front so the token can be stored
+        # against the same key lifecycle.configure_agent will look up.
+        host_data = get_host(host)
+        if not host_data:
+            console.print(f"[red]Error:[/red] Host '{host}' not found")
+            return False
+        canonical_hostname = host_data["hostname"]
+        instance_key = get_instance_key(
+            canonical_hostname, claw_type, installed_name or claw_type
+        )
+
+        # For hermes, configure_agent's hydration block reads
+        # DISCORD_BOT_TOKEN from secrets.json BEFORE running the ansible
+        # playbook (the playbook needs the token to render .env). So the
+        # secret must be persisted first. For openclaw the sync uses the
+        # ansible-vars passthrough and W4 keeps the "sync first" order.
+        if claw_type == "hermes":
+            set_instance_secret(
+                instance_key, "DISCORD_BOT_TOKEN", bot_token, "Discord bot token"
+            )
+            console.print("[green]✓[/green] Discord bot token stored securely")
+
+        # Sync channel config to agent
         console.print("Syncing channel config to agent... ", end="")
         try:
             _sync_channel_config(host, claw_type, channels_config, installed_name)
@@ -804,20 +926,13 @@ def _run_channels_stage(
             )
             return False
 
-        # Store bot token as secret only after successful sync (W4)
-        # Use canonical hostname for instance_key to match lifecycle.py (B3)
-        host_data = get_host(host)
-        if not host_data:
-            console.print(f"[red]Error:[/red] Host '{host}' not found")
-            return False
-        canonical_hostname = host_data["hostname"]
-        instance_key = get_instance_key(
-            canonical_hostname, claw_type, installed_name or claw_type
-        )
-        set_instance_secret(
-            instance_key, "DISCORD_BOT_TOKEN", bot_token, "Discord bot token"
-        )
-        console.print("[green]✓[/green] Discord bot token stored securely")
+        # Store bot token as secret only after successful sync (W4) — for
+        # openclaw/zeroclaw. Hermes already stored it above.
+        if claw_type != "hermes":
+            set_instance_secret(
+                instance_key, "DISCORD_BOT_TOKEN", bot_token, "Discord bot token"
+            )
+            console.print("[green]✓[/green] Discord bot token stored securely")
 
     elif selected_channel == "slack":
         console.print("\n[bold]Slack Configuration (Socket Mode)[/bold]")

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -787,7 +787,7 @@ def _run_channels_stage(
                 for uid in ids:
                     if not re.match(r"^\d{17,19}$", uid):
                         console.print(
-                            f"[red]Error:[/red] Invalid user ID '{uid}' (17-19 digits required)"
+                            f"[red]Error:[/red] Invalid user ID '{rich_escape(uid)}' (17-19 digits required)"
                         )
                         return False
                 allowed_users = ids
@@ -837,7 +837,7 @@ def _run_channels_stage(
                 ):
                     if not re.match(r"^\d{17,19}$", cid):
                         console.print(
-                            f"[red]Error:[/red] Invalid channel ID '{cid}' (17-19 digits required)"
+                            f"[red]Error:[/red] Invalid channel ID '{rich_escape(cid)}' (17-19 digits required)"
                         )
                         return False
                     allowed_channels.append(cid)

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -809,9 +809,21 @@ def _run_channels_stage(
 
             home_channel_name = "Home"
             if home_channel_raw:
-                home_channel_name = typer.prompt(
+                home_channel_name_raw = typer.prompt(
                     "Discord home channel name", default="Home"
                 ).strip() or "Home"
+                # Reject control chars (especially newlines) so a pasted value
+                # can't inject `\nMALICIOUS_VAR=...` into ~/.hermes/.env. Allow
+                # printable ASCII + common punctuation; cap length.
+                if len(home_channel_name_raw) > 64 or not re.match(
+                    r"^[A-Za-z0-9 _\-./#]+$", home_channel_name_raw
+                ):
+                    console.print(
+                        "[red]Error:[/red] Home channel name must be 1-64 chars "
+                        "of letters/digits/spaces/_-./# (no newlines or shell metachars)."
+                    )
+                    return False
+                home_channel_name = home_channel_name_raw
 
             allowed_channels_raw = typer.prompt(
                 "Allowed Discord channel IDs (comma-separated, Enter for any channel)",

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -770,6 +770,52 @@ def configure_agent(
                 "key": api_server_key,
             }
 
+        # Hermes Discord: merge persisted channels.discord shape from hosts.json
+        # with anything passed in config_data, then hydrate the bot token from
+        # secrets.json. Mirrors the api_server.key pattern. If discord is not
+        # enabled this block is a no-op — .env.j2 emits no DISCORD_* lines.
+        persisted_channels = agent_record.get("config", {}).get("channels") or {}
+        if not isinstance(persisted_channels, dict):
+            persisted_channels = {}
+        persisted_discord = persisted_channels.get("discord") or {}
+        if not isinstance(persisted_discord, dict):
+            persisted_discord = {}
+
+        incoming_channels = config_data.get("channels") or {}
+        if not isinstance(incoming_channels, dict):
+            incoming_channels = {}
+        incoming_discord = incoming_channels.get("discord") or {}
+        if not isinstance(incoming_discord, dict):
+            incoming_discord = {}
+
+        # Merge persisted onto incoming so an explicit caller-provided field
+        # wins, but fields the caller didn't set (e.g. _sync_provider_config
+        # only carrying provider) inherit from hosts.json.
+        merged_discord = {**persisted_discord, **incoming_discord}
+
+        if merged_discord.get("enabled"):
+            discord_secret = get_instance_secrets(instance_key).get(
+                "DISCORD_BOT_TOKEN"
+            )
+            discord_token = (
+                discord_secret["value"]
+                if isinstance(discord_secret, dict)
+                else None
+            )
+            if not isinstance(discord_token, str) or len(discord_token) < 50:
+                return (
+                    False,
+                    "Discord enabled for this agent but DISCORD_BOT_TOKEN is "
+                    "missing or invalid in secrets.json. Re-run "
+                    "'clm agent configure <name> --stage channels' to set it.",
+                )
+            merged_discord["bot_token"] = discord_token
+
+        if persisted_discord or incoming_discord:
+            merged_channels = {**persisted_channels, **incoming_channels}
+            merged_channels["discord"] = merged_discord
+            config_data["channels"] = merged_channels
+
     # Validate config data before running Ansible
     # Validate required provider fields (must check dict type first)
     required_provider_fields = ["name", "type", "default_model"]
@@ -1019,10 +1065,23 @@ def configure_agent(
             # render it, but the canonical store is secrets.json. Keeping it
             # in hosts.json after configure would defeat the B3 migration.
             persisted_config = dict(config_data)
-            if resolved_type == "hermes" and "api_server" in persisted_config:
-                api_server_persisted = dict(persisted_config["api_server"])
-                api_server_persisted.pop("key", None)
-                persisted_config["api_server"] = api_server_persisted
+            if resolved_type == "hermes":
+                if "api_server" in persisted_config:
+                    api_server_persisted = dict(persisted_config["api_server"])
+                    api_server_persisted.pop("key", None)
+                    persisted_config["api_server"] = api_server_persisted
+                # B3 invariant for Discord: bot_token lives in secrets.json
+                # only. Mirror the api_server.key strip so re-persisting
+                # config_data doesn't leak the token back into hosts.json.
+                channels_persisted = persisted_config.get("channels")
+                if isinstance(channels_persisted, dict):
+                    channels_persisted = dict(channels_persisted)
+                    discord_persisted = channels_persisted.get("discord")
+                    if isinstance(discord_persisted, dict):
+                        discord_persisted = dict(discord_persisted)
+                        discord_persisted.pop("bot_token", None)
+                        channels_persisted["discord"] = discord_persisted
+                    persisted_config["channels"] = channels_persisted
 
             h["agents"][agent_key]["config"] = persisted_config
 

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -1073,15 +1073,28 @@ def configure_agent(
                 # B3 invariant for Discord: bot_token lives in secrets.json
                 # only. Mirror the api_server.key strip so re-persisting
                 # config_data doesn't leak the token back into hosts.json.
+                # Defense in depth: if channels is an unexpected type, drop
+                # it entirely rather than risk leaking a misplaced token.
                 channels_persisted = persisted_config.get("channels")
-                if isinstance(channels_persisted, dict):
-                    channels_persisted = dict(channels_persisted)
-                    discord_persisted = channels_persisted.get("discord")
-                    if isinstance(discord_persisted, dict):
-                        discord_persisted = dict(discord_persisted)
-                        discord_persisted.pop("bot_token", None)
-                        channels_persisted["discord"] = discord_persisted
-                    persisted_config["channels"] = channels_persisted
+                if "channels" in persisted_config:
+                    if isinstance(channels_persisted, dict):
+                        channels_persisted = dict(channels_persisted)
+                        discord_persisted = channels_persisted.get("discord")
+                        if isinstance(discord_persisted, dict):
+                            discord_persisted = dict(discord_persisted)
+                            discord_persisted.pop("bot_token", None)
+                            channels_persisted["discord"] = discord_persisted
+                        persisted_config["channels"] = channels_persisted
+                    else:
+                        # Unexpected shape (string/list/etc.) — drop rather
+                        # than risk persisting a token via an unknown path.
+                        logger.warning(
+                            "Dropping unexpected channels block (type=%s) for "
+                            "agent %s during persist to avoid B3 violation.",
+                            type(channels_persisted).__name__,
+                            agent_key,
+                        )
+                        persisted_config.pop("channels", None)
 
             h["agents"][agent_key]["config"] = persisted_config
 

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -68,13 +68,23 @@ onboarding:
 
     channels:
       required: true
-      description: "Configure communication channel (cli only; external messaging gateways deferred)"
+      description: "Configure communication channels (cli always on; discord optional)"
       tasks:
         - id: confirm_cli
           name: "Confirm CLI channel"
           type: confirm
           message: "Hermes will use the loopback api_server platform on 127.0.0.1:8642 as its CLI-equivalent endpoint."
           default: true
+        - id: select_discord
+          name: "Enable Discord channel (optional)"
+          type: confirm
+          message: "Enable Discord messaging for this agent?"
+          default: false
+        # When select_discord=yes, the CLI prompts interactively for the bot
+        # token, allowed-user IDs, optional home channel, optional allowed
+        # channel allowlist, and require-mention toggle. Token persists to
+        # secrets.json under DISCORD_BOT_TOKEN; the rest land in hosts.json
+        # under config.channels.discord.
 
     validate:
       required: true

--- a/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
@@ -172,11 +172,12 @@
         - config.channels.discord.enabled | default(false)
 
     - name: Verify .env declares Discord user allowlist when Discord enabled
-      ansible.builtin.shell: |
-        grep -qE '^(DISCORD_ALLOWED_USERS=.+|DISCORD_ALLOW_ALL_USERS=true)' "/home/{{ agent_name }}/.hermes/.env"
+      ansible.builtin.command:
+        cmd: grep -qE "^(DISCORD_ALLOWED_USERS=.+|DISCORD_ALLOW_ALL_USERS=true)" "/home/{{ agent_name }}/.hermes/.env"
       register: discord_allowlist_check
       changed_when: false
       failed_when: discord_allowlist_check.rc != 0
+      no_log: true
       when:
         - config.channels is defined
         - config.channels.discord is defined

--- a/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
@@ -155,6 +155,33 @@
       failed_when: api_server_key_check.rc != 0
       no_log: true
 
+    # Discord platform verification — only runs when channels.discord.enabled
+    # is true. Confirms the bot token landed in .env and the allowlist guard
+    # (at least one of DISCORD_ALLOWED_USERS / DISCORD_ALLOW_ALL_USERS) is
+    # present, since hermes denies every message without one of those.
+    - name: Verify .env contains DISCORD_BOT_TOKEN when Discord enabled
+      ansible.builtin.command:
+        cmd: grep -q '^DISCORD_BOT_TOKEN=' "/home/{{ agent_name }}/.hermes/.env"
+      register: discord_token_check
+      changed_when: false
+      failed_when: discord_token_check.rc != 0
+      no_log: true
+      when:
+        - config.channels is defined
+        - config.channels.discord is defined
+        - config.channels.discord.enabled | default(false)
+
+    - name: Verify .env declares Discord user allowlist when Discord enabled
+      ansible.builtin.shell: |
+        grep -qE '^(DISCORD_ALLOWED_USERS=.+|DISCORD_ALLOW_ALL_USERS=true)' "/home/{{ agent_name }}/.hermes/.env"
+      register: discord_allowlist_check
+      changed_when: false
+      failed_when: discord_allowlist_check.rc != 0
+      when:
+        - config.channels is defined
+        - config.channels.discord is defined
+        - config.channels.discord.enabled | default(false)
+
     # Force the restart handler to fire NOW so probes below run against the
     # newly-rendered config.
     - name: Apply pending restart before probing

--- a/src/clawrium/platform/registry/hermes/templates/.env.j2
+++ b/src/clawrium/platform/registry/hermes/templates/.env.j2
@@ -27,3 +27,35 @@ API_SERVER_ENABLED=1
 API_SERVER_HOST={{ api_server.host | default('127.0.0.1') }}
 API_SERVER_PORT={{ api_server.port | default(8642) | int }}
 API_SERVER_KEY={{ api_server.key }}
+
+# Discord platform (only emitted when channels.discord.enabled and token
+# present). bot_token is hydrated from secrets.json by lifecycle.configure_agent
+# and stripped from hosts.json by install.py's updater closure (B3 invariant).
+# Use dict.get() pattern (not attribute access) so undefined keys don't error
+# under Ansible 2.20+'s strict Jinja mode.
+{% set channels = config.channels | default({}) %}
+{% set discord = channels.get('discord', {}) if channels else {} %}
+{% if discord.get('enabled') and discord.get('bot_token') %}
+DISCORD_BOT_TOKEN={{ discord.get('bot_token') }}
+{% if discord.get('allowed_users') %}
+DISCORD_ALLOWED_USERS={{ discord.get('allowed_users') | join(',') }}
+{% endif %}
+{% if discord.get('allow_all_users') %}
+DISCORD_ALLOW_ALL_USERS=true
+{% endif %}
+{% if discord.get('home_channel') %}
+DISCORD_HOME_CHANNEL={{ discord.get('home_channel') }}
+{% endif %}
+{% if discord.get('home_channel_name') %}
+DISCORD_HOME_CHANNEL_NAME={{ discord.get('home_channel_name') }}
+{% endif %}
+{% if discord.get('home_channel_thread_id') %}
+DISCORD_HOME_CHANNEL_THREAD_ID={{ discord.get('home_channel_thread_id') }}
+{% endif %}
+{% if discord.get('allowed_channels') %}
+DISCORD_ALLOWED_CHANNELS={{ discord.get('allowed_channels') | join(',') }}
+{% endif %}
+{% if 'require_mention' in discord %}
+DISCORD_REQUIRE_MENTION={{ discord.get('require_mention') | string | lower }}
+{% endif %}
+{% endif %}

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -2701,6 +2701,74 @@ class TestRunChannelsStageHermesDiscord:
 
         assert result is False
 
+    def test_hermes_discord_rejects_newline_in_home_channel_name(
+        self, isolated_config: Path
+    ):
+        """Newline (or other shell metachars) in home_channel_name would
+        inject arbitrary env vars into .env on render. CLI must reject
+        before persisting."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            onboarding_state="channels",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        with patch("clawrium.cli.agent.typer.prompt") as mock_p:
+            mock_p.side_effect = [
+                2,  # discord
+                self._valid_token(),
+                "740723459344302120",
+                "1503238729962356777",  # home channel
+                "Home\nMALICIOUS_VAR=pwned",  # injection attempt
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "hermes", False, "assistant"
+            )
+        assert result is False
+
+    def test_hermes_discord_rejects_too_long_home_channel_name(
+        self, isolated_config: Path
+    ):
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        with patch("clawrium.cli.agent.typer.prompt") as mock_p:
+            mock_p.side_effect = [
+                2,
+                self._valid_token(),
+                "740723459344302120",
+                "1503238729962356777",
+                "A" * 100,  # > 64 chars
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "hermes", False, "assistant"
+            )
+        assert result is False
+
     def test_openclaw_discord_still_uses_guilds_shape(
         self, isolated_config: Path
     ):

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -2769,6 +2769,117 @@ class TestRunChannelsStageHermesDiscord:
             )
         assert result is False
 
+    def test_hermes_discord_rejects_user_id_boundaries(
+        self, isolated_config: Path
+    ):
+        """User IDs outside the 17-19 digit range are rejected before any
+        secret is stored. Tests both ends of the boundary plus a shell-meta
+        injection attempt."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        for bad_id in [
+            "1234567890123456",  # 16 digits — too short
+            "12345678901234567890",  # 20 digits — too long
+            "1234567890123456789;rm -rf /",  # shell metachar injection
+            "[bold red]inject[/bold red]",  # rich markup injection
+        ]:
+            with patch("clawrium.cli.agent.typer.prompt") as mock_p:
+                mock_p.side_effect = [
+                    2,  # discord
+                    self._valid_token(),
+                    bad_id,
+                ]
+                result = _run_channels_stage(
+                    "192.168.1.100", "hermes", False, "assistant"
+                )
+            assert result is False, f"accepted invalid user ID: {bad_id!r}"
+
+    def test_hermes_discord_rejects_home_channel_id_boundaries(
+        self, isolated_config: Path
+    ):
+        """Home channel ID outside 17-19 digits is rejected."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        for bad_id in [
+            "1234567890123456",  # 16 digits
+            "12345678901234567890",  # 20 digits
+            "1234567890123456789;evil",
+        ]:
+            with patch("clawrium.cli.agent.typer.prompt") as mock_p:
+                mock_p.side_effect = [
+                    2,
+                    self._valid_token(),
+                    "740723459344302120",
+                    bad_id,  # invalid home channel
+                ]
+                result = _run_channels_stage(
+                    "192.168.1.100", "hermes", False, "assistant"
+                )
+            assert result is False, f"accepted invalid home channel: {bad_id!r}"
+
+    def test_hermes_discord_rejects_allowed_channels_boundaries(
+        self, isolated_config: Path
+    ):
+        """Any malformed allowed_channels entry rejects the whole list."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        with patch("clawrium.cli.agent.typer.prompt") as mock_p:
+            mock_p.side_effect = [
+                2,
+                self._valid_token(),
+                "740723459344302120",
+                "1503238729962356777",  # home channel
+                "Home",
+                # Mix of valid + invalid — the invalid entry must reject.
+                "1503238729962356777,not-a-channel",
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "hermes", False, "assistant"
+            )
+        assert result is False
+
     def test_openclaw_discord_still_uses_guilds_shape(
         self, isolated_config: Path
     ):

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -2404,3 +2404,346 @@ class TestEditConfigWorkflow:
             assert Path(preserved_path).exists(), (
                 f"Preserved file should exist: {preserved_path}"
             )
+
+
+class TestRunChannelsStageHermesDiscord:
+    """Tests for the hermes-specific Discord channels branch (issue #324)."""
+
+    def _valid_token(self) -> str:
+        # 50-120 chars matching ^[A-Za-z0-9._+/=-]+$
+        return "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMw"
+
+    def test_hermes_channel_list_includes_discord(self, isolated_config: Path):
+        """The hermes guard is gone: discord is offered to hermes agents."""
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(isolated_config, claw_type="hermes")
+
+        # Choose option 1 (cli) — we only want to inspect the rendered menu.
+        result = runner.invoke(
+            app,
+            ["agent", "configure", "assistant", "--stage", "channels"],
+            input="1\n",
+            env=os.environ,
+        )
+
+        assert "cli" in result.output.lower()
+        assert "discord" in result.output.lower()
+        # Slack stays out of the hermes list (no wiring yet).
+        assert "slack" not in result.output.lower()
+
+    def test_hermes_discord_writes_token_secret_and_hosts_config(
+        self, isolated_config: Path
+    ):
+        """Selecting discord on hermes stores the token in secrets.json and
+        the non-sensitive config (allowed_users / home_channel / etc.) in
+        hosts.json — no bot_token in the synced shape."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            onboarding_state="channels",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        stored_secrets: list[dict] = []
+        synced_configs: list[dict] = []
+
+        def capture_secret(instance_key, key, value, description):
+            stored_secrets.append(
+                {"instance_key": instance_key, "key": key, "value": value}
+            )
+
+        def capture_sync(host, claw_type, channels_config, installed_name):
+            synced_configs.append(channels_config)
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch(
+                "clawrium.core.secrets.set_instance_secret", side_effect=capture_secret
+            ),
+            patch("clawrium.cli.agent._sync_channel_config", side_effect=capture_sync),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,  # Select discord
+                self._valid_token(),  # Bot token
+                "740723459344302120",  # Allowed user IDs
+                "1503238729962356777",  # Home channel ID
+                "Home",  # Home channel name
+                "",  # Allowed channels (any)
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "hermes", False, "assistant"
+            )
+
+        assert result is True
+        assert len(stored_secrets) == 1
+        assert stored_secrets[0]["key"] == "DISCORD_BOT_TOKEN"
+        assert stored_secrets[0]["value"] == self._valid_token()
+
+        assert len(synced_configs) == 1
+        discord_cfg = synced_configs[0]["discord"]
+        # Hermes shape — flat, env-var-mapped.
+        assert discord_cfg["enabled"] is True
+        assert discord_cfg["allowed_users"] == ["740723459344302120"]
+        assert discord_cfg["allow_all_users"] is False
+        assert discord_cfg["home_channel"] == "1503238729962356777"
+        assert discord_cfg["home_channel_name"] == "Home"
+        assert discord_cfg["require_mention"] is True
+        # CRITICAL: bot_token must NOT be in the hosts.json shape.
+        assert "bot_token" not in discord_cfg
+        # And we must not regress to the openclaw guilds-shape.
+        assert "guilds" not in discord_cfg
+        assert "groupPolicy" not in discord_cfg
+
+    def test_hermes_discord_rejects_invalid_user_id(self, isolated_config: Path):
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        with patch("clawrium.cli.agent.typer.prompt") as mock_p:
+            mock_p.side_effect = [
+                2,  # Select discord
+                self._valid_token(),
+                "1234",  # Invalid user ID (too short)
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "hermes", False, "assistant"
+            )
+        assert result is False
+
+    def test_hermes_discord_all_requires_confirmation(
+        self, isolated_config: Path
+    ):
+        """Passing 'all' for allowed users triggers a second confirm prompt
+        and only sets allow_all_users when the user confirms."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            onboarding_state="channels",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        synced: list[dict] = []
+
+        def capture_sync(host, claw_type, channels_config, installed_name):
+            synced.append(channels_config)
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm") as mock_c,
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent._sync_channel_config", side_effect=capture_sync),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,
+                self._valid_token(),
+                "all",  # open-bot
+                "",  # home channel skip
+                "",  # allowed channels any
+            ]
+            # First confirm = open-bot acceptance, second = require_mention default
+            mock_c.side_effect = [True, True]
+            result = _run_channels_stage(
+                "192.168.1.100", "hermes", False, "assistant"
+            )
+
+        assert result is True
+        assert synced[0]["discord"]["allow_all_users"] is True
+        assert synced[0]["discord"]["allowed_users"] == []
+
+    def test_hermes_discord_all_aborts_when_not_confirmed(
+        self, isolated_config: Path
+    ):
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=False),
+        ):
+            mock_p.side_effect = [
+                2,
+                self._valid_token(),
+                "all",
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "hermes", False, "assistant"
+            )
+        assert result is False
+
+    def test_hermes_discord_skip_home_channel(self, isolated_config: Path):
+        """An empty home_channel input is accepted; home_channel and
+        home_channel_name are absent from the synced shape."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            onboarding_state="channels",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        synced: list[dict] = []
+
+        def capture_sync(host, claw_type, channels_config, installed_name):
+            synced.append(channels_config)
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent._sync_channel_config", side_effect=capture_sync),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,
+                self._valid_token(),
+                "740723459344302120",
+                "",  # skip home channel
+                "",  # allowed channels any
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "hermes", False, "assistant"
+            )
+
+        assert result is True
+        d = synced[0]["discord"]
+        assert "home_channel" not in d
+        assert "home_channel_name" not in d
+
+    def test_hermes_discord_allowed_channels_validated(
+        self, isolated_config: Path
+    ):
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            onboarding_state="channels",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        with patch("clawrium.cli.agent.typer.prompt") as mock_p:
+            mock_p.side_effect = [
+                2,
+                self._valid_token(),
+                "740723459344302120",
+                "1503238729962356777",  # home channel
+                "Home",
+                "abc,123",  # invalid allowed channels
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "hermes", False, "assistant"
+            )
+
+        assert result is False
+
+    def test_openclaw_discord_still_uses_guilds_shape(
+        self, isolated_config: Path
+    ):
+        """Regression guard: openclaw's existing guilds-{} shape is preserved
+        — the hermes branch must not infect non-hermes claws."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="openclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "p", "type": "openai"}},
+        )
+
+        synced: list[dict] = []
+
+        def capture_sync(host, claw_type, channels_config, installed_name):
+            synced.append(channels_config)
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent._sync_channel_config", side_effect=capture_sync),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,
+                self._valid_token(),
+                "123456789012345678",  # guild ID
+                "987654321098765432",  # channel ID
+                "740723459344302120",  # user ID
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "openclaw", False, "assistant"
+            )
+
+        assert result is True
+        d = synced[0]["discord"]
+        # openclaw shape preserved
+        assert "guilds" in d
+        assert "123456789012345678" in d["guilds"]
+        assert d["groupPolicy"] == "allowlist"
+        # And the hermes-only flat fields are NOT injected.
+        assert "allowed_users" not in d
+        assert "home_channel" not in d

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -1284,6 +1284,238 @@ class TestConfigureYamlDiscordVerifyTasks:
             assert "channels" in joined and "discord" in joined and "enabled" in joined
 
 
+class TestHermesDiscordSecretsHygieneNegative:
+    """B3 negative guard: even if an upstream caller injects bot_token into
+    config_data directly, the updater closure strips it before persisting."""
+
+    def test_strip_runs_even_when_bot_token_injected_into_config_data(
+        self, tmp_path: Path
+    ):
+        """Simulate a future code path (or test harness) that accidentally
+        passes config_data with bot_token already set — the updater closure
+        MUST still strip it. This is the failure mode the strip exists to
+        guard against; we test it explicitly here."""
+        token = "E" * 64
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {
+                        "api_server": {
+                            "enabled": True,
+                            "host": "127.0.0.1",
+                            "port": 8642,
+                        },
+                        "channels": {
+                            "discord": {
+                                "enabled": True,
+                                "allowed_users": ["111111111111111111"],
+                            }
+                        },
+                    },
+                }
+            },
+        }
+        # Caller passes config_data with bot_token already inlined — this is
+        # the leaky scenario the strip exists to defeat.
+        config_data = {
+            "provider": {
+                "name": "p",
+                "type": "openrouter",
+                "default_model": "x",
+            },
+            "channels": {
+                "discord": {
+                    "enabled": True,
+                    "allowed_users": ["111111111111111111"],
+                    "bot_token": "INJECTED-FROM-CALLER",  # must be stripped
+                }
+            },
+        }
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+        captured: dict = {}
+
+        def fake_update_host(hostname_arg, updater):
+            updated = updater({"agents": dict(host["agents"])})
+            captured["agents"] = updated["agents"]
+            return True
+
+        secrets = {
+            "HERMES_API_SERVER_KEY": {
+                "key": "HERMES_API_SERVER_KEY",
+                "value": "a" * 64,
+                "created_at": "2026-05-10T00:00:00+00:00",
+                "updated_at": "2026-05-10T00:00:00+00:00",
+                "description": "",
+            },
+            "DISCORD_BOT_TOKEN": {
+                "key": "DISCORD_BOT_TOKEN",
+                "value": token,
+                "created_at": "2026-05-10T00:00:00+00:00",
+                "updated_at": "2026-05-10T00:00:00+00:00",
+                "description": "Discord bot token",
+            },
+        }
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ),
+            patch(
+                "clawrium.core.lifecycle.ansible_runner.run",
+                return_value=MagicMock(status="successful", events=[]),
+            ),
+            patch(
+                "clawrium.core.lifecycle.update_host", side_effect=fake_update_host
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets", return_value=secrets
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host", "hermes", config_data, agent_name="hermes-test"
+            )
+
+        assert success is True, error
+        persisted_discord = (
+            captured["agents"]["hermes-test"]
+            .get("config", {})
+            .get("channels", {})
+            .get("discord", {})
+        )
+        # Even though the caller passed bot_token, the strip layer caught it.
+        assert "bot_token" not in persisted_discord, (
+            f"Strip layer failed to catch injected bot_token: {persisted_discord}"
+        )
+
+
+class TestHermesDiscordIdempotency:
+    """Re-running channels configure with the same inputs must produce
+    byte-identical .env output and same DISCORD_BOT_TOKEN value."""
+
+    def test_reconfigure_renders_byte_identical_env(self, tmp_path: Path):
+        """Two configure calls hydrate the same DISCORD_BOT_TOKEN value and
+        the same channels.discord shape; .env.j2 against both produces
+        byte-identical output (no field reordering, no whitespace drift)."""
+        token = "F" * 64
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {
+                        "api_server": {
+                            "enabled": True,
+                            "host": "127.0.0.1",
+                            "port": 8642,
+                        },
+                        "channels": {
+                            "discord": {
+                                "enabled": True,
+                                "allowed_users": ["111111111111111111"],
+                                "home_channel": "222222222222222222",
+                                "home_channel_name": "Home",
+                                "require_mention": True,
+                            }
+                        },
+                    },
+                }
+            },
+        }
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+        secrets = {
+            "HERMES_API_SERVER_KEY": {
+                "key": "HERMES_API_SERVER_KEY",
+                "value": "a" * 64,
+                "created_at": "2026-05-10T00:00:00+00:00",
+                "updated_at": "2026-05-10T00:00:00+00:00",
+                "description": "",
+            },
+            "DISCORD_BOT_TOKEN": {
+                "key": "DISCORD_BOT_TOKEN",
+                "value": token,
+                "created_at": "2026-05-10T00:00:00+00:00",
+                "updated_at": "2026-05-10T00:00:00+00:00",
+                "description": "Discord bot token",
+            },
+        }
+        renders: list[str] = []
+
+        def fake_run(**kwargs):
+            sent = kwargs["inventory"]["all"]["vars"]["config"]
+            # Render .env.j2 with the hydrated config and capture the output.
+            from jinja2 import Environment, FileSystemLoader
+
+            env_jinja = Environment(
+                loader=FileSystemLoader(str(HERMES_TEMPLATES)),
+                keep_trailing_newline=True,
+            )
+            tpl = env_jinja.get_template(".env.j2")
+            renders.append(
+                tpl.render(config=sent, provider_api_key="sk-x", agent_name="h")
+            )
+            m = MagicMock()
+            m.status = "successful"
+            m.events = []
+            return m
+
+        for _ in range(2):
+            with (
+                patch("clawrium.core.lifecycle.get_host", return_value=host),
+                patch(
+                    "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                    return_value=playbook,
+                ),
+                patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ),
+                patch(
+                    "clawrium.core.lifecycle.ansible_runner.run",
+                    side_effect=fake_run,
+                ),
+                patch("clawrium.core.lifecycle.update_host", return_value=True),
+                patch(
+                    "clawrium.core.lifecycle.get_instance_secrets",
+                    return_value=secrets,
+                ),
+            ):
+                success, error = configure_agent(
+                    "test-host",
+                    "hermes",
+                    {
+                        "provider": {
+                            "name": "p",
+                            "type": "openrouter",
+                            "default_model": "x",
+                        }
+                    },
+                    agent_name="hermes-test",
+                )
+                assert success is True, error
+
+        assert len(renders) == 2
+        assert renders[0] == renders[1], "non-idempotent .env render"
+        # And the rendered token is the expected value.
+        assert f"DISCORD_BOT_TOKEN={token}" in renders[0]
+
+
 class TestDiscordSecretRemoval:
     """clm agent remove purges DISCORD_BOT_TOKEN alongside HERMES_API_SERVER_KEY
     via remove_instance_secrets() — no Discord-specific code path needed."""

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -743,3 +743,568 @@ class TestConfigureYamlHandlerShape:
             f"{len(restart_handlers)} restart: "
             f"{[h.get('name') for h in handlers]}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Discord channel — .env.j2 rendering + lifecycle hydration + B3 strip
+# ---------------------------------------------------------------------------
+
+
+class TestEnvTemplateDiscordBranch:
+    """Verify the Discord block in .env.j2 emits the right env vars under
+    each config shape (issue #324)."""
+
+    def _base_config(self) -> dict:
+        return {
+            "provider": {"type": "openrouter", "default_model": "anthropic/x"},
+            "api_server": {
+                "key": "a" * 64,
+                "host": "127.0.0.1",
+                "port": 8642,
+                "enabled": True,
+            },
+        }
+
+    def test_discord_block_omitted_when_disabled(self):
+        cfg = self._base_config()
+        cfg["channels"] = {"discord": {"enabled": False}}
+        rendered = _render_env(cfg, provider_api_key="sk-x")
+        assert "DISCORD_BOT_TOKEN" not in rendered
+        assert "DISCORD_ALLOWED_USERS" not in rendered
+
+    def test_discord_block_omitted_when_channels_missing(self):
+        rendered = _render_env(self._base_config(), provider_api_key="sk-x")
+        assert "DISCORD_" not in rendered
+
+    def test_discord_block_omitted_when_enabled_but_no_token(self):
+        """Partial config — enabled but token missing — must not emit an
+        empty DISCORD_BOT_TOKEN= line that would crash discord.py."""
+        cfg = self._base_config()
+        cfg["channels"] = {
+            "discord": {
+                "enabled": True,
+                "allowed_users": ["740723459344302120"],
+            }
+        }
+        rendered = _render_env(cfg, provider_api_key="sk-x")
+        assert "DISCORD_BOT_TOKEN" not in rendered
+        # Other DISCORD_* lines guarded behind the same `if` should also be absent.
+        assert "DISCORD_ALLOWED_USERS" not in rendered
+
+    def test_discord_minimal_renders_token_and_allowed_users(self):
+        cfg = self._base_config()
+        cfg["channels"] = {
+            "discord": {
+                "enabled": True,
+                "bot_token": "BOT.TOKEN.VALUE",
+                "allowed_users": ["740723459344302120"],
+            }
+        }
+        rendered = _render_env(cfg, provider_api_key="sk-x")
+        assert "DISCORD_BOT_TOKEN=BOT.TOKEN.VALUE" in rendered
+        assert "DISCORD_ALLOWED_USERS=740723459344302120" in rendered
+        # Optional vars not provided should not appear as empty lines.
+        assert "DISCORD_HOME_CHANNEL=" not in rendered
+        assert "DISCORD_ALLOWED_CHANNELS=" not in rendered
+
+    def test_discord_full_renders_all_envvars(self):
+        cfg = self._base_config()
+        cfg["channels"] = {
+            "discord": {
+                "enabled": True,
+                "bot_token": "BOT.TOKEN.VALUE",
+                "allowed_users": ["111111111111111111", "222222222222222222"],
+                "home_channel": "333333333333333333",
+                "home_channel_name": "General",
+                "home_channel_thread_id": "444444444444444444",
+                "allowed_channels": ["555555555555555555", "666666666666666666"],
+                "require_mention": True,
+            }
+        }
+        rendered = _render_env(cfg, provider_api_key="sk-x")
+        assert "DISCORD_BOT_TOKEN=BOT.TOKEN.VALUE" in rendered
+        assert (
+            "DISCORD_ALLOWED_USERS=111111111111111111,222222222222222222"
+            in rendered
+        )
+        assert "DISCORD_HOME_CHANNEL=333333333333333333" in rendered
+        assert "DISCORD_HOME_CHANNEL_NAME=General" in rendered
+        assert "DISCORD_HOME_CHANNEL_THREAD_ID=444444444444444444" in rendered
+        assert (
+            "DISCORD_ALLOWED_CHANNELS=555555555555555555,666666666666666666"
+            in rendered
+        )
+        assert "DISCORD_REQUIRE_MENTION=true" in rendered
+        # allow_all_users defaults absent
+        assert "DISCORD_ALLOW_ALL_USERS" not in rendered
+
+    def test_discord_allow_all_users_renders_when_true(self):
+        cfg = self._base_config()
+        cfg["channels"] = {
+            "discord": {
+                "enabled": True,
+                "bot_token": "BOT.TOKEN.VALUE",
+                "allow_all_users": True,
+            }
+        }
+        rendered = _render_env(cfg, provider_api_key="sk-x")
+        assert "DISCORD_ALLOW_ALL_USERS=true" in rendered
+
+    def test_discord_require_mention_false_renders_lowercase(self):
+        cfg = self._base_config()
+        cfg["channels"] = {
+            "discord": {
+                "enabled": True,
+                "bot_token": "BOT.TOKEN.VALUE",
+                "allowed_users": ["111111111111111111"],
+                "require_mention": False,
+            }
+        }
+        rendered = _render_env(cfg, provider_api_key="sk-x")
+        assert "DISCORD_REQUIRE_MENTION=false" in rendered
+
+
+class TestHermesDiscordHydration:
+    """lifecycle.configure_agent hydrates DISCORD_BOT_TOKEN from secrets.json
+    and threads it onto config_data['channels']['discord']['bot_token'] when
+    the user has enabled the Discord channel for the agent."""
+
+    def _make_host(self, discord_persisted: dict | None = None) -> dict:
+        agent_config: dict = {
+            "api_server": {"enabled": True, "host": "127.0.0.1", "port": 8642},
+            "provider": {
+                "name": "p",
+                "type": "openrouter",
+                "default_model": "x",
+            },
+        }
+        if discord_persisted is not None:
+            agent_config["channels"] = {"discord": discord_persisted}
+        return {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": agent_config,
+                }
+            },
+        }
+
+    def _secrets_with(self, api_key: str, discord_token: str | None) -> dict:
+        s = {
+            "HERMES_API_SERVER_KEY": {
+                "key": "HERMES_API_SERVER_KEY",
+                "value": api_key,
+                "created_at": "2026-05-10T00:00:00+00:00",
+                "updated_at": "2026-05-10T00:00:00+00:00",
+                "description": "",
+            }
+        }
+        if discord_token is not None:
+            s["DISCORD_BOT_TOKEN"] = {
+                "key": "DISCORD_BOT_TOKEN",
+                "value": discord_token,
+                "created_at": "2026-05-10T00:00:00+00:00",
+                "updated_at": "2026-05-10T00:00:00+00:00",
+                "description": "Discord bot token",
+            }
+        return s
+
+    def test_discord_token_hydrated_into_ansible_config(self, tmp_path: Path):
+        token = "B" * 64
+        host = self._make_host(
+            discord_persisted={
+                "enabled": True,
+                "allowed_users": ["740723459344302120"],
+                "home_channel": "1503238729962356777",
+                "home_channel_name": "Home",
+                "require_mention": True,
+            }
+        )
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+        captured = {}
+
+        def fake_run(**kwargs):
+            captured["inventory"] = kwargs["inventory"]
+            m = MagicMock()
+            m.status = "successful"
+            m.events = []
+            return m
+
+        secrets = self._secrets_with("a" * 64, token)
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ),
+            patch(
+                "clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run
+            ),
+            patch("clawrium.core.lifecycle.update_host", return_value=True),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets", return_value=secrets
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host",
+                "hermes",
+                {
+                    "provider": {
+                        "name": "p",
+                        "type": "openrouter",
+                        "default_model": "x",
+                    }
+                },
+                agent_name="hermes-test",
+            )
+
+        assert success is True, error
+        sent = captured["inventory"]["all"]["vars"]["config"]
+        assert sent["channels"]["discord"]["bot_token"] == token
+        # Persisted shape from hosts.json is merged onto config_data.
+        assert sent["channels"]["discord"]["allowed_users"] == ["740723459344302120"]
+        assert sent["channels"]["discord"]["home_channel"] == "1503238729962356777"
+
+    def test_discord_disabled_does_not_hydrate(self, tmp_path: Path):
+        """When discord.enabled is False (or missing), no DISCORD_BOT_TOKEN is
+        threaded onto config_data, even if the token exists in secrets.json."""
+        host = self._make_host(discord_persisted=None)
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+        captured = {}
+
+        def fake_run(**kwargs):
+            captured["inventory"] = kwargs["inventory"]
+            m = MagicMock()
+            m.status = "successful"
+            m.events = []
+            return m
+
+        # Discord secret exists but channels.discord block doesn't — hydration
+        # block should be a no-op.
+        secrets = self._secrets_with("a" * 64, "Z" * 64)
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ),
+            patch(
+                "clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run
+            ),
+            patch("clawrium.core.lifecycle.update_host", return_value=True),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets", return_value=secrets
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host",
+                "hermes",
+                {
+                    "provider": {
+                        "name": "p",
+                        "type": "openrouter",
+                        "default_model": "x",
+                    }
+                },
+                agent_name="hermes-test",
+            )
+
+        assert success is True, error
+        sent = captured["inventory"]["all"]["vars"]["config"]
+        # channels block either absent or, if present, no bot_token field.
+        discord = sent.get("channels", {}).get("discord", {})
+        assert "bot_token" not in discord
+
+    def test_discord_enabled_without_token_rejected(self, tmp_path: Path):
+        host = self._make_host(
+            discord_persisted={
+                "enabled": True,
+                "allowed_users": ["740723459344302120"],
+            }
+        )
+        # secrets.json has only api_server key, no DISCORD_BOT_TOKEN
+        secrets = self._secrets_with("a" * 64, None)
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets", return_value=secrets
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host",
+                "hermes",
+                {
+                    "provider": {
+                        "name": "p",
+                        "type": "openrouter",
+                        "default_model": "x",
+                    }
+                },
+                agent_name="hermes-test",
+            )
+        assert success is False
+        assert "DISCORD_BOT_TOKEN" in error
+        assert "secrets.json" in error or "configure" in error.lower()
+
+    def test_discord_reconfigure_does_not_rotate_token(self, tmp_path: Path):
+        """Two configure calls must hydrate the byte-identical token from
+        secrets.json (idempotency)."""
+        token = "C" * 64
+        host = self._make_host(
+            discord_persisted={
+                "enabled": True,
+                "allowed_users": ["740723459344302120"],
+            }
+        )
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+        secrets = self._secrets_with("a" * 64, token)
+        seen_tokens = []
+
+        def fake_run(**kwargs):
+            sent = kwargs["inventory"]["all"]["vars"]["config"]
+            seen_tokens.append(sent["channels"]["discord"]["bot_token"])
+            m = MagicMock()
+            m.status = "successful"
+            m.events = []
+            return m
+
+        for _ in range(2):
+            with (
+                patch("clawrium.core.lifecycle.get_host", return_value=host),
+                patch(
+                    "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                    return_value=playbook,
+                ),
+                patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ),
+                patch(
+                    "clawrium.core.lifecycle.ansible_runner.run",
+                    side_effect=fake_run,
+                ),
+                patch("clawrium.core.lifecycle.update_host", return_value=True),
+                patch(
+                    "clawrium.core.lifecycle.get_instance_secrets",
+                    return_value=secrets,
+                ),
+            ):
+                success, error = configure_agent(
+                    "test-host",
+                    "hermes",
+                    {
+                        "provider": {
+                            "name": "p",
+                            "type": "openrouter",
+                            "default_model": "x",
+                        }
+                    },
+                    agent_name="hermes-test",
+                )
+                assert success is True, error
+
+        assert len(seen_tokens) == 2
+        assert seen_tokens[0] == seen_tokens[1] == token
+
+
+class TestHermesDiscordSecretsHygiene:
+    """B3 invariant for Discord: bot_token must never appear in hosts.json
+    after configure (mirror of the api_server.key strip)."""
+
+    def test_configure_strips_discord_bot_token_from_persisted_hosts_json(
+        self, tmp_path: Path
+    ):
+        token = "D" * 64
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {
+                        "api_server": {
+                            "enabled": True,
+                            "host": "127.0.0.1",
+                            "port": 8642,
+                        },
+                        "channels": {
+                            "discord": {
+                                "enabled": True,
+                                "allowed_users": ["740723459344302120"],
+                                "home_channel": "1503238729962356777",
+                            }
+                        },
+                    },
+                }
+            },
+        }
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        captured = {}
+
+        def fake_update_host(hostname_arg, updater):
+            updated = updater({"agents": dict(host["agents"])})
+            captured["agents"] = updated["agents"]
+            return True
+
+        secrets = {
+            "HERMES_API_SERVER_KEY": {
+                "key": "HERMES_API_SERVER_KEY",
+                "value": "a" * 64,
+                "created_at": "2026-05-10T00:00:00+00:00",
+                "updated_at": "2026-05-10T00:00:00+00:00",
+                "description": "",
+            },
+            "DISCORD_BOT_TOKEN": {
+                "key": "DISCORD_BOT_TOKEN",
+                "value": token,
+                "created_at": "2026-05-10T00:00:00+00:00",
+                "updated_at": "2026-05-10T00:00:00+00:00",
+                "description": "Discord bot token",
+            },
+        }
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ),
+            patch(
+                "clawrium.core.lifecycle.ansible_runner.run",
+                return_value=MagicMock(status="successful", events=[]),
+            ),
+            patch(
+                "clawrium.core.lifecycle.update_host", side_effect=fake_update_host
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets", return_value=secrets
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host",
+                "hermes",
+                {
+                    "provider": {
+                        "name": "p",
+                        "type": "openrouter",
+                        "default_model": "x",
+                    }
+                },
+                agent_name="hermes-test",
+            )
+
+        assert success is True, error
+        persisted_discord = (
+            captured["agents"]["hermes-test"]
+            .get("config", {})
+            .get("channels", {})
+            .get("discord", {})
+        )
+        # B3 invariant: bot_token must NOT be persisted.
+        assert "bot_token" not in persisted_discord, (
+            "Discord bot token leaked into hosts.json: " f"{persisted_discord}"
+        )
+        # Non-sensitive shape preserved.
+        assert persisted_discord.get("enabled") is True
+        assert persisted_discord.get("allowed_users") == ["740723459344302120"]
+        assert persisted_discord.get("home_channel") == "1503238729962356777"
+
+
+class TestConfigureYamlDiscordVerifyTasks:
+    """The configure.yaml playbook gates Discord verification tasks on the
+    enabled flag — they must not run for cli-only agents."""
+
+    def _playbook(self) -> dict:
+        playbook_path = (
+            Path(__file__).parent.parent
+            / "src/clawrium/platform/registry/hermes/playbooks/configure.yaml"
+        )
+        return yaml.safe_load(playbook_path.read_text())[0]
+
+    def test_discord_token_verify_task_gated_on_enabled(self):
+        play = self._playbook()
+        tasks = play.get("tasks", [])
+        names = [t.get("name", "") for t in tasks]
+        token_tasks = [
+            t for t in tasks if "DISCORD_BOT_TOKEN" in t.get("name", "")
+        ]
+        assert token_tasks, (
+            "expected a DISCORD_BOT_TOKEN verify task in configure.yaml: " f"{names}"
+        )
+        for task in token_tasks:
+            when_clauses = task.get("when") or []
+            joined = " ".join(when_clauses) if isinstance(when_clauses, list) else str(
+                when_clauses
+            )
+            assert "channels" in joined and "discord" in joined and "enabled" in joined, (
+                f"DISCORD_BOT_TOKEN task missing gating clause: {when_clauses}"
+            )
+
+    def test_discord_allowlist_verify_task_gated_on_enabled(self):
+        play = self._playbook()
+        tasks = play.get("tasks", [])
+        allowlist_tasks = [
+            t for t in tasks if "allowlist" in t.get("name", "").lower()
+        ]
+        assert allowlist_tasks, "expected a Discord allowlist verify task"
+        for task in allowlist_tasks:
+            when_clauses = task.get("when") or []
+            joined = " ".join(when_clauses) if isinstance(when_clauses, list) else str(
+                when_clauses
+            )
+            assert "channels" in joined and "discord" in joined and "enabled" in joined
+
+
+class TestDiscordSecretRemoval:
+    """clm agent remove purges DISCORD_BOT_TOKEN alongside HERMES_API_SERVER_KEY
+    via remove_instance_secrets() — no Discord-specific code path needed."""
+
+    def test_remove_instance_secrets_purges_discord_token(self, tmp_path: Path):
+        import os
+
+        from clawrium.core.secrets import (
+            list_instances_with_secrets,
+            remove_instance_secrets,
+            set_instance_secret,
+        )
+
+        os.environ["CLAWRIUM_CONFIG_DIR"] = str(tmp_path)
+        try:
+            ik = "host:hermes:agent"
+            set_instance_secret(ik, "HERMES_API_SERVER_KEY", "a" * 64, "")
+            set_instance_secret(ik, "DISCORD_BOT_TOKEN", "B" * 64, "Discord")
+            assert ik in list_instances_with_secrets()
+
+            assert remove_instance_secrets(ik) is True
+            assert ik not in list_instances_with_secrets()
+        finally:
+            os.environ.pop("CLAWRIUM_CONFIG_DIR", None)


### PR DESCRIPTION
## Summary

Phase 6 of #68 — native Discord wiring for clm-managed hermes agents. The key discovery during planning: clm already had Discord wiring for openclaw/zeroclaw in `_run_channels_stage`. Phase 6 is mostly (a) dropping the hermes guard, (b) branching config-build on `claw_type` since hermes' env-var contract differs from openclaw's `guilds: {}` shape, (c) hydrating `DISCORD_BOT_TOKEN` from `secrets.json` in `lifecycle.configure_agent` (mirroring `HERMES_API_SERVER_KEY`), and (d) extending `.env.j2` + `configure.yaml` for Discord.

- Hermes channels stage now offers `[cli, discord]` (slack out-of-scope until hermes wiring lands).
- `DISCORD_BOT_TOKEN` persisted only in `secrets.json`; non-sensitive Discord config in `hosts.json`. B3 invariant proven by regression test.
- Idempotent: re-configure produces byte-identical `.env` (md5-matched in E2E + unit test).
- CLI guards: rich-markup escape on user-supplied IDs in error output; `DISCORD_ALLOW_ALL_USERS` requires explicit second confirm (open-bot warning); home_channel_name validated against control chars + 64-char cap.

**Stacked on PR #325** (\`issue-324-plan\` — the plan doc). Merge #325 first; GitHub will auto-retarget this PR's base to \`main\`.

**Manual self-review only — ATX reviews disabled by orchestrator for cost control on this iteration.**

## Schema additions

### `hosts.json` (per-agent record)

```json
"config": {
  "api_server": {"enabled": true, "host": "127.0.0.1", "port": 8642},
  "provider": {...},
  "channels": {
    "selected": "discord",
    "discord": {
      "enabled": true,
      "allowed_users": ["740723459344302120"],
      "home_channel": "<channel_id>",
      "home_channel_name": "Home",
      "allowed_channels": [],
      "require_mention": true,
      "allow_all_users": false
    }
  }
}
```

### `secrets.json` (per-instance entry)

```json
"192.168.1.36:hermes:espresso": {
  "HERMES_API_SERVER_KEY": {...},
  "DISCORD_BOT_TOKEN": {"value": "<token>", "description": "Discord bot token", ...}
}
```

### CLI flow (before / after)

**Before**: `clm agent configure <hermes-name>` → channels stage offered only `cli`. Users had to hand-roll `DISCORD_*` lines into `~/.hermes/.env` post-install, and any `clm agent configure` re-run would wipe them.

**After**: channels stage offers `[cli, discord]`. Picking discord prompts for bot token (validated regex), allowed users (or `all` with second-confirm), home channel ID, home channel name, allowed channels, require-mention. Token persists to `secrets.json` (B3); non-sensitive fields to `hosts.json`. `.env.j2` renders the Discord block guarded on `discord.enabled AND discord.bot_token`. Verify tasks in `configure.yaml` confirm token + allowlist landed.

Non-interactive flags exposed for automation: `--discord-token`, `--discord-allowed-users`, `--discord-home-channel`, `--discord-home-channel-name`, `--discord-allowed-channels`, `--discord-require-mention / --no-discord-require-mention`.

## Testing

### Test Results

- [x] All existing tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New tests added for new functionality

```
============================ 1596 passed in 12.79s =============================
```

Baseline was 1566; +30 new tests on this branch covering CLI branches, secrets hygiene, idempotency, template render, B3 invariant guards, and boundary/injection rejection.

### Test Coverage

Files changed in this PR:
- `src/clawrium/cli/agent.py` — `_run_channels_stage` now branches on `claw_type`; hermes-specific prompts added
- `src/clawrium/core/lifecycle.py` — Discord hydration block + defense-in-depth channels-block strip
- `src/clawrium/core/install.py` — updater closure strips `channels.discord.bot_token` for B3
- `src/clawrium/platform/registry/hermes/manifest.yaml` — channels stage schema
- `src/clawrium/platform/registry/hermes/templates/.env.j2` — guarded Discord block (7 env vars)
- `src/clawrium/platform/registry/hermes/playbooks/configure.yaml` — Discord verify tasks (gated on enabled, `no_log: true`)
- `docs/agent-support/hermes.md` — replaced "deferred" callout with full walkthrough + troubleshooting
- `docs/agent-support/index.md` — Quick Comparison row updated to Discord ✅

New test files / sections:
- `tests/test_hermes_configure.py` — Discord secrets hygiene class (B3 strip, hydration, idempotency, template render, validator, ansible task gating)
- `tests/test_cli_agent_configure.py` — `TestRunChannelsStageHermesDiscord` (CLI branches, prompts, validation, open-bot confirm, boundary rejection)

### Manual Testing — E2E on wolf-i / espresso

Goal: migrate the existing `espresso` hermes agent from hand-rolled `.env` Discord lines to clm-managed wiring without dropping Discord connectivity.

Outcome (executed in prior sub-agent run, see plan Prompt Log):

1. Snapshot of `~/.hermes/.env` captured pre-migration.
2. `clm agent configure espresso --stage channels` walked through with snapshot values (same token, same allowed user, same home channel ID).
3. Verified: `secrets.json` instance entry gained `DISCORD_BOT_TOKEN`; `hosts.json` `agents.espresso.config.channels.discord` populated without `bot_token` field (B3); `~/.hermes/.env` re-rendered with manual comment block stripped, clm-managed `DISCORD_*` lines present.
4. Service auto-restarted via configure handler; `/health` returned 200; 3 ESTAB sockets to Cloudflare Discord IPs preserved across the restart.
5. Idempotency confirmed: re-running the channels stage with identical inputs produced byte-identical `.env` (md5 unchanged).
6. Functional test: allowed user posted in Discord channel; bot responded via local-inx Ollama (qwen3-coder:30b-128k) — same behavior as pre-migration.
7. Removal smoke (then re-install): `clm agent remove espresso --force` purged the secrets.json instance entry including `DISCORD_BOT_TOKEN`; re-install + re-configure accepted a fresh token (no leftover).

After E2E, espresso is left in **WORKING clm-managed state** on wolf-i. No hand-rolled `.env` lines remain.

### Security Checklist

- [x] No hardcoded secrets or credentials — test fixtures use obvious dummy tokens (`MTIzNDU2...` base64 of `123456...`)
- [x] Input validation for user-provided data — bot token regex `^[A-Za-z0-9._+/=-]{50,120}$`; user/channel IDs `^\d{17,19}$`; home_channel_name whitelist `[A-Za-z0-9 _\-./#]+` + 64-char cap + control-char reject
- [x] No SQL/command injection — IDs validated before any persist or shell context; `ansible.builtin.command` (not `shell`) used everywhere a shell isn't required; quoted paths in remaining `command` cmds
- [x] No rich-markup injection — `rich_escape()` on all user-supplied strings in error output (two new call sites added this PR)
- [x] `no_log: true` on every ansible task that touches `DISCORD_BOT_TOKEN` (verify tasks lines 156, 168 in `configure.yaml`)
- [x] `DISCORD_ALLOW_ALL_USERS=true` requires explicit second confirm (open-bot security warning shown first)
- [x] B3 invariant — `DISCORD_BOT_TOKEN` strip from `hosts.json` proven by positive + negative regression tests
- [x] Dependencies from trusted sources — no new third-party deps added
- [x] Openclaw Discord regression check — `_run_channels_stage` openclaw branch unchanged; existing openclaw tests pass byte-for-byte (`test_openclaw_discord_still_uses_guilds_shape` is the explicit guard)

## Reviewer Notes

- **Stacked PR**: base = `issue-324-plan`. Merge PR #325 first, then GitHub will auto-retarget this PR to `main`.
- **No ATX iteration loop on this run** — orchestrator disabled ATX for cost. Two earlier sub-agent runs in this branch did go through one ATX cycle (commit `97e8dbd` addresses iter-1 blockers); the current PR head includes that work plus a final hardening commit.
- **Risk 1 from plan (Discord `/sethome` writes to config.yaml clm wipes)**: addressed by extending `config.yaml.j2` to emit `discord:` block sourced from `hosts.json` (clm stays authoritative). See template diff.
- **Risk 3 (open-bot)**: enforced by interactive second-confirm prompt before `allow_all_users: true` is accepted.
- **Out of scope** (tracked as follow-ups per plan): Slack/Telegram/etc., advanced Discord env vars (auto-thread, reactions, ignored channels, free-response), multi-bot-per-host pressure testing.

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)