### PR TITLE
docs(sidebar): reorganize left sidebar — promote Web Dashboard, surface Agent Support, demote Architecture

### DIFF
--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -37,7 +37,7 @@ Clawrium gives you `kubectl`-style fleet control for AI agents:
 - **Specialized agents.** Run a fleet of purpose-built agents - a research agent, a support agent, an internal assistant - each with its own context and configuration.
 - **Model flexibility.** Use any provider: OpenAI, Anthropic, local Ollama, or self-hosted inference.
 - **Lifecycle management.** Upgrades, rollbacks, secrets rotation - handled from one place.
-- **Local web dashboard.** `clm gui` opens a visual fleet view on `127.0.0.1` — chat with agents, browse topology, manage providers. See the [Web Dashboard guide](./guides/web-dashboard.md).
+- **Local web dashboard.** `clm gui` opens a visual fleet view on `127.0.0.1` — chat with agents, browse topology, manage providers. See the [Web Dashboard guide](./web-dashboard.md).
 
 ## How It Works
 

--- a/website/docs/reference/cli/gui.md
+++ b/website/docs/reference/cli/gui.md
@@ -48,7 +48,7 @@ The dashboard surfaces the same data as the CLI, with a few interactive niceties
 - **Agent detail** — chat with a running agent, view logs, edit memory, inspect config
 - **Settings** — version info, usage DB controls (export / clear), Danger Zone
 
-A walkthrough with screenshots lives in the [Web Dashboard guide](../../guides/web-dashboard.md).
+A walkthrough with screenshots lives in the [Web Dashboard guide](../../web-dashboard.md).
 
 ## Installation requirement
 

--- a/website/docs/web-dashboard.md
+++ b/website/docs/web-dashboard.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 5
 description: Walk through the Clawrium web dashboard - fleet overview, topology, providers, agent detail, and settings.
 keywords: [gui, web dashboard, ui, fleet, topology, providers, chat]
 ---
@@ -76,4 +75,4 @@ The GUI is a read-leaning convenience layer; the CLI remains the source of truth
 
 ## Troubleshooting
 
-See the [`clm gui` CLI reference](../reference/cli/gui.md#troubleshooting) for symptom / fix pairs (port-in-use, missing extras, dev-vs-prod port confusion).
+See the [`clm gui` CLI reference](./reference/cli/gui.md#troubleshooting) for symptom / fix pairs (port-in-use, missing extras, dev-vs-prod port confusion).

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -2,9 +2,10 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 
 // Sidebar ordered for adoption funnel:
 // 1. Quick wins first (Quickstart, Installation)
-// 2. Concepts (What is a Claw?, Architecture)
-// 3. Deep dives (Guides, Agent Support)
-// 4. Reference last
+// 2. Practical guides
+// 3. Agent surface area (Agent Support, Web Dashboard)
+// 4. Operational sections (Scenarios, Host Configuration, Providers, Channels, Integrations)
+// 5. Reference and architecture last
 
 const sidebars: SidebarsConfig = {
   tutorialSidebar: [
@@ -19,10 +20,22 @@ const sidebars: SidebarsConfig = {
         'guides/host-setup',
         'guides/agent-onboarding',
         'guides/fleet-management',
-        'guides/web-dashboard',
       ],
     },
-    'architecture',
+    {
+      type: 'category',
+      label: 'Agent Support',
+      link: {
+        type: 'doc',
+        id: 'agent-support/index',
+      },
+      items: [
+        'agent-support/openclaw',
+        'agent-support/hermes',
+        'agent-support/zeroclaw',
+      ],
+    },
+    'web-dashboard',
     {
       type: 'category',
       label: 'Scenarios',
@@ -58,19 +71,6 @@ const sidebars: SidebarsConfig = {
             'host-configuration/os-support/macos',
           ],
         },
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Agent Support',
-      link: {
-        type: 'doc',
-        id: 'agent-support/index',
-      },
-      items: [
-        'agent-support/openclaw',
-        'agent-support/hermes',
-        'agent-support/zeroclaw',
       ],
     },
     {
@@ -145,6 +145,7 @@ const sidebars: SidebarsConfig = {
         },
       ],
     },
+    'architecture',
     'troubleshooting',
     'contributing',
   ],


### PR DESCRIPTION
## Summary

Reorganizes the Docusaurus left sidebar to surface practical/adoption content earlier and push reference/architecture material later.

- Promote `web-dashboard` to a top-level sidebar entry (out of `Guides`)
- Move `Agent Support` to immediately follow `Guides`
- Move `Architecture` to immediately follow `Reference`
- Update two internal cross-references and one in-file relative link

## Sidebar Order (Before → After)

| # | Before | After |
|---|--------|-------|
| 1 | Introduction | Introduction |
| 2 | Installation | Installation |
| 3 | Guides (incl. Web Dashboard) | Guides |
| 4 | Architecture | **Agent Support** |
| 5 | Scenarios | **Web Dashboard** (root) |
| 6 | Host Configuration | Scenarios |
| 7 | Agent Support | Host Configuration |
| 8 | Providers | Providers |
| 9 | Channels | Channels |
| 10 | Integrations | Integrations |
| 11 | Reference | Reference |
| 12 | Troubleshooting | **Architecture** |
| 13 | Contributing | Troubleshooting |
| 14 | — | Contributing |

## Testing

### Test Results
- [x] All existing tests pass (`make test` — 1770 passed)
- [x] Linter passes (`make lint`)
- [x] Docusaurus build succeeds with no broken-link errors (`npm run build` in `website/`)

### Manual Testing
- Built the site locally, served it on `127.0.0.1:36100`, and walked the rendered sidebar order via `.docusaurus/` JSON metadata. Order matches the table above.
- Grepped for stale `guides/web-dashboard` references across `website/`; zero occurrences remain.

## ATX Review Summary

**Final Review: Rating 5/5**
**Total Cost: \$1.26 | Total Time: ~30s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 5/5 | None | Ready | \$1.26 | ~30s | leader, ansible-playbook-reviewer, security-secrets-reviewer, cli-ux-reviewer, core-lifecycle-reviewer, test-coverage-reviewer |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 5/5)</summary>

**Blocking Issues:** None

**Warnings:** None

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | `.docusaurus/` cache may contain stale references to the old path | N/A — generated artifacts, not committed |

All five domain reviewers with direct diff access independently agreed: sidebar order correct, zero stale references, relative-link adjustment confirmed by passing build, `sidebar_position` frontmatter correctly removed, no files outside `website/` touched.

</details>

Closes #353

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>