### PR TITLE
fix(305): converge openclaw binary discovery on per-agent install

### DIFF
--- a/.itx/305/00_PLAN.md
+++ b/.itx/305/00_PLAN.md
@@ -1,26 +1,182 @@
-# Issue #305 — Bug Report (no plan yet)
+# Issue #305 — Implementation Plan (v2, post-ATX review)
 
-Bug filed via `/itx:bug-new` on 2026-05-09. No implementation plan yet — run `/itx:plan-create 305` to scope a fix.
+> **v1 → v2 changes:** Addresses 5 blocking issues from ATX review of v1. New: explicit `creates:` removal, ExecStart-change restart handler, mirrored unsafe-path validator with prescribed task ordering, expanded test specification including `start.yaml` coverage and `ansible.builtin.stat` mock event shape. Hardening gaps (installer checksum, npm pin, verbose secret logging) deferred to **#343** with explicit out-of-scope note.
 
-Surfaced while testing PR #304 (issue #163) against the `maurice` openclaw agent on `wolf-i`. The version-aware skip path could not fire because the runtime binary the systemd service executes (`/usr/local/bin/openclaw`, found via `which openclaw`) drifts in version from the per-agent install location (`/home/<agent>/.openclaw/bin/openclaw`). Result: every reinstall rotates gateway token + device credentials.
+## Customer Outcome
 
-See issue body on GitHub for full reproducer and three suggested fix directions.
+Re-running `clm agent install` on an OpenClaw agent that is already at the manifest-pinned version completes in seconds, preserves `config.gateway.device` and `config.gateway.auth` byte-identical in `hosts.json`, and never re-pairs — even on hosts where a system-wide `/usr/local/bin/openclaw` exists at a different version than the per-agent install at `/home/<agent>/.openclaw/bin/openclaw`. The systemd unit's `ExecStart` always points at the binary clawrium actually manages, and the running daemon picks up that binary without waiting for a reboot.
+
+## Root Cause
+
+Install and runtime use different sources of truth for which binary "counts":
+
+- **Install** writes to `/home/<agent>/.openclaw/bin/openclaw` via `install-cli.sh --prefix /home/<agent>/.openclaw`.
+- **Discovery** (in both `install.yaml` and `start.yaml`) uses `which openclaw` — which on hosts with a system-wide install resolves to `/usr/local/bin/openclaw` regardless of what was just installed.
+- **Version check** (added in #163 / PR #304) reads `--version` from the `which`-discovered binary, not the per-agent one.
+- **systemd `ExecStart`** runs `{{ openclaw_runtime_binary }}`, which is also set from the `which` result.
+
+Net effect: on any host where the system-wide binary version differs from the manifest target, `openclaw_already_installed` is always false, the skip path never fires, every re-install rotates gateway/device credentials, and the actually-running daemon stays on the system-wide version indefinitely. Pre-#163 the bug was silent (skip on binary existence); post-#163 it surfaces as perpetual re-pair.
+
+## Approach
+
+**Option 1 from the issue: prefer per-agent binary when present.** Cheapest fix, keeps the per-agent isolation model, preserves system-wide as a fallback for legacy hosts where someone manually installed openclaw before clawrium managed it.
+
+Rejected alternatives:
+- *Option 2 (always install per-agent, drop PATH discovery):* would silently strand the existing system-wide binary on hosts that have one — and lose the "fall back to a working binary if the agent install failed mid-flight" property. Larger scope, not needed to fix this bug.
+- *Option 3 (always install system-wide):* loses per-agent version pinning, larger blast radius, not aligned with the existing `--prefix /home/<agent>/.openclaw` design choice.
+
+## Files to Modify
+
+### 1. `src/clawrium/platform/registry/openclaw/playbooks/install.yaml`
+
+Concrete ordered task changes (named so they don't collide with `_install_was_skipped` substring matching):
+
+1. **New task** `Check per-agent openclaw binary` — `ansible.builtin.stat` on `/home/{{ agent_name }}/.openclaw/bin/openclaw`, register `openclaw_per_agent_stat`. Runs **before** the existing `Discover openclaw binary in PATH` task.
+2. **Keep existing** `Discover openclaw binary in PATH` (the `which openclaw` task) unchanged. It runs second.
+3. **New task** `Resolve openclaw binary (per-agent preferred, PATH fallback)` — `set_fact` for `openclaw_discovered_binary`:
+   - `/home/{{ agent_name }}/.openclaw/bin/openclaw` if `openclaw_per_agent_stat.stat.exists`
+   - else `openclaw_which_result.stdout` if `(openclaw_which_result.rc | default(1)) == 0`
+   - else `''`
+4. **Modify** the existing `Validate discovered binary path` task to validate `openclaw_discovered_binary` instead of `openclaw_which_result.stdout`. **Drop W3's proposed guard condition** — the per-agent path begins with `/home/`, already in the allowlist, so the validator passes unconditionally on the preferred branch and continues to gate the PATH-fallback branch. No ordering hazard.
+5. **Modify** `Get installed openclaw version` to invoke `{{ openclaw_discovered_binary }} --version` and gate on `openclaw_discovered_binary | length > 0`.
+6. **Modify** `Set install skip condition` so `openclaw_already_installed` is gated on `openclaw_discovered_binary | length > 0` (not `openclaw_which_result.rc`) and `openclaw_runtime_binary` is set from `openclaw_discovered_binary` with the same fallback (`/home/.../.openclaw/bin/openclaw`) when empty.
+7. **Modify** the `Mark install as skipped when already installed` debug task message to the exact string: `"OpenClaw v{{ openclaw_installed_version | default('unknown') }} already installed at {{ openclaw_discovered_binary }}. Skipping binary install."` (W2). The Python `_install_was_skipped` detection matches the task **name**, not the message, so the string change is safe — confirm by grep before the rename.
+8. **Modify** the `Note that --force was supplied` debug task to reference `openclaw_discovered_binary | default('<no prior install>')`.
+9. **B1 — Remove the `creates:` guard** on the `Install OpenClaw CLI runtime` task. Idempotency is fully covered by `when: not openclaw_already_installed`. Today the guard would silently skip the binary install on the "per-agent at non-target version" scenario while the pairing block still rotates credentials — exactly the regression test case 2 below targets.
+10. **B3 — Add `Restart openclaw service on ExecStart change` task** after the `Create systemd service file` task (which already `notify: Reload systemd`). New task:
+    - Captures the unit-file write result via `register: openclaw_unit_file_result` on the existing copy task.
+    - New `ansible.builtin.systemd` task with `name: "{{ agent_type }}-{{ agent_name }}"`, `state: restarted`, `daemon_reload: yes`, `when: openclaw_unit_file_result.changed`.
+    - This must execute **before** the `Enable and start openclaw service` task (which is a no-op on already-active services and won't pick up the binary change on its own).
+
+### 2. `src/clawrium/platform/registry/openclaw/playbooks/start.yaml`
+
+Mirror the discovery order; add the unsafe-path validator (B4); add the restart-on-change handler (B3). Concrete ordered tasks (replacing today's lines 22–30 block):
+
+1. **New** `Check per-agent openclaw binary` — `ansible.builtin.stat` on `/home/{{ agent_name }}/.openclaw/bin/openclaw`, register `openclaw_per_agent_stat`.
+2. **Existing** `Discover openclaw binary in PATH` — `which openclaw`, unchanged.
+3. **New** `Validate discovered PATH binary` — `ansible.builtin.fail` with the same allowlist used in `install.yaml`, **gated on**: `(not openclaw_per_agent_stat.stat.exists) and (openclaw_which_result.rc | default(1)) == 0`. This is the precise ordering called out in B4: only validate the `which` result when we're actually going to use it as the fallback. The per-agent path is allowlisted by construction (`/home/...`), so no validator needed on that branch.
+4. **New** `Resolve openclaw binary (per-agent preferred, PATH fallback)` — `set_fact openclaw_runtime_binary` with the same fallback chain as `install.yaml`.
+5. **Existing** `Sync systemd service file` (the `copy` task) — unchanged in body; the `ExecStart` now resolves from the new fact. Keep `register: service_file_changed`.
+6. **Existing** `Reload systemd if service file changed` — unchanged.
+7. **B3 — New** `Restart openclaw service if unit file changed` — `ansible.builtin.systemd` with `name`, `state: restarted`, `when: service_file_changed.changed`. Placed before the existing `Start openclaw service` task.
+
+### 3. `src/clawrium/platform/registry/openclaw/manifest.yaml`
+
+No changes for this bug. (Checksum field is in **#343 scope**, not here.)
+
+### 4. Tests
+
+Test files touched: `tests/test_install_skip.py`, plus a new `tests/test_start_binary_discovery.py` (B5).
+
+**Mock helper to add in `test_install_skip.py`** (and reuse in the new start test file):
+
+```python
+def _stat_event(task_name: str, path: str, exists: bool) -> dict:
+    return {
+        "event": "runner_on_ok",
+        "event_data": {
+            "task": task_name,
+            "res": {
+                "stat": {"exists": exists, "path": path} if exists else {"exists": False},
+                "changed": False,
+            },
+        },
+    }
+```
+
+**Existing fixture to update (W1):** `test_install_reuses_existing_installed_name_and_reports_skip` — change the simulated discovery to emit `_stat_event("Check per-agent openclaw binary", "/home/<agent>/.openclaw/bin/openclaw", exists=True)` plus a per-agent `--version` result at the target version. Drop the `/usr/local/bin/openclaw` `which` event (or keep it at a *different* version to exercise the precedence rule). Add an assertion: `openclaw_runtime_binary == "/home/<agent>/.openclaw/bin/openclaw"` in the resolved set_fact event.
+
+**New named test cases in `test_install_skip.py`:**
+
+| # | Function name | Scenario | Expected |
+|---|---------------|----------|----------|
+| T1 | `test_install_skips_when_per_agent_binary_at_target_and_system_diverges` | per-agent stat: exists, `--version` = target; `which`: `/usr/local/bin/openclaw` at different version | skip fires; no pairing tasks observed; `openclaw_runtime_binary` is per-agent path |
+| T2 | `test_install_reinstalls_when_per_agent_binary_at_non_target_even_if_system_matches` | per-agent stat: exists, `--version` ≠ target; `which`: system at target version | does NOT skip; binary install task runs; pairing tasks run |
+| T3 | `test_install_falls_back_to_path_when_per_agent_binary_absent` | per-agent stat: not exists; `which`: system at target version | skip fires via PATH fallback; `openclaw_runtime_binary` is the `which` result |
+| T4 | `test_install_proceeds_with_install_when_no_binary_anywhere` | per-agent stat: not exists; `which`: rc=1 | does NOT skip; install + pairing both run; `openclaw_runtime_binary` falls back to static per-agent path |
+
+**New `tests/test_start_binary_discovery.py` cases (B5):**
+
+| # | Function name | Scenario | Expected |
+|---|---------------|----------|----------|
+| S1 | `test_start_uses_per_agent_binary_when_present` | per-agent stat exists; `which` returns system path | unit file `ExecStart` resolves to per-agent path; validator does **not** run |
+| S2 | `test_start_falls_back_to_path_binary_when_per_agent_absent` | per-agent stat absent; `which` rc=0 | `ExecStart` is the `which` result; validator runs and passes |
+| S3 | `test_start_rejects_unsafe_path_binary` | per-agent stat absent; `which` returns `/tmp/openclaw` | playbook fails on `Validate discovered PATH binary`; unit file not rewritten |
+| S4 | `test_start_restarts_service_when_unit_file_changes` | unit file content differs from on-disk version | `Restart openclaw service if unit file changed` runs with `state: restarted` |
+
+**Python-side parser test (W4):** extend `test_openclaw_skip_detection_matches_fact_and_marker` (in whichever existing file owns it — grep before edit) with two cases:
+- negative: event stream emits the `openclaw_discovered_binary` set_fact **alone** ⇒ skip NOT detected (the resolved-binary fact is metadata, not a skip signal — guards against future regressions where someone adds an over-broad substring match on it)
+- positive: event stream emits the resolved-binary set_fact AND `openclaw_already_installed=True` ⇒ skip detected (the canonical skip path)
+
+## Steps
+
+1. **install.yaml** — apply the 10 ordered changes in §1 above (stat → which → resolve → validate-on-discovered → version check → skip-condition → debug strings → `creates:` removal → restart-on-change handler).
+2. **start.yaml** — apply the 7 ordered changes in §2 (stat → which → validate-on-which-only → resolve → unit-file copy with register → daemon-reload → restart-on-change → start).
+3. **Tests** — add the `_stat_event` helper, update the W1 fixture, add the 4 install-skip cases and 4 start-discovery cases above, extend the Python parser test (W4). Audit `tests/test_lifecycle.py` and `tests/test_cli_agent_start.py` for mocks that emit `Discover openclaw binary in PATH` without a matching stat event and update them (S3 from review).
+4. **`make test && make lint`** — both must pass clean.
+5. **Manual verification on wolf-i/maurice** (mandatory acceptance gate):
+   - **Reproducer:** repeat the #305 table (runs 1/2/3) with the fix applied; `device.id` and `gateway.auth` must be byte-identical across runs 2 and 3.
+   - **ExecStart convergence:** `systemctl cat openclaw-maurice.service` shows `ExecStart=/home/maurice/.openclaw/bin/openclaw …`, not `/usr/local/bin/openclaw …`, after a re-install.
+   - **Live daemon swap (B3 acceptance):** `pgrep -a -u maurice openclaw` shows the per-agent binary in the cmdline within seconds of the install completing — **no reboot, no manual restart**. The daemon's reported version (`curl … /version` or whatever the gateway exposes) matches the manifest target.
+
+## Test Strategy
+
+- `make test` — covers all unit-level changes including the new `tests/test_start_binary_discovery.py`.
+- `make lint` — `ruff check src tests`.
+- Manual reproducer on wolf-i is the acceptance gate — the cred-rotation symptom and the live daemon swap are not observable from unit tests alone.
+
+## Risks
+
+1. **Behavior change for hosts that intentionally rely on a system-wide override.** If anyone is using a hand-installed `/usr/local/bin/openclaw` to override the per-agent binary, this fix shifts them onto the per-agent binary silently. Acceptable: the playbook's contract is "manage the per-agent install"; using the system-wide one was an accident of `which` resolution, not a feature. Surface this in the PR body.
+2. **`state: restarted` on the unit causes a brief gateway downtime mid-install.** The pairing block runs immediately after this restart, which already implies a brief window of disconnection. Acceptable; matches the semantics of a "fresh install" path. On the skip path (`openclaw_already_installed=True`), the unit file should be byte-identical, so the restart task no-ops.
+3. **Test fixture migration.** The W1 fixture rewrite must be carefully reviewed — it's easy to write a new fixture that passes for the wrong reason (e.g., asserting on a substring that happens to appear in both old and new task names). Mitigation: every new assertion includes the *exact* path string and the *exact* task name.
+4. **`ansible.builtin.stat` event shape.** Mocks must emit `res.stat.exists` (boolean) not `res.stdout`/`res.rc` — flagged explicitly in B5; the `_stat_event` helper enforces this.
+
+## Out of Scope
+
+- **Migration of host records that already drifted.** Existing `hosts.json` entries for agents that have been re-paired N times will have whatever credentials the last run produced; this fix prevents *future* rotation but does not reconcile past damage.
+- **Provenance of the system-wide `/usr/local/bin/openclaw` on wolf-i.** Separate operational question.
+- **Installer integrity (B2), `npm install ws` pinning (W5), and verbose secret logging (W6).** Tracked in **#343**; orthogonal hardening pass, not part of the discovery-convergence bug fix.
+- **`device.privateKey` storage location.** Currently lives in `hosts.json` rather than `secrets.json`; architectural inconsistency surfaced by reviewer (S2). Out of scope for this bug — file a separate issue if pursued.
+
+## Subtasks
+
+None — single concern (binary discovery convergence), 2 source files + 2 test files. Direct execution via `/itx:execute 305`.
+
+## ATX Review Summary (v1 → v2)
+
+| Blocker | v1 status | v2 resolution |
+|---------|-----------|---------------|
+| B1 — `creates:` defeats version skip | Not mentioned | §1 step 9: removed; idempotency covered by `when:` gate |
+| B2 — installer checksum bypass | Not mentioned | Deferred to **#343** with explicit out-of-scope note |
+| B3 — ExecStart change leaves daemon stale | Risk-only | §1 step 10 + §2 step 7: explicit `state: restarted when: …changed` tasks in both playbooks |
+| B4 — start.yaml lacks validator | Not mentioned | §2 step 3: validator mirrored with correct ordering (stat → which → validate-only-when-which-chosen → resolve) |
+| B5 — start.yaml has no tests | Not specified | §4 + new `tests/test_start_binary_discovery.py` with 4 named cases; `_stat_event` helper specified |
+
+| Warning | v2 resolution |
+|---------|---------------|
+| W1 — old skip fixture simulates buggy state | §4 W1 fixture rewrite with explicit assertions |
+| W2 — debug string unspecified | §1 step 7 gives exact string and confirms `_install_was_skipped` matches task name |
+| W3 — validator guard rationale incorrect | §1 step 4 drops the unnecessary guard with rationale |
+| W4 — Python-side parser untested | §4 W4 test extension specified |
+| W5 — `npm install ws` unpinned | Deferred to **#343** |
+| W6 — secrets logged at verbosity=1 | Deferred to **#343** |
+
+Suggestions S1–S4 from the review folded into Risks (S1), Out of Scope (S2), Steps (S3 — audit `test_lifecycle.py` / `test_cli_agent_start.py`), and §1 task-naming (S4).
 
 ---
 
 <details>
 <summary>Prompt Log</summary>
 
-**Stage**: bug-creation
-**Skill**: /itx:bug-new
-**Timestamp**: 2026-05-09T19:05:00Z
+**Stage**: planning (v2 — ATX revision)
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-05-11T00:00:00Z
 **Model**: claude-opus-4-7
 
 ```prompt
-yes add a bug with details
-[surfaced from prior conversation: testing PR #304 on wolf-i/maurice revealed
- that /usr/local/bin/openclaw drifts in version from per-agent install path,
- making the new version-aware skip path unreachable on hosts in this state]
+v1: /itx-plan-create 305
+v2: revised in response to Stop-hook ATX review of v1 plan (5 blockers, 6 warnings, 4 suggestions). All 5 blockers resolved in plan body; B2/W5/W6 hardening gaps deferred to tracking issue #343.
 ```
 
 </details>

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -34,7 +34,7 @@ import ansible_runner
 from clawrium.core.config import get_config_dir
 from clawrium.core.hosts import get_host, update_host
 from clawrium.core.keys import get_host_private_key
-from clawrium.core.lifecycle import _resolve_agent_type
+from clawrium.core.lifecycle import _cleanup_ansible_artifacts, _resolve_agent_type
 from clawrium.core.names import (
     generate_random_name,
     is_name_available_on_host,
@@ -375,6 +375,12 @@ def run_installation(
     preserved_onboarding = [
         None
     ]  # Capture onboarding to restore after ansible succeeds
+    # #305: capture gateway config (auth token, device credentials, url, port)
+    # before set_installing() wipes the agent record. On the skip path the
+    # playbook intentionally does NOT re-emit these facts, so set_installed()
+    # has nothing to write back — without this capture the credentials would
+    # silently disappear on every clean re-install at the same version.
+    preserved_gateway = [None]
 
     def set_installing(h: dict) -> dict:
         # Check for incomplete installation under lock (unless cleanup or resume)
@@ -423,6 +429,14 @@ def run_installation(
         if resume:
             if chosen_name[0] not in h["agents"]:
                 raise InstallationError("Cannot resume: agent was removed")
+            # Resume path does NOT wipe the record (only fields are reassigned),
+            # but the skip-path warning still reads from `preserved_gateway`.
+            # Capture here too so resume+skip+existing-creds doesn't falsely
+            # warn "credentials missing" (Round 2 W1).
+            if claw_name == "openclaw":
+                preserved_gateway[0] = (
+                    h["agents"][chosen_name[0]].get("config", {}).get("gateway")
+                )
             h["agents"][chosen_name[0]]["status"] = "installing"
             h["agents"][chosen_name[0]]["error"] = None
             h["agents"][chosen_name[0]]["version"] = matched_version  # Update version
@@ -433,6 +447,16 @@ def run_installation(
             # UNLESS cleanup_failed=True, then we force a fresh install
             if chosen_name[0] in h.get("agents", {}) and not cleanup_failed:
                 preserved_onboarding[0] = h["agents"][chosen_name[0]].get("onboarding")
+                # Round 2 W4: scope to openclaw — the restore branch in
+                # set_installed() is the only consumer and is openclaw-specific.
+                # Other agent types may have unrelated `config.gateway` shapes
+                # that should NOT be restored under this code path.
+                if claw_name == "openclaw":
+                    preserved_gateway[0] = (
+                        h["agents"][chosen_name[0]]
+                        .get("config", {})
+                        .get("gateway")
+                    )
 
             h["agents"][chosen_name[0]] = {
                 "type": claw_name,
@@ -772,20 +796,14 @@ def run_installation(
         if claw_name == "openclaw":
             if install_skipped:
                 # Skip path: playbook intentionally did not emit credential facts
-                # (template-write + pairing block were gated). Verify that the
-                # existing hosts.json record actually has the credentials before
-                # going silent — otherwise surface a warning so corrupt state is
-                # visible.
-                existing_host = get_host(hostname)
-                existing_gateway = (
-                    (existing_host or {})
-                    .get("agents", {})
-                    .get(agent_name, {})
-                    .get("config", {})
-                    .get("gateway", {})
-                )
+                # (template-write + pairing block were gated). Read from the
+                # in-memory `preserved_gateway` snapshot captured before
+                # set_installing() wiped the agent record — reading the host
+                # record here would always observe the wiped state and falsely
+                # report "credentials missing" on every clean re-install.
+                preserved = preserved_gateway[0] or {}
                 has_existing_creds = bool(
-                    existing_gateway.get("auth") and existing_gateway.get("device")
+                    preserved.get("auth") and preserved.get("device")
                 )
                 if has_existing_creds:
                     emit("claw", "Reusing existing gateway credentials (skip path)")
@@ -820,6 +838,23 @@ def run_installation(
                 # This is done AFTER ansible succeeds to prevent corrupted state
                 if preserved_onboarding[0]:
                     h["agents"][agent_name]["onboarding"] = preserved_onboarding[0]
+
+                # #305: on the skip path the playbook does not re-emit gateway
+                # facts (template-write + pairing block are gated). Restore the
+                # gateway config we captured in set_installing() so re-running
+                # `clm agent install` at the same version does not silently drop
+                # the agent's auth token + device credentials. Scoped to
+                # openclaw (Round 2 W4) — other agent types do not store
+                # gateway credentials in this shape.
+                if (
+                    claw_name == "openclaw"
+                    and install_skipped
+                    and preserved_gateway[0]
+                    and not gateway_token
+                ):
+                    if "config" not in h["agents"][agent_name]:
+                        h["agents"][agent_name]["config"] = {}
+                    h["agents"][agent_name]["config"]["gateway"] = preserved_gateway[0]
 
                 # Store gateway authentication (OpenClaw only)
                 if gateway_token and gateway_url:
@@ -920,3 +955,14 @@ def run_installation(
 
         # Re-raise the exception
         raise
+    finally:
+        # CWE-312: ansible-runner caches the gateway token, device token, and
+        # device private key under `artifacts/<uuid>/fact_cache/<hostname>`
+        # via `cacheable: true` on the Save-all-credentials task. Without this
+        # cleanup the secrets persist on disk indefinitely. Mirrors the
+        # pattern in lifecycle.py's `_run_lifecycle_playbook`. The two child
+        # dirs are deterministic and `_cleanup_ansible_artifacts` guards
+        # internally with `.exists()`, so it's a safe no-op if a partial
+        # failure aborted before either subdir was created.
+        _cleanup_ansible_artifacts(install_log_dir / "base")
+        _cleanup_ansible_artifacts(install_log_dir / "claw")

--- a/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
@@ -13,27 +13,54 @@
         create_home: yes
         shell: /bin/bash
 
+    - name: Check per-agent openclaw binary
+      ansible.builtin.stat:
+        path: "/home/{{ agent_name }}/.openclaw/bin/openclaw"
+      register: openclaw_per_agent_stat
+
     - name: Discover openclaw binary in PATH
       ansible.builtin.command: which openclaw
       register: openclaw_which_result
       changed_when: false
       failed_when: false
 
+    # W2: a zero-byte or non-executable per-agent file (e.g. crashed mid-flight
+    # install artifact) must NOT be accepted as a working binary — that would
+    # silently produce an ExecStart that crash-loops under systemd's Restart=always.
+    - name: Resolve openclaw binary (per-agent preferred, PATH fallback)
+      ansible.builtin.set_fact:
+        openclaw_discovered_binary: >-
+          {{ ('/home/' ~ agent_name ~ '/.openclaw/bin/openclaw')
+             if (openclaw_per_agent_stat.stat.exists
+                 and openclaw_per_agent_stat.stat.executable | default(false)
+                 and (openclaw_per_agent_stat.stat.size | default(0)) > 0)
+             else (openclaw_which_result.stdout
+                   if (openclaw_which_result.rc | default(1)) == 0
+                   else '') }}
+
+    # The validator runs unconditionally on the RESOLVED binary — not on the
+    # raw `which` result and not gated on stat existence. Round 2 ATX flagged
+    # that gating on `not openclaw_per_agent_stat.stat.exists` creates a
+    # security gap: a zero-byte or non-executable per-agent file is rejected
+    # by W2's executable+size check, falls through to the PATH binary, but
+    # would then bypass this validator. Validating the resolved variable
+    # closes that path. The per-agent /home/... case trivially passes the
+    # allowlist — that's correct, not a no-op.
     - name: Validate discovered binary path
       ansible.builtin.fail:
-        msg: "Discovered openclaw binary at unsafe path: {{ openclaw_which_result.stdout }}. Expected under /usr/local/bin/, /usr/bin/, or /home/."
+        msg: "Discovered openclaw binary at unsafe path: {{ openclaw_discovered_binary }}. Expected under /usr/local/bin/, /usr/bin/, or /home/."
       when: >
-        (openclaw_which_result.rc | default(1)) == 0 and
-        not (openclaw_which_result.stdout.startswith('/usr/local/bin/') or
-             openclaw_which_result.stdout.startswith('/usr/bin/') or
-             openclaw_which_result.stdout.startswith('/home/'))
+        (openclaw_discovered_binary | length) > 0 and
+        not (openclaw_discovered_binary.startswith('/usr/local/bin/') or
+             openclaw_discovered_binary.startswith('/usr/bin/') or
+             openclaw_discovered_binary.startswith('/home/'))
 
     - name: Get installed openclaw version
-      ansible.builtin.command: "{{ openclaw_which_result.stdout }} --version"
+      ansible.builtin.command: "{{ openclaw_discovered_binary }} --version"
       register: openclaw_version_check
       changed_when: false
       failed_when: false
-      when: (openclaw_which_result.rc | default(1)) == 0
+      when: (openclaw_discovered_binary | length) > 0
 
     # Defensive parse: empty string on no-match means a version check failure
     # is treated as "version unknown" -> not a match -> reinstall (safe default).
@@ -47,21 +74,21 @@
     - name: Set install skip condition
       ansible.builtin.set_fact:
         openclaw_already_installed: >-
-          {{ (openclaw_which_result.rc | default(1)) == 0
+          {{ (openclaw_discovered_binary | length) > 0
              and (openclaw_installed_version | default('')) == openclaw_target_version
              and not (force_install | default(false) | bool) }}
-        openclaw_runtime_binary: "{{ openclaw_which_result.stdout if (openclaw_which_result.rc | default(1)) == 0 else '/home/' ~ agent_name ~ '/.openclaw/bin/openclaw' }}"
+        openclaw_runtime_binary: "{{ openclaw_discovered_binary if (openclaw_discovered_binary | length) > 0 else '/home/' ~ agent_name ~ '/.openclaw/bin/openclaw' }}"
 
     - name: Mark install as skipped when already installed
       ansible.builtin.debug:
-        msg: "OpenClaw v{{ openclaw_installed_version | default('unknown') }} already installed at {{ openclaw_which_result.stdout }}. Skipping binary install."
+        msg: "OpenClaw v{{ openclaw_installed_version | default('unknown') }} already installed at {{ openclaw_discovered_binary }}. Skipping binary install."
       when: openclaw_already_installed
 
     - name: Note that --force was supplied (overriding skip)
       ansible.builtin.debug:
-        msg: "force=true: reinstalling OpenClaw at {{ openclaw_which_result.stdout | default('<no prior install>') }}"
+        msg: "force=true: reinstalling OpenClaw at {{ openclaw_discovered_binary | default('<no prior install>') }}"
       when:
-        - (openclaw_which_result.rc | default(1)) == 0
+        - (openclaw_discovered_binary | length) > 0
         - force_install | default(false) | bool
 
     - name: Download OpenClaw installer script
@@ -88,7 +115,6 @@
           - --version
           - "{{ openclaw_target_version }}"
           - --no-onboard
-        creates: "/home/{{ agent_name }}/.openclaw/bin/openclaw"
       become_user: "{{ agent_name }}"
       when: not openclaw_already_installed
 
@@ -174,7 +200,19 @@
           [Install]
           WantedBy=multi-user.target
         mode: "0644"
-      notify: Reload systemd
+      register: openclaw_unit_file_result
+
+    # B3: when the unit file's ExecStart changes (e.g., binary path shifts from
+    # /usr/local/bin/openclaw to /home/<agent>/.openclaw/bin/openclaw), the next
+    # `state: started` is a no-op on already-active services. Force a restart so
+    # the daemon picks up the new binary without waiting for a reboot.
+    - name: Restart openclaw service on ExecStart change
+      ansible.builtin.systemd:
+        name: "{{ agent_type }}-{{ agent_name }}"
+        state: restarted
+        enabled: yes
+        daemon_reload: yes
+      when: openclaw_unit_file_result.changed
 
     - name: Enable and start openclaw service
       ansible.builtin.systemd:
@@ -276,8 +314,3 @@
         cacheable: true
       no_log: true
       when: not openclaw_already_installed
-
-  handlers:
-    - name: Reload systemd
-      ansible.builtin.systemd:
-        daemon_reload: yes

--- a/src/clawrium/platform/registry/openclaw/playbooks/start.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/start.yaml
@@ -19,15 +19,43 @@
         msg: "OpenClaw service not installed. Run 'clm agent install' first."
       when: not service_file.stat.exists
 
+    - name: Check per-agent openclaw binary
+      ansible.builtin.stat:
+        path: "/home/{{ agent_name }}/.openclaw/bin/openclaw"
+      register: openclaw_per_agent_stat
+
     - name: Discover openclaw binary in PATH
       ansible.builtin.command: which openclaw
       register: openclaw_which_result
       changed_when: false
       failed_when: false
 
-    - name: Set openclaw binary path
+    # W2: a zero-byte or non-executable per-agent file (e.g. crashed mid-flight
+    # install artifact) must NOT be accepted as a working binary — otherwise the
+    # service enters an infinite Restart=always crash-loop.
+    - name: Resolve openclaw binary (per-agent preferred, PATH fallback)
       ansible.builtin.set_fact:
-        openclaw_runtime_binary: "{{ openclaw_which_result.stdout if (openclaw_which_result.rc | default(1)) == 0 else '/home/' ~ agent_name ~ '/.openclaw/bin/openclaw' }}"
+        openclaw_runtime_binary: >-
+          {{ ('/home/' ~ agent_name ~ '/.openclaw/bin/openclaw')
+             if (openclaw_per_agent_stat.stat.exists
+                 and openclaw_per_agent_stat.stat.executable | default(false)
+                 and (openclaw_per_agent_stat.stat.size | default(0)) > 0)
+             else (openclaw_which_result.stdout
+                   if (openclaw_which_result.rc | default(1)) == 0
+                   else ('/home/' ~ agent_name ~ '/.openclaw/bin/openclaw')) }}
+
+    # Validator runs on the RESOLVED variable (the same one written to
+    # ExecStart), not on the raw `which` result. This closes the gap where a
+    # bad per-agent binary gets rejected by W2 but the PATH fallback then
+    # bypasses validation. Per-agent /home/... trivially passes.
+    - name: Validate resolved binary path
+      ansible.builtin.fail:
+        msg: "Resolved openclaw binary at unsafe path: {{ openclaw_runtime_binary }}. Expected under /usr/local/bin/, /usr/bin/, or /home/."
+      when: >
+        (openclaw_runtime_binary | length) > 0 and
+        not (openclaw_runtime_binary.startswith('/usr/local/bin/') or
+             openclaw_runtime_binary.startswith('/usr/bin/') or
+             openclaw_runtime_binary.startswith('/home/'))
 
     - name: Sync systemd service file
       ansible.builtin.copy:
@@ -51,8 +79,17 @@
         mode: "0644"
       register: service_file_changed
 
-    - name: Reload systemd if service file changed
+    # B3 + W3: bundle daemon_reload with the restart so `systemctl restart`
+    # cannot fire against stale unit content if the prior reload step is
+    # reordered or removed. `enabled: yes` (W1) closes the boot-time window
+    # between `state: restarted` and the later `state: started, enabled: yes`
+    # task — otherwise a reboot mid-install would leave the service running
+    # but not registered for boot.
+    - name: Restart openclaw service if unit file changed
       ansible.builtin.systemd:
+        name: "{{ agent_type }}-{{ agent_name }}"
+        state: restarted
+        enabled: yes
         daemon_reload: yes
       when: service_file_changed.changed
 
@@ -61,7 +98,6 @@
         name: "{{ agent_type }}-{{ agent_name }}"
         state: started
         enabled: yes
-        daemon_reload: yes
       register: start_result
 
     - name: Wait for service to be active

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1416,7 +1416,20 @@ def test_install_rejects_duplicate_name_same_host(monkeypatch, tmp_path):
             "os_version": "24.04",
             "memtotal_mb": 4096,
         },
-        "agents": {"zeroclaw": {"agent_name": "work-assistant"}},
+        # R3-B1: keyed by agent name with an explicit `type` and a non-terminal
+        # status so the duplicate-name guard is exercised on its intended code
+        # path. Pre-fix the key was the claw type, which made `h['agents'].get(name)`
+        # return None — `not existing_agent` then short-circuited to the "already
+        # in use" error for the wrong reason (None, not a real conflict).
+        # Status='removing' (not in {installed, failed}) is what trips the guard
+        # at install.py:411 when the record IS found by name.
+        "agents": {
+            "work-assistant": {
+                "type": "zeroclaw",
+                "agent_name": "work-assistant",
+                "status": "removing",
+            }
+        },
     }
     monkeypatch.setattr(clawrium.core.install, "get_host", lambda x: host_with_claw)
 

--- a/tests/test_install_binary_discovery.py
+++ b/tests/test_install_binary_discovery.py
@@ -1,0 +1,198 @@
+"""Static YAML-structure tests for the openclaw `install` playbook.
+
+Mirrors `test_start_binary_discovery.py` for `install.yaml`. Round 2 ATX
+review flagged that the install playbook's #305 changes (W2 executable+size
+guard in Resolve, W4 validator on the resolved variable, the ExecStart-change
+restart task, and the B1 `creates:` removal) were entirely unguarded by tests.
+
+Running real ansible isn't feasible in unit tests, but the relevant properties
+are statically expressible from the playbook structure.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+INSTALL_PLAYBOOK = (
+    Path(__file__).parent.parent
+    / "src"
+    / "clawrium"
+    / "platform"
+    / "registry"
+    / "openclaw"
+    / "playbooks"
+    / "install.yaml"
+)
+
+PER_AGENT_CONCAT = "'/home/' ~ agent_name ~ '/.openclaw/bin/openclaw'"
+
+
+@pytest.fixture(scope="module")
+def install_tasks() -> list[dict]:
+    play = yaml.safe_load(INSTALL_PLAYBOOK.read_text())
+    assert isinstance(play, list) and len(play) == 1, (
+        "install.yaml must be a single play"
+    )
+    tasks = play[0].get("tasks", [])
+    assert tasks, "install.yaml must declare tasks"
+    return tasks
+
+
+def _task_by_name(tasks: list[dict], name: str) -> dict | None:
+    return next((t for t in tasks if t.get("name") == name), None)
+
+
+def _index_by_name(tasks: list[dict], name: str) -> int:
+    return next(i for i, t in enumerate(tasks) if t.get("name") == name)
+
+
+def test_install_resolve_rejects_non_executable_per_agent_binary(
+    install_tasks: list[dict],
+) -> None:
+    """W2 — per-agent branch must require stat.executable AND stat.size > 0.
+
+    A zero-byte or non-executable file (e.g. crashed mid-flight install) must
+    NOT silently become the runtime binary — that produces an ExecStart that
+    crash-loops under systemd's Restart=always.
+    """
+    resolve = _task_by_name(
+        install_tasks,
+        "Resolve openclaw binary (per-agent preferred, PATH fallback)",
+    )
+    assert resolve is not None
+    set_fact = resolve.get("ansible.builtin.set_fact") or resolve.get("set_fact")
+    assert set_fact is not None
+    expr = set_fact["openclaw_discovered_binary"]
+
+    # All three predicates must appear in the per-agent branch guard.
+    assert "openclaw_per_agent_stat.stat.exists" in expr
+    assert "openclaw_per_agent_stat.stat.executable" in expr
+    assert "openclaw_per_agent_stat.stat.size" in expr
+    # And the per-agent path must come before the `which` fallback in the
+    # conditional — otherwise PATH wins and the discovery convergence breaks.
+    assert PER_AGENT_CONCAT in expr
+    assert expr.index("openclaw_per_agent_stat.stat.exists") < expr.index(
+        "openclaw_which_result.stdout"
+    )
+
+
+def test_install_validator_runs_on_resolved_variable(
+    install_tasks: list[dict],
+) -> None:
+    """Round 2 B1 — validator must run on `openclaw_discovered_binary`
+    (the resolved variable, which is what propagates to ExecStart), NOT on
+    `openclaw_which_result.stdout` (the raw PATH discovery).
+
+    The earlier W4 fix (gate validator on `not stat.exists`) is REJECTED: it
+    let a non-executable per-agent file fall back to an unvalidated PATH
+    binary that then reached ExecStart unchecked.
+    """
+    validate = _task_by_name(install_tasks, "Validate discovered binary path")
+    assert validate is not None
+    when = validate["when"]
+
+    # Must check the resolved variable, not the raw which result.
+    assert "openclaw_discovered_binary" in when
+    assert "openclaw_which_result.stdout" not in when
+
+    # Must NOT be gated on stat.exists — that's the regressed behavior.
+    assert "not openclaw_per_agent_stat.stat.exists" not in when
+
+    # Allowlist content present.
+    for allowed in ("/usr/local/bin/", "/usr/bin/", "/home/"):
+        assert allowed in when, f"Allowlist missing prefix {allowed!r}"
+
+    # Must be a fail task (debug wouldn't stop the playbook).
+    assert (
+        validate.get("ansible.builtin.fail") is not None
+        or validate.get("fail") is not None
+    )
+
+
+def test_install_discovery_task_ordering(install_tasks: list[dict]) -> None:
+    """Required order: stat → which → resolve → validate → version-check.
+
+    Resolve must run before Validate (the validator reads the resolved fact).
+    Version-check must run after Validate (otherwise an unsafe PATH binary
+    would be invoked with `--version` before the safety check).
+    """
+    stat_idx = _index_by_name(install_tasks, "Check per-agent openclaw binary")
+    which_idx = _index_by_name(install_tasks, "Discover openclaw binary in PATH")
+    resolve_idx = _index_by_name(
+        install_tasks, "Resolve openclaw binary (per-agent preferred, PATH fallback)"
+    )
+    validate_idx = _index_by_name(install_tasks, "Validate discovered binary path")
+    version_idx = _index_by_name(install_tasks, "Get installed openclaw version")
+    assert stat_idx < which_idx < resolve_idx < validate_idx < version_idx
+
+
+def test_install_creates_guard_removed_from_runtime_install(
+    install_tasks: list[dict],
+) -> None:
+    """B1 (v1) — the `Install OpenClaw CLI runtime` task must NOT carry a
+    `creates:` argument. The pre-fix guard silently bypassed the install when
+    the per-agent file existed at any version, masking version drift and the
+    credential-rotation bug. Idempotency is owned by `when: not
+    openclaw_already_installed` instead.
+    """
+    install_task = _task_by_name(install_tasks, "Install OpenClaw CLI runtime")
+    assert install_task is not None
+    cmd = install_task.get("ansible.builtin.command") or install_task.get("command")
+    assert cmd is not None, "Install task must use ansible.builtin.command"
+    # `creates:` would live inside the command module dict, not at task level.
+    if isinstance(cmd, dict):
+        assert "creates" not in cmd, (
+            "creates: guard reintroduced — masks #305 credential-rotation bug"
+        )
+    # And the `when:` gate is what actually owns idempotency now.
+    assert "not openclaw_already_installed" in install_task["when"]
+
+
+def test_install_restarts_service_on_execstart_change(
+    install_tasks: list[dict],
+) -> None:
+    """B3 — explicit `state: restarted` on unit-file change.
+
+    `state: started` on an already-active service is a no-op even after a
+    unit-file rewrite — exactly the path that left the running daemon stuck
+    on `/usr/local/bin/openclaw` while the ExecStart pointed at the per-agent
+    binary in issue #305. The restart task must be gated on the unit-file
+    copy's `changed` flag and must run BEFORE the regular `Enable and start`
+    task. It must also bundle `daemon_reload: yes` so a stale-unit restart
+    is impossible.
+    """
+    sync = _task_by_name(install_tasks, "Create systemd service file")
+    assert sync is not None
+    assert sync.get("register") == "openclaw_unit_file_result"
+
+    restart = _task_by_name(install_tasks, "Restart openclaw service on ExecStart change")
+    assert restart is not None
+    systemd = restart.get("ansible.builtin.systemd") or restart.get("systemd")
+    assert systemd is not None
+    assert systemd.get("state") == "restarted"
+    assert systemd.get("enabled") is True  # W1
+    assert systemd.get("daemon_reload") is True  # W3/W6
+    assert "openclaw_unit_file_result.changed" in restart["when"]
+
+    restart_idx = _index_by_name(
+        install_tasks, "Restart openclaw service on ExecStart change"
+    )
+    start_idx = _index_by_name(install_tasks, "Enable and start openclaw service")
+    assert restart_idx < start_idx
+
+
+def test_install_systemd_unit_uses_resolved_runtime_binary(
+    install_tasks: list[dict],
+) -> None:
+    """Sanity guard against future regression of the original #305 root cause.
+
+    The unit file content must reference `{{ openclaw_runtime_binary }}` — the
+    resolved fact — and never `openclaw_which_result.stdout` directly.
+    """
+    sync = _task_by_name(install_tasks, "Create systemd service file")
+    copy = sync.get("ansible.builtin.copy") or sync.get("copy")
+    content = copy["content"]
+    assert "ExecStart={{ openclaw_runtime_binary }}" in content
+    assert "openclaw_which_result.stdout" not in content

--- a/tests/test_install_skip.py
+++ b/tests/test_install_skip.py
@@ -77,7 +77,121 @@ def _result_with_events(tmp_path, events):
     return SuccessfulResult()
 
 
+def _stat_event(
+    task_name: str,
+    path: str,
+    exists: bool,
+    executable: bool = True,
+    size: int = 1024,
+) -> dict:
+    """Emit a `runner_on_ok` event shaped like ansible.builtin.stat output.
+
+    Used to simulate the `Check per-agent openclaw binary` task without invoking
+    real ansible. Note the `res.stat.exists` / `res.stat.path` / `res.stat.executable`
+    / `res.stat.size` shape — distinct from `res.stdout` / `res.rc` used by
+    `command` tasks. The executable + size fields are load-bearing: the resolve
+    set_fact in the playbook gates the per-agent branch on `stat.exists AND
+    stat.executable AND stat.size > 0`, so a mock that omits them would model
+    an event that would NOT take the per-agent branch under real ansible.
+    """
+    if exists:
+        stat_payload: dict = {
+            "exists": True,
+            "path": path,
+            "executable": executable,
+            "size": size,
+        }
+    else:
+        stat_payload = {"exists": False}
+    return {
+        "event": "runner_on_ok",
+        "event_data": {
+            "task": task_name,
+            "res": {"stat": stat_payload, "changed": False},
+        },
+    }
+
+
+def _which_event(stdout: str, rc: int = 0) -> dict:
+    return {
+        "event": "runner_on_ok",
+        "event_data": {
+            "task": "Discover openclaw binary in PATH",
+            "res": {"stdout": stdout, "rc": rc},
+        },
+    }
+
+
+def _resolved_binary_event(path: str) -> dict:
+    return {
+        "event": "runner_on_ok",
+        "event_data": {
+            "task": "Resolve openclaw binary (per-agent preferred, PATH fallback)",
+            "res": {"ansible_facts": {"openclaw_discovered_binary": path}},
+        },
+    }
+
+
+def _version_event(stdout: str, rc: int = 0) -> dict:
+    return {
+        "event": "runner_on_ok",
+        "event_data": {
+            "task": "Get installed openclaw version",
+            "res": {"stdout": stdout, "rc": rc},
+        },
+    }
+
+
+def _parse_version_event(version: str) -> dict:
+    return {
+        "event": "runner_on_ok",
+        "event_data": {
+            "task": "Parse installed openclaw version",
+            "res": {"ansible_facts": {"openclaw_installed_version": version}},
+        },
+    }
+
+
+def _skip_condition_event(already_installed: bool, runtime_binary: str) -> dict:
+    return {
+        "event": "runner_on_ok",
+        "event_data": {
+            "task": "Set install skip condition",
+            "res": {
+                "ansible_facts": {
+                    "openclaw_already_installed": already_installed,
+                    "openclaw_runtime_binary": runtime_binary,
+                }
+            },
+        },
+    }
+
+
+def _skip_marker_event(version: str, path: str) -> dict:
+    return {
+        "event": "runner_on_ok",
+        "event_data": {
+            "task": "Mark install as skipped when already installed",
+            "res": {
+                "msg": (
+                    f"OpenClaw v{version} already installed at {path}. "
+                    "Skipping binary install."
+                )
+            },
+        },
+    }
+
+
 def test_install_reuses_existing_installed_name_and_reports_skip(monkeypatch, tmp_path):
+    """Skip path must preserve the existing agent's gateway credentials.
+
+    B2 fix (ATX review v1): the agent record is keyed by agent name, not by
+    claw type, and `run_installation` is invoked with `name='existing-agent'`
+    so it targets the same key. Otherwise the install code would generate a
+    random new name, the `agents.openclaw` record would stay untouched, and
+    the credential assertions below would pass trivially regardless of what
+    the install code actually wrote (the false positive flagged in review v1).
+    """
     from clawrium.core.install import run_installation
 
     preserved_device = {
@@ -95,7 +209,8 @@ def test_install_reuses_existing_installed_name_and_reports_skip(monkeypatch, tm
             "memtotal_mb": 4096,
         },
         "agents": {
-            "openclaw": {
+            "existing-agent": {
+                "type": "openclaw",
                 "status": "installed",
                 "installed_at": "2026-04-10T00:00:00+00:00",
                 "error": None,
@@ -116,72 +231,46 @@ def test_install_reuses_existing_installed_name_and_reports_skip(monkeypatch, tm
 
     import ansible_runner
 
+    per_agent_path = "/home/existing-agent/.openclaw/bin/openclaw"
+    # Per-agent binary present at target version; a stale system-wide binary
+    # also exists at a different version — discovery must prefer per-agent.
     run_side_effect = [
         _result_with_events(tmp_path, []),
         _result_with_events(
             tmp_path,
             [
-                {
-                    "event": "runner_on_ok",
-                    "event_data": {
-                        "task": "Discover openclaw binary in PATH",
-                        "res": {"stdout": "/usr/local/bin/openclaw", "rc": 0},
-                    },
-                },
-                {
-                    "event": "runner_on_ok",
-                    "event_data": {
-                        "task": "Get installed openclaw version",
-                        "res": {"stdout": "openclaw 2026.4.2", "rc": 0},
-                    },
-                },
-                {
-                    "event": "runner_on_ok",
-                    "event_data": {
-                        "task": "Parse installed openclaw version",
-                        "res": {
-                            "ansible_facts": {
-                                "openclaw_installed_version": "2026.4.2",
-                            }
-                        },
-                    },
-                },
-                {
-                    "event": "runner_on_ok",
-                    "event_data": {
-                        "task": "Set install skip condition",
-                        "res": {
-                            "ansible_facts": {
-                                "openclaw_already_installed": True,
-                                "openclaw_runtime_binary": "/usr/local/bin/openclaw",
-                            }
-                        },
-                    },
-                },
-                {
-                    "event": "runner_on_ok",
-                    "event_data": {
-                        "task": "Mark install as skipped when already installed",
-                        "res": {
-                            "msg": "OpenClaw v2026.4.2 already installed at /usr/local/bin/openclaw. Skipping binary install."
-                        },
-                    },
-                },
+                _stat_event(
+                    "Check per-agent openclaw binary", per_agent_path, exists=True
+                ),
+                _which_event("/usr/local/bin/openclaw", rc=0),
+                _resolved_binary_event(per_agent_path),
+                _version_event("openclaw 2026.4.2", rc=0),
+                _parse_version_event("2026.4.2"),
+                _skip_condition_event(
+                    already_installed=True, runtime_binary=per_agent_path
+                ),
+                _skip_marker_event("2026.4.2", per_agent_path),
             ],
         ),
     ]
     mock_run = Mock(side_effect=run_side_effect)
     monkeypatch.setattr(ansible_runner, "run", mock_run)
 
-    result = run_installation("openclaw", "test-host")
+    result = run_installation("openclaw", "test-host", name="existing-agent")
 
     assert result["success"] is True
     assert result["skipped"] is True
     assert result["skip_reason"] == "already_installed"
-    assert host_state[0]["agents"]["openclaw"]["agent_name"] == "existing-agent"
-    # Existing gateway URL, auth token, and device credentials must be byte-identical
-    # after the skip — proves pairing did not re-run and rotate credentials.
-    gateway = host_state[0]["agents"]["openclaw"]["config"]["gateway"]
+    agent_record = host_state[0]["agents"]["existing-agent"]
+    assert agent_record["agent_name"] == "existing-agent"
+    assert agent_record["status"] == "installed"
+    # B3 regression guard: gateway URL, auth token, and device credentials
+    # must be byte-identical after the skip. Pre-fix, set_installing() wiped
+    # the agent record and set_installed() had no captured snapshot to write
+    # back, so credentials silently disappeared even though `skipped=True`
+    # was reported. The `preserved_gateway` capture in install.py restores
+    # them under `install_skipped=True and gateway_token is None`.
+    gateway = agent_record["config"]["gateway"]
     assert gateway["url"] == "ws://example:40001"
     assert gateway["auth"] == "preserved-gateway-token-aaaaaaaaaaaaaa"
     assert gateway["device"] == preserved_device
@@ -208,7 +297,8 @@ def test_install_existing_agent_different_version_proceeds_with_install(
             "memtotal_mb": 4096,
         },
         "agents": {
-            "openclaw": {
+            "existing-agent": {
+                "type": "openclaw",
                 "status": "installed",
                 "installed_at": "2026-04-10T00:00:00+00:00",
                 "error": None,
@@ -218,66 +308,53 @@ def test_install_existing_agent_different_version_proceeds_with_install(
         },
     }
 
-    _setup_common(monkeypatch, tmp_path, host)
+    host_state = _setup_common(monkeypatch, tmp_path, host)
 
     import ansible_runner
 
     # Mismatched version: installed=2026.3.1, target=2026.4.2 (from manifest in
     # _setup_common). Playbook emits the version facts but NOT the skip marker.
+    per_agent_path = "/home/existing-agent/.openclaw/bin/openclaw"
     run_side_effect = [
         _result_with_events(tmp_path, []),
         _result_with_events(
             tmp_path,
             [
-                {
-                    "event": "runner_on_ok",
-                    "event_data": {
-                        "task": "Discover openclaw binary in PATH",
-                        "res": {"stdout": "/usr/local/bin/openclaw", "rc": 0},
-                    },
-                },
-                {
-                    "event": "runner_on_ok",
-                    "event_data": {
-                        "task": "Get installed openclaw version",
-                        "res": {"stdout": "openclaw 2026.3.1", "rc": 0},
-                    },
-                },
-                {
-                    "event": "runner_on_ok",
-                    "event_data": {
-                        "task": "Parse installed openclaw version",
-                        "res": {
-                            "ansible_facts": {
-                                "openclaw_installed_version": "2026.3.1",
-                            }
-                        },
-                    },
-                },
-                {
-                    "event": "runner_on_ok",
-                    "event_data": {
-                        "task": "Set install skip condition",
-                        "res": {
-                            "ansible_facts": {
-                                "openclaw_already_installed": False,
-                                "openclaw_runtime_binary": "/usr/local/bin/openclaw",
-                            }
-                        },
-                    },
-                },
+                _stat_event(
+                    "Check per-agent openclaw binary", per_agent_path, exists=False
+                ),
+                _which_event("/usr/local/bin/openclaw", rc=0),
+                _resolved_binary_event("/usr/local/bin/openclaw"),
+                _version_event("openclaw 2026.3.1", rc=0),
+                _parse_version_event("2026.3.1"),
+                _skip_condition_event(
+                    already_installed=False, runtime_binary="/usr/local/bin/openclaw"
+                ),
             ],
         ),
     ]
     mock_run = Mock(side_effect=run_side_effect)
     monkeypatch.setattr(ansible_runner, "run", mock_run)
 
-    result = run_installation("openclaw", "test-host")
+    # `name=` targets the existing agent record. Without it install would
+    # generate a fresh name and the "different version" scenario the test
+    # claims to exercise wouldn't actually be exercised.
+    result = run_installation("openclaw", "test-host", name="existing-agent")
 
     assert result["success"] is True
     assert result.get("skipped") is not True
     assert result.get("skip_reason") is None
     assert mock_run.call_count == 2
+    # R3-W4 / R4-W2: only `status` and `installed_at` prove set_installed
+    # actually ran; `version` is written by set_installing BEFORE ansible
+    # executes, so a version assertion on its own would not catch a
+    # set_installed failure. Asserting all three discriminates between
+    # "manifest cache regression" (would also flip version) and "set_installed
+    # never reached" (would leave status=installing, installed_at=None).
+    agent_record = host_state[0]["agents"]["existing-agent"]
+    assert agent_record["status"] == "installed"
+    assert agent_record["installed_at"] is not None
+    assert agent_record["version"] == "2026.4.2"
 
 
 def test_openclaw_skip_detection_matches_fact_and_marker():
@@ -328,6 +405,68 @@ def test_openclaw_skip_detection_matches_fact_and_marker():
         ]
 
     assert _openclaw_install_was_skipped(ResultFalsePositive()) is False
+
+    # W4 (#305): the resolved-binary set_fact does NOT itself signal a skip.
+    # Only `openclaw_already_installed=True` or the skip-marker task name does.
+    # This guards against future regressions where someone adds an over-broad
+    # substring match on `openclaw_discovered_binary` and accidentally claims
+    # every install was skipped.
+    class ResultResolvedOnly:
+        events = [
+            {
+                "event": "runner_on_ok",
+                "event_data": {
+                    "task": (
+                        "Resolve openclaw binary (per-agent preferred, PATH fallback)"
+                    ),
+                    "res": {
+                        "ansible_facts": {
+                            "openclaw_discovered_binary": (
+                                "/home/agent/.openclaw/bin/openclaw"
+                            )
+                        }
+                    },
+                },
+            }
+        ]
+
+    assert _openclaw_install_was_skipped(ResultResolvedOnly()) is False
+
+    # And once the skip-condition fact also lands, detection flips True.
+    class ResultResolvedAndSkipped:
+        events = [
+            {
+                "event": "runner_on_ok",
+                "event_data": {
+                    "task": (
+                        "Resolve openclaw binary (per-agent preferred, PATH fallback)"
+                    ),
+                    "res": {
+                        "ansible_facts": {
+                            "openclaw_discovered_binary": (
+                                "/home/agent/.openclaw/bin/openclaw"
+                            )
+                        }
+                    },
+                },
+            },
+            {
+                "event": "runner_on_ok",
+                "event_data": {
+                    "task": "Set install skip condition",
+                    "res": {
+                        "ansible_facts": {
+                            "openclaw_already_installed": True,
+                            "openclaw_runtime_binary": (
+                                "/home/agent/.openclaw/bin/openclaw"
+                            ),
+                        }
+                    },
+                },
+            },
+        ]
+
+    assert _openclaw_install_was_skipped(ResultResolvedAndSkipped()) is True
 
 
 def test_install_failure_sets_failed_status_without_installed_timestamp(
@@ -402,7 +541,8 @@ def test_install_with_force_skips_skip_logic(monkeypatch, tmp_path):
             "memtotal_mb": 4096,
         },
         "agents": {
-            "openclaw": {
+            "existing-agent": {
+                "type": "openclaw",
                 "status": "installed",
                 "installed_at": "2026-04-10T00:00:00+00:00",
                 "error": None,
@@ -432,7 +572,9 @@ def test_install_with_force_skips_skip_logic(monkeypatch, tmp_path):
         ansible_runner, "run", _capture_inventory_run(captured_inventories)
     )
 
-    result = run_installation("openclaw", "test-host", force=True)
+    result = run_installation(
+        "openclaw", "test-host", name="existing-agent", force=True
+    )
 
     # Two playbooks run: base + agent. Both receive the same inventory vars.
     assert len(captured_inventories) == 2
@@ -495,7 +637,8 @@ def test_install_with_unparseable_version_proceeds_with_install(monkeypatch, tmp
             "memtotal_mb": 4096,
         },
         "agents": {
-            "openclaw": {
+            "existing-agent": {
+                "type": "openclaw",
                 "status": "installed",
                 "installed_at": "2026-04-10T00:00:00+00:00",
                 "error": None,
@@ -504,64 +647,368 @@ def test_install_with_unparseable_version_proceeds_with_install(monkeypatch, tmp
             }
         },
     }
-    _setup_common(monkeypatch, tmp_path, host)
+    host_state = _setup_common(monkeypatch, tmp_path, host)
 
     import ansible_runner
 
     # Playbook reports binary exists but version output is garbage; skip marker
     # is NOT emitted because installed_version != target_version.
+    per_agent_path = "/home/existing-agent/.openclaw/bin/openclaw"
     run_side_effect = [
         _result_with_events(tmp_path, []),
         _result_with_events(
             tmp_path,
             [
-                {
-                    "event": "runner_on_ok",
-                    "event_data": {
-                        "task": "Discover openclaw binary in PATH",
-                        "res": {"stdout": "/usr/local/bin/openclaw", "rc": 0},
-                    },
-                },
-                {
-                    "event": "runner_on_ok",
-                    "event_data": {
-                        "task": "Get installed openclaw version",
-                        "res": {
-                            "stdout": "openclaw: command moved, please reinstall",
-                            "rc": 0,
-                        },
-                    },
-                },
-                {
-                    "event": "runner_on_ok",
-                    "event_data": {
-                        "task": "Parse installed openclaw version",
-                        "res": {
-                            "ansible_facts": {
-                                "openclaw_installed_version": "",
-                            }
-                        },
-                    },
-                },
-                {
-                    "event": "runner_on_ok",
-                    "event_data": {
-                        "task": "Set install skip condition",
-                        "res": {
-                            "ansible_facts": {
-                                "openclaw_already_installed": False,
-                                "openclaw_runtime_binary": "/usr/local/bin/openclaw",
-                            }
-                        },
-                    },
-                },
+                _stat_event(
+                    "Check per-agent openclaw binary", per_agent_path, exists=False
+                ),
+                _which_event("/usr/local/bin/openclaw", rc=0),
+                _resolved_binary_event("/usr/local/bin/openclaw"),
+                _version_event("openclaw: command moved, please reinstall", rc=0),
+                _parse_version_event(""),
+                _skip_condition_event(
+                    already_installed=False, runtime_binary="/usr/local/bin/openclaw"
+                ),
             ],
         ),
     ]
     mock_run = Mock(side_effect=run_side_effect)
     monkeypatch.setattr(ansible_runner, "run", mock_run)
 
-    result = run_installation("openclaw", "test-host")
+    # `name=` so the install code targets the existing record rather than
+    # generating a fresh name (which would make "no skip marker" trivially true).
+    result = run_installation("openclaw", "test-host", name="existing-agent")
 
     assert result["success"] is True
     assert result.get("skipped") is not True
+    # R3-W4 + R4-W1: status + installed_at confirm set_installed ran;
+    # version assertion catches manifest-cache regressions that would write
+    # the wrong matched_version. Symmetric with the different-version test.
+    agent_record = host_state[0]["agents"]["existing-agent"]
+    assert agent_record["status"] == "installed"
+    assert agent_record["installed_at"] is not None
+    assert agent_record["version"] == "2026.4.2"
+
+
+# -----------------------------------------------------------------------------
+# Issue #305 — binary discovery convergence tests
+#
+# These cases exercise the "per-agent stat then PATH fallback" precedence
+# explicitly. They prove:
+#   * the skip path fires when the per-agent binary is at target *even if* a
+#     system-wide binary at a different version exists (T1 — the #305 fix);
+#   * a per-agent binary at the wrong version forces a reinstall, even if a
+#     system-wide binary happens to be at the target version (T2 — per-agent
+#     wins, so the playbook converges on the binary clawrium manages);
+#   * PATH fallback still works when the per-agent path is absent (T3);
+#   * with no binary anywhere, install proceeds and `openclaw_runtime_binary`
+#     falls back to the static per-agent path (T4).
+# -----------------------------------------------------------------------------
+
+
+def _host_with_existing_agent(version: str = "2026.4.2") -> dict:
+    # B2 fix (ATX v1): keyed by agent name, with explicit `type` field, so the
+    # install code's lookups actually find this record when invoked with
+    # `name='existing-agent'`. The pre-fix shape (`agents.openclaw`) was never
+    # touched by install.py and made the credential assertions trivially pass.
+    return {
+        "hostname": "test-host",
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+        "agents": {
+            "existing-agent": {
+                "type": "openclaw",
+                "status": "installed",
+                "installed_at": "2026-04-10T00:00:00+00:00",
+                "error": None,
+                "agent_name": "existing-agent",
+                "version": version,
+                "config": {
+                    "gateway": {
+                        "url": "ws://example:40001",
+                        "auth": "preserved-gateway-token-aaaaaaaaaaaaaa",
+                        "device": {
+                            "id": "device-abc",
+                            "token": "token-xyz",
+                            "privateKey": "PEM-DATA-HERE",
+                        },
+                    }
+                },
+            }
+        },
+    }
+
+
+def test_install_skips_when_per_agent_binary_at_target_and_system_diverges(
+    monkeypatch, tmp_path
+):
+    """T1 — the #305 fix.
+
+    Per-agent binary exists at the target version; a system-wide binary also
+    exists but at a different version. The playbook must prefer the per-agent
+    binary, observe a version match, fire the skip path, and preserve the
+    existing gateway credentials byte-identical.
+    """
+    from clawrium.core.install import run_installation
+
+    per_agent_path = "/home/existing-agent/.openclaw/bin/openclaw"
+    host = _host_with_existing_agent()
+    host_state = _setup_common(monkeypatch, tmp_path, host)
+
+    import ansible_runner
+
+    run_side_effect = [
+        _result_with_events(tmp_path, []),
+        _result_with_events(
+            tmp_path,
+            [
+                _stat_event(
+                    "Check per-agent openclaw binary", per_agent_path, exists=True
+                ),
+                _which_event("/usr/local/bin/openclaw", rc=0),
+                _resolved_binary_event(per_agent_path),
+                _version_event("openclaw 2026.4.2", rc=0),
+                _parse_version_event("2026.4.2"),
+                _skip_condition_event(
+                    already_installed=True, runtime_binary=per_agent_path
+                ),
+                _skip_marker_event("2026.4.2", per_agent_path),
+            ],
+        ),
+    ]
+    mock_run = Mock(side_effect=run_side_effect)
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    result = run_installation("openclaw", "test-host", name="existing-agent")
+
+    assert result["success"] is True
+    assert result["skipped"] is True
+    assert result["skip_reason"] == "already_installed"
+    gateway = host_state[0]["agents"]["existing-agent"]["config"]["gateway"]
+    assert gateway["auth"] == "preserved-gateway-token-aaaaaaaaaaaaaa"
+    assert gateway["device"]["id"] == "device-abc"
+    assert gateway["device"]["token"] == "token-xyz"
+
+
+def test_install_reinstalls_when_per_agent_binary_at_non_target_even_if_system_matches(
+    monkeypatch, tmp_path
+):
+    """T2 — per-agent precedence regression guard.
+
+    Per-agent binary at the wrong version, system-wide binary at the target
+    version. Per-agent must win, the version mismatch must defeat the skip
+    path, and the install must proceed. The previous `creates:` guard on the
+    install task would have silently masked this case — that guard is removed.
+    """
+    from clawrium.core.install import run_installation
+
+    per_agent_path = "/home/existing-agent/.openclaw/bin/openclaw"
+    host = _host_with_existing_agent()
+    _setup_common(monkeypatch, tmp_path, host)
+    # Need `name=` so the agent record under "existing-agent" is targeted;
+    # otherwise install would generate a random name and a different code
+    # path that doesn't exercise the per-agent stat precedence rule.
+
+    import ansible_runner
+
+    run_side_effect = [
+        _result_with_events(tmp_path, []),
+        _result_with_events(
+            tmp_path,
+            [
+                _stat_event(
+                    "Check per-agent openclaw binary", per_agent_path, exists=True
+                ),
+                _which_event("/usr/local/bin/openclaw", rc=0),
+                _resolved_binary_event(per_agent_path),
+                _version_event("openclaw 2026.3.1", rc=0),
+                _parse_version_event("2026.3.1"),
+                _skip_condition_event(
+                    already_installed=False, runtime_binary=per_agent_path
+                ),
+            ],
+        ),
+    ]
+    mock_run = Mock(side_effect=run_side_effect)
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    result = run_installation("openclaw", "test-host", name="existing-agent")
+
+    assert result["success"] is True
+    assert result.get("skipped") is not True
+
+
+def test_install_falls_back_to_path_when_per_agent_binary_absent(
+    monkeypatch, tmp_path
+):
+    """T3 — PATH fallback when no per-agent binary exists.
+
+    A legacy host where someone hand-installed `/usr/local/bin/openclaw` at the
+    target version, and the agent has never been installed by clawrium. The
+    skip path still fires via the PATH-discovered binary; runtime path is the
+    `which` result.
+    """
+    from clawrium.core.install import run_installation
+
+    per_agent_path = "/home/existing-agent/.openclaw/bin/openclaw"
+    host = _host_with_existing_agent()
+    _setup_common(monkeypatch, tmp_path, host)
+
+    import ansible_runner
+
+    run_side_effect = [
+        _result_with_events(tmp_path, []),
+        _result_with_events(
+            tmp_path,
+            [
+                _stat_event(
+                    "Check per-agent openclaw binary", per_agent_path, exists=False
+                ),
+                _which_event("/usr/local/bin/openclaw", rc=0),
+                _resolved_binary_event("/usr/local/bin/openclaw"),
+                _version_event("openclaw 2026.4.2", rc=0),
+                _parse_version_event("2026.4.2"),
+                _skip_condition_event(
+                    already_installed=True,
+                    runtime_binary="/usr/local/bin/openclaw",
+                ),
+                _skip_marker_event("2026.4.2", "/usr/local/bin/openclaw"),
+            ],
+        ),
+    ]
+    mock_run = Mock(side_effect=run_side_effect)
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    result = run_installation("openclaw", "test-host", name="existing-agent")
+
+    assert result["success"] is True
+    assert result["skipped"] is True
+
+
+def test_install_proceeds_with_install_when_no_binary_anywhere(monkeypatch, tmp_path):
+    """T4 — fresh install: no binary anywhere.
+
+    Neither the per-agent path nor `which openclaw` resolves. The skip path
+    does not fire; `openclaw_runtime_binary` falls back to the static
+    per-agent path so the systemd unit's ExecStart converges on the binary the
+    install step is about to write.
+    """
+    from clawrium.core.install import run_installation
+
+    per_agent_path = "/home/fresh-agent/.openclaw/bin/openclaw"
+    host = {
+        "hostname": "test-host",
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    _setup_common(monkeypatch, tmp_path, host)
+
+    import ansible_runner
+
+    run_side_effect = [
+        _result_with_events(tmp_path, []),
+        _result_with_events(
+            tmp_path,
+            [
+                _stat_event(
+                    "Check per-agent openclaw binary", per_agent_path, exists=False
+                ),
+                _which_event("", rc=1),
+                _resolved_binary_event(""),
+                _skip_condition_event(
+                    already_installed=False, runtime_binary=per_agent_path
+                ),
+            ],
+        ),
+    ]
+    mock_run = Mock(side_effect=run_side_effect)
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    result = run_installation("openclaw", "test-host", name="fresh-agent")
+
+    assert result["success"] is True
+    assert result.get("skipped") is not True
+
+
+def test_install_python_skip_detection_with_path_fallback_runtime_binary(
+    monkeypatch, tmp_path
+):
+    """Round 3 B2: Python skip detection is path-agnostic.
+
+    Python's `_install_was_skipped` reads only the `Set install skip condition`
+    fact and the `Mark install as skipped` task name — never the stat or
+    resolved-binary events. So a non-executable per-agent stat (which the
+    playbook's `stat.executable AND stat.size > 0` guard rejects in favour of
+    PATH fallback) is BYTE-EQUIVALENT to "no per-agent binary" from the Python
+    layer's perspective. The corresponding playbook guard is verified
+    statically in `tests/test_install_binary_discovery.py`; the Python-side
+    behavior we still need to pin is: when the runtime_binary in the
+    skip-condition event is the PATH fallback, the skip is still detected and
+    the existing gateway credentials are still preserved by the openclaw-
+    specific restore branch in `set_installed`.
+    """
+    from clawrium.core.install import run_installation
+
+    per_agent_path = "/home/existing-agent/.openclaw/bin/openclaw"
+    host = _host_with_existing_agent()
+    host_state = _setup_common(monkeypatch, tmp_path, host)
+
+    import ansible_runner
+
+    run_side_effect = [
+        _result_with_events(tmp_path, []),
+        _result_with_events(
+            tmp_path,
+            [
+                # Per-agent file present but non-executable -> per-agent branch
+                # of the resolve set_fact would reject it under real ansible;
+                # event stream models the PATH-fallback path.
+                _stat_event(
+                    "Check per-agent openclaw binary",
+                    per_agent_path,
+                    exists=True,
+                    executable=False,
+                    size=0,
+                ),
+                _which_event("/usr/local/bin/openclaw", rc=0),
+                _resolved_binary_event("/usr/local/bin/openclaw"),
+                _version_event("openclaw 2026.4.2", rc=0),
+                _parse_version_event("2026.4.2"),
+                _skip_condition_event(
+                    already_installed=True,
+                    runtime_binary="/usr/local/bin/openclaw",
+                ),
+                _skip_marker_event("2026.4.2", "/usr/local/bin/openclaw"),
+            ],
+        ),
+    ]
+    mock_run = Mock(side_effect=run_side_effect)
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    result = run_installation("openclaw", "test-host", name="existing-agent")
+
+    assert result["success"] is True
+    assert result["skipped"] is True
+    # Distinct from T3 (per-agent absent / path target): here a per-agent file
+    # exists but is broken. The credential-preservation branch in
+    # set_installed() must still fire — preservation does NOT depend on which
+    # branch resolved the binary, only on `install_skipped` + captured
+    # `preserved_gateway`. R4-W3: assert ALL four sub-fields so a partial-dict
+    # corruption (e.g. accidental merge instead of atomic replace) is caught,
+    # not only top-level auth/device.id.
+    gateway = host_state[0]["agents"]["existing-agent"]["config"]["gateway"]
+    assert gateway["url"] == "ws://example:40001"
+    assert gateway["auth"] == "preserved-gateway-token-aaaaaaaaaaaaaa"
+    assert gateway["device"]["id"] == "device-abc"
+    assert gateway["device"]["token"] == "token-xyz"
+    assert gateway["device"]["privateKey"] == "PEM-DATA-HERE"

--- a/tests/test_start_binary_discovery.py
+++ b/tests/test_start_binary_discovery.py
@@ -1,0 +1,191 @@
+"""Tests for binary discovery convergence in the openclaw `start` playbook.
+
+The `start` playbook regenerates the systemd unit file every time it runs. If
+its binary discovery diverges from `install.yaml`, a `clm agent start` on a
+host where `/usr/local/bin/openclaw` exists at version A will silently rewrite
+the unit's `ExecStart` to point at the system-wide binary, even when the
+per-agent install at `/home/<agent>/.openclaw/bin/openclaw` is the binary
+clawrium just wrote at version B (issue #305).
+
+These tests parse the playbook YAML and assert the ordering, conditions, and
+register-keys called out in the v2 plan (B3, B4, S1–S4). Running real ansible
+isn't feasible in unit tests, but every property under test is statically
+expressible from the playbook structure.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+START_PLAYBOOK = (
+    Path(__file__).parent.parent
+    / "src"
+    / "clawrium"
+    / "platform"
+    / "registry"
+    / "openclaw"
+    / "playbooks"
+    / "start.yaml"
+)
+
+# Inside a `{{ ... }}` Jinja expression the per-agent path is built via string
+# concatenation: `'/home/' ~ agent_name ~ '/.openclaw/bin/openclaw'`. Outside
+# a Jinja expression it's the templated form `/home/{{ agent_name }}/...`. We
+# accept either, since both render to the same path.
+PER_AGENT_CONCAT = "'/home/' ~ agent_name ~ '/.openclaw/bin/openclaw'"
+
+
+@pytest.fixture(scope="module")
+def start_tasks() -> list[dict]:
+    play = yaml.safe_load(START_PLAYBOOK.read_text())
+    # The file is a single-play list; pull tasks out.
+    assert isinstance(play, list) and len(play) == 1, "start.yaml must be a single play"
+    tasks = play[0].get("tasks", [])
+    assert tasks, "start.yaml must declare tasks"
+    return tasks
+
+
+def _task_by_name(tasks: list[dict], name: str) -> dict | None:
+    return next((t for t in tasks if t.get("name") == name), None)
+
+
+def _index_by_name(tasks: list[dict], name: str) -> int:
+    return next(i for i, t in enumerate(tasks) if t.get("name") == name)
+
+
+def test_start_uses_per_agent_binary_when_present(start_tasks: list[dict]) -> None:
+    """S1 — per-agent precedence in the resolution step.
+
+    The `set_fact` task must prefer the per-agent path whenever
+    `openclaw_per_agent_stat.stat.exists` is truthy. We assert by string-
+    matching the Jinja2 expression because a structural assertion would require
+    evaluating Jinja2.
+    """
+    resolve = _task_by_name(
+        start_tasks, "Resolve openclaw binary (per-agent preferred, PATH fallback)"
+    )
+    assert resolve is not None, "Resolve task missing from start.yaml"
+
+    set_fact = resolve.get("ansible.builtin.set_fact") or resolve.get("set_fact")
+    assert set_fact is not None, "Resolve task must use set_fact"
+
+    expr = set_fact["openclaw_runtime_binary"]
+    # Per-agent path must appear; chosen first (`if openclaw_per_agent_stat.stat.exists`).
+    assert PER_AGENT_CONCAT in expr
+    assert "openclaw_per_agent_stat.stat.exists" in expr
+    # And the per-agent branch must come before the `which` fallback in the conditional.
+    assert expr.index("openclaw_per_agent_stat.stat.exists") < expr.index(
+        "openclaw_which_result.stdout"
+    )
+
+
+def test_start_validator_runs_on_resolved_variable(
+    start_tasks: list[dict],
+) -> None:
+    """Round 2 B1 — validator must run on `openclaw_runtime_binary` (the
+    resolved variable that propagates to ExecStart), NOT on
+    `openclaw_which_result.stdout` (the raw PATH discovery).
+
+    The earlier S2 design (gate validator on `not stat.exists` and validate
+    `which.stdout`) was REJECTED in round 2: it let a zero-byte per-agent
+    file fall back to an unvalidated PATH binary, which then reached the
+    systemd ExecStart unchecked. Validating the resolved fact closes that
+    gap. The per-agent /home/... case trivially passes the allowlist — which
+    is correct, not a no-op.
+    """
+    validate = _task_by_name(start_tasks, "Validate resolved binary path")
+    assert validate is not None, "Validate task missing from start.yaml"
+
+    when = validate["when"]
+    # Must check the resolved variable, not the raw which result.
+    assert "openclaw_runtime_binary" in when
+    assert "openclaw_which_result.stdout" not in when
+    # Must NOT be gated on stat.exists — that's the regressed behavior.
+    assert "not openclaw_per_agent_stat.stat.exists" not in when
+
+    # Ordering check: stat → which → resolve → validate.
+    # Validator now runs AFTER resolve so it can read the resolved fact.
+    stat_idx = _index_by_name(start_tasks, "Check per-agent openclaw binary")
+    which_idx = _index_by_name(start_tasks, "Discover openclaw binary in PATH")
+    resolve_idx = _index_by_name(
+        start_tasks, "Resolve openclaw binary (per-agent preferred, PATH fallback)"
+    )
+    validate_idx = _index_by_name(start_tasks, "Validate resolved binary path")
+    assert stat_idx < which_idx < resolve_idx < validate_idx
+
+
+def test_start_rejects_unsafe_path_binary(start_tasks: list[dict]) -> None:
+    """S3 — unsafe path rejection.
+
+    When the resolved binary is outside the allowlist (e.g. `/tmp/openclaw`
+    from a PATH fallback), the validator's `ansible.builtin.fail` must
+    trigger and stop the playbook before the unit file is rewritten.
+    """
+    validate = _task_by_name(start_tasks, "Validate resolved binary path")
+    assert validate is not None
+
+    # Must be a `fail` task, not a debug — debug wouldn't stop the playbook.
+    # Use explicit `.get(...) is not None` instead of `'fail' in validate`:
+    # the substring form would match any dict key containing "fail" (e.g.
+    # `failed_when`), letting an accidentally-removed fail module slip past.
+    assert (
+        validate.get("ansible.builtin.fail") is not None
+        or validate.get("fail") is not None
+    )
+
+    when = validate["when"]
+    # Allowlist must include exactly these prefixes; anything else (incl. /tmp)
+    # should fail.
+    for allowed in ("/usr/local/bin/", "/usr/bin/", "/home/"):
+        assert allowed in when, f"Allowlist missing prefix {allowed!r}"
+
+
+def test_start_restarts_service_when_unit_file_changes(
+    start_tasks: list[dict],
+) -> None:
+    """S4 / B3 — explicit restart-on-change.
+
+    `state: started` on an already-active service is a no-op even after a
+    unit-file rewrite. The playbook must include an explicit `state: restarted`
+    task gated on the unit-file copy's `changed` flag, placed before the
+    regular `Start openclaw service` task.
+    """
+    sync = _task_by_name(start_tasks, "Sync systemd service file")
+    assert sync is not None
+    assert sync.get("register") == "service_file_changed"
+
+    restart = _task_by_name(start_tasks, "Restart openclaw service if unit file changed")
+    assert restart is not None, "B3 restart task missing from start.yaml"
+
+    systemd = restart.get("ansible.builtin.systemd") or restart.get("systemd")
+    assert systemd is not None
+    assert systemd.get("state") == "restarted"
+    assert "service_file_changed.changed" in restart["when"]
+
+    # Restart must run before the regular Start task.
+    restart_idx = _index_by_name(
+        start_tasks, "Restart openclaw service if unit file changed"
+    )
+    start_idx = _index_by_name(start_tasks, "Start openclaw service")
+    assert restart_idx < start_idx
+
+
+def test_start_systemd_unit_uses_resolved_runtime_binary(
+    start_tasks: list[dict],
+) -> None:
+    """Sanity guard against future regression of the original #305 root cause.
+
+    The unit file content must reference `{{ openclaw_runtime_binary }}` — the
+    resolved fact — and never `openclaw_which_result.stdout` directly. If
+    anyone "simplifies" the playbook by inlining the `which` result back into
+    `ExecStart`, that change is the #305 bug returning, and this test will
+    fail.
+    """
+    sync = _task_by_name(start_tasks, "Sync systemd service file")
+    assert sync is not None
+    copy = sync.get("ansible.builtin.copy") or sync.get("copy")
+    content = copy["content"]
+    assert "ExecStart={{ openclaw_runtime_binary }}" in content
+    assert "openclaw_which_result.stdout" not in content


### PR DESCRIPTION
## Summary

Re-running `clm agent install` against an already-up-to-date OpenClaw agent on a host with a stale system-wide `/usr/local/bin/openclaw` would silently rotate the agent's gateway token and device credentials on every invocation, while the running systemd daemon stayed pinned to the wrong binary.

- **Install + start playbooks**: stat the per-agent path (`/home/<agent>/.openclaw/bin/openclaw`) first with executable+size guards, fall back to `which`, then validate the resolved variable. The systemd unit's `ExecStart`, the version check, and the skip-detection fact all converge on the same variable. An explicit `state: restarted when: unit_file.changed` task swaps the live daemon onto the new binary without waiting for a reboot.
- **install.py**: `preserved_gateway` is captured before `set_installing()` wipes the agent record and restored in `set_installed()` on the skip path so credentials genuinely survive a clean re-install. Scoped to `claw_name == "openclaw"`. Resume branch also captures so the skip-path warning isn't a false positive. CWE-312: a `finally` block now cleans `ansible-runner` artifacts that previously persisted `gateway_token` / `device_token` / `device_private_key` indefinitely.

## Testing

### Test Results
- [x] All existing tests pass (`make test` — 1706 passed)
- [x] Linter passes (`make lint` — clean)
- [x] New tests added for new functionality

### Test Coverage
- `tests/test_install_skip.py` — `_stat_event` / `_resolved_binary_event` / `_skip_*_event` helpers; rewrote 4 stale type-keyed fixtures into name-keyed fixtures with explicit `type` field; new cases T1–T4 covering the four per-agent×PATH discovery quadrants; new path-fallback skip-detection case with full gateway preservation assertions
- `tests/test_install_binary_discovery.py` — **new**, 6 static YAML-parse cases pinning install.yaml structure (Resolve guard, validator runs on resolved variable, task ordering, `creates:` removed, ExecStart-restart shape, ExecStart uses resolved fact)
- `tests/test_start_binary_discovery.py` — **new**, 5 cases for start.yaml structure (per-agent precedence, validator runs on resolved variable, unsafe-path rejection, restart-on-change shape, ExecStart uses resolved fact)
- `tests/test_install.py` — fixed `test_install_rejects_duplicate_name_same_host` fixture so it exercises the real name-collision rejection path

### Manual Testing

The cred-rotation symptom isn't observable from unit tests alone. Acceptance gate on `wolf-i`/`maurice`:
- Re-run the #305 reproducer table (runs 1/2/3); `device.id` and `gateway.auth` byte-identical across runs 2 and 3.
- `systemctl cat openclaw-maurice.service` shows `ExecStart=/home/maurice/.openclaw/bin/openclaw …`, not `/usr/local/bin/openclaw …`.
- `pgrep -a -u maurice openclaw` shows the per-agent binary in the cmdline within seconds of install completion — no reboot, no manual restart.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation: validator runs on the same variable that propagates to `ExecStart`, allowlisted to `/home/`, `/usr/bin/`, `/usr/local/bin/`. Removed `creates:` guard that masked version drift. Agent-name path-traversal: `^[a-z][a-z0-9_-]{0,31}$` validation at `install.py:272` / `lifecycle.py:229` / `validation.py:959` prevents injection in stat/copy/pgrep paths.
- [x] No SQL injection / XSS / command injection risks introduced (Ansible argv form used for the installer invocation)
- [x] CWE-312 closed: `_cleanup_ansible_artifacts` invoked in `finally` block strips `artifacts/` and `env/` containing cacheable secrets

## ATX Review Summary

**Final Review: Aggregate 3.7/5**
**Total Cost: $11.95 | Total Time: 43m 39s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1, B2, B3 | Fixed / Deferred | $3.83 | 11m33s | ansible, security, test-coverage, core-lifecycle |
| 2 | 2/5 | B1, B2, B3, B4 | All fixed | $3.20 | 11m15s | ansible, security, test-coverage, core-lifecycle |
| 3 | 2/5 | B1, B2 | All fixed | $2.37 | 10m26s | ansible, test-coverage, core-lifecycle (security max-turns) |
| 4 | 3.7/5 | None | Ready | $2.55 | 10m25s | security, test-coverage, core-lifecycle |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `install.yaml:82-90` | CWE-494: installer fetched without integrity check | Deferred to #343 — orthogonal hardening; manifest entries have no `sha256:` field today |
| B2 | `tests/test_install_skip.py:236-244,725-732` | Fixtures used claw type as `agents` key — `run_installation()` writes under a generated random name, so credential assertions passed trivially | Fixed — fixtures keyed by agent name with explicit `type` field; `name='existing-agent'` passed to `run_installation` |
| B3 | `install.py:437-444,779-797` | `set_installing()` wiped the agent record before ansible ran; on skip path `set_installed()` had nothing to write back, silently dropping credentials | Fixed — `preserved_gateway` captured in `set_installing`, restored in `set_installed` when `install_skipped and preserved and not gateway_token` |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `install.yaml:197`, `start.yaml:85` | Restart tasks missing `enabled: yes` (brief boot-time gap before next Enable task) | Fixed — added |
| W2 | `start.yaml:46`, `install.yaml:36` | Per-agent stat accepted zero-byte / non-executable file as working binary | Fixed — `stat.executable AND stat.size > 0` guard in Resolve |
| W3 | `start.yaml:77-89` | `daemon_reload` split from restart task; out-of-order edits could `restart` against stale unit | Fixed — bundled into restart task; separate Reload task removed |
| W4 | `install.yaml:36-43` | Validator was a structural no-op on per-agent branch | Acknowledged in R1; fix reversed in R2 (see R2-B1) |
| W5 | `tests/test_install_skip.py:80-106` | `_stat_event` helper missing `event_data.host` field | Deferred — mocks don't read `host` today; tracked in #343 |
| W6 | `tests/test_install_skip.py` | `_install_was_skipped` not parametrized across hermes/zeroclaw | Deferred — orthogonal to discovery convergence; tracked in #343 |

</details>

<details>
<summary>Review 2 Details (2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `install.yaml:49-54`, `start.yaml:39-44` | R1's W4 fix created security bypass: per-agent rejected by W2 + PATH fallback bypassed validator | Fixed — validator runs unconditionally on resolved variable in both playbooks; start.yaml validator moved to after resolve |
| B2 | `tests/test_install_skip.py:264-327` | `test_install_existing_agent_different_version_proceeds_with_install` still stale-fixture | Fixed — name-keyed + `name='existing-agent'` |
| B3 | `tests/test_install_skip.py:498-553,586-647` | `test_install_with_force_skips_skip_logic` + `test_install_with_unparseable_version_proceeds_with_install` still stale-fixture | Fixed — same pattern |
| B4 | (absent) | Zero playbook-structure tests for install.yaml changes | Fixed — new `tests/test_install_binary_discovery.py` with 6 named cases |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `install.py:784-802` | Resume branch didn't capture `preserved_gateway`; skip-path warning falsely fired | Fixed — capture added in resume branch |
| W3 | `install.py:606-658` | CWE-312: `ansible-runner` fact_cache persisted `openclaw_gateway_token` / `device_token` / `device_private_key` indefinitely | Fixed — `finally` block calls `_cleanup_ansible_artifacts` on both base_data_dir + claw_data_dir |
| W4 | `install.py:440,834` | `preserved_gateway` capture/restore not scoped to openclaw | Fixed — both sites gated on `claw_name == "openclaw"` |
| W6 | `install.yaml:202,317-321` | Triple `daemon_reload` on unit-file change (restart task + start task + handler) | Fixed — `notify: Reload systemd` removed; trailing handlers block deleted |
| W7 | `start.yaml:96-102` | Unconditional `daemon_reload: yes` on Start task | Fixed — removed; restart task owns reload for changed paths |
| W8 | `tests/test_install_skip.py:80-96` | `_stat_event` missing executable/size meant tests modeled events real ansible would reject | Fixed — defaults added; new `test_install_python_skip_detection_with_path_fallback_runtime_binary` case |
| W2 | `install.py:440` | `cleanup_failed=True` against installed agent drops gateway creds on skip path | Deferred — edge case; tracked in #343 |
| W5 | `install.py:513-529` | `gateway_auth_token` generated unconditionally before skip detection | Deferred — restructure required; tracked in #343 |

</details>

<details>
<summary>Review 3 Details (2/5 — test-coverage only; security max-turns)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_install.py:1419` | `test_install_rejects_duplicate_name_same_host` used type-keyed fixture; `existing_agent` was None and raise fired via `not existing_agent` branch — wrong code path | Fixed — name-keyed fixture with `type=zeroclaw, status='removing'` so the rejection fires via the real name-collision branch |
| B2 | `tests/test_install_skip.py:926` | `test_install_falls_back_to_path_when_per_agent_binary_non_executable` was byte-equivalent to T3 from Python's perspective | Fixed — renamed to `test_install_python_skip_detection_with_path_fallback_runtime_binary`; distinct assertion that gateway credentials survive when resolved binary is the PATH fallback |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W3 | `install.py:964-966` | `locals()` lookup in finally block was fragile | Fixed — explicit `install_log_dir/'base'` + `install_log_dir/'claw'` paths |
| W4 | `tests/test_install_skip.py:311,641` | Two B2/B3 fix tests lacked state assertions | Fixed — `host_state` captured, `status == 'installed'` + `installed_at` + `version` asserted |
| W1 | `install.yaml:222` | Redundant `daemon_reload: yes` on Enable+start task | Deferred — restart task owns the change path; tracked in #343 |
| W2 | `install.yaml:49-56 vs :80+196` | Defense-in-depth: validate `openclaw_runtime_binary` immediately before unit-file write | Deferred — current chain is safe; tracked in #343 |
| W5 | `tests/` | `finally`-block invocation not directly tested | Deferred — `_cleanup_ansible_artifacts` itself is unit-tested in `test_lifecycle.py`; tracked in #343 |
| W6 | `tests/test_install_prompts.py:61` | Resume+gateway-preservation test missing | Deferred — resume isn't the #305 customer-outcome happy path; tracked in #343 |

</details>

<details>
<summary>Review 4 Details (3.7/5 — merge gate satisfied)</summary>

**Blocking Issues:** None.

**Warnings (all addressed in this commit):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `tests/test_install_skip.py:681-684` | Unparseable-version test missing `version == '2026.4.2'` assertion (asymmetric with different-version test) | Fixed — assertion added |
| W2 | `tests/test_install_skip.py:348-350` | Misleading comment attributed all assertions to `set_installed`; `version` is written by `set_installing` | Fixed — comment rewritten to attribute correctly |
| W3 | `tests/test_install_skip.py:1001-1003` | Path-fallback skip test only asserted top-level `auth` + `device.id`; partial-dict corruption could slip past | Fixed — `gateway.url` + `device.token` + `device.privateKey` assertions added |
| W4 | `tests/test_install_skip.py:840` | T3 credential preservation still unasserted | Deferred — R4-W3 covers the convergent path; tracked in #343 |

**Security Findings:**

| # | File | Finding | Action |
|---|------|---------|--------|
| S1 | `src/clawrium/core/install.py:958-968` | `inventory/` subdirectory not cleaned up (contains serialized provider API keys + `gateway_auth_token`); CWE-312 (low severity — 0700 parent dir) | Deferred — tracked in #343; two-line follow-up |
| S2 | `src/clawrium/core/install.py:521-523` | MD5 used for port-slot distribution; not security-relevant but scanner noise | Deferred — inline comment in #343 |

</details>

## Reviewer Notes

- **Behavior change:** hosts intentionally relying on a hand-installed `/usr/local/bin/openclaw` to override the per-agent binary will now use the per-agent binary instead. The playbook's contract is "manage the per-agent install"; using the system-wide one was an accident of `which` resolution, not a feature. Surfaced here for awareness.
- **Issue #343** tracks: installer integrity checksum (R1-B1), npm pin (R1-W5 v1), verbose secret logging (R1-W6 v1), `gateway_auth_token` unconditional generation (R2-W5), `cleanup_failed` credential edge case (R2-W2), redundant `daemon_reload` (R3-W1), defense-in-depth validator (R3-W2), dedicated finally-block test (R3-W5), resume+gateway preservation test (R3-W6), T3 credential preservation (R4-W4), `inventory/` cleanup (R4-S1), MD5 comment (R4-S2).

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>