### PR TITLE
feat(chat): hermes chat end-to-end (single-turn, non-streaming) [Phase 1 of #322]

### DIFF
--- a/.itx/330/01_EXECUTION.md
+++ b/.itx/330/01_EXECUTION.md
@@ -1,0 +1,65 @@
+# Execution — Issue #330: Phase 1 (hermes chat E2E, single-turn, non-streaming)
+
+## Scope Implemented
+
+Phase 1 of #322, exactly as scoped:
+
+1. **`core/install.py:847-851`** — new hermes installs persist `agent_record.config.api_server.host == "0.0.0.0"` in hosts.json.
+2. **`core/lifecycle.py` hermes branch** — opportunistic migration: legacy `host == "127.0.0.1"` records are rewritten to `"0.0.0.0"` (in-memory + persisted via `update_host`) on the next `configure_agent` call. Idempotent — re-running on an already-migrated record is a no-op.
+3. **`core/registry.py`** — extended `FeaturesConfig` TypedDict + `_validate_features` with closed enum `chat: {type: Literal["openai", "websocket"]}`. Manifest validator rejects anything else.
+4. **Manifests** — `hermes/manifest.yaml` advertises `features.chat.type: openai`; `openclaw/manifest.yaml` advertises `features.chat.type: websocket`.
+5. **`pyproject.toml`** — added `httpx>=0.27` (async HTTP, needed because `requests` is sync-only).
+6. **`core/chat.py`** — extracted `ChatBackend` Protocol (async `connect`, `send_message`, `close`). `OpenClawChatClient` conforms with zero behavior change.
+7. **`core/chat_hermes.py`** (new) — `HermesOpenAIBackend`:
+   - `POST {base_url}/chat/completions` via `httpx.AsyncClient`, non-streaming (`stream: false`).
+   - `Authorization: Bearer <HERMES_API_SERVER_KEY>` header.
+   - Maps `httpx.ConnectError` → `ChatConnectionError`, `httpx.TimeoutException` → `ChatConnectionError`, 401/403 → `ChatAuthenticationError`, 5xx → `ChatProtocolError`.
+   - No history yet (phase 2 scope).
+8. **`cli/chat.py`** — replaced the openclaw type gate at L78 with dispatch by `features.chat.type` (`websocket` → `_build_openclaw_backend`, `openai` → `_build_hermes_backend`). Hermes backend constructor mirrors `lifecycle.py:734-771` for bearer lookup and `_reconstruct_gateway_url` for URL construction (uses `host_record.hostname` for the dial target, never `api_server.host`).
+
+## Notable Design Decisions
+
+- **Bearer lookup happens at the CLI layer**, not inside `HermesOpenAIBackend`. The backend takes an already-resolved `SecretStr`. This keeps the backend pure (no I/O at construction) and makes unit tests trivial via `httpx.MockTransport`.
+- **`_chat_loop` signature change**: now takes a `backend: ChatBackend` instead of openclaw-specific kwargs (gateway_url, auth_token, device_id, device_private_key). The renderer (`on_delta` + final-text handling) is unchanged — phase 1 hermes fires `on_delta` once with the full reply so the REPL UI works without modification.
+- **`api_server.host` is the bind, not the reach.** Even after the migration writes `"0.0.0.0"` to hosts.json, `_build_hermes_backend` constructs the URL from `host_record.hostname`. `0.0.0.0` is not a dial target.
+
+## Exit Criteria Status
+
+- [x] `clm chat <hermes-name>` plumbing wires backend correctly (unit-tested; manual roundtrip is in #322 Slice 1 acceptance).
+- [x] `clm chat <openclaw-name>` byte-for-byte unchanged — existing `tests/test_cli_chat.py` openclaw tests pass verbatim; `tests/test_core_chat.py` passes verbatim.
+- [x] Manifest validator rejects `features.chat.type` outside `{"openai", "websocket"}` (`test_load_manifest_rejects_unknown_chat_type` in `tests/test_registry.py`).
+- [x] New hermes installs persist `agent_record.config.api_server.host == "0.0.0.0"` (`test_install_hermes_persists_zero_bind_in_hosts_json` in `tests/test_install.py`).
+- [x] Existing hermes installs with `"127.0.0.1"` are migrated; second configure is a no-op (`TestHermesBindMigration` in `tests/test_hermes_configure.py`).
+- [x] `HERMES_API_SERVER_KEY` sourced from `secrets.json`; missing key produces friendly error (`TestHermesChat::test_missing_api_server_key`).
+- [x] `make test` green (1623 passed).
+- [x] `make lint` clean.
+- [ ] Manual verification (`ss -tlnp` on real hermes host) — deferred to deploy-time check by the operator; the migration runs on `clm agent configure <name>`.
+
+## Files Touched
+
+- Modified: `src/clawrium/core/install.py`, `src/clawrium/core/lifecycle.py`, `src/clawrium/core/registry.py`, `src/clawrium/core/chat.py`, `src/clawrium/cli/chat.py`, `src/clawrium/platform/registry/hermes/manifest.yaml`, `src/clawrium/platform/registry/openclaw/manifest.yaml`, `pyproject.toml`, `tests/test_cli_chat.py`, `tests/test_hermes_configure.py`, `tests/test_install.py`, `tests/test_registry.py`
+- New: `src/clawrium/core/chat_hermes.py`, `tests/test_chat_hermes.py`
+
+## Deferred (not in this PR)
+
+Per Slice 1 scope:
+- Multi-turn history (Slice 2 / phase 2).
+- SSE streaming (Slice 3 / phase 3).
+- Polished error messaging for `--session` warning, 401/403 remediation hints, service-down hints (Slice 4 / phase 4).
+- `docs/research/aichat.md` (Slice 5 / phase 5).
+
+---
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: execution
+**Skill**: /itx-execute
+**Timestamp**: 2026-05-11
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 330
+```
+
+</details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pyyaml>=6.0.0",
     "packaging>=24.0",
     "requests>=2.31.0",
+    "httpx>=0.27",
     "websockets>=12.0",
     "msgpack>=1.1.2",
     "textual>=3.0.0,<4.0.0",

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -56,7 +56,13 @@ def chat(
         "main",
         "--session",
         "-s",
-        help="Gateway session key (for example: main, direct:<channel>, or thread-specific key)",
+        help=(
+            "Gateway session key for WebSocket-backed agents "
+            "(for example: main, direct:<channel>, or thread-specific key). "
+            "OpenAI-backed agents (e.g. hermes) accept the flag but ignore it "
+            "in Phase 1 — server-side session routing is not wired through "
+            "/v1/chat/completions yet."
+        ),
     ),
     timeout: float = typer.Option(
         120.0,
@@ -99,6 +105,12 @@ def chat(
     display_host = (
         host_record.get("alias") or host_record.get("hostname") or "unknown-host"
     )
+    # `canonical_name` is the Unix-level agent name used in secret instance
+    # keys (host:type:name). Must NOT fall back to `agent_type` — that would
+    # mint a wrong instance_key (e.g. host:hermes:hermes) and the bearer
+    # lookup would silently miss the real entry.
+    canonical_name = agent_record.get("agent_name") or agent_name
+    # `display_agent` is for printing only; safe to fall back further.
     display_agent = (
         agent_record.get("agent_name")
         or agent_record.get("name")
@@ -118,7 +130,7 @@ def chat(
                 agent_record=agent_record,
                 host_record=host_record,
                 agent_type=agent_type,
-                agent_name=str(display_agent),
+                agent_name=str(canonical_name),
                 response_timeout_seconds=timeout,
             )
         else:

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -1,4 +1,10 @@
-"""Interactive chat command for OpenClaw agents."""
+"""Interactive chat command for installed agents.
+
+Dispatch is driven by `features.chat.type` in the agent manifest:
+
+- ``websocket`` → openclaw gateway over WebSocket (existing behavior).
+- ``openai``    → hermes (and future agents) over OpenAI-compatible HTTP.
+"""
 
 from __future__ import annotations
 
@@ -12,12 +18,20 @@ from rich.markup import escape as rich_escape
 
 from clawrium.core.chat import (
     ChatAuthenticationError,
+    ChatBackend,
     ChatConnectionError,
     ChatProtocolError,
     OpenClawChatClient,
     SecretStr,
 )
+from clawrium.core.chat_hermes import HermesOpenAIBackend
 from clawrium.core.hosts import get_agent_by_name, HostsFileCorruptedError
+from clawrium.core.registry import (
+    ManifestNotFoundError,
+    ManifestParseError,
+    load_manifest,
+)
+from clawrium.core.secrets import get_instance_key, get_instance_secrets
 
 console = Console()
 
@@ -75,19 +89,12 @@ def chat(
         raise typer.Exit(code=1)
 
     host_record, agent_type, agent_record = resolved
-    if agent_type != "openclaw":
-        console.print(
-            f"[red]Error:[/red] Chat is currently supported for OpenClaw only (got {rich_escape(agent_type)})"
-        )
-        raise typer.Exit(code=1)
 
     try:
-        gateway = _extract_gateway_config(agent_record, host_record)
+        chat_type = _resolve_chat_type(agent_type)
     except ValueError as exc:
         console.print(f"[red]Error:[/red] {rich_escape(str(exc))}")
         raise typer.Exit(code=1)
-    gateway_url = gateway["url"]
-    auth_token = SecretStr(gateway["auth"])
 
     display_host = (
         host_record.get("alias") or host_record.get("hostname") or "unknown-host"
@@ -96,24 +103,43 @@ def chat(
         agent_record.get("agent_name")
         or agent_record.get("name")
         or agent_name
-        or "openclaw"
+        or agent_type
     )
+
+    try:
+        if chat_type == "websocket":
+            backend = _build_openclaw_backend(
+                agent_record=agent_record,
+                host_record=host_record,
+                response_timeout_seconds=timeout,
+            )
+        elif chat_type == "openai":
+            backend = _build_hermes_backend(
+                agent_record=agent_record,
+                host_record=host_record,
+                agent_type=agent_type,
+                agent_name=str(display_agent),
+                response_timeout_seconds=timeout,
+            )
+        else:
+            console.print(
+                f"[red]Error:[/red] Chat is not supported for agent type "
+                f"'{rich_escape(agent_type)}'."
+            )
+            raise typer.Exit(code=1)
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] {rich_escape(str(exc))}")
+        raise typer.Exit(code=1)
 
     console.print(
         f"[green]Connected target:[/green] {rich_escape(str(display_agent))} on {rich_escape(str(display_host))}"
     )
     console.print("Type /exit or press Ctrl+D to end the chat session.")
 
-    device_id = gateway.get("device_id")
-    device_private_key = gateway.get("device_private_key")
-
     try:
         asyncio.run(
             _chat_loop(
-                gateway_url=str(gateway_url),
-                auth_token=auth_token,
-                device_id=device_id,
-                device_private_key=device_private_key,
+                backend=backend,
                 session_key=session,
                 response_timeout_seconds=timeout,
                 idle_timeout_seconds=idle_timeout,
@@ -140,23 +166,13 @@ def chat(
 
 
 async def _chat_loop(
-    gateway_url: str,
-    auth_token: SecretStr,
-    device_id: str | None,
-    device_private_key: str | None,
+    backend: ChatBackend,
     session_key: str,
     response_timeout_seconds: float,
     idle_timeout_seconds: float,
 ) -> None:
-    client = OpenClawChatClient(
-        gateway_url=gateway_url,
-        auth_token=auth_token,
-        device_id=device_id,
-        device_private_key=device_private_key,
-        timeout_seconds=response_timeout_seconds,
-    )
-    with console.status("Connecting to gateway...", spinner="dots"):
-        await client.connect()
+    with console.status("Connecting to agent...", spinner="dots"):
+        await backend.connect()
 
     try:
         while True:
@@ -190,7 +206,7 @@ async def _chat_loop(
                     shown_prefix = True
                 console.print(delta, end="", markup=False, highlight=False)
 
-            final_text = await client.send_message(
+            final_text = await backend.send_message(
                 message=message,
                 session_key=session_key,
                 on_delta=on_delta,
@@ -203,7 +219,7 @@ async def _chat_loop(
             else:
                 console.print("agent> [no response]", markup=False, highlight=False)
     finally:
-        await client.close()
+        await backend.close()
 
 
 async def _read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
@@ -215,6 +231,100 @@ async def _read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
     except TimeoutError:
         task.cancel()
         raise
+
+
+def _resolve_chat_type(agent_type: str) -> str:
+    """Read `features.chat.type` from the agent manifest.
+
+    Raises ValueError when the manifest cannot be loaded or does not advertise
+    chat support, so the caller can surface a friendly typer.Exit(1).
+    """
+    try:
+        manifest = load_manifest(agent_type)
+    except (ManifestNotFoundError, ManifestParseError) as exc:
+        raise ValueError(
+            f"Could not load manifest for agent type '{agent_type}': {exc}"
+        ) from exc
+
+    features = manifest.get("features") or {}
+    chat = features.get("chat") if isinstance(features, dict) else None
+    if not isinstance(chat, dict):
+        raise ValueError(
+            f"Chat is not supported for agent type '{agent_type}'."
+        )
+    chat_type = chat.get("type")
+    if not isinstance(chat_type, str) or not chat_type:
+        raise ValueError(
+            f"Chat is not supported for agent type '{agent_type}'."
+        )
+    return chat_type
+
+
+def _build_openclaw_backend(
+    agent_record: dict[str, Any],
+    host_record: dict[str, Any],
+    response_timeout_seconds: float,
+) -> ChatBackend:
+    gateway = _extract_gateway_config(agent_record, host_record)
+    return OpenClawChatClient(
+        gateway_url=gateway["url"],
+        auth_token=SecretStr(gateway["auth"]),
+        device_id=gateway.get("device_id"),
+        device_private_key=gateway.get("device_private_key"),
+        timeout_seconds=response_timeout_seconds,
+    )
+
+
+def _build_hermes_backend(
+    agent_record: dict[str, Any],
+    host_record: dict[str, Any],
+    agent_type: str,
+    agent_name: str,
+    response_timeout_seconds: float,
+) -> ChatBackend:
+    """Construct a HermesOpenAIBackend from the persisted hosts.json record.
+
+    - URL: `http://{host_record.hostname}:{api_server.port}/v1` — mirrors
+      openclaw's `_reconstruct_gateway_url`, which uses the host record's
+      reachable address rather than `api_server.host` (that's the bind, not
+      the dial target).
+    - Bearer: `secrets.json[<instance_key>].HERMES_API_SERVER_KEY` — mirrors
+      lifecycle.py:734-771.
+    """
+    config = agent_record.get("config")
+    if not isinstance(config, dict):
+        raise ValueError("Agent config missing. Re-run 'clm agent configure'.")
+    api_server = config.get("api_server")
+    if not isinstance(api_server, dict):
+        raise ValueError(
+            "Hermes api_server config missing. Re-run 'clm agent configure'."
+        )
+
+    port = api_server.get("port")
+    if not isinstance(port, int) or port <= 0:
+        raise ValueError(
+            "Hermes api_server.port missing or invalid. Re-run 'clm agent configure'."
+        )
+
+    hostname = host_record.get("hostname")
+    if not isinstance(hostname, str) or not hostname.strip():
+        raise ValueError("Host primary address not found.")
+
+    instance_key = get_instance_key(hostname, agent_type, agent_name)
+    secret_entry = get_instance_secrets(instance_key).get("HERMES_API_SERVER_KEY")
+    raw_token = secret_entry["value"] if secret_entry else None
+    if not isinstance(raw_token, str) or not raw_token.strip():
+        raise ValueError(
+            "HERMES_API_SERVER_KEY missing from secrets.json. "
+            "Re-run 'clm agent install --type hermes ...' to generate one."
+        )
+
+    base_url = f"http://{hostname}:{port}/v1"
+    return HermesOpenAIBackend(
+        base_url=base_url,
+        auth_token=SecretStr(raw_token),
+        timeout_seconds=response_timeout_seconds,
+    )
 
 
 def _extract_gateway_config(

--- a/src/clawrium/core/chat.py
+++ b/src/clawrium/core/chat.py
@@ -8,7 +8,7 @@ import json
 import time
 import uuid
 from collections import deque
-from typing import Any, Callable
+from typing import Any, Callable, Protocol, runtime_checkable
 from urllib.parse import urlparse
 
 import websockets
@@ -21,6 +21,7 @@ __all__ = [
     "ChatConnectionError",
     "ChatAuthenticationError",
     "ChatProtocolError",
+    "ChatBackend",
     "SecretStr",
     "OpenClawChatClient",
 ]
@@ -59,6 +60,29 @@ class SecretStr:
 
     def __str__(self) -> str:
         return "***"
+
+
+@runtime_checkable
+class ChatBackend(Protocol):
+    """Protocol implemented by transport-specific chat clients.
+
+    Implementations must be safely usable from `cli/chat.py:_chat_loop` —
+    connect once, send N messages, then close. `send_message` MUST invoke
+    `on_delta` for incremental output when streaming is supported, and return
+    the assembled final text when the turn completes.
+    """
+
+    async def connect(self) -> None: ...
+
+    async def send_message(
+        self,
+        message: str,
+        session_key: str,
+        on_delta: Callable[[str], None] | None = None,
+        response_timeout_seconds: float = 120.0,
+    ) -> str: ...
+
+    async def close(self) -> None: ...
 
 
 class OpenClawChatClient:

--- a/src/clawrium/core/chat_hermes.py
+++ b/src/clawrium/core/chat_hermes.py
@@ -1,0 +1,178 @@
+"""Hermes chat backend (OpenAI-compatible HTTP).
+
+Phase 1 scope: single-turn, non-streaming POST to /v1/chat/completions.
+Multi-turn history (phase 2), SSE streaming (phase 3), and polished error
+messaging (phase 4) land in follow-up slices of #322.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import httpx
+
+from clawrium.core.chat import (
+    ChatAuthenticationError,
+    ChatConnectionError,
+    ChatProtocolError,
+    SecretStr,
+)
+
+__all__ = ["HermesOpenAIBackend"]
+
+
+class HermesOpenAIBackend:
+    """OpenAI-compatible HTTP chat client for hermes.
+
+    `base_url` is the gateway origin including the `/v1` suffix
+    (e.g. `http://wolf-i.local:8642/v1`). The backend appends
+    `/chat/completions` for each request.
+
+    `model` is forwarded as the OpenAI `model` field. Hermes ignores it for
+    routing today but the wire format requires it; pass whatever string the
+    server is configured to accept (defaults to "hermes").
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        auth_token: SecretStr | str,
+        model: str = "hermes",
+        timeout_seconds: float = 120.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._auth_token = (
+            auth_token
+            if isinstance(auth_token, SecretStr)
+            else SecretStr(auth_token)
+        )
+        self._model = model
+        self._timeout_seconds = timeout_seconds
+        self._client: httpx.AsyncClient | None = None
+
+    async def connect(self) -> None:
+        """Open the underlying HTTP client.
+
+        No network call yet — keep the connect step cheap and let the first
+        `send_message` surface auth/connectivity errors. Slice 4 adds an
+        explicit health probe with a friendly remediation hint.
+        """
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._timeout_seconds)
+
+    async def close(self) -> None:
+        if self._client is not None:
+            try:
+                await self._client.aclose()
+            except Exception:
+                pass
+            self._client = None
+
+    async def send_message(
+        self,
+        message: str,
+        session_key: str = "main",
+        on_delta: Callable[[str], None] | None = None,
+        response_timeout_seconds: float = 120.0,
+    ) -> str:
+        """POST a single user message and return the assistant reply.
+
+        Phase 1 does not retain history across calls and does not stream.
+        `session_key` is accepted for signature parity with the openclaw
+        backend; it is ignored for OpenAI-typed agents (Slice 4 will surface a
+        dim warning for non-default values at the CLI layer).
+        `on_delta` is also accepted for signature parity and is invoked once
+        with the full reply so the existing renderer in `cli/chat.py` works
+        unchanged.
+        """
+        if self._client is None:
+            raise ChatConnectionError("Hermes chat backend not connected")
+
+        body: dict[str, Any] = {
+            "model": self._model,
+            "messages": [{"role": "user", "content": message}],
+            "stream": False,
+        }
+        headers = {
+            "Authorization": f"Bearer {self._auth_token.get_secret_value()}",
+            "Content-Type": "application/json",
+        }
+
+        url = f"{self._base_url}/chat/completions"
+        try:
+            response = await self._client.post(
+                url,
+                json=body,
+                headers=headers,
+                timeout=response_timeout_seconds,
+            )
+        except httpx.ConnectError as exc:
+            raise ChatConnectionError(
+                f"Failed to reach hermes at {self._base_url}: {exc}"
+            ) from exc
+        except httpx.TimeoutException as exc:
+            raise ChatConnectionError(
+                f"Timed out waiting for hermes response after "
+                f"{response_timeout_seconds}s"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise ChatConnectionError(f"HTTP error talking to hermes: {exc}") from exc
+
+        if response.status_code in (401, 403):
+            raise ChatAuthenticationError(
+                f"Hermes rejected bearer token ({response.status_code})"
+            )
+        if response.status_code >= 400:
+            raise ChatProtocolError(
+                f"Hermes returned HTTP {response.status_code}: "
+                f"{_short_body(response.text)}"
+            )
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise ChatProtocolError(
+                "Hermes returned non-JSON response to chat.completions"
+            ) from exc
+
+        text = _extract_assistant_text(payload)
+        if not text:
+            raise ChatProtocolError(
+                "Hermes response missing assistant content"
+            )
+
+        if on_delta is not None:
+            on_delta(text)
+        return text
+
+
+def _extract_assistant_text(payload: Any) -> str:
+    """Pull assistant text from an OpenAI-shaped chat.completions response."""
+    if not isinstance(payload, dict):
+        return ""
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return ""
+    first = choices[0]
+    if not isinstance(first, dict):
+        return ""
+    message = first.get("message")
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        return "".join(parts)
+    return ""
+
+
+def _short_body(body: str, limit: int = 200) -> str:
+    cleaned = body.strip().replace("\n", " ")
+    if len(cleaned) > limit:
+        return cleaned[:limit] + "..."
+    return cleaned

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -846,7 +846,7 @@ def run_installation(
                         h["agents"][agent_name]["config"] = {}
                     h["agents"][agent_name]["config"]["api_server"] = {
                         "enabled": True,
-                        "host": "127.0.0.1",
+                        "host": "0.0.0.0",
                         "port": 8642,
                     }
             return h

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -754,6 +754,34 @@ def configure_agent(
             )
 
         if isinstance(persisted_api_server, dict):
+            # Opportunistic migration: legacy hermes installs persisted
+            # host="127.0.0.1". The OpenAI-compatible gateway must bind a
+            # reachable interface so `clm chat <hermes>` works from any clm
+            # machine. Hermes' own startup check (api_server.py:3150) refuses
+            # to bind non-loopback unless a strong API_SERVER_KEY is set; we
+            # always generate a 64-char hex key, so the safety check passes.
+            # Rewrite in-memory and persist before merging.
+            if persisted_api_server.get("host") == "127.0.0.1":
+                persisted_api_server = {**persisted_api_server, "host": "0.0.0.0"}
+
+                def _migrate_bind(h: dict) -> dict:
+                    agents = h.get("agents") or {}
+                    record = agents.get(agent_key)
+                    if not isinstance(record, dict):
+                        return h
+                    config = record.get("config")
+                    if not isinstance(config, dict):
+                        return h
+                    api_server = config.get("api_server")
+                    if (
+                        isinstance(api_server, dict)
+                        and api_server.get("host") == "127.0.0.1"
+                    ):
+                        api_server["host"] = "0.0.0.0"
+                    return h
+
+                update_host(host["hostname"], _migrate_bind)
+
             existing_api_server = config_data.get("api_server") or {}
             if not isinstance(existing_api_server, dict):
                 existing_api_server = {}
@@ -765,7 +793,7 @@ def configure_agent(
             # alongside the token from secrets.json so the playbook can run.
             config_data["api_server"] = {
                 "enabled": True,
-                "host": "127.0.0.1",
+                "host": "0.0.0.0",
                 "port": 8642,
                 "key": api_server_key,
             }

--- a/src/clawrium/core/registry.py
+++ b/src/clawrium/core/registry.py
@@ -6,7 +6,7 @@ platform compatibility, onboarding metadata, and secret requirements.
 
 import logging
 import re
-from typing import Any, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 import yaml
 from packaging.version import InvalidVersion, Version
@@ -127,10 +127,17 @@ class WorkspaceConfig(TypedDict):
     memory_path: NotRequired[str]
 
 
+class ChatFeatureConfig(TypedDict):
+    """Chat capability descriptor."""
+
+    type: Literal["openai", "websocket"]
+
+
 class FeaturesConfig(TypedDict):
     """Capability flags advertised by an agent manifest."""
 
     memory: NotRequired[bool]
+    chat: NotRequired[ChatFeatureConfig]
 
 
 class AgentManifest(TypedDict):
@@ -495,6 +502,9 @@ def _validate_workspace(workspace_value: object, agent_type: str) -> WorkspaceCo
     return validated
 
 
+_ALLOWED_CHAT_TYPES = ("openai", "websocket")
+
+
 def _validate_features(features_value: object, agent_type: str) -> FeaturesConfig:
     """Validate features capability block."""
     features = _as_dict(features_value, "features", agent_type)
@@ -507,6 +517,18 @@ def _validate_features(features_value: object, agent_type: str) -> FeaturesConfi
                 agent_type, "has invalid `features.memory` (expected boolean)"
             )
         validated["memory"] = memory_flag
+
+    if "chat" in features:
+        chat_value = features["chat"]
+        chat_block = _as_dict(chat_value, "features.chat", agent_type)
+        chat_type = chat_block.get("type")
+        if chat_type not in _ALLOWED_CHAT_TYPES:
+            allowed = ", ".join(repr(t) for t in _ALLOWED_CHAT_TYPES)
+            _raise_parse_error(
+                agent_type,
+                f"has invalid `features.chat.type` (expected one of {allowed})",
+            )
+        validated["chat"] = {"type": chat_type}
 
     return validated
 

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -10,6 +10,9 @@ workspace:
 # Capability flags advertised by this manifest.
 features:
   memory: true
+  # Chat dispatch resolves to the OpenAI-compatible HTTP backend for hermes.
+  chat:
+    type: openai
 
 # Secrets configuration.
 # All provider keys are optional: Phase 1 installs the binary in an inert state.

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -44,9 +44,11 @@ secrets:
 #              AGENTS.md) inside ~/.hermes/ on the agent host; clm does not
 #              push identity files in this iteration. The wizard records this
 #              stage as SKIPPED and advances.
-#   channels   default `cli`. The api_server platform (loopback
-#              OpenAI-compatible HTTP API at 127.0.0.1:8642) is the local
-#              CLI-equivalent endpoint. External messaging gateways
+#   channels   default `cli`. The api_server platform exposes an
+#              OpenAI-compatible HTTP API on 0.0.0.0:8642 (all interfaces,
+#              bearer-token protected via HERMES_API_SERVER_KEY) so
+#              `clm chat <hermes>` can reach it at http://<host-ip>:8642/v1
+#              from any clm machine on the LAN. External messaging gateways
 #              (Discord/Slack/Telegram/etc.) are out of scope and tracked as a
 #              separate follow-up issue.
 #   validate   Composite shell-level check: `hermes --version` succeeds,
@@ -76,7 +78,7 @@ onboarding:
         - id: confirm_cli
           name: "Confirm CLI channel"
           type: confirm
-          message: "Hermes will use the loopback api_server platform on 127.0.0.1:8642 as its CLI-equivalent endpoint."
+          message: "Hermes will expose its OpenAI-compatible API on all interfaces (0.0.0.0:8642), bearer-token protected, reachable at http://<host-ip>:8642/v1 from any clm machine on the LAN."
           default: true
         - id: select_discord
           name: "Enable Discord channel (optional)"
@@ -105,7 +107,7 @@ onboarding:
         - id: health_check
           name: "Verify api_server /health returns 200"
           type: command
-          command: "curl -fsS http://127.0.0.1:8642/health"
+          command: "curl -fsS http://0.0.0.0:8642/health"
 
 # Note: The hermes installer is a single bash script served from
 # raw.githubusercontent.com at the pinned tag. The same script content is

--- a/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
@@ -206,7 +206,8 @@
       ansible.builtin.debug:
         msg: |
           Hermes agent '{{ agent_name }}' configured for provider '{{ config.provider.type | default('auto') }}'.
-          Local OpenAI-compatible API: http://127.0.0.1:{{ config.api_server.port | default(8642) | int }}
+          OpenAI-compatible API exposed on all interfaces (0.0.0.0:{{ config.api_server.port | default(8642) | int }}), bearer-token protected (HERMES_API_SERVER_KEY).
+          Reachable at http://<host-ip>:{{ config.api_server.port | default(8642) | int }}/v1 from any clm machine on the LAN.
           Service: hermes-{{ agent_name }}.service (active)
 
   handlers:

--- a/src/clawrium/platform/registry/openclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/openclaw/manifest.yaml
@@ -11,6 +11,9 @@ workspace:
 # Capability flags advertised by this manifest.
 features:
   memory: true
+  # Chat dispatch resolves to the WebSocket gateway client for openclaw.
+  chat:
+    type: websocket
 
 # Secrets configuration
 # Note: Provider-specific API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)

--- a/tests/test_chat_hermes.py
+++ b/tests/test_chat_hermes.py
@@ -1,0 +1,245 @@
+"""Unit tests for HermesOpenAIBackend (phase 1: non-streaming, single-turn)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from clawrium.core.chat import (
+    ChatAuthenticationError,
+    ChatConnectionError,
+    ChatProtocolError,
+    SecretStr,
+)
+from clawrium.core.chat_hermes import HermesOpenAIBackend
+
+
+def _build_backend(transport: httpx.MockTransport, **overrides: Any) -> HermesOpenAIBackend:
+    backend = HermesOpenAIBackend(
+        base_url=overrides.pop("base_url", "http://hermes.test:8642/v1"),
+        auth_token=overrides.pop("auth_token", SecretStr("token-abc")),
+        model=overrides.pop("model", "hermes"),
+        timeout_seconds=overrides.pop("timeout_seconds", 30.0),
+    )
+    # Replace the client created in connect() with one bound to the mock transport.
+    backend._client = httpx.AsyncClient(transport=transport, timeout=30.0)
+    return backend
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_happy_path_returns_assistant_content():
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content.decode())
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {"message": {"role": "assistant", "content": "hi from hermes"}}
+                ]
+            },
+        )
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        result = _run(backend.send_message("hello"))
+    finally:
+        _run(backend.close())
+
+    assert result == "hi from hermes"
+    assert captured["url"] == "http://hermes.test:8642/v1/chat/completions"
+    assert captured["headers"]["authorization"] == "Bearer token-abc"
+    assert captured["body"]["model"] == "hermes"
+    assert captured["body"]["stream"] is False
+    assert captured["body"]["messages"] == [
+        {"role": "user", "content": "hello"}
+    ]
+
+
+def test_send_message_invokes_on_delta_with_full_text():
+    """Phase 1 is non-streaming; on_delta is fired once with the entire reply so
+    the existing renderer in cli/chat.py works unchanged."""
+    deltas: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "complete reply"}}]},
+        )
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        _run(backend.send_message("ping", on_delta=deltas.append))
+    finally:
+        _run(backend.close())
+
+    assert deltas == ["complete reply"]
+
+
+def test_unauthorized_response_raises_auth_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, text="bad token")
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(ChatAuthenticationError, match="401"):
+            _run(backend.send_message("ping"))
+    finally:
+        _run(backend.close())
+
+
+def test_forbidden_response_raises_auth_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="forbidden")
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(ChatAuthenticationError, match="403"):
+            _run(backend.send_message("ping"))
+    finally:
+        _run(backend.close())
+
+
+def test_server_error_raises_protocol_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(ChatProtocolError, match="500"):
+            _run(backend.send_message("ping"))
+    finally:
+        _run(backend.close())
+
+
+def test_connect_error_raises_connection_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(ChatConnectionError, match="Failed to reach hermes"):
+            _run(backend.send_message("ping"))
+    finally:
+        _run(backend.close())
+
+
+def test_timeout_raises_connection_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("slow")
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(ChatConnectionError, match="Timed out"):
+            _run(backend.send_message("ping", response_timeout_seconds=0.5))
+    finally:
+        _run(backend.close())
+
+
+def test_send_without_connect_raises_connection_error():
+    backend = HermesOpenAIBackend(
+        base_url="http://hermes.test:8642/v1",
+        auth_token=SecretStr("tok"),
+    )
+    with pytest.raises(ChatConnectionError, match="not connected"):
+        _run(backend.send_message("ping"))
+
+
+def test_missing_choices_raises_protocol_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": []})
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(ChatProtocolError, match="missing assistant content"):
+            _run(backend.send_message("ping"))
+    finally:
+        _run(backend.close())
+
+
+def test_non_json_response_raises_protocol_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b"not json at all",
+            headers={"content-type": "text/plain"},
+        )
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(ChatProtocolError, match="non-JSON"):
+            _run(backend.send_message("ping"))
+    finally:
+        _run(backend.close())
+
+
+def test_base_url_trailing_slash_is_normalized():
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200, json={"choices": [{"message": {"content": "ok"}}]}
+        )
+
+    backend = _build_backend(
+        httpx.MockTransport(handler), base_url="http://hermes.test:8642/v1/"
+    )
+    try:
+        _run(backend.send_message("ping"))
+    finally:
+        _run(backend.close())
+
+    assert captured["url"] == "http://hermes.test:8642/v1/chat/completions"
+
+
+def test_content_blocks_list_is_concatenated():
+    """OpenAI-style content blocks (list of {type, text}) collapse to a string."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {
+                            "content": [
+                                {"type": "text", "text": "part one "},
+                                {"type": "text", "text": "part two"},
+                            ]
+                        }
+                    }
+                ]
+            },
+        )
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        result = _run(backend.send_message("ping"))
+    finally:
+        _run(backend.close())
+
+    assert result == "part one part two"
+
+
+def test_connect_is_idempotent():
+    """Repeated connect() calls do not replace an existing client (resource leak guard)."""
+    backend = HermesOpenAIBackend(
+        base_url="http://hermes.test:8642/v1",
+        auth_token=SecretStr("tok"),
+    )
+    _run(backend.connect())
+    first_client = backend._client
+    _run(backend.connect())
+    assert backend._client is first_client
+    _run(backend.close())

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -636,3 +636,88 @@ class TestHermesChat:
         assert result.exit_code == 0
         assert "0.0.0.0" not in captured["backend"]._base_url
         assert "wolf-i.lan" in captured["backend"]._base_url
+
+    def _setup_resolved_hermes(self, monkeypatch):
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_agent_by_name",
+            lambda _name: (self.HOST, "hermes", self.AGENT),
+        )
+        monkeypatch.setattr(
+            "clawrium.cli.chat._resolve_chat_type", lambda _agent_type: "openai"
+        )
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_instance_secrets",
+            lambda _key: {
+                "HERMES_API_SERVER_KEY": {
+                    "key": "HERMES_API_SERVER_KEY",
+                    "value": "f" * 64,
+                }
+            },
+        )
+
+    def test_service_unreachable(self, monkeypatch):
+        """ChatConnectionError from the backend surfaces as exit 1 with a
+        remediation hint (mirrors the openclaw connection-failure path)."""
+        from clawrium.core.chat import ChatConnectionError
+
+        self._setup_resolved_hermes(monkeypatch)
+
+        def fake_asyncio_run(_coro):
+            _coro.close()
+            raise ChatConnectionError("connection refused on 192.168.1.50:8642")
+
+        monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
+
+        result = runner.invoke(app, ["chat", "hermes-test"])
+
+        assert result.exit_code == 1
+        assert "connection failed" in result.output.lower()
+        assert "connection refused" in result.output.lower()
+        # Remediation hint must be present so the user knows what to do next.
+        assert "configure" in result.output.lower() or "install" in result.output.lower()
+
+    def test_authentication_failure(self, monkeypatch):
+        """ChatAuthenticationError from the backend surfaces as exit 1."""
+        from clawrium.core.chat import ChatAuthenticationError
+
+        self._setup_resolved_hermes(monkeypatch)
+
+        def fake_asyncio_run(_coro):
+            _coro.close()
+            raise ChatAuthenticationError("Hermes rejected bearer token (401)")
+
+        monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
+
+        result = runner.invoke(app, ["chat", "hermes-test"])
+
+        assert result.exit_code == 1
+        assert "authentication failed" in result.output.lower()
+        assert "401" in result.output
+
+
+# ---------------------------------------------------------------------------
+# ChatBackend Protocol conformance (W5) — both transports satisfy the Protocol
+# so the dispatch in cli/chat.py can pass either through `_chat_loop` without
+# transport-specific knowledge.
+# ---------------------------------------------------------------------------
+
+
+def test_openclaw_satisfies_chat_backend_protocol():
+    from clawrium.core.chat import ChatBackend, OpenClawChatClient, SecretStr
+
+    client = OpenClawChatClient(
+        gateway_url="ws://example.test:40123",
+        auth_token=SecretStr("token"),
+    )
+    assert isinstance(client, ChatBackend)
+
+
+def test_hermes_satisfies_chat_backend_protocol():
+    from clawrium.core.chat import ChatBackend, SecretStr
+    from clawrium.core.chat_hermes import HermesOpenAIBackend
+
+    backend = HermesOpenAIBackend(
+        base_url="http://example.test:8642/v1",
+        auth_token=SecretStr("token"),
+    )
+    assert isinstance(backend, ChatBackend)

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 
 from clawrium.cli import chat as chat_module
 from clawrium.cli.main import app
-from clawrium.core.chat import ChatProtocolError, SecretStr
+from clawrium.core.chat import ChatProtocolError
 from clawrium.core.hosts import HostsFileCorruptedError
 
 
@@ -65,8 +65,9 @@ def test_chat_reconstructs_gateway_url_from_current_host(monkeypatch):
 
     captured_args: dict[str, object] = {}
 
-    async def mock_chat_loop(gateway_url, **kwargs):
-        captured_args["gateway_url"] = gateway_url
+    async def mock_chat_loop(backend, **kwargs):
+        captured_args["backend"] = backend
+        captured_args["gateway_url"] = backend.gateway_url
 
     monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
 
@@ -96,8 +97,9 @@ def test_chat_reconstructs_gateway_url_preserves_wss_scheme(monkeypatch):
 
     captured_args: dict[str, object] = {}
 
-    async def mock_chat_loop(gateway_url, **kwargs):
-        captured_args["gateway_url"] = gateway_url
+    async def mock_chat_loop(backend, **kwargs):
+        captured_args["backend"] = backend
+        captured_args["gateway_url"] = backend.gateway_url
 
     monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
 
@@ -126,8 +128,9 @@ def test_chat_extracts_port_from_url_when_not_in_config(monkeypatch):
 
     captured_args: dict[str, object] = {}
 
-    async def mock_chat_loop(gateway_url, **kwargs):
-        captured_args["gateway_url"] = gateway_url
+    async def mock_chat_loop(backend, **kwargs):
+        captured_args["backend"] = backend
+        captured_args["gateway_url"] = backend.gateway_url
 
     monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
 
@@ -203,8 +206,9 @@ def test_chat_gateway_url_reconstruction_defaults_scheme_to_ws(monkeypatch):
 
     captured_args: dict[str, object] = {}
 
-    async def mock_chat_loop(gateway_url, **kwargs):
-        captured_args["gateway_url"] = gateway_url
+    async def mock_chat_loop(backend, **kwargs):
+        captured_args["backend"] = backend
+        captured_args["gateway_url"] = backend.gateway_url
 
     monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
 
@@ -239,7 +243,8 @@ def test_chat_handles_ambiguous_agent_name(monkeypatch):
     assert "ambiguous" in result.output.lower()
 
 
-def test_chat_rejects_non_openclaw_agent(monkeypatch):
+def test_chat_rejects_agent_without_chat_feature(monkeypatch):
+    """Agent types whose manifest does not declare `features.chat.type` are rejected."""
     host = {"hostname": "192.168.1.100", "alias": "server1"}
     agent = {
         "agent_name": "zc-work",
@@ -253,11 +258,20 @@ def test_chat_rejects_non_openclaw_agent(monkeypatch):
     monkeypatch.setattr(
         "clawrium.cli.chat.get_agent_by_name", lambda _name: (host, "zeroclaw", agent)
     )
+    # Force the resolver to behave as if zeroclaw advertises no chat feature, so
+    # this test stays meaningful even if zeroclaw's bundled manifest later opts
+    # into chat.
+    monkeypatch.setattr(
+        "clawrium.cli.chat._resolve_chat_type",
+        lambda agent_type: (_ for _ in ()).throw(
+            ValueError(f"Chat is not supported for agent type '{agent_type}'.")
+        ),
+    )
 
     result = runner.invoke(app, ["chat", "zc-work"])
 
     assert result.exit_code == 1
-    assert "supported for openclaw" in result.output.lower()
+    assert "not supported" in result.output.lower()
 
 
 def test_chat_invokes_async_loop(monkeypatch):
@@ -383,11 +397,6 @@ def test_chat_sanitizes_gateway_error_output(monkeypatch):
 
 def test_chat_loop_handles_idle_timeout_and_closes_client(monkeypatch):
     fake_client = FakeChatClient()
-    monkeypatch.setattr(
-        chat_module,
-        "OpenClawChatClient",
-        lambda *args, **kwargs: fake_client,
-    )
 
     async def fake_read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
         raise TimeoutError
@@ -396,10 +405,7 @@ def test_chat_loop_handles_idle_timeout_and_closes_client(monkeypatch):
 
     asyncio.run(
         chat_module._chat_loop(
-            gateway_url="ws://test-host:40123",
-            auth_token=SecretStr("token"),
-            device_id=None,
-            device_private_key=None,
+            backend=fake_client,
             session_key="main",
             response_timeout_seconds=30.0,
             idle_timeout_seconds=10.0,
@@ -434,11 +440,6 @@ class FakeChatClient:
 
 def test_chat_loop_sends_message_and_exits_on_command(monkeypatch):
     fake_client = FakeChatClient()
-    monkeypatch.setattr(
-        chat_module,
-        "OpenClawChatClient",
-        lambda *args, **kwargs: fake_client,
-    )
 
     inputs = iter(["   ", "hello", "/exit"])
 
@@ -449,10 +450,7 @@ def test_chat_loop_sends_message_and_exits_on_command(monkeypatch):
 
     asyncio.run(
         chat_module._chat_loop(
-            gateway_url="ws://test-host:40123",
-            auth_token=SecretStr("token"),
-            device_id=None,
-            device_private_key=None,
+            backend=fake_client,
             session_key="main",
             response_timeout_seconds=30.0,
             idle_timeout_seconds=10.0,
@@ -467,11 +465,6 @@ def test_chat_loop_sends_message_and_exits_on_command(monkeypatch):
 
 def test_chat_loop_handles_eof_and_closes_client(monkeypatch):
     fake_client = FakeChatClient()
-    monkeypatch.setattr(
-        chat_module,
-        "OpenClawChatClient",
-        lambda *args, **kwargs: fake_client,
-    )
 
     async def fake_read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
         raise EOFError
@@ -480,10 +473,7 @@ def test_chat_loop_handles_eof_and_closes_client(monkeypatch):
 
     asyncio.run(
         chat_module._chat_loop(
-            gateway_url="ws://test-host:40123",
-            auth_token=SecretStr("token"),
-            device_id=None,
-            device_private_key=None,
+            backend=fake_client,
             session_key="main",
             response_timeout_seconds=30.0,
             idle_timeout_seconds=10.0,
@@ -496,11 +486,6 @@ def test_chat_loop_handles_eof_and_closes_client(monkeypatch):
 
 def test_chat_loop_handles_keyboard_interrupt_and_closes_client(monkeypatch):
     fake_client = FakeChatClient()
-    monkeypatch.setattr(
-        chat_module,
-        "OpenClawChatClient",
-        lambda *args, **kwargs: fake_client,
-    )
 
     async def fake_read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
         raise KeyboardInterrupt
@@ -509,10 +494,7 @@ def test_chat_loop_handles_keyboard_interrupt_and_closes_client(monkeypatch):
 
     asyncio.run(
         chat_module._chat_loop(
-            gateway_url="ws://test-host:40123",
-            auth_token=SecretStr("token"),
-            device_id=None,
-            device_private_key=None,
+            backend=fake_client,
             session_key="main",
             response_timeout_seconds=30.0,
             idle_timeout_seconds=10.0,
@@ -521,3 +503,136 @@ def test_chat_loop_handles_keyboard_interrupt_and_closes_client(monkeypatch):
 
     assert fake_client.connected is True
     assert fake_client.closed is True
+
+
+# ---------------------------------------------------------------------------
+# Hermes chat dispatch — agents whose manifest advertises features.chat.type
+# == "openai" route to HermesOpenAIBackend instead of OpenClawChatClient.
+# ---------------------------------------------------------------------------
+
+
+class TestHermesChat:
+    """Phase 1 dispatch + secret hydration tests for hermes chat."""
+
+    HOST = {"hostname": "wolf-i.lan", "alias": "wolf-i"}
+    AGENT = {
+        "agent_name": "hermes-test",
+        "config": {
+            "api_server": {
+                "enabled": True,
+                "host": "0.0.0.0",
+                "port": 8642,
+            }
+        },
+    }
+
+    def _patch_resolve(self, monkeypatch, agent_type: str = "hermes"):
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_agent_by_name",
+            lambda _name: (self.HOST, agent_type, self.AGENT),
+        )
+        monkeypatch.setattr(
+            "clawrium.cli.chat._resolve_chat_type", lambda _agent_type: "openai"
+        )
+
+    def test_dispatches_to_hermes_backend(self, monkeypatch):
+        self._patch_resolve(monkeypatch)
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_instance_secrets",
+            lambda _key: {
+                "HERMES_API_SERVER_KEY": {
+                    "key": "HERMES_API_SERVER_KEY",
+                    "value": "a" * 64,
+                }
+            },
+        )
+
+        captured: dict[str, object] = {}
+
+        async def mock_chat_loop(backend, **kwargs):
+            captured["backend"] = backend
+
+        monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
+
+        result = runner.invoke(app, ["chat", "hermes-test"])
+
+        assert result.exit_code == 0
+        backend = captured["backend"]
+        # base_url is reconstructed from host_record.hostname (the reachable
+        # address) and api_server.port (the bind port). Note: api_server.host
+        # is the bind address, NOT the dial target.
+        assert backend._base_url == "http://wolf-i.lan:8642/v1"
+
+    def test_missing_api_server_key(self, monkeypatch):
+        """Missing HERMES_API_SERVER_KEY in secrets.json surfaces a friendly error."""
+        self._patch_resolve(monkeypatch)
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_instance_secrets", lambda _key: {}
+        )
+
+        result = runner.invoke(app, ["chat", "hermes-test"])
+
+        assert result.exit_code == 1
+        assert "hermes_api_server_key" in result.output.lower()
+        assert "re-run" in result.output.lower()
+
+    def test_missing_api_server_block(self, monkeypatch):
+        """Missing api_server config block surfaces a friendly error."""
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_agent_by_name",
+            lambda _name: (self.HOST, "hermes", {"agent_name": "hermes-test", "config": {}}),
+        )
+        monkeypatch.setattr(
+            "clawrium.cli.chat._resolve_chat_type", lambda _agent_type: "openai"
+        )
+
+        result = runner.invoke(app, ["chat", "hermes-test"])
+
+        assert result.exit_code == 1
+        assert "api_server" in result.output.lower()
+        assert "configure" in result.output.lower()
+
+    def test_url_uses_host_record_hostname_not_bind_address(self, monkeypatch):
+        """The dial target must come from host_record.hostname, never api_server.host.
+        After the bind migration, api_server.host is "0.0.0.0", which is not a valid
+        connect target — this guards the regression where someone might wire the
+        wrong field through."""
+        agent_with_zero_bind = {
+            "agent_name": "hermes-test",
+            "config": {
+                "api_server": {
+                    "enabled": True,
+                    "host": "0.0.0.0",  # bind, not reach
+                    "port": 8642,
+                }
+            },
+        }
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_agent_by_name",
+            lambda _name: (self.HOST, "hermes", agent_with_zero_bind),
+        )
+        monkeypatch.setattr(
+            "clawrium.cli.chat._resolve_chat_type", lambda _agent_type: "openai"
+        )
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_instance_secrets",
+            lambda _key: {
+                "HERMES_API_SERVER_KEY": {
+                    "key": "HERMES_API_SERVER_KEY",
+                    "value": "b" * 64,
+                }
+            },
+        )
+
+        captured: dict[str, object] = {}
+
+        async def mock_chat_loop(backend, **kwargs):
+            captured["backend"] = backend
+
+        monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
+
+        result = runner.invoke(app, ["chat", "hermes-test"])
+
+        assert result.exit_code == 0
+        assert "0.0.0.0" not in captured["backend"]._base_url
+        assert "wolf-i.lan" in captured["backend"]._base_url

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -1652,18 +1652,40 @@ class TestHermesBindMigration:
         assert sent["api_server"]["host"] == "0.0.0.0"
 
     def test_migration_is_idempotent(self, tmp_path: Path):
-        """A second configure on an already-migrated record makes no further
-        rewrite calls — host stays at 0.0.0.0 and no migration update_host fires."""
+        """A second configure on an already-migrated record makes no migration
+        write. configure_agent still performs its single post-Ansible persist
+        of the agent record (line 1137), so we expect exactly one update_host
+        call total — the persist, not a migration rewrite. A no-op migration
+        write would push the count to two and this assertion would catch it."""
         host, captured = self._run_configure("0.0.0.0", tmp_path)
 
         assert (
             host["agents"]["hermes-test"]["config"]["api_server"]["host"] == "0.0.0.0"
         )
-        # No update_host call should have rewritten the bind, because it was
-        # already 0.0.0.0. Any update_host calls made here must NOT change the
-        # host field.
-        for snapshot in captured["update_calls"]:
-            assert snapshot["host"] == "0.0.0.0"
+        # Exactly one update_host call: the final post-Ansible persist.
+        # If the migration block ever fires unnecessarily, count goes to 2.
+        assert len(captured["update_calls"]) == 1, (
+            f"expected 1 update_host call (post-Ansible persist only), "
+            f"got {len(captured['update_calls'])}: {captured['update_calls']}"
+        )
+        # And the persisted value is still 0.0.0.0 (sanity check).
+        assert captured["update_calls"][0]["host"] == "0.0.0.0"
+
+    def test_migration_pass_writes_twice(self, tmp_path: Path):
+        """On a legacy 127.0.0.1 record, configure_agent calls update_host
+        exactly twice: once for the migration rewrite, once for the
+        post-Ansible persist. This pairs with `test_migration_is_idempotent`
+        — together they prove the migration runs exactly when it should."""
+        _host, captured = self._run_configure("127.0.0.1", tmp_path)
+
+        assert len(captured["update_calls"]) == 2, (
+            f"expected 2 update_host calls (migration + post-Ansible persist), "
+            f"got {len(captured['update_calls'])}: {captured['update_calls']}"
+        )
+        # The migration write (first) and the persist (second) both end with
+        # host=0.0.0.0 because the migration mutates the fixture in place.
+        assert captured["update_calls"][0]["host"] == "0.0.0.0"
+        assert captured["update_calls"][1]["host"] == "0.0.0.0"
 
     def test_legacy_missing_api_server_block_uses_zero_bind_default(
         self, tmp_path: Path

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -413,7 +413,9 @@ class TestConfigureAgentApiServerKey:
         # value is now sourced from secrets.json, not hosts.json.
         sent_config = captured["inventory"]["all"]["vars"]["config"]
         assert sent_config["api_server"]["key"] == persisted_key
-        assert sent_config["api_server"]["host"] == "127.0.0.1"
+        # Migration: legacy 127.0.0.1 is rewritten to 0.0.0.0 so hermes binds a
+        # reachable interface (Phase 1 of #322 — `clm chat <hermes>` over LAN).
+        assert sent_config["api_server"]["host"] == "0.0.0.0"
         assert sent_config["api_server"]["port"] == 8642
 
     def test_hermes_reconfigure_does_not_rotate_persisted_key(self, tmp_path: Path):
@@ -613,9 +615,9 @@ class TestHermesApiServerKeySecretsHygiene:
         assert "key" not in persisted_api_server, (
             "hermes bearer token leaked into hosts.json: " f"{persisted_api_server}"
         )
-        # Non-sensitive shape is preserved.
+        # Non-sensitive shape is preserved (with the host migration applied).
         assert persisted_api_server.get("enabled") is True
-        assert persisted_api_server.get("host") == "127.0.0.1"
+        assert persisted_api_server.get("host") == "0.0.0.0"
         assert persisted_api_server.get("port") == 8642
 
     def test_configure_rejects_invalid_hex_key_in_secrets(self, tmp_path: Path):
@@ -1540,3 +1542,184 @@ class TestDiscordSecretRemoval:
             assert ik not in list_instances_with_secrets()
         finally:
             os.environ.pop("CLAWRIUM_CONFIG_DIR", None)
+
+
+# ---------------------------------------------------------------------------
+# Bind migration (Phase 1 of #322) — opportunistically rewrite legacy
+# host="127.0.0.1" to "0.0.0.0" in hosts.json on the next configure call.
+# ---------------------------------------------------------------------------
+
+
+class TestHermesBindMigration:
+    """Existing hermes installs with loopback bind get rewritten on configure."""
+
+    def _persisted_key_secret(self, key_value: str) -> dict:
+        return {
+            "HERMES_API_SERVER_KEY": {
+                "key": "HERMES_API_SERVER_KEY",
+                "value": key_value,
+                "created_at": "2026-05-10T00:00:00+00:00",
+                "updated_at": "2026-05-10T00:00:00+00:00",
+                "description": "",
+            }
+        }
+
+    def _make_host(self, host_value: str) -> dict:
+        return {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {
+                        "api_server": {
+                            "enabled": True,
+                            "host": host_value,
+                            "port": 8642,
+                        }
+                    },
+                }
+            },
+        }
+
+    def _run_configure(self, host_value: str, tmp_path: Path):
+        host = self._make_host(host_value)
+        config_data = {
+            "provider": {
+                "name": "p",
+                "type": "openrouter",
+                "default_model": "x",
+            },
+        }
+
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        captured = {"inventory": None, "update_calls": []}
+
+        def fake_update_host(hostname_arg, updater):
+            # Mutate the in-memory fixture so subsequent reads see the migration.
+            updated = updater(host)
+            captured["update_calls"].append(
+                updated["agents"]["hermes-test"]["config"]["api_server"].copy()
+            )
+            return True
+
+        def fake_run(**kwargs):
+            captured["inventory"] = kwargs["inventory"]
+            mock = MagicMock()
+            mock.status = "successful"
+            mock.events = []
+            return mock
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ),
+            patch("clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run),
+            patch(
+                "clawrium.core.lifecycle.update_host", side_effect=fake_update_host
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                return_value=self._persisted_key_secret("a" * 64),
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host", "hermes", config_data, agent_name="hermes-test"
+            )
+        assert success is True, error
+        return host, captured
+
+    def test_legacy_loopback_is_rewritten_to_zero_bind(self, tmp_path: Path):
+        """Persisted host=127.0.0.1 must be rewritten to 0.0.0.0 on configure."""
+        host, captured = self._run_configure("127.0.0.1", tmp_path)
+
+        # The in-memory fixture was mutated by the migration's update_host call.
+        assert (
+            host["agents"]["hermes-test"]["config"]["api_server"]["host"] == "0.0.0.0"
+        )
+        # The config sent to the playbook reflects the migrated bind.
+        sent = captured["inventory"]["all"]["vars"]["config"]
+        assert sent["api_server"]["host"] == "0.0.0.0"
+
+    def test_migration_is_idempotent(self, tmp_path: Path):
+        """A second configure on an already-migrated record makes no further
+        rewrite calls — host stays at 0.0.0.0 and no migration update_host fires."""
+        host, captured = self._run_configure("0.0.0.0", tmp_path)
+
+        assert (
+            host["agents"]["hermes-test"]["config"]["api_server"]["host"] == "0.0.0.0"
+        )
+        # No update_host call should have rewritten the bind, because it was
+        # already 0.0.0.0. Any update_host calls made here must NOT change the
+        # host field.
+        for snapshot in captured["update_calls"]:
+            assert snapshot["host"] == "0.0.0.0"
+
+    def test_legacy_missing_api_server_block_uses_zero_bind_default(
+        self, tmp_path: Path
+    ):
+        """If hosts.json has no api_server block at all (legacy/corrupted),
+        configure rebuilds defaults with host=0.0.0.0 — not the loopback we
+        used to ship with."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {},  # no api_server block
+                }
+            },
+        }
+        config_data = {
+            "provider": {"name": "p", "type": "openrouter", "default_model": "x"},
+        }
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        captured = {}
+
+        def fake_run(**kwargs):
+            captured["inventory"] = kwargs["inventory"]
+            mock = MagicMock()
+            mock.status = "successful"
+            mock.events = []
+            return mock
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ),
+            patch("clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run),
+            patch("clawrium.core.lifecycle.update_host", return_value=True),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                return_value=self._persisted_key_secret("b" * 64),
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host", "hermes", config_data, agent_name="hermes-test"
+            )
+
+        assert success is True, error
+        sent = captured["inventory"]["all"]["vars"]["config"]
+        assert sent["api_server"]["host"] == "0.0.0.0"
+        assert sent["api_server"]["port"] == 8642

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2019,3 +2019,113 @@ def test_install_openclaw_without_token_succeeds(monkeypatch, tmp_path):
     # Verify installation succeeded
     assert result["success"] is True
     assert result["error"] is None
+
+
+def test_install_hermes_persists_zero_bind_in_hosts_json(monkeypatch, tmp_path):
+    """New hermes installs must persist api_server.host == "0.0.0.0" so the
+    next configure picks up a network-reachable bind. The bearer token lives
+    in secrets.json, not hosts.json (B3 invariant)."""
+    from clawrium.core.install import run_installation
+    import clawrium.core.install
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mock_manifest = {
+        "name": "hermes",
+        "entries": [
+            {
+                "version": "2026.5.7",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc123",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.11"},
+                },
+            }
+        ],
+    }
+    monkeypatch.setattr(
+        clawrium.core.install, "load_manifest", lambda x: mock_manifest
+    )
+
+    compatible_host = {
+        "hostname": "test-host",
+        "port": 22,
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host", lambda x: compatible_host
+    )
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *a, **k: {
+            "compatible": True,
+            "matched_entry": mock_manifest["entries"][0],
+            "reasons": [],
+        },
+    )
+
+    key_file = tmp_path / "key"
+    key_file.write_text("k")
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda x: key_file
+    )
+
+    persistent_host = dict(compatible_host)
+    update_calls: list = []
+
+    def mock_update_host(hostname, updater):
+        nonlocal persistent_host
+        if "agents" not in persistent_host:
+            persistent_host["agents"] = {}
+        persistent_host = updater(persistent_host)
+        update_calls.append((hostname, persistent_host.copy()))
+        return True
+
+    monkeypatch.setattr(clawrium.core.install, "update_host", mock_update_host)
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", lambda h, c: True
+    )
+    monkeypatch.setattr(
+        clawrium.core.install, "get_instance_secrets", lambda _k: {}
+    )
+    set_calls: list = []
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "set_instance_secret",
+        lambda *a, **k: set_calls.append((a, k)) or True,
+    )
+
+    class SuccessfulResult:
+        status = "successful"
+
+        class Config:
+            artifact_dir = tmp_path / "artifacts"
+
+        config = Config()
+
+    import ansible_runner
+
+    monkeypatch.setattr(ansible_runner, "run", Mock(return_value=SuccessfulResult()))
+
+    result = run_installation("hermes", "test-host", name="hermes-test")
+
+    assert result["success"] is True
+
+    final = update_calls[-1][1]
+    api_server = final["agents"]["hermes-test"]["config"]["api_server"]
+    assert api_server["enabled"] is True
+    assert api_server["host"] == "0.0.0.0"
+    assert api_server["port"] == 8642
+    # B3 invariant: bearer never lands in hosts.json
+    assert "key" not in api_server

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -205,6 +205,66 @@ def test_load_manifest_negative_min_memory(monkeypatch):
         load_manifest("openclaw")
 
 
+def test_load_manifest_rejects_unknown_chat_type(monkeypatch):
+    """Manifest validator must reject `features.chat.type` outside the closed enum."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    manifest["features"] = {"chat": {"type": "bogus"}}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    with pytest.raises(ManifestParseError, match="features.chat.type"):
+        load_manifest("openclaw")
+
+
+def test_load_manifest_accepts_chat_type_openai(monkeypatch):
+    """`features.chat.type: openai` is a valid value and survives normalization."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    manifest["features"] = {"chat": {"type": "openai"}}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    loaded = load_manifest("openclaw")
+    assert loaded.get("features", {}).get("chat", {}).get("type") == "openai"
+
+
+def test_load_manifest_accepts_chat_type_websocket(monkeypatch):
+    """`features.chat.type: websocket` is a valid value and survives normalization."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    manifest["features"] = {"chat": {"type": "websocket"}}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    loaded = load_manifest("openclaw")
+    assert loaded.get("features", {}).get("chat", {}).get("type") == "websocket"
+
+
+def test_load_manifest_chat_block_must_be_object(monkeypatch):
+    """`features.chat` must be a dict, not a scalar — rejects sloppy YAML."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    manifest["features"] = {"chat": "openai"}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    with pytest.raises(ManifestParseError, match="features.chat"):
+        load_manifest("openclaw")
+
+
+def test_hermes_manifest_declares_chat_openai():
+    """The bundled hermes manifest must advertise the OpenAI chat backend."""
+    manifest = load_manifest("hermes")
+    assert manifest.get("features", {}).get("chat", {}).get("type") == "openai"
+
+
+def test_openclaw_manifest_declares_chat_websocket():
+    """The bundled openclaw manifest must advertise the WebSocket chat backend."""
+    manifest = load_manifest("openclaw")
+    assert manifest.get("features", {}).get("chat", {}).get("type") == "websocket"
+
+
 def test_list_claws():
     """Test list_claws returns openclaw and zeroclaw."""
     claws = list_claws()

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,20 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -299,6 +313,7 @@ source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },
     { name = "fuzzyfinder" },
+    { name = "httpx" },
     { name = "msgpack" },
     { name = "packaging" },
     { name = "paramiko" },
@@ -322,6 +337,7 @@ dev = [
 requires-dist = [
     { name = "ansible-runner", specifier = ">=2.4.0" },
     { name = "fuzzyfinder", specifier = ">=2.1.0,<3.0.0" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "msgpack", specifier = ">=1.1.2" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "paramiko", specifier = ">=3.0.0" },
@@ -559,6 +575,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3c/16/27e312d2b4bdb9f5101b68031048d790edd348a31ee80c3f77066c04d311/fuzzyfinder-2.3.0.tar.gz", hash = "sha256:3d2de6650852fdf3da896917b2fe88550d854dda590de5f239c2899f7eaf20df", size = 78588, upload-time = "2025-04-20T22:20:43.731Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/c3/e64d5e277373e93b75d9711e46dd7903887e8efa8ecc033e2c5df760e309/fuzzyfinder-2.3.0-py3-none-any.whl", hash = "sha256:4ee35618ca6e1562a235d0f40f594b36ae374e55650a251d52add353b7e3f215", size = 19303, upload-time = "2025-04-20T22:20:41.966Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Foundation slice for `clm chat <hermes-name>`: hermes gateway now binds `0.0.0.0` (gated by the existing 64-char `HERMES_API_SERVER_KEY`), chat dispatch is driven by `features.chat.type` in the manifest, and a new `HermesOpenAIBackend` speaks `POST /v1/chat/completions` over `httpx`.
- Existing `host: "127.0.0.1"` records are migrated to `"0.0.0.0"` opportunistically on the next `clm agent configure <name>` — idempotent on subsequent runs.
- `OpenClawChatClient` is unchanged in behavior; it now conforms to a new `ChatBackend` Protocol so the REPL loop in `cli/chat.py` is transport-agnostic.

## What's NOT in this PR (deferred per the parent plan)
- Multi-turn history → Slice 2.
- SSE streaming → Slice 3.
- Polished error messages for 401/403, service-down, and `--session`-with-hermes → Slice 4.
- `docs/research/aichat.md` → Slice 5.

## Testing

### Test Results
- [x] All existing tests pass (`make test` — 1628 passed)
- [x] Linter passes (`make lint` clean)
- [x] New tests added for new functionality

### Test Coverage
- New: `tests/test_chat_hermes.py` — `HermesOpenAIBackend` unit tests via `httpx.MockTransport` (happy path, 401/403, 5xx, ConnectError, ReadTimeout, missing-choices, non-JSON, content-blocks list, base-url normalization, connect idempotency).
- New: `tests/test_cli_chat.py::TestHermesChat` — dispatch by `features.chat.type=="openai"`, missing-`HERMES_API_SERVER_KEY` friendly error, missing `api_server` block error, URL uses `host_record.hostname` (not `api_server.host`), `test_service_unreachable`, `test_authentication_failure`.
- New: `tests/test_hermes_configure.py::TestHermesBindMigration` — `127.0.0.1 -> 0.0.0.0` rewrite, exactly-1 update_host call on the no-op idempotent path, exactly-2 on the migration path.
- New: `tests/test_install.py::test_install_hermes_persists_zero_bind_in_hosts_json`.
- New: `tests/test_registry.py` — closed-enum validation for `features.chat.type` (reject unknown, accept `openai`/`websocket`, reject non-object `features.chat`, smoke-check the bundled manifests).
- New: Protocol conformance tests for both `OpenClawChatClient` and `HermesOpenAIBackend`.

### Manual Testing
- Manual `clm chat <hermes-name>` roundtrip from a separate clm machine, and `ss -tlnp` confirming `0.0.0.0:8642`, are part of Exit Criteria. They require a real hermes install + configure pass — defer to the operator who deploys this change.

### Security Checklist
- [x] No hardcoded secrets or credentials (bearer hydrates from `secrets.json`; never persisted to `hosts.json` — B3 invariant unchanged).
- [x] Input validation for user-provided data (chat type validated at manifest load time via closed enum).
- [x] No SQL injection, XSS, or command injection risks.
- [x] Dependencies are from trusted sources (`httpx>=0.27` — FastAPI-ecosystem standard, BSD-licensed).

## ATX Review Summary

**Final Review: Rating 3.5/5**
**Total Cost: $4.24 | Total Time: 17m 46s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1 | All fixed in `e9d3a12` | $2.68 | 9m 33s | leader, ansible-playbook-reviewer (3/5), cli-ux-reviewer (3/5), core-lifecycle-reviewer (FAILED), security-secrets-reviewer (FAILED), test-coverage-reviewer (2/5) |
| 2 | 3.5/5 | None | New non-blocking warnings (see below) | $1.56 | 8m 13s | leader, ansible-playbook-reviewer, cli-ux-reviewer, core-lifecycle-reviewer (FAILED), security-secrets-reviewer, test-coverage-reviewer |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_cli_chat.py` | Missing CLI error-handler tests for hermes (`ChatConnectionError` and `ChatAuthenticationError` paths at `cli/chat.py:148-160`) | Fixed — `test_service_unreachable` (`tests/test_cli_chat.py:658`) + `test_authentication_failure` (`tests/test_cli_chat.py:679`) added to `TestHermesChat` |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `src/clawrium/platform/registry/hermes/manifest.yaml` (L47-51 comment, L79 confirm.message, L108 curl probe) | Stale `loopback` / `127.0.0.1` strings — must reflect the new bind | Fixed — all three references updated to `0.0.0.0:8642` with bearer-token + LAN-URL phrasing |
| W2 | `src/clawrium/platform/registry/hermes/playbooks/configure.yaml:208-210` | Success message advertised `http://127.0.0.1:...` | Fixed — message at L206-210 now reflects 0.0.0.0 bind + bearer requirement + LAN-reachable URL |
| W3 | `src/clawrium/cli/chat.py:103-107, 121` | `display_agent` (which falls back through `agent_type`) was being passed as `agent_name` into `get_instance_key`, producing a wrong key | Fixed (architecturally) — `canonical_name = agent_record.get("agent_name") or agent_name` (chat.py:112) drives the secret lookup; `display_agent` remains print-only |
| W4 | `src/clawrium/cli/chat.py:55-60` | `--session` help text was openclaw-specific | Fixed — help text now distinguishes WebSocket-backed routing vs. OpenAI-backed accept-and-ignore behaviour in Phase 1 (UNCONFIRMED: core-lifecycle specialist hit max-turns in Review 2; manual verify recommended) |
| W5 | `tests/test_cli_chat.py` | `ChatBackend` Protocol conformance untested | Fixed — `test_openclaw_satisfies_chat_backend_protocol` and `test_hermes_satisfies_chat_backend_protocol` added via `isinstance(..., ChatBackend)` (L705-723) |
| W6 | `tests/test_hermes_configure.py::test_migration_is_idempotent` | Idempotency test only checked end-state, not call counts | Fixed — now asserts exactly 1 `update_host` call for the no-op path; companion `test_migration_pass_writes_twice` asserts exactly 2 for the legacy 127.0.0.1 path |

</details>

<details>
<summary>Review 2 Details (Rating 3.5/5)</summary>

**Blocking Issues:** None.

**Resolutions verified by Review 2:**

| # | Status |
|---|--------|
| B1 | RESOLVED — `test_service_unreachable` (L658) + `test_authentication_failure` (L679) confirmed in `TestHermesChat` |
| W1 | RESOLVED — every `127.0.0.1` / loopback string in `manifest.yaml` updated to `0.0.0.0` + LAN URLs |
| W2 | RESOLVED — `configure.yaml:206-210` success message confirmed |
| W3 | RESOLVED (architecturally) — `canonical_name` fix at `cli/chat.py:112` is correct; see new warning W3-followup below |
| W4 | UNCONFIRMED — `core-lifecycle-reviewer` failed (max turns, both attempts); manual verify of `cli/chat.py:55-60` `--session` help text recommended |
| W5 | RESOLVED — `test_*_satisfies_chat_backend_protocol` added (L705-723) |
| W6 | RESOLVED — idempotency test now asserts call counts (1 for already-migrated, 2 for legacy) |

**New non-blocking warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W3-followup | `tests/test_cli_chat.py::TestHermesChat` | Fixtures hard-code `agent_name` and mock `get_instance_secrets` as a key-ignoring `lambda`, so the W3 fix can't regress *through the tests* — i.e. a future regression would slip past. Suggest adding `test_canonical_name_uses_agent_name_param_not_agent_type` that asserts the exact instance_key constructed for lookup. | Acknowledged — track in follow-up |
| pre-existing | `src/clawrium/core/chat_hermes.py::HermesOpenAIBackend.send_message` | Error-path coverage incomplete (pre-existing, not introduced by this PR) | Acknowledged — track in follow-up |

**Specialist coverage**

| Specialist | Status |
|------------|--------|
| ansible-playbook-reviewer | ✅ Complete |
| cli-ux-reviewer | ✅ Complete |
| core-lifecycle-reviewer | ❌ Failed (max turns, both attempts) |
| security-secrets-reviewer | ✅ Complete |
| test-coverage-reviewer | ✅ Complete |

</details>

## Reviewer Notes
- **`api_server.host` is the bind, not the reach.** `_build_hermes_backend` in `cli/chat.py` constructs the dial URL from `host_record.hostname` — exact mirror of openclaw's `_reconstruct_gateway_url`. The migrated `0.0.0.0` is never used as a connect target.
- **Bind change exposes the port to the LAN.** Hermes' own startup safety check (`api_server.py:3150`, verified against tag `v2026.5.7`) refuses to bind non-loopback unless a strong, non-placeholder `API_SERVER_KEY` is configured. We always generate one (`secrets.token_hex(32)`), so the safety check passes. Threat model parity with openclaw's existing `bind: "lan"`.
- **`_chat_loop` signature change** — now takes `backend: ChatBackend` instead of openclaw-specific kwargs. Existing openclaw tests that mocked `OpenClawChatClient` were updated to pass a fake backend directly.
- **Manual verify recommended**: `cli/chat.py:55-60` `--session` help text (W4) — Review 2's `core-lifecycle-reviewer` failed on both attempts and could not confirm.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
