### PR TITLE
feat(integrations): unified atlassian integration with hermes MCP support

### DIFF
--- a/.itx/348/00_PLAN.md
+++ b/.itx/348/00_PLAN.md
@@ -1,0 +1,349 @@
+# Issue 348: Atlassian Integration for Hermes Agent (MCP)
+
+## Summary
+
+Enable the hermes agent to interact with Atlassian Cloud (Jira + Confluence) via
+the `mcp-atlassian` MCP server. Additionally, merge the existing separate `jira`
+and `confluence` integration types into a single unified `atlassian` type across
+all agent types.
+
+This is a headless, no-UI workflow that uses API token authentication — no
+browser-based OAuth approval is required at any point.
+
+## Problem Statement
+
+1. Hermes agents have no way to interact with Atlassian services
+2. Hermes `config.yaml.j2` doesn't produce the `mcp_servers:` section
+3. The existing `jira` and `confluence` integration types are redundant — on
+   Atlassian Cloud they share the same account, instance URL, and API token
+4. Maintaining two types creates confusion and doubles credential entry
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Single `atlassian` integration type | Same account, same token, same instance for Jira + Confluence on Cloud |
+| Remove `jira` and `confluence` types | Eliminates redundancy; single source of truth for Atlassian credentials |
+| API Token auth (not OAuth) | OAuth requires browser approval — incompatible with headless remote agents |
+| `uvx mcp-atlassian` stdio transport | Hermes manages subprocess lifecycle; no separate service to run |
+| Pre-install via `uv tool install` | Avoids download latency on every agent restart |
+| Derive `CONFLUENCE_URL` as `ATLASSIAN_URL + /wiki` | Atlassian Cloud standard; simplifies credential collection |
+| Update openclaw template for new type | Openclaw gets same credential simplification benefit |
+
+## Auth Strategy
+
+The `mcp-atlassian` server (v0.21.1) supports three authentication methods:
+
+| Method | Headless? | Use Case |
+|--------|-----------|----------|
+| API Token (`USERNAME` + `API_TOKEN`) | Yes | Atlassian Cloud (recommended) |
+| Personal Access Token (PAT) | Yes | Server/Data Center |
+| OAuth 2.0 (`--oauth-setup`) | No (needs browser) | Not applicable |
+
+**This feature uses API Token auth exclusively.**
+
+Credentials required from the user (one-time, collected by `clm integration add`):
+
+- `ATLASSIAN_URL` — Instance URL (e.g., `https://company.atlassian.net`)
+- `ATLASSIAN_EMAIL` — Account email
+- `ATLASSIAN_API_TOKEN` — Token from https://id.atlassian.com/manage-profile/security/api-tokens
+
+Optional:
+- `CONFLUENCE_SPACES_FILTER` — Comma-separated space keys
+- `JIRA_PROJECTS_FILTER` — Comma-separated project keys
+
+## Architecture
+
+```
+clm integration add work-atlassian --type atlassian
+clm agent integration add vand work-atlassian
+clm agent configure vand
+    │
+    ▼
+configure_agent() [lifecycle.py — no changes needed]
+    │
+    ├── Loads integration: {"work-atlassian": {type: "atlassian", credentials: {...}}}
+    ├── Passes to Ansible as `integrations` var
+    │
+    ▼
+configure.yaml playbook [UPDATED]
+    │
+    ├── Pre-installs mcp-atlassian via `uv tool install`
+    ├── Renders config.yaml.j2 → ~/.hermes/config.yaml
+    │       └── NEW: mcp_servers section
+    └── Restarts hermes service
+    │
+    ▼
+Hermes at startup reads config.yaml, launches mcp-atlassian subprocess:
+    uvx mcp-atlassian  (with env vars for auth)
+    │
+    ▼
+Tools registered as: mcp_work_atlassian_jira_search, mcp_work_atlassian_confluence_get_page, etc.
+```
+
+## Rendered Config Example (Hermes)
+
+After `clm agent configure vand`, the deployed `~/.hermes/config.yaml`:
+
+```yaml
+model:
+  provider: bedrock
+  default: us.anthropic.claude-sonnet-4-20250514-v1:0
+
+mcp_servers:
+  work_atlassian:
+    command: "uvx"
+    args: ["mcp-atlassian"]
+    env:
+      JIRA_URL: "https://company.atlassian.net"
+      JIRA_USERNAME: "dev@company.com"
+      JIRA_API_TOKEN: "ATATT3xFf..."
+      CONFLUENCE_URL: "https://company.atlassian.net/wiki"
+      CONFLUENCE_USERNAME: "dev@company.com"
+      CONFLUENCE_API_TOKEN: "ATATT3xFf..."
+      JIRA_PROJECTS_FILTER: "PROJ,OPS"
+      CONFLUENCE_SPACES_FILTER: "ENG,PLATFORM"
+```
+
+## Changes Required
+
+### 1. `src/clawrium/core/integrations.py` — Replace `jira` + `confluence` with `atlassian`
+
+**Remove** the `jira` and `confluence` entries from `INTEGRATION_TYPES`.
+
+**Add** the unified `atlassian` type:
+
+```python
+"atlassian": {
+    "description": "Atlassian Cloud (Jira + Confluence) via API token",
+    "credentials": [
+        {
+            "key": "ATLASSIAN_URL",
+            "description": "Atlassian instance URL (e.g., https://company.atlassian.net)",
+            "required": True,
+        },
+        {
+            "key": "ATLASSIAN_EMAIL",
+            "description": "Account email for authentication",
+            "required": True,
+        },
+        {
+            "key": "ATLASSIAN_API_TOKEN",
+            "description": "API token (create at https://id.atlassian.com/manage-profile/security/api-tokens)",
+            "required": True,
+        },
+        {
+            "key": "CONFLUENCE_SPACES_FILTER",
+            "description": "Comma-separated Confluence space keys to filter (optional)",
+            "required": False,
+        },
+        {
+            "key": "JIRA_PROJECTS_FILTER",
+            "description": "Comma-separated Jira project keys to filter (optional)",
+            "required": False,
+        },
+    ],
+},
+```
+
+### 2. `src/clawrium/platform/registry/hermes/templates/config.yaml.j2` — Render MCP servers
+
+Append after the existing `model:` block:
+
+```jinja2
+{# --- MCP Servers (from assigned integrations) --- #}
+{% if integrations is defined and integrations | length > 0 %}
+{% set mcp_entries = [] %}
+{% for name, integration in integrations.items() %}
+{% if integration.type == 'atlassian' %}{% if mcp_entries.append(name) %}{% endif %}{% endif %}
+{% endfor %}
+{% if mcp_entries | length > 0 %}
+
+mcp_servers:
+{% for name in mcp_entries %}
+{% set intg = integrations[name] %}
+{% set server_name = name | replace('-', '_') %}
+  {{ server_name }}:
+    command: "uvx"
+    args: ["mcp-atlassian"]
+    env:
+      JIRA_URL: "{{ intg.credentials.ATLASSIAN_URL }}"
+      JIRA_USERNAME: "{{ intg.credentials.ATLASSIAN_EMAIL }}"
+      JIRA_API_TOKEN: "{{ intg.credentials.ATLASSIAN_API_TOKEN }}"
+      CONFLUENCE_URL: "{{ intg.credentials.ATLASSIAN_URL }}/wiki"
+      CONFLUENCE_USERNAME: "{{ intg.credentials.ATLASSIAN_EMAIL }}"
+      CONFLUENCE_API_TOKEN: "{{ intg.credentials.ATLASSIAN_API_TOKEN }}"
+{% if intg.credentials.CONFLUENCE_SPACES_FILTER is defined and intg.credentials.CONFLUENCE_SPACES_FILTER %}
+      CONFLUENCE_SPACES_FILTER: "{{ intg.credentials.CONFLUENCE_SPACES_FILTER }}"
+{% endif %}
+{% if intg.credentials.JIRA_PROJECTS_FILTER is defined and intg.credentials.JIRA_PROJECTS_FILTER %}
+      JIRA_PROJECTS_FILTER: "{{ intg.credentials.JIRA_PROJECTS_FILTER }}"
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endif %}
+```
+
+### 3. `src/clawrium/platform/registry/hermes/manifest.yaml` — Add `uv` dependency
+
+```yaml
+requirements:
+  dependencies:
+    - python: ">=3.11"
+    - ripgrep: "latest"
+    - ffmpeg: "latest"
+    - uv: "latest"
+```
+
+### 4. `src/clawrium/platform/registry/hermes/playbooks/configure.yaml` — Install MCP package
+
+Add task before service restart:
+
+```yaml
+- name: Pre-install mcp-atlassian for Atlassian integrations
+  ansible.builtin.command:
+    cmd: "uv tool install mcp-atlassian"
+  become: true
+  become_user: "{{ agent_user }}"
+  when: >
+    integrations is defined and
+    (integrations | dict2items | selectattr('value.type', 'equalto', 'atlassian') | list | length > 0)
+  register: mcp_install_result
+  changed_when: "'Installed' in mcp_install_result.stdout"
+  failed_when: mcp_install_result.rc != 0
+```
+
+### 5. `src/clawrium/platform/registry/openclaw/templates/.env.j2` — Update for `atlassian` type
+
+Replace the separate `jira` and `confluence` blocks (lines 73-92) with a single
+`atlassian` block that renders the same env vars openclaw expects:
+
+```jinja2
+{% elif integration.type == 'atlassian' %}
+{% if integration.ATLASSIAN_URL is defined %}
+JIRA_URL={{ shell_quote(integration.ATLASSIAN_URL) }}
+CONFLUENCE_URL={{ shell_quote(integration.ATLASSIAN_URL + '/wiki') }}
+{% endif %}
+{% if integration.ATLASSIAN_EMAIL is defined %}
+JIRA_EMAIL={{ shell_quote(integration.ATLASSIAN_EMAIL) }}
+CONFLUENCE_EMAIL={{ shell_quote(integration.ATLASSIAN_EMAIL) }}
+{% endif %}
+{% if integration.ATLASSIAN_API_TOKEN is defined %}
+JIRA_API_TOKEN={{ shell_quote(integration.ATLASSIAN_API_TOKEN) }}
+CONFLUENCE_API_TOKEN={{ shell_quote(integration.ATLASSIAN_API_TOKEN) }}
+{% endif %}
+```
+
+### 6. `docs/agent-support/hermes.md` — Update support matrix
+
+- MCP server registration: Supported (atlassian)
+- Document the headless auth flow
+
+### 7. Tests — Update all references
+
+**`tests/test_core_integrations.py`:**
+- Update `expected_types` set: remove `jira`, `confluence`, add `atlassian`
+- Update all test fixtures using `type: "jira"` → `type: "atlassian"`
+- Update credential key assertions
+
+**`tests/test_lifecycle_integrations.py`:**
+- Update fixture `type: "jira"` → `type: "atlassian"`
+
+**`tests/test_cli_integration.py`:**
+- Update assertions checking for "jira"/"confluence" in output → "atlassian"
+- Update fixture types
+
+**`tests/test_hermes_configure.py` (new tests):**
+- `test_config_template_renders_mcp_servers_with_atlassian_integration`
+- `test_config_template_no_mcp_servers_without_integrations`
+- `test_config_template_mcp_server_name_sanitization`
+- `test_config_template_mcp_optional_filters`
+- `test_config_template_multiple_atlassian_integrations`
+
+## Migration Impact
+
+### Breaking Change: `jira` and `confluence` types removed (no auto-migration)
+
+Any existing integrations stored as `type: "jira"` or `type: "confluence"` in
+`~/.config/clawrium/integrations.json` are invalid after this change. There is
+**no automatic migration** — by design, the codebase keeps a single source of
+truth for Atlassian credentials and does not carry compatibility shims.
+
+**Required user steps:**
+1. `clm integration remove <old-jira-name>` and `clm integration remove <old-confluence-name>`
+2. `clm integration add <new-name> --type atlassian` with the unified credentials
+
+CLI commands that hit a stale type (manual JSON edit, downgrade/upgrade cross)
+print a clean remediation message instead of a traceback (`clm integration show`
+/ `credentials`), but no automatic rewrite is performed.
+
+## User Workflow
+
+```bash
+# One-time: generate API token (from any browser, any machine)
+# https://id.atlassian.com/manage-profile/security/api-tokens
+
+# Register integration (headless CLI)
+clm integration add work-atlassian --type atlassian
+# Prompts for: ATLASSIAN_URL, ATLASSIAN_EMAIL, ATLASSIAN_API_TOKEN
+# Optionally: CONFLUENCE_SPACES_FILTER, JIRA_PROJECTS_FILTER
+
+# Assign to agent
+clm agent integration add vand work-atlassian
+
+# Deploy configuration (renders MCP config, installs package, restarts)
+clm agent configure vand
+
+# Verify
+clm agent chat vand
+> list my open jira tickets
+> search confluence for onboarding docs
+```
+
+## Headless Guarantees
+
+| Concern | Resolution |
+|---------|-----------|
+| OAuth needs browser | Not used. API token auth only. |
+| Token refresh | Not needed. API tokens are long-lived (until manually revoked). |
+| `--oauth-setup` flag | Never invoked. |
+| MCP server startup | `uvx mcp-atlassian` with env vars. No interactive prompts. |
+| Package installation | `uv tool install` is non-interactive. |
+
+## Out of Scope
+
+- Atlassian Server/Data Center PAT auth (future: add `ATLASSIAN_PERSONAL_TOKEN` field)
+- OAuth 2.0 support (requires browser; fundamentally incompatible with headless)
+- HTTP/SSE transport for mcp-atlassian (stdio is simpler for single-agent use)
+- Tool filtering (`--enabled-tools`, `--toolsets`) — can be added later as optional credentials
+
+## Dependencies
+
+- `mcp-atlassian` >= 0.21.1 (PyPI, installed via `uvx`)
+- `uv` >= 0.1.0 (for `uvx` subprocess runner)
+- Hermes >= 2026.5.7 (native `mcp_servers:` config support)
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| `mcp-atlassian` breaking changes | Pin version in `uv tool install mcp-atlassian==0.21.1` |
+| `uvx` not in PATH for agent user | Install playbook ensures `uv` is available system-wide |
+| Large tool surface (72 tools) | Use `TOOLSETS` env var to limit to core set in future iteration |
+| API token permissions too broad | Document minimum required Atlassian permissions |
+| Breaking existing `jira`/`confluence` integrations | Auto-migration in `load_integrations()` |
+
+## File Change Summary
+
+| File | Change |
+|------|--------|
+| `src/clawrium/core/integrations.py` | Remove `jira`+`confluence`, add `atlassian`, add migration |
+| `src/clawrium/platform/registry/hermes/templates/config.yaml.j2` | Add `mcp_servers:` rendering |
+| `src/clawrium/platform/registry/hermes/manifest.yaml` | Add `uv` dependency |
+| `src/clawrium/platform/registry/hermes/playbooks/configure.yaml` | Add mcp-atlassian install task |
+| `src/clawrium/platform/registry/openclaw/templates/.env.j2` | Replace jira/confluence blocks with atlassian |
+| `docs/agent-support/hermes.md` | Update MCP support status |
+| `tests/test_core_integrations.py` | Update for new type |
+| `tests/test_lifecycle_integrations.py` | Update fixtures |
+| `tests/test_cli_integration.py` | Update assertions |
+| `tests/test_hermes_configure.py` | Add MCP rendering tests |

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -116,6 +116,19 @@ def ps(
     status_command(host=host)
 
 
+def _print_configure_warnings(_stage: str, message: str) -> None:
+    """on_event callback for configure_agent that surfaces WARNING-prefixed
+    messages to the terminal so silent lifecycle gaps (e.g. an integration
+    with an unknown type) become visible during `clm agent configure`."""
+    if message.startswith("WARNING:"):
+        # Escape `message` before embedding in a Rich markup span — the
+        # lifecycle warning interpolates `integration_type` from
+        # integrations.json, which may be hand-edited and contain Rich
+        # tokens like `[bold]`. Without escape Rich would either garble the
+        # output or raise MarkupError mid-configure.
+        console.print(f"  [yellow]{rich_escape(message)}[/yellow]")
+
+
 def _validate_name_component(name: str, component_type: str) -> None:
     """Validate a name component against safe character set.
 
@@ -339,12 +352,15 @@ def _sync_provider_config(
     if "api_server" in existing_config:
         config_data["api_server"] = existing_config["api_server"]
 
-    # Call configure_agent to apply configuration via Ansible
+    # Call configure_agent to apply configuration via Ansible. The on_event
+    # callback surfaces lifecycle WARNINGs (e.g. an integration with an unknown
+    # type) so they don't get swallowed into logger.info.
     success, error = configure_agent(
         host,
         claw_type,
         config_data,
         agent_name=installed_name,
+        on_event=_print_configure_warnings,
     )
 
     if not success:
@@ -615,6 +631,7 @@ def _run_identity_stage(
             existing_config,
             agent_name=agent_name,
             extra_vars={"identity_files": identity_vars},
+            on_event=_print_configure_warnings,
         )
         if success:
             console.print("[green]✓[/green]")
@@ -697,6 +714,7 @@ def _sync_channel_config(
         claw_type,
         existing_config,
         agent_name=installed_name,
+        on_event=_print_configure_warnings,
     )
 
     if not success:
@@ -1558,6 +1576,7 @@ def _run_edit_config(
             claw_type,
             edited_config,
             agent_name=installed_name,
+            on_event=_print_configure_warnings,
         )
 
         if not success:
@@ -2629,7 +2648,7 @@ def integrations_add(
 
     Examples:
         clm agent integration add my-agent work-github
-        clm agent integration add my-agent company-jira
+        clm agent integration add my-agent work-atlassian
     """
     from clawrium.core.integrations import (
         add_agent_integration,

--- a/src/clawrium/cli/integration.py
+++ b/src/clawrium/cli/integration.py
@@ -31,9 +31,28 @@ console = Console()
 
 integration_app = typer.Typer(
     name="integration",
-    help="Manage external service integrations (GitHub, Jira, etc.)",
+    help="Manage external service integrations (GitHub, Atlassian, etc.)",
     no_args_is_help=True,
 )
+
+
+def _supported_types_help() -> str:
+    return "Integration type (" + ", ".join(sorted(INTEGRATION_TYPES.keys())) + ")"
+
+
+def _unknown_type_remediation(integration_type: str, name: str) -> str:
+    # rich_escape both fields because integration_type comes from
+    # integrations.json (potentially hand-edited) and could contain Rich
+    # markup tokens like `[bold]`. name is regex-validated at add-time, but
+    # escaping it costs nothing.
+    safe_type = rich_escape(integration_type)
+    safe_name = rich_escape(name)
+    return (
+        f"Integration type '{safe_type}' is not a known type "
+        f"({', '.join(sorted(INTEGRATION_TYPES.keys()))}). "
+        f"Run `clm integration remove {safe_name}` then "
+        f"`clm integration add {safe_name} --type <valid-type>` to recover."
+    )
 
 
 def _mask_credential(value: str | None) -> str:
@@ -109,9 +128,16 @@ def list_integrations() -> None:
         else:
             cred_display = "none"
 
+        # Surface unknown types (manual edits, removed types) at-a-glance so a
+        # fleet audit catches them before configure runs.
+        if integration_type not in INTEGRATION_TYPES:
+            type_cell = f"[yellow]{rich_escape(integration_type)} (unknown)[/yellow]"
+        else:
+            type_cell = rich_escape(integration_type)
+
         table.add_row(
             rich_escape(integration_name),
-            rich_escape(integration_type),
+            type_cell,
             cred_display,
             added,
         )
@@ -126,7 +152,7 @@ def add(
         ...,
         "--type",
         "-t",
-        help="Integration type (github, gitlab, jira, confluence, linear, notion)",
+        help=_supported_types_help(),
     ),
 ) -> None:
     """Add a new external service integration.
@@ -135,7 +161,7 @@ def add(
 
     Examples:
         clm integration add my-github --type github
-        clm integration add work-jira --type jira
+        clm integration add work-atlassian --type atlassian
     """
     # Validate integration name
     try:
@@ -243,8 +269,15 @@ def show(
 
     integration_type = integration.get("type", "?")
 
+    # Match `list`'s yellow `(unknown)` indicator so a stale entry is
+    # spottable at-a-glance, not just at the error block below.
+    if integration_type not in INTEGRATION_TYPES:
+        type_display = f"[yellow]{rich_escape(integration_type)} (unknown)[/yellow]"
+    else:
+        type_display = rich_escape(integration_type)
+
     console.print(f"\n[bold]Integration: {rich_escape(name)}[/bold]\n")
-    console.print(f"  Type: {rich_escape(integration_type)}")
+    console.print(f"  Type: {type_display}")
     console.print(f"  Created: {integration.get('created_at', '-')}")
     console.print(f"  Updated: {integration.get('updated_at', '-')}")
 
@@ -257,8 +290,15 @@ def show(
     else:
         console.print("\n  [yellow]No credentials configured[/yellow]")
 
-    # Show required credentials for this type
-    credential_defs = get_credentials_for_type(integration_type)
+    # Show required credentials for this type. An unknown type (e.g., a
+    # manual edit to integrations.json) surfaces a clean remediation message
+    # and exits non-zero so scripts that `&&`-chain on `clm integration show`
+    # halt rather than silently proceeding.
+    try:
+        credential_defs = get_credentials_for_type(integration_type)
+    except InvalidIntegrationTypeError:
+        console.print(f"\n  [red]Error:[/red] {_unknown_type_remediation(integration_type, name)}")
+        raise typer.Exit(code=1)
     required_keys = {c["key"] for c in credential_defs if c.get("required", False)}
     missing_keys = required_keys - set(credentials.keys())
 
@@ -280,7 +320,7 @@ def remove(
     unless --force is used.
 
     Examples:
-        clm integration remove old-jira
+        clm integration remove old-atlassian
         clm integration remove my-github --force
     """
     # Check integration exists
@@ -363,8 +403,12 @@ def credentials(
         else:
             console.print("  No credentials configured")
 
-        # Show what's required
-        credential_defs = get_credentials_for_type(integration_type)
+        # Show what's required. Unknown type → exit 1 so scripts notice.
+        try:
+            credential_defs = get_credentials_for_type(integration_type)
+        except InvalidIntegrationTypeError:
+            console.print(f"\n  [red]Error:[/red] {_unknown_type_remediation(integration_type, name)}")
+            raise typer.Exit(code=1)
         required_keys = {c["key"] for c in credential_defs if c.get("required", False)}
         missing = required_keys - set(credentials_dict.keys())
         if missing:
@@ -373,7 +417,11 @@ def credentials(
         return
 
     # Update mode - prompt for all credentials
-    credential_defs = get_credentials_for_type(integration_type)
+    try:
+        credential_defs = get_credentials_for_type(integration_type)
+    except InvalidIntegrationTypeError:
+        console.print(f"\n  [red]Error:[/red] {_unknown_type_remediation(integration_type, name)}")
+        raise typer.Exit(code=1)
     credentials_to_store: list[tuple[str, str, str]] = []
 
     console.print(f"\n[bold]Update credentials for {rich_escape(name)}:[/bold]\n")

--- a/src/clawrium/core/integrations.py
+++ b/src/clawrium/core/integrations.py
@@ -1,7 +1,8 @@
 """Integration storage operations for Clawrium.
 
 Integrations are external services that agents can connect to for
-enhanced functionality (e.g., GitHub for code review, Jira for tickets).
+enhanced functionality (e.g., GitHub for code review, Atlassian (Jira +
+Confluence) for project tracking and docs).
 """
 
 import fcntl
@@ -74,43 +75,33 @@ INTEGRATION_TYPES: dict[str, dict] = {
             },
         ],
     },
-    "jira": {
-        "description": "Jira for issue tracking and project management",
+    "atlassian": {
+        "description": "Atlassian Cloud (Jira + Confluence) via API token",
         "credentials": [
             {
-                "key": "JIRA_URL",
-                "description": "Jira instance URL (e.g., https://company.atlassian.net)",
+                "key": "ATLASSIAN_URL",
+                "description": "Atlassian instance URL (e.g., https://company.atlassian.net)",
                 "required": True,
             },
             {
-                "key": "JIRA_EMAIL",
-                "description": "Email address for authentication",
+                "key": "ATLASSIAN_EMAIL",
+                "description": "Account email for authentication",
                 "required": True,
             },
             {
-                "key": "JIRA_API_TOKEN",
-                "description": "API token for authentication",
-                "required": True,
-            },
-        ],
-    },
-    "confluence": {
-        "description": "Confluence for documentation and knowledge base",
-        "credentials": [
-            {
-                "key": "CONFLUENCE_URL",
-                "description": "Confluence instance URL",
+                "key": "ATLASSIAN_API_TOKEN",
+                "description": "API token (create at https://id.atlassian.com/manage-profile/security/api-tokens)",
                 "required": True,
             },
             {
-                "key": "CONFLUENCE_EMAIL",
-                "description": "Email address for authentication",
-                "required": True,
+                "key": "CONFLUENCE_SPACES_FILTER",
+                "description": "Comma-separated Confluence space keys to filter (optional)",
+                "required": False,
             },
             {
-                "key": "CONFLUENCE_API_TOKEN",
-                "description": "API token for authentication",
-                "required": True,
+                "key": "JIRA_PROJECTS_FILTER",
+                "description": "Comma-separated Jira project keys to filter (optional)",
+                "required": False,
             },
         ],
     },
@@ -308,7 +299,6 @@ def load_integrations() -> list[dict]:
     try:
         with open(integrations_path) as f:
             data = json.load(f)
-            # Validate it's a list of dicts
             if not isinstance(data, list):
                 raise IntegrationsFileCorruptedError(
                     f"integrations.json is not a list: {integrations_path}"

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -714,6 +714,7 @@ def configure_agent(
     """
     from clawrium.core.providers import get_provider_api_key, get_provider_aws_credentials
     from clawrium.core.integrations import (
+        INTEGRATION_TYPES,
         get_agent_integrations,
         get_integration,
         get_integration_credentials,
@@ -1017,6 +1018,23 @@ def configure_agent(
             )
             continue
         integration_type = integration.get("type", "")
+        # Surface unknown types (e.g., a stale `jira`/`confluence` record from
+        # before this PR, or a missing/empty `type` from a hand-edited file)
+        # so the user knows MCP wiring will be a no-op rather than silently
+        # shipping a green configure with no Atlassian access. Empty string is
+        # not a key in INTEGRATION_TYPES, so the same branch catches both.
+        if integration_type not in INTEGRATION_TYPES:
+            valid = ", ".join(sorted(INTEGRATION_TYPES.keys()))
+            warning_msg = (
+                f"WARNING: integration '{integration_name}' has unknown type "
+                f"'{integration_type}' — skipping. Valid types: {valid}. "
+                f"Run `clm integration remove {integration_name}` and "
+                f"`clm integration add {integration_name} --type <valid-type>` "
+                "to recover."
+            )
+            emit("configure", warning_msg)
+            logger.warning(warning_msg)
+            continue
         credentials = get_integration_credentials(integration_name)
         if credentials:
             # Store by integration_name with type and credentials

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -28,6 +28,10 @@ secrets:
       description: "Anthropic API key"
     - key: OPENAI_API_KEY
       description: "OpenAI API key"
+    # Atlassian credentials are NOT listed here: they live in the per-integration
+    # credential store (managed via `clm integration credentials`) and a single
+    # hermes agent may have multiple atlassian integrations (team-a, team-b)
+    # with distinct tokens — a single manifest key would be ambiguous.
 
 # Onboarding workflow configuration.
 #
@@ -136,6 +140,7 @@ platforms:
         python: ">=3.11"
         ripgrep: "*"
         ffmpeg: "*"
+        uv: "*"
   - version: "2026.5.7"
     os: ubuntu
     os_version: "22.04"
@@ -148,3 +153,4 @@ platforms:
         python: ">=3.11"
         ripgrep: "*"
         ffmpeg: "*"
+        uv: "*"

--- a/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
@@ -1,6 +1,22 @@
 ---
 - hosts: all
   become: yes
+  vars:
+    # Pinned versions for the Atlassian MCP integration toolchain.
+    # Bump these deliberately after verifying the new release's env-var
+    # interface; both are exercised on every `clm agent configure`.
+    mcp_atlassian_version: "0.21.1"
+    uv_version: "0.5.20"
+    # Precomputed convenience flag — true iff this run has at least one
+    # atlassian integration assigned. Avoids repeating the dict2items filter
+    # chain on every `when:` clause below.
+    atlassian_integration_assigned: >-
+      {{
+        integrations is defined
+        and (integrations | dict2items
+              | selectattr('value.type', 'equalto', 'atlassian')
+              | list | length > 0)
+      }}
   tasks:
     - name: Check if agent user exists
       ansible.builtin.getent:
@@ -72,7 +88,8 @@
 
     # Render ~/.hermes/config.yaml (model.provider, model.default,
     # model.base_url). Hermes deep-merges with DEFAULT_CONFIG so omitted
-    # top-level keys keep their hermes defaults.
+    # top-level keys keep their hermes defaults. no_log because mcp_servers
+    # entries now contain the Atlassian API token verbatim.
     - name: Render ~/.hermes/config.yaml from template
       ansible.builtin.template:
         src: "{{ template_path }}/config.yaml.j2"
@@ -81,6 +98,7 @@
         group: "{{ agent_name }}"
         mode: "0600"
         force: yes
+      no_log: true
       notify: Restart hermes service
 
     # Per-provider credential verification — uses `grep -q` so we get a clean
@@ -182,6 +200,57 @@
         - config.channels is defined
         - config.channels.discord is defined
         - config.channels.discord.enabled | default(false)
+
+    # MCP toolchain bootstrap — only runs when an atlassian integration is
+    # assigned, so non-MCP agents pay zero overhead.
+    #
+    # Why pip instead of astral.sh's install.sh:
+    # `pip install` verifies the downloaded wheel against PyPI's published
+    # hashes — no separate `get_url` + `checksum:` ceremony required, no
+    # post-install cleanup of an installer script, and no curl|sh execution
+    # of remote code. Pinned version keeps the toolchain reproducible.
+    - name: Install pinned uv for agent user (via pip)
+      ansible.builtin.pip:
+        name: "uv=={{ uv_version }}"
+        extra_args: "--user"
+      become: true
+      become_user: "{{ agent_name }}"
+      when:
+        - atlassian_integration_assigned | bool
+
+    - name: Assert uv binary is present
+      ansible.builtin.stat:
+        path: "/home/{{ agent_name }}/.local/bin/uv"
+      register: uv_binary_stat
+      when:
+        - atlassian_integration_assigned | bool
+
+    - name: Fail with clear message if uv install did not land the binary
+      ansible.builtin.fail:
+        msg: >-
+          uv installation failed for agent '{{ agent_name }}': expected
+          /home/{{ agent_name }}/.local/bin/uv to exist after `pip install
+          --user uv=={{ uv_version }}`. Verify outbound access to PyPI from
+          the agent host and re-run `clm agent configure {{ agent_name }}`.
+      when:
+        - atlassian_integration_assigned | bool
+        - not (uv_binary_stat.stat.exists | default(false))
+
+    # Install MCP server packages for assigned integrations. `uv tool install
+    # --force` is idempotent when the version matches and surfaces actual
+    # upgrades when the pin moves — preferable to a `creates:` guard pointing
+    # at a non-version-stamped venv path (which would silently skip the task
+    # on version bumps).
+    - name: Pre-install mcp-atlassian (pinned, force-idempotent)
+      ansible.builtin.command:
+        cmd: "/home/{{ agent_name }}/.local/bin/uv tool install --force mcp-atlassian=={{ mcp_atlassian_version }}"
+      become: true
+      become_user: "{{ agent_name }}"
+      register: mcp_atlassian_install
+      changed_when: "'Installed' in (mcp_atlassian_install.stdout | default(''))"
+      no_log: true
+      when:
+        - atlassian_integration_assigned | bool
 
     # Force the restart handler to fire NOW so probes below run against the
     # newly-rendered config.

--- a/src/clawrium/platform/registry/hermes/templates/config.yaml.j2
+++ b/src/clawrium/platform/registry/hermes/templates/config.yaml.j2
@@ -3,6 +3,13 @@
 #
 # Hermes deep-merges this file with its DEFAULT_CONFIG at load time, so any
 # top-level keys not listed here retain their hermes defaults.
+{# YAML-safe single-quote escaping. Single-quoted YAML scalars do not
+   interpret escapes, so doubling embedded single quotes is sufficient to
+   neutralize tokens containing colons, quotes, newlines, etc. Mirrors the
+   shell_quote pattern in openclaw/.env.j2. #}
+{%- macro yaml_quote(value) -%}
+'{{ value | string | replace("'", "''") }}'
+{%- endmacro -%}
 {% set provider = config.provider | default({}) %}
 {% set provider_type = provider.type | default('') %}
 {% set model_id = provider.default_model | default('') %}
@@ -38,4 +45,49 @@ model:
 {% if provider_type == 'bedrock' %}
 bedrock:
   region: "{{ provider.region | default('us-east-1') }}"
+{% endif %}
+
+{# --- MCP Servers (from assigned integrations) ---
+   Each atlassian integration becomes a stdio MCP server entry. Credentials
+   are emitted as single-quoted YAML scalars via yaml_quote to prevent token
+   contents from breaking out of the scalar. CONFLUENCE_URL is derived as
+   ATLASSIAN_URL + '/wiki' (Atlassian Cloud convention only — Data Center /
+   Server installs use a different URL layout and are out of scope). #}
+{% if integrations is defined and integrations | length > 0 %}
+{% set mcp_entries = [] %}
+{% for name, integration in integrations.items() %}
+{% if integration.type == 'atlassian' %}{% if mcp_entries.append(name) %}{% endif %}{% endif %}
+{% endfor %}
+{% if mcp_entries | length > 0 %}
+mcp_servers:
+{% for name in mcp_entries %}
+{% set intg = integrations[name] %}
+{% set server_name = name | replace('-', '_') %}
+{# Strip trailing slash on the instance URL before deriving CONFLUENCE_URL so
+   a user-entered 'https://co.atlassian.net/' doesn't render '//wiki'. #}
+{% set atlassian_url = (intg.ATLASSIAN_URL | default('')).rstrip('/') %}
+  {{ server_name }}:
+    command: "/home/{{ agent_name }}/.local/bin/uvx"
+    {# Pin runtime version with --from so a missing tool venv (manual delete,
+       partial cleanup) does not silently resolve to mcp-atlassian latest. #}
+    {# `mcp_atlassian_version` is required: the playbook supplies it via
+       `vars:` so install and runtime stay in lockstep. No Jinja fallback —
+       drift between pre-install pin and runtime pin would silently install
+       one version and launch another. #}
+    args: ["--from", "mcp-atlassian=={{ mcp_atlassian_version }}", "mcp-atlassian"]
+    env:
+      JIRA_URL: {{ yaml_quote(atlassian_url) }}
+      JIRA_USERNAME: {{ yaml_quote(intg.ATLASSIAN_EMAIL | default('')) }}
+      JIRA_API_TOKEN: {{ yaml_quote(intg.ATLASSIAN_API_TOKEN | default('')) }}
+      CONFLUENCE_URL: {{ yaml_quote(atlassian_url + '/wiki') }}
+      CONFLUENCE_USERNAME: {{ yaml_quote(intg.ATLASSIAN_EMAIL | default('')) }}
+      CONFLUENCE_API_TOKEN: {{ yaml_quote(intg.ATLASSIAN_API_TOKEN | default('')) }}
+{% if intg.CONFLUENCE_SPACES_FILTER is defined and intg.CONFLUENCE_SPACES_FILTER %}
+      CONFLUENCE_SPACES_FILTER: {{ yaml_quote(intg.CONFLUENCE_SPACES_FILTER) }}
+{% endif %}
+{% if intg.JIRA_PROJECTS_FILTER is defined and intg.JIRA_PROJECTS_FILTER %}
+      JIRA_PROJECTS_FILTER: {{ yaml_quote(intg.JIRA_PROJECTS_FILTER) }}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% endif %}

--- a/src/clawrium/platform/registry/openclaw/templates/.env.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/.env.j2
@@ -70,25 +70,21 @@ GITLAB_TOKEN={{ shell_quote(integration.GITLAB_TOKEN) }}
 {% if integration.GITLAB_URL is defined %}
 GITLAB_URL={{ shell_quote(integration.GITLAB_URL) }}
 {% endif %}
-{% elif integration.type == 'jira' %}
-{% if integration.JIRA_URL is defined %}
-JIRA_URL={{ shell_quote(integration.JIRA_URL) }}
+{% elif integration.type == 'atlassian' %}
+{% if integration.ATLASSIAN_URL is defined %}
+{# Strip trailing slash before deriving the Confluence URL. Atlassian Cloud
+   convention only — Data Center installs use a different URL layout. #}
+{% set atlassian_url = integration.ATLASSIAN_URL.rstrip('/') %}
+JIRA_URL={{ shell_quote(atlassian_url) }}
+CONFLUENCE_URL={{ shell_quote(atlassian_url + '/wiki') }}
 {% endif %}
-{% if integration.JIRA_EMAIL is defined %}
-JIRA_EMAIL={{ shell_quote(integration.JIRA_EMAIL) }}
+{% if integration.ATLASSIAN_EMAIL is defined %}
+JIRA_EMAIL={{ shell_quote(integration.ATLASSIAN_EMAIL) }}
+CONFLUENCE_EMAIL={{ shell_quote(integration.ATLASSIAN_EMAIL) }}
 {% endif %}
-{% if integration.JIRA_API_TOKEN is defined %}
-JIRA_API_TOKEN={{ shell_quote(integration.JIRA_API_TOKEN) }}
-{% endif %}
-{% elif integration.type == 'confluence' %}
-{% if integration.CONFLUENCE_URL is defined %}
-CONFLUENCE_URL={{ shell_quote(integration.CONFLUENCE_URL) }}
-{% endif %}
-{% if integration.CONFLUENCE_EMAIL is defined %}
-CONFLUENCE_EMAIL={{ shell_quote(integration.CONFLUENCE_EMAIL) }}
-{% endif %}
-{% if integration.CONFLUENCE_API_TOKEN is defined %}
-CONFLUENCE_API_TOKEN={{ shell_quote(integration.CONFLUENCE_API_TOKEN) }}
+{% if integration.ATLASSIAN_API_TOKEN is defined %}
+JIRA_API_TOKEN={{ shell_quote(integration.ATLASSIAN_API_TOKEN) }}
+CONFLUENCE_API_TOKEN={{ shell_quote(integration.ATLASSIAN_API_TOKEN) }}
 {% endif %}
 {% elif integration.type == 'linear' %}
 {% if integration.LINEAR_API_KEY is defined %}

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
@@ -29,6 +29,10 @@
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
         mode: "0600"
+      # The rendered config.toml embeds integration secrets (github_token,
+      # jira_api_token, confluence_api_token, etc.); suppress Ansible's default
+      # diff/callback so the rendered file body does not surface in logs.
+      no_log: true
       notify: Restart zeroclaw service
 
     - name: Ensure service is enabled

--- a/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
+++ b/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
@@ -37,26 +37,22 @@ gitlab_token = "{{ integration.GITLAB_TOKEN | replace('\\', '\\\\') | replace('"
 gitlab_url = "{{ integration.GITLAB_URL }}"
 {% endif %}
 {% endif %}
-{% if integration.type == 'jira' %}
-{% if integration.JIRA_URL is defined %}
-jira_url = "{{ integration.JIRA_URL }}"
+{% if integration.type == 'atlassian' %}
+{# Unified Atlassian credentials drive both jira_* and confluence_* TOML keys.
+   CONFLUENCE_URL is derived as ATLASSIAN_URL + '/wiki' (Cloud convention only;
+   Data Center / Server use a different URL layout, out of scope). #}
+{% if integration.ATLASSIAN_URL is defined %}
+{% set atlassian_url = integration.ATLASSIAN_URL.rstrip('/') %}
+jira_url = "{{ atlassian_url }}"
+confluence_url = "{{ atlassian_url }}/wiki"
 {% endif %}
-{% if integration.JIRA_EMAIL is defined %}
-jira_email = "{{ integration.JIRA_EMAIL }}"
+{% if integration.ATLASSIAN_EMAIL is defined %}
+jira_email = "{{ integration.ATLASSIAN_EMAIL }}"
+confluence_email = "{{ integration.ATLASSIAN_EMAIL }}"
 {% endif %}
-{% if integration.JIRA_API_TOKEN is defined %}
-jira_api_token = "{{ integration.JIRA_API_TOKEN | replace('\\', '\\\\') | replace('"', '\\"') }}"
-{% endif %}
-{% endif %}
-{% if integration.type == 'confluence' %}
-{% if integration.CONFLUENCE_URL is defined %}
-confluence_url = "{{ integration.CONFLUENCE_URL }}"
-{% endif %}
-{% if integration.CONFLUENCE_EMAIL is defined %}
-confluence_email = "{{ integration.CONFLUENCE_EMAIL }}"
-{% endif %}
-{% if integration.CONFLUENCE_API_TOKEN is defined %}
-confluence_api_token = "{{ integration.CONFLUENCE_API_TOKEN | replace('\\', '\\\\') | replace('"', '\\"') }}"
+{% if integration.ATLASSIAN_API_TOKEN is defined %}
+jira_api_token = "{{ integration.ATLASSIAN_API_TOKEN | replace('\\', '\\\\') | replace('"', '\\"') }}"
+confluence_api_token = "{{ integration.ATLASSIAN_API_TOKEN | replace('\\', '\\\\') | replace('"', '\\"') }}"
 {% endif %}
 {% endif %}
 {% if integration.type == 'linear' and integration.LINEAR_API_KEY is defined %}

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -21,8 +21,7 @@ class TestIntegrationTypes:
         assert result.exit_code == 0
         assert "github" in result.output
         assert "gitlab" in result.output
-        assert "jira" in result.output
-        assert "confluence" in result.output
+        assert "atlassian" in result.output
         assert "linear" in result.output
         assert "notion" in result.output
 
@@ -42,7 +41,7 @@ class TestIntegrationList:
         isolated_config.mkdir(parents=True, exist_ok=True)
         integrations = [
             {"name": "work-github", "type": "github", "created_at": "2026-04-15T10:00:00Z"},
-            {"name": "company-jira", "type": "jira", "created_at": "2026-04-15T11:00:00Z"},
+            {"name": "company-atlassian", "type": "atlassian", "created_at": "2026-04-15T11:00:00Z"},
         ]
         (isolated_config / INTEGRATIONS_FILE).write_text(json.dumps(integrations))
 
@@ -50,9 +49,9 @@ class TestIntegrationList:
 
         assert result.exit_code == 0
         assert "work-github" in result.output
-        assert "company-jira" in result.output
+        assert "company-atlassian" in result.output
         assert "github" in result.output
-        assert "jira" in result.output
+        assert "atlassian" in result.output
 
 
 class TestIntegrationAdd:
@@ -314,3 +313,69 @@ class TestIntegrationCredentials:
         assert "GITHUB_TOKEN" in result.output
         # Token should be masked
         assert "ghp_test123" not in result.output
+
+
+class TestIntegrationStaleType:
+    """Tests for CLI behavior on integration records with an unknown type.
+
+    A stale `jira`/`confluence` record (or any manual edit pointing at a type
+    not in INTEGRATION_TYPES) must NOT raise an unhandled exception, must
+    surface a remediation message, and — for non-display commands — must exit
+    non-zero so script chains don't silently proceed.
+    """
+
+    def _seed_stale_jira(self, isolated_config):
+        # Deliberately pick a name that does NOT contain 'jira' so that an
+        # assertion like `'jira' in result.output` proves the *type* was
+        # rendered, not just the name.
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        (isolated_config / INTEGRATIONS_FILE).write_text(
+            json.dumps([{"name": "stale-ticket", "type": "jira"}])
+        )
+
+    def test_show_with_unknown_type_exits_nonzero_with_remediation(self, isolated_config):
+        self._seed_stale_jira(isolated_config)
+        result = runner.invoke(app, ["integration", "show", "stale-ticket"])
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(
+            result.exception, SystemExit
+        ), f"Unexpected exception: {result.exception!r}"
+        assert "not a known type" in result.output.lower()
+        assert "Error:" in result.output
+        # Remediation must interpolate the actual integration name, not <name>.
+        assert "stale-ticket" in result.output
+        assert "<name>" not in result.output
+
+    def test_credentials_read_with_unknown_type_exits_nonzero(self, isolated_config):
+        self._seed_stale_jira(isolated_config)
+        result = runner.invoke(app, ["integration", "credentials", "stale-ticket"])
+
+        assert result.exit_code == 1
+        assert "not a known type" in result.output.lower()
+        assert "Error:" in result.output
+        assert "stale-ticket" in result.output
+        assert "<name>" not in result.output
+
+    def test_credentials_update_with_unknown_type_exits_nonzero(self, isolated_config):
+        self._seed_stale_jira(isolated_config)
+        result = runner.invoke(
+            app, ["integration", "credentials", "stale-ticket", "--update"]
+        )
+
+        assert result.exit_code == 1
+        assert "not a known type" in result.output.lower()
+        assert "Error:" in result.output
+        assert "stale-ticket" in result.output
+        assert "<name>" not in result.output
+
+    def test_list_marks_unknown_type_with_indicator(self, isolated_config):
+        self._seed_stale_jira(isolated_config)
+        result = runner.invoke(app, ["integration", "list"])
+
+        assert result.exit_code == 0
+        # Both halves of the rendered cell must survive: the stale type name
+        # and the "(unknown)" suffix.
+        assert "(unknown)" in result.output
+        assert "jira" in result.output
+        assert "stale-ticket" in result.output

--- a/tests/test_configure_zeroclaw.py
+++ b/tests/test_configure_zeroclaw.py
@@ -1,0 +1,115 @@
+"""Rendering tests for zeroclaw config.toml.j2.
+
+Covers the unified `atlassian` integration branch added in issue #348:
+trailing-slash URL normalization (so CONFLUENCE_URL doesn't double-slash) and
+TOML escape correctness on the api_token fields (which embed secrets).
+"""
+
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+
+ZEROCLAW_TEMPLATES = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "clawrium"
+    / "platform"
+    / "registry"
+    / "zeroclaw"
+    / "templates"
+)
+
+_BASE_CONFIG = {
+    "gateway": {"host": "localhost", "port": 4080, "allow_public_bind": False},
+}
+
+
+def _render_config_toml(integrations: dict) -> str:
+    env = Environment(loader=FileSystemLoader(str(ZEROCLAW_TEMPLATES)))
+    # The zeroclaw template uses Ansible's `bool` filter for the gateway flag.
+    # Mirror Ansible's string coercion (which treats 'no', 'false', '0', '' as
+    # False) — a plain `bool()` diverges silently for those string inputs.
+    def _ansible_bool(v):
+        if isinstance(v, str):
+            return v.lower() not in ("no", "false", "0", "")
+        return bool(v)
+    env.filters["bool"] = _ansible_bool
+    template = env.get_template("config.toml.j2")
+    return template.render(config=_BASE_CONFIG, integrations=integrations)
+
+
+class TestZeroclawAtlassianRendering:
+    """Verify the unified atlassian branch in config.toml.j2 emits correct TOML."""
+
+    def test_atlassian_renders_jira_and_confluence_urls(self):
+        rendered = _render_config_toml({
+            "work": {
+                "type": "atlassian",
+                "ATLASSIAN_URL": "https://co.atlassian.net",
+                "ATLASSIAN_EMAIL": "u@co.com",
+                "ATLASSIAN_API_TOKEN": "token",
+            }
+        })
+        assert 'jira_url = "https://co.atlassian.net"' in rendered
+        assert 'confluence_url = "https://co.atlassian.net/wiki"' in rendered
+        assert 'jira_email = "u@co.com"' in rendered
+        assert 'confluence_email = "u@co.com"' in rendered
+
+    def test_atlassian_trailing_slash_does_not_produce_double_slash(self):
+        """A user-entered URL with trailing slash collapses before /wiki."""
+        rendered = _render_config_toml({
+            "work": {
+                "type": "atlassian",
+                "ATLASSIAN_URL": "https://co.atlassian.net/",
+                "ATLASSIAN_EMAIL": "u@co.com",
+                "ATLASSIAN_API_TOKEN": "token",
+            }
+        })
+        assert 'jira_url = "https://co.atlassian.net"' in rendered
+        assert 'confluence_url = "https://co.atlassian.net/wiki"' in rendered
+        assert "//wiki" not in rendered
+
+    def test_atlassian_api_token_toml_escaping(self):
+        """API tokens containing quotes and backslashes must be TOML-escaped on
+        both jira_api_token and confluence_api_token (same value, same macro).
+        """
+        token = 'tok"with"quote\\and\\backslash'
+        rendered = _render_config_toml({
+            "work": {
+                "type": "atlassian",
+                "ATLASSIAN_URL": "https://co.atlassian.net",
+                "ATLASSIAN_EMAIL": "u@co.com",
+                "ATLASSIAN_API_TOKEN": token,
+            }
+        })
+        # Expected after escape: \\ for backslash, \" for quote.
+        expected_escaped = r'tok\"with\"quote\\and\\backslash'
+        assert f'jira_api_token = "{expected_escaped}"' in rendered
+        assert f'confluence_api_token = "{expected_escaped}"' in rendered
+
+    def test_non_atlassian_integrations_do_not_render_atlassian_keys(self):
+        """A github integration must not produce jira_* or confluence_* keys."""
+        rendered = _render_config_toml({
+            "work": {"type": "github", "GITHUB_TOKEN": "ghp_test"}
+        })
+        assert "jira_url" not in rendered
+        assert "confluence_url" not in rendered
+        assert "jira_api_token" not in rendered
+        assert "confluence_api_token" not in rendered
+        assert 'github_token = "ghp_test"' in rendered
+
+    def test_atlassian_partial_dict_omits_absent_keys(self):
+        """Per-key `is defined` guards in the template must drop unset fields
+        cleanly — never produce stray `= ''` or `= None` lines from the missing
+        ATLASSIAN_EMAIL/ATLASSIAN_API_TOKEN halves.
+        """
+        rendered = _render_config_toml({
+            "work": {"type": "atlassian", "ATLASSIAN_URL": "https://co.atlassian.net"},
+        })
+        assert 'jira_url = "https://co.atlassian.net"' in rendered
+        assert 'confluence_url = "https://co.atlassian.net/wiki"' in rendered
+        assert "jira_email" not in rendered
+        assert "confluence_email" not in rendered
+        assert "jira_api_token" not in rendered
+        assert "confluence_api_token" not in rendered

--- a/tests/test_core_integrations.py
+++ b/tests/test_core_integrations.py
@@ -115,7 +115,7 @@ class TestIntegrationTypes:
 
     def test_integration_types_has_expected_types(self):
         """INTEGRATION_TYPES contains expected integration types."""
-        expected_types = {"github", "gitlab", "jira", "confluence", "linear", "notion"}
+        expected_types = {"github", "gitlab", "atlassian", "linear", "notion"}
         assert set(INTEGRATION_TYPES.keys()) == expected_types
 
     def test_each_type_has_description_and_credentials(self):
@@ -131,13 +131,13 @@ class TestIntegrationTypes:
         keys = [c["key"] for c in github["credentials"]]
         assert "GITHUB_TOKEN" in keys
 
-    def test_jira_has_required_credentials(self):
-        """Jira integration requires URL, email, and token."""
-        jira = INTEGRATION_TYPES["jira"]
-        keys = [c["key"] for c in jira["credentials"]]
-        assert "JIRA_URL" in keys
-        assert "JIRA_EMAIL" in keys
-        assert "JIRA_API_TOKEN" in keys
+    def test_atlassian_has_required_credentials(self):
+        """Atlassian integration requires URL, email, and token."""
+        atlassian = INTEGRATION_TYPES["atlassian"]
+        keys = [c["key"] for c in atlassian["credentials"]]
+        assert "ATLASSIAN_URL" in keys
+        assert "ATLASSIAN_EMAIL" in keys
+        assert "ATLASSIAN_API_TOKEN" in keys
 
 
 class TestIntegrationInstanceKey:
@@ -168,7 +168,7 @@ class TestLoadIntegrations:
         """Loads integrations from valid JSON file."""
         integrations = [
             {"name": "work-github", "type": "github"},
-            {"name": "company-jira", "type": "jira"},
+            {"name": "company-atlassian", "type": "atlassian"},
         ]
         integrations_file = tmp_path / INTEGRATIONS_FILE
         integrations_file.write_text(json.dumps(integrations))
@@ -177,7 +177,7 @@ class TestLoadIntegrations:
             result = load_integrations()
             assert len(result) == 2
             assert result[0]["name"] == "work-github"
-            assert result[1]["type"] == "jira"
+            assert result[1]["type"] == "atlassian"
 
     def test_raises_on_invalid_json(self, tmp_path):
         """Raises IntegrationsFileCorruptedError on invalid JSON."""
@@ -249,16 +249,16 @@ class TestGetIntegration:
         """Returns integration dict when name matches."""
         integrations = [
             {"name": "work-github", "type": "github"},
-            {"name": "company-jira", "type": "jira"},
+            {"name": "company-atlassian", "type": "atlassian"},
         ]
         integrations_file = tmp_path / INTEGRATIONS_FILE
         integrations_file.write_text(json.dumps(integrations))
 
         with patch("clawrium.core.integrations.get_config_dir", return_value=tmp_path):
-            result = get_integration("company-jira")
+            result = get_integration("company-atlassian")
             assert result is not None
-            assert result["name"] == "company-jira"
-            assert result["type"] == "jira"
+            assert result["name"] == "company-atlassian"
+            assert result["type"] == "atlassian"
 
     def test_returns_none_when_not_found(self, tmp_path):
         """Returns None when integration name not found."""
@@ -277,7 +277,7 @@ class TestRemoveIntegration:
         """Removes integration and returns True."""
         integrations = [
             {"name": "work-github", "type": "github"},
-            {"name": "company-jira", "type": "jira"},
+            {"name": "company-atlassian", "type": "atlassian"},
         ]
         integrations_file = tmp_path / INTEGRATIONS_FILE
         integrations_file.write_text(json.dumps(integrations))
@@ -294,7 +294,7 @@ class TestRemoveIntegration:
             assert result is True
             remaining = load_integrations()
             assert len(remaining) == 1
-            assert remaining[0]["name"] == "company-jira"
+            assert remaining[0]["name"] == "company-atlassian"
 
     def test_returns_false_when_not_found(self, tmp_path):
         """Returns False when integration not found."""

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -2340,3 +2340,225 @@ class TestHermesSlackSecretsHygiene:
         assert "app_token" not in persisted_slack, (
             f"Strip layer failed to catch injected app_token: {persisted_slack}"
         )
+
+
+# ---------------------------------------------------------------------------
+# config.yaml.j2 rendering — MCP servers from integrations
+# ---------------------------------------------------------------------------
+
+
+def _render_config_yaml_with_integrations(
+    config: dict,
+    integrations: dict,
+    agent_name: str = "h",
+    mcp_atlassian_version: str = "0.21.1",
+) -> str:
+    env = Environment(
+        loader=FileSystemLoader(str(HERMES_TEMPLATES)),
+        keep_trailing_newline=True,
+    )
+    template = env.get_template("config.yaml.j2")
+    return template.render(
+        config=config,
+        integrations=integrations,
+        agent_name=agent_name,
+        mcp_atlassian_version=mcp_atlassian_version,
+    )
+
+
+class TestConfigYamlMCPServers:
+    """Verify MCP server blocks render correctly from integrations."""
+
+    def _base_config(self) -> dict:
+        return {
+            "provider": {"type": "bedrock", "default_model": "anthropic.claude-sonnet-4-20250514-v1:0", "region": "us-east-1"},
+        }
+
+    def test_no_mcp_servers_when_no_integrations(self):
+        """config.yaml has no mcp_servers key when integrations is empty."""
+        rendered = _render_config_yaml_with_integrations(self._base_config(), {})
+        assert "mcp_servers" not in rendered
+
+    def test_no_mcp_servers_when_integrations_undefined(self):
+        """config.yaml has no mcp_servers key when integrations is not passed."""
+        rendered = _render_config_yaml(self._base_config())
+        assert "mcp_servers" not in rendered
+
+    def test_no_mcp_servers_for_non_atlassian_integrations(self):
+        """Non-atlassian integrations don't produce mcp_servers."""
+        integrations = {
+            "work-github": {
+                "type": "github",
+                "GITHUB_TOKEN": "ghp_test123",
+            }
+        }
+        rendered = _render_config_yaml_with_integrations(self._base_config(), integrations)
+        assert "mcp_servers" not in rendered
+
+    def test_atlassian_integration_renders_mcp_server(self):
+        """Atlassian integration renders mcp-atlassian server config."""
+        integrations = {
+            "work-atlassian": {
+                "type": "atlassian",
+                "ATLASSIAN_URL": "https://company.atlassian.net",
+                "ATLASSIAN_EMAIL": "dev@company.com",
+                "ATLASSIAN_API_TOKEN": "secret_token_123",
+            }
+        }
+        rendered = _render_config_yaml_with_integrations(self._base_config(), integrations)
+        parsed = yaml.safe_load(rendered)
+
+        assert "mcp_servers" in parsed
+        # Server name: hyphens replaced with underscores
+        assert "work_atlassian" in parsed["mcp_servers"]
+        server = parsed["mcp_servers"]["work_atlassian"]
+        assert server["command"] == "/home/h/.local/bin/uvx"
+        # args pin the runtime mcp-atlassian version via `--from` so a missing
+        # uv tool venv cannot silently resolve to latest.
+        assert server["args"] == ["--from", "mcp-atlassian==0.21.1", "mcp-atlassian"]
+        assert server["env"]["JIRA_URL"] == "https://company.atlassian.net"
+        assert server["env"]["JIRA_USERNAME"] == "dev@company.com"
+        assert server["env"]["JIRA_API_TOKEN"] == "secret_token_123"
+        assert server["env"]["CONFLUENCE_URL"] == "https://company.atlassian.net/wiki"
+        assert server["env"]["CONFLUENCE_USERNAME"] == "dev@company.com"
+        assert server["env"]["CONFLUENCE_API_TOKEN"] == "secret_token_123"
+
+    def test_atlassian_with_space_and_project_filters(self):
+        """Optional CONFLUENCE_SPACES_FILTER and JIRA_PROJECTS_FILTER render."""
+        integrations = {
+            "filtered-atlassian": {
+                "type": "atlassian",
+                "ATLASSIAN_URL": "https://co.atlassian.net",
+                "ATLASSIAN_EMAIL": "user@co.com",
+                "ATLASSIAN_API_TOKEN": "token",
+                "CONFLUENCE_SPACES_FILTER": "ENG,PROD",
+                "JIRA_PROJECTS_FILTER": "PROJ,OPS",
+            }
+        }
+        rendered = _render_config_yaml_with_integrations(self._base_config(), integrations)
+        parsed = yaml.safe_load(rendered)
+
+        server = parsed["mcp_servers"]["filtered_atlassian"]
+        assert server["env"]["CONFLUENCE_SPACES_FILTER"] == "ENG,PROD"
+        assert server["env"]["JIRA_PROJECTS_FILTER"] == "PROJ,OPS"
+
+    def test_atlassian_without_optional_filters_omits_them(self):
+        """When no filters are provided, those keys are absent from env."""
+        integrations = {
+            "plain-atlassian": {
+                "type": "atlassian",
+                "ATLASSIAN_URL": "https://co.atlassian.net",
+                "ATLASSIAN_EMAIL": "user@co.com",
+                "ATLASSIAN_API_TOKEN": "token",
+            }
+        }
+        rendered = _render_config_yaml_with_integrations(self._base_config(), integrations)
+        parsed = yaml.safe_load(rendered)
+
+        server = parsed["mcp_servers"]["plain_atlassian"]
+        assert "CONFLUENCE_SPACES_FILTER" not in server["env"]
+        assert "JIRA_PROJECTS_FILTER" not in server["env"]
+
+    def test_multiple_atlassian_integrations_render_separate_servers(self):
+        """Multiple atlassian integrations each get their own server entry."""
+        integrations = {
+            "team-a": {
+                "type": "atlassian",
+                "ATLASSIAN_URL": "https://teama.atlassian.net",
+                "ATLASSIAN_EMAIL": "a@team.com",
+                "ATLASSIAN_API_TOKEN": "token_a",
+            },
+            "team-b": {
+                "type": "atlassian",
+                "ATLASSIAN_URL": "https://teamb.atlassian.net",
+                "ATLASSIAN_EMAIL": "b@team.com",
+                "ATLASSIAN_API_TOKEN": "token_b",
+            },
+        }
+        rendered = _render_config_yaml_with_integrations(self._base_config(), integrations)
+        parsed = yaml.safe_load(rendered)
+
+        assert "team_a" in parsed["mcp_servers"]
+        assert "team_b" in parsed["mcp_servers"]
+        assert parsed["mcp_servers"]["team_a"]["env"]["JIRA_URL"] == "https://teama.atlassian.net"
+        assert parsed["mcp_servers"]["team_b"]["env"]["JIRA_URL"] == "https://teamb.atlassian.net"
+
+    def test_mixed_integrations_only_atlassian_renders_mcp(self):
+        """Only atlassian types produce mcp_servers entries; others ignored."""
+        integrations = {
+            "my-github": {
+                "type": "github",
+                "GITHUB_TOKEN": "ghp_xxx",
+            },
+            "my-atlassian": {
+                "type": "atlassian",
+                "ATLASSIAN_URL": "https://co.atlassian.net",
+                "ATLASSIAN_EMAIL": "u@co.com",
+                "ATLASSIAN_API_TOKEN": "tok",
+            },
+        }
+        rendered = _render_config_yaml_with_integrations(self._base_config(), integrations)
+        parsed = yaml.safe_load(rendered)
+
+        assert "mcp_servers" in parsed
+        assert len(parsed["mcp_servers"]) == 1
+        assert "my_atlassian" in parsed["mcp_servers"]
+
+    def test_trailing_slash_url_does_not_produce_double_slash(self):
+        """ATLASSIAN_URL with trailing slash collapses to a single slash before /wiki."""
+        integrations = {
+            "trailing-slash": {
+                "type": "atlassian",
+                "ATLASSIAN_URL": "https://co.atlassian.net/",
+                "ATLASSIAN_EMAIL": "u@co.com",
+                "ATLASSIAN_API_TOKEN": "tok",
+            }
+        }
+        rendered = _render_config_yaml_with_integrations(self._base_config(), integrations)
+        parsed = yaml.safe_load(rendered)
+
+        server = parsed["mcp_servers"]["trailing_slash"]
+        assert server["env"]["JIRA_URL"] == "https://co.atlassian.net"
+        assert server["env"]["CONFLUENCE_URL"] == "https://co.atlassian.net/wiki"
+
+    def test_token_with_special_chars_does_not_break_yaml(self):
+        """A token containing characters that could break out of a YAML scalar is neutralized.
+
+        Single-quoted YAML scalars fold newlines into spaces, so we check the
+        token does NOT inject top-level keys rather than asserting byte
+        equality (folding is a property of YAML, not an injection)."""
+        nasty_token = "abc'def\"\nrogue: true\nadmin: yes\n: sneaky"
+        integrations = {
+            "nasty": {
+                "type": "atlassian",
+                "ATLASSIAN_URL": "https://co.atlassian.net",
+                "ATLASSIAN_EMAIL": "u@co.com",
+                "ATLASSIAN_API_TOKEN": nasty_token,
+            }
+        }
+        rendered = _render_config_yaml_with_integrations(self._base_config(), integrations)
+        parsed = yaml.safe_load(rendered)
+
+        env = parsed["mcp_servers"]["nasty"]["env"]
+        # Both JIRA_API_TOKEN and CONFLUENCE_API_TOKEN render via the same
+        # yaml_quote macro — assert symmetrically so a macro removal on either
+        # line is caught.
+        for token_key in ("JIRA_API_TOKEN", "CONFLUENCE_API_TOKEN"):
+            assert isinstance(env[token_key], str), token_key
+            assert "abc'def" in env[token_key], token_key
+            # Injection text stays inside the scalar; it does NOT escape.
+            assert "rogue" in env[token_key], token_key
+
+        # No injected top-level keys.
+        assert "rogue" not in parsed
+        assert "admin" not in parsed
+        # No injected sibling keys inside the env dict either.
+        assert set(env.keys()) <= {
+            "JIRA_URL",
+            "JIRA_USERNAME",
+            "JIRA_API_TOKEN",
+            "CONFLUENCE_URL",
+            "CONFLUENCE_USERNAME",
+            "CONFLUENCE_API_TOKEN",
+        }
+

--- a/tests/test_lifecycle_integrations.py
+++ b/tests/test_lifecycle_integrations.py
@@ -18,7 +18,7 @@ class TestConfigureAgentIntegrationLoading:
                 "test-agent": {
                     "type": "openclaw",
                     "status": "installed",
-                    "integrations": ["work-github", "company-jira"],
+                    "integrations": ["work-github", "company-atlassian"],
                 }
             },
         }
@@ -69,14 +69,14 @@ class TestConfigureAgentIntegrationLoading:
             (template_dir / "config.toml.j2").write_text("# config")
 
             mock_resolve.return_value = ("test-agent", "openclaw", mock_host["agents"]["test-agent"])
-            mock_get_integrations.return_value = ["work-github", "company-jira"]
+            mock_get_integrations.return_value = ["work-github", "company-atlassian"]
             mock_get_integration.side_effect = [
                 {"name": "work-github", "type": "github"},
-                {"name": "company-jira", "type": "jira"},
+                {"name": "company-atlassian", "type": "atlassian"},
             ]
             mock_get_credentials.side_effect = [
                 {"GITHUB_TOKEN": "ghp_test123"},
-                {"JIRA_URL": "https://jira.example.com", "JIRA_EMAIL": "test@example.com", "JIRA_API_TOKEN": "jira_token"},
+                {"ATLASSIAN_URL": "https://company.atlassian.net", "ATLASSIAN_EMAIL": "test@example.com", "ATLASSIAN_API_TOKEN": "atlassian_token"},
             ]
             mock_run.return_value = mock_ansible_success
 
@@ -241,3 +241,108 @@ class TestConfigureAgentIntegrationLoading:
 
             # Should continue without failing
             mock_run.assert_called_once()
+
+    def test_unknown_type_integration_emits_warning_and_is_excluded(
+        self, mock_host, mock_ansible_success, tmp_path
+    ):
+        """A stale `jira`-typed record fires the configure-stage warning and is
+        excluded from ansible extravars, rather than silently shipping a green
+        configure with the broken record loaded.
+        """
+        events: list[tuple[str, str]] = []
+
+        with patch(
+            "clawrium.core.lifecycle.get_host", return_value=mock_host
+        ), patch(
+            "clawrium.core.lifecycle._resolve_agent_record"
+        ) as mock_resolve, patch(
+            "clawrium.core.integrations.get_agent_integrations"
+        ) as mock_get_integrations, patch(
+            "clawrium.core.integrations.get_integration"
+        ) as mock_get_integration, patch(
+            "clawrium.core.integrations.get_integration_credentials"
+        ) as mock_get_credentials, patch(
+            "clawrium.core.lifecycle.ansible_runner.run"
+        ) as mock_run, patch(
+            "clawrium.core.lifecycle.update_host", return_value=True
+        ), patch(
+            "clawrium.core.lifecycle.get_host_private_key", return_value="ssh-key-content"
+        ), patch(
+            "clawrium.core.lifecycle._get_lifecycle_playbook_path"
+        ) as mock_playbook_path, patch(
+            "clawrium.core.lifecycle._resolve_agent_type", return_value="openclaw"
+        ), patch(
+            "clawrium.core.lifecycle.get_instance_secrets", return_value={}
+        ), patch(
+            "clawrium.core.lifecycle._cleanup_ansible_artifacts"
+        ), patch(
+            "clawrium.core.lifecycle._get_logs_dir", return_value=tmp_path / "logs"
+        ):
+            playbook = tmp_path / "configure.yaml"
+            playbook.write_text("---\n- hosts: all\n")
+            mock_playbook_path.return_value = playbook
+
+            mock_resolve.return_value = (
+                "test-agent",
+                "openclaw",
+                mock_host["agents"]["test-agent"],
+            )
+            mock_get_integrations.return_value = ["old-jira", "work-github"]
+            mock_get_integration.side_effect = [
+                {"name": "old-jira", "type": "jira"},
+                {"name": "work-github", "type": "github"},
+            ]
+            # Keyed-by-name side_effect: robust to ordering. If the guard
+            # regresses and credentials are fetched for the stale record, the
+            # `call_count` assertion below produces a clean failure rather
+            # than a StopIteration traceback.
+            def _credentials_by_name(name: str) -> dict:
+                return {
+                    "old-jira": {"JIRA_API_TOKEN": "would-be-leaked"},
+                    "work-github": {"GITHUB_TOKEN": "ghp_test"},
+                }.get(name, {})
+
+            mock_get_credentials.side_effect = _credentials_by_name
+            mock_run.return_value = mock_ansible_success
+
+            from clawrium.core.lifecycle import configure_agent
+
+            with patch("clawrium.core.lifecycle.Path") as mock_path_cls:
+                mock_template_path = MagicMock()
+                mock_template_path.exists.return_value = True
+                mock_path_cls.return_value.parent.parent.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value = mock_template_path
+
+                result, _ = configure_agent(
+                    "test-host",
+                    "test-agent",
+                    {},
+                    on_event=lambda stage, msg: events.append((stage, msg)),
+                )
+
+            assert result is True
+            # Warning fired on the configure stage for the stale record.
+            unknown_events = [(s, m) for s, m in events if "unknown type" in m.lower()]
+            assert unknown_events, f"WARNING never emitted; events={events!r}"
+            assert all(s == "configure" for s, _ in unknown_events), (
+                f"WARNING fired on wrong stage; events={unknown_events!r}"
+            )
+            warning_messages = [m for _, m in unknown_events]
+            assert any("old-jira" in m for m in warning_messages)
+            assert any("jira" in m for m in warning_messages)
+            # Valid-types hint included for actionability.
+            assert any("Valid types" in m for m in warning_messages)
+
+            # Credentials were NOT requested for the stale record (continue
+            # fires before credential load). Only the github load remains.
+            assert mock_get_credentials.call_count == 1
+
+            # Stale record is excluded from the ansible vars; the valid one
+            # passes through. Vars travel inside inventory[all][vars].
+            inventory = mock_run.call_args.kwargs["inventory"]
+            ansible_vars = inventory["all"]["vars"]
+            integrations_var = ansible_vars.get("integrations", {})
+            assert "old-jira" not in integrations_var
+            assert "work-github" in integrations_var
+            assert integrations_var["work-github"]["type"] == "github"
+            # Credential payload reaches inventory, not just the record shape.
+            assert integrations_var["work-github"]["GITHUB_TOKEN"] == "ghp_test"


### PR DESCRIPTION
## Summary

- Replaces separate `jira` and `confluence` integration types with a unified `atlassian` type (one credential set: URL, email, API token) that drives the `mcp-atlassian` MCP server in hermes and existing env vars in openclaw + zeroclaw.
- Hermes `config.yaml.j2` emits a `mcp_servers:` block with YAML-injection-safe credential quoting (`yaml_quote` macro); runtime version pinned via `uvx --from mcp-atlassian=={{ mcp_atlassian_version }}`.
- Hermes `configure.yaml` installs `uv` via `pip install --user uv=={{ uv_version }}` (PyPI hash-verified — no `curl|sh`) and pre-installs `mcp-atlassian` with `uv tool install --force` for true upgrade idempotency. Both gated on `atlassian_integration_assigned` and `no_log: true`.

## Closes

Closes #348

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — **1741 passed**
- [x] Linter passes (`make lint`) — clean
- [x] New tests added for new functionality

### Test Coverage
- `tests/test_hermes_configure.py`: 6 new MCP-server rendering tests (atlassian rendering, trailing-slash URL normalization, YAML injection safety with symmetric `JIRA_API_TOKEN`/`CONFLUENCE_API_TOKEN` assertions)
- `tests/test_configure_zeroclaw.py`: **new** — 4 rendering tests (trailing slash, TOML escape on both api_token fields, partial-dict guards, non-atlassian isolation)
- `tests/test_cli_integration.py`: `TestIntegrationStaleType` — 4 tests covering `show`, `credentials`, `credentials --update`, `list` against an integration record with an unknown type (no traceback, clean Error: prefix, exit code 1, remediation references the actual integration name)
- `tests/test_lifecycle_integrations.py`: new `test_unknown_type_integration_emits_warning_and_is_excluded` capturing `on_event` callbacks and inspecting inventory extravars to prove the stale record is skipped before credential load and excluded from the Ansible payload

### Manual Testing
- Verified template rendering paths via 14 new rendering tests (6 hermes + 4 zeroclaw + 4 stale-type CLI)
- Verified stale-type behavior in lifecycle + CLI surfaces via dedicated tests
- ATX iteration 7 confirmed Atlassian MCP wiring is correct and version-pinned at both install and runtime

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (URL trailing slash stripped, YAML/TOML quoting applied to credentials, integration name regex-validated at add-time)
- [x] No SQL injection, XSS, or command injection risks (verified via `yaml_quote` macro for YAML, existing TOML escape chain for TOML, rich_escape on all user-controlled fields routed through Rich console)
- [x] Dependencies are from trusted sources (`uv` and `mcp-atlassian` both pinned via PyPI with pip's built-in hash verification)

## Breaking Change

Existing `type: "jira"` and `type: "confluence"` integration records become invalid (no auto-migration — explicit design decision). The user-facing impact is bounded by:

- `clm integration list` marks the row `[yellow]<type> (unknown)[/yellow]`
- `clm integration show <name>` and `clm integration credentials <name>` exit 1 with a remediation message that interpolates the actual name: `Run \`clm integration remove <name>\` then \`clm integration add <name> --type <valid-type>\` to recover.`
- `clm agent configure` emits a yellow WARNING (via the new `_print_configure_warnings` on_event callback) and skips the stale record rather than silently producing broken Ansible config.

Required user steps: `clm integration remove <old-name>` then `clm integration add <new-name> --type atlassian`.

## ATX Review Summary

**Final Review: Rating 4/5 — APPROVED TO MERGE**
**Total Cost: \$16.83 | 7 iterations**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 2/5 | B1, B2, B3, B4, B5, B6, B7 | All fixed |
| 2 | 2/5 | B1, B2, B3 (partial), B6 (partial), B-new-1, B-new-2 | All fixed |
| 3 | 2/5 | B1-i3, B2-i3 | All fixed |
| 4 | 2/5 | B1-i4, B2-i4, B3-i4 | All fixed |
| 5 | 3/5 | W-new-1, W-new-2 | All fixed |
| 6 | 2/5 | B-new-1 (no_log), B-new-2 (rendering tests) | All fixed |
| 7 | 4/5 | None | **Approved** |

> Note: ATX does not expose model information per agent.

<details>
<summary>Final review (Iteration 7, Rating 4/5)</summary>

**Confirmed Resolutions:**

| # | Status |
|---|--------|
| B-new-1 (no_log on zeroclaw template) | Resolved |
| B-new-2 (zeroclaw rendering tests, 4/4 passing) | Resolved |

**Remaining (non-blocking, tracked as follow-ups):**

| # | Issue | Action |
|---|-------|--------|
| W1 | TOML token escaping handles `\` and `"` but not `\n`/`\r` (Atlassian tokens are base64-ish — near-zero practical risk) | Deferred to follow-up |
| S1 | `uv tool install --force` always reports changed (no handler notify — cosmetic) | Deferred |
| S3 | Add early-fail validation for unset `CLAWRIUM_PROVIDER_API_KEY` in zeroclaw configure | Deferred |
| S4 | URL fields in TOML use unescaped interpolation (matches pre-existing `gitlab_url` pattern) | Deferred |
| S5 | `/wiki` suffix is Cloud-only (Data Center/Server out of scope per design) | Deferred |

W2 (bool stub string coercion) and W3 (partial-dict test) — addressed inline in this PR.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>