### PR TITLE
feat(zeroclaw): align core install with v0.7.5 (install-disabled)

### DIFF
--- a/.itx/356/01_EXECUTION.md
+++ b/.itx/356/01_EXECUTION.md
@@ -1,0 +1,60 @@
+# Issue 356 — Subtask A Execution Log
+
+Parent: #112
+Plan section: `.itx/112/00_PLAN.md` — Subtask A — Core installation
+alignment for ZeroClaw v0.7.5.
+
+## Goal
+
+`clm agent install --type zeroclaw --host <h>` lands the v0.7.5 binary
+with the systemd unit dropped **disabled, not started**, matching the
+hermes install-disabled / configure-enables pattern.
+
+## Changes
+
+| Path | Change |
+|---|---|
+| `src/clawrium/platform/registry/zeroclaw/manifest.yaml` | Bumped all 5 platform entries `0.5.7` → `0.7.5`; refreshed SHA256s from the upstream `SHA256SUMS` file; dropped the `~/.zeroclaw/config.toml` check from the validate stage (configure.yaml owns rendering now). |
+| `src/clawrium/platform/registry/zeroclaw/playbooks/install.yaml` | Rewritten to mirror hermes: version-aware skip (`force_install` extra-var override), `/usr/sbin/nologin` shell on the agent user, systemd unit dropped disabled and not started, inline `config.toml` rendering removed, `~/.zeroclaw/{workspace,state}` scaffolded at 0700. |
+| `tests/test_registry.py` | Updated `test_load_manifest_zeroclaw_with_onboarding` to reflect that the validate stage no longer carries `config_check`. |
+
+## SHA256 provenance
+
+Pulled from
+`https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.7.5/SHA256SUMS`:
+
+| Tarball | SHA256 |
+|---|---|
+| `zeroclaw-armv7-unknown-linux-gnueabihf.tar.gz` | `32b11166fae1647a1ea39bac0d4b14073183cd034c42a25cb543615074aefd77` |
+| `zeroclaw-aarch64-unknown-linux-gnu.tar.gz` | `0b1197f1d80243e5c748b63a550cc6dfc37e407c4d15f729b32324ba9fe4c2ac` |
+| `zeroclaw-x86_64-unknown-linux-gnu.tar.gz` | `8bc8276a8d8faefb3e4a824f33876929e7466f632ee7c5363936368a1af2e4f7` |
+
+## Verification
+
+- `make test` — 1769 passed, 0 failed.
+- `make lint` — `ruff` and `next lint` clean.
+
+Manual install on Pi (armv7l), Ubuntu aarch64, Ubuntu x86_64 is left to
+the maintainer; the playbook is structurally identical to hermes's
+verified install flow.
+
+## Out of Scope
+
+Providers, chat backend, workspace files, memory CLI, integrations,
+docs. Those land in Subtasks B / C / D.
+
+---
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-15T10:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 356
+```
+
+</details>

--- a/src/clawrium/core/health.py
+++ b/src/clawrium/core/health.py
@@ -349,6 +349,8 @@ def check_claw_health(
         # Quote the -f pattern so ansible's command module shlex-splits it into a
         # single argument; otherwise pgrep would treat 'gateway run' as extra args.
         check_cmd = f'pgrep -u {claw_user} -f "hermes gateway run"'
+    elif agent_type == "zeroclaw":
+        check_cmd = f'pgrep -u {claw_user} -f "zeroclaw daemon"'
     else:
         check_cmd = f"pgrep -u {claw_user} node"
 

--- a/src/clawrium/platform/registry/zeroclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/manifest.yaml
@@ -51,63 +51,58 @@ onboarding:
           name: "Verify binary installed"
           type: command
           command: "zeroclaw --version"
-        - id: config_check
-          name: "Verify config exists"
-          type: file_exists
-          paths:
-            - "~/.zeroclaw/config.toml"
 
 # Note: Same statically-linked binary is used across OS versions (Ubuntu 22.04/24.04)
 # so SHA256 checksums are identical per architecture.
 platforms:
   # Raspberry Pi 2/3 (armv7l) - Debian 13 (trixie)
-  - version: "0.5.7"
+  - version: "0.7.5"
     os: debian
     os_version: "13"
     arch: armv7l
-    sha256: "a294a8caac8304c3b895f80334f9750fba5fbf4787ca7675857e112c04914585"
+    sha256: "32b11166fae1647a1ea39bac0d4b14073183cd034c42a25cb543615074aefd77"
     requirements:
       min_memory_mb: 512  # Pi 2 has ~920MB usable (1GB - video mem)
       gpu_required: false
       dependencies:
         python: ">=3.9"
   # Raspberry Pi 4/5 (aarch64) - Ubuntu
-  - version: "0.5.7"
+  - version: "0.7.5"
     os: ubuntu
     os_version: "22.04"
     arch: aarch64
-    sha256: "33e3838ff86c1cbf423bdd9ce539bf1794f9b9641cbf75fa2d5d02cf466bc849"
+    sha256: "0b1197f1d80243e5c748b63a550cc6dfc37e407c4d15f729b32324ba9fe4c2ac"
     requirements:
       min_memory_mb: 1024
       gpu_required: false
       dependencies:
         python: ">=3.9"
-  - version: "0.5.7"
+  - version: "0.7.5"
     os: ubuntu
     os_version: "24.04"
     arch: aarch64
-    sha256: "33e3838ff86c1cbf423bdd9ce539bf1794f9b9641cbf75fa2d5d02cf466bc849"
+    sha256: "0b1197f1d80243e5c748b63a550cc6dfc37e407c4d15f729b32324ba9fe4c2ac"
     requirements:
       min_memory_mb: 1024
       gpu_required: false
       dependencies:
         python: ">=3.9"
   # Desktop/Server x86_64 - Ubuntu
-  - version: "0.5.7"
+  - version: "0.7.5"
     os: ubuntu
     os_version: "22.04"
     arch: x86_64
-    sha256: "c0ab82725795d97e08542b9475aa31db27a3fa76e8e5b1e3c8ec43fbbd3c4ecd"
+    sha256: "8bc8276a8d8faefb3e4a824f33876929e7466f632ee7c5363936368a1af2e4f7"
     requirements:
       min_memory_mb: 1024
       gpu_required: false
       dependencies:
         python: ">=3.9"
-  - version: "0.5.7"
+  - version: "0.7.5"
     os: ubuntu
     os_version: "24.04"
     arch: x86_64
-    sha256: "c0ab82725795d97e08542b9475aa31db27a3fa76e8e5b1e3c8ec43fbbd3c4ecd"
+    sha256: "8bc8276a8d8faefb3e4a824f33876929e7466f632ee7c5363936368a1af2e4f7"
     requirements:
       min_memory_mb: 1024
       gpu_required: false

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/install.yaml
@@ -12,7 +12,6 @@
       - aarch64
       - x86_64
     release_arch: "{{ arch_map[ansible_architecture] }}"
-    release_url: "https://github.com/zeroclaw-labs/zeroclaw/releases/download/{{ claw_version }}/zeroclaw-{{ release_arch }}.tar.gz"
 
   pre_tasks:
     - name: Validate architecture is supported
@@ -21,12 +20,24 @@
       when: ansible_architecture not in supported_architectures
 
   tasks:
+    - name: Normalize target ZeroClaw version (strip leading 'v')
+      ansible.builtin.set_fact:
+        zeroclaw_target_version: "{{ (claw_version | default('v0.7.5')) | regex_replace('^v', '') }}"
+
+    - name: Resolve ZeroClaw release tag (always 'v'-prefixed)
+      ansible.builtin.set_fact:
+        zeroclaw_target_tag: "v{{ zeroclaw_target_version }}"
+        release_url: "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v{{ zeroclaw_target_version }}/zeroclaw-{{ release_arch }}.tar.gz"
+
+    # Use /usr/sbin/nologin since the agent user is a service account: it runs
+    # `zeroclaw daemon` under systemd and is not meant for interactive login.
+    # Reduces lateral-movement attack surface if the account is ever compromised.
     - name: Create agent user
       ansible.builtin.user:
         name: "{{ agent_name }}"
         state: present
         create_home: yes
-        shell: /bin/bash
+        shell: /usr/sbin/nologin
 
     - name: Create bin directory
       ansible.builtin.file:
@@ -36,12 +47,57 @@
         group: "{{ agent_name }}"
         mode: "0755"
 
+    # Version-aware skip: re-running install on a host that already has the
+    # target version is a no-op for the binary install step. `--force` (via the
+    # `force_install` extra var) overrides this.
+    - name: Discover zeroclaw binary at agent's install path
+      ansible.builtin.stat:
+        path: "/home/{{ agent_name }}/bin/zeroclaw"
+      register: zeroclaw_binary_stat
+
+    - name: Get installed zeroclaw version
+      ansible.builtin.command: "/home/{{ agent_name }}/bin/zeroclaw --version"
+      register: zeroclaw_version_check
+      changed_when: false
+      failed_when: false
+      become_user: "{{ agent_name }}"
+      when: zeroclaw_binary_stat.stat.exists
+
+    # Defensive parse: empty string on no-match means a version check failure is
+    # treated as "version unknown" -> not a match -> reinstall (safe default).
+    - name: Parse installed zeroclaw version
+      ansible.builtin.set_fact:
+        zeroclaw_installed_version: "{{ (zeroclaw_version_check.stdout | default('')) | regex_search('([0-9]+\\.[0-9]+\\.[0-9]+)') | default('', true) }}"
+      when:
+        - zeroclaw_version_check is defined
+        - (zeroclaw_version_check.rc | default(1)) == 0
+
+    - name: Set install skip condition
+      ansible.builtin.set_fact:
+        zeroclaw_already_installed: >-
+          {{ zeroclaw_binary_stat.stat.exists
+             and (zeroclaw_installed_version | default('')) == zeroclaw_target_version
+             and not (force_install | default(false) | bool) }}
+
+    - name: Mark install as skipped when already installed
+      ansible.builtin.debug:
+        msg: "ZeroClaw v{{ zeroclaw_installed_version | default('unknown') }} already installed at /home/{{ agent_name }}/bin/zeroclaw. Skipping binary install."
+      when: zeroclaw_already_installed
+
+    - name: Note that --force was supplied (overriding skip)
+      ansible.builtin.debug:
+        msg: "force=true: reinstalling ZeroClaw at /home/{{ agent_name }}/bin/zeroclaw"
+      when:
+        - zeroclaw_binary_stat.stat.exists
+        - force_install | default(false) | bool
+
     - name: Download zeroclaw binary
       ansible.builtin.get_url:
         url: "{{ release_url }}"
         dest: "/tmp/zeroclaw-{{ release_arch }}.tar.gz"
         mode: "0644"
         checksum: "sha256:{{ claw_sha256 }}"
+      when: not zeroclaw_already_installed
 
     - name: Extract zeroclaw binary
       ansible.builtin.unarchive:
@@ -50,21 +106,15 @@
         remote_src: yes
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
+      when: not zeroclaw_already_installed
 
     - name: Cleanup tarball
       ansible.builtin.file:
         path: "/tmp/zeroclaw-{{ release_arch }}.tar.gz"
         state: absent
+      when: not zeroclaw_already_installed
 
-    - name: Create workspace directory
-      ansible.builtin.file:
-        path: "/home/{{ agent_name }}/workspace"
-        state: directory
-        owner: "{{ agent_name }}"
-        group: "{{ agent_name }}"
-        mode: "0700"
-
-    - name: Create config directory
+    - name: Create zeroclaw config directory
       ansible.builtin.file:
         path: "/home/{{ agent_name }}/.zeroclaw"
         state: directory
@@ -72,29 +122,27 @@
         group: "{{ agent_name }}"
         mode: "0700"
 
-    - name: Calculate unique gateway port (40000-42000 range)
-      ansible.builtin.set_fact:
-        gateway_port: "{{ 40000 + ((agent_name | hash('md5') | int(base=16)) % 2000) }}"
-
-    - name: Create zeroclaw config
-      ansible.builtin.copy:
-        dest: "/home/{{ agent_name }}/.zeroclaw/config.toml"
-        content: |
-          [gateway]
-          host = "0.0.0.0"
-          port = {{ gateway_port }}
-          allow_public_bind = true
-
-          {% if llm_provider_url is defined %}
-          default_provider = "custom:{{ llm_provider_url }}"
-          default_model = "{{ llm_model | default('llama3') }}"
-          api_key = "{{ llm_api_key | default('') }}"
-          {% endif %}
+    - name: Scaffold workspace directory
+      ansible.builtin.file:
+        path: "/home/{{ agent_name }}/.zeroclaw/workspace"
+        state: directory
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
-        mode: "0600"
+        mode: "0700"
 
-    - name: Create systemd service file
+    - name: Scaffold state directory
+      ansible.builtin.file:
+        path: "/home/{{ agent_name }}/.zeroclaw/state"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0700"
+
+    # Service is dropped DISABLED and NOT started. `clm agent configure` renders
+    # config.toml with provider credentials and turns the unit on. Inline config
+    # rendering used to live here; it now belongs to configure.yaml so install
+    # remains a pure "binary present, unit dropped" step.
+    - name: Create systemd service file (disabled, not started)
       ansible.builtin.copy:
         dest: "/etc/systemd/system/{{ agent_type }}-{{ agent_name }}.service"
         content: |
@@ -105,7 +153,7 @@
           [Service]
           Type=simple
           User={{ agent_name }}
-          WorkingDirectory=/home/{{ agent_name }}/workspace
+          WorkingDirectory=/home/{{ agent_name }}/.zeroclaw
           ExecStart=/home/{{ agent_name }}/bin/zeroclaw daemon
           Restart=on-failure
           RestartSec=5
@@ -115,12 +163,16 @@
         mode: "0644"
       notify: Reload systemd
 
-    - name: Enable and start zeroclaw service
+    - name: Reload systemd to pick up unit file
       ansible.builtin.systemd:
-        name: "{{ agent_type }}-{{ agent_name }}"
-        enabled: yes
-        state: started
         daemon_reload: yes
+
+    - name: Display install success
+      ansible.builtin.debug:
+        msg: |
+          ZeroClaw {{ zeroclaw_target_version }} installed for agent '{{ agent_name }}'.
+          Service unit {{ agent_type }}-{{ agent_name }}.service dropped (disabled, stopped).
+          Run `clm agent configure {{ agent_name }}` to render config.toml and start the daemon.
 
   handlers:
     - name: Reload systemd

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/install.yaml
@@ -161,7 +161,6 @@
           [Install]
           WantedBy=multi-user.target
         mode: "0644"
-      notify: Reload systemd
 
     - name: Reload systemd to pick up unit file
       ansible.builtin.systemd:
@@ -172,9 +171,4 @@
         msg: |
           ZeroClaw {{ zeroclaw_target_version }} installed for agent '{{ agent_name }}'.
           Service unit {{ agent_type }}-{{ agent_name }}.service dropped (disabled, stopped).
-          Run `clm agent configure {{ agent_name }}` to render config.toml and start the daemon.
-
-  handlers:
-    - name: Reload systemd
-      ansible.builtin.systemd:
-        daemon_reload: yes
+          Run 'clm agent configure {{ agent_name }}' to render config.toml and start the daemon.

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/remove.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/remove.yaml
@@ -39,17 +39,6 @@
         state: absent
       when: bin_dir.stat.exists
 
-    - name: Check if workspace directory exists
-      ansible.builtin.stat:
-        path: "/home/{{ agent_name }}/workspace"
-      register: workspace_dir
-
-    - name: Remove workspace directory
-      ansible.builtin.file:
-        path: "/home/{{ agent_name }}/workspace"
-        state: absent
-      when: workspace_dir.stat.exists
-
     - name: Check if config directory exists
       ansible.builtin.stat:
         path: "/home/{{ agent_name }}/.zeroclaw"

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/start.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/start.yaml
@@ -30,16 +30,14 @@
 
     - name: Verify process is running
       ansible.builtin.command:
-        cmd: pgrep -u {{ agent_name }} zeroclaw
-      register: process_check
-      changed_when: false
-      failed_when: process_check.rc != 0
-
-    - name: Get process info
-      ansible.builtin.command:
-        cmd: pgrep -u {{ agent_name }} zeroclaw
+        argv:
+          - pgrep
+          - -u
+          - "{{ agent_name }}"
+          - zeroclaw
       register: pid_result
       changed_when: false
+      failed_when: pid_result.rc != 0
 
     - name: Display success message
       ansible.builtin.debug:

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/stop.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/stop.yaml
@@ -27,7 +27,11 @@
 
     - name: Verify process is stopped
       ansible.builtin.command:
-        cmd: pgrep -u {{ agent_name }} zeroclaw
+        argv:
+          - pgrep
+          - -u
+          - "{{ agent_name }}"
+          - zeroclaw
       register: process_check
       changed_when: false
       failed_when: process_check.rc == 0

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1431,6 +1431,43 @@ class TestProcessNameByAgentType:
         module_args = first_call.kwargs.get("module_args", "")
         assert "pgrep -u wolf-i openclaw" == module_args
 
+    def test_zeroclaw_pgrep_returns_stopped_when_no_process(self):
+        """zeroclaw pgrep with `-f "zeroclaw daemon"` returning rc=1 surfaces as STOPPED.
+
+        Negative-path counterpart to test_zeroclaw_uses_zeroclaw_daemon_process_name;
+        mirrors the hermes pattern at test_hermes_pgrep_returns_stopped_when_no_process.
+        """
+        host = {
+            "hostname": "192.168.1.100",
+            "port": 22,
+            "user": "xclm",
+            "key_id": "testhost",
+            "agents": {
+                "my-zeroclaw": {
+                    "type": "zeroclaw",
+                    "agent_name": "zc-edge",
+                    "version": "0.7.5",
+                    "status": "installed",
+                }
+            },
+        }
+
+        mock_runner = MagicMock()
+        mock_runner.status = "failed"
+        mock_runner.events = [
+            {"event": "runner_on_failed", "event_data": {"res": {"rc": 1}}}
+        ]
+
+        with patch("clawrium.core.health.get_host_private_key", return_value="/fake/key"):
+            with patch("clawrium.core.health.ansible_runner.run", return_value=mock_runner) as mock_run:
+                with patch("clawrium.core.health.get_required_secrets", return_value=[]):
+                    result = check_claw_health("my-zeroclaw", host)
+
+        module_args = mock_run.call_args_list[0].kwargs.get("module_args", "")
+        assert module_args == 'pgrep -u zc-edge -f "zeroclaw daemon"'
+        assert result["process_running"] is False
+        assert result["status"] in (ClawStatus.STOPPED, ClawStatus.PENDING_ONBOARD)
+
     def test_zeroclaw_uses_zeroclaw_daemon_process_name(self):
         """zeroclaw agent type uses 'pgrep -u {user} -f "zeroclaw daemon"'.
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1431,8 +1431,12 @@ class TestProcessNameByAgentType:
         module_args = first_call.kwargs.get("module_args", "")
         assert "pgrep -u wolf-i openclaw" == module_args
 
-    def test_zeroclaw_uses_node_process_name(self):
-        """zeroclaw agent type uses 'pgrep -u {user} node'."""
+    def test_zeroclaw_uses_zeroclaw_daemon_process_name(self):
+        """zeroclaw agent type uses 'pgrep -u {user} -f "zeroclaw daemon"'.
+
+        Previously zeroclaw fell through to the catch-all `pgrep node`, which
+        meant clm ps reported zeroclaw as STOPPED even when the daemon was
+        healthy. Fixed in ATX review of PR #361 (W1)."""
         host = {
             "hostname": "192.168.1.100",
             "port": 22,
@@ -1442,7 +1446,7 @@ class TestProcessNameByAgentType:
                 "my-zeroclaw": {
                     "type": "zeroclaw",
                     "agent_name": "zc-edge",
-                    "version": "0.1.0",
+                    "version": "0.7.5",
                 }
             },
         }
@@ -1456,12 +1460,12 @@ class TestProcessNameByAgentType:
                 with patch("clawrium.core.health.get_required_secrets", return_value=[]):
                     check_claw_health("my-zeroclaw", host)
 
-        # Verify first call (pgrep) uses 'node' process name
+        # Verify first call (pgrep) uses -f "zeroclaw daemon"
         # Second call is for system info (cpu/memory)
         assert len(mock_run.call_args_list) >= 1
         first_call = mock_run.call_args_list[0]
         module_args = first_call.kwargs.get("module_args", "")
-        assert "pgrep -u zc-edge node" == module_args
+        assert 'pgrep -u zc-edge -f "zeroclaw daemon"' == module_args
 
     def test_missing_type_defaults_to_node(self):
         """Agent without type field defaults to 'node' process name."""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -974,10 +974,12 @@ def test_load_manifest_zeroclaw_with_onboarding():
     # Validate validate stage structure
     validate = stages["validate"]
     assert "tasks" in validate
-    # Should have binary_check and config_check
+    # binary_check only; config.toml is rendered by configure.yaml, so the
+    # file_exists check belongs to the configure stage now, not install-time
+    # validation.
     task_ids = [t["id"] for t in validate["tasks"]]
     assert "binary_check" in task_ids
-    assert "config_check" in task_ids
+    assert "config_check" not in task_ids
 
 
 def test_onboarding_task_types():

--- a/tests/test_registry_zeroclaw.py
+++ b/tests/test_registry_zeroclaw.py
@@ -1,0 +1,245 @@
+"""Tests for the zeroclaw agent type registration in the bundled registry.
+
+Parity with tests/test_registry_hermes.py — exercises the install playbook
+shape, manifest checksums, run_installation extra_vars, and skip detection
+specific to zeroclaw. Added per ATX review of PR #361 (NEW-B2).
+"""
+
+from clawrium.core.registry import load_manifest
+
+
+def test_zeroclaw_manifest_has_installer_checksum():
+    """Every platform entry must declare a 64-char hex sha256 and version 0.7.5."""
+    manifest = load_manifest("zeroclaw")
+
+    assert len(manifest["platforms"]) == 5, (
+        "zeroclaw must publish 5 platform entries (armv7l Debian 13, "
+        "aarch64 Ubuntu 22.04/24.04, x86_64 Ubuntu 22.04/24.04)"
+    )
+    for entry in manifest["platforms"]:
+        assert entry["version"] == "0.7.5", (
+            f"Platform entry version mismatch: {entry.get('os')} "
+            f"{entry.get('os_version')} {entry.get('arch')} -> {entry.get('version')!r}"
+        )
+        sha256 = entry.get("sha256")
+        assert isinstance(sha256, str), (
+            f"Platform entry missing sha256: {entry.get('os')} {entry.get('os_version')}"
+        )
+        assert len(sha256) == 64, (
+            f"sha256 must be 64 hex chars, got {len(sha256)}: {sha256!r}"
+        )
+        # Verify all chars are valid hex
+        int(sha256, 16)
+
+
+def test_zeroclaw_install_playbook_shape():
+    """The zeroclaw install playbook must encode the install-disabled invariants."""
+    from importlib.resources import files
+    import yaml
+
+    zeroclaw_pkg = files("clawrium.platform.registry.zeroclaw")
+    playbook_path = zeroclaw_pkg / "playbooks" / "install.yaml"
+
+    content = playbook_path.read_text()
+
+    # Required structural elements.
+    assert "- hosts:" in content
+    assert "agent_name" in content
+    # Agent user is a service account: nologin shell reduces lateral-movement
+    # surface if the account is ever compromised.
+    assert "shell: /usr/sbin/nologin" in content
+    # WorkingDirectory must be inside ~/.zeroclaw (not ~/workspace which is the
+    # legacy path; the install playbook now scaffolds ~/.zeroclaw/workspace
+    # and ~/.zeroclaw/state).
+    assert "WorkingDirectory=/home/{{ agent_name }}/.zeroclaw" in content
+    assert "ExecStart=/home/{{ agent_name }}/bin/zeroclaw daemon" in content
+    # Workspace + state scaffolding must land inside ~/.zeroclaw.
+    assert "/home/{{ agent_name }}/.zeroclaw/workspace" in content
+    assert "/home/{{ agent_name }}/.zeroclaw/state" in content
+    # Service unit MUST NOT be enabled or started in install.yaml — `clm agent
+    # configure` owns the start half of the lifecycle.
+    data = yaml.safe_load(content)
+    tasks = data[0]["tasks"]
+    enable_tasks = [
+        t
+        for t in tasks
+        if t.get("ansible.builtin.systemd", {}).get("enabled") is True
+        or t.get("ansible.builtin.systemd", {}).get("state") == "started"
+    ]
+    assert enable_tasks == [], (
+        "install.yaml must not enable or start the zeroclaw service; "
+        "configure.yaml owns the start half of the lifecycle"
+    )
+
+
+def test_zeroclaw_remove_playbook_cleans_workspace_and_state():
+    """remove.yaml must clean the unit, ~/.zeroclaw (covers workspace+state),
+    the bin directory, and the agent user. Must NOT reference the legacy
+    ~/workspace path (NEW-B1)."""
+    from importlib.resources import files
+
+    zeroclaw_pkg = files("clawrium.platform.registry.zeroclaw")
+    remove_path = zeroclaw_pkg / "playbooks" / "remove.yaml"
+    content = remove_path.read_text()
+
+    assert "/etc/systemd/system/{{ agent_type }}-{{ agent_name }}.service" in content
+    # Removing ~/.zeroclaw cascades to workspace + state subdirs.
+    assert "/home/{{ agent_name }}/.zeroclaw" in content
+    assert "/home/{{ agent_name }}/bin" in content
+    assert "remove: yes" in content
+    # Legacy ~/workspace must not be referenced — install no longer scaffolds it.
+    assert "/home/{{ agent_name }}/workspace" not in content
+
+
+def _zeroclaw_install_setup(monkeypatch, tmp_path, host_record: dict, version: str = "0.7.5"):
+    """Shared setup for zeroclaw install mock tests. Mirrors hermes pattern."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mock_manifest = {
+        "name": "zeroclaw",
+        "entries": [
+            {
+                "version": version,
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "8bc8276a8d8faefb3e4a824f33876929e7466f632ee7c5363936368a1af2e4f7",
+                "requirements": {
+                    "min_memory_mb": 1024,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.9"},
+                },
+            }
+        ],
+    }
+
+    import clawrium.core.install
+
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *args, **kwargs: {
+            "compatible": True,
+            "matched_entry": mock_manifest["entries"][0],
+            "reasons": [],
+        },
+    )
+
+    host_state = [host_record]
+
+    def mock_get_host(_):
+        return host_state[0]
+
+    def mock_update_host(_, updater):
+        host_state[0] = updater(host_state[0])
+        return True
+
+    monkeypatch.setattr(clawrium.core.install, "get_host", mock_get_host)
+    monkeypatch.setattr(clawrium.core.install, "update_host", mock_update_host)
+
+    key_file = tmp_path / "test_key"
+    key_file.write_text("fake key")
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda _: key_file
+    )
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", lambda h, c: True
+    )
+
+    return host_state
+
+
+def _capture_run(captured: list):
+    """Mock for ansible_runner.run that captures call kwargs and returns
+    a successful result with the recorded events."""
+
+    def _runner(*args, **kwargs):
+        captured.append(kwargs)
+
+        class Result:
+            status = "successful"
+
+            class Config:
+                artifact_dir = "/tmp/nonexistent"
+
+            config = Config()
+            events = kwargs.get("_events", [])
+
+        return Result()
+
+    return _runner
+
+
+def test_zeroclaw_install_passes_correct_extra_vars(monkeypatch, tmp_path):
+    """run_installation('zeroclaw', ...) must inject agent_type='zeroclaw',
+    claw_version='v0.7.5', and the manifest sha256 into the playbook inventory."""
+    from clawrium.core.install import run_installation
+
+    host = {
+        "hostname": "test-host",
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    _zeroclaw_install_setup(monkeypatch, tmp_path, host)
+
+    import ansible_runner
+
+    captured: list = []
+    monkeypatch.setattr(ansible_runner, "run", _capture_run(captured))
+
+    result = run_installation("zeroclaw", "test-host", name="zc-test")
+
+    assert result["success"] is True
+    assert result["agent"] == "zeroclaw"
+    assert result["version"] == "0.7.5"
+    # base + claw playbook
+    assert len(captured) == 2
+    inv_vars = captured[1]["inventory"]["all"]["vars"]
+    assert inv_vars["agent_name"] == "zc-test"
+    assert inv_vars["agent_type"] == "zeroclaw"
+    assert inv_vars["claw_version"] == "v0.7.5"
+    assert (
+        inv_vars["claw_sha256"]
+        == "8bc8276a8d8faefb3e4a824f33876929e7466f632ee7c5363936368a1af2e4f7"
+    )
+    assert inv_vars["force_install"] is False
+
+    playbook_path = captured[1]["playbook"]
+    assert "registry/zeroclaw/playbooks/install.yaml" in playbook_path
+
+
+def test_install_was_skipped_handles_zeroclaw_fact():
+    """The generalized skip detection helper recognizes zeroclaw_already_installed."""
+    from clawrium.core.install import _install_was_skipped
+
+    class Result:
+        events = [
+            {
+                "event": "runner_on_ok",
+                "event_data": {
+                    "task": "Set install skip condition",
+                    "res": {"ansible_facts": {"zeroclaw_already_installed": True}},
+                },
+            }
+        ]
+
+    assert _install_was_skipped(Result(), "zeroclaw") is True
+    # hermes fact does not trigger zeroclaw skip detection.
+    class HermesResult:
+        events = [
+            {
+                "event": "runner_on_ok",
+                "event_data": {
+                    "task": "Set install skip condition",
+                    "res": {"ansible_facts": {"hermes_already_installed": True}},
+                },
+            }
+        ]
+
+    assert _install_was_skipped(HermesResult(), "zeroclaw") is False

--- a/tests/test_registry_zeroclaw.py
+++ b/tests/test_registry_zeroclaw.py
@@ -72,6 +72,67 @@ def test_zeroclaw_install_playbook_shape():
     )
 
 
+def test_zeroclaw_start_playbook_uses_argv_list_form():
+    """Pin the W9 fix: pgrep in start.yaml MUST use argv-list form, not a
+    `cmd:` string. Unquoted agent_name interpolated into a shell-split string
+    is a command-injection vector if an agent name ever contains whitespace
+    or shell metacharacters."""
+    from importlib.resources import files
+    import yaml
+
+    zeroclaw_pkg = files("clawrium.platform.registry.zeroclaw")
+    start_path = zeroclaw_pkg / "playbooks" / "start.yaml"
+    data = yaml.safe_load(start_path.read_text())
+    tasks = data[0]["tasks"]
+
+    pgrep_tasks = [
+        t
+        for t in tasks
+        if isinstance(t.get("ansible.builtin.command"), dict)
+        and "pgrep" in str(t["ansible.builtin.command"])
+    ]
+    assert pgrep_tasks, "start.yaml must contain at least one pgrep task"
+    for task in pgrep_tasks:
+        cmd_block = task["ansible.builtin.command"]
+        assert "cmd" not in cmd_block, (
+            f"pgrep task '{task.get('name')}' must use argv-list form, not "
+            f"cmd: string (W9). Found: {cmd_block!r}"
+        )
+        assert "argv" in cmd_block, (
+            f"pgrep task '{task.get('name')}' must declare argv: list (W9)."
+        )
+        argv = cmd_block["argv"]
+        assert argv[0] == "pgrep"
+        # The agent_name token must be a standalone argv element so shell
+        # metacharacters in the name cannot split into extra arguments.
+        assert "{{ agent_name }}" in argv
+
+
+def test_zeroclaw_stop_playbook_uses_argv_list_form():
+    """Mirror of test_zeroclaw_start_playbook_uses_argv_list_form for stop.yaml."""
+    from importlib.resources import files
+    import yaml
+
+    zeroclaw_pkg = files("clawrium.platform.registry.zeroclaw")
+    stop_path = zeroclaw_pkg / "playbooks" / "stop.yaml"
+    data = yaml.safe_load(stop_path.read_text())
+    tasks = data[0]["tasks"]
+
+    pgrep_tasks = [
+        t
+        for t in tasks
+        if isinstance(t.get("ansible.builtin.command"), dict)
+        and "pgrep" in str(t["ansible.builtin.command"])
+    ]
+    assert pgrep_tasks, "stop.yaml must contain at least one pgrep task"
+    for task in pgrep_tasks:
+        cmd_block = task["ansible.builtin.command"]
+        assert "cmd" not in cmd_block
+        assert "argv" in cmd_block
+        assert cmd_block["argv"][0] == "pgrep"
+        assert "{{ agent_name }}" in cmd_block["argv"]
+
+
 def test_zeroclaw_remove_playbook_cleans_workspace_and_state():
     """remove.yaml must clean the unit, ~/.zeroclaw (covers workspace+state),
     the bin directory, and the agent user. Must NOT reference the legacy


### PR DESCRIPTION
## Summary

- Bumps the ZeroClaw registry from `0.5.7` to `0.7.5` across all 5 platform entries with SHA256s pulled from the upstream `SHA256SUMS`.
- Rewrites `playbooks/install.yaml` to mirror hermes: version-aware skip, `--force` override, inline `config.toml` rendering removed, `~/.zeroclaw/{workspace,state}` scaffolded at 0700, systemd unit dropped **disabled and not started**.
- `clm agent configure` (already rendering `config.toml` from the template) now owns the configure-enables half of the lifecycle; the validate stage drops its `~/.zeroclaw/config.toml` `file_exists` check accordingly.
- Closes ATX review blockers W1/W9/NEW-B1/NEW-B2/NEW-W1/NEW-W2/NEW-W4 (commit 3282ec1) and the subsequent NEW-W6/NEW-W7 regression test gaps (commit c1b28f9).

Parent: #112 (Subtask A). Providers, chat backend, workspace files, memory CLI, integrations, and docs are out of scope and land in Subtasks B / C / D.

## ATX Review Summary

**Final Review: Rating 4/5** ✅ Merge threshold met
**Total Cost: $4.60 | Reviews: 2 successful (1 transient timeout retried)**

| Review | Commit | Rating | Blockers | Status | Cost |
|--------|--------|--------|----------|--------|------|
| 1 | 2a06dcb | 2/5 | B3 (deferred), B6, W1, W2, W3, W9, NEW-B1, NEW-B2 | 7 of 8 fixed in next commit | $2.92 |
| 2 | 3282ec1 | 3/5 | NEW-W5 (false positive), NEW-W6, NEW-W7 | Resolved in next commit | (count omitted in first run) |
| 3 | c1b28f9 | **4/5** | None | Ready | $1.68 |

<details>
<summary>Review 1 Details (Rating 2/5) — commit 2a06dcb</summary>

**Blocking / Tracked Issues**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B3 | `src/clawrium/core/install.py` | `preserved_gateway` only handles openclaw | Deferred to Subtask B per reviewer (bearer-token key path lands in #357) |
| B6 | `playbooks/install.yaml` | Inline TOML `copy:` rendering of `api_key` without `no_log` | Already addressed in original PR — install.yaml no longer renders config inline |
| W1 | `src/clawrium/core/health.py` | Missing `elif agent_type == 'zeroclaw'` branch | Fixed in 3282ec1 — added `pgrep -u <user> -f "zeroclaw daemon"` branch |
| W2 | `playbooks/install.yaml` | Workspace path `~/workspace` vs `~/.zeroclaw/workspace` | Already corrected in original PR |
| W3 | `manifest.yaml` validate stage | Stale `config_check` task | Already removed in original PR |
| W9 | `playbooks/start.yaml`, `stop.yaml` | Unquoted `pgrep -u {{ agent_name }} ...` | Fixed in 3282ec1 — switched to argv-list form |
| NEW-B1 | `playbooks/remove.yaml` | Stale `~/workspace` cleanup (path no longer scaffolded) | Fixed in 3282ec1 — dropped stale stat+remove; `~/.zeroclaw` cleanup cascades |
| NEW-B2 | `tests/` | Zero new tests for 170-line playbook rewrite | Fixed in 3282ec1 — added `tests/test_registry_zeroclaw.py` with 5 tests mirroring `test_registry_hermes.py` |

**Warnings**

| # | File | Warning | Action |
|---|------|---------|--------|
| NEW-W1 | `playbooks/install.yaml` | Double `daemon_reload` (notify + explicit task) | Fixed in 3282ec1 |
| NEW-W2 | `playbooks/start.yaml` | Duplicate `pgrep` task | Fixed in 3282ec1 |
| NEW-W4 | `playbooks/install.yaml` | Backtick vs single-quote in debug msg | Fixed in 3282ec1 |

</details>

<details>
<summary>Review 2 Details (Rating 3/5) — commit 3282ec1</summary>

**Confirmation:** All 7 previously-tracked items resolved cleanly. No new blockers.

**Remaining Warnings**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| NEW-W5 | `playbooks/` | Proposed `health.yaml` playbook missing | **Rejected as false positive** — no agent in the registry ships health.yaml; `health.py` uses `ansible_runner` with `module="command"` directly. Confirmed by review 3. |
| NEW-W6 | `tests/test_health.py` | Negative-path health test parity gap with hermes | Fixed in c1b28f9 — added `test_zeroclaw_pgrep_returns_stopped_when_no_process` |
| NEW-W7 | `tests/` | W9 argv-form fix untested | Fixed in c1b28f9 — added `test_zeroclaw_start/stop_playbook_uses_argv_list_form` |

NEW-W9 (TOCTOU in remove.yaml) deferred to follow-up issue per reviewer's "low-urgency" framing.

</details>

<details>
<summary>Review 3 Details (Rating 4/5) — commit c1b28f9</summary>

**Verdict:** Merge-ready. Zero blocking issues remain.

**Non-Blocking Findings**

| # | File | Note |
|---|------|------|
| W1 | `core/health.py` | `ClawStatus.STOPPED` is dead code (consistent with existing hermes test pattern); recommend tightening assertion in follow-up |
| W2 | `core/lifecycle.py:984` | Pre-existing Discord secret access pattern, out of scope |

</details>

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — **1778 passed, 0 failed** (+9 from baseline 1769)
- [x] Linter passes (`make lint`) — `ruff` and `next lint` clean
- [x] New tests added covering installer checksum, install playbook shape, remove playbook paths, run_installation extra_vars, skip detection, argv-form pgrep regression (start + stop), and negative-path health probe

### Test Coverage
- Files changed: `manifest.yaml`, `install.yaml`, `configure.yaml` (untouched here), `start.yaml`, `stop.yaml`, `remove.yaml`, `health.py`, `test_registry.py`, `test_health.py`, plus new `test_registry_zeroclaw.py` and `.itx/356/01_EXECUTION.md`
- New tests: `tests/test_registry_zeroclaw.py` (7 tests) + 1 new + 1 renamed in `tests/test_health.py`
- Coverage impact: increased (new files start at 100% on the test paths added)

### Manual Testing
End-to-end install/remove on `wolf-i` (Ubuntu 24.04 x86_64):

- `clm agent install --type zeroclaw --host wolf-i --name zc-test --yes` → 17 ok, 9 changed; `clm ps` shows zc-test v0.7.5 `pending onboard`
- Remote: `systemctl status zeroclaw-zc-test` → `inactive (dead)`, `disabled; preset: enabled`
- Re-run install → 16 ok, **0 changed**, 5 skipped, "ZeroClaw v0.7.5 already installed at /home/zc-test/bin/zeroclaw"
- `clm agent remove zc-test --force` → unit, home dir, agent user all removed; SSH verification returns "no such user" and "no such service"

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] `pgrep` agent_name interpolation switched to argv-list form to neutralize shell metacharacter splitting (W9)
- [x] No SQL injection, XSS, or command injection risks
- [x] Tarball checksums pinned via SHA256 from upstream `SHA256SUMS`

## Reviewer Notes

**SHA256 provenance.** Pulled directly from `https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.7.5/SHA256SUMS`:

| Tarball | SHA256 |
|---|---|
| `zeroclaw-armv7-unknown-linux-gnueabihf.tar.gz` | `32b11166fae1647a1ea39bac0d4b14073183cd034c42a25cb543615074aefd77` |
| `zeroclaw-aarch64-unknown-linux-gnu.tar.gz` | `0b1197f1d80243e5c748b63a550cc6dfc37e407c4d15f729b32324ba9fe4c2ac` |
| `zeroclaw-x86_64-unknown-linux-gnu.tar.gz` | `8bc8276a8d8faefb3e4a824f33876929e7466f632ee7c5363936368a1af2e4f7` |

**B3 deferral.** ATX reviewer explicitly tracked `install.py preserved_gateway` for Subtask B (#357) not Subtask A. The bearer-token key path it gates is introduced when the chat/configure flow lands in #357, so the guard can be generalized there.

Closes #356

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>