### PR TITLE
docs(334): aichat investigation note for hermes chat

### DIFF
--- a/.itx/322/00_PLAN.md
+++ b/.itx/322/00_PLAN.md
@@ -64,7 +64,7 @@ The only structural difference vs openclaw is the transport itself (HTTP + SSE v
 ### New
 - `src/clawrium/core/chat_hermes.py` — `HermesOpenAIBackend`:
   - `__init__(base_url, auth_token: SecretStr, timeout: float)`
-  - `connect()` — `GET <base>/health` with 5s timeout for fail-fast. Maps connection refused → `ChatConnectionError` with a remediation hint pointing at `systemctl --user status hermes-<name>`.
+  - `connect()` — `GET <base>/health` with 5s timeout for fail-fast. Maps connection refused → `ChatConnectionError` with a remediation hint pointing at `systemctl status hermes-<name>.service` (system unit; no `--user` — hermes installs at `/etc/systemd/system/`).
   - `send_message(message, on_delta, response_timeout_seconds)` — `POST /v1/chat/completions` with `Authorization: Bearer …`, body `{model, messages, stream: true}`. Streams SSE via `httpx.AsyncClient.stream()`, parses `data: {...}` lines, extracts `choices[0].delta.content`. Handles `data: [DONE]` sentinel and `:keep-alive` comments. Falls back to single-JSON-response path on non-SSE content-type.
   - Maintains `self._history: list[dict]` for client-side conversation continuity within a REPL session.
 - `tests/test_chat_hermes.py` — backend unit tests.
@@ -180,7 +180,7 @@ Each subtask delivers a user-visible improvement to `clm chat <hermes-name>` and
 
 **Scope** (each failure path gets a friendly message + remediation hint):
 - Missing/invalid `HERMES_API_SERVER_KEY` → "Re-run `clm agent install --type hermes`" (mirrors `lifecycle.py:748-754`).
-- Service unreachable / connection refused → "Check `systemctl --user status hermes-<name>` on the agent host" plus a hint about `clm agent configure` if the bind looks stale.
+- Service unreachable / connection refused → "Check `systemctl status hermes-<name>.service` on the agent host" (system scope; no `--user`) plus a hint about `clm agent configure` if the bind looks stale.
 - Bearer rejected (401/403) → "Token mismatch. Re-run `clm agent configure <name>`."
 - `--session` passed to a hermes agent → dim warning explaining it's a no-op for OpenAI-typed agents.
 

--- a/.itx/334/01_EXECUTION.md
+++ b/.itx/334/01_EXECUTION.md
@@ -2,20 +2,36 @@
 
 **Slice 5 of parent #322** — aichat investigation note (docs-only, non-user-facing).
 
+This issue has no standalone `00_PLAN.md`; the plan lives in `.itx/322/00_PLAN.md` under "Slice 5 — aichat investigation note" (line 191).
+
+## Entry criteria
+
+- Per `.itx/322/00_PLAN.md` line 204: "Slice 5 can land at any time." Independent of Slices 1–4 — the doc describes target design, not extant code. No upstream dependency.
+
 ## Scope
 
-Single new file: `docs/research/aichat.md` (~1 page).
+Single new file under `docs/research/` plus a discoverability entry in `docs/index.md`.
+
+**Scope expansion during execution**: added `docs/index.md` "Design Decisions" entry (originally not in issue scope; required for discoverability per ATX Round 1 W7) and two `systemctl` corrections in `.itx/322/00_PLAN.md:67,183` (factual bug surfaced by ATX Round 2 W-R2-4 — keeps the parent plan accurate for Slice 4 implementers). Both are local, no upstream dependency.
 
 ## Exit criteria
 
-- [x] `docs/research/aichat.md` exists with four sections: what aichat is, three options considered, why ref-impl for v1, patterns worth stealing.
-- [x] Linked from issue #322 (PR closes #334, which is itself a child of #322 — link relationship preserved via parent reference).
+- [x] `docs/research/aichat.md` exists with four sections (what aichat is, three options considered, why ref-impl for v1, patterns worth stealing).
+- [x] Linked from `docs/index.md` under a new "Design Decisions" section.
+- [x] Discoverable from parent #322 via the PR comment posted after merge (see Follow-ups).
 - [x] `make lint` clean.
+- [x] `make test` clean (no regressions; docs-only).
+- [x] ATX automated review iterated to Rating > 3/5 with all blocking issues resolved.
 
 ## Notes
 
-- Docs-only change. No code touched. No tests added (no behavior to test).
+- Docs-only change. No source code touched. No tests added (no behavior to test).
+- The doc explicitly flags its own status: "Slices 1–4 are unbuilt at the time this lands; symbols described (`ChatBackend`, `HermesOpenAIBackend`, `httpx`, `features.chat.type`, `test_sse_edge_cases`) are *target design*, not present code."
 - Project board status update skipped — local `gh` token lacks `project` scope. Non-blocking.
+
+## Follow-ups (after merge)
+
+- Comment on #322 linking the merged doc: *"Slice 5 complete. aichat investigation note: `docs/research/aichat.md` (PR #335)."*
 
 ## Prompt Log
 
@@ -30,5 +46,84 @@ Single new file: `docs/research/aichat.md` (~1 page).
 ```prompt
 /itx-execute 334
 ```
+
+</details>
+
+<details>
+<summary>ATX Review (manual CLI, Round 1)</summary>
+
+**Tool**: `atx review request --prompt "..."` (MCP unavailable in session; used CLI fallback)
+**Timestamp**: 2026-05-11T15:19:06Z
+**Rating**: 2/5
+**Blockers**: 2 (B1 `test_sse_edge_cases` doesn't exist; B2 `httpx` not in dep tree) — both tense errors
+**Cost**: $2.6784
+**Agents**: leader, core-lifecycle, cli-ux, security-secrets, test-coverage, ansible-playbook
+
+Fixes applied:
+
+| # | Status | Resolution |
+|---|--------|-----------|
+| B1 | Fixed | Switched to future tense; corrected path to `tests/test_chat_hermes.py::test_sse_edge_cases (Slice 3)`. |
+| B2 | Fixed | Rewrote to say Slice 1 will add `httpx>=0.27`. |
+| W1 | Clarified | Kept `HERMES_API_SERVER_KEY` (correct in clm's `secrets.json` per `install.py:535`) and explicitly noted it's rendered into hermes' `.env` as `API_SERVER_KEY`. |
+| W2 | Fixed | `systemctl status hermes-<agent-name>` (no `--user`, full unit name; system unit at `/etc/systemd/system/`). |
+| W3 | Fixed | Model selection corrected to `config.provider.default_model` (rendered by `templates/config.yaml.j2:8`); `features.chat.type` clarified as discriminator only. |
+| W4 | Fixed | Added top-of-doc status callout; future-tense audit of `ChatBackend`, `HermesOpenAIBackend`, `_build_hermes_base_url`. |
+| W5 | Fixed | Added injection-safety bullet to "When to reconsider sidecar" referencing PR #68 incident. |
+| W6 | Fixed | Added explicit "LAN transport is plaintext HTTP" bullet noting the deliberate trade and hermes' own strong-key enforcement. |
+| W7 | Fixed | Added "Design Decisions" section to `docs/index.md` linking the new doc. |
+| W8 | Fixed | Added "Secret exposure" Con to sidecar option (`ps aux` / `/proc` bearer leakage). |
+| W9 | Fixed | Added "Subprocess lifecycle" Con to sidecar option (PTY + SIGINT forwarding). |
+| W10 | Acknowledged | "Linked from #322" satisfied via follow-up comment after merge (recorded in Follow-ups above). |
+| W11 | Acknowledged | Plan deviation now documented explicitly in this log's preamble. |
+| W12 | Fixed | Entry criteria section added above. |
+
+Suggestions S1, S5: incorporated (newcomer context paragraph; promoted "When to reconsider sidecar" reasoning inline). S2, S3, S4, S7: incorporated into the patterns section (version pinning, credential storage, exception sanitization, Rust-binary pinning). S6: not applicable — model is correctly `claude-opus-4-7` per session context.
+
+</details>
+
+<details>
+<summary>ATX Review (manual CLI, Round 2)</summary>
+
+**Tool**: `atx review request`
+**Timestamp**: 2026-05-11T15:34:00Z
+**Rating**: 3/5 (threshold > 3/5)
+**Blockers**: 0
+**Warnings**: 7
+**Cost**: $1.9811
+
+Round 1 fixes all verified clear. New warnings raised and resolved:
+
+| # | Status | Resolution |
+|---|--------|-----------|
+| W-R2-1 | Documented | Verified `_sanitize_exception_text` bearer-token gap (regex `\b(token|auth|password)\b\s*[:=]\s*` doesn't match `Authorization: Bearer <token>` — no `\b` after `auth`, no `:`/`=` between `Bearer` and the token). Doc now flags the gap explicitly and prescribes a `(?i)\bBearer\s+([A-Za-z0-9._~+/-]{8,})` → `Bearer ***` fix to land with Slice 3. Fixing the function itself is out of scope for this docs-only PR. |
+| W-R2-2 | Fixed | Expanded `'L3150'` shorthand to `'gateway/platforms/api_server.py:3150–3169 (is_network_accessible guard)'` and noted `docs/agent-support/hermes.md:191` will need a follow-up update in Slice 1. |
+| W-R2-3 | Fixed | Rewrote model-selection bullet: `config.provider.default_model` is the `hosts.json` input, rendered as `model.default` in `~/.hermes/config.yaml` by `templates/config.yaml.j2:33–34` (read at line 8). |
+| W-R2-4 | Fixed | Corrected `.itx/322/00_PLAN.md:67,183` to drop `--user` and use full unit name (`systemctl status hermes-<name>.service`). |
+| W-R2-5 | Fixed | `docs/index.md` link description switched to future tense + `(planned — see #322)`. |
+| W-R2-6 | Fixed | Patterns section tense audit pass — `introduces`/`flips`/`reads` → `will introduce`/`will flip`/`will source`. |
+| W-R2-7 | Fixed | Scope-expansion sentence added above. |
+
+Suggestion S-1 (canonical stdin pipe pattern): not incorporated — adds implementation detail beyond what a reconsideration note needs.
+
+</details>
+
+<details>
+<summary>ATX Review (manual CLI, Round 3)</summary>
+
+**Tool**: `atx review request`
+**Timestamp**: 2026-05-11T15:42:00Z
+**Rating**: blocked (review confirmed the local changes weren't yet committed; threshold not assessable)
+**Blockers**: 1 (B1 — staged-but-not-committed changes)
+**Warnings**: 2 (W-R3-1, W-R3-2)
+**Cost**: see ATX log
+
+| # | Status | Resolution |
+|---|--------|-----------|
+| B1 | Fixed by Round 4 commit | All R2+R3 fixes amended into a single squashed commit on `issue-334-aichat-doc`; force-push to update PR #335. |
+| W-R3-1 | Fixed | `clm sources` → `clm will source` in patterns section. |
+| W-R3-2 | Fixed | `{8,}` quantifier in prescribed Bearer regex relaxed to `{1,}` (false positives are acceptable for sanitization; short test tokens must still redact). |
+
+Round 3 also surfaced unrelated carry-forward items (`docs/agent-support/hermes.md:191,116`, Slice 1 test gaps). All belong to #322 Slices 1/3, not this PR.
 
 </details>

--- a/.itx/334/01_EXECUTION.md
+++ b/.itx/334/01_EXECUTION.md
@@ -127,3 +127,29 @@ Suggestion S-1 (canonical stdin pipe pattern): not incorporated — adds impleme
 Round 3 also surfaced unrelated carry-forward items (`docs/agent-support/hermes.md:191,116`, Slice 1 test gaps). All belong to #322 Slices 1/3, not this PR.
 
 </details>
+
+<details>
+<summary>ATX Review (manual CLI, Round 4 — final)</summary>
+
+**Tool**: `atx review request`
+**Timestamp**: 2026-05-11T15:46:00Z
+**Rating**: 4/5 ✅ (threshold > 3/5 cleared)
+**Blockers**: 0
+**Warnings**: 1 (W-R4-1, deferred-to-Slice-3)
+**Suggestions**: 4 (all deferred to Slice 3 or noted as quality-of-life)
+**Composite specialist ratings**: security-secrets 4/5, cli-ux 4/5, test-coverage 3/5
+
+W-R4-1 (no xfail anchor for the sanitizer gap): acknowledged. Belongs to Slice 3 of #322, not this docs-only PR. Suggestions S-R4-1..S-R4-4 all queued for Slice 3.
+
+**Disposition**: PR #335 ready to merge.
+
+</details>
+
+## ATX iteration summary
+
+| Round | Rating | Blockers | Disposition |
+|-------|--------|----------|-------------|
+| 1 | 2/5 | B1, B2 | Both fixed |
+| 2 | 3/5 | 0 | 7 warnings — all fixed |
+| 3 | blocked | B1 (uncommitted) | Fixed by commit `dea2408` + 2 warnings fixed |
+| 4 | **4/5** | 0 | Merge-eligible; 1 deferred warning belongs to Slice 3 of #322 |

--- a/.itx/334/01_EXECUTION.md
+++ b/.itx/334/01_EXECUTION.md
@@ -1,0 +1,34 @@
+# Issue #334 — Execution Log
+
+**Slice 5 of parent #322** — aichat investigation note (docs-only, non-user-facing).
+
+## Scope
+
+Single new file: `docs/research/aichat.md` (~1 page).
+
+## Exit criteria
+
+- [x] `docs/research/aichat.md` exists with four sections: what aichat is, three options considered, why ref-impl for v1, patterns worth stealing.
+- [x] Linked from issue #322 (PR closes #334, which is itself a child of #322 — link relationship preserved via parent reference).
+- [x] `make lint` clean.
+
+## Notes
+
+- Docs-only change. No code touched. No tests added (no behavior to test).
+- Project board status update skipped — local `gh` token lacks `project` scope. Non-blocking.
+
+## Prompt Log
+
+<details>
+<summary>Execution</summary>
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-11T15:05:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 334
+```
+
+</details>

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,10 @@ When a host is removed with `clm host remove`, both the host entry in `hosts.jso
 | **Agent Name** | The unique identifier for an installed agent instance |
 | **Registry** | Platform-defined agent types with versions, dependencies, and templates |
 
+## Design Decisions
+
+- [aichat investigation](research/aichat.md) — why `clm chat` will be a pure-Python REPL on `httpx` instead of shelling out to [aichat](https://github.com/sigoden/aichat) (in progress — see [#322](https://github.com/ric03uec/clawrium/issues/322)).
+
 ## FAQ
 
 ### 1. Why not Kubernetes?

--- a/docs/research/aichat.md
+++ b/docs/research/aichat.md
@@ -1,0 +1,84 @@
+# aichat investigation — why we built our own REPL
+
+Investigation note for issue #322 (generalize `clm chat` for hermes via OpenAI-compatible HTTP).
+
+## What aichat is
+
+[aichat](https://github.com/sigoden/aichat) is a Rust CLI for chatting with any OpenAI-compatible HTTP endpoint. It ships base-url configuration, multi-turn conversation history, model selection, slash-commands, session persistence, RAG, and a TUI. It's mature, well-maintained, and covers ~100% of the chat-client surface we'd ever need.
+
+The question was whether to use it instead of writing our own client inside `clm`.
+
+## Three options considered
+
+### 1. aichat as a Rust library
+
+**Verdict**: impractical.
+
+aichat is published as a binary, not as a stable library API. There's no `crates.io` package surface intended for embedding. We'd have to vendor a Rust crate inside a Python project — `clm` is Python + Typer, `pyo3` bindings or a Rust submodule would dwarf the rest of the codebase, and we'd own all the maintenance.
+
+### 2. aichat as a sidecar binary (clm shells out)
+
+**Pros**:
+
+- Zero TUI work — aichat already has a polished REPL.
+- Multi-provider, multi-model, slash-commands, session history all free.
+
+**Cons**:
+
+- Extra runtime dependency. Every host running `clm chat` needs the aichat binary installed and on `$PATH`.
+- Cross-platform Rust binary distribution. We'd have to bundle, fetch, or instruct users to install — none of which fits the `uv tool install clawrium` story.
+- UX inconsistency. The rest of `clm` is Typer + Rich; shelling into aichat means a different prompt style, different keybinds, different config surface, different error formatting.
+- Config drift. aichat has its own config file (`~/.config/aichat/config.yaml`); we'd either generate it from `hosts.json` (extra moving part) or ask users to maintain both.
+- Updates are out of band. aichat releases land on its own cadence; a breaking change to its config schema becomes our incident.
+
+### 3. Pure Python reference implementation (chosen for v1)
+
+**Pros**:
+
+- Consistent UX with `clm chat <openclaw-name>` and the rest of the CLI. Same Rich rendering, same Ctrl-C behavior, same exit-code conventions.
+- No new system dependency — `httpx` is already in our dep tree after Slice 1.
+- Errors map cleanly to `clm`'s remediation hints (`HERMES_API_SERVER_KEY` missing → "Re-run install"; `ConnectError` → "Check `systemctl --user status hermes`").
+- Backend abstraction (`ChatBackend` protocol) reused for openclaw — one chat command, two transports.
+
+**Cons**:
+
+- More code to own. SSE parsing, history accumulation, model selection, and error mapping are all hand-rolled.
+- We will reinvent features aichat already has (slash-commands, persistent sessions) if users ask for them.
+
+## Why reference-implementation for v1
+
+Three reasons:
+
+1. **The minimum viable chat against hermes is small** — a couple hundred lines of `httpx` + SSE parsing — once you accept "no TUI bells, just openclaw parity." aichat solves a much larger problem than we have.
+2. **Distribution simplicity wins**. `uv tool install clawrium` already gives users a working `clm chat`. Adding "and also install aichat" is a real onboarding regression.
+3. **The abstraction we need anyway**. Slice 1 introduces a `ChatBackend` protocol so openclaw (websocket) and hermes (OpenAI HTTP) share the same CLI surface. Once that protocol exists, a Python `HermesOpenAIBackend` is the natural fit; an aichat-shelling-out backend is a second special case.
+
+### What would tip us toward sidecar later
+
+We'd reconsider aichat (or another existing client) as a sidecar if:
+
+- **Users ask for a richer TUI** — pane-based history, search, image attachments, full markdown rendering of agent output.
+- **Slash-commands and session persistence become load-bearing**. Right now `/reset` is the only slash-command and history is in-memory per REPL. If users want `/save`, `/load`, named conversations, branching, the maintenance burden flips.
+- **Multi-provider support outside our agents** — i.e., `clm chat` against arbitrary OpenAI-compatible endpoints that aren't `clm`-managed agents. Today the value of `clm chat` is that it knows which agent on which host with which bearer; the moment that constraint relaxes, aichat's generality wins.
+
+None of these are on the v1 roadmap. Revisit if a real user asks.
+
+## Patterns worth stealing from aichat
+
+Things aichat does well that the Python implementation should mirror:
+
+- **Base-url config as a per-target field**. aichat lets you point `client.api_base` at any OpenAI-compatible URL with a bearer token. Our `_build_hermes_base_url(api_server, host_record)` mirrors this — `http://{host_record.hostname}:{port}/v1` — keeping the bind/reach split clean (`api_server.host` is the bind address, not the URL).
+- **Conversation history as a plain list of `{role, content}` dicts**, appended client-side per turn, included verbatim in the next request. Don't try to be clever — the server is stateless, the client owns history. `/reset` is just `messages.clear()`.
+- **Model selection as a config field, not a flag**. aichat reads the model from its per-client config; we read it from the agent manifest (`features.chat.model`) with no CLI override in v1. Add `--model` only if users actually want to switch.
+- **Error mapping by status code**:
+  - `401` → bearer wrong → "Re-run install to regenerate `HERMES_API_SERVER_KEY`."
+  - `429` → rate limit → surface the upstream `Retry-After` header verbatim; don't auto-retry in the REPL.
+  - `503` / `ConnectError` → service unreachable → "Check `systemctl --user status hermes` on `<host>`."
+  - `5xx` other → print the body; let the user file an issue.
+- **SSE handling**: aichat tolerates `data: [DONE]` sentinels, `:keep-alive` comment frames, and partial JSON across chunks. Our handwritten parser needs the same tolerance — covered by `test_sse_edge_cases`.
+
+## Refs
+
+- Parent: [#322](https://github.com/ric03uec/clawrium/issues/322)
+- This issue: [#334](https://github.com/ric03uec/clawrium/issues/334)
+- aichat: <https://github.com/sigoden/aichat>

--- a/docs/research/aichat.md
+++ b/docs/research/aichat.md
@@ -2,6 +2,10 @@
 
 Investigation note for issue #322 (generalize `clm chat` for hermes via OpenAI-compatible HTTP).
 
+> **Status (2026-05-11)**: This doc records the design decision behind Slices 1–4 of #322. It lands **before** those slices; symbols like `ChatBackend`, `HermesOpenAIBackend`, `_build_hermes_base_url`, `test_sse_edge_cases`, the `features.chat.type` enum, and the `httpx` dependency are the *target design* described in `.itx/322/00_PLAN.md`, not present code. Future tense is used where appropriate; assume nothing here exists in `src/` until the corresponding slice merges.
+
+> **Context for newcomers**: Hermes is a self-hosted agent type that exposes an OpenAI-compatible HTTP gateway (`POST /v1/chat/completions`) secured by a bearer token. Contrast with openclaw, which exposes a WebSocket gateway. `clm chat` already works against openclaw; #322 generalizes it to hermes.
+
 ## What aichat is
 
 [aichat](https://github.com/sigoden/aichat) is a Rust CLI for chatting with any OpenAI-compatible HTTP endpoint. It ships base-url configuration, multi-turn conversation history, model selection, slash-commands, session persistence, RAG, and a TUI. It's mature, well-maintained, and covers ~100% of the chat-client surface we'd ever need.
@@ -26,19 +30,21 @@ aichat is published as a binary, not as a stable library API. There's no `crates
 **Cons**:
 
 - Extra runtime dependency. Every host running `clm chat` needs the aichat binary installed and on `$PATH`.
-- Cross-platform Rust binary distribution. We'd have to bundle, fetch, or instruct users to install — none of which fits the `uv tool install clawrium` story.
+- Cross-platform Rust binary distribution. We'd have to bundle, fetch, or instruct users to install — none of which fits the `uv tool install clawrium` story. The binary cannot be hash-pinned in `pyproject.toml`.
 - UX inconsistency. The rest of `clm` is Typer + Rich; shelling into aichat means a different prompt style, different keybinds, different config surface, different error formatting.
 - Config drift. aichat has its own config file (`~/.config/aichat/config.yaml`); we'd either generate it from `hosts.json` (extra moving part) or ask users to maintain both.
-- Updates are out of band. aichat releases land on its own cadence; a breaking change to its config schema becomes our incident.
+- Updates are out of band. aichat releases land on its own cadence; a breaking change to its config schema becomes our incident, and we have no automatic enforcement against it.
+- Secret exposure. The bearer would have to reach aichat somehow — as a CLI arg it appears in `ps aux` / `/proc/<pid>/cmdline`; as an env var it's still visible to same-uid processes via `/proc/<pid>/environ`. Neither matches the `0o600` `secrets.json` posture clm uses today.
+- Subprocess lifecycle. "Zero TUI work" overstates the pro — an interactive REPL child needs PTY allocation (otherwise aichat disables readline/colour) and SIGINT forwarding (otherwise Ctrl-C in `clm` doesn't reach aichat cleanly).
 
 ### 3. Pure Python reference implementation (chosen for v1)
 
 **Pros**:
 
 - Consistent UX with `clm chat <openclaw-name>` and the rest of the CLI. Same Rich rendering, same Ctrl-C behavior, same exit-code conventions.
-- No new system dependency — `httpx` is already in our dep tree after Slice 1.
-- Errors map cleanly to `clm`'s remediation hints (`HERMES_API_SERVER_KEY` missing → "Re-run install"; `ConnectError` → "Check `systemctl --user status hermes`").
-- Backend abstraction (`ChatBackend` protocol) reused for openclaw — one chat command, two transports.
+- No new system dependency. Slice 1 will add `httpx>=0.27` to `pyproject.toml` — small, well-maintained, BSD-licensed, FastAPI-ecosystem standard. No Rust toolchain, no binary distribution.
+- Errors will map cleanly to `clm`'s remediation hints (`HERMES_API_SERVER_KEY` missing in `secrets.json` → "Re-run install"; `ConnectError` → "Check `systemctl status hermes-<agent-name>` on `<host>`").
+- Backend abstraction (`ChatBackend` protocol introduced in Slice 1) reused for openclaw — one chat command, two transports.
 
 **Cons**:
 
@@ -60,22 +66,26 @@ We'd reconsider aichat (or another existing client) as a sidecar if:
 - **Users ask for a richer TUI** — pane-based history, search, image attachments, full markdown rendering of agent output.
 - **Slash-commands and session persistence become load-bearing**. Right now `/reset` is the only slash-command and history is in-memory per REPL. If users want `/save`, `/load`, named conversations, branching, the maintenance burden flips.
 - **Multi-provider support outside our agents** — i.e., `clm chat` against arbitrary OpenAI-compatible endpoints that aren't `clm`-managed agents. Today the value of `clm chat` is that it knows which agent on which host with which bearer; the moment that constraint relaxes, aichat's generality wins.
+- **Injection safety is a hard constraint**: if we ever do shell out to aichat, user chat messages MUST be piped to its stdin — never interpolated into a shell command or CLI argument, and never with `shell=True`. PR #68 already had to fix a command-injection bug in `validate_hermes_health`; the next sidecar implementation cannot repeat it.
 
 None of these are on the v1 roadmap. Revisit if a real user asks.
 
 ## Patterns worth stealing from aichat
 
-Things aichat does well that the Python implementation should mirror:
+Things aichat does well that the Python implementation should mirror (all of these are *target design* — not yet present in `src/`):
 
-- **Base-url config as a per-target field**. aichat lets you point `client.api_base` at any OpenAI-compatible URL with a bearer token. Our `_build_hermes_base_url(api_server, host_record)` mirrors this — `http://{host_record.hostname}:{port}/v1` — keeping the bind/reach split clean (`api_server.host` is the bind address, not the URL).
-- **Conversation history as a plain list of `{role, content}` dicts**, appended client-side per turn, included verbatim in the next request. Don't try to be clever — the server is stateless, the client owns history. `/reset` is just `messages.clear()`.
-- **Model selection as a config field, not a flag**. aichat reads the model from its per-client config; we read it from the agent manifest (`features.chat.model`) with no CLI override in v1. Add `--model` only if users actually want to switch.
+- **Base-url config as a per-target field**. aichat lets you point `client.api_base` at any OpenAI-compatible URL with a bearer token. The planned `_build_hermes_base_url(api_server, host_record)` will mirror this — `http://{host_record.hostname}:{port}/v1` — keeping the bind/reach split clean: `api_server.host` in `hosts.json` is the *bind* address (Slice 1 will flip it from `127.0.0.1` to `0.0.0.0` per `.itx/322/00_PLAN.md`), while `host_record.hostname` is the *reach* address used in the URL.
+- **LAN transport is plaintext HTTP** — this is a deliberate trade, not an oversight. The threat model matches openclaw's existing `bind: "lan"`: bearer + Authorization header travel over LAN HTTP. Hermes' own startup check (`gateway/platforms/api_server.py:3150–3169`, the `is_network_accessible` guard) refuses to bind a non-loopback interface without a strong, non-placeholder key; our 64-char hex `secrets.token_hex(32)` (`core/install.py:547`) satisfies that. TLS / SSH-tunnel is out of scope for v1 and would be a follow-up if homelab threat models tighten. (Slice 1 will also need to update `docs/agent-support/hermes.md:191` which currently states non-loopback is unsupported.)
+- **Conversation history as a plain list of `{role, content}` dicts**, appended client-side per turn, included verbatim in the next request. Don't try to be clever — the server is stateless, the client owns history. `/reset` will just `messages.clear()`.
+- **Model selection as a config field, not a flag**. aichat reads the model from its per-client config; clm will source the model from `config.provider.default_model` in the agent's persisted `hosts.json` entry, which `templates/config.yaml.j2` will render as `model.default` in `~/.hermes/config.yaml` during `clm agent configure` (template reads the value at line 8: `{% set model_id = provider.default_model | default('') %}`, and writes it at lines 33–34 under the top-level `model:` block). Separately, `features.chat.type` in the manifest (added by Slice 1) is purely a dispatch *discriminator* — `"websocket"` for openclaw, `"openai"` for hermes — not for model selection. No `--model` CLI override in v1.
+- **Credential surface**: aichat stores credentials in `~/.config/aichat/config.yaml` which is world-readable by default. clm will read the bearer from `~/.config/clawrium/secrets.json` (`0o600`) via `get_instance_secrets()` — never from a config file, never via an env var that could leak to `0644`.
 - **Error mapping by status code**:
-  - `401` → bearer wrong → "Re-run install to regenerate `HERMES_API_SERVER_KEY`."
+  - `401` → bearer wrong → "Re-run install to regenerate the hermes bearer (`HERMES_API_SERVER_KEY` in `clm`'s `secrets.json` per `core/install.py:535,550`; rendered into the agent's `.env` as `API_SERVER_KEY` by `templates/.env.j2:29`)."
   - `429` → rate limit → surface the upstream `Retry-After` header verbatim; don't auto-retry in the REPL.
-  - `503` / `ConnectError` → service unreachable → "Check `systemctl --user status hermes` on `<host>`."
+  - `503` / `ConnectError` → service unreachable → "Check `systemctl status hermes-<agent-name>.service` on `<host>`." (Hermes installs as a system unit at `/etc/systemd/system/hermes-<agent-name>.service`, not a user unit — no `--user` flag.)
   - `5xx` other → print the body; let the user file an issue.
-- **SSE handling**: aichat tolerates `data: [DONE]` sentinels, `:keep-alive` comment frames, and partial JSON across chunks. Our handwritten parser needs the same tolerance — covered by `test_sse_edge_cases`.
+  - **All httpx exception strings** must pass through a sanitizer before display — raw httpx exceptions can include full URLs and request headers, which means the bearer can leak into terminal scrollback. Openclaw's `_sanitize_exception_text` (`cli/chat.py:309–317`) is the right starting model, **but it has a known gap**: the current regex `\b(token|auth|password)\b\s*[:=]\s*` does not match `"Authorization: Bearer <token>"` — `\bauth\b` fails before the `o` in `Authorization`, and there is no `:`/`=` between `Bearer` and the token. Slice 3 must extend the sanitizer with an explicit `(?i)\bBearer\s+([A-Za-z0-9._~+/-]{1,})` → `Bearer ***` substitution before reusing the function for hermes, or the gap propagates. (Use `{1,}` — not `{8,}` — so the regex doesn't silently let short test/dev tokens through.)
+- **SSE handling**: aichat tolerates `data: [DONE]` sentinels, `:keep-alive` comment frames, and partial JSON across chunks. The planned handwritten parser will need the same tolerance — to be covered by `tests/test_chat_hermes.py::test_sse_edge_cases` in Slice 3.
 
 ## Refs
 


### PR DESCRIPTION
## Summary

- Adds `docs/research/aichat.md` recording the design decision behind `clm chat <hermes>` — pure-Python REPL on `httpx` instead of shelling out to [aichat](https://github.com/sigoden/aichat).
- Documents the three options weighed (Rust library, sidecar binary, Python ref impl), the reasoning for v1, what would tip us toward sidecar later (with an explicit subprocess-injection-safety constraint), and patterns worth mirroring (base-url + bind/reach split, plaintext-LAN trade-off, client-owned history, model field mapping, credential surface, status-code error mapping with a flagged Bearer-token sanitizer gap, SSE tolerance).
- Adds a "Design Decisions" discoverability entry in `docs/index.md`.
- Corrects `systemctl --user` → system-scope references in `.itx/322/00_PLAN.md:67,183` so Slice 4's remediation hint won't ship with a wrong command.
- Closes the "investigate aichat" AC from #322 (Slice 5).

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — 1596 passed
- [x] Linter passes (`make lint`) — All checks passed
- [x] New tests added for new functionality — N/A (docs-only)

### Test Coverage
- Files changed: `docs/research/aichat.md` (new), `docs/index.md`, `.itx/322/00_PLAN.md` (2 systemctl scope fixes), `.itx/334/01_EXECUTION.md` (new)
- New tests: N/A
- Coverage impact: N/A (no source code changed)

### Manual Testing
Read-through of the doc; verified the four required sections from issue #334 are present. Verified every codebase reference (env var names, file paths, line numbers, systemctl scope) against the working tree. Verified the prescribed Bearer-regex sanitizer gap empirically against `_sanitize_exception_text` in `src/clawrium/cli/chat.py:309-317`.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — N/A
- [x] No SQL injection, XSS, or command injection risks — N/A (markdown only); the doc itself flags injection safety for any future sidecar implementation
- [x] Dependencies are from trusted sources — N/A (no dep changes)

## ATX Review Summary

**Final Review: Rating 4/5**

> **Note**: ATX MCP tool was unavailable in this session; review was driven via the `atx review request` CLI per `AGENTS.md`. Iteration history maintained in `.itx/334/01_EXECUTION.md`.

| Review | Rating | Blocking Issues | Status | Agents |
|--------|--------|-----------------|--------|--------|
| 1 | 2/5 | B1, B2 | All fixed | leader, core-lifecycle, cli-ux, security-secrets, test-coverage, ansible-playbook |
| 2 | 3/5 | None | 7 warnings — all fixed | leader, cli-ux, security-secrets, core-lifecycle |
| 3 | blocked | B1 (uncommitted changes) | Fixed by commit `dea2408` | leader, ansible, cli-ux, security, core-lifecycle |
| 4 | 4/5 | None | Ready — 1 warning deferred to Slice 3 of #322 | leader, security-secrets, cli-ux, test-coverage |

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `docs/research/aichat.md` | `test_sse_edge_cases` referenced in present tense — test does not exist (Slice 3 not yet merged) | Fixed — switched to future tense + corrected path to `tests/test_chat_hermes.py::test_sse_edge_cases` |
| B2 | `docs/research/aichat.md` | `httpx` described as already in dep tree — not in `pyproject.toml` (Slice 1 not yet merged) | Fixed — rewrote to state Slice 1 will add `httpx>=0.27` |

**Warnings (all fixed in Round 2 pass):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `aichat.md` | `HERMES_API_SERVER_KEY` vs `API_SERVER_KEY` confusion | Clarified — kept `HERMES_API_SERVER_KEY` (correct in clm's `secrets.json` per `install.py:535`); explicitly noted it's rendered into hermes' `.env` as `API_SERVER_KEY` |
| W2 | `aichat.md` | Wrong `systemctl --user` scope | Fixed — system unit form (`systemctl status hermes-<name>.service`) |
| W3 | `aichat.md` | `features.chat.model` is a phantom field | Fixed — model selection now correctly mapped to `config.provider.default_model` (input) and `model.default` (output) |
| W4 | `aichat.md` | Present-tense description of unbuilt artifacts | Fixed — top-of-doc status callout + tense audit |
| W5 | `aichat.md` | "Revisit if sidecar" had no injection-safety checkpoint | Fixed — added stdin-only / no-`shell=True` bullet referencing PR #68 incident |
| W6 | `aichat.md` | Cleartext bearer over LAN unaddressed | Fixed — documented as deliberate trade gated by hermes' own `is_network_accessible` check (`gateway/platforms/api_server.py:3150-3169`) |
| W7 | `docs/index.md` | No discoverability path | Fixed — added "Design Decisions" section |
| W8 | `aichat.md` | Sidecar bearer leakage via `ps aux` / `/proc` not mentioned | Fixed — added "Secret exposure" Con |
| W9 | `aichat.md` | Sidecar PTY / SIGINT lifecycle not mentioned | Fixed — added "Subprocess lifecycle" Con |
| W10 | `.itx/334/01_EXECUTION.md` | "Linked from #322" not satisfied | Acknowledged — follow-up comment on #322 scheduled post-merge |
| W11 | `.itx/334/` | Missing `00_PLAN.md` | Acknowledged — deviation documented in `01_EXECUTION.md` preamble (plan lives in `.itx/322/00_PLAN.md`) |
| W12 | `.itx/334/01_EXECUTION.md` | No entry-criteria section | Fixed — added |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

| # | File | Warning | Action |
|---|------|---------|--------|
| W-R2-1 | `cli/chat.py:312-316` | `_sanitize_exception_text` Bearer-token regex gap (`\b(token\|auth\|password)\b\s*[:=]\s*` doesn't match `Authorization: Bearer <token>`) | Documented in the doc with the specific regex extension Slice 3 must apply; fix to the function itself is out of scope for this docs-only PR |
| W-R2-2 | `aichat.md` | `L3150` unattributed shorthand | Fixed — expanded to `gateway/platforms/api_server.py:3150-3169 (is_network_accessible guard)`; flagged `docs/agent-support/hermes.md:191` for Slice 1 follow-up |
| W-R2-3 | `aichat.md` | Residual model-mapping inaccuracy | Fixed — `config.provider.default_model` is `hosts.json` input, rendered as `model.default` in `~/.hermes/config.yaml` by `templates/config.yaml.j2:33-34` (read at line 8) |
| W-R2-4 | `.itx/322/00_PLAN.md:67,183` | Wrong `systemctl --user` in parent plan | Fixed — both occurrences corrected to system-scope form |
| W-R2-5 | `docs/index.md` | Link description present-tense | Fixed — future-tense + `(in progress — see #322)` |
| W-R2-6 | `aichat.md` | Three surviving present-tense verbs in Patterns section | Fixed — tense audit pass |
| W-R2-7 | `.itx/334/01_EXECUTION.md` | Scope expansion for `docs/index.md` not flagged | Fixed — added |

</details>

<details>
<summary>Review 3 Details (blocked — uncommitted state)</summary>

| # | Status | Resolution |
|---|--------|-----------|
| B1 (R3) | Fixed | All R2+R3 changes committed in `dea2408` and pushed |
| W-R3-1 | Fixed | `clm sources` → `clm will source` (final tense miss) |
| W-R3-2 | Fixed | Bearer regex prescription quantifier `{8,}` → `{1,}` (token length should not be a security feature) |

</details>

<details>
<summary>Review 4 Details (Rating 4/5 — final, merge-eligible)</summary>

Zero blockers. One warning (W-R4-1: no `@pytest.mark.xfail` anchor for the sanitizer gap) and four suggestions (`=` in Bearer char class, anchor rationale, `.service` suffix consistency, parametrize existing sanitize test) — all deferred to Slice 3 of #322 per ATX's own disposition.

Per-specialist ratings: security-secrets 4/5, cli-ux 4/5, test-coverage 3/5 (docs-only, no test surface), core-lifecycle N/A (max-turns timeout — not material for a docs commit).

Composite: 4/5 — clears the > 3/5 threshold.

</details>

Co-Authored-By: Claude <noreply@anthropic.com>