### PR TITLE
fix(322): recover #339 friendly-errors changes lost to wrong base branch

### DIFF
--- a/.itx/333/01_EXECUTION.md
+++ b/.itx/333/01_EXECUTION.md
@@ -1,0 +1,59 @@
+# Execution — Issue #333: Phase 4: failures are obvious and recoverable
+
+## Summary
+
+Implemented friendly error messages and remediation hints for hermes (OpenAI-typed) chat failures, ensuring no raw `httpx` exception text leaks to the user.
+
+## Changes
+
+### `src/clawrium/core/chat_hermes.py`
+- Dropped raw `httpx` exception text from `ChatConnectionError` messages. Internal transport details (errno codes, socket addrs, file paths) no longer reach the CLI layer. Friendly remediation belongs to the CLI; the backend stays terse.
+
+### `src/clawrium/cli/chat.py`
+- Added a dim `--session` no-op warning for OpenAI-typed agents when the value differs from `main`. Chat continues regardless (signature parity with openclaw).
+- Branched the error handlers by `chat_type`:
+  - `openai` + `ChatAuthenticationError` → "Token mismatch. Re-run `clm agent configure <name>`."
+  - `openai` + `ChatConnectionError` → "Check `systemctl --user status hermes-<name>` on the agent host." Adds a legacy-bind hint when persisted `api_server.host == "127.0.0.1"` (pre-migration installs).
+  - `websocket` path unchanged.
+
+### `tests/test_cli_chat.py`
+- `test_service_unreachable` — refined to assert the systemctl hint and absence of legacy hint under the standard 0.0.0.0 bind.
+- `test_service_unreachable_legacy_bind_hint` — new; pre-migration `127.0.0.1` bind surfaces the configure hint.
+- `test_401_remediation` — renamed/replaced the prior `test_authentication_failure`; asserts the "Re-run `clm agent configure <name>`" message.
+- `test_session_flag_warns_for_hermes` + `test_session_flag_default_does_not_warn` — covers the non-default-session warning and confirms the happy path stays quiet.
+- `test_connection_error_does_not_leak_httpx_internals` — CLI-level sanitizer guard.
+
+### `tests/test_chat_hermes.py`
+- `test_connection_error_does_not_leak_httpx_internals` — backend-level sanitizer guard for `httpx.ConnectError` with internal text.
+- `test_http_error_does_not_leak_httpx_internals` — same for generic `httpx.HTTPError`.
+
+## Verification
+
+- `make test` — 1634 passed.
+- `make lint` — clean.
+
+## Exit Criteria Mapping
+
+| Exit Criterion | Covered by |
+|---|---|
+| `test_service_unreachable` — connection refused → friendly remediation; legacy-bind hint when applicable | `test_service_unreachable` + `test_service_unreachable_legacy_bind_hint` |
+| `test_401_remediation` — 401/403 → "Re-run `clm agent configure`" | `test_401_remediation` |
+| `test_session_flag_warns_for_hermes` — non-default `--session` → dim warning | `test_session_flag_warns_for_hermes` |
+| No raw `httpx` exception strings reach the user | Backend sanitizer tests (`test_chat_hermes.py`) + CLI guard (`test_connection_error_does_not_leak_httpx_internals`) |
+| `make test` green; `make lint` clean | Verified |
+
+## Prompt Log
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-11T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 333
+```
+
+</details>

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -131,6 +131,14 @@ def chat(
                 response_timeout_seconds=timeout,
             )
         elif chat_type == "openai":
+            # `--session` has no server-side effect for OpenAI-typed agents in
+            # phase 1 (history is client-side). Warn dim once so the user
+            # understands the flag is accepted but ignored; chat continues.
+            if session != "main":
+                console.print(
+                    "[dim]`--session` is a no-op for OpenAI-typed agents "
+                    "(phase 1 has no server-side session routing).[/dim]"
+                )
             backend = _build_hermes_backend(
                 agent_record=agent_record,
                 host_record=host_record,
@@ -172,14 +180,40 @@ def chat(
         console.print(
             f"[red]Authentication failed:[/red] {rich_escape(_sanitize_exception_text(exc))}"
         )
+        if chat_type == "openai":
+            console.print(
+                f"Token mismatch. Re-run 'clm agent configure {rich_escape(str(canonical_name))}'."
+            )
         raise typer.Exit(code=1)
     except ChatConnectionError as exc:
         console.print(
             f"[red]Connection failed:[/red] {rich_escape(_sanitize_exception_text(exc))}"
         )
-        console.print(
-            "Verify the host is online and the recorded gateway URL/token are current (re-run configure/install if needed)."
-        )
+        if chat_type == "openai":
+            console.print(
+                f"Check 'systemctl --user status hermes-{rich_escape(str(canonical_name))}' on the agent host."
+            )
+            # Legacy install hint: persisted bind still on loopback means the
+            # opportunistic 127.0.0.1 → 0.0.0.0 migration in lifecycle hasn't
+            # run for this agent yet. Re-running configure flips it.
+            api_server = (
+                agent_record.get("config", {}).get("api_server")
+                if isinstance(agent_record.get("config"), dict)
+                else None
+            )
+            if (
+                isinstance(api_server, dict)
+                and api_server.get("host") == "127.0.0.1"
+            ):
+                console.print(
+                    f"Legacy bind detected (127.0.0.1). "
+                    f"Re-run 'clm agent configure {rich_escape(str(canonical_name))}' "
+                    f"to bind a reachable interface."
+                )
+        else:
+            console.print(
+                "Verify the host is online and the recorded gateway URL/token are current (re-run configure/install if needed)."
+            )
         raise typer.Exit(code=1)
     except ChatProtocolError as exc:
         console.print(

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -131,14 +131,6 @@ def chat(
                 response_timeout_seconds=timeout,
             )
         elif chat_type == "openai":
-            # `--session` has no server-side effect for OpenAI-typed agents in
-            # phase 1 (history is client-side). Warn dim once so the user
-            # understands the flag is accepted but ignored; chat continues.
-            if session != "main":
-                console.print(
-                    "[dim]`--session` is a no-op for OpenAI-typed agents "
-                    "(phase 1 has no server-side session routing).[/dim]"
-                )
             backend = _build_hermes_backend(
                 agent_record=agent_record,
                 host_record=host_record,
@@ -155,6 +147,16 @@ def chat(
     except ValueError as exc:
         console.print(f"[red]Error:[/red] {rich_escape(str(exc))}")
         raise typer.Exit(code=1)
+
+    # Emit the `--session` no-op notice only after backend construction
+    # succeeds so the user doesn't see a misleading "chat is about to start"
+    # warning followed by a hard error.
+    if chat_type == "openai" and session != "main":
+        console.print(
+            "[dim]`--session` is accepted but has no effect for this agent type "
+            "— conversation history is in-memory only and will not be routed to "
+            "a named session.[/dim]"
+        )
 
     console.print(
         f"[green]Connected target:[/green] {rich_escape(str(display_agent))} on {rich_escape(str(display_host))}"
@@ -190,26 +192,36 @@ def chat(
             f"[red]Connection failed:[/red] {rich_escape(_sanitize_exception_text(exc))}"
         )
         if chat_type == "openai":
-            console.print(
-                f"Check 'systemctl --user status hermes-{rich_escape(str(canonical_name))}' on the agent host."
-            )
-            # Legacy install hint: persisted bind still on loopback means the
-            # opportunistic 127.0.0.1 → 0.0.0.0 migration in lifecycle hasn't
-            # run for this agent yet. Re-running configure flips it.
-            api_server = (
-                agent_record.get("config", {}).get("api_server")
-                if isinstance(agent_record.get("config"), dict)
-                else None
-            )
-            if (
-                isinstance(api_server, dict)
-                and api_server.get("host") == "127.0.0.1"
-            ):
+            # The backend uses two distinct ChatConnectionError messages:
+            # - "Failed to reach hermes at <url>" for connect-refused / DNS
+            # - "Timed out waiting for hermes response after Ns" for timeouts
+            # A genuine timeout means the service is up but slow; the right
+            # remediation is `--timeout`, not `systemctl`.
+            if str(exc).startswith("Timed out"):
                 console.print(
-                    f"Legacy bind detected (127.0.0.1). "
-                    f"Re-run 'clm agent configure {rich_escape(str(canonical_name))}' "
-                    f"to bind a reachable interface."
+                    f"Try a higher --timeout value (current: {timeout}s)."
                 )
+            else:
+                console.print(
+                    f"Check 'systemctl --user status hermes-{rich_escape(str(canonical_name))}' on the agent host."
+                )
+                # Legacy install hint: persisted bind still on loopback means the
+                # opportunistic 127.0.0.1 → 0.0.0.0 migration in lifecycle hasn't
+                # run for this agent yet. Re-running configure flips it.
+                api_server = (
+                    agent_record.get("config", {}).get("api_server")
+                    if isinstance(agent_record.get("config"), dict)
+                    else None
+                )
+                if (
+                    isinstance(api_server, dict)
+                    and api_server.get("host") == "127.0.0.1"
+                ):
+                    console.print(
+                        f"Legacy bind detected (127.0.0.1). "
+                        f"Re-run 'clm agent configure {rich_escape(str(canonical_name))}' "
+                        f"to bind a reachable interface."
+                    )
         else:
             console.print(
                 "Verify the host is online and the recorded gateway URL/token are current (re-run configure/install if needed)."
@@ -418,11 +430,15 @@ def _build_hermes_backend(
 
     instance_key = get_instance_key(hostname, agent_type, agent_name)
     secret_entry = get_instance_secrets(instance_key).get("HERMES_API_SERVER_KEY")
-    raw_token = secret_entry["value"] if secret_entry else None
+    # `.get("value")` not `["value"]`: a truthy-but-malformed entry (no
+    # "value" field) would otherwise raise KeyError and escape the outer
+    # `except ValueError` handler, dumping a traceback to the user.
+    raw_token = secret_entry.get("value") if secret_entry else None
     if not isinstance(raw_token, str) or not raw_token.strip():
         raise ValueError(
             "HERMES_API_SERVER_KEY missing from secrets.json. "
-            "Re-run 'clm agent install --type hermes ...' to generate one."
+            f"Re-run 'clm agent install --type {agent_type} --host {hostname}' "
+            "to regenerate the API key."
         )
 
     base_url = f"http://{hostname}:{port}/v1"
@@ -543,6 +559,15 @@ def _sanitize_exception_text(exc: Exception, max_len: int = 500) -> str:
     cleaned = re.sub(
         r"(?i)\b([A-Za-z0-9_]*(?:token|auth|password|key|bearer|secret|apikey|authorization)[A-Za-z0-9_]*)\s*[:=]\s*([^\s,;]+)",
         r"\1=***",
+        cleaned,
+    )
+    # Bearer scheme uses a space separator and is not covered by the
+    # token=/auth= pattern above. Mask the credential, keep the scheme word.
+    cleaned = re.sub(r"(?i)\bbearer\s+(\S+)", "Bearer ***", cleaned)
+    # api_key / api-key / apikey variants with = or : separator.
+    cleaned = re.sub(
+        r"(?i)\bapi[_-]?key\s*[:=]\s*([^\s,;]+)",
+        "api_key=***",
         cleaned,
     )
     return cleaned[:max_len]

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -539,7 +539,18 @@ def _validate_session_key(session_key: str) -> None:
 
 
 def _sanitize_exception_text(exc: Exception, max_len: int = 500) -> str:
-    cleaned = re.sub(r"[\x00-\x1f\x7f-\x9f]", " ", str(exc))
+    # Strip C0/C1 control bytes AND Unicode bidi-formatting + zero-width
+    # codepoints. The bidi/zero-width additions close the W-A bypass:
+    # otherwise a remote-supplied error message can embed RTLO (U+202E) /
+    # ZWSP / BOM to flip the visible order or hide payloads in copy-paste.
+    cleaned = re.sub(
+        r"[\x00-\x1f\x7f-\x9f"
+        r"​-‍⁠﻿"
+        r"‪-‮⁦-⁩"
+        r"]",
+        " ",
+        str(exc),
+    )
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
     # First pass: redact `<scheme> <value>` header forms like
     # `Authorization: Bearer abc-123` and the shorthand `bearer abc-123`.

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -540,14 +540,19 @@ def _validate_session_key(session_key: str) -> None:
 
 def _sanitize_exception_text(exc: Exception, max_len: int = 500) -> str:
     # Strip C0/C1 control bytes AND Unicode bidi-formatting + zero-width
-    # codepoints. The bidi/zero-width additions close the W-A bypass:
-    # otherwise a remote-supplied error message can embed RTLO (U+202E) /
-    # ZWSP / BOM to flip the visible order or hide payloads in copy-paste.
+    # + line/paragraph-separator codepoints. Same coverage as
+    # chat_hermes._CONTROL_CHARS_RE (keep in sync). Closes the W-A bypass
+    # where a remote-supplied error body can embed RTLO/LRM/LINE-SEP/etc.
     cleaned = re.sub(
-        r"[\x00-\x1f\x7f-\x9f"
-        r"​-‍⁠﻿"
-        r"‪-‮⁦-⁩"
-        r"]",
+        "["
+        "\x00-\x1f\x7f-\x9f"
+        "\u200b-\u200f"      # ZWSP, ZWNJ, ZWJ, LRM, RLM
+        "\u2028-\u2029"      # LINE / PARAGRAPH SEPARATOR
+        "\u202a-\u202e"      # LRE, RLE, PDF, LRO, RLO
+        "\u2060"             # WORD JOINER
+        "\u2066-\u2069"      # LRI, RLI, FSI, PDI
+        "\ufeff"             # ZWNBSP / BOM
+        "]",
         " ",
         str(exc),
     )

--- a/src/clawrium/cli/tui/widgets/chat_panel.py
+++ b/src/clawrium/cli/tui/widgets/chat_panel.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from rich.markup import escape
@@ -14,6 +13,7 @@ from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Input, RichLog
 
+from clawrium.cli.chat import _sanitize_exception_text
 from clawrium.core.chat import (
     ChatAuthenticationError,
     ChatConnectionError,
@@ -22,22 +22,21 @@ from clawrium.core.chat import (
     SecretStr,
 )
 
-# Strip C0/C1 control bytes PLUS Unicode bidi-formatting + zero-width
-# codepoints. The bidi/zero-width additions close the W-A bypass where a
-# remote-supplied error message could embed RTLO (U+202E) / ZWSP / BOM to
-# reverse displayed text or hide payloads in copy-paste output.
-_CONTROL_CHARS_RE = re.compile(
-    r"[\x00-\x1f\x7f-\x9f"
-    r"​-‍⁠﻿"
-    r"‪-‮⁦-⁩"
-    r"]"
-)
-
 
 def _scrub_exception(exc: BaseException, limit: int = 200) -> str:
-    """Strip C0/C1 controls (incl. CR, ANSI) and Unicode bidi/zero-width
-    chars from exception text for safe terminal display."""
-    return _CONTROL_CHARS_RE.sub(" ", str(exc))[:limit]
+    """Strip control/bidi/zero-width chars AND redact bearer/key/token
+    keywords from exception text before TUI display.
+
+    Delegates to the CLI's `_sanitize_exception_text` so the TUI path has
+    keyword-redaction parity with the CLI path. The CLI sanitizer requires
+    `Exception`; cast `BaseException` (Textual hands us either).
+    Truncates at `limit` chars for the compact TUI log line.
+    """
+    sanitized = _sanitize_exception_text(
+        exc if isinstance(exc, Exception) else Exception(str(exc)),
+        max_len=limit,
+    )
+    return sanitized[:limit]
 
 
 class ChatPanel(Widget):

--- a/src/clawrium/cli/tui/widgets/chat_panel.py
+++ b/src/clawrium/cli/tui/widgets/chat_panel.py
@@ -22,11 +22,21 @@ from clawrium.core.chat import (
     SecretStr,
 )
 
-_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+# Strip C0/C1 control bytes PLUS Unicode bidi-formatting + zero-width
+# codepoints. The bidi/zero-width additions close the W-A bypass where a
+# remote-supplied error message could embed RTLO (U+202E) / ZWSP / BOM to
+# reverse displayed text or hide payloads in copy-paste output.
+_CONTROL_CHARS_RE = re.compile(
+    r"[\x00-\x1f\x7f-\x9f"
+    r"​-‍⁠﻿"
+    r"‪-‮⁦-⁩"
+    r"]"
+)
 
 
 def _scrub_exception(exc: BaseException, limit: int = 200) -> str:
-    """Strip C0/C1 controls (incl. CR, ANSI) from exception text for safe display."""
+    """Strip C0/C1 controls (incl. CR, ANSI) and Unicode bidi/zero-width
+    chars from exception text for safe terminal display."""
     return _CONTROL_CHARS_RE.sub(" ", str(exc))[:limit]
 
 

--- a/src/clawrium/core/chat_hermes.py
+++ b/src/clawrium/core/chat_hermes.py
@@ -157,9 +157,11 @@ class HermesOpenAIBackend:
                 timeout=response_timeout_seconds,
             ) as response:
                 if response.status_code in (401, 403):
-                    raise ChatAuthenticationError(
-                        f"Hermes rejected bearer token ({response.status_code})"
-                    )
+                    # Drop the raw HTTP status from the exception message —
+                    # the remediation hint at the CLI layer is what the user
+                    # needs, not the wire-level code. (Internal callers can
+                    # still distinguish via the exception type.)
+                    raise ChatAuthenticationError("Hermes rejected bearer token")
                 if response.status_code >= 400:
                     await response.aread()
                     raise ChatProtocolError(

--- a/src/clawrium/core/chat_hermes.py
+++ b/src/clawrium/core/chat_hermes.py
@@ -173,8 +173,11 @@ class HermesOpenAIBackend:
                 else:
                     text = await _consume_json_response(response, on_delta)
         except httpx.ConnectError as exc:
+            # Drop raw httpx text — it leaks transport internals (e.g. errno,
+            # socket addrs) into user-facing errors. Slice 4 owns the friendly
+            # remediation hint at the CLI layer.
             raise ChatConnectionError(
-                f"Failed to reach hermes at {self._base_url}: {exc}"
+                f"Failed to reach hermes at {self._base_url}"
             ) from exc
         except httpx.TimeoutException as exc:
             raise ChatConnectionError(
@@ -182,7 +185,7 @@ class HermesOpenAIBackend:
                 f"{response_timeout_seconds}s"
             ) from exc
         except httpx.HTTPError as exc:
-            raise ChatConnectionError(f"HTTP error talking to hermes: {exc}") from exc
+            raise ChatConnectionError("HTTP error talking to hermes") from exc
 
         # Stream completed without raising — append the turn. Truncation keeps
         # entries aligned to user/assistant pairs so the wire format never

--- a/src/clawrium/core/chat_hermes.py
+++ b/src/clawrium/core/chat_hermes.py
@@ -362,7 +362,17 @@ def _extract_delta_content(chunk: Any) -> str:
     return ""
 
 
-_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+# Error-path sanitizer — same coverage as _ASSISTANT_TEXT_STRIP_RE plus \n/\t
+# (error bodies are inlined into single-line exception messages, so newlines
+# and tabs are stripped too). Includes bidi/zero-width chars to match the
+# happy-path sanitizer, closing the W-A bypass where a 400-response body
+# could carry RTLO chars through _short_body.
+_CONTROL_CHARS_RE = re.compile(
+    r"[\x00-\x1f\x7f-\x9f"
+    r"​-‍⁠﻿"
+    r"‪-‮⁦-⁩"
+    r"]"
+)
 _WHITESPACE_RUN_RE = re.compile(r" +")
 
 # Strip control / display-manipulating characters from server-supplied

--- a/src/clawrium/core/chat_hermes.py
+++ b/src/clawrium/core/chat_hermes.py
@@ -99,7 +99,7 @@ class HermesOpenAIBackend:
         message: str,
         session_key: str = "main",
         on_delta: Callable[[str], None] | None = None,
-        response_timeout_seconds: float = 120.0,
+        response_timeout_seconds: float | None = None,
     ) -> str:
         """POST a user message with accumulated history and return the reply.
 
@@ -133,6 +133,13 @@ class HermesOpenAIBackend:
         """
         if self._client is None:
             raise ChatConnectionError("Hermes chat backend not connected")
+
+        # Honor caller-supplied per-request timeout; otherwise fall back to
+        # the instance default set at __init__ (the prior code shipped a
+        # hardcoded 120s here, silently overriding any `timeout_seconds=X`
+        # passed to the constructor — W4 in the v2 review).
+        if response_timeout_seconds is None:
+            response_timeout_seconds = self._timeout_seconds
 
         self.last_send_dropped_turns = 0
         outgoing_messages = self._history + [{"role": "user", "content": message}]
@@ -358,15 +365,28 @@ def _extract_delta_content(chunk: Any) -> str:
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 _WHITESPACE_RUN_RE = re.compile(r" +")
 
-# Strip C0/C1 control characters from server-supplied assistant text before it
-# reaches any renderer. Preserves only \t (\x09) and \n (\x0a) — LLM replies
-# legitimately contain newlines (markdown, code, paragraphs) and occasional
-# tabs (indented code). Everything else — including \r (overwrite), \x1b
-# (ANSI escape), \x07 (bell), \x08 (backspace), and the C1 block — is
-# stripped at the backend boundary so neither the CLI's direct console.print
-# nor the TUI's RichLog.write can be tricked into terminal manipulation by a
-# malicious or compromised hermes server.
-_ASSISTANT_TEXT_STRIP_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+# Strip control / display-manipulating characters from server-supplied
+# assistant text before it reaches any renderer. Preserves only \t (\x09) and
+# \n (\x0a) — LLM replies legitimately contain newlines (markdown, code,
+# paragraphs) and occasional tabs (indented code).
+#
+# Stripped:
+#   - C0 (\x00-\x08, \x0b-\x1f) — \r overwrite, \x1b ANSI, \x07 bell, etc.
+#   - DEL + C1 (\x7f-\x9f) — including the 8-bit CSI alias at \x9b.
+#   - Unicode bidi formatting controls (‪-‮, ⁦-⁩) — RTLO
+#     and friends can reverse the visual order of displayed text, e.g. let
+#     a malicious server flip "rm -rf /tmp" into something that LOOKS benign
+#     in the terminal but copy-pastes as destructive.
+#   - Zero-width characters (​ ZWSP, ‌ ZWNJ, ‍ ZWJ, ⁠
+#     WORD JOINER, ﻿ BOM/ZWNBSP) — hide invisible payloads in
+#     copy-pasted output.
+# Rich's markup=False blocks `[…]` escapes but does not strip any of the above.
+_ASSISTANT_TEXT_STRIP_RE = re.compile(
+    r"[\x00-\x08\x0b-\x1f\x7f-\x9f"
+    r"​-‍⁠﻿"
+    r"‪-‮⁦-⁩"
+    r"]"
+)
 
 
 def _sanitize_assistant_text(text: str) -> str:

--- a/src/clawrium/core/chat_hermes.py
+++ b/src/clawrium/core/chat_hermes.py
@@ -364,38 +364,45 @@ def _extract_delta_content(chunk: Any) -> str:
 
 # Error-path sanitizer — same coverage as _ASSISTANT_TEXT_STRIP_RE plus \n/\t
 # (error bodies are inlined into single-line exception messages, so newlines
-# and tabs are stripped too). Includes bidi/zero-width chars to match the
-# happy-path sanitizer, closing the W-A bypass where a 400-response body
-# could carry RTLO chars through _short_body.
+# and tabs are stripped too). Strips:
+#   - C0/C1 control bytes (\x00-\x1f, \x7f-\x9f)
+#   - Zero-width chars: ZWSP (U+200B) through WJ (U+2060) inclusive range
+#     + BOM/ZWNBSP (U+FEFF)
+#   - Bidi formatting controls: LRM (U+200E), RLM (U+200F),
+#     LRE-RLO + PDF (U+202A-U+202E), isolates LRI-FSI + PDI (U+2066-U+2069)
+#   - Line/paragraph separators (U+2028, U+2029) — non-newline whitespace
+#     that splits lines in some renderers
+# Uses \uXXXX escapes throughout for grep-ability and to keep the source
+# free of invisible chars that an editor's auto-fixer might "fix" away.
 _CONTROL_CHARS_RE = re.compile(
-    r"[\x00-\x1f\x7f-\x9f"
-    r"​-‍⁠﻿"
-    r"‪-‮⁦-⁩"
-    r"]"
+    "["
+    "\x00-\x1f\x7f-\x9f"
+    "\u200b-\u200f"      # ZWSP, ZWNJ, ZWJ, LRM, RLM
+    "\u2028-\u2029"      # LINE / PARAGRAPH SEPARATOR
+    "\u202a-\u202e"      # LRE, RLE, PDF, LRO, RLO
+    "\u2060"             # WORD JOINER
+    "\u2066-\u2069"      # LRI, RLI, FSI, PDI
+    "\ufeff"             # ZWNBSP / BOM
+    "]"
 )
 _WHITESPACE_RUN_RE = re.compile(r" +")
 
 # Strip control / display-manipulating characters from server-supplied
-# assistant text before it reaches any renderer. Preserves only \t (\x09) and
-# \n (\x0a) — LLM replies legitimately contain newlines (markdown, code,
-# paragraphs) and occasional tabs (indented code).
-#
-# Stripped:
-#   - C0 (\x00-\x08, \x0b-\x1f) — \r overwrite, \x1b ANSI, \x07 bell, etc.
-#   - DEL + C1 (\x7f-\x9f) — including the 8-bit CSI alias at \x9b.
-#   - Unicode bidi formatting controls (‪-‮, ⁦-⁩) — RTLO
-#     and friends can reverse the visual order of displayed text, e.g. let
-#     a malicious server flip "rm -rf /tmp" into something that LOOKS benign
-#     in the terminal but copy-pastes as destructive.
-#   - Zero-width characters (​ ZWSP, ‌ ZWNJ, ‍ ZWJ, ⁠
-#     WORD JOINER, ﻿ BOM/ZWNBSP) — hide invisible payloads in
-#     copy-pasted output.
-# Rich's markup=False blocks `[…]` escapes but does not strip any of the above.
+# assistant text before it reaches any renderer. Preserves only \t (\x09)
+# and \n (\x0a) — LLM replies legitimately contain newlines (markdown, code,
+# paragraphs) and occasional tabs (indented code). Same coverage as
+# _CONTROL_CHARS_RE except \n + \t are excluded from the C0 class so they
+# survive into the rendered output.
 _ASSISTANT_TEXT_STRIP_RE = re.compile(
-    r"[\x00-\x08\x0b-\x1f\x7f-\x9f"
-    r"​-‍⁠﻿"
-    r"‪-‮⁦-⁩"
-    r"]"
+    "["
+    "\x00-\x08\x0b-\x1f\x7f-\x9f"
+    "\u200b-\u200f"      # ZWSP, ZWNJ, ZWJ, LRM, RLM
+    "\u2028-\u2029"      # LINE / PARAGRAPH SEPARATOR
+    "\u202a-\u202e"      # LRE, RLE, PDF, LRO, RLO
+    "\u2060"             # WORD JOINER
+    "\u2066-\u2069"      # LRI, RLI, FSI, PDI
+    "\ufeff"             # ZWNBSP / BOM
+    "]"
 )
 
 

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -534,7 +534,10 @@ def run_installation(
         existing_entry = get_instance_secrets(instance_key).get(
             "HERMES_API_SERVER_KEY"
         )
-        existing_key = existing_entry["value"] if existing_entry else None
+        # `.get("value")` not `["value"]`: a truthy-but-malformed entry (no
+        # "value" field, e.g. hand-edited secrets.json) would otherwise raise
+        # KeyError straight out of the install flow.
+        existing_key = existing_entry.get("value") if existing_entry else None
         if _is_valid_hermes_api_server_key(existing_key):
             hermes_api_server_key = existing_key
         else:

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -743,7 +743,10 @@ def configure_agent(
             host["hostname"], resolved_type, unix_agent_name
         )
         secret_entry = get_instance_secrets(instance_key).get("HERMES_API_SERVER_KEY")
-        api_server_key = secret_entry["value"] if secret_entry else None
+        # `.get("value")` not `["value"]`: a truthy-but-malformed entry (no
+        # "value" field) would otherwise raise KeyError out of configure
+        # instead of routing through the validity check below.
+        api_server_key = secret_entry.get("value") if secret_entry else None
 
         if not _is_valid_hermes_api_server_key(api_server_key):
             return (

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -829,7 +829,7 @@ def configure_agent(
                 "DISCORD_BOT_TOKEN"
             )
             discord_token = (
-                discord_secret["value"]
+                discord_secret.get("value")
                 if isinstance(discord_secret, dict)
                 else None
             )

--- a/tests/test_chat_hermes.py
+++ b/tests/test_chat_hermes.py
@@ -101,10 +101,15 @@ def test_unauthorized_response_raises_auth_error():
 
     backend = _build_backend(httpx.MockTransport(handler))
     try:
-        with pytest.raises(ChatAuthenticationError, match="401"):
+        with pytest.raises(ChatAuthenticationError) as excinfo:
             _run(backend.send_message("ping"))
     finally:
         _run(backend.close())
+
+    # The exception message must not echo the raw HTTP status — the type
+    # alone discriminates auth failures from other errors.
+    assert "401" not in str(excinfo.value)
+    assert "rejected bearer token" in str(excinfo.value)
 
 
 def test_forbidden_response_raises_auth_error():
@@ -113,10 +118,13 @@ def test_forbidden_response_raises_auth_error():
 
     backend = _build_backend(httpx.MockTransport(handler))
     try:
-        with pytest.raises(ChatAuthenticationError, match="403"):
+        with pytest.raises(ChatAuthenticationError) as excinfo:
             _run(backend.send_message("ping"))
     finally:
         _run(backend.close())
+
+    assert "403" not in str(excinfo.value)
+    assert "rejected bearer token" in str(excinfo.value)
 
 
 def test_server_error_raises_protocol_error():
@@ -506,6 +514,32 @@ def test_connection_error_does_not_leak_httpx_internals():
     assert "httpx" not in message
     assert "/usr/lib" not in message
     assert "Failed to reach hermes" in message
+
+
+def test_protocol_error_body_strips_control_chars():
+    """ChatProtocolError messages route response bodies through _short_body,
+    which must drop ANSI/control sequences as defence in depth — a future
+    caller that bypasses the CLI sanitizer should still not be able to
+    smuggle terminal escapes via a 4xx/5xx response body."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            500,
+            content=b"boom\r\x1b[31mred\x1b[0m\x07bell",
+            headers={"content-type": "text/plain"},
+        )
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(ChatProtocolError) as excinfo:
+            _run(backend.send_message("ping"))
+    finally:
+        _run(backend.close())
+
+    message = str(excinfo.value)
+    assert "\x1b" not in message
+    assert "\r" not in message
+    assert "\x07" not in message
 
 
 def test_http_error_does_not_leak_httpx_internals():

--- a/tests/test_chat_hermes.py
+++ b/tests/test_chat_hermes.py
@@ -868,3 +868,122 @@ def test_sse_read_error_mid_stream_raises_connection_error():
             _run(backend.send_message("ping"))
     finally:
         _run(backend.close())
+
+
+def test_sse_on_delta_failure_mid_stream_does_not_pollute_history():
+    """The "render before history" invariant must hold for the SSE path,
+    not just the JSON fallback. Returns N SSE chunks; on_delta raises on
+    chunk 2. After the failure, history must equal its pre-call snapshot —
+    no phantom partial turn (which would inflate every subsequent request).
+    """
+    chunk_count = {"n": 0}
+
+    def boom_on_chunk_two(_text: str) -> None:
+        chunk_count["n"] += 1
+        if chunk_count["n"] == 2:
+            raise RuntimeError("broken pipe mid-stream")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = (
+            b'data: {"choices":[{"delta":{"content":"first"}}]}\n\n'
+            b'data: {"choices":[{"delta":{"content":"second"}}]}\n\n'
+            b'data: {"choices":[{"delta":{"content":"third"}}]}\n\n'
+            b"data: [DONE]\n\n"
+        )
+        return _sse_response(body)
+
+    backend = _build_backend(httpx.MockTransport(handler))
+
+    try:
+        # First, prime history with one successful turn so we have a non-empty
+        # snapshot to assert against.
+        def first_handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, json={"choices": [{"message": {"content": "prime"}}]}
+            )
+
+        backend._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(first_handler), timeout=30.0
+        )
+        _run(backend.send_message("warmup"))
+        pre_failure_snapshot = list(backend._history)
+        assert len(pre_failure_snapshot) == 2
+
+        # Swap to the SSE handler and trigger the mid-stream raise.
+        backend._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), timeout=30.0
+        )
+        with pytest.raises(RuntimeError, match="broken pipe mid-stream"):
+            _run(backend.send_message("failing", on_delta=boom_on_chunk_two))
+
+        assert backend._history == pre_failure_snapshot, (
+            "SSE path corrupted _history despite on_delta raising mid-stream"
+        )
+    finally:
+        _run(backend.close())
+
+
+def test_assistant_text_bidi_overrides_are_stripped():
+    """Unicode bidi-override characters (RTLO, ZWSP, etc.) can flip the
+    visual order of displayed text or hide invisible payloads in
+    copy-pasted output. Strip them at the backend boundary so neither the
+    CLI's console.print nor the TUI's RichLog.write is fooled.
+    """
+    leaky = "rm -rf /‮tmp‬"  # RTLO + PDF — visual reverse
+    invisible = "before​after"  # ZWSP — invisible in terminal
+    bom = "﻿trailing"  # BOM/ZWNBSP — invisible
+    payload = leaky + invisible + bom
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"choices": [{"message": {"content": payload}}]}
+        )
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        result = _run(backend.send_message("hi"))
+    finally:
+        _run(backend.close())
+
+    # Each bidi/zero-width char must be gone.
+    for char in ("‮", "‬", "​", "﻿"):
+        assert char not in result, f"{hex(ord(char))} survived sanitizer"
+
+
+def test_response_timeout_seconds_defaults_to_instance_timeout():
+    """Constructor's `timeout_seconds` must control per-request timeout when
+    no explicit value is passed to send_message. The prior signature hardcoded
+    120s in the kwarg default, silently overriding any caller-supplied
+    instance timeout (W4 in the v2 review).
+    """
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # httpx exposes the request timeout via extensions when set
+        captured["timeout"] = request.extensions.get("timeout")
+        return httpx.Response(
+            200, json={"choices": [{"message": {"content": "ok"}}]}
+        )
+
+    backend = HermesOpenAIBackend(
+        base_url="http://hermes.test:8642/v1",
+        auth_token=SecretStr("tok"),
+        timeout_seconds=7.5,
+    )
+    backend._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), timeout=7.5
+    )
+    try:
+        _run(backend.send_message("ping"))
+    finally:
+        _run(backend.close())
+
+    # httpx records per-call timeout under all four phases when explicitly set
+    timeout = captured["timeout"]
+    assert timeout is not None
+    # All four phases set to the instance default (7.5s), not 120s
+    for phase in ("connect", "read", "write", "pool"):
+        if phase in timeout and timeout[phase] is not None:
+            assert timeout[phase] == 7.5, (
+                f"{phase} timeout was {timeout[phase]}, expected 7.5"
+            )

--- a/tests/test_chat_hermes.py
+++ b/tests/test_chat_hermes.py
@@ -945,9 +945,41 @@ def test_assistant_text_bidi_overrides_are_stripped():
     finally:
         _run(backend.close())
 
-    # Each bidi/zero-width char must be gone.
+    # Positive assertion: surrounding ASCII is preserved verbatim, only the
+    # bidi/zero-width chars are stripped. Without this, a sanitizer bug that
+    # over-stripped to "" would silently pass the negative checks below.
+    expected = "rm -rf /tmpbeforeaftertrailing"
+    assert result == expected, (
+        f"Sanitizer over- or under-stripped: got {result!r}, expected {expected!r}"
+    )
+    # Defense in depth: each bidi/zero-width char individually verified gone.
     for char in ("‮", "‬", "​", "﻿"):
         assert char not in result, f"{hex(ord(char))} survived sanitizer"
+
+
+def test_error_path_short_body_strips_bidi_overrides():
+    """W-A regression: error-response bodies must also be sanitized for bidi
+    and zero-width chars, not just assistant-content text. A compromised
+    hermes returning HTTP 4xx/5xx with RTLO chars in the body would otherwise
+    smuggle them through `_short_body` into the ChatProtocolError message.
+    """
+    from clawrium.core.chat_hermes import _short_body
+
+    payload = "error ‮evil‬ before​after ﻿bom"
+    cleaned = _short_body(payload)
+
+    # Surrounding ASCII preserved; bidi/zero-width stripped to spaces and
+    # whitespace runs collapsed.
+    assert "‮" not in cleaned
+    assert "‬" not in cleaned
+    assert "​" not in cleaned
+    assert "﻿" not in cleaned
+    # Positive assertion guards against over-stripping.
+    assert "error" in cleaned
+    assert "evil" in cleaned
+    assert "before" in cleaned
+    assert "after" in cleaned
+    assert "bom" in cleaned
 
 
 def test_response_timeout_seconds_defaults_to_instance_timeout():
@@ -978,12 +1010,22 @@ def test_response_timeout_seconds_defaults_to_instance_timeout():
     finally:
         _run(backend.close())
 
-    # httpx records per-call timeout under all four phases when explicitly set
+    # httpx records the per-call timeout under request.extensions["timeout"].
     timeout = captured["timeout"]
-    assert timeout is not None
-    # All four phases set to the instance default (7.5s), not 120s
-    for phase in ("connect", "read", "write", "pool"):
-        if phase in timeout and timeout[phase] is not None:
-            assert timeout[phase] == 7.5, (
-                f"{phase} timeout was {timeout[phase]}, expected 7.5"
-            )
+    assert timeout is not None, (
+        "httpx did not record a per-call timeout — cannot verify W4 fix"
+    )
+    # At least one phase must reflect the instance-level 7.5s default; the
+    # bug being guarded against was send_message hardcoding 120s and ignoring
+    # the constructor's timeout_seconds entirely. Asserting *some* phase
+    # carries the expected value is sufficient — different httpx versions
+    # populate different subsets of phases.
+    matching_phases = [
+        phase
+        for phase in ("connect", "read", "write", "pool")
+        if timeout.get(phase) == 7.5
+    ]
+    assert matching_phases, (
+        f"No phase carried the instance timeout (7.5s); got {timeout!r}. "
+        f"The constructor's timeout_seconds is not threading to send_message."
+    )

--- a/tests/test_chat_hermes.py
+++ b/tests/test_chat_hermes.py
@@ -482,6 +482,50 @@ def test_on_delta_failure_does_not_pollute_history():
         _run(backend.close())
 
 
+def test_connection_error_does_not_leak_httpx_internals():
+    """httpx exception text (errno codes, file paths, internal types) MUST NOT
+    appear in the ChatConnectionError message. The CLI surfaces the error
+    string verbatim, so any leakage reaches the user."""
+    leaky_message = (
+        "[Errno 111] Connection refused; "
+        "/usr/lib/python3/dist-packages/httpx/_transports/default.py"
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError(leaky_message)
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(ChatConnectionError) as excinfo:
+            _run(backend.send_message("ping"))
+    finally:
+        _run(backend.close())
+
+    message = str(excinfo.value)
+    assert "Errno" not in message
+    assert "httpx" not in message
+    assert "/usr/lib" not in message
+    assert "Failed to reach hermes" in message
+
+
+def test_http_error_does_not_leak_httpx_internals():
+    """Generic httpx.HTTPError (non-connect, non-timeout) also gets sanitized."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.HTTPError("internal httpx error: pool_timeout etc")
+
+    backend = _build_backend(httpx.MockTransport(handler))
+    try:
+        with pytest.raises(ChatConnectionError) as excinfo:
+            _run(backend.send_message("ping"))
+    finally:
+        _run(backend.close())
+
+    message = str(excinfo.value)
+    assert "pool_timeout" not in message
+    assert "httpx" not in message
+
+
 def test_connect_is_idempotent():
     """Repeated connect() calls do not replace an existing client (resource leak guard)."""
     backend = HermesOpenAIBackend(

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -796,15 +796,15 @@ class TestHermesChat:
         )
 
     def test_service_unreachable(self, monkeypatch):
-        """ChatConnectionError from the backend surfaces as exit 1 with a
-        remediation hint (mirrors the openclaw connection-failure path)."""
+        """ChatConnectionError from the hermes backend surfaces a systemctl
+        remediation hint pointing at the agent host's user service unit."""
         from clawrium.core.chat import ChatConnectionError
 
         self._setup_resolved_hermes(monkeypatch)
 
         def fake_asyncio_run(_coro):
             _coro.close()
-            raise ChatConnectionError("connection refused on 192.168.1.50:8642")
+            raise ChatConnectionError("Failed to reach hermes at http://wolf-i.lan:8642/v1")
 
         monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
 
@@ -812,12 +812,57 @@ class TestHermesChat:
 
         assert result.exit_code == 1
         assert "connection failed" in result.output.lower()
-        assert "connection refused" in result.output.lower()
-        # Remediation hint must be present so the user knows what to do next.
-        assert "configure" in result.output.lower() or "install" in result.output.lower()
+        # systemctl hint is the canonical remediation for unreachable hermes.
+        assert "systemctl --user status hermes-hermes-test" in result.output
+        # No legacy-bind hint because the standard fixture binds 0.0.0.0.
+        assert "legacy bind" not in result.output.lower()
 
-    def test_authentication_failure(self, monkeypatch):
-        """ChatAuthenticationError from the backend surfaces as exit 1."""
+    def test_service_unreachable_legacy_bind_hint(self, monkeypatch):
+        """When the persisted bind is still 127.0.0.1 (pre-migration), surface
+        a follow-on hint nudging the user to run `clm agent configure`."""
+        from clawrium.core.chat import ChatConnectionError
+
+        legacy_agent = {
+            "agent_name": "hermes-test",
+            "config": {
+                "api_server": {
+                    "enabled": True,
+                    "host": "127.0.0.1",
+                    "port": 8642,
+                }
+            },
+        }
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_agent_by_name",
+            lambda _name: (self.HOST, "hermes", legacy_agent),
+        )
+        monkeypatch.setattr(
+            "clawrium.cli.chat._resolve_chat_type", lambda _agent_type: "openai"
+        )
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_instance_secrets",
+            lambda _key: {
+                "HERMES_API_SERVER_KEY": {
+                    "key": "HERMES_API_SERVER_KEY",
+                    "value": "c" * 64,
+                }
+            },
+        )
+
+        def fake_asyncio_run(_coro):
+            _coro.close()
+            raise ChatConnectionError("Failed to reach hermes at http://wolf-i.lan:8642/v1")
+
+        monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
+
+        result = runner.invoke(app, ["chat", "hermes-test"])
+
+        assert result.exit_code == 1
+        assert "legacy bind" in result.output.lower()
+        assert "clm agent configure hermes-test" in result.output
+
+    def test_401_remediation(self, monkeypatch):
+        """401/403 surfaces a 'Re-run clm agent configure' remediation hint."""
         from clawrium.core.chat import ChatAuthenticationError
 
         self._setup_resolved_hermes(monkeypatch)
@@ -833,6 +878,75 @@ class TestHermesChat:
         assert result.exit_code == 1
         assert "authentication failed" in result.output.lower()
         assert "401" in result.output
+        assert "re-run" in result.output.lower()
+        assert "clm agent configure hermes-test" in result.output
+
+    def test_session_flag_warns_for_hermes(self, monkeypatch):
+        """Passing `--session <non-default>` to a hermes agent logs a dim
+        warning and continues; chat still starts."""
+        self._setup_resolved_hermes(monkeypatch)
+
+        captured: dict[str, object] = {}
+
+        async def mock_chat_loop(backend, **kwargs):
+            captured["session_key"] = kwargs.get("session_key")
+
+        monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
+
+        result = runner.invoke(
+            app, ["chat", "hermes-test", "--session", "custom-session"]
+        )
+
+        assert result.exit_code == 0
+        assert "no-op" in result.output.lower()
+        assert "openai-typed" in result.output.lower()
+        # Chat still proceeded — session_key was forwarded verbatim.
+        assert captured["session_key"] == "custom-session"
+
+    def test_session_flag_default_does_not_warn(self, monkeypatch):
+        """Default --session=main must not trigger the no-op warning."""
+        self._setup_resolved_hermes(monkeypatch)
+
+        async def mock_chat_loop(backend, **kwargs):
+            return None
+
+        monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
+
+        result = runner.invoke(app, ["chat", "hermes-test"])
+
+        assert result.exit_code == 0
+        assert "no-op" not in result.output.lower()
+
+    def test_connection_error_does_not_leak_httpx_internals(self, monkeypatch):
+        """No raw httpx exception strings (errno codes, internal type names)
+        reach the user. The backend strips them; this test guards the CLI
+        path too in case a future regression reintroduces leakage."""
+        from clawrium.core.chat import ChatConnectionError
+
+        self._setup_resolved_hermes(monkeypatch)
+
+        # Construct a ChatConnectionError whose message intentionally contains
+        # httpx-style internals. If a future change pipes the raw exception
+        # text from chat_hermes.py through unchanged, this test will fail.
+        leaky_text = (
+            "[Errno 111] Connection refused; httpx.ConnectError: "
+            "_ssl.c:1056 path=/usr/lib/python3/dist-packages/httpx/_transports/default.py"
+        )
+
+        def fake_asyncio_run(_coro):
+            _coro.close()
+            raise ChatConnectionError(leaky_text)
+
+        monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
+
+        result = runner.invoke(app, ["chat", "hermes-test"])
+
+        assert result.exit_code == 1
+        # Even if a ChatConnectionError carries leaky text (as a defensive
+        # guard against backend bugs), the CLI sanitizer collapses control
+        # chars; the remediation hint surfaces below the error line so the
+        # user always sees an actionable next step.
+        assert "systemctl --user status hermes-hermes-test" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -862,14 +862,16 @@ class TestHermesChat:
         assert "clm agent configure hermes-test" in result.output
 
     def test_401_remediation(self, monkeypatch):
-        """401/403 surfaces a 'Re-run clm agent configure' remediation hint."""
+        """401 path surfaces a 'Re-run clm agent configure' remediation hint.
+        The exception message no longer carries the raw HTTP status code; the
+        type alone discriminates auth failures from other errors."""
         from clawrium.core.chat import ChatAuthenticationError
 
         self._setup_resolved_hermes(monkeypatch)
 
         def fake_asyncio_run(_coro):
             _coro.close()
-            raise ChatAuthenticationError("Hermes rejected bearer token (401)")
+            raise ChatAuthenticationError("Hermes rejected bearer token")
 
         monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
 
@@ -877,7 +879,31 @@ class TestHermesChat:
 
         assert result.exit_code == 1
         assert "authentication failed" in result.output.lower()
-        assert "401" in result.output
+        assert "re-run" in result.output.lower()
+        assert "clm agent configure hermes-test" in result.output
+        # Status code MUST NOT appear in user output (exit criterion: no raw
+        # HTTP codes dumped). The exception type is the discriminator.
+        assert "401" not in result.output
+        assert "403" not in result.output
+
+    def test_403_remediation(self, monkeypatch):
+        """403 path produces the same remediation as 401 (same exception
+        type from the backend — both are 'bearer rejected')."""
+        from clawrium.core.chat import ChatAuthenticationError
+
+        self._setup_resolved_hermes(monkeypatch)
+
+        def fake_asyncio_run(_coro):
+            _coro.close()
+            # Backend raises the same exception type for 403 as for 401.
+            raise ChatAuthenticationError("Hermes rejected bearer token")
+
+        monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
+
+        result = runner.invoke(app, ["chat", "hermes-test"])
+
+        assert result.exit_code == 1
+        assert "authentication failed" in result.output.lower()
         assert "re-run" in result.output.lower()
         assert "clm agent configure hermes-test" in result.output
 
@@ -898,10 +924,42 @@ class TestHermesChat:
         )
 
         assert result.exit_code == 0
-        assert "no-op" in result.output.lower()
-        assert "openai-typed" in result.output.lower()
+        # The user-facing copy must use plain language (no "phase 1" jargon)
+        # and must not appear before the "Connected target:" line — the
+        # warning fires only after backend construction succeeds.
+        assert "no effect for this agent type" in result.output
+        assert "phase 1" not in result.output.lower()
+        warn_idx = result.output.find("no effect for this agent type")
+        connected_idx = result.output.find("Connected target")
+        assert warn_idx >= 0 and connected_idx >= 0
+        assert warn_idx < connected_idx
         # Chat still proceeded — session_key was forwarded verbatim.
-        assert captured["session_key"] == "custom-session"
+        assert captured.get("session_key") == "custom-session"
+
+    def test_session_flag_warning_not_emitted_when_backend_build_fails(
+        self, monkeypatch
+    ):
+        """Backend construction failure (e.g. missing key) must NOT be
+        preceded by the --session warning. The warning fires only after a
+        successful backend build."""
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_agent_by_name",
+            lambda _name: (self.HOST, "hermes", self.AGENT),
+        )
+        monkeypatch.setattr(
+            "clawrium.cli.chat._resolve_chat_type", lambda _agent_type: "openai"
+        )
+        # No HERMES_API_SERVER_KEY -> _build_hermes_backend raises ValueError.
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_instance_secrets", lambda _key: {}
+        )
+
+        result = runner.invoke(
+            app, ["chat", "hermes-test", "--session", "custom-session"]
+        )
+
+        assert result.exit_code == 1
+        assert "no effect for this agent type" not in result.output
 
     def test_session_flag_default_does_not_warn(self, monkeypatch):
         """Default --session=main must not trigger the no-op warning."""
@@ -918,35 +976,107 @@ class TestHermesChat:
         assert "no-op" not in result.output.lower()
 
     def test_connection_error_does_not_leak_httpx_internals(self, monkeypatch):
-        """No raw httpx exception strings (errno codes, internal type names)
-        reach the user. The backend strips them; this test guards the CLI
-        path too in case a future regression reintroduces leakage."""
-        from clawrium.core.chat import ChatConnectionError
+        """End-to-end: a real httpx ConnectError carrying transport
+        internals bubbles through HermesOpenAIBackend → ChatConnectionError
+        → CLI without those internals reaching the user.
+
+        The load-bearing protection lives in `chat_hermes.py` exception
+        construction (the backend builds ChatConnectionError with a clean
+        URL-only message — see `_send_message`). The CLI sanitizer does
+        NOT strip `Errno`/`httpx`/path tokens, so this test would fail if a
+        future change re-introduced `f"...: {exc}"` to the backend."""
+        import httpx as _httpx
 
         self._setup_resolved_hermes(monkeypatch)
 
-        # Construct a ChatConnectionError whose message intentionally contains
-        # httpx-style internals. If a future change pipes the raw exception
-        # text from chat_hermes.py through unchanged, this test will fail.
         leaky_text = (
             "[Errno 111] Connection refused; httpx.ConnectError: "
             "_ssl.c:1056 path=/usr/lib/python3/dist-packages/httpx/_transports/default.py"
         )
 
+        def handler(request: _httpx.Request) -> _httpx.Response:
+            raise _httpx.ConnectError(leaky_text)
+
+        real_async_client = _httpx.AsyncClient
+
+        def make_client(*args, **kwargs):
+            # Discard any transport the backend might pass; wire ours in.
+            kwargs.pop("transport", None)
+            return real_async_client(
+                transport=_httpx.MockTransport(handler), **kwargs
+            )
+
+        monkeypatch.setattr(
+            "clawrium.core.chat_hermes.httpx.AsyncClient", make_client
+        )
+
+        # Feed one message into the REPL so send_message() actually runs.
+        result = runner.invoke(app, ["chat", "hermes-test"], input="hello\n")
+
+        assert result.exit_code == 1
+        # Remediation hint surfaces unconditionally below the error line.
+        assert "systemctl --user status hermes-hermes-test" in result.output
+        # Absence assertions: these tokens must never reach user output. If
+        # any flip in the future, fix `chat_hermes.py` (the backend layer),
+        # not the CLI sanitizer — `_sanitize_exception_text` is defence in
+        # depth and does NOT strip these patterns.
+        assert "Errno" not in result.output
+        assert "httpx" not in result.output
+        assert "/usr/lib" not in result.output
+
+    def test_service_timeout(self, monkeypatch):
+        """Timeout-originated ChatConnectionError surfaces a --timeout hint,
+        not a systemctl hint (the service is up but slow, not down)."""
+        from clawrium.core.chat import ChatConnectionError
+
+        self._setup_resolved_hermes(monkeypatch)
+
         def fake_asyncio_run(_coro):
             _coro.close()
-            raise ChatConnectionError(leaky_text)
+            raise ChatConnectionError(
+                "Timed out waiting for hermes response after 120.0s"
+            )
 
         monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
 
         result = runner.invoke(app, ["chat", "hermes-test"])
 
         assert result.exit_code == 1
-        # Even if a ChatConnectionError carries leaky text (as a defensive
-        # guard against backend bugs), the CLI sanitizer collapses control
-        # chars; the remediation hint surfaces below the error line so the
-        # user always sees an actionable next step.
-        assert "systemctl --user status hermes-hermes-test" in result.output
+        assert "connection failed" in result.output.lower()
+        assert "--timeout" in result.output
+        # systemctl hint is for connect-refused, not timeouts.
+        assert "systemctl" not in result.output
+
+    def test_malformed_secret_entry_missing_value(self, monkeypatch):
+        """A secrets.json entry missing the 'value' field must surface a
+        friendly ValueError-routed error, not a Python KeyError traceback."""
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_agent_by_name",
+            lambda _name: (self.HOST, "hermes", self.AGENT),
+        )
+        monkeypatch.setattr(
+            "clawrium.cli.chat._resolve_chat_type", lambda _agent_type: "openai"
+        )
+        # Truthy dict, but no "value" field — the old code would KeyError.
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_instance_secrets",
+            lambda _key: {
+                "HERMES_API_SERVER_KEY": {"key": "HERMES_API_SERVER_KEY"}
+            },
+        )
+
+        result = runner.invoke(app, ["chat", "hermes-test"])
+
+        assert result.exit_code == 1
+        assert "hermes_api_server_key" in result.output.lower()
+        assert "re-run" in result.output.lower()
+        # Interpolated remediation must include both agent_type and host.
+        assert "--type hermes" in result.output
+        assert "--host wolf-i.lan" in result.output
+        # KeyError tracebacks contain this token; assert absence as a regression
+        # canary against the original `secret_entry["value"]` access.
+        assert "KeyError" not in result.output
+        assert "Traceback" not in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -301,6 +301,47 @@ class TestConfigurePlaybookShape:
 class TestConfigureAgentApiServerKey:
     """configure_agent() must enforce + reuse the persisted api_server.key for hermes."""
 
+    def test_hermes_malformed_secret_entry_missing_value_returns_error(self):
+        """A secrets.json entry that exists but is missing the 'value' field
+        must NOT raise KeyError out of configure_agent. The existing missing-
+        key error path catches it via the validity check (value resolves to
+        None) and returns a friendly remediation tuple."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {},
+                }
+            },
+        }
+        config_data = {
+            "gateway": {"host": "127.0.0.1", "port": 8642},
+            "provider": {
+                "name": "p",
+                "type": "openrouter",
+                "default_model": "x",
+            },
+        }
+        # Truthy dict, no "value" key — the original `secret_entry["value"]`
+        # access would raise KeyError before the validity check ran.
+        malformed_secrets = {
+            "HERMES_API_SERVER_KEY": {"key": "HERMES_API_SERVER_KEY"}
+        }
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                return_value=malformed_secrets,
+            ):
+                success, error = configure_agent(
+                    "test-host", "hermes", config_data, agent_name="hermes-test"
+                )
+        assert success is False
+        assert "HERMES_API_SERVER_KEY" in error
+        assert "install" in error
+
     def test_hermes_without_persisted_key_returns_error(self):
         """Reject configure when secrets.json has no HERMES_API_SERVER_KEY."""
         host = {

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2021,6 +2021,120 @@ def test_install_openclaw_without_token_succeeds(monkeypatch, tmp_path):
     assert result["error"] is None
 
 
+def test_install_hermes_malformed_existing_secret_entry(monkeypatch, tmp_path):
+    """A pre-existing HERMES_API_SERVER_KEY secrets entry that is missing the
+    "value" field (truthy dict, no 'value' key — e.g. hand-edited
+    secrets.json) must NOT raise KeyError out of run_installation. The
+    install path should treat it as a corrupted entry and regenerate.
+
+    Regression guard for the `existing_entry["value"]` access pattern."""
+    from clawrium.core.install import run_installation
+    import clawrium.core.install
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mock_manifest = {
+        "name": "hermes",
+        "entries": [
+            {
+                "version": "2026.5.7",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc123",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.11"},
+                },
+            }
+        ],
+    }
+    monkeypatch.setattr(
+        clawrium.core.install, "load_manifest", lambda x: mock_manifest
+    )
+
+    compatible_host = {
+        "hostname": "test-host",
+        "port": 22,
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host", lambda x: compatible_host
+    )
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *a, **k: {
+            "compatible": True,
+            "matched_entry": mock_manifest["entries"][0],
+            "reasons": [],
+        },
+    )
+
+    key_file = tmp_path / "key"
+    key_file.write_text("k")
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda x: key_file
+    )
+
+    persistent_host = dict(compatible_host)
+
+    def mock_update_host(hostname, updater):
+        nonlocal persistent_host
+        if "agents" not in persistent_host:
+            persistent_host["agents"] = {}
+        persistent_host = updater(persistent_host)
+        return True
+
+    monkeypatch.setattr(clawrium.core.install, "update_host", mock_update_host)
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", lambda h, c: True
+    )
+    # Truthy dict, no "value" field — would have raised KeyError before fix.
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "get_instance_secrets",
+        lambda _k: {"HERMES_API_SERVER_KEY": {"key": "HERMES_API_SERVER_KEY"}},
+    )
+    set_calls: list = []
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "set_instance_secret",
+        lambda *a, **k: set_calls.append((a, k)) or True,
+    )
+
+    class SuccessfulResult:
+        status = "successful"
+
+        class Config:
+            artifact_dir = tmp_path / "artifacts"
+
+        config = Config()
+
+    import ansible_runner
+
+    monkeypatch.setattr(ansible_runner, "run", Mock(return_value=SuccessfulResult()))
+
+    # The load-bearing assertion: this call must not raise KeyError.
+    result = run_installation("hermes", "test-host", name="hermes-test")
+
+    assert result["success"] is True
+    # Malformed entry → treated as corrupted → fresh key generated and
+    # persisted under the canonical instance key.
+    assert len(set_calls) == 1
+    args, _kwargs = set_calls[0]
+    # set_instance_secret(instance_key, "HERMES_API_SERVER_KEY", token, ...)
+    assert args[1] == "HERMES_API_SERVER_KEY"
+    assert isinstance(args[2], str) and len(args[2]) == 64
+
+
 def test_install_hermes_persists_zero_bind_in_hosts_json(monkeypatch, tmp_path):
     """New hermes installs must persist api_server.host == "0.0.0.0" so the
     next configure picks up a network-reachable bind. The bearer token lives

--- a/tests/test_tui/test_tui_chat.py
+++ b/tests/test_tui/test_tui_chat.py
@@ -187,3 +187,71 @@ class TestDetailScreenChatEnabled:
         )
         screen = DetailScreen(agent=agent)
         assert screen._is_chat_enabled() is False
+
+
+class TestScrubException:
+    """`_scrub_exception` in chat_panel.py must redact credentials AND strip
+    display-manipulating chars — parity with the CLI's `_sanitize_exception_text`.
+    """
+
+    def test_strips_control_and_bidi_chars(self):
+        from clawrium.cli.tui.widgets.chat_panel import _scrub_exception
+
+        exc = Exception("ok\x1bbad\rmore‮flip‬end")
+        cleaned = _scrub_exception(exc)
+        assert "\x1b" not in cleaned
+        assert "\r" not in cleaned
+        assert "‮" not in cleaned
+        assert "‬" not in cleaned
+        # Positive: surrounding ASCII preserved.
+        assert "ok" in cleaned
+        assert "bad" in cleaned
+        assert "end" in cleaned
+
+    def test_strips_line_paragraph_separators(self):
+        """U+2028 / U+2029 break line-oriented parsing in some renderers."""
+        from clawrium.cli.tui.widgets.chat_panel import _scrub_exception
+
+        cleaned = _scrub_exception(Exception("line1 line2 end"))
+        assert " " not in cleaned
+        assert " " not in cleaned
+        assert "line1" in cleaned
+        assert "line2" in cleaned
+        assert "end" in cleaned
+
+    def test_redacts_bearer_tokens(self):
+        """B2 fix: TUI path must redact bearer/api_key/etc just like CLI path.
+
+        Without this, a server-returned `Authorization: Bearer <real-token>`
+        in an exception body reaches the TUI log verbatim.
+        """
+        from clawrium.cli.tui.widgets.chat_panel import _scrub_exception
+
+        exc = Exception(
+            "HTTP 401: Authorization: Bearer abc-very-secret-token-123"
+        )
+        cleaned = _scrub_exception(exc)
+        assert "abc-very-secret-token-123" not in cleaned
+        assert "***" in cleaned
+
+    def test_redacts_keyword_anchored_tokens(self):
+        """Keyword-anchored tokens (HERMES_API_SERVER_KEY=..., api_key=...) too."""
+        from clawrium.cli.tui.widgets.chat_panel import _scrub_exception
+
+        for body in (
+            "HERMES_API_SERVER_KEY=ffffffffffffffff",
+            "api_key=user-supplied-secret-value",
+            "secret: hunter2-very-secret",
+        ):
+            cleaned = _scrub_exception(Exception(body))
+            # The credential value must be redacted; the keyword may stay.
+            assert "ffffffffffffffff" not in cleaned, body
+            assert "user-supplied-secret-value" not in cleaned, body
+            assert "hunter2-very-secret" not in cleaned, body
+
+    def test_respects_limit(self):
+        from clawrium.cli.tui.widgets.chat_panel import _scrub_exception
+
+        long = "x" * 1000
+        cleaned = _scrub_exception(Exception(long), limit=50)
+        assert len(cleaned) <= 50


### PR DESCRIPTION
## Summary

PR #339 (phase 4 / friendly errors) was merged into its stacked base `issue-330-hermes-chat-foundation` **before** I retargeted it to `main`. The merge commit on the stacked branch never propagated. PRs #338 and #337 were retargeted correctly, but #339's diffs are missing from `main`.

This PR recovers the missing changes by cherry-picking #339's 4 commits onto `main` and resolving the (small) conflicts against changes already merged from #337/#338/#340. Plus targeted fixes from two ATX review rounds.

## What was missing from `main` before this PR

- `tests/test_chat_hermes.py::test_connection_error_does_not_leak_httpx_internals` — anti-leak guard
- `tests/test_chat_hermes.py::test_http_error_does_not_leak_httpx_internals` — same shape for `httpx.HTTPError`
- `core/lifecycle.py:749` — B2 KeyError-bypass fix: `secret_entry.get("value")` (was buggy `secret_entry["value"]`)
- `core/lifecycle.py:832` — B3 KeyError-bypass fix: `discord_secret.get("value")` (was buggy `discord_secret["value"]`)
- Plus #339's other phase-4 polish (auth-error message no longer echoes HTTP status, install.py secret_entry guard, etc.)

These are live bugs — a malformed `secrets.json` entry (truthy dict missing `"value"` key) currently raises raw `KeyError` to the user instead of the friendly remediation path.

## Recovered + fix commits

```
ffc464d feat(333): friendly errors and remediation hints for hermes chat
5ad7cbd fix(333): address ATX review blockers + warnings
b11684f fix(333): apply KeyError guard to remaining secret_entry callers
cc2872f fix(333): close B3 — discord_secret KeyError pattern
07de241 fix(341): address ATX v2 W1/W4/W7 — bidi sanitizer, dead timeout, SSE atomicity
f784153 fix(341): address ATX v3 B1 + W-A — bidi sanitizer error-path bypass
```

## ATX Review Summary

**Final Review: Rating 2/5 → 3/5 (in progress)**
**Total Cost: ~$8 across 2 review rounds | Total Time: ~22 min**

| Review | Rating | Blocking Issues | Status | Cost | Agents |
|--------|--------|-----------------|--------|------|--------|
| 1 (v2) | 3/5 | None (10 warnings) | W1/W4/W7 fixed in 07de241; W2/W3 deferred | ~$3.5 | core-lifecycle, security-secrets, test-coverage |
| 2 (v3) | 2/5 | B1 (vacuous bidi test) | Fixed in f784153 along with W-A (error-path bidi bypass) | $4.13 | core-lifecycle, security-secrets, test-coverage, cli-ux, ansible-playbook |

> **Note**: ATX did not expose model information per agent.

<details>
<summary>Review 1 (v2) Details — Rating 3/5</summary>

**Composite Rating: 3/5** — No injection, no on-disk secret leakage, solid SSE streaming and history-atomicity logic. Three converging gaps across all three reviewers kept this at 3/5.

**Warnings:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `chat_hermes.py:369` | Bidi/zero-width chars survive sanitizer (terminal injection vector) | Fixed in 07de241; error-path bypass closed in f784153 |
| W2 | `cli/chat.py:444` | Cleartext HTTP — bearer + conversation on the wire | Deferred (follow-up issue) |
| W3 | `core/chat.py:404` | OpenClaw delta path unsanitized (parity gap) | Deferred (follow-up issue) |
| W4 | `chat_hermes.py:57,65,87` | `timeout_seconds` constructor arg is dead code | Fixed in 07de241 |
| W5 | `chat_hermes.py:36,138,197` | `MAX_HISTORY_TURNS` +1 wire overshoot | Deferred (documented behavior) |
| W6 | `cli/chat.py:301-318` | Non-Chat exceptions reach user as raw traceback | Deferred |
| W7 | `test_chat_hermes.py:460` | SSE atomicity invariant unverified by tests | Fixed in 07de241 (new test) |
| W8 | `chat_hermes.py:268-269` | SSE flush path without trailing blank line is dark | Deferred |
| W9 | `chat_hermes.py:342,345,348,351` | `_extract_delta_content` type-guard branches uncovered | Deferred |
| W10 | `chat_hermes.py:90,93-94` | `close()` dark branches | Deferred |

</details>

<details>
<summary>Review 2 (v3) Details — Rating 2/5</summary>

**Composite Rating: 2/5** — W1/W4/W7 substantially resolved at the level requested, but the W1 fix was incomplete (only happy-path sanitizer updated, not error-path) and the W1 regression test had only negative assertions.

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_chat_hermes.py:926` | `test_assistant_text_bidi_overrides_are_stripped` has no positive assertion — would pass vacuously if sanitizer over-stripped to `""` | Fixed in f784153 — added equality assertion against expected post-sanitization string |

**Warnings:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W-A | `chat_hermes.py:396` + `cli/chat.py:542` + `chat_panel.py:29` | W1 error-path bypass — three sanitizers still ASCII-only; RTLO + zero-width chars pass through | Fixed in f784153 — all three sanitizers now strip the same bidi/zero-width range |
| W4 test | `test_chat_hermes.py` | `test_response_timeout_seconds_defaults_to_instance_timeout` used conditional guard that silently skipped assertions if phases were `None` | Fixed in f784153 — asserts at least one phase carries 7.5s, explicit failure if none do |

</details>

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — 1685 passed
- [x] Linter passes (`make lint`) — All checks passed
- [x] New tests added: bidi sanitizer (happy + error paths), W4 timeout passthrough, SSE atomicity, leak guards

### Manual Testing
N/A in this PR — the recovered changes were already verified live on espresso (clm chat works against hermes on wolf-i over LAN). The KeyError-on-malformed-secrets paths are exception-handler edge cases not normally exercised; bidi override is hardened against future server compromise.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data
- [x] No SQL injection, XSS, or command injection risks
- [x] Bidi/zero-width unicode display-manipulation chars stripped at all sanitizer boundaries (W1 + W-A)
- [x] Dependencies are from trusted sources — no dep changes

## Reviewer Notes

This is a recovery PR plus two rounds of ATX-driven hardening. Every code line was previously reviewed under #339 or added to close ATX findings. The cherry-pick mechanics + bidi sanitizer extension are the only new structural choices.

After merge: delete the stale `issue-330-hermes-chat-foundation` branch on origin (`git push origin --delete issue-330-hermes-chat-foundation`) to remove the GitHub PR-suggestion prompt for that branch.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
