### PR TITLE
feat(zeroclaw): providers + WebSocket chat backend (Subtask B of #112)

### DIFF
--- a/.itx/357/01_EXECUTION.md
+++ b/.itx/357/01_EXECUTION.md
@@ -1,0 +1,156 @@
+# Issue 357 — Subtask B Execution Notes
+
+## Architectural Decision: bearer-token data path (B2)
+
+The configure flow renders `config.toml`, starts the daemon, completes the
+pairing handshake against the just-started daemon, and persists the resulting
+bearer token to `hosts.json` under `agents.<n>.config.gateway.auth`.
+
+Two options were on the table:
+
+- **(a)** add Ansible fact-cache extraction to `configure_agent()` mirroring
+  the OpenClaw pattern in `install.py:688-794`, and have `configure.yaml`
+  emit the bearer token as a host fact.
+- **(b)** have the Python CLI layer make direct HTTP calls
+  (`GET /pair/code` → `POST /pair`) against the daemon after `configure_agent()`
+  returns, and write the result to `hosts.json` from the CLI.
+
+**Decision: (a).**
+
+Reasons:
+
+1. The pairing handshake must run *after* the daemon is up, which means the
+   playbook needs a daemon-startup step + a `/health/providers` readiness probe
+   regardless. Doing the `/pair/code` and `/pair` calls one task later — while
+   we still hold the SSH/become context — keeps the entire daemon-lifecycle
+   sequence in one place. Splitting it (playbook starts daemon, Python finishes
+   pairing) creates a brittle ordering contract across two different process
+   boundaries.
+2. The OpenClaw pattern is the established one in this codebase; mirroring it
+   means the same `_resolve_chat_type` → gateway-config reader in
+   `cli/chat.py` keeps working without a second hosts.json shape.
+3. The CLI host running `clm` may not have direct LAN reachability to the
+   agent host's pairing port (the host could sit behind a router that
+   forwards SSH but not 4080). Pairing inside the playbook always works
+   because it's loopback on the agent host.
+
+Trade-off: configure now extracts Ansible fact cache (new code path in
+`configure_agent()`), instead of just driving the playbook. This is small,
+matches `install.py`, and is covered by tests.
+
+## Security Considerations (B4)
+
+Default bind in this PR: `host = "0.0.0.0"`, `allow_public_bind = true`,
+`require_pairing = true`. Upstream ZeroClaw defaults to `127.0.0.1` and
+`allow_public_bind = false`.
+
+### Threat model
+
+LAN-trusted dev / home network. The clm operator's machine and the agent
+host are on the same trusted network (homelab, dev LAN). The agent host is
+addressable only from peers on that LAN, and the daemon's pairing-token
+auth gates every endpoint.
+
+### Why match Hermes' posture
+
+Hermes binds `0.0.0.0` with a 64-char hex `API_SERVER_KEY` (see
+`lifecycle.py:780-815`). The reason is identical: cross-LAN `clm chat <n>`
+is the entire point — a clm machine connects from any peer on the LAN
+without having to set up an SSH tunnel per session. Without bearer-token
+enforcement this would be unsafe; with it, the only thing exposed is
+"deny unless you hold the bearer token."
+
+### Concretely
+
+- `require_pairing = true` means the gateway rejects every request without
+  a paired bearer token (verified against
+  `crates/zeroclaw-gateway/src/api_pairing.rs`).
+- The bearer token is captured during configure and persisted to
+  `hosts.json` under `agents.<n>.config.gateway.auth`. `clm chat` reads
+  it back and sends `Authorization: Bearer <token>`.
+- Pairing tokens are the auth boundary. There is no TLS — `ws://` is used
+  on the LAN. Production / shared-network deployments should layer an SSH
+  tunnel (`ssh -L 4080:127.0.0.1:4080 <host>`) and chat via
+  `localhost`, but that is operator-configured, not the default for the
+  LAN dev experience this PR targets.
+- Bearer token is stored at `0600` on disk inside `~/.config/clawrium/`
+  (the existing hosts.json mode).
+
+## Frame handling decisions (B5, B7)
+
+For `chat_zeroclaw.py` the wire protocol from
+`crates/zeroclaw-gateway/src/ws.rs` is handled as:
+
+| Frame | Behavior |
+|---|---|
+| `connected`, `session_start` | accepted, no surface output |
+| `chunk` | sanitized + accumulated + delivered via `on_delta` |
+| `thinking` | sanitized + dim-printed (does not feed the accumulator) |
+| `tool_call` | sanitized + dim-printed |
+| `tool_result` | sanitized + dim-printed |
+| `done` | terminates the turn, returns accumulated text |
+| `error` | raises `ChatProtocolError(sanitized_message)` |
+| `aborted` | raises `ChatProtocolError("turn aborted")` |
+| `chunk_reset` | clears the accumulator (mid-turn reset) |
+| `approval_request` | raises `ChatProtocolError(...)` — surfacing inline UX is out of scope for this PR |
+| unknown `type` | logged-and-dropped (forward compat) |
+
+All server-supplied text goes through the bidi/control sanitizer
+re-exported from `core/chat.py` (renamed `sanitize_server_text` so both
+chat backends share it) and `rich.markup.escape` before any
+`console.print`.
+
+## Test plan additions (B8)
+
+`tests/test_configure_zeroclaw.py` is rewritten to cover the v0.7.5 schema:
+
+- One `provider`-block-rendering test per provider (anthropic, openai,
+  ollama, openrouter) asserting the `kind` discriminator, `model`, and
+  `api_key`/`base_url` selection.
+- `gateway.host == "0.0.0.0"`, `gateway.allow_public_bind == true`,
+  `gateway.require_pairing == true` rendered as the chosen security
+  defaults.
+- `default_provider` and `default_model` rendered at the top level.
+
+The pre-existing Atlassian integration tests are removed: the v0.7.5
+template no longer emits an `[integrations]` block (issue #112 plan
+removes it from this template; integrations will land as a follow-up
+issue outside #112).
+
+## ATX Round 1 — Bearer-token-at-rest (B7) clarification
+
+The Round 1 reviewer flagged the bearer token being persisted in
+`hosts.json` as a credential-storage regression. The decision (and the
+mitigating constraints) are:
+
+- `hosts.json` is written exclusively via `core/hosts.py::update_host`
+  and its siblings, all of which `os.fchmod(fd, 0o600)` after creation
+  (see `core/hosts.py:127, 168, 308, 345`). The file is owner-readable
+  only; it is not world-readable at any point.
+- OpenClaw already stores its bearer token at the same key path
+  (`config.gateway.auth`). Mirroring that shape lets `_extract_gateway_config`
+  in `cli/chat.py` route both transports through one reader.
+- The issue #112 plan explicitly directs this storage location for
+  parity with openclaw (see `.itx/112/00_PLAN.md` "Implications for
+  clm" → bearer-token bullet).
+- A future hardening pass can migrate both openclaw and zeroclaw
+  bearer tokens from hosts.json to `secrets.json` in lockstep; doing
+  zeroclaw alone would split the storage convention without a
+  corresponding security gain.
+
+The `0600` mode is the load-bearing invariant. Tests covering
+`core/hosts.py` already pin it (`test_secrets_*` files); no new test
+is required here.
+
+## ATX Round 1 — Idempotent re-pairing (B3) flag surface
+
+Configure now passes `existing_gateway_token` and `force_repair` to the
+playbook as Ansible vars:
+
+- When `existing_gateway_token` is present and at least 16 chars, the
+  playbook skips the `/pair/code` → `/pair` exchange and echoes the
+  existing token back as the cacheable fact. Live `clm chat` sessions
+  survive routine reconfigure runs.
+- `force_repair: true` overrides the skip and re-mints. Wired today via
+  the `extra_vars` parameter on `configure_agent`; CLI surface (a
+  `--force-repair` flag on `clm agent configure`) is a small follow-up.

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -4,6 +4,9 @@ Dispatch is driven by `features.chat.type` in the agent manifest:
 
 - ``websocket`` → openclaw gateway over WebSocket (existing behavior).
 - ``openai``    → hermes (and future agents) over OpenAI-compatible HTTP.
+- ``zeroclaw``  → ZeroClaw gateway over WebSocket with bearer-token auth
+                  (tagged-JSON envelope; distinct from openclaw's frame
+                  schema, so it gets a dedicated dispatch value).
 """
 
 from __future__ import annotations
@@ -25,6 +28,10 @@ from clawrium.core.chat import (
     SecretStr,
 )
 from clawrium.core.chat_hermes import HermesOpenAIBackend
+from clawrium.core.chat_zeroclaw import (
+    RECV_TIMEOUT_MSG_PREFIX as ZEROCLAW_RECV_TIMEOUT_MSG_PREFIX,
+    ZeroClawChatBackend,
+)
 from clawrium.core.hosts import get_agent_by_name, HostsFileCorruptedError
 from clawrium.core.registry import (
     ManifestNotFoundError,
@@ -138,6 +145,12 @@ def chat(
                 agent_name=str(canonical_name),
                 response_timeout_seconds=timeout,
             )
+        elif chat_type == "zeroclaw":
+            backend = _build_zeroclaw_backend(
+                agent_record=agent_record,
+                host_record=host_record,
+                response_timeout_seconds=timeout,
+            )
         else:
             console.print(
                 f"[red]Error:[/red] Chat is not supported for agent type "
@@ -150,12 +163,26 @@ def chat(
 
     # Emit the `--session` no-op notice only after backend construction
     # succeeds so the user doesn't see a misleading "chat is about to start"
-    # warning followed by a hard error.
+    # warning followed by a hard error. ATX Round 1 W7: zeroclaw too —
+    # the ZeroClaw gateway owns session state and there is no separate
+    # session-key concept on the wire.
+    #
+    # ATX Round 2 S5: distinct wording per backend — hermes/openai's
+    # history is client-side in-memory; zeroclaw's session state lives
+    # on the gateway daemon for the lifetime of the WebSocket. The old
+    # generic "in-memory only" line was accurate for hermes but
+    # misleading for zeroclaw.
     if chat_type == "openai" and session != "main":
         console.print(
             "[dim]`--session` is accepted but has no effect for this agent type "
             "— conversation history is in-memory only and will not be routed to "
             "a named session.[/dim]"
+        )
+    elif chat_type == "zeroclaw" and session != "main":
+        console.print(
+            "[dim]`--session` is accepted but has no effect for zeroclaw — the "
+            "gateway daemon owns session state for the duration of this "
+            "WebSocket connection.[/dim]"
         )
 
     console.print(
@@ -182,7 +209,7 @@ def chat(
         console.print(
             f"[red]Authentication failed:[/red] {rich_escape(_sanitize_exception_text(exc))}"
         )
-        if chat_type == "openai":
+        if chat_type in ("openai", "zeroclaw"):
             console.print(
                 f"Token mismatch. Re-run 'clm agent configure {rich_escape(str(canonical_name))}'."
             )
@@ -222,6 +249,38 @@ def chat(
                         f"Re-run 'clm agent configure {rich_escape(str(canonical_name))}' "
                         f"to bind a reachable interface."
                     )
+        elif chat_type == "zeroclaw":
+            # ATX Round 1 W6 / Round 2 W8: distinguish three connection
+            # failure modes. `chat_zeroclaw.py` emits three word-stable
+            # ChatConnectionError messages:
+            #
+            #   "Timed out connecting to ZeroClaw gateway at <url>"
+            #       -> TCP handshake never completed; firewall / wrong
+            #          port / host down. A higher --timeout won't help
+            #          because the connect path doesn't honor request
+            #          timeout. Route to a reachability hint.
+            #
+            #   "Timed out waiting for ZeroClaw response after Ns"
+            #       -> Connection succeeded but the agent is slow.
+            #          Route to the --timeout hint.
+            #
+            #   "Failed to reach ZeroClaw gateway at <url>: <reason>"
+            #       -> Connect failed immediately (OSError). Same as
+            #          connect-timeout: reachability hint.
+            # ATX Round 3 W2: use the shared constant exported by the
+            # zeroclaw backend so reworded exception messages can't
+            # silently misroute the hint.
+            msg = str(exc)
+            if msg.startswith(ZEROCLAW_RECV_TIMEOUT_MSG_PREFIX):
+                console.print(
+                    f"Try a higher --timeout value (current: {timeout}s)."
+                )
+            else:
+                console.print(
+                    f"Verify the agent host is reachable and re-run "
+                    f"'clm agent configure {rich_escape(str(canonical_name))}' "
+                    f"if the pairing token is stale."
+                )
         else:
             console.print(
                 "Verify the host is online and the recorded gateway URL/token are current (re-run configure/install if needed)."
@@ -313,6 +372,27 @@ async def _chat_loop(
                     f"[red]Protocol error:[/red] "
                     f"{rich_escape(_sanitize_exception_text(exc))}"
                 )
+                # ATX Round 2 W2 / Round 4 W-A: some protocol errors
+                # (e.g. zeroclaw `approval_request`) tear down the
+                # transport before re-raising. Continuing the REPL
+                # after such an error would send the next message into
+                # a stuck connection and produce a misleading "host
+                # unreachable" error on the *next* user turn. Break
+                # cleanly so the user sees the right remediation up
+                # front.
+                #
+                # `backend.is_connected` is declared in the
+                # `ChatBackend` Protocol; reading the attribute
+                # directly (not via `getattr(..., True)`) makes a
+                # missing-property regression an immediate
+                # AttributeError instead of a silent always-True
+                # fallback.
+                if not backend.is_connected:
+                    console.print(
+                        "[dim]Chat session ended. Reconnect with "
+                        "`clm chat <name>` to start a new session.[/dim]"
+                    )
+                    break
                 console.print("[dim]Continuing chat session.[/dim]")
                 continue
             finally:
@@ -389,6 +469,34 @@ def _build_openclaw_backend(
         auth_token=SecretStr(gateway["auth"]),
         device_id=gateway.get("device_id"),
         device_private_key=gateway.get("device_private_key"),
+        timeout_seconds=response_timeout_seconds,
+    )
+
+
+def _build_zeroclaw_backend(
+    agent_record: dict[str, Any],
+    host_record: dict[str, Any],
+    response_timeout_seconds: float,
+) -> ChatBackend:
+    """Construct a ZeroClawChatBackend from the persisted hosts.json record.
+
+    Reuses `_extract_gateway_config` for shape parity with openclaw — the
+    bearer token and URL live under the same `config.gateway.{auth,url}`
+    keys, written by `clm agent configure` (issue #357).
+
+    The path-suffix `/ws/chat` is appended if the persisted URL was only
+    the gateway origin. ZeroClaw's chat endpoint is `GET /ws/chat`; older
+    persisted records (or hand-edited ones) may omit the path.
+    """
+    gateway = _extract_gateway_config(agent_record, host_record)
+    url = gateway["url"]
+    # Idempotent suffix: append `/ws/chat` only when missing. ZeroClaw's
+    # gateway rejects connections at the bare root path.
+    if "/ws/chat" not in url:
+        url = url.rstrip("/") + "/ws/chat"
+    return ZeroClawChatBackend(
+        gateway_url=url,
+        auth_token=SecretStr(gateway["auth"]),
         timeout_seconds=response_timeout_seconds,
     )
 

--- a/src/clawrium/core/chat.py
+++ b/src/clawrium/core/chat.py
@@ -93,6 +93,25 @@ class ChatBackend(Protocol):
         """
         ...
 
+    @property
+    def is_connected(self) -> bool:
+        """Whether `send_message` would succeed without a fresh `connect()`.
+
+        Optimistic contract: `True` after a successful `connect()` and
+        before an explicit `close()`. It is NOT a heartbeat — a server-
+        initiated TCP close between turns will leave it `True` until the
+        next failed `send_message`. The REPL uses this to decide
+        between continuing a chat session and breaking after a
+        `ChatProtocolError` that the backend self-tore-down on
+        (e.g. zeroclaw's `approval_request` branch).
+
+        Backends without an explicit lifecycle (HTTP-style hermes) MAY
+        return `True` constantly — `close()` flips it to `False` so the
+        REPL's break-on-disconnect contract is still meaningful when
+        an `approval_request`-shaped path lands in those backends later.
+        """
+        ...
+
 
 class OpenClawChatClient:
     """Minimal WebSocket client for OpenClaw gateway chat RPC."""
@@ -259,6 +278,14 @@ class OpenClawChatClient:
             except Exception:
                 pass
             self._ws = None
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether `send_message` would succeed without a fresh connect.
+
+        See `ChatBackend.is_connected` for the optimistic contract.
+        """
+        return self._ws is not None
 
     def clear_history(self) -> None:
         """No-op: openclaw's gateway owns conversation state, not the client."""

--- a/src/clawrium/core/chat_hermes.py
+++ b/src/clawrium/core/chat_hermes.py
@@ -94,6 +94,16 @@ class HermesOpenAIBackend:
                 pass
             self._client = None
 
+    @property
+    def is_connected(self) -> bool:
+        """Whether `send_message` would succeed without a fresh connect.
+
+        See `ChatBackend.is_connected` — optimistic; HTTP has no kept-
+        open transport, so this tracks the lifecycle of the underlying
+        `httpx.AsyncClient` only.
+        """
+        return self._client is not None
+
     async def send_message(
         self,
         message: str,

--- a/src/clawrium/core/chat_zeroclaw.py
+++ b/src/clawrium/core/chat_zeroclaw.py
@@ -1,0 +1,484 @@
+"""ZeroClaw gateway chat backend (WebSocket, bearer-token paired).
+
+The ZeroClaw gateway speaks tagged-JSON envelopes over a single WebSocket
+connection (`GET /ws/chat`). Auth happens by sending the paired bearer
+token in the `Authorization: Bearer <token>` upgrade header. The frame
+schema is documented inline below.
+
+This file deliberately does NOT reuse openclaw's `OpenClawChatClient`
+because the wire formats differ:
+
+- openclaw: req/res RPC-style envelopes with `id`, `method`, `params`;
+  event frames carry `event`/`payload`. Server emits assistant text via
+  `chat` events with `state="streaming"|"final"`.
+- zeroclaw: tagged-JSON server frames keyed by a single top-level
+  `type` field (`chunk`, `thinking`, `tool_call`, `tool_result`, `done`,
+  `error`, `aborted`, `chunk_reset`, `approval_request`, `session_start`,
+  `connected`). The client sends `{"type":"message","content":"..."}`.
+
+Conversation state is owned by the gateway: one WebSocket connection is
+one session, the daemon retains turns internally, and `clear_history()`
+is a no-op (matching openclaw — the REPL `/reset` command prints an
+explicit notice for gateway-owned backends so the user is not misled).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+import logging
+import socket
+from typing import Any, Callable
+
+import websockets
+from websockets.exceptions import (
+    ConnectionClosed,
+    InvalidStatus,
+    WebSocketException,
+)
+
+from clawrium.core.chat import (
+    ChatAuthenticationError,
+    ChatConnectionError,
+    ChatProtocolError,
+    SecretStr,
+)
+# Reuse the sanitizer + control-char regex from chat_hermes so all
+# server-supplied text passes through the same bidi/zero-width strip
+# before reaching any Rich renderer. Keeps the four sanitizer call sites
+# (cli/chat.py, core/chat_hermes.py, here, and the future memory CLI)
+# in lockstep — a fix in chat_hermes propagates here for free.
+from clawrium.core.chat_hermes import _sanitize_assistant_text
+
+__all__ = [
+    "RECV_TIMEOUT_MSG_PREFIX",
+    "ZeroClawChatBackend",
+    "sanitize_server_text",
+]
+
+logger = logging.getLogger(__name__)
+
+
+# Frame types the server is allowed to emit. Anything outside this set is
+# logged and dropped (forward-compat — upstream may add new event types
+# without bumping a protocol version, and we don't want unrelated tooling
+# events to crash the REPL).
+_KNOWN_SERVER_FRAMES = frozenset({
+    "connected",
+    "session_start",
+    "chunk",
+    "thinking",
+    "tool_call",
+    "tool_result",
+    "approval_request",
+    "chunk_reset",
+    "done",
+    "error",
+    "aborted",
+})
+
+
+def sanitize_server_text(text: Any) -> str:
+    """Strip C0/C1, zero-width, bidi, line/paragraph-separator codepoints.
+
+    Returns "" for non-string inputs so callers can safely pass any field
+    pulled out of the parsed JSON frame without an `isinstance` ladder.
+    """
+    if not isinstance(text, str):
+        return ""
+    return _sanitize_assistant_text(text)
+
+
+# ATX Round 2 W2 / Round 3 W2: shared string constant for the recv-
+# timeout discriminator. cli/chat.py uses this to distinguish recv-
+# timeout (route to --timeout hint) from connect-timeout / reachability
+# errors. Importing the constant avoids the string-coupling failure mode
+# where a reworded exception message silently misroutes the hint.
+RECV_TIMEOUT_MSG_PREFIX = "Timed out waiting for ZeroClaw response"
+
+
+# ATX Round 1 W9 / Round 3 W7: a non-TLS WebSocket against a non-loopback
+# host means the bearer token traverses the network in cleartext. Surface
+# a one-shot warning so a misconfigured deployment is noisy at chat-start.
+#
+# Loopback recognition:
+#  - String literal matches for the common forms: localhost, 127.0.0.1,
+#    ::1, and the bare "" that urlparse occasionally returns for malformed
+#    inputs.
+#  - Optional getaddrinfo resolution for hostnames that pointed at
+#    loopback via /etc/hosts (e.g. `local.dev`). Skipped on resolution
+#    failure so a transient DNS hiccup never SUPPRESSES the warning.
+def _warn_if_token_in_cleartext(gateway_url: str) -> None:
+    from urllib.parse import urlparse
+    parsed = urlparse(gateway_url)
+    if parsed.scheme != "ws":
+        return
+    host = (parsed.hostname or "").lower()
+    # Literal loopback forms — handles the canonical configure-time URL.
+    if host in {"localhost", "localhost.localdomain", "127.0.0.1", "::1", ""}:
+        return
+    # Best-effort resolution: a hostname pointed at loopback via
+    # /etc/hosts (common in dev VMs) should not trigger the warning.
+    # Defensive: any resolver failure means we DO emit the warning —
+    # mis-warning is preferable to silently dropping a real exposure.
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except (socket.gaierror, OSError, UnicodeError):
+        infos = []
+    if infos:
+        try:
+            if all(
+                ipaddress.ip_address(info[4][0]).is_loopback for info in infos
+            ):
+                return
+        except (ValueError, IndexError):
+            pass
+    logger.warning(
+        "ZeroClaw chat is using a non-TLS WebSocket (ws://) to a "
+        "non-loopback host (%s). The bearer token will travel in "
+        "cleartext on the LAN — consider tunneling over SSH or "
+        "switching the gateway to wss://.",
+        host,
+    )
+
+
+class ZeroClawChatBackend:
+    """WebSocket chat client for ZeroClaw's `/ws/chat` endpoint.
+
+    Implements the `ChatBackend` protocol from `core/chat.py`. One
+    instance corresponds to one chat REPL session; `connect` opens the
+    socket, `send_message` round-trips a single user message, and `close`
+    tears the connection down.
+
+    Conversation history lives server-side. `clear_history()` is a no-op
+    by design — the REPL routes /reset to an explicit "gateway owns
+    session state" notice when history_capable is False.
+    """
+
+    def __init__(
+        self,
+        gateway_url: str,
+        auth_token: SecretStr | str,
+        timeout_seconds: float = 120.0,
+    ) -> None:
+        self.gateway_url = gateway_url
+        self._auth_token = (
+            auth_token
+            if isinstance(auth_token, SecretStr)
+            else SecretStr(auth_token)
+        )
+        self._timeout_seconds = timeout_seconds
+        self._ws: Any | None = None
+
+    async def connect(self) -> None:
+        """Open the WebSocket and authenticate via the bearer header.
+
+        Auth: `Authorization: Bearer <token>` upgrade header (verified
+        against `crates/zeroclaw-gateway/src/ws.rs` —
+        ZeroClaw also accepts `Sec-WebSocket-Protocol: bearer.<token>`
+        and `?token=` query, but the header form is the canonical one
+        and avoids leaking the token into proxy logs or URL caches).
+
+        ATX Round 1 W9: emits a stderr warning when the configured URL
+        is non-TLS (`ws://`) AND the host portion is non-loopback. The
+        pairing flow always writes `ws://` against the daemon's loopback
+        bind, so a non-loopback `ws://` URL is operator-introduced (e.g.
+        hand-edited hosts.json or LAN-exposed daemon) and means the
+        bearer token would travel cleartext over the LAN.
+        """
+        token = self._auth_token.get_secret_value()
+        if not token:
+            raise ChatAuthenticationError(
+                "ZeroClaw gateway auth token is empty. "
+                "Re-run `clm agent configure <name>`."
+            )
+
+        _warn_if_token_in_cleartext(self.gateway_url)
+
+        # ATX Round 1 W5: drop the redundant `asyncio.wait_for` wrapper.
+        # `websockets.connect(open_timeout=...)` is the canonical timeout
+        # mechanism; wrapping it in `wait_for` adds a second cancellation
+        # boundary whose interaction with `open_timeout` differs across
+        # Python versions, creating a 3.10-vs-3.12 edge-case footgun for
+        # zero functional gain.
+        try:
+            self._ws = await websockets.connect(
+                self.gateway_url,
+                additional_headers=[("Authorization", f"Bearer {token}")],
+                open_timeout=self._timeout_seconds,
+                close_timeout=self._timeout_seconds,
+            )
+        except (TimeoutError, asyncio.TimeoutError) as exc:
+            # ATX Round 1 B5: catch both TimeoutError and
+            # asyncio.TimeoutError. They are aliased on Python 3.11+ but
+            # remain distinct classes on 3.10 (our declared minimum
+            # runtime), where `websockets.connect(open_timeout=...)`
+            # raises `asyncio.TimeoutError` which would NOT match `except
+            # TimeoutError` alone — a guaranteed crash on 3.10.
+            raise ChatConnectionError(
+                f"Timed out connecting to ZeroClaw gateway at {self.gateway_url}"
+            ) from exc
+        except InvalidStatus as exc:
+            # 401/403 surface as a dedicated auth error so the CLI can
+            # route the user to `clm agent configure`. websockets ≥14
+            # raises InvalidStatus carrying a `.response` (Response object
+            # with `.status_code`); older releases used `.status_code`
+            # directly. Probe both shapes.
+            response = getattr(exc, "response", None)
+            status = getattr(response, "status_code", None)
+            if status is None:
+                status = getattr(exc, "status_code", None)
+            if status in (401, 403):
+                raise ChatAuthenticationError(
+                    "ZeroClaw gateway rejected the bearer token. "
+                    "Re-run `clm agent configure <name>` to re-pair."
+                ) from exc
+            raise ChatConnectionError(
+                f"ZeroClaw gateway returned HTTP {status} during connect"
+            ) from exc
+        except OSError as exc:
+            raise ChatConnectionError(
+                f"Failed to reach ZeroClaw gateway at {self.gateway_url}: {exc}"
+            ) from exc
+        except WebSocketException as exc:
+            raise ChatConnectionError(
+                f"WebSocket connection failed: {exc}"
+            ) from exc
+
+    async def close(self) -> None:
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether `send_message()` would succeed without a new connect.
+
+        ATX Round 2 W2: the REPL reads this after catching
+        `ChatProtocolError` to decide between "continue" and "session
+        ended". `approval_request` tears down the socket before raising
+        so the REPL can see is_connected == False and break instead of
+        looping into a stuck connection.
+        """
+        return self._ws is not None
+
+    def clear_history(self) -> None:
+        """No-op: ZeroClaw's gateway owns conversation state."""
+
+    async def send_message(
+        self,
+        message: str,
+        session_key: str = "main",
+        on_delta: Callable[[str], None] | None = None,
+        response_timeout_seconds: float = 120.0,
+    ) -> str:
+        """Send one user message and stream the assistant's reply.
+
+        Reads server frames until a terminal frame (`done` / `error` /
+        `aborted`) arrives. Streaming `chunk` frames feed `on_delta` and
+        accumulate into a local buffer used as a fallback when `done`
+        does not carry `full_response`. `chunk_reset` clears the local
+        buffer mid-turn so the eventual fallback (or return value) only
+        reflects post-reset content.
+
+        `session_key` is accepted for signature parity with the openclaw
+        backend; it is ignored — one WebSocket connection IS the session
+        and is established at `connect()`.
+        """
+        if self._ws is None:
+            raise ChatConnectionError("ZeroClaw chat backend not connected")
+
+        await self._send_json({"type": "message", "content": message})
+
+        accumulator: list[str] = []
+        while True:
+            frame = await self._recv_json(timeout=response_timeout_seconds)
+            frame_type = frame.get("type")
+
+            if frame_type not in _KNOWN_SERVER_FRAMES:
+                # Forward-compat: log and skip. ZeroClaw may add frame
+                # types (e.g. richer tool envelopes); the REPL should
+                # not crash on a tag it doesn't recognize.
+                logger.debug("Ignoring unknown ZeroClaw frame type: %r", frame_type)
+                continue
+
+            if frame_type in ("connected", "session_start"):
+                continue
+
+            if frame_type == "chunk":
+                delta = sanitize_server_text(frame.get("content"))
+                if not delta:
+                    continue
+                accumulator.append(delta)
+                if on_delta is not None:
+                    on_delta(delta)
+                continue
+
+            if frame_type == "thinking":
+                # Thinking frames are advisory — surface via on_delta in
+                # a discoverable way without polluting the accumulator
+                # (the final return value should be the assistant reply,
+                # not the chain-of-thought).
+                thought = sanitize_server_text(frame.get("content"))
+                if thought and on_delta is not None:
+                    # Wrapped so the REPL can distinguish thoughts from
+                    # assistant text. The CLI renderer prints deltas
+                    # verbatim; an unobtrusive prefix keeps thoughts
+                    # readable but distinct.
+                    on_delta(f"[thinking] {thought}\n")
+                continue
+
+            if frame_type == "tool_call":
+                # Tool call frames carry `name` + JSON `arguments`.
+                # Sanitize both before surfacing so a malicious tool
+                # name / argument blob can't smuggle bidi marks or rich
+                # markup into the terminal.
+                tool_name = sanitize_server_text(frame.get("name"))
+                raw_args = frame.get("arguments")
+                if isinstance(raw_args, (dict, list)):
+                    args_text = sanitize_server_text(json.dumps(raw_args))
+                else:
+                    args_text = sanitize_server_text(raw_args)
+                if on_delta is not None and tool_name:
+                    on_delta(f"[tool_call] {tool_name}({args_text})\n")
+                continue
+
+            if frame_type == "tool_result":
+                result_text = sanitize_server_text(frame.get("content"))
+                if result_text and on_delta is not None:
+                    on_delta(f"[tool_result] {result_text}\n")
+                continue
+
+            if frame_type == "chunk_reset":
+                # Mid-turn reset: the server is telling us to throw away
+                # the chunks emitted before this frame (e.g. provider
+                # retry, soft abort). Drop the local buffer so the
+                # eventual fallback only reflects post-reset content.
+                # The renderer can't un-print, but the final return
+                # value will be correct.
+                accumulator.clear()
+                continue
+
+            if frame_type == "approval_request":
+                # Inline tool-approval UX is out of scope for #357. ATX
+                # Round 1 W2: the server holds the connection open
+                # waiting for an `approval_response` frame. If we raise
+                # without closing, the REPL's inner try/except catches
+                # the error, prints "Continuing chat session.", and the
+                # *next* user message hits a half-broken connection
+                # (the server replays the approval request or returns
+                # error frames). Explicitly close the socket before
+                # raising so the REPL's outer cleanup path drops the
+                # connection and the user is forced to re-`connect()`
+                # (which today means re-running `clm chat`).
+                #
+                # ATX Round 1 B6: sanitize EVERY caller-visible field
+                # from the approval frame — `tool`, `name`, AND the
+                # `prompt`/`command` text the server may include. A
+                # malicious server could otherwise smuggle bidi marks /
+                # Rich markup through the prompt field.
+                request_label = sanitize_server_text(
+                    frame.get("tool") or frame.get("name") or "tool"
+                )
+                request_prompt = sanitize_server_text(frame.get("prompt"))
+                # `prompt` is optional in the wire format; if present we
+                # include a truncated form in the error so the user can
+                # tell which approval was triggered. Truncation bounds
+                # the error-message length even if the server sends a
+                # multi-kilobyte prompt.
+                detail = f" (tool='{request_label}')"
+                if request_prompt:
+                    detail += f" prompt={request_prompt[:200]!r}"
+                await self.close()
+                # ATX Round 2 W9: include a concrete next step. Without
+                # a pointer to the config file the user has to guess
+                # where tool-allow lists live.
+                raise ChatProtocolError(
+                    "ZeroClaw requested tool approval" + detail + ". "
+                    "Inline approval is not supported yet; either "
+                    "pre-approve the tool in ~/.zeroclaw/config.toml "
+                    "on the agent host, or disable the tool there and "
+                    "re-run `clm agent configure <name>`."
+                )
+
+            if frame_type == "done":
+                # `done` carries `full_response`, token counts, cost,
+                # provider, model. Prefer the server-provided full text
+                # when present (it accounts for chunk_reset cleanly);
+                # fall back to the local accumulator otherwise.
+                full = sanitize_server_text(frame.get("full_response"))
+                if full:
+                    return full
+                return "".join(accumulator).strip()
+
+            if frame_type == "error":
+                msg = (
+                    sanitize_server_text(frame.get("message"))
+                    or sanitize_server_text(frame.get("error"))
+                    or "ZeroClaw reported an unspecified error"
+                )
+                raise ChatProtocolError(msg)
+
+            if frame_type == "aborted":
+                # Silently ignoring aborted would cause the REPL to hang
+                # waiting for `done` that will never come. Surface as a
+                # protocol error so the REPL can move to the next turn.
+                reason = sanitize_server_text(frame.get("reason")) or "no reason given"
+                raise ChatProtocolError(f"ZeroClaw aborted the turn: {reason}")
+
+    async def _send_json(self, payload: dict[str, Any]) -> None:
+        if self._ws is None:
+            raise ChatConnectionError("WebSocket is not connected")
+        try:
+            await self._ws.send(json.dumps(payload))
+        except ConnectionClosed as exc:
+            raise ChatConnectionError(
+                "ZeroClaw gateway closed the connection"
+            ) from exc
+        except WebSocketException as exc:
+            raise ChatConnectionError(
+                f"Failed to send to ZeroClaw gateway: {exc}"
+            ) from exc
+
+    async def _recv_json(self, timeout: float) -> dict[str, Any]:
+        if self._ws is None:
+            raise ChatConnectionError("WebSocket is not connected")
+        try:
+            raw = await asyncio.wait_for(self._ws.recv(), timeout=timeout)
+        except (TimeoutError, asyncio.TimeoutError) as exc:
+            # ATX Round 1 B5: see connect() comment — 3.10 distinguishes
+            # TimeoutError and asyncio.TimeoutError. asyncio.wait_for
+            # raises the asyncio variant on 3.10 which slips past a bare
+            # `except TimeoutError`.
+            raise ChatConnectionError(
+                f"Timed out waiting for ZeroClaw response after {timeout}s"
+            ) from exc
+        except ConnectionClosed as exc:
+            raise ChatConnectionError(
+                "ZeroClaw gateway closed the connection"
+            ) from exc
+        except WebSocketException as exc:
+            raise ChatConnectionError(f"Connection lost: {exc}") from exc
+
+        if isinstance(raw, bytes):
+            try:
+                raw = raw.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ChatProtocolError(
+                    "ZeroClaw sent non-UTF-8 WebSocket frame"
+                ) from exc
+        if not isinstance(raw, str):
+            raise ChatProtocolError("ZeroClaw sent non-text WebSocket frame")
+        try:
+            frame = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ChatProtocolError(
+                "ZeroClaw sent malformed JSON frame"
+            ) from exc
+        if not isinstance(frame, dict):
+            raise ChatProtocolError("ZeroClaw frame must be a JSON object")
+        return frame

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -433,7 +433,12 @@ def run_installation(
             # but the skip-path warning still reads from `preserved_gateway`.
             # Capture here too so resume+skip+existing-creds doesn't falsely
             # warn "credentials missing" (Round 2 W1).
-            if claw_name == "openclaw":
+            #
+            # Includes zeroclaw — pairing-bearer token lands in
+            # `config.gateway.auth` during `clm agent configure` (issue #357).
+            # Re-running install on a paired zeroclaw must not wipe the token,
+            # so the restore path in set_installed() needs the snapshot.
+            if claw_name in ("openclaw", "zeroclaw"):
                 preserved_gateway[0] = (
                     h["agents"][chosen_name[0]].get("config", {}).get("gateway")
                 )
@@ -447,11 +452,16 @@ def run_installation(
             # UNLESS cleanup_failed=True, then we force a fresh install
             if chosen_name[0] in h.get("agents", {}) and not cleanup_failed:
                 preserved_onboarding[0] = h["agents"][chosen_name[0]].get("onboarding")
-                # Round 2 W4: scope to openclaw — the restore branch in
-                # set_installed() is the only consumer and is openclaw-specific.
-                # Other agent types may have unrelated `config.gateway` shapes
-                # that should NOT be restored under this code path.
-                if claw_name == "openclaw":
+                # Round 2 W4: scope to claws that store credentials in
+                # `config.gateway`. The restore branch in set_installed() is
+                # the only consumer; other agent types may have unrelated
+                # `config.gateway` shapes that should NOT be restored.
+                #
+                # Includes zeroclaw — pairing-bearer token lands in
+                # `config.gateway.auth` during `clm agent configure`
+                # (issue #357). Re-running install on a paired zeroclaw must
+                # not wipe the token.
+                if claw_name in ("openclaw", "zeroclaw"):
                     preserved_gateway[0] = (
                         h["agents"][chosen_name[0]]
                         .get("config", {})
@@ -824,6 +834,16 @@ def run_installation(
                         "warn",
                         "Gateway URL not captured - manual configuration may be needed",
                     )
+        elif claw_name == "zeroclaw" and install_skipped:
+            # ZeroClaw install does NOT pair (pairing lives in configure.yaml),
+            # so a re-install at the same version is a pure binary no-op. The
+            # preserved_gateway capture is purely to keep the bearer token
+            # (set by a prior `clm agent configure`) from being wiped on the
+            # restore path in set_installed(). Emit a status line so a user
+            # re-running install can tell credentials were retained.
+            preserved = preserved_gateway[0] or {}
+            if preserved.get("auth"):
+                emit("claw", "Reusing existing gateway credentials (skip path)")
 
         # Step 10: Update host with success status and gateway auth
         def set_installed(h: dict) -> dict:
@@ -843,11 +863,16 @@ def run_installation(
                 # facts (template-write + pairing block are gated). Restore the
                 # gateway config we captured in set_installing() so re-running
                 # `clm agent install` at the same version does not silently drop
-                # the agent's auth token + device credentials. Scoped to
-                # openclaw (Round 2 W4) — other agent types do not store
-                # gateway credentials in this shape.
+                # the agent's auth token + device credentials. Scoped to claws
+                # that store credentials under `config.gateway`:
+                # - openclaw: token + device credentials, captured during install
+                # - zeroclaw: bearer token, captured during configure (#357)
+                # `gateway_token` is only ever set for openclaw, so the
+                # `and not gateway_token` guard is effectively openclaw-only;
+                # for zeroclaw we always want the restore on skip because
+                # install never minted a fresh token.
                 if (
-                    claw_name == "openclaw"
+                    claw_name in ("openclaw", "zeroclaw")
                     and install_skipped
                     and preserved_gateway[0]
                     and not gateway_token

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -4,6 +4,7 @@ This module handles start, stop, and restart operations for agent instances
 running on remote hosts via systemd service management.
 """
 
+import json
 import logging
 import os
 import re
@@ -980,9 +981,18 @@ def configure_agent(
             host["hostname"], resolved_type, unix_agent_name
         )
         instance_secrets = get_instance_secrets(instance_key)
-        if "DISCORD_BOT_TOKEN" in instance_secrets:
-            discord_bot_token = instance_secrets["DISCORD_BOT_TOKEN"]["value"]
-            emit("configure", "Loaded Discord bot token from secrets")
+        # ATX Round 2 W4: match the safe `.get("value")` pattern used
+        # by the Hermes API-server-key path (line ~762). A malformed
+        # secrets.json entry (truthy dict without a "value" field)
+        # otherwise raises KeyError, which the outer `except Exception`
+        # silently swallows into an empty token and the user can't tell
+        # why Discord/Slack stopped working.
+        discord_entry = instance_secrets.get("DISCORD_BOT_TOKEN")
+        if isinstance(discord_entry, dict):
+            discord_value = discord_entry.get("value")
+            if isinstance(discord_value, str):
+                discord_bot_token = discord_value
+                emit("configure", "Loaded Discord bot token from secrets")
     except Exception as e:
         logger.warning("Failed to load Discord bot token for %s: %s", agent_key, e)
 
@@ -994,12 +1004,19 @@ def configure_agent(
             host["hostname"], resolved_type, unix_agent_name
         )
         instance_secrets = get_instance_secrets(instance_key)
-        if "SLACK_BOT_TOKEN" in instance_secrets:
-            slack_bot_token = instance_secrets["SLACK_BOT_TOKEN"]["value"]
-            emit("configure", "Loaded Slack bot token from secrets")
-        if "SLACK_APP_TOKEN" in instance_secrets:
-            slack_app_token = instance_secrets["SLACK_APP_TOKEN"]["value"]
-            emit("configure", "Loaded Slack app token from secrets")
+        # ATX Round 2 W4: same safe-indexing pattern as Discord above.
+        slack_bot_entry = instance_secrets.get("SLACK_BOT_TOKEN")
+        if isinstance(slack_bot_entry, dict):
+            slack_bot_value = slack_bot_entry.get("value")
+            if isinstance(slack_bot_value, str):
+                slack_bot_token = slack_bot_value
+                emit("configure", "Loaded Slack bot token from secrets")
+        slack_app_entry = instance_secrets.get("SLACK_APP_TOKEN")
+        if isinstance(slack_app_entry, dict):
+            slack_app_value = slack_app_entry.get("value")
+            if isinstance(slack_app_value, str):
+                slack_app_token = slack_app_value
+                emit("configure", "Loaded Slack app token from secrets")
     except Exception as e:
         logger.warning("Failed to load Slack tokens for %s: %s", agent_key, e)
 
@@ -1102,6 +1119,55 @@ def configure_agent(
         "integrations": integrations_data,
     }
 
+    # ZeroClaw idempotent re-configure (ATX Round 1 B3): pass any
+    # existing bearer token in via Ansible vars so the configure playbook
+    # can skip the pairing handshake when already paired. Without this
+    # every configure call would mint a fresh token and silently
+    # invalidate any in-flight `clm chat` WebSocket.
+    if resolved_type == "zeroclaw":
+        existing_gateway = agent_record.get("config", {}).get("gateway") or {}
+        existing_token = existing_gateway.get("auth")
+        # ATX Round 2 W5: keep the Python-side threshold consistent with
+        # the playbook's `length >= 16` check. A 1-15 char hand-edited
+        # token would otherwise be passed in but silently rejected by the
+        # playbook, causing an opaque re-pair.
+        if (
+            isinstance(existing_token, str)
+            and len(existing_token.strip()) >= 16
+        ):
+            ansible_vars["existing_gateway_token"] = existing_token.strip()
+        else:
+            # ATX Round 3 W5 / Round 4 B1: when a too-short token
+            # forces a re-pair, surface that explicitly so the operator
+            # can tell whether any live `clm chat` sessions are about
+            # to break. Suppressed when there is no token at all
+            # (first configure) — that's the normal mint path, not an
+            # unexpected re-pair.
+            #
+            # Must use the `WARNING:` prefix + stage="configure" pattern
+            # (mirrors the integration-type warning at lifecycle.py:1046)
+            # so cli/agent.py's `_print_configure_warnings` callback
+            # routes the message to the user. The callback dispatches
+            # on the `WARNING:` prefix; a `stage="warn"` event with a
+            # different prefix is silently dropped at the terminal.
+            if isinstance(existing_token, str) and existing_token.strip():
+                warning_msg = (
+                    f"WARNING: Existing gateway token for {agent_key} "
+                    f"is shorter than 16 characters — treating as "
+                    f"absent. A new pairing handshake will be performed "
+                    f"and any live `clm chat {agent_key}` session will "
+                    f"need to reconnect."
+                )
+                emit("configure", warning_msg)
+                logger.warning(warning_msg)
+            ansible_vars["existing_gateway_token"] = ""
+        # `force_repair` flows in via extra_vars when the CLI surfaces
+        # an explicit rotation flag; default false so normal reconfigures
+        # are idempotent. ATX Round 2 S1: direct assignment — `setdefault`
+        # on a freshly constructed dict reads as a guard that doesn't
+        # exist in practice.
+        ansible_vars["force_repair"] = False
+
     # Merge extra_vars (not persisted to hosts.json)
     if extra_vars:
         ansible_vars.update(extra_vars)
@@ -1161,6 +1227,127 @@ def configure_agent(
                         error_msg = res["stderr"]
                         break
             return False, error_msg
+
+        # ZeroClaw: extract the bearer token + gateway URL the configure
+        # playbook minted via the pairing handshake. configure.yaml emits
+        # them as cacheable host facts (`zeroclaw_gateway_token` and
+        # `zeroclaw_gateway_url`); we read them out of the fact cache and
+        # surface them via `config_data["gateway"]` so the updater below
+        # persists them to hosts.json under
+        # `agents.<n>.config.gateway.{auth,url}`. Mirrors the OpenClaw fact
+        # extraction in install.py:688-794. Done outside the updater closure
+        # so any read failure surfaces as a configure-time error rather than
+        # corrupting hosts.json silently.
+        zc_gateway_token: str | None = None
+        zc_gateway_url: str | None = None
+        if resolved_type == "zeroclaw":
+            try:
+                artifacts_dir = Path(result.config.artifact_dir)
+                fact_cache_dir = artifacts_dir / "fact_cache"
+                if fact_cache_dir.exists():
+                    for fact_file in fact_cache_dir.glob("*"):
+                        try:
+                            with open(fact_file) as fh:
+                                facts = json.load(fh)
+                        except (json.JSONDecodeError, IOError) as file_err:
+                            logger.debug(
+                                "Skipping fact file %s: %s", fact_file, file_err
+                            )
+                            continue
+                        payload = facts.get("__payload__")
+                        if not isinstance(payload, str) or not payload:
+                            continue
+                        try:
+                            parsed = json.loads(payload)
+                        except json.JSONDecodeError:
+                            continue
+                        if not isinstance(parsed, dict):
+                            continue
+
+                        token_raw = parsed.get("zeroclaw_gateway_token")
+                        url_raw = parsed.get("zeroclaw_gateway_url")
+                        health_warn_raw = parsed.get(
+                            "zeroclaw_provider_health_warning"
+                        )
+
+                        # Tolerate Ansible's occasional `{"value": "..."}`
+                        # wrapping for cacheable string facts.
+                        if isinstance(token_raw, dict):
+                            token_raw = token_raw.get("value")
+                        if isinstance(url_raw, dict):
+                            url_raw = url_raw.get("value")
+                        if isinstance(health_warn_raw, dict):
+                            health_warn_raw = health_warn_raw.get("value")
+                        if isinstance(token_raw, str):
+                            token_raw = token_raw.strip()
+                        if isinstance(url_raw, str):
+                            url_raw = url_raw.strip()
+
+                        # ATX Round 2 W1: when the playbook recorded a
+                        # 401 from /health/providers, surface a one-shot
+                        # warning to the CLI event stream. Without this
+                        # the operator finishes configure with exit 0
+                        # and a silently-misconfigured provider — they
+                        # only learn at the next `clm chat` invocation.
+                        if health_warn_raw is True or health_warn_raw == "true":
+                            # ATX Round 4 B1: same "WARNING:" /
+                            # stage="configure" pattern as the
+                            # short-token re-pair warning above —
+                            # ensures `_print_configure_warnings`
+                            # actually surfaces this to the user
+                            # instead of silently emitting at INFO.
+                            health_warning_msg = (
+                                f"WARNING: /health/providers returned "
+                                f"401 — gateway is reachable but "
+                                f"provider "
+                                f"'{config_data.get('provider', {}).get('type', '?')}' "
+                                f"credentials may be invalid. Verify "
+                                f"the API key and re-run "
+                                f"`clm agent configure {agent_key}` "
+                                f"if needed."
+                            )
+                            emit("configure", health_warning_msg)
+                            logger.warning(health_warning_msg)
+
+                        if (
+                            isinstance(token_raw, str) and token_raw
+                            and isinstance(url_raw, str) and url_raw
+                        ):
+                            zc_gateway_token = token_raw
+                            zc_gateway_url = url_raw
+                            emit("configure", "Pairing token captured")
+                            break
+            except Exception as exc:
+                logger.warning(
+                    "Failed to extract zeroclaw gateway facts: %s",
+                    exc,
+                    exc_info=True,
+                )
+
+            if not zc_gateway_token or not zc_gateway_url:
+                # The playbook succeeded but the token did not surface in
+                # the fact cache. Fail fast — without a bearer token, the
+                # later `clm chat` call has nothing to authenticate with
+                # and would dead-end at the gateway.
+                return (
+                    False,
+                    "Configure playbook succeeded but the pairing token "
+                    "was not captured. Re-run `clm agent configure "
+                    f"{agent_key}` and check daemon logs at "
+                    f"`journalctl --unit zeroclaw-{agent_key}` for the "
+                    "pairing handshake.",
+                )
+
+            # Surface to the updater via config_data so the gateway block
+            # round-trips into hosts.json on the same write that persists
+            # everything else from this configure call.
+            existing_gateway = config_data.get("gateway")
+            if not isinstance(existing_gateway, dict):
+                existing_gateway = {}
+            existing_gateway = dict(existing_gateway)
+            existing_gateway["auth"] = zc_gateway_token
+            existing_gateway["url"] = zc_gateway_url
+            config_data["gateway"] = existing_gateway
 
         # B2: Only update hosts.json after Ansible succeeds
         emit("configure", "Saving configuration to hosts.json...")

--- a/src/clawrium/core/registry.py
+++ b/src/clawrium/core/registry.py
@@ -130,7 +130,7 @@ class WorkspaceConfig(TypedDict):
 class ChatFeatureConfig(TypedDict):
     """Chat capability descriptor."""
 
-    type: Literal["openai", "websocket"]
+    type: Literal["openai", "websocket", "zeroclaw"]
 
 
 class FeaturesConfig(TypedDict):
@@ -502,7 +502,7 @@ def _validate_workspace(workspace_value: object, agent_type: str) -> WorkspaceCo
     return validated
 
 
-_ALLOWED_CHAT_TYPES = ("openai", "websocket")
+_ALLOWED_CHAT_TYPES = ("openai", "websocket", "zeroclaw")
 
 
 def _validate_features(features_value: object, agent_type: str) -> FeaturesConfig:

--- a/src/clawrium/platform/registry/zeroclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/manifest.yaml
@@ -2,6 +2,15 @@ agent:
   type: zeroclaw
   description: "Lightweight AI assistant for edge devices and Raspberry Pi"
 
+# Capability flags advertised by this manifest.
+features:
+  # Chat dispatch routes to `core/chat_zeroclaw.py` (WebSocket client speaking
+  # ZeroClaw's tagged-JSON envelope). Distinct from openclaw's `websocket`
+  # value because the frame schemas differ (different `type` values, different
+  # auth header, different stream semantics).
+  chat:
+    type: zeroclaw
+
 # Secrets required for this agent (installation fails when missing)
 secrets:
   required:

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
@@ -1,6 +1,12 @@
 ---
 - hosts: all
   become: yes
+  vars:
+    # Loopback URLs — the daemon binds 0.0.0.0 but the playbook always talks
+    # to it via 127.0.0.1 so the bearer token never traverses the network
+    # before pairing completes.
+    gateway_port: "{{ config.gateway.port }}"
+    gateway_local_base: "http://127.0.0.1:{{ gateway_port }}"
   tasks:
     - name: Check if agent user exists
       ansible.builtin.getent:
@@ -11,10 +17,21 @@
 
     - name: Fail if agent not installed
       ansible.builtin.fail:
-        msg: "Agent user '{{ agent_name }}' not found. Run 'clm agent install' first."
+        msg: "Agent user '{{ agent_name }}' not found. Run 'clm agent install --type zeroclaw ...' first."
       when: user_check.msg is defined
 
-    - name: Ensure config directory exists
+    - name: Validate provider configuration is present
+      ansible.builtin.fail:
+        msg: >-
+          ZeroClaw configure requires config.provider.type to be one of
+          anthropic|openai|ollama|openrouter. Re-run via
+          `clm agent configure {{ agent_name }} --stage providers`.
+      when:
+        - config.provider is not defined
+          or config.provider.type is not defined
+          or config.provider.type not in ['anthropic','openai','ollama','openrouter']
+
+    - name: Ensure ~/.zeroclaw config directory exists
       ansible.builtin.file:
         path: "/home/{{ agent_name }}/.zeroclaw"
         state: directory
@@ -22,29 +39,220 @@
         group: "{{ agent_name }}"
         mode: "0700"
 
-    - name: Write zeroclaw config from template
+    # Render ~/.zeroclaw/config.toml. no_log because provider_api_key is
+    # embedded verbatim. 0600 with agent ownership so only the service user
+    # (and root) can read. Ansible's default `force: yes` (not set here)
+    # only restarts the daemon when content changes — ATX S1 fix.
+    - name: Render ~/.zeroclaw/config.toml from template
       ansible.builtin.template:
         src: "{{ template_path }}/config.toml.j2"
         dest: "/home/{{ agent_name }}/.zeroclaw/config.toml"
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
         mode: "0600"
-      # The rendered config.toml embeds integration secrets (github_token,
-      # jira_api_token, confluence_api_token, etc.); suppress Ansible's default
-      # diff/callback so the rendered file body does not surface in logs.
       no_log: true
       notify: Restart zeroclaw service
 
-    - name: Ensure service is enabled
+    - name: Enable zeroclaw service
       ansible.builtin.systemd:
         name: "{{ agent_type }}-{{ agent_name }}"
         enabled: yes
         daemon_reload: yes
 
+    # Apply pending restart (from the template task) before the readiness
+    # probe so /health is observing the just-rendered config, not the
+    # previous incarnation.
+    - name: Apply pending restart before probing
+      ansible.builtin.meta: flush_handlers
+
+    - name: Start zeroclaw service
+      ansible.builtin.systemd:
+        name: "{{ agent_type }}-{{ agent_name }}"
+        state: started
+
+    # Fail fast if the daemon crashed on startup — better than waiting out
+    # 30×2s of /health retries (ATX W4). ActiveState may be `activating`
+    # momentarily; accept that as in-progress and let the health probe
+    # finish the wait.
+    - name: Verify zeroclaw service did not crash on startup
+      ansible.builtin.command:
+        cmd: "systemctl show -p ActiveState --value {{ agent_type }}-{{ agent_name }}"
+      register: service_state
+      changed_when: false
+      failed_when: service_state.stdout.strip() in ['failed', 'inactive']
+
+    # Wait for the daemon to come up. /health/providers is the canonical
+    # readiness signal — it 200s only after the provider config has been
+    # parsed and the gateway is listening. Accept 401 too because the
+    # endpoint may require pairing-auth before serving — the existence of
+    # a response means the gateway is up.
+    - name: Probe /health/providers
+      ansible.builtin.uri:
+        url: "{{ gateway_local_base }}/health/providers"
+        method: GET
+        status_code: [200, 401]
+        timeout: 5
+      register: health_probe
+      retries: 30
+      delay: 2
+      until: health_probe.status in [200, 401]
+      # ATX Round 3 S1: bring the health probe in line with the rest of
+      # the playbook's `no_log: true` hygiene. The probe body itself is
+      # non-secret but the registered `health_probe` is later used in
+      # `set_fact` branches gated on `status` — suppress to keep the
+      # log surface tight at high verbosity.
+      no_log: true
+
+    # ATX Round 1 W3 + Round 2 W1 + Round 3 W1: surface a non-fatal
+    # warning when /health/providers returns 401. The gateway is up but
+    # the provider credentials probably mismatch the API key supplied in
+    # config.toml — chat calls will fail at request time.
+    #
+    # The fact (not just the debug task) is what configure_agent reads —
+    # `ansible_runner.run(quiet=True)` does not surface `runner_on_debug`
+    # events, so a pure `debug:` task would be silently swallowed at the
+    # CLI layer. Recording it as a cacheable fact ensures the warning
+    # propagates through the same fact-cache path the bearer token uses.
+    #
+    # Round 3 W1: assign the literal boolean unconditionally so a healthy
+    # run (status 200) clears any stale `true` left over from a prior
+    # 401 — `cacheable: true` would otherwise keep the previous value
+    # persisted in Ansible's fact cache and emit a phantom warning on
+    # every subsequent configure.
+    - name: Record provider-health warning state
+      ansible.builtin.set_fact:
+        zeroclaw_provider_health_warning: "{{ health_probe.status == 401 }}"
+        cacheable: true
+
+    - name: Warn when /health/providers returned 401
+      ansible.builtin.debug:
+        msg: >-
+          /health/providers returned 401 — gateway is reachable but
+          provider credentials may be invalid. Verify the API key for
+          provider '{{ config.provider.type }}' and re-run
+          `clm agent configure {{ agent_name }}` if needed.
+      when: health_probe.status == 401
+
+    # ATX B3: skip the pairing handshake when configure_agent already
+    # passed an existing bearer token from hosts.json. The persisted
+    # token remains valid across configure runs unless --force-repair is
+    # supplied, so re-running configure does NOT invalidate live chat
+    # sessions. The token is echoed back as a cacheable fact so
+    # configure_agent's fact-extraction path always finds it (skip and
+    # mint paths emit the same fact).
+    #
+    # `existing_gateway_token` and `force_repair` are top-level Ansible
+    # vars passed in by configure_agent via extra_vars (see
+    # core/lifecycle.py `_zeroclaw_extra_vars`). They are `default('')` /
+    # `default(false)` so a fresh configure (no persisted token) takes
+    # the mint path automatically.
+    - name: Determine whether re-pairing is required
+      ansible.builtin.set_fact:
+        zeroclaw_needs_pairing: >-
+          {{ (force_repair | default(false) | bool)
+             or (existing_gateway_token | default('') | length < 16) }}
+
+    # Pairing handshake (mint path) — two-step:
+    #   1. GET /pair/code     -> daemon emits a one-shot pairing code
+    #   2. POST /pair {code:} -> daemon mints a bearer token bound to that code
+    # Both calls are loopback so the code/token never traverses the LAN.
+    # `no_log: true` on every step so the credentials never reach Ansible
+    # logs even at -vvv (ATX B4 + W8).
+    - name: Request pairing code
+      ansible.builtin.uri:
+        url: "{{ gateway_local_base }}/pair/code"
+        method: GET
+        status_code: 200
+        timeout: 10
+        return_content: yes
+      register: pair_code_response
+      no_log: true
+      when: zeroclaw_needs_pairing
+
+    # ATX B4: validation fails must not echo `pair_code_response.json.keys()`
+    # into logs (registered var from a `no_log: true` task). Keep the
+    # diagnostic generic. Operators can re-run at higher verbosity if needed.
+    - name: Validate pairing code shape
+      ansible.builtin.fail:
+        msg: >-
+          /pair/code did not return a usable code field. Re-run
+          `clm agent configure {{ agent_name }} --force-repair` and
+          check daemon logs at
+          `journalctl --unit {{ agent_type }}-{{ agent_name }}`.
+      when:
+        - zeroclaw_needs_pairing
+        - pair_code_response.json is not defined
+          or pair_code_response.json.code is not defined
+          or pair_code_response.json.code | length < 1
+      no_log: true
+
+    - name: Exchange pairing code for bearer token
+      ansible.builtin.uri:
+        url: "{{ gateway_local_base }}/pair"
+        method: POST
+        status_code: 200
+        timeout: 10
+        body_format: json
+        body:
+          code: "{{ pair_code_response.json.code }}"
+        return_content: yes
+      register: pair_response
+      no_log: true
+      when: zeroclaw_needs_pairing
+
+    - name: Validate bearer token shape
+      ansible.builtin.fail:
+        msg: >-
+          /pair did not return a usable token. Re-run
+          `clm agent configure {{ agent_name }} --force-repair`; check
+          daemon logs at
+          `journalctl --unit {{ agent_type }}-{{ agent_name }}`.
+      when:
+        - zeroclaw_needs_pairing
+        - pair_response.json is not defined
+          or pair_response.json.token is not defined
+          or pair_response.json.token | length < 16
+      no_log: true
+
+    # Resolve the final bearer-token value: freshly minted on the mint
+    # path, echoed-back from hosts.json on the skip path. Surfaced via a
+    # single set_fact below so the fact-emission task is identical for
+    # both branches.
+    - name: Resolve effective gateway bearer token
+      ansible.builtin.set_fact:
+        effective_gateway_token: >-
+          {{ pair_response.json.token if zeroclaw_needs_pairing
+             else existing_gateway_token }}
+      no_log: true
+
+    # Emit gateway token + URL as cacheable host facts. configure_agent()
+    # reads them out of artifacts/<run>/fact_cache and persists them to
+    # hosts.json under agents.<n>.config.gateway.{auth,url}. Mirrors the
+    # OpenClaw fact-emission pattern in install.py:307-316. `no_log: true`
+    # so the value isn't echoed at -vvv (ATX W8).
+    - name: Save gateway credentials as cacheable facts
+      ansible.builtin.set_fact:
+        zeroclaw_gateway_token: "{{ effective_gateway_token }}"
+        zeroclaw_gateway_url: "ws://{{ ansible_host }}:{{ gateway_port }}/ws/chat"
+        cacheable: true
+      no_log: true
+
+    - name: Display configure success
+      ansible.builtin.debug:
+        msg: |
+          ZeroClaw agent '{{ agent_name }}' configured with provider
+          '{{ config.provider.type }}'.
+          Pairing: {{ 'fresh token minted' if zeroclaw_needs_pairing
+                      else 'existing token reused (use --force-repair to rotate)' }}.
+          Service: {{ agent_type }}-{{ agent_name }}.service (active)
+
   handlers:
+    # Single canonical restart handler. daemon_reload covers config-file
+    # changes that don't touch the unit, and the same restart fires once per
+    # configure regardless of how many notify directives match.
     - name: Restart zeroclaw service
       ansible.builtin.systemd:
         name: "{{ agent_type }}-{{ agent_name }}"
         state: restarted
+        enabled: yes
         daemon_reload: yes
-      ignore_errors: yes

--- a/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
+++ b/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
@@ -1,65 +1,71 @@
+{# Managed by clawrium (clm). Do not edit by hand — re-render with
+   `clm agent configure {{ agent_name | default('<name>') }}`.
+
+   v0.7.5 schema:
+   - [gateway] binds 0.0.0.0 with require_pairing = true so cross-LAN
+     `clm chat` works and the bearer token captured in configure is the
+     auth boundary. See .itx/357/01_EXECUTION.md "Security Considerations".
+   - [providers.models.<name>] sub-table per provider with a `kind`
+     discriminator. Only the four providers in scope for #112 are emitted:
+     anthropic, openai, ollama, openrouter.
+   - Integrations block intentionally removed per #112 plan; reintroduced
+     under a follow-up issue.
+#}
+{# TOML-safe basic-string escaping. Must cover four character classes that
+   could escape a "…" basic string and inject arbitrary keys:
+     - backslash and double-quote (the basic-string terminators)
+     - CR / LF (split the string across lines, anything past `\n` is parsed
+       as a new TOML statement — classic injection vector)
+     - tab (less dangerous on its own, but TOML treats raw tabs in basic
+       strings inconsistently across parsers)
+   Order matters: backslash must escape first so the literal-`\` produced
+   by every subsequent replacement is itself doubled. ATX Round 1 B1. #}
+{%- macro toml_escape(value) -%}
+{{ value | string
+   | replace('\\', '\\\\')
+   | replace('"', '\\"')
+   | replace('\r', '\\r')
+   | replace('\n', '\\n')
+   | replace('\t', '\\t') }}
+{%- endmacro -%}
+{% set provider = config.provider | default({}) %}
+{% set provider_type = provider.type | default('') %}
+{% set model_id = provider.default_model | default('') %}
+{% set endpoint = provider.endpoint | default('') %}
 [gateway]
-host = "{{ config.gateway.host }}"
-port = {{ config.gateway.port }}
+{# Every variable interpolated into a "…" basic string passes through
+   toml_escape so a hand-edited host (or future provider_type/model_id
+   that picks up user input) cannot break out of the string. ATX
+   Round 1 B2. #}
+host = "{{ toml_escape(config.gateway.host) }}"
+port = {{ config.gateway.port | int }}
 allow_public_bind = {{ config.gateway.allow_public_bind | bool | lower }}
+require_pairing = {{ (config.gateway.require_pairing | default(true)) | bool | lower }}
 
-{% if config.provider is defined and config.provider %}
-{% if config.provider.type == "ollama" %}
-default_provider = "custom:{{ config.provider.endpoint }}"
-{% elif config.provider.type == "anthropic" %}
-default_provider = "anthropic"
-{% elif config.provider.type == "openai" %}
-default_provider = "openai"
-{% elif config.provider.type == "openrouter" %}
-default_provider = "openrouter"
-{% endif %}
-{% if config.provider.default_model %}
-default_model = "{{ config.provider.default_model }}"
-{% endif %}
-{% if lookup('env', 'CLAWRIUM_PROVIDER_API_KEY') %}
-api_key = "{{ lookup('env', 'CLAWRIUM_PROVIDER_API_KEY') | replace('\\', '\\\\') | replace('"', '\\"') }}"
-{% endif %}
+{% if provider_type in ['anthropic', 'openai', 'ollama', 'openrouter'] %}
+default_provider = "{{ toml_escape(provider_type) }}"
+{% if model_id %}
+default_model = "{{ toml_escape(model_id) }}"
 {% endif %}
 
-{% if integrations is defined and integrations %}
-[integrations]
-{# Integrations are keyed by name with type and credentials #}
-{# Multiple integrations of same type are supported #}
-{% for name, integration in integrations.items() %}
-{% if integration.type == 'github' and integration.GITHUB_TOKEN is defined %}
-github_token = "{{ integration.GITHUB_TOKEN | replace('\\', '\\\\') | replace('"', '\\"') }}"
+{# Section header is a bare TOML key; restrict to the allow-list above so
+   no caller-supplied content reaches the header (which has its own
+   escaping rules different from basic strings). The `in [...]` guard
+   above already enforces this. #}
+[providers.models.{{ provider_type }}]
+kind = "{{ toml_escape(provider_type) }}"
+{% if model_id %}
+model = "{{ toml_escape(model_id) }}"
 {% endif %}
-{% if integration.type == 'gitlab' %}
-{% if integration.GITLAB_TOKEN is defined %}
-gitlab_token = "{{ integration.GITLAB_TOKEN | replace('\\', '\\\\') | replace('"', '\\"') }}"
+{% if provider_type == 'ollama' %}
+{# Ollama / OpenAI-compatible local endpoint: base_url, no api_key. #}
+{% if endpoint %}
+base_url = "{{ toml_escape(endpoint) }}"
 {% endif %}
-{% if integration.GITLAB_URL is defined %}
-gitlab_url = "{{ integration.GITLAB_URL }}"
-{% endif %}
-{% endif %}
-{% if integration.type == 'atlassian' %}
-{# Unified Atlassian credentials drive both jira_* and confluence_* TOML keys.
-   CONFLUENCE_URL is derived as ATLASSIAN_URL + '/wiki' (Cloud convention only;
-   Data Center / Server use a different URL layout, out of scope). #}
-{% if integration.ATLASSIAN_URL is defined %}
-{% set atlassian_url = integration.ATLASSIAN_URL.rstrip('/') %}
-jira_url = "{{ atlassian_url }}"
-confluence_url = "{{ atlassian_url }}/wiki"
-{% endif %}
-{% if integration.ATLASSIAN_EMAIL is defined %}
-jira_email = "{{ integration.ATLASSIAN_EMAIL }}"
-confluence_email = "{{ integration.ATLASSIAN_EMAIL }}"
-{% endif %}
-{% if integration.ATLASSIAN_API_TOKEN is defined %}
-jira_api_token = "{{ integration.ATLASSIAN_API_TOKEN | replace('\\', '\\\\') | replace('"', '\\"') }}"
-confluence_api_token = "{{ integration.ATLASSIAN_API_TOKEN | replace('\\', '\\\\') | replace('"', '\\"') }}"
+{% else %}
+{# anthropic / openai / openrouter: api_key from the playbook var. #}
+{% if provider_api_key | default('') %}
+api_key = "{{ toml_escape(provider_api_key) }}"
 {% endif %}
 {% endif %}
-{% if integration.type == 'linear' and integration.LINEAR_API_KEY is defined %}
-linear_api_key = "{{ integration.LINEAR_API_KEY | replace('\\', '\\\\') | replace('"', '\\"') }}"
-{% endif %}
-{% if integration.type == 'notion' and integration.NOTION_API_KEY is defined %}
-notion_api_key = "{{ integration.NOTION_API_KEY | replace('\\', '\\\\') | replace('"', '\\"') }}"
-{% endif %}
-{% endfor %}
 {% endif %}

--- a/tests/test_chat_zeroclaw.py
+++ b/tests/test_chat_zeroclaw.py
@@ -1,0 +1,825 @@
+"""Tests for the ZeroClaw chat backend (`core/chat_zeroclaw.py`).
+
+Coverage required by issue #357 (Subtask B, B7):
+- connect_success / connect_failure / auth_error
+- streaming chunk frames feed on_delta and accumulate
+- done frame terminates the turn (prefers full_response)
+- error frame raises ChatProtocolError
+- aborted frame raises ChatProtocolError (silently ignoring would hang)
+- chunk_reset clears the accumulator mid-turn
+- approval_request surfaces (raises until inline UX exists)
+- protocol_conformance: unknown frame types are dropped, not errored
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from websockets.exceptions import WebSocketException
+
+from clawrium.core.chat import (
+    ChatAuthenticationError,
+    ChatConnectionError,
+    ChatProtocolError,
+    SecretStr,
+)
+from clawrium.core.chat_zeroclaw import ZeroClawChatBackend
+
+
+class FakeWebSocket:
+    """Deterministic fake WebSocket for ZeroClaw frame tests."""
+
+    def __init__(self, frames: list[object]):
+        self._frames = list(frames)
+        self.sent: list[dict] = []
+        self.closed = False
+
+    async def recv(self) -> object:
+        if not self._frames:
+            raise RuntimeError("No more frames queued")
+        frame = self._frames.pop(0)
+        if isinstance(frame, Exception):
+            raise frame
+        if isinstance(frame, (str, bytes)):
+            return frame
+        return json.dumps(frame)
+
+    async def send(self, data: str) -> None:
+        self.sent.append(json.loads(data))
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _make_backend(monkeypatch, frames):
+    fake_ws = FakeWebSocket(frames)
+
+    async def fake_connect(*_args, **_kwargs):
+        return fake_ws
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.websockets.connect", fake_connect
+    )
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://test-host:4080/ws/chat",
+        auth_token=SecretStr("paired-bearer-token"),
+        timeout_seconds=5.0,
+    )
+    return backend, fake_ws
+
+
+# ---------------------------------------------------------------------------
+# Connect tests
+# ---------------------------------------------------------------------------
+
+
+def test_connect_success(monkeypatch):
+    """Connect opens the WS and forwards the bearer token in the Auth header."""
+    captured: dict[str, object] = {}
+
+    async def fake_connect(url, additional_headers=None, **_kwargs):
+        captured["url"] = url
+        captured["headers"] = additional_headers
+        return FakeWebSocket([])
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.websockets.connect", fake_connect
+    )
+
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://test-host:4080/ws/chat",
+        auth_token=SecretStr("paired-bearer-token"),
+    )
+    asyncio.run(backend.connect())
+
+    assert captured["url"] == "ws://test-host:4080/ws/chat"
+    # Auth header carries the bearer scheme. List-of-tuples form is what
+    # the websockets library accepts; assert the token is present and the
+    # scheme word stays in place so a future refactor doesn't strip it.
+    headers = dict(captured["headers"])
+    assert headers["Authorization"] == "Bearer paired-bearer-token"
+
+
+def test_connect_failure(monkeypatch):
+    """OSError during the WS handshake surfaces as ChatConnectionError."""
+
+    async def fake_connect(*_args, **_kwargs):
+        raise OSError("Connection refused")
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.websockets.connect", fake_connect
+    )
+
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://nowhere:4080/ws/chat",
+        auth_token=SecretStr("bearer"),
+    )
+    with pytest.raises(ChatConnectionError):
+        asyncio.run(backend.connect())
+
+
+def test_auth_error(monkeypatch):
+    """A 401 from the gateway surfaces as ChatAuthenticationError so the
+    CLI can route the user to `clm agent configure`."""
+    from websockets.exceptions import InvalidStatus
+
+    class _FakeResponse:
+        status_code = 401
+        headers: dict = {}
+        body = b""
+
+    async def fake_connect(*_args, **_kwargs):
+        raise InvalidStatus(_FakeResponse())
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.websockets.connect", fake_connect
+    )
+
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://test-host:4080/ws/chat",
+        auth_token=SecretStr("wrong-token"),
+    )
+    with pytest.raises(ChatAuthenticationError):
+        asyncio.run(backend.connect())
+
+
+def test_connect_rejects_empty_bearer():
+    """An empty bearer must fail before opening the socket — the gateway
+    would 401 anyway, but failing early surfaces a clearer error message."""
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://test-host:4080/ws/chat",
+        auth_token=SecretStr(""),
+    )
+    with pytest.raises(ChatAuthenticationError):
+        asyncio.run(backend.connect())
+
+
+# ---------------------------------------------------------------------------
+# Frame parsing tests
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_chunk_frames(monkeypatch):
+    """chunk frames feed on_delta in order and accumulate for the return."""
+    frames = [
+        {"type": "session_start"},
+        {"type": "chunk", "content": "Hello"},
+        {"type": "chunk", "content": ", "},
+        {"type": "chunk", "content": "world!"},
+        {"type": "done"},  # no full_response — fall back to accumulator
+    ]
+    backend, fake_ws = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    deltas: list[str] = []
+    result = asyncio.run(
+        backend.send_message("hi", on_delta=lambda d: deltas.append(d))
+    )
+
+    assert deltas == ["Hello", ", ", "world!"]
+    assert result == "Hello, world!"
+    assert fake_ws.sent == [{"type": "message", "content": "hi"}]
+
+
+def test_done_frame_terminates(monkeypatch):
+    """done with full_response is used as the return value even when
+    chunks were streamed (mirrors the server having authoritative text)."""
+    frames = [
+        {"type": "chunk", "content": "Hel"},
+        {"type": "chunk", "content": "lo"},
+        {
+            "type": "done",
+            "full_response": "Hello, world! (authoritative)",
+            "tokens_in": 5,
+            "tokens_out": 10,
+        },
+    ]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    result = asyncio.run(backend.send_message("hi"))
+    assert result == "Hello, world! (authoritative)"
+
+
+def test_error_frame_raises(monkeypatch):
+    """error frames raise ChatProtocolError with the server message."""
+    frames = [
+        {"type": "chunk", "content": "Partial..."},
+        {"type": "error", "message": "Provider rate limited"},
+    ]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    with pytest.raises(ChatProtocolError, match="rate limited"):
+        asyncio.run(backend.send_message("hi"))
+
+
+def test_aborted_frame_raises_ChatProtocolError(monkeypatch):
+    """aborted MUST raise — silently ignoring it would cause the REPL to
+    hang waiting for a `done` that never arrives."""
+    frames = [
+        {"type": "chunk", "content": "Partial..."},
+        {"type": "aborted", "reason": "user cancelled"},
+    ]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    with pytest.raises(ChatProtocolError, match="aborted"):
+        asyncio.run(backend.send_message("hi"))
+
+
+def test_chunk_reset_clears_accumulator(monkeypatch):
+    """chunk_reset drops everything streamed before it. The final return
+    must reflect post-reset content only.
+
+    `on_delta` callers can't un-print, but the accumulator is the source
+    of truth for the return value when `done` lacks full_response. A
+    correct return is what gets persisted in REPL state / piped to
+    follow-on tooling, so it must be the post-reset text."""
+    frames = [
+        {"type": "chunk", "content": "throwaway-A "},
+        {"type": "chunk", "content": "throwaway-B"},
+        {"type": "chunk_reset"},
+        {"type": "chunk", "content": "kept-1 "},
+        {"type": "chunk", "content": "kept-2"},
+        {"type": "done"},
+    ]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    deltas: list[str] = []
+    result = asyncio.run(
+        backend.send_message("hi", on_delta=lambda d: deltas.append(d))
+    )
+
+    # on_delta was called for the pre-reset chunks too (we can't un-print).
+    assert "throwaway-A " in deltas
+    # But the accumulator-based return value must NOT include them.
+    assert result == "kept-1 kept-2"
+
+
+def test_approval_request_surfaces_or_raises(monkeypatch):
+    """approval_request raises ChatProtocolError until inline approval UX
+    exists. The decision is documented in .itx/357/01_EXECUTION.md."""
+    frames = [
+        {"type": "chunk", "content": "Looking at the codebase..."},
+        {
+            "type": "approval_request",
+            "request_id": "req-1",
+            "tool": "shell",
+            "command": "rm -rf /",
+        },
+    ]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    with pytest.raises(ChatProtocolError, match="approval"):
+        asyncio.run(backend.send_message("hi"))
+
+
+def test_approval_request_closes_socket_before_raising(monkeypatch):
+    """ATX Round 1 W2 / Round 3 W11: approval_request must close the
+    WebSocket before raising so the REPL can't loop into a half-broken
+    connection.
+
+    Without the close, the server is blocked awaiting an
+    `approval_response` frame and the next user message either hits a
+    repeated approval_request (infinite loop) or a silent hang."""
+    frames = [
+        {
+            "type": "approval_request",
+            "request_id": "req-1",
+            "tool": "shell",
+        },
+    ]
+    backend, fake_ws = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    with pytest.raises(ChatProtocolError):
+        asyncio.run(backend.send_message("hi"))
+
+    # close() must have fired before the raise so the REPL's `except
+    # ChatProtocolError` branch doesn't keep using a stuck socket.
+    assert fake_ws.closed is True
+    # ATX Round 3 W11: ALSO assert is_connected — the REPL break
+    # contract reads `getattr(backend, 'is_connected', True)`, not
+    # the underlying WS attribute. A refactor that keeps `_ws` set
+    # while flagging `closed=True` would silently break the REPL.
+    assert backend.is_connected is False
+
+
+def test_approval_request_sanitizes_prompt_field(monkeypatch):
+    """ATX Round 1 B6: the `prompt` field on approval_request must pass
+    through bidi/control-char sanitization before reaching the error
+    message. A malicious server could otherwise smuggle bidi marks
+    into the terminal via the surfaced exception."""
+    # RLO embedded in a "harmless" prompt.
+    poisoned_prompt = "run this command‮; rm -rf / ;"
+    frames = [
+        {
+            "type": "approval_request",
+            "request_id": "req-1",
+            "tool": "shell",
+            "prompt": poisoned_prompt,
+        },
+    ]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    with pytest.raises(ChatProtocolError) as excinfo:
+        asyncio.run(backend.send_message("hi"))
+
+    # The bidi codepoint must NOT appear in the exception text.
+    assert "‮" not in str(excinfo.value)
+    # But the prompt content (post-sanitization) does, so the user can
+    # still identify which approval was triggered.
+    assert "rm -rf" in str(excinfo.value)
+
+
+def test_cleartext_warning_emitted_for_non_loopback_ws(monkeypatch, caplog):
+    """ATX Round 1 W9: a non-TLS WebSocket to a non-loopback host emits
+    a warning (the bearer token would traverse the LAN cleartext)."""
+    import logging
+
+    async def fake_connect(*_args, **_kwargs):
+        return FakeWebSocket([])
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.websockets.connect", fake_connect
+    )
+
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://pi-edge.lan:4080/ws/chat",
+        auth_token=SecretStr("paired"),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="clawrium.core.chat_zeroclaw"):
+        asyncio.run(backend.connect())
+
+    assert any("cleartext" in rec.message for rec in caplog.records)
+
+
+def test_cleartext_warning_suppressed_for_loopback(monkeypatch, caplog):
+    """ATX Round 1 W9: loopback hosts must NOT trigger the cleartext
+    warning — the LAN-exposure threat doesn't apply on 127.0.0.1."""
+    import logging
+
+    async def fake_connect(*_args, **_kwargs):
+        return FakeWebSocket([])
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.websockets.connect", fake_connect
+    )
+
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://127.0.0.1:4080/ws/chat",
+        auth_token=SecretStr("paired"),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="clawrium.core.chat_zeroclaw"):
+        asyncio.run(backend.connect())
+
+    assert not any("cleartext" in rec.message for rec in caplog.records)
+
+
+def test_protocol_conformance(monkeypatch):
+    """Unknown frame types are dropped (forward-compat) rather than
+    raising. ZeroClaw may add frame types between releases; the REPL
+    should not crash on a tag it doesn't recognize."""
+    frames = [
+        {"type": "unknown-future-event", "payload": "ignored"},
+        {"type": "chunk", "content": "Hello"},
+        {"type": "another-future", "data": {"x": 1}},
+        {"type": "done"},
+    ]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    result = asyncio.run(backend.send_message("hi"))
+    assert result == "Hello"
+
+
+def test_thinking_frame_does_not_pollute_accumulator(monkeypatch):
+    """thinking frames are advisory — they reach on_delta but must NOT
+    feed the assistant-text accumulator (the return value should be the
+    reply, not the chain-of-thought)."""
+    frames = [
+        {"type": "thinking", "content": "Let me consider..."},
+        {"type": "chunk", "content": "The answer is 42."},
+        {"type": "done"},
+    ]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    deltas: list[str] = []
+    result = asyncio.run(
+        backend.send_message("hi", on_delta=lambda d: deltas.append(d))
+    )
+
+    # Thinking surfaced to the user with a discoverable prefix.
+    assert any("thinking" in d.lower() for d in deltas)
+    # Return value is the chunk text only, not the thinking text.
+    assert result == "The answer is 42."
+
+
+def test_sanitizes_bidi_in_chunk_content(monkeypatch):
+    """A `chunk` carrying bidi/zero-width characters must be stripped
+    before reaching on_delta — same coverage as chat_hermes' sanitizer.
+    Closes the "malicious server smuggles RLO/LRM into the terminal"
+    threat."""
+    # U+202E (RLO) + U+200B (ZWSP) embedded in legitimate text.
+    poisoned = "safe‮DANGER​text"
+    frames = [
+        {"type": "chunk", "content": poisoned},
+        {"type": "done"},
+    ]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    deltas: list[str] = []
+    result = asyncio.run(
+        backend.send_message("hi", on_delta=lambda d: deltas.append(d))
+    )
+
+    # Both bidi codepoints are stripped.
+    assert "‮" not in deltas[0]
+    assert "​" not in deltas[0]
+    # The non-control characters survive.
+    assert "safe" in result and "DANGER" in result and "text" in result
+
+
+def test_send_message_not_connected_raises():
+    """Calling send_message before connect() raises a clear error."""
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://test-host:4080/ws/chat",
+        auth_token=SecretStr("paired"),
+    )
+    with pytest.raises(ChatConnectionError):
+        asyncio.run(backend.send_message("hi"))
+
+
+def test_malformed_json_frame_raises_protocol_error(monkeypatch):
+    """A non-JSON frame from the gateway raises ChatProtocolError so the
+    REPL can show a clean error rather than a JSONDecodeError stack."""
+    frames = ["not valid json {"]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    with pytest.raises(ChatProtocolError):
+        asyncio.run(backend.send_message("hi"))
+
+
+def test_non_dict_frame_raises_protocol_error(monkeypatch):
+    """A JSON-array frame (legal JSON but not the expected envelope)
+    raises ChatProtocolError. Guards against a malformed server."""
+    frames = ['["chunk", "content"]']
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    with pytest.raises(ChatProtocolError):
+        asyncio.run(backend.send_message("hi"))
+
+
+def test_connection_lost_during_send_raises(monkeypatch):
+    """WS connection drop during send_message raises ChatConnectionError."""
+    frames = [WebSocketException("connection lost")]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    with pytest.raises(ChatConnectionError):
+        asyncio.run(backend.send_message("hi"))
+
+
+def test_close_is_idempotent(monkeypatch):
+    """Multiple close() calls must not raise."""
+    backend, fake_ws = _make_backend(monkeypatch, [])
+    asyncio.run(backend.connect())
+    asyncio.run(backend.close())
+    asyncio.run(backend.close())
+    assert fake_ws.closed is True
+
+
+def test_is_connected_reflects_socket_state(monkeypatch):
+    """ATX Round 2 W2: `is_connected` is the contract the REPL uses to
+    decide between continuing the chat session and breaking. It must
+    track the WebSocket's actual state."""
+    backend, _ = _make_backend(monkeypatch, [])
+    assert backend.is_connected is False
+    asyncio.run(backend.connect())
+    assert backend.is_connected is True
+    asyncio.run(backend.close())
+    assert backend.is_connected is False
+
+
+def test_connect_asyncio_timeout_raises_ChatConnectionError(monkeypatch):
+    """ATX Round 2 W3 (pins B5): explicitly raise asyncio.TimeoutError
+    (the class distinct from builtins.TimeoutError on Python 3.10) and
+    verify the connect path catches it. Without this test, removing
+    `asyncio.TimeoutError` from the catch tuple would pass all other
+    tests on Python 3.11+ (where the two classes are aliased) but
+    crash production on 3.10."""
+
+    async def fake_connect(*_args, **_kwargs):
+        raise asyncio.TimeoutError("simulated open_timeout")
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.websockets.connect", fake_connect
+    )
+
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://test-host:4080/ws/chat",
+        auth_token=SecretStr("bearer"),
+    )
+    with pytest.raises(ChatConnectionError):
+        asyncio.run(backend.connect())
+
+
+def test_recv_asyncio_timeout_raises_ChatConnectionError(monkeypatch):
+    """ATX Round 2 W3 (pins B5) for the recv path. asyncio.wait_for()
+    raises asyncio.TimeoutError, not builtins.TimeoutError, on 3.10."""
+    backend, _ = _make_backend(monkeypatch, [])
+    asyncio.run(backend.connect())
+
+    async def fake_recv():
+        raise asyncio.TimeoutError("simulated recv timeout")
+
+    # Replace the WS recv with one that raises asyncio.TimeoutError so
+    # _recv_json's `except (TimeoutError, asyncio.TimeoutError)` is the
+    # only thing standing between the test and an unhandled exception.
+    backend._ws.recv = fake_recv  # type: ignore[attr-defined]
+
+    # The send_message path goes through _send_json (which succeeds —
+    # the fake WebSocket buffers the send) and then awaits _recv_json,
+    # which will raise the timeout above.
+    with pytest.raises(ChatConnectionError, match="Timed out"):
+        asyncio.run(backend.send_message("hi"))
+
+
+def test_non_auth_http_error_raises_ChatConnectionError(monkeypatch):
+    """ATX Round 2 S6: 503/500-class InvalidStatus must surface as
+    ChatConnectionError, NOT ChatAuthenticationError. Only 401/403
+    means "auth is wrong"; other HTTP errors mean the gateway is up
+    but unhappy."""
+    from websockets.exceptions import InvalidStatus
+
+    class _FakeResponse:
+        status_code = 503
+        headers: dict = {}
+        body = b""
+
+    async def fake_connect(*_args, **_kwargs):
+        raise InvalidStatus(_FakeResponse())
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.websockets.connect", fake_connect
+    )
+
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://test-host:4080/ws/chat",
+        auth_token=SecretStr("paired"),
+    )
+    with pytest.raises(ChatConnectionError, match="503"):
+        asyncio.run(backend.connect())
+
+
+def test_cleartext_warning_suppressed_for_localhost_string(monkeypatch, caplog):
+    """ATX Round 3 W7: `localhost` (the string literal) is a loopback
+    form even though it isn't a valid `ipaddress.ip_address()` argument.
+    Pre-fix, a naive `ipaddress` check would raise ValueError and the
+    warning helper would either crash or fall through to emit a false
+    cleartext warning."""
+    import logging
+
+    async def fake_connect(*_args, **_kwargs):
+        return FakeWebSocket([])
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.websockets.connect", fake_connect
+    )
+
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://localhost:4080/ws/chat",
+        auth_token=SecretStr("paired"),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="clawrium.core.chat_zeroclaw"):
+        asyncio.run(backend.connect())
+
+    assert not any("cleartext" in rec.message for rec in caplog.records)
+
+
+def test_cleartext_warning_suppressed_for_ipv6_loopback(monkeypatch, caplog):
+    """ATX Round 3 W7: `::1` is the IPv6 loopback and must be recognized."""
+    import logging
+
+    async def fake_connect(*_args, **_kwargs):
+        return FakeWebSocket([])
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.websockets.connect", fake_connect
+    )
+
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://[::1]:4080/ws/chat",
+        auth_token=SecretStr("paired"),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="clawrium.core.chat_zeroclaw"):
+        asyncio.run(backend.connect())
+
+    assert not any("cleartext" in rec.message for rec in caplog.records)
+
+
+def test_cleartext_warning_suppressed_for_etc_hosts_loopback(
+    monkeypatch, caplog
+):
+    """ATX Round 4 W-C / Round 5 W-3: a hostname that resolves to a
+    loopback address (e.g. `mydev.local` in /etc/hosts) must skip the
+    cleartext warning. The negative assertion (no warning emitted) is
+    fragile on its own — code that short-circuits before the resolver
+    call would satisfy it vacuously. Pin the contract by also asserting
+    `getaddrinfo` was actually invoked with the expected host."""
+    import logging
+    import socket
+
+    async def fake_connect(*_args, **_kwargs):
+        return FakeWebSocket([])
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.websockets.connect", fake_connect
+    )
+
+    resolver_calls: list[str] = []
+
+    def fake_getaddrinfo(host, *_args, **_kwargs):
+        resolver_calls.append(host)
+        # Resolve mydev.local -> 127.0.0.1 (mirrors /etc/hosts behavior).
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0)),
+        ]
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.socket.getaddrinfo", fake_getaddrinfo
+    )
+
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://mydev.local:4080/ws/chat",
+        auth_token=SecretStr("paired"),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="clawrium.core.chat_zeroclaw"):
+        asyncio.run(backend.connect())
+
+    # No cleartext warning landed in the log stream.
+    assert not any("cleartext" in rec.message for rec in caplog.records)
+    # Resolver actually ran against the configured host — the negative
+    # assertion above isn't a vacuous pass.
+    assert "mydev.local" in resolver_calls, (
+        f"Expected getaddrinfo to be called with 'mydev.local'; "
+        f"saw {resolver_calls!r}"
+    )
+
+
+def test_cleartext_warning_emitted_when_resolver_fails(monkeypatch, caplog):
+    """ATX Round 4 W-C: when getaddrinfo fails (DNS hiccup, isolated
+    container, etc.) for a non-literal-loopback host, the warning MUST
+    still fire — false positive is preferable to silent miss of a real
+    cleartext exposure."""
+    import logging
+    import socket
+
+    async def fake_connect(*_args, **_kwargs):
+        return FakeWebSocket([])
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.websockets.connect", fake_connect
+    )
+
+    def fake_getaddrinfo(*_args, **_kwargs):
+        raise socket.gaierror("no resolver available")
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.socket.getaddrinfo", fake_getaddrinfo
+    )
+
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://some-host.lan:4080/ws/chat",
+        auth_token=SecretStr("paired"),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="clawrium.core.chat_zeroclaw"):
+        asyncio.run(backend.connect())
+
+    assert any("cleartext" in rec.message for rec in caplog.records), (
+        "Expected the cleartext warning to fire when resolver fails; "
+        "silent suppression would mask a real LAN exposure."
+    )
+
+
+def test_tool_call_frame_sanitizes_name_and_args(monkeypatch):
+    """ATX Round 4 W-D / Round 5 W-2: tool_call frames pass through
+    on_delta with the tool name + JSON-encoded arguments. RLO codepoints
+    embedded in EITHER the `name` field OR any `arguments` value MUST
+    be stripped before reaching the renderer."""
+    frames = [
+        {
+            "type": "tool_call",
+            "name": "shell‮tool",  # RLO embedded in name
+            "arguments": {
+                "cmd": "ls‮ -la",  # RLO embedded in an argument VALUE
+                "cwd": "/tmp",
+            },
+        },
+        {"type": "done"},
+    ]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    deltas: list[str] = []
+    asyncio.run(
+        backend.send_message("hi", on_delta=lambda d: deltas.append(d))
+    )
+
+    # NO RLO codepoint anywhere in any emitted delta — neither from the
+    # name field nor from the argument values. A regression that drops
+    # sanitization from the JSON-encoded arguments path would surface
+    # the RLO here.
+    assert not any("‮" in d for d in deltas), deltas
+    # The legitimate tool name parts survive sanitization.
+    assert any("shell" in d and "tool" in d for d in deltas), deltas
+    # The arguments JSON renders into the delta line (legitimate text
+    # survives, RLO is gone).
+    assert any("ls" in d and "-la" in d for d in deltas), deltas
+
+
+def test_tool_result_frame_delivered_via_on_delta(monkeypatch):
+    """ATX Round 4 W-D: tool_result frames are advisory output and
+    must reach on_delta with the [tool_result] prefix."""
+    frames = [
+        {"type": "tool_result", "content": "command output here"},
+        {"type": "done"},
+    ]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    deltas: list[str] = []
+    asyncio.run(
+        backend.send_message("hi", on_delta=lambda d: deltas.append(d))
+    )
+
+    assert any(
+        "[tool_result]" in d and "command output here" in d
+        for d in deltas
+    ), deltas
+
+
+def test_valid_utf8_bytes_frame_is_decoded(monkeypatch):
+    """ATX Round 4 W-E: a `bytes` WebSocket frame carrying valid UTF-8
+    must be decoded and parsed transparently. Servers occasionally send
+    text frames as binary depending on the proxy chain."""
+    frames = [
+        b'{"type": "chunk", "content": "Hello"}',
+        b'{"type": "done"}',
+    ]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    result = asyncio.run(backend.send_message("hi"))
+    assert result == "Hello"
+
+
+def test_invalid_utf8_bytes_frame_raises_protocol_error(monkeypatch):
+    """ATX Round 4 W-E: a `bytes` frame with invalid UTF-8 surfaces as
+    ChatProtocolError, not a raw UnicodeDecodeError."""
+    frames = [b"\xff\xfe invalid utf-8"]
+    backend, _ = _make_backend(monkeypatch, frames)
+    asyncio.run(backend.connect())
+
+    with pytest.raises(ChatProtocolError):
+        asyncio.run(backend.send_message("hi"))
+
+
+def test_cleartext_warning_suppressed_for_wss_non_loopback(monkeypatch, caplog):
+    """ATX Round 2 S6: a `wss://` URL to a non-loopback host must NOT
+    trigger the cleartext warning — TLS protects the bearer token in
+    transit."""
+    import logging
+
+    async def fake_connect(*_args, **_kwargs):
+        return FakeWebSocket([])
+
+    monkeypatch.setattr(
+        "clawrium.core.chat_zeroclaw.websockets.connect", fake_connect
+    )
+
+    backend = ZeroClawChatBackend(
+        gateway_url="wss://pi-edge.lan:4080/ws/chat",
+        auth_token=SecretStr("paired"),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="clawrium.core.chat_zeroclaw"):
+        asyncio.run(backend.connect())
+
+    assert not any("cleartext" in rec.message for rec in caplog.records)

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -463,12 +463,23 @@ class FakeChatClient:
         self.closed = False
         self.last_kwargs: dict[str, object] = {}
         self.clear_history_calls = 0
+        # ATX Round 4 W-A / Round 5 W-4: implement the `is_connected`
+        # Protocol member explicitly so the REPL can read it directly
+        # (no fallback via `getattr(..., True)`). Lifecycle MUST match
+        # real backends: starts False, flips to True only after
+        # `connect()` succeeds, flips back to False on `close()`.
+        # Without this, a test that checks `is_connected` before
+        # `connect()` inherits a wrong precondition (the real backend
+        # would be False there).
+        self.is_connected: bool = False
 
     async def connect(self):
         self.connected = True
+        self.is_connected = True
 
     async def close(self):
         self.closed = True
+        self.is_connected = False
 
     def clear_history(self) -> None:
         self.clear_history_calls += 1
@@ -622,6 +633,87 @@ def test_chat_loop_surfaces_history_truncation_notice(monkeypatch, capsys):
     captured = capsys.readouterr().out
     assert "dropped 3 oldest turns" in captured
     assert "Use /reset to start fresh" in captured
+
+
+def test_chat_loop_breaks_when_protocol_error_disconnects_backend(
+    monkeypatch, capsys
+):
+    """ATX Round 2 W2 / Round 3 B1: when a ChatProtocolError leaves the
+    backend disconnected (e.g. zeroclaw's approval_request handler
+    closes the socket before raising), the REPL must break immediately,
+    not print 'Continuing chat session.' and loop back to read.
+
+    This test fails if the `if not getattr(backend, 'is_connected', True)
+    : break` branch is removed:
+    - the read counter would exceed 1 (the loop would solicit a 2nd input)
+    - the captured stdout would contain 'Continuing chat session.'
+    - the captured stdout would NOT contain 'Chat session ended'
+    """
+    from clawrium.cli.chat import _chat_loop
+
+    class DisconnectingClient:
+        """Fake backend whose send_message raises ChatProtocolError and
+        marks itself disconnected — mirrors ZeroClawChatBackend's
+        approval_request behavior."""
+
+        def __init__(self):
+            self.is_connected = True
+            self.closed = False
+
+        async def connect(self):
+            pass
+
+        async def close(self):
+            self.closed = True
+            self.is_connected = False
+
+        async def send_message(self, message, session_key, on_delta, response_timeout_seconds):
+            self.is_connected = False  # mirrors `await self.close()` in approval_request
+            raise ChatProtocolError("ZeroClaw requested tool approval (tool='shell')")
+
+        def clear_history(self):
+            pass
+
+    client = DisconnectingClient()
+    # Queue TWO inputs so a non-breaking loop has a second user message
+    # to send. The break contract requires read_count == 1; without the
+    # break the loop would consume both.
+    inputs = iter(["please do something", "another message"])
+    read_count = {"n": 0}
+
+    async def fake_read(*_args, **_kwargs):
+        read_count["n"] += 1
+        try:
+            return next(inputs)
+        except StopIteration:
+            raise EOFError
+
+    monkeypatch.setattr(chat_module, "_read_user_input", fake_read)
+
+    asyncio.run(
+        _chat_loop(
+            backend=client,
+            session_key="main",
+            response_timeout_seconds=5.0,
+            idle_timeout_seconds=0.0,
+            chat_type="zeroclaw",
+        )
+    )
+
+    captured = capsys.readouterr()
+
+    # Pin contracts:
+    #  1. Exactly one prompt was issued — the loop broke before re-reading.
+    assert read_count["n"] == 1, (
+        f"Expected the loop to break after 1 read; got {read_count['n']}"
+    )
+    #  2. The session-ended message landed on stdout.
+    assert "Chat session ended" in captured.out, captured.out
+    #  3. The 'continue' branch did NOT fire.
+    assert "Continuing chat session." not in captured.out, captured.out
+    #  4. The backend was closed (idempotent — approval_request already
+    #     closed; the outer finally re-runs close()).
+    assert client.closed is True
 
 
 def test_chat_loop_handles_keyboard_interrupt_and_closes_client(monkeypatch):
@@ -1105,3 +1197,211 @@ def test_hermes_satisfies_chat_backend_protocol():
         auth_token=SecretStr("token"),
     )
     assert isinstance(backend, ChatBackend)
+
+
+def test_zeroclaw_satisfies_chat_backend_protocol():
+    from clawrium.core.chat import ChatBackend, SecretStr
+    from clawrium.core.chat_zeroclaw import ZeroClawChatBackend
+
+    backend = ZeroClawChatBackend(
+        gateway_url="ws://example.test:4080/ws/chat",
+        auth_token=SecretStr("token"),
+    )
+    assert isinstance(backend, ChatBackend)
+
+
+# ---------------------------------------------------------------------------
+# ZeroClaw chat dispatch — agents whose manifest advertises features.chat.type
+# == "zeroclaw" route to ZeroClawChatBackend.
+# ---------------------------------------------------------------------------
+
+
+class TestZeroclawChat:
+    """Dispatch + missing-credential tests for the zeroclaw chat path."""
+
+    HOST = {"hostname": "pi-edge.lan", "alias": "pi-edge"}
+    AGENT = {
+        "agent_name": "zc-test",
+        "config": {
+            "gateway": {
+                "url": "ws://pi-edge.lan:4080/ws/chat",
+                "auth": "paired-bearer-token",
+                "port": 4080,
+            }
+        },
+    }
+
+    def _patch_resolve(self, monkeypatch, agent=None):
+        monkeypatch.setattr(
+            "clawrium.cli.chat.get_agent_by_name",
+            lambda _name: (self.HOST, "zeroclaw", agent or self.AGENT),
+        )
+        monkeypatch.setattr(
+            "clawrium.cli.chat._resolve_chat_type", lambda _agent_type: "zeroclaw"
+        )
+
+    def test_dispatch_to_zeroclaw_backend(self, monkeypatch):
+        """A manifest advertising features.chat.type == zeroclaw routes to
+        ZeroClawChatBackend with the bearer + URL from hosts.json."""
+        self._patch_resolve(monkeypatch)
+
+        captured: dict[str, object] = {}
+
+        async def mock_chat_loop(backend, **_kwargs):
+            captured["backend"] = backend
+
+        monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
+
+        result = runner.invoke(app, ["chat", "zc-test"])
+
+        assert result.exit_code == 0, result.output
+        backend = captured["backend"]
+        # Must be the ZeroClaw backend, not the openclaw client.
+        from clawrium.core.chat_zeroclaw import ZeroClawChatBackend
+        assert isinstance(backend, ZeroClawChatBackend)
+        # URL ends with /ws/chat (idempotent suffix append).
+        assert backend.gateway_url.endswith("/ws/chat")
+
+    def test_missing_gateway_token_exits_1(self, monkeypatch):
+        """Agent record without gateway.auth surfaces a friendly error."""
+        agent_no_token = {
+            "agent_name": "zc-test",
+            "config": {
+                "gateway": {
+                    "url": "ws://pi-edge.lan:4080/ws/chat",
+                    "port": 4080,
+                }
+            },
+        }
+        self._patch_resolve(monkeypatch, agent=agent_no_token)
+
+        result = runner.invoke(app, ["chat", "zc-test"])
+
+        assert result.exit_code == 1
+        assert "token is missing" in result.output.lower()
+
+    def test_missing_gateway_url_exits_1(self, monkeypatch):
+        """Agent record without gateway.url surfaces a friendly error."""
+        agent_no_url = {
+            "agent_name": "zc-test",
+            "config": {
+                "gateway": {
+                    "auth": "paired-bearer-token",
+                    "port": 4080,
+                }
+            },
+        }
+        self._patch_resolve(monkeypatch, agent=agent_no_url)
+
+        result = runner.invoke(app, ["chat", "zc-test"])
+
+        assert result.exit_code == 1
+        assert "url is missing" in result.output.lower()
+
+    def test_auth_error_surfaces_configure_hint(self, monkeypatch):
+        """A ChatAuthenticationError from the backend surfaces the
+        `clm agent configure <name>` remediation hint — the only path
+        to recover a rotated pairing token."""
+        from clawrium.core.chat import ChatAuthenticationError
+
+        self._patch_resolve(monkeypatch)
+
+        def fake_asyncio_run(_coro):
+            _coro.close()
+            raise ChatAuthenticationError("ZeroClaw gateway rejected the bearer token")
+
+        monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
+
+        result = runner.invoke(app, ["chat", "zc-test"])
+
+        assert result.exit_code == 1
+        assert "authentication failed" in result.output.lower()
+        assert "clm agent configure zc-test" in result.output
+
+    def test_timeout_surfaces_timeout_hint(self, monkeypatch):
+        """ATX Round 1 W6 / Round 4 W-B: a recv-timeout ChatConnectionError
+        routes to the --timeout hint. Construct the exception text from
+        the same `RECV_TIMEOUT_MSG_PREFIX` constant the CLI imports so a
+        rewording of the prefix cannot break the routing test silently."""
+        from clawrium.core.chat import ChatConnectionError
+        from clawrium.core.chat_zeroclaw import RECV_TIMEOUT_MSG_PREFIX
+
+        self._patch_resolve(monkeypatch)
+
+        def fake_asyncio_run(_coro):
+            _coro.close()
+            raise ChatConnectionError(f"{RECV_TIMEOUT_MSG_PREFIX} after 5s")
+
+        monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
+
+        result = runner.invoke(app, ["chat", "zc-test"])
+
+        assert result.exit_code == 1
+        assert "Try a higher --timeout" in result.output
+
+    def test_unreachable_surfaces_configure_hint(self, monkeypatch):
+        """ATX Round 1 W6: a non-timeout ChatConnectionError prints the
+        agent-reachability hint pointing at `clm agent configure` (for
+        stale pairing tokens)."""
+        from clawrium.core.chat import ChatConnectionError
+
+        self._patch_resolve(monkeypatch)
+
+        def fake_asyncio_run(_coro):
+            _coro.close()
+            raise ChatConnectionError(
+                "Failed to reach ZeroClaw gateway at ws://pi-edge.lan:4080/ws/chat"
+            )
+
+        monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
+
+        result = runner.invoke(app, ["chat", "zc-test"])
+
+        assert result.exit_code == 1
+        assert "clm agent configure zc-test" in result.output
+        # The timeout-specific hint must NOT fire on the unreachable path.
+        assert "Try a higher --timeout" not in result.output
+
+    def test_session_flag_no_op_notice_emitted_for_zeroclaw(self, monkeypatch):
+        """ATX Round 1 W7: `--session` is accepted but has no effect on
+        zeroclaw (gateway owns session state). The CLI should print the
+        same no-op notice it prints for openai-typed agents."""
+        self._patch_resolve(monkeypatch)
+
+        async def mock_chat_loop(backend, **_kwargs):  # noqa: ARG001
+            return None
+
+        monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
+
+        result = runner.invoke(app, ["chat", "zc-test", "--session", "custom"])
+
+        assert result.exit_code == 0, result.output
+        assert "--session" in result.output
+
+    def test_url_appended_with_ws_chat_path_when_missing(self, monkeypatch):
+        """When the persisted URL has no /ws/chat suffix (e.g. host record
+        reconstruction strips it), the backend re-appends it idempotently
+        so the gateway accepts the upgrade."""
+        agent_no_path = {
+            "agent_name": "zc-test",
+            "config": {
+                "gateway": {
+                    "url": "ws://pi-edge.lan:4080",
+                    "auth": "paired-bearer-token",
+                    "port": 4080,
+                }
+            },
+        }
+        self._patch_resolve(monkeypatch, agent=agent_no_path)
+
+        captured: dict[str, object] = {}
+
+        async def mock_chat_loop(backend, **_kwargs):
+            captured["backend"] = backend
+
+        monkeypatch.setattr(chat_module, "_chat_loop", mock_chat_loop)
+
+        result = runner.invoke(app, ["chat", "zc-test"])
+
+        assert result.exit_code == 0, result.output
+        assert captured["backend"].gateway_url.endswith("/ws/chat")

--- a/tests/test_configure_claw.py
+++ b/tests/test_configure_claw.py
@@ -69,9 +69,25 @@ class TestConfigureClaw:
         playbook = tmp_path / "configure.yaml"
         playbook.write_text("---\n")
 
+        # Issue #357: configure_agent reads pairing token + gateway URL out
+        # of the Ansible fact cache for zeroclaw. Set up a fact file so the
+        # extraction succeeds and the failure path under test (update_host
+        # returning False) is what surfaces — not the new fact-missing
+        # fail-fast path.
+        artifacts_dir = tmp_path / "artifacts"
+        fact_cache_dir = artifacts_dir / "fact_cache"
+        fact_cache_dir.mkdir(parents=True)
+        (fact_cache_dir / "test-host").write_text(json.dumps({
+            "__payload__": json.dumps({
+                "zeroclaw_gateway_token": "paired-bearer-token",
+                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+            }),
+        }))
+
         mock_runner = MagicMock()
         mock_runner.status = "successful"
         mock_runner.events = []
+        mock_runner.config.artifact_dir = str(artifacts_dir)
 
         with patch("clawrium.core.lifecycle.get_host", return_value=host):
             with patch(
@@ -299,9 +315,23 @@ class TestConfigureClaw:
         playbook = tmp_path / "configure.yaml"
         playbook.write_text("---\n")
 
+        # Issue #357: configure_agent reads pairing token + gateway URL out
+        # of the Ansible fact cache for zeroclaw. Set up a fact file so the
+        # happy path can complete fact extraction.
+        artifacts_dir = tmp_path / "artifacts"
+        fact_cache_dir = artifacts_dir / "fact_cache"
+        fact_cache_dir.mkdir(parents=True)
+        (fact_cache_dir / "test-host").write_text(json.dumps({
+            "__payload__": json.dumps({
+                "zeroclaw_gateway_token": "paired-bearer-token",
+                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+            }),
+        }))
+
         mock_runner = MagicMock()
         mock_runner.status = "successful"
         mock_runner.events = []
+        mock_runner.config.artifact_dir = str(artifacts_dir)
 
         with patch("clawrium.core.lifecycle.get_host", return_value=host):
             with patch(
@@ -333,6 +363,977 @@ class TestConfigureClaw:
 
         assert success is True
         assert error is None
+
+
+class TestConfigureZeroclawFactExtraction:
+    """Coverage for the bearer-token fact-extraction path added by issue #357.
+
+    `configure_agent()` reads `zeroclaw_gateway_token` + `zeroclaw_gateway_url`
+    out of the Ansible fact cache after a successful configure run, and
+    persists them to `hosts.json` under `agents.<n>.config.gateway`. These
+    tests pin the happy path and the three failure modes ATX flagged as
+    "zero test coverage" in Round 1 W1:
+
+    1. Happy path: fact present, hosts.json updated with auth + url
+    2. Fact cache absent (missing fact_cache_dir)
+    3. __payload__ key missing
+    4. Token empty after strip
+    """
+
+    HOST = {
+        "hostname": "test-host",
+        "key_id": "test",
+        "agent_name": "xclm",
+        "port": 22,
+        "agents": {"zer-test": {"type": "zeroclaw"}},
+    }
+    CONFIG_DATA = {
+        "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
+        "provider": {
+            "name": "test-provider",
+            "type": "anthropic",
+            "default_model": "claude-sonnet-4-5",
+        },
+    }
+
+    def _setup_artifacts(self, tmp_path: Path, payload: dict | None) -> Path:
+        """Create an artifacts dir with one fact file carrying `payload`."""
+        artifacts_dir = tmp_path / "artifacts"
+        fact_cache_dir = artifacts_dir / "fact_cache"
+        fact_cache_dir.mkdir(parents=True)
+        if payload is not None:
+            (fact_cache_dir / "test-host").write_text(json.dumps({
+                "__payload__": json.dumps(payload),
+            }))
+        return artifacts_dir
+
+    def _run_configure(self, tmp_path: Path, artifacts_dir: Path):
+        key_path = tmp_path / "key"
+        key_path.write_text("key")
+        template_dir = tmp_path / "templates"
+        template_dir.mkdir()
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+        mock_runner.config.artifact_dir = str(artifacts_dir)
+
+        captured: dict[str, object] = {}
+
+        def fake_update_host(_hostname, updater):
+            # Pull the persisted record by running the updater against a
+            # fresh host dict (mirrors update_host's contract — caller
+            # gets to inspect what would be written).
+            h = {"hostname": "test-host", "agents": {"zer-test": {"type": "zeroclaw"}}}
+            captured["host"] = updater(h)
+            return True
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=self.HOST):
+            with patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        return_value=mock_runner,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle.update_host",
+                            side_effect=fake_update_host,
+                        ):
+                            with patch(
+                                "clawrium.core.providers.get_provider_api_key",
+                                return_value="",
+                            ):
+                                success, error = configure_agent(
+                                    "test-host", "zeroclaw", dict(self.CONFIG_DATA)
+                                )
+        return success, error, captured
+
+    def test_happy_path_persists_token_and_url_to_hosts_json(self, tmp_path: Path):
+        """Fact present → success → hosts.json carries the gateway block."""
+        artifacts_dir = self._setup_artifacts(tmp_path, {
+            "zeroclaw_gateway_token": "freshly-paired-bearer-token-1234",
+            "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+        })
+
+        success, error, captured = self._run_configure(tmp_path, artifacts_dir)
+
+        assert success is True, error
+        agent_record = captured["host"]["agents"]["zer-test"]
+        gateway = agent_record["config"]["gateway"]
+        assert gateway["auth"] == "freshly-paired-bearer-token-1234"
+        assert gateway["url"] == "ws://test-host:40000/ws/chat"
+
+    def test_returns_false_when_fact_cache_dir_absent(self, tmp_path: Path):
+        """No fact_cache directory → fail-fast with operator guidance."""
+        # Create artifacts_dir without fact_cache.
+        artifacts_dir = tmp_path / "artifacts"
+        artifacts_dir.mkdir()
+
+        success, error, _ = self._run_configure(tmp_path, artifacts_dir)
+
+        assert success is False
+        assert "pairing token was not captured" in error
+        # Operator-visible remediation hint is non-empty.
+        assert "clm agent configure" in error
+
+    def test_returns_false_when_payload_key_missing(self, tmp_path: Path):
+        """Fact file present but lacking __payload__ → fail-fast."""
+        artifacts_dir = tmp_path / "artifacts"
+        fact_cache_dir = artifacts_dir / "fact_cache"
+        fact_cache_dir.mkdir(parents=True)
+        # Fact file with arbitrary content but no __payload__ envelope.
+        (fact_cache_dir / "test-host").write_text(json.dumps({"other": "data"}))
+
+        success, error, _ = self._run_configure(tmp_path, artifacts_dir)
+
+        assert success is False
+        assert "pairing token was not captured" in error
+        # ATX Round 2 W10: every failure-mode test asserts the remediation
+        # hint too, so a regression that drops the operator guidance can't
+        # ship green.
+        assert "clm agent configure" in error
+
+    def test_returns_false_when_token_empty_after_strip(self, tmp_path: Path):
+        """Whitespace-only token must be rejected — the eventual chat
+        client would fail with an empty Bearer header, which is a worse
+        error than failing fast here."""
+        artifacts_dir = self._setup_artifacts(tmp_path, {
+            "zeroclaw_gateway_token": "   ",
+            "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+        })
+
+        success, error, _ = self._run_configure(tmp_path, artifacts_dir)
+
+        assert success is False
+        assert "pairing token was not captured" in error
+        assert "clm agent configure" in error
+
+    def test_returns_false_when_url_missing(self, tmp_path: Path):
+        """Token present but URL missing → also fail-fast (the chat path
+        needs both to construct a connection)."""
+        artifacts_dir = self._setup_artifacts(tmp_path, {
+            "zeroclaw_gateway_token": "paired-bearer-token-abc",
+            # zeroclaw_gateway_url intentionally omitted
+        })
+
+        success, error, _ = self._run_configure(tmp_path, artifacts_dir)
+
+        assert success is False
+        assert "pairing token was not captured" in error
+        assert "clm agent configure" in error
+
+    def test_no_health_warning_when_fact_absent(self, tmp_path: Path):
+        """ATX Round 3 W10: when the playbook did NOT set
+        zeroclaw_provider_health_warning (i.e. health 200), no warn
+        event must fire. Without this negative test, code that
+        unconditionally emits the warning would pass the suite."""
+        artifacts_dir = self._setup_artifacts(tmp_path, {
+            "zeroclaw_gateway_token": "freshly-paired-bearer-token-1234",
+            "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+            # zeroclaw_provider_health_warning intentionally absent
+        })
+
+        events: list[tuple[str, str]] = []
+
+        def on_event(stage: str, message: str) -> None:
+            events.append((stage, message))
+
+        success, error, _ = self._run_configure_with_callback(
+            tmp_path, artifacts_dir, on_event
+        )
+
+        assert success is True, error
+        # ATX Round 4 B1: configure_warnings flow through stage="configure"
+        # with a "WARNING:" prefix (matches the integration-warning
+        # pattern at lifecycle.py:1046). Pure stage="warn" events were
+        # dropped at the terminal by `_print_configure_warnings`.
+        warn_events = [
+            (s, m) for s, m in events
+            if s == "configure" and m.startswith("WARNING:")
+        ]
+        assert not warn_events, f"Unexpected warn events: {warn_events!r}"
+
+    def test_no_health_warning_when_fact_false(self, tmp_path: Path):
+        """ATX Round 3 W1+W10: a healthy run (status 200) sets
+        zeroclaw_provider_health_warning=False — the value MUST be
+        respected and the warn event MUST NOT fire. Pre-fix, the
+        unconditional-True set_fact left stale `True` in the fact cache,
+        causing a phantom warning on healthy reconfigures."""
+        artifacts_dir = self._setup_artifacts(tmp_path, {
+            "zeroclaw_gateway_token": "freshly-paired-bearer-token-1234",
+            "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+            "zeroclaw_provider_health_warning": False,
+        })
+
+        events: list[tuple[str, str]] = []
+
+        def on_event(stage: str, message: str) -> None:
+            events.append((stage, message))
+
+        success, error, _ = self._run_configure_with_callback(
+            tmp_path, artifacts_dir, on_event
+        )
+
+        assert success is True, error
+        warn_events = [
+            (s, m) for s, m in events
+            if s == "configure" and m.startswith("WARNING:")
+        ]
+        assert not warn_events, f"Unexpected warn events: {warn_events!r}"
+
+    def _run_configure_with_callback(
+        self, tmp_path: Path, artifacts_dir: Path, on_event
+    ):
+        """Variant of _run_configure that wires an on_event callback
+        through to configure_agent. Used by the health-warning tests."""
+        key_path = tmp_path / "key"
+        key_path.write_text("key")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+        mock_runner.config.artifact_dir = str(artifacts_dir)
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=self.HOST):
+            with patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        return_value=mock_runner,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle.update_host",
+                            return_value=True,
+                        ):
+                            with patch(
+                                "clawrium.core.providers.get_provider_api_key",
+                                return_value="",
+                            ):
+                                success, error = configure_agent(
+                                    "test-host",
+                                    "zeroclaw",
+                                    dict(self.CONFIG_DATA),
+                                    on_event=on_event,
+                                )
+        return success, error, {}
+
+    def test_provider_health_warning_surfaces_via_event_callback(self, tmp_path: Path):
+        """ATX Round 2 W1: when the playbook records
+        zeroclaw_provider_health_warning = True (set when /health/providers
+        returns 401), configure_agent surfaces the warning via the
+        on_event callback. Without this, the warning would be silently
+        swallowed because `ansible_runner.run(quiet=True)` does not emit
+        `runner_on_debug` events to the caller."""
+        artifacts_dir = self._setup_artifacts(tmp_path, {
+            "zeroclaw_gateway_token": "freshly-paired-bearer-token-1234",
+            "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+            "zeroclaw_provider_health_warning": True,
+        })
+
+        events: list[tuple[str, str]] = []
+
+        def on_event(stage: str, message: str) -> None:
+            events.append((stage, message))
+
+        key_path = tmp_path / "key"
+        key_path.write_text("key")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+        mock_runner.config.artifact_dir = str(artifacts_dir)
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=self.HOST):
+            with patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        return_value=mock_runner,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle.update_host",
+                            return_value=True,
+                        ):
+                            with patch(
+                                "clawrium.core.providers.get_provider_api_key",
+                                return_value="",
+                            ):
+                                success, error = configure_agent(
+                                    "test-host",
+                                    "zeroclaw",
+                                    dict(self.CONFIG_DATA),
+                                    on_event=on_event,
+                                )
+
+        assert success is True, error
+        # ATX Round 4 B1: warnings flow through stage="configure" with
+        # a "WARNING:" prefix so `_print_configure_warnings` actually
+        # surfaces them to the user. A bare stage="warn" event would be
+        # silently dropped at the terminal.
+        warn_events = [
+            (s, m) for s, m in events
+            if s == "configure" and m.startswith("WARNING:")
+        ]
+        assert warn_events, f"Expected a WARNING: event; got {events!r}"
+        warn_msg = warn_events[0][1]
+        assert "401" in warn_msg
+        assert "credentials may be invalid" in warn_msg
+
+    def test_malformed_discord_secret_does_not_raise(self, tmp_path: Path):
+        """ATX Round 3 W4: a malformed secrets.json entry (a dict that
+        lacks the expected `value` field — e.g. only `created_at`)
+        must silently produce an empty token rather than raise
+        KeyError. Pre-fix, the bare `instance_secrets["..."]["value"]`
+        indexing raised, was swallowed by `except Exception` → empty
+        token, but the user got zero indication. Post-fix the same
+        empty-token outcome holds AND the .get() guard makes the
+        behavior intentional (not accidental)."""
+        artifacts_dir = self._setup_artifacts(tmp_path, {
+            "zeroclaw_gateway_token": "freshly-paired-bearer-token-1234",
+            "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+        })
+
+        key_path = tmp_path / "key"
+        key_path.write_text("key")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+        mock_runner.config.artifact_dir = str(artifacts_dir)
+
+        captured: dict[str, object] = {}
+
+        def capture_run(*, inventory, **_kwargs):
+            captured["inventory"] = inventory
+            return mock_runner
+
+        # Inject a malformed Discord secret: dict without "value".
+        malformed_secrets = {
+            "DISCORD_BOT_TOKEN": {"created_at": "2026-05-01T00:00:00Z"},
+            "SLACK_BOT_TOKEN": {"corrupted": True},
+            "SLACK_APP_TOKEN": "raw-string-not-a-dict",
+        }
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=self.HOST):
+            with patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        side_effect=capture_run,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle.update_host",
+                            return_value=True,
+                        ):
+                            with patch(
+                                "clawrium.core.providers.get_provider_api_key",
+                                return_value="",
+                            ):
+                                with patch(
+                                    "clawrium.core.lifecycle.get_instance_secrets",
+                                    return_value=malformed_secrets,
+                                ):
+                                    success, error = configure_agent(
+                                        "test-host",
+                                        "zeroclaw",
+                                        dict(self.CONFIG_DATA),
+                                    )
+
+        assert success is True, error
+        # All three token vars are empty — the W4 guard caught the
+        # malformed shape, no KeyError surfaced.
+        ansible_vars = captured["inventory"]["all"]["vars"]
+        assert ansible_vars["discord_bot_token"] == ""
+        assert ansible_vars["slack_bot_token"] == ""
+        assert ansible_vars["slack_app_token"] == ""
+
+    def test_value_wrapped_facts_are_unwrapped(self, tmp_path: Path):
+        """Ansible occasionally wraps cacheable string facts in
+        {"value": ...}. The extraction must tolerate both shapes."""
+        artifacts_dir = self._setup_artifacts(tmp_path, {
+            "zeroclaw_gateway_token": {"value": "wrapped-bearer-token-xyz"},
+            "zeroclaw_gateway_url": {"value": "ws://test-host:40000/ws/chat"},
+        })
+
+        success, error, captured = self._run_configure(tmp_path, artifacts_dir)
+
+        assert success is True, error
+        gateway = captured["host"]["agents"]["zer-test"]["config"]["gateway"]
+        assert gateway["auth"] == "wrapped-bearer-token-xyz"
+
+
+class TestConfigureZeroclawIdempotentRepair:
+    """ATX Round 1 B3: re-running configure on an already-paired zeroclaw
+    must NOT re-pair (which would invalidate the live token). The
+    configure playbook receives `existing_gateway_token` from configure_agent
+    and skips the /pair/code → /pair handshake when it's non-empty."""
+
+    def test_existing_token_passed_to_playbook_as_ansible_var(self, tmp_path: Path):
+        """Verify configure_agent forwards the persisted token into the
+        Ansible vars so the playbook can take its idempotent skip path."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "zer-test": {
+                    "type": "zeroclaw",
+                    "config": {
+                        "gateway": {
+                            "auth": "existing-paired-token-from-prior-configure",
+                            "url": "ws://test-host:40000/ws/chat",
+                        }
+                    },
+                }
+            },
+        }
+        config_data = {
+            "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
+            "provider": {
+                "name": "test-provider",
+                "type": "anthropic",
+                "default_model": "claude-sonnet-4-5",
+            },
+        }
+
+        key_path = tmp_path / "key"
+        key_path.write_text("key")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        # Set up fact cache so fact extraction also succeeds.
+        artifacts_dir = tmp_path / "artifacts"
+        fact_cache_dir = artifacts_dir / "fact_cache"
+        fact_cache_dir.mkdir(parents=True)
+        (fact_cache_dir / "test-host").write_text(json.dumps({
+            "__payload__": json.dumps({
+                "zeroclaw_gateway_token": "existing-paired-token-from-prior-configure",
+                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+            }),
+        }))
+
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+        mock_runner.config.artifact_dir = str(artifacts_dir)
+
+        captured: dict[str, object] = {}
+
+        def capture_run(*, inventory, **_kwargs):
+            captured["inventory"] = inventory
+            return mock_runner
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        side_effect=capture_run,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle.update_host",
+                            return_value=True,
+                        ):
+                            with patch(
+                                "clawrium.core.providers.get_provider_api_key",
+                                return_value="",
+                            ):
+                                success, error = configure_agent(
+                                    "test-host", "zeroclaw", config_data
+                                )
+
+        assert success is True, error
+        # The existing token is passed to the playbook so it can skip pairing.
+        ansible_vars = captured["inventory"]["all"]["vars"]
+        assert ansible_vars["existing_gateway_token"] == (
+            "existing-paired-token-from-prior-configure"
+        )
+        assert ansible_vars["force_repair"] is False
+
+    def test_force_repair_true_forwarded_to_playbook(self, tmp_path: Path):
+        """ATX Round 2 W7: explicit `force_repair=True` via `extra_vars`
+        must reach the playbook so the operator can rotate the bearer
+        token. Without this test, dropping the `update(extra_vars)` call
+        in configure_agent would silently neuter the rotation path."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "zer-test": {
+                    "type": "zeroclaw",
+                    "config": {
+                        "gateway": {
+                            "auth": "existing-paired-token-from-prior-configure",
+                            "url": "ws://test-host:40000/ws/chat",
+                        }
+                    },
+                }
+            },
+        }
+        config_data = {
+            "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
+            "provider": {
+                "name": "test-provider",
+                "type": "anthropic",
+                "default_model": "claude-sonnet-4-5",
+            },
+        }
+
+        key_path = tmp_path / "key"
+        key_path.write_text("key")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        artifacts_dir = tmp_path / "artifacts"
+        fact_cache_dir = artifacts_dir / "fact_cache"
+        fact_cache_dir.mkdir(parents=True)
+        (fact_cache_dir / "test-host").write_text(json.dumps({
+            "__payload__": json.dumps({
+                "zeroclaw_gateway_token": "fresh-bearer-token-after-repair",
+                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+            }),
+        }))
+
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+        mock_runner.config.artifact_dir = str(artifacts_dir)
+
+        captured: dict[str, object] = {}
+
+        def capture_run(*, inventory, **_kwargs):
+            captured["inventory"] = inventory
+            return mock_runner
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        side_effect=capture_run,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle.update_host",
+                            return_value=True,
+                        ):
+                            with patch(
+                                "clawrium.core.providers.get_provider_api_key",
+                                return_value="",
+                            ):
+                                success, error = configure_agent(
+                                    "test-host",
+                                    "zeroclaw",
+                                    config_data,
+                                    extra_vars={"force_repair": True},
+                                )
+
+        assert success is True, error
+        ansible_vars = captured["inventory"]["all"]["vars"]
+        assert ansible_vars["force_repair"] is True
+
+    def test_empty_token_on_first_configure_passes_empty_string(self, tmp_path: Path):
+        """ATX Round 2 W7: a first-time configure (no persisted gateway
+        block) MUST pass `existing_gateway_token=""` so the playbook
+        takes the mint path. This pins the contract that the empty
+        string — not absence or None — is the signal."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {"zer-test": {"type": "zeroclaw"}},  # no config.gateway
+        }
+        config_data = {
+            "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
+            "provider": {
+                "name": "test-provider",
+                "type": "anthropic",
+                "default_model": "claude-sonnet-4-5",
+            },
+        }
+
+        key_path = tmp_path / "key"
+        key_path.write_text("key")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        artifacts_dir = tmp_path / "artifacts"
+        fact_cache_dir = artifacts_dir / "fact_cache"
+        fact_cache_dir.mkdir(parents=True)
+        (fact_cache_dir / "test-host").write_text(json.dumps({
+            "__payload__": json.dumps({
+                "zeroclaw_gateway_token": "freshly-minted-token-on-first-configure",
+                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+            }),
+        }))
+
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+        mock_runner.config.artifact_dir = str(artifacts_dir)
+
+        captured: dict[str, object] = {}
+
+        def capture_run(*, inventory, **_kwargs):
+            captured["inventory"] = inventory
+            return mock_runner
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        side_effect=capture_run,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle.update_host",
+                            return_value=True,
+                        ):
+                            with patch(
+                                "clawrium.core.providers.get_provider_api_key",
+                                return_value="",
+                            ):
+                                success, error = configure_agent(
+                                    "test-host", "zeroclaw", config_data
+                                )
+
+        assert success is True, error
+        ansible_vars = captured["inventory"]["all"]["vars"]
+        assert ansible_vars["existing_gateway_token"] == ""
+
+    def test_short_existing_token_treated_as_absent(self, tmp_path: Path):
+        """ATX Round 2 W5: a 1-15-char persisted token must be treated
+        as absent (the playbook's `length >= 16` gate would reject it
+        anyway). Without this guard, the Python side passes a too-short
+        token through and the playbook silently re-pairs, surprising the
+        operator."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "zer-test": {
+                    "type": "zeroclaw",
+                    "config": {
+                        "gateway": {
+                            # 15 characters — one short of the 16-char floor.
+                            "auth": "shortenedtokenz",
+                            "url": "ws://test-host:40000/ws/chat",
+                        }
+                    },
+                }
+            },
+        }
+        config_data = {
+            "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
+            "provider": {
+                "name": "test-provider",
+                "type": "anthropic",
+                "default_model": "claude-sonnet-4-5",
+            },
+        }
+
+        key_path = tmp_path / "key"
+        key_path.write_text("key")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        artifacts_dir = tmp_path / "artifacts"
+        fact_cache_dir = artifacts_dir / "fact_cache"
+        fact_cache_dir.mkdir(parents=True)
+        (fact_cache_dir / "test-host").write_text(json.dumps({
+            "__payload__": json.dumps({
+                "zeroclaw_gateway_token": "freshly-paired-bearer-token-1234",
+                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+            }),
+        }))
+
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+        mock_runner.config.artifact_dir = str(artifacts_dir)
+
+        captured: dict[str, object] = {}
+
+        def capture_run(*, inventory, **_kwargs):
+            captured["inventory"] = inventory
+            return mock_runner
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        side_effect=capture_run,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle.update_host",
+                            return_value=True,
+                        ):
+                            with patch(
+                                "clawrium.core.providers.get_provider_api_key",
+                                return_value="",
+                            ):
+                                success, error = configure_agent(
+                                    "test-host", "zeroclaw", config_data
+                                )
+
+        assert success is True, error
+        ansible_vars = captured["inventory"]["all"]["vars"]
+        # 15-char token is filtered to "" by configure_agent so the
+        # playbook takes the mint path.
+        assert ansible_vars["existing_gateway_token"] == ""
+
+    def test_short_existing_token_emits_warning_via_on_event(self, tmp_path: Path):
+        """ATX Round 5 W-1: when a sub-16-char token forces a re-pair,
+        the warning MUST flow through on_event with stage='configure'
+        and a `WARNING:` prefix — that's the only shape `cli/agent.py`'s
+        `_print_configure_warnings` callback surfaces to the terminal.
+        Pre-fix, the path emitted via stage='warn' which the callback
+        silently dropped (the user re-paired and broke their live
+        `clm chat` with zero indication)."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "zer-test": {
+                    "type": "zeroclaw",
+                    "config": {
+                        "gateway": {
+                            # 15 chars — under the 16-char floor.
+                            "auth": "shortenedtokenz",
+                            "url": "ws://test-host:40000/ws/chat",
+                        }
+                    },
+                }
+            },
+        }
+        config_data = {
+            "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
+            "provider": {
+                "name": "test-provider",
+                "type": "anthropic",
+                "default_model": "claude-sonnet-4-5",
+            },
+        }
+
+        key_path = tmp_path / "key"
+        key_path.write_text("key")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        artifacts_dir = tmp_path / "artifacts"
+        fact_cache_dir = artifacts_dir / "fact_cache"
+        fact_cache_dir.mkdir(parents=True)
+        (fact_cache_dir / "test-host").write_text(json.dumps({
+            "__payload__": json.dumps({
+                "zeroclaw_gateway_token": "freshly-paired-bearer-token-1234",
+                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+            }),
+        }))
+
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+        mock_runner.config.artifact_dir = str(artifacts_dir)
+
+        events: list[tuple[str, str]] = []
+
+        def on_event(stage: str, message: str) -> None:
+            events.append((stage, message))
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        return_value=mock_runner,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle.update_host",
+                            return_value=True,
+                        ):
+                            with patch(
+                                "clawrium.core.providers.get_provider_api_key",
+                                return_value="",
+                            ):
+                                success, error = configure_agent(
+                                    "test-host",
+                                    "zeroclaw",
+                                    config_data,
+                                    on_event=on_event,
+                                )
+
+        assert success is True, error
+        short_token_warnings = [
+            (s, m) for s, m in events
+            if s == "configure"
+            and m.startswith("WARNING:")
+            and "shorter than 16" in m
+        ]
+        assert short_token_warnings, (
+            f"Expected a stage='configure' / 'WARNING:'-prefixed event "
+            f"about the short token; saw {events!r}"
+        )
+        # The user-facing message must reference the agent so they know
+        # which session needs to reconnect.
+        assert "zer-test" in short_token_warnings[0][1]
+
+    def test_token_of_exactly_16_chars_passes_through(self, tmp_path: Path):
+        """ATX Round 3 W9: a token at the 16-char boundary must pass
+        through unchanged (this is the positive boundary of the W5
+        guard). Pre-fix, an off-by-one (`> 16` instead of `>= 16`)
+        would silently re-pair every 16-char token; this test fails
+        if the comparison drifts."""
+        sixteen_char_token = "a" * 16
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "zer-test": {
+                    "type": "zeroclaw",
+                    "config": {
+                        "gateway": {
+                            "auth": sixteen_char_token,
+                            "url": "ws://test-host:40000/ws/chat",
+                        }
+                    },
+                }
+            },
+        }
+        config_data = {
+            "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
+            "provider": {
+                "name": "test-provider",
+                "type": "anthropic",
+                "default_model": "claude-sonnet-4-5",
+            },
+        }
+
+        key_path = tmp_path / "key"
+        key_path.write_text("key")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        artifacts_dir = tmp_path / "artifacts"
+        fact_cache_dir = artifacts_dir / "fact_cache"
+        fact_cache_dir.mkdir(parents=True)
+        (fact_cache_dir / "test-host").write_text(json.dumps({
+            "__payload__": json.dumps({
+                "zeroclaw_gateway_token": sixteen_char_token,
+                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+            }),
+        }))
+
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+        mock_runner.config.artifact_dir = str(artifacts_dir)
+
+        captured: dict[str, object] = {}
+
+        def capture_run(*, inventory, **_kwargs):
+            captured["inventory"] = inventory
+            return mock_runner
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        side_effect=capture_run,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle.update_host",
+                            return_value=True,
+                        ):
+                            with patch(
+                                "clawrium.core.providers.get_provider_api_key",
+                                return_value="",
+                            ):
+                                success, error = configure_agent(
+                                    "test-host", "zeroclaw", config_data
+                                )
+
+        assert success is True, error
+        ansible_vars = captured["inventory"]["all"]["vars"]
+        assert ansible_vars["existing_gateway_token"] == sixteen_char_token
 
 
 class TestOpenClawTemplate:

--- a/tests/test_configure_zeroclaw.py
+++ b/tests/test_configure_zeroclaw.py
@@ -1,8 +1,16 @@
-"""Rendering tests for zeroclaw config.toml.j2.
+"""Rendering tests for the v0.7.5 zeroclaw config.toml.j2 template.
 
-Covers the unified `atlassian` integration branch added in issue #348:
-trailing-slash URL normalization (so CONFLUENCE_URL doesn't double-slash) and
-TOML escape correctness on the api_token fields (which embed secrets).
+Covers issue #357 (Subtask B):
+- gateway block: host, port, allow_public_bind, require_pairing
+- top-level default_provider + default_model
+- per-provider [providers.models.<name>] sub-table with `kind` discriminator
+- api_key for anthropic/openai/openrouter; base_url for ollama
+- TOML escape correctness on api_key (containing quotes / backslashes)
+
+Provider scope is intentionally limited to the four #112 providers:
+anthropic, openai, ollama, openrouter. The legacy integrations block
+(github, gitlab, atlassian, linear, notion) is removed from this
+template by #357 and tracked as a follow-up outside #112.
 """
 
 from pathlib import Path
@@ -20,96 +28,251 @@ ZEROCLAW_TEMPLATES = (
     / "templates"
 )
 
-_BASE_CONFIG = {
-    "gateway": {"host": "localhost", "port": 4080, "allow_public_bind": False},
+_GATEWAY_DEFAULTS = {
+    "host": "0.0.0.0",
+    "port": 4080,
+    "allow_public_bind": True,
+    "require_pairing": True,
 }
 
 
-def _render_config_toml(integrations: dict) -> str:
+def _ansible_bool(v):
+    """Mirror Ansible's string coercion in the `bool` filter."""
+    if isinstance(v, str):
+        return v.lower() not in ("no", "false", "0", "")
+    return bool(v)
+
+
+def _render(provider: dict | None, provider_api_key: str = "") -> str:
+    """Render `config.toml.j2` with the given provider block."""
     env = Environment(loader=FileSystemLoader(str(ZEROCLAW_TEMPLATES)))
-    # The zeroclaw template uses Ansible's `bool` filter for the gateway flag.
-    # Mirror Ansible's string coercion (which treats 'no', 'false', '0', '' as
-    # False) — a plain `bool()` diverges silently for those string inputs.
-    def _ansible_bool(v):
-        if isinstance(v, str):
-            return v.lower() not in ("no", "false", "0", "")
-        return bool(v)
     env.filters["bool"] = _ansible_bool
     template = env.get_template("config.toml.j2")
-    return template.render(config=_BASE_CONFIG, integrations=integrations)
+    config = {"gateway": dict(_GATEWAY_DEFAULTS)}
+    if provider is not None:
+        config["provider"] = provider
+    return template.render(config=config, provider_api_key=provider_api_key)
 
 
-class TestZeroclawAtlassianRendering:
-    """Verify the unified atlassian branch in config.toml.j2 emits correct TOML."""
+class TestGatewayBlock:
+    """The [gateway] header lands the security defaults from issue #357."""
 
-    def test_atlassian_renders_jira_and_confluence_urls(self):
-        rendered = _render_config_toml({
-            "work": {
-                "type": "atlassian",
-                "ATLASSIAN_URL": "https://co.atlassian.net",
-                "ATLASSIAN_EMAIL": "u@co.com",
-                "ATLASSIAN_API_TOKEN": "token",
-            }
-        })
-        assert 'jira_url = "https://co.atlassian.net"' in rendered
-        assert 'confluence_url = "https://co.atlassian.net/wiki"' in rendered
-        assert 'jira_email = "u@co.com"' in rendered
-        assert 'confluence_email = "u@co.com"' in rendered
+    def test_gateway_block_emits_security_defaults(self):
+        rendered = _render(
+            provider={"type": "anthropic", "default_model": "claude-sonnet-4-5"},
+            provider_api_key="sk-test",
+        )
+        assert "[gateway]" in rendered
+        assert 'host = "0.0.0.0"' in rendered
+        assert "port = 4080" in rendered
+        assert "allow_public_bind = true" in rendered
+        assert "require_pairing = true" in rendered
 
-    def test_atlassian_trailing_slash_does_not_produce_double_slash(self):
-        """A user-entered URL with trailing slash collapses before /wiki."""
-        rendered = _render_config_toml({
-            "work": {
-                "type": "atlassian",
-                "ATLASSIAN_URL": "https://co.atlassian.net/",
-                "ATLASSIAN_EMAIL": "u@co.com",
-                "ATLASSIAN_API_TOKEN": "token",
-            }
-        })
-        assert 'jira_url = "https://co.atlassian.net"' in rendered
-        assert 'confluence_url = "https://co.atlassian.net/wiki"' in rendered
-        assert "//wiki" not in rendered
+    def test_gateway_require_pairing_defaults_to_true_when_unset(self):
+        """`require_pairing` MUST default to true when the caller doesn't pass
+        it. A silent false default would let the daemon accept unauthenticated
+        requests — the threat model in .itx/357/01_EXECUTION.md rules that
+        out."""
+        env = Environment(loader=FileSystemLoader(str(ZEROCLAW_TEMPLATES)))
+        env.filters["bool"] = _ansible_bool
+        template = env.get_template("config.toml.j2")
+        # Build the config without require_pairing to force the default.
+        config = {
+            "gateway": {"host": "0.0.0.0", "port": 4080, "allow_public_bind": True},
+            "provider": {"type": "anthropic"},
+        }
+        rendered = template.render(config=config, provider_api_key="sk-test")
+        assert "require_pairing = true" in rendered
 
-    def test_atlassian_api_token_toml_escaping(self):
-        """API tokens containing quotes and backslashes must be TOML-escaped on
-        both jira_api_token and confluence_api_token (same value, same macro).
-        """
-        token = 'tok"with"quote\\and\\backslash'
-        rendered = _render_config_toml({
-            "work": {
-                "type": "atlassian",
-                "ATLASSIAN_URL": "https://co.atlassian.net",
-                "ATLASSIAN_EMAIL": "u@co.com",
-                "ATLASSIAN_API_TOKEN": token,
-            }
-        })
-        # Expected after escape: \\ for backslash, \" for quote.
-        expected_escaped = r'tok\"with\"quote\\and\\backslash'
-        assert f'jira_api_token = "{expected_escaped}"' in rendered
-        assert f'confluence_api_token = "{expected_escaped}"' in rendered
 
-    def test_non_atlassian_integrations_do_not_render_atlassian_keys(self):
-        """A github integration must not produce jira_* or confluence_* keys."""
-        rendered = _render_config_toml({
-            "work": {"type": "github", "GITHUB_TOKEN": "ghp_test"}
-        })
-        assert "jira_url" not in rendered
-        assert "confluence_url" not in rendered
-        assert "jira_api_token" not in rendered
-        assert "confluence_api_token" not in rendered
-        assert 'github_token = "ghp_test"' in rendered
+class TestProviderRenderingAnthropic:
+    def test_anthropic_renders_sub_table_with_api_key(self):
+        rendered = _render(
+            provider={"type": "anthropic", "default_model": "claude-sonnet-4-5"},
+            provider_api_key="sk-ant-test",
+        )
+        assert 'default_provider = "anthropic"' in rendered
+        assert 'default_model = "claude-sonnet-4-5"' in rendered
+        assert "[providers.models.anthropic]" in rendered
+        assert 'kind = "anthropic"' in rendered
+        assert 'model = "claude-sonnet-4-5"' in rendered
+        assert 'api_key = "sk-ant-test"' in rendered
+        # Anthropic must NOT emit base_url (that's ollama only).
+        assert "base_url" not in rendered
 
-    def test_atlassian_partial_dict_omits_absent_keys(self):
-        """Per-key `is defined` guards in the template must drop unset fields
-        cleanly — never produce stray `= ''` or `= None` lines from the missing
-        ATLASSIAN_EMAIL/ATLASSIAN_API_TOKEN halves.
-        """
-        rendered = _render_config_toml({
-            "work": {"type": "atlassian", "ATLASSIAN_URL": "https://co.atlassian.net"},
-        })
-        assert 'jira_url = "https://co.atlassian.net"' in rendered
-        assert 'confluence_url = "https://co.atlassian.net/wiki"' in rendered
-        assert "jira_email" not in rendered
-        assert "confluence_email" not in rendered
-        assert "jira_api_token" not in rendered
-        assert "confluence_api_token" not in rendered
+    def test_anthropic_api_key_toml_escaped(self):
+        """A key with embedded quotes / backslashes must be TOML-escaped."""
+        key = 'sk"with"quote\\and\\bs'
+        rendered = _render(
+            provider={"type": "anthropic", "default_model": "claude-sonnet-4-5"},
+            provider_api_key=key,
+        )
+        # Per TOML basic-string rules: \\ for backslash, \" for quote.
+        assert 'api_key = "sk\\"with\\"quote\\\\and\\\\bs"' in rendered
+
+    def test_api_key_with_control_chars_is_escaped(self):
+        """ATX Round 1 B1: an api_key containing CR/LF/TAB must NOT be
+        able to break out of the TOML basic string and inject keys. The
+        escape macro must encode \\r, \\n, \\t as TOML escape sequences."""
+        key = "leading\ninjected_key = \"evil\"\nokay"
+        rendered = _render(
+            provider={"type": "anthropic", "default_model": "claude-sonnet-4-5"},
+            provider_api_key=key,
+        )
+        # The literal newline must be encoded; the rendered file must
+        # have api_key on exactly one line (no break-out).
+        assert 'api_key = "leading\\ninjected_key = \\"evil\\"\\nokay"' in rendered
+        # And no injected `injected_key = "evil"` TOML statement.
+        for line in rendered.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("injected_key"):
+                raise AssertionError(
+                    f"TOML injection succeeded — got bare key line: {stripped!r}"
+                )
+
+    def test_api_key_with_carriage_return_is_escaped(self):
+        """`\\r` alone also splits TOML lines on some parsers; escape it."""
+        key = "abc\rdef"
+        rendered = _render(
+            provider={"type": "anthropic", "default_model": "x"},
+            provider_api_key=key,
+        )
+        assert 'api_key = "abc\\rdef"' in rendered
+
+    def test_api_key_with_tab_is_escaped(self):
+        """ATX Round 2 W6: a raw `\\t` in a TOML basic string is
+        permitted by spec but parsed inconsistently across implementations;
+        toml_escape must encode it. This pins the escape behavior so a
+        future refactor can't drop the `\\t` branch from the macro."""
+        key = "abc\tdef"
+        rendered = _render(
+            provider={"type": "anthropic", "default_model": "x"},
+            provider_api_key=key,
+        )
+        assert 'api_key = "abc\\tdef"' in rendered
+
+
+class TestProviderRenderingOpenAI:
+    def test_openai_renders_sub_table_with_api_key(self):
+        rendered = _render(
+            provider={"type": "openai", "default_model": "gpt-4o"},
+            provider_api_key="sk-oa-test",
+        )
+        assert 'default_provider = "openai"' in rendered
+        assert 'default_model = "gpt-4o"' in rendered
+        assert "[providers.models.openai]" in rendered
+        assert 'kind = "openai"' in rendered
+        assert 'model = "gpt-4o"' in rendered
+        assert 'api_key = "sk-oa-test"' in rendered
+        assert "base_url" not in rendered
+
+
+class TestProviderRenderingOpenRouter:
+    def test_openrouter_renders_sub_table_with_api_key(self):
+        rendered = _render(
+            provider={
+                "type": "openrouter",
+                "default_model": "anthropic/claude-3.5-sonnet",
+            },
+            provider_api_key="sk-or-test",
+        )
+        assert 'default_provider = "openrouter"' in rendered
+        assert 'default_model = "anthropic/claude-3.5-sonnet"' in rendered
+        assert "[providers.models.openrouter]" in rendered
+        assert 'kind = "openrouter"' in rendered
+        assert 'model = "anthropic/claude-3.5-sonnet"' in rendered
+        assert 'api_key = "sk-or-test"' in rendered
+        assert "base_url" not in rendered
+
+
+class TestProviderRenderingOllama:
+    def test_ollama_renders_sub_table_with_base_url(self):
+        rendered = _render(
+            provider={
+                "type": "ollama",
+                "default_model": "llama3",
+                "endpoint": "http://192.168.1.50:11434",
+            },
+            # provider_api_key is intentionally NOT used for ollama; pass
+            # something non-empty to verify it does not leak through.
+            provider_api_key="should-not-render-for-ollama",
+        )
+        assert 'default_provider = "ollama"' in rendered
+        assert 'default_model = "llama3"' in rendered
+        assert "[providers.models.ollama]" in rendered
+        assert 'kind = "ollama"' in rendered
+        assert 'model = "llama3"' in rendered
+        assert 'base_url = "http://192.168.1.50:11434"' in rendered
+        # Ollama is unauthenticated; api_key must NEVER render for it.
+        assert "api_key" not in rendered
+        assert "should-not-render-for-ollama" not in rendered
+
+    def test_ollama_base_url_toml_escaped(self):
+        endpoint = 'http://host:11434/v1"path'
+        rendered = _render(
+            provider={
+                "type": "ollama",
+                "default_model": "llama3",
+                "endpoint": endpoint,
+            },
+        )
+        assert 'base_url = "http://host:11434/v1\\"path"' in rendered
+
+
+class TestProviderRenderingUnsupportedProvider:
+    """Unsupported provider types must NOT emit a providers.models block.
+
+    The configure playbook fails-fast on these via its `Validate provider
+    configuration is present` task, so the template's tolerant behavior
+    (render gateway, skip provider) keeps the playbook's failure message
+    as the user-facing error rather than producing malformed TOML.
+    """
+
+    def test_unknown_provider_type_skips_provider_block(self):
+        rendered = _render(
+            provider={"type": "bedrock", "default_model": "anthropic.claude-3"},
+            provider_api_key="aws-sig",
+        )
+        # gateway block is still emitted.
+        assert "[gateway]" in rendered
+        # providers.models block is NOT emitted for unknown types.
+        assert "[providers.models" not in rendered
+        assert "default_provider" not in rendered
+
+    def test_no_provider_dict_skips_provider_block(self):
+        rendered = _render(provider=None)
+        assert "[gateway]" in rendered
+        assert "[providers.models" not in rendered
+        assert "default_provider" not in rendered
+
+
+class TestIntegrationsRemoved:
+    """The legacy `[integrations]` block must NOT render in v0.7.5.
+
+    Integrations (github/gitlab/atlassian/linear/notion) are explicitly
+    out of scope for #112 and will land in a follow-up issue. A regression
+    that re-introduces them would silently leak integration credentials
+    into config.toml on every configure run.
+    """
+
+    def test_no_integrations_block_rendered_for_any_provider(self):
+        for provider_type in ("anthropic", "openai", "openrouter", "ollama"):
+            kwargs = {"type": provider_type, "default_model": "m"}
+            if provider_type == "ollama":
+                kwargs["endpoint"] = "http://localhost:11434"
+            rendered = _render(provider=kwargs, provider_api_key="k")
+            assert "[integrations]" not in rendered, (
+                f"integrations block leaked for provider {provider_type}"
+            )
+            for token_name in (
+                "github_token",
+                "gitlab_token",
+                "jira_url",
+                "jira_api_token",
+                "confluence_url",
+                "linear_api_key",
+                "notion_api_key",
+            ):
+                assert token_name not in rendered, (
+                    f"{token_name} leaked for provider {provider_type}"
+                )

--- a/tests/test_install_skip.py
+++ b/tests/test_install_skip.py
@@ -182,6 +182,167 @@ def _skip_marker_event(version: str, path: str) -> dict:
     }
 
 
+def _setup_common_zeroclaw(monkeypatch, tmp_path, host_record: dict, version: str = "0.7.5"):
+    """Same as `_setup_common` but pinned to the zeroclaw manifest shape.
+
+    Added for ATX Round 1 W1: re-install on a paired zeroclaw must not
+    wipe `config.gateway.auth`. The B3 regression guard from issue #357
+    needs the same skip-path harness openclaw uses, with a manifest the
+    install code accepts.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mock_manifest = {
+        "name": "zeroclaw",
+        "entries": [
+            {
+                "version": version,
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "deadbeef",
+                "requirements": {
+                    "min_memory_mb": 1024,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.9"},
+                },
+            }
+        ],
+    }
+
+    import clawrium.core.install
+
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *args, **kwargs: {
+            "compatible": True,
+            "matched_entry": mock_manifest["entries"][0],
+            "reasons": [],
+        },
+    )
+
+    host_state = [host_record]
+
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host", lambda _: host_state[0]
+    )
+
+    def mock_update_host(_, updater):
+        host_state[0] = updater(host_state[0])
+        return True
+
+    monkeypatch.setattr(clawrium.core.install, "update_host", mock_update_host)
+
+    key_file = tmp_path / "test_key"
+    key_file.write_text("fake key")
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda _: key_file
+    )
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", lambda h, c: True
+    )
+
+    return host_state
+
+
+def _zeroclaw_skip_marker_event(version: str) -> dict:
+    """Emit the playbook task that triggers `_install_was_skipped`."""
+    return {
+        "event": "runner_on_ok",
+        "event_data": {
+            "task": "Mark install as skipped when already installed",
+            "res": {
+                "msg": (
+                    f"ZeroClaw v{version} already installed at "
+                    "/home/zer-test/bin/zeroclaw. Skipping binary install."
+                )
+            },
+        },
+    }
+
+
+def _zeroclaw_skip_fact_event() -> dict:
+    """Emit the playbook task that sets the skip fact."""
+    return {
+        "event": "runner_on_ok",
+        "event_data": {
+            "task": "Set install skip condition",
+            "res": {"ansible_facts": {"zeroclaw_already_installed": True}},
+        },
+    }
+
+
+def test_zeroclaw_reinstall_preserves_paired_gateway_token(monkeypatch, tmp_path):
+    """ATX Round 1 W1: re-installing on an already-paired zeroclaw must
+    preserve the `config.gateway.auth` bearer token in hosts.json.
+
+    Pre-#357 install.py only restored `preserved_gateway` for openclaw.
+    The B3 generalization adds zeroclaw to the restore set; this test
+    pins the contract so a future refactor of the guard doesn't silently
+    drop zeroclaw."""
+    from clawrium.core.install import run_installation
+
+    host = {
+        "hostname": "test-host",
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+        "agents": {
+            "zer-paired": {
+                "type": "zeroclaw",
+                "status": "installed",
+                "installed_at": "2026-05-01T00:00:00+00:00",
+                "error": None,
+                "agent_name": "zer-paired",
+                "version": "0.7.5",
+                "config": {
+                    "gateway": {
+                        "url": "ws://test-host:40000/ws/chat",
+                        "auth": "paired-token-from-prior-configure-abc123",
+                    }
+                },
+            }
+        },
+    }
+
+    host_state = _setup_common_zeroclaw(monkeypatch, tmp_path, host)
+
+    import ansible_runner
+
+    run_side_effect = [
+        _result_with_events(tmp_path, []),
+        _result_with_events(
+            tmp_path,
+            [
+                _zeroclaw_skip_fact_event(),
+                _zeroclaw_skip_marker_event("0.7.5"),
+            ],
+        ),
+    ]
+    mock_run = Mock(side_effect=run_side_effect)
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    result = run_installation("zeroclaw", "test-host", name="zer-paired")
+
+    assert result["success"] is True
+    assert result["skipped"] is True
+    assert result["skip_reason"] == "already_installed"
+
+    # The bearer token MUST be byte-identical after the skip. Pre-#357
+    # generalization, `claw_name == "openclaw"` excluded zeroclaw from
+    # the restore path and this assertion would fail.
+    agent_record = host_state[0]["agents"]["zer-paired"]
+    gateway = agent_record["config"]["gateway"]
+    assert gateway["auth"] == "paired-token-from-prior-configure-abc123"
+    assert gateway["url"] == "ws://test-host:40000/ws/chat"
+
+
 def test_install_reuses_existing_installed_name_and_reports_skip(monkeypatch, tmp_path):
     """Skip path must preserve the existing agent's gateway credentials.
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1045,12 +1045,16 @@ def test_manifest_accepts_workspace_and_features_fields(monkeypatch):
 
 
 def test_manifest_workspace_optional_for_legacy_types():
-    """Legacy zeroclaw manifest (no workspace/features) still validates."""
+    """ZeroClaw manifest now declares features.chat (issue #357 wires the
+    WebSocket chat backend) but still does not declare workspace —
+    workspace files land in Subtask C."""
     manifest = load_manifest("zeroclaw")
-    # zeroclaw does not declare workspace or features in Phase 1; both must be absent
-    # (or empty) without breaking validation.
     assert "workspace" not in manifest
-    assert "features" not in manifest
+    # features.chat.type == "zeroclaw" advertises the new dispatch value
+    # introduced in #357. Other feature flags remain absent until later
+    # subtasks (e.g. features.memory in Subtask C).
+    features = manifest.get("features", {})
+    assert features.get("chat", {}).get("type") == "zeroclaw"
 
 
 def test_manifest_rejects_invalid_workspace_memory_path(monkeypatch):


### PR DESCRIPTION
## Summary

- Aligns ZeroClaw configure + chat with upstream v0.7.5: rewrites `config.toml.j2` for the `[providers.models.<name>]` schema with `kind` discriminator, automates the pairing handshake in `configure.yaml`, and introduces a dedicated WebSocket chat backend in `core/chat_zeroclaw.py`.
- `clm chat <zeroclaw-agent>` now connects, sends `{"type":"message"}` frames, streams chunks, and terminates on `done` — with bidi/control-char sanitization at every server-text site and a tear-down-and-break contract for `approval_request`.
- Generalizes `install.py`'s `preserved_gateway` guards so re-installing a paired zeroclaw doesn't wipe `config.gateway.auth` (#112 Subtask B / ATX W3).

Closes #357

## Testing

### Test Results
- [x] All existing tests pass (`make test` — 1849 passed)
- [x] Linter passes (`make lint`)
- [x] New tests added for new functionality (~250 cases across pairing-extraction, idempotent re-configure, force_repair rotation, all 11 WebSocket frame types, Python-3.10 TimeoutError path, bidi sanitization parity, `/etc/hosts` loopback resolution, bytes-frame UTF-8, install-skip preservation of paired tokens)

### Test Coverage
- Files changed: `cli/chat.py`, `core/chat.py`, `core/chat_hermes.py`, `core/chat_zeroclaw.py` (new), `core/install.py`, `core/lifecycle.py`, `core/registry.py`, `platform/registry/zeroclaw/{manifest.yaml,playbooks/configure.yaml,templates/config.toml.j2}`
- New tests: `tests/test_chat_zeroclaw.py` (new) plus extensions to `test_cli_chat.py`, `test_configure_claw.py`, `test_configure_zeroclaw.py`, `test_install_skip.py`, `test_registry.py`
- Coverage impact: increased

### Manual Testing
Not yet run against a real Pi/Ubuntu host — the playbook's pairing handshake assumes upstream `GET /pair/code` → `POST /pair` shape (verified against issue body + upstream `crates/zeroclaw-gateway/src/api_pairing.rs` notes). Integration verification on a real host is a follow-up before close.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (TOML escape covers `\\`, `"`, `\r`, `\n`, `\t`; pairing token length-gated at 16 chars; all server-supplied chat text passes through the bidi/zero-width strip shared with `chat_hermes`)
- [x] No SQL injection, XSS, or command injection risks (TOML basic-string escape pinned by tests; no shell-out from this PR)
- [x] Dependencies are from trusted sources (no new deps)

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: ~\$14.85 | Total Time: ~46m | Agents: leader, security, cli-ux, core-lifecycle, ansible-registry, test-coverage**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1-B7 | All fixed | \$2.08 | 11m | leader, security, cli-ux, ansible-registry, core-lifecycle |
| 2 | 3/5 | none | All warnings addressed | \$3.88 | 12m | leader, security, cli-ux, core-lifecycle, ansible-registry |
| 3 | 3/5 | B1 | All addressed | \$3.30 | 9m | leader, security, cli-ux, ansible-registry, core-lifecycle, test-coverage |
| 4 | 3/5 | B1 (new) | All addressed | \$3.29 | 9m | leader, security, cli-ux, core-lifecycle, ansible-registry, test-coverage |
| 5 | 4/5 | none | W-1 through W-4 fixed in final commit | \$2.27 | 8m | leader, security, cli-ux, test-coverage |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Round 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `config.toml.j2` | TOML control-char injection via `\r`/`\n`/`\t` | Fixed — `toml_escape` now escapes all four classes in correct order |
| B2 | `config.toml.j2` | host/provider_type/model_id unescaped | Fixed — all interpolations pass through `toml_escape`; port is `\| int` |
| B3 | `configure.yaml` | Pairing handshake non-idempotent | Fixed — `zeroclaw_needs_pairing` gates the exchange on `existing_gateway_token` |
| B4 | `configure.yaml` | `no_log: true` missing on validation tasks | Fixed — every pairing-validation `fail` task carries `no_log: true` |
| B5 | `chat_zeroclaw.py` | Python 3.10 crash on `asyncio.TimeoutError` | Fixed — `except (TimeoutError, asyncio.TimeoutError)` at both call sites |
| B6 | `chat_zeroclaw.py` | approval_request `prompt` field not sanitized | Fixed — `sanitize_server_text` on every approval frame field; WS closed before raise |
| B7 | `lifecycle.py` | Bearer token in `hosts.json` flagged | Out-of-scope — `hosts.json` is `0600` at every write site (`hosts.py:127,168,308,345`); openclaw uses the same shape; documented in `.itx/357/01_EXECUTION.md` |

**Warnings:** all 10 fixed (test coverage, 401 surfacing, fast-fail on systemd, redundant `wait_for`, timeout-hint discrimination, `--session` notice, cacheable-fact `no_log`, cleartext warning, `workspace.memory_path` deferred to Subtask C).

</details>

<details>
<summary>Round 2 Details (Rating 3/5)</summary>

10 warnings — all addressed: 401 fact propagation through Python event loop (W1), REPL break on backend disconnect via `is_connected` property (W2), explicit `asyncio.TimeoutError` test pins (W3), `.get('value')` for Discord/Slack secrets (W4), 16-char Python-side threshold (W5), tab-escape test (W6), `force_repair=True` + first-configure tests (W7), connect-timeout vs recv-timeout discrimination (W8), actionable approval message (W9), assertion-depth uniformity across failure tests (W10).

</details>

<details>
<summary>Round 3 Details (Rating 3/5)</summary>

**Blocking:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `test_cli_chat.py` | Loop-break test was vacuous | Fixed — three independent assertions (read_count==1, 'Chat session ended' in stdout, 'Continuing chat session.' NOT in stdout) |

Plus 11 warnings: stale cacheable fact (W1), shared `RECV_TIMEOUT_MSG_PREFIX` constant (W2), `is_connected` in `ChatBackend` Protocol + openclaw/hermes (W3), malformed-dict regression test (W4), warn-event on short-token re-pair (W5), localhost loopback string + getaddrinfo (W7), 16-char positive boundary (W9), negative health-warning tests (W10), is_connected assertion in close-on-approval test (W11), `no_log` on health probe (S1).

</details>

<details>
<summary>Round 4 Details (Rating 3/5)</summary>

**Blocking:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `lifecycle.py:1146` | `emit('warn', ...)` was dead — `_print_configure_warnings` dispatches on `'WARNING:'` prefix | Fixed — both short-token and 401 paths now use `'WARNING:'` prefix + `stage='configure'` + `logger.warning()`, matching `lifecycle.py:1046`'s integration-warning pattern |

Plus 5 warnings: `is_connected` on `FakeChatClient` + direct attribute access (W-A), constant-coupling in timeout test (W-B), getaddrinfo success/failure path tests (W-C), tool_call/tool_result tests (W-D), bytes-frame UTF-8 tests (W-E).

</details>

<details>
<summary>Round 5 Details (Rating 4/5 — merge-ready)</summary>

No blockers. 4 warnings addressed in the final commit:

| # | File | Issue | Resolution |
|---|------|-------|------------|
| W-1 | `test_configure_claw.py` | Short-token re-pair path lacked on_event assertion | Added `test_short_existing_token_emits_warning_via_on_event` |
| W-2 | `test_chat_zeroclaw.py` | tool_call RLO test covered `name` but not `arguments` values | RLO now embedded in argument VALUE; sanitization stripped |
| W-3 | `test_chat_zeroclaw.py` | etc-hosts loopback negative assertion was vacuous | Now asserts `getaddrinfo` was actually called with the expected host |
| W-4 | `test_cli_chat.py` | `FakeChatClient.is_connected` lifecycle diverged from real backend | Now starts `False`, flips `True` on `connect()`, `False` on `close()` |

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>