### PR TITLE
fix(hermes): auto-install ripgrep and ffmpeg via apt (#344)

### DIFF
--- a/.itx/344/00_PLAN.md
+++ b/.itx/344/00_PLAN.md
@@ -1,0 +1,85 @@
+# Issue #344 — Auto-install hermes system dependencies (ripgrep, ffmpeg)
+
+## Customer Outcome
+`clm agent install --type hermes --host <target>` succeeds on a fresh Ubuntu host without the operator having to SSH in and `apt-get install` ripgrep and ffmpeg by hand.
+
+## Problem Summary
+`src/clawrium/platform/registry/hermes/playbooks/install.yaml` currently runs preflight `which rg` / `which ffmpeg` checks and HARD-FAILS with a remediation message when either binary is missing (lines 25–52). The manifest already declares both as platform dependencies (`manifest.yaml` lines 116–117, 125–126), but nothing in the playbook acts on those declarations — they are documentation only.
+
+## Approach
+Replace the "fail if missing" preflight tasks with idempotent `apt` installs. The playbook already runs `become: yes`, so package installation works without additional privilege escalation. Use `update_cache: yes` with a `cache_valid_time` so we don't punish well-maintained hosts with a full apt-update on every install.
+
+Trade-off considered: leaving the `which` detection in place and only running `apt` when missing is fractionally faster on hosts where the binaries exist, but it adds two tasks and a `when:` branch for what `apt: state=present` already handles idempotently. Choosing the simpler form.
+
+Out of scope: non-apt distros (RHEL/Fedora/Arch). The manifest pins `os: ubuntu` for both supported platforms (`manifest.yaml` lines 105, 112), so a `become + apt` task is sufficient. If/when non-Debian support lands, swap to `ansible.builtin.package` with `module_defaults`.
+
+## Files to Modify
+
+### `src/clawrium/platform/registry/hermes/playbooks/install.yaml`
+Replace lines 25–52 (the four preflight tasks: `which rg` check, fail-if-missing, `which ffmpeg` check, fail-if-missing) with a single `ansible.builtin.apt` task installing both packages.
+
+Proposed replacement:
+
+```yaml
+    # Hermes upstream installer requires `rg` and `ffmpeg` on PATH. Install
+    # them via apt before invoking the installer rather than failing with a
+    # manual-remediation message. The playbook already runs `become: yes`,
+    # so no extra escalation is needed. `cache_valid_time` avoids hammering
+    # apt mirrors when the cache is recent.
+    - name: Install hermes system dependencies (ripgrep, ffmpeg)
+      ansible.builtin.apt:
+        name:
+          - ripgrep
+          - ffmpeg
+        state: present
+        update_cache: yes
+        cache_valid_time: 3600
+```
+
+### `tests/test_registry_hermes.py`
+Lines 131–135 assert that `which rg` and `which ffmpeg` appear in the install playbook. Update the assertions to verify the new behavior: apt task present, both package names listed.
+
+Proposed change:
+
+```python
+    # Hermes upstream installer requires ripgrep and ffmpeg. Verify they are
+    # installed via apt rather than expected to be pre-provisioned.
+    assert "ansible.builtin.apt" in content
+    assert "ripgrep" in content
+    assert "ffmpeg" in content
+```
+
+## Steps
+1. Edit `install.yaml` — replace the four preflight tasks with the single `apt` install task.
+2. Update `tests/test_registry_hermes.py` assertions to match.
+3. Run `make test` and `make lint`. Fix any failures.
+4. Manual smoke (optional, if a target host is available): `clm agent install --type hermes --host <fresh-ubuntu>` on a host where `rg` and `ffmpeg` are absent, confirm install succeeds.
+
+## Test Strategy
+- **Unit**: existing `test_registry_hermes.py` covers playbook structure — update assertions and run `make test`.
+- **Idempotency**: `apt: state=present` is idempotent by design; re-running the playbook on a host where both packages exist must be a no-op (already covered by the broader install-skip path on subsequent runs).
+- **Manual**: smoke install on a fresh Ubuntu 22.04 and/or 24.04 host where `rg` and `ffmpeg` are absent.
+
+## Risks
+- **Apt lock contention**: if another process holds `/var/lib/dpkg/lock-frontend`, the task fails. Acceptable — same failure mode the user would hit running apt manually. Not worth a retry loop in v1.
+- **Cache staleness**: `cache_valid_time: 3600` means if a host hasn't updated its cache in over an hour, we trigger `apt-get update` before install. That's the right default; adds 5–30s on first install per host but avoids stale-index failures.
+- **Network**: hosts behind restrictive egress that block Ubuntu mirrors will fail. Same failure mode as today's "install ripgrep manually" path — not a regression.
+
+## Subtasks
+None — single-file behavior change with a paired test update. Below the 3-file threshold.
+
+---
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: planning
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-05-15T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+344 plan create only. dont update issue
+```
+
+</details>

--- a/src/clawrium/platform/registry/hermes/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/install.yaml
@@ -22,34 +22,19 @@
         create_home: yes
         shell: /usr/sbin/nologin
 
-    # Preflight: hermes upstream installer requires `rg` and `ffmpeg` on PATH.
-    # We treat their absence as a hard failure with a clear remediation message
-    # rather than letting hermes-install.sh fail mid-flight.
-    - name: Preflight — check ripgrep (rg) is installed
-      ansible.builtin.command: which rg
-      register: hermes_rg_check
-      changed_when: false
-      failed_when: false
-
-    - name: Preflight — fail if ripgrep missing
-      ansible.builtin.fail:
-        msg: |
-          ripgrep (binary `rg`) is required by hermes but was not found on this host.
-          Install it with: sudo apt-get update && sudo apt-get install -y ripgrep
-      when: hermes_rg_check.rc != 0
-
-    - name: Preflight — check ffmpeg is installed
-      ansible.builtin.command: which ffmpeg
-      register: hermes_ffmpeg_check
-      changed_when: false
-      failed_when: false
-
-    - name: Preflight — fail if ffmpeg missing
-      ansible.builtin.fail:
-        msg: |
-          ffmpeg is required by hermes but was not found on this host.
-          Install it with: sudo apt-get update && sudo apt-get install -y ffmpeg
-      when: hermes_ffmpeg_check.rc != 0
+    # Hermes upstream installer requires `rg` and `ffmpeg` on PATH. Install
+    # them via apt before invoking the installer rather than failing with a
+    # manual-remediation message. The play already runs `become: yes`, so no
+    # extra escalation is needed. `cache_valid_time` avoids hammering apt
+    # mirrors when the cache is recent.
+    - name: Install hermes system dependencies (ripgrep, ffmpeg)
+      ansible.builtin.apt:
+        name:
+          - ripgrep
+          - ffmpeg
+        state: present
+        update_cache: yes
+        cache_valid_time: 3600
 
     # Version-aware skip: re-running install on a host that already has the
     # target version is a no-op for the binary install step. `--force` (via

--- a/tests/test_registry_hermes.py
+++ b/tests/test_registry_hermes.py
@@ -787,12 +787,19 @@ def test_hermes_install_apt_failure_raises(monkeypatch, tmp_path):
         config = Config()
         events = []
 
-    monkeypatch.setattr(
-        ansible_runner, "run", Mock(side_effect=[BaseResult(), AptFailedResult()])
-    )
+    # run() is called twice: base playbook (success) then claw install.yaml
+    # (apt fails). The match= string below matches every claw-side failure,
+    # since the error is status-driven (see core/install.py:677) — this is
+    # intentional and matches test_hermes_install_checksum_failure_raises.
+    mock_run = Mock(side_effect=[BaseResult(), AptFailedResult()])
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
 
     with pytest.raises(InstallationError, match="Agent playbook failed"):
         run_installation("hermes", "test-host", name="hermes-test")
+
+    # Guard against a future short-circuit that skips the claw playbook
+    # entirely — the apt failure can only be reached if both calls fire.
+    assert mock_run.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry_hermes.py
+++ b/tests/test_registry_hermes.py
@@ -128,11 +128,24 @@ def test_hermes_install_playbook_shape():
     assert "--hermes-home" in content
     assert "/home/{{ agent_name }}/.hermes" in content
     assert "/home/{{ agent_name }}/.local/bin/hermes" in content
-    # Preflight checks reference the canonical binary names. We use `which`
-    # (executable in /usr/bin) rather than the shell builtin `command -v`,
-    # since ansible.builtin.command does not invoke a shell.
-    assert "which rg" in content
-    assert "which ffmpeg" in content
+    # Hermes upstream installer requires ripgrep and ffmpeg. Verify the
+    # playbook installs them via apt rather than expecting them to be
+    # pre-provisioned on the target host (issue #344). Structural check
+    # (not substring) so a change to state=latest or removal of
+    # cache_valid_time is caught here, not in production.
+    parsed = yaml.safe_load(content)
+    parsed_tasks = parsed[0]["tasks"]
+    apt_tasks = [t for t in parsed_tasks if "ansible.builtin.apt" in t]
+    assert len(apt_tasks) == 1, (
+        "install.yaml must have exactly one apt task installing hermes system deps"
+    )
+    apt_args = apt_tasks[0]["ansible.builtin.apt"]
+    assert apt_args["state"] == "present", (
+        "apt task must use state=present (not latest) to remain idempotent"
+    )
+    assert set(apt_args["name"]) >= {"ripgrep", "ffmpeg"}
+    assert apt_args["update_cache"] is True
+    assert apt_args["cache_valid_time"] == 3600
     # Service unit MUST NOT be enabled or started in install.yaml.
     # ExecStart must use `hermes gateway run` (NOT `start`): the `start`
     # subcommand fails with "Gateway service is not installed" because hermes
@@ -703,6 +716,84 @@ def test_hermes_install_checksum_failure_raises(monkeypatch, tmp_path):
 
     monkeypatch.setattr(
         ansible_runner, "run", Mock(side_effect=[BaseResult(), FailedResult()])
+    )
+
+    with pytest.raises(InstallationError, match="Agent playbook failed"):
+        run_installation("hermes", "test-host", name="hermes-test")
+
+
+def test_hermes_install_playbook_apt_idempotency_attrs():
+    """Dedicated guard for the apt task's idempotency contract (issue #344
+    ATX review B3): a code change to state=latest or removal of
+    cache_valid_time must fail CI even if the broader playbook-shape test
+    is refactored."""
+    from importlib.resources import files
+    import yaml
+
+    hermes_pkg = files("clawrium.platform.registry.hermes")
+    install_path = hermes_pkg / "playbooks" / "install.yaml"
+    data = yaml.safe_load(install_path.read_text())
+    tasks = data[0]["tasks"]
+
+    apt_tasks = [t for t in tasks if "ansible.builtin.apt" in t]
+    assert len(apt_tasks) == 1
+    apt_args = apt_tasks[0]["ansible.builtin.apt"]
+    assert apt_args["state"] == "present"
+    assert apt_args["cache_valid_time"] == 3600
+
+
+def test_hermes_install_apt_failure_raises(monkeypatch, tmp_path):
+    """Issue #344 ATX review B2: when the apt task fails (e.g. package
+    not found, mirror unreachable), ansible_runner returns status='failed'
+    and run_installation must raise InstallationError."""
+    from clawrium.core.install import InstallationError, run_installation
+
+    host = {
+        "hostname": "test-host",
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    _hermes_install_setup(monkeypatch, tmp_path, host)
+
+    import ansible_runner
+    from unittest.mock import Mock
+
+    class BaseResult:
+        status = "successful"
+
+        class Config:
+            artifact_dir = "/tmp/nonexistent"
+
+        config = Config()
+        events = []
+
+    class AptFailedResult:
+        status = "failed"
+
+        class Config:
+            artifact_dir = "/tmp/nonexistent"
+
+        config = Config()
+        events = [
+            {
+                "event": "runner_on_failed",
+                "event_data": {
+                    "task": "Install hermes system dependencies (ripgrep, ffmpeg)",
+                    "res": {
+                        "msg": "E: Unable to locate package ripgrep",
+                        "failed": True,
+                    },
+                },
+            }
+        ]
+
+    monkeypatch.setattr(
+        ansible_runner, "run", Mock(side_effect=[BaseResult(), AptFailedResult()])
     )
 
     with pytest.raises(InstallationError, match="Agent playbook failed"):

--- a/tests/test_registry_hermes.py
+++ b/tests/test_registry_hermes.py
@@ -740,6 +740,8 @@ def test_hermes_install_playbook_apt_idempotency_attrs():
     apt_args = apt_tasks[0]["ansible.builtin.apt"]
     assert apt_args["state"] == "present"
     assert apt_args["cache_valid_time"] == 3600
+    assert apt_args["update_cache"] is True
+    assert set(apt_args["name"]) >= {"ripgrep", "ffmpeg"}
 
 
 def test_hermes_install_apt_failure_raises(monkeypatch, tmp_path):
@@ -773,24 +775,17 @@ def test_hermes_install_apt_failure_raises(monkeypatch, tmp_path):
         events = []
 
     class AptFailedResult:
+        # Simulates `apt-get install ripgrep` failing with
+        # "E: Unable to locate package". Error detection in
+        # run_installation is status-driven, not event-driven, so the
+        # events list is intentionally empty.
         status = "failed"
 
         class Config:
             artifact_dir = "/tmp/nonexistent"
 
         config = Config()
-        events = [
-            {
-                "event": "runner_on_failed",
-                "event_data": {
-                    "task": "Install hermes system dependencies (ripgrep, ffmpeg)",
-                    "res": {
-                        "msg": "E: Unable to locate package ripgrep",
-                        "failed": True,
-                    },
-                },
-            }
-        ]
+        events = []
 
     monkeypatch.setattr(
         ansible_runner, "run", Mock(side_effect=[BaseResult(), AptFailedResult()])


### PR DESCRIPTION
## Summary

- Replace the four preflight `which`/`fail` tasks in `src/clawrium/platform/registry/hermes/playbooks/install.yaml` with a single idempotent `ansible.builtin.apt` task that installs `ripgrep` and `ffmpeg`.
- Updates `tests/test_registry_hermes.py` with parsed-YAML structural assertions for the new task plus dedicated tests for idempotency attributes (`state=present`, `update_cache=true`, `cache_valid_time=3600`, package name set) and an apt-failure path that raises `InstallationError`.
- The play already runs `become: yes`, so no extra privilege escalation is needed. `cache_valid_time: 3600` avoids hammering apt mirrors on recent hosts.

Closes #344

## Testing

- `make test` — 1911 Python tests + 48 GUI tests pass.
- `make lint` — clean.
- **End-to-end verification on wolf-i**: installed a fresh hermes test agent (`deps-test`) using the updated playbook. The new `Install hermes system dependencies (ripgrep, ffmpeg)` task ran as expected (no-op, deps already present), and the full play completed successfully through systemd unit drop. Test agent removed after verification.

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $5.39 | Total Time: ~4m | Iterations: 4**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1, B2, B3 | All fixed | $0.95 | ~60s | leader, security-reviewer, test-coverage-reviewer, ansible-registry-reviewer |
| 2 | 3/5 | B3 (partial), W1 (S2) | All fixed | $0.73 | ~60s | leader, ansible, test-coverage, security |
| 3 | 3/5 | Commit hygiene (B3 fix unstaged) | Fixed | $1.49 | ~60s | leader, ansible, test-coverage, core-lifecycle, security |
| 4 | 4/5 | None | Approved | $2.22 | ~60s | leader, ansible, core-lifecycle, security, test-coverage, cli-ux |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_registry_hermes.py:134-136` | Substring assertions (`'ansible.builtin.apt' in content`, `'ripgrep' in content`, `'ffmpeg' in content`) — pass even if `state` is wrong or `cache_valid_time` is removed | Fixed — replaced with parsed-YAML structural check on `state`, name set, `update_cache`, `cache_valid_time` |
| B2 | `tests/test_registry_hermes.py` (missing) | No failure-path test for the apt task | Fixed — added `test_hermes_install_apt_failure_raises` mirroring the checksum-failure test |
| B3 | `tests/test_registry_hermes.py` (missing) | No dedicated idempotency-attrs guard | Fixed — added `test_hermes_install_playbook_apt_idempotency_attrs` |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `install.yaml:31` | apt packages not version-pinned (supply-chain) | Acknowledged — packages are from Ubuntu `main`, low risk; deferred |
| W2 | `tests:437` | `_capture_run` always returns success | Acknowledged — refactor deferred |
| W3 | `install.yaml` | Apt task runs unconditionally even on version-skip path | Acknowledged — by design |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B3 (partial) | `tests/test_registry_hermes.py` (dedicated test) | Idempotency test omitted `update_cache` and package-name assertions, making it dependent on the broader shape test | Fixed — added `assert apt_args['update_cache'] is True` and `set(apt_args['name']) >= {'ripgrep', 'ffmpeg'}` |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 (S2) | `AptFailedResult.events` | Decorative events payload implies depth that isn't tested | Fixed — stripped to `[]` with a comment naming the simulated failure scenario |

</details>

<details>
<summary>Review 3 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| Hygiene | `tests/test_registry_hermes.py` | Iteration-2 fixes (B3 assertions + W1 comment) existed in working tree but were unstaged when iteration 3 was requested | Fixed — committed as `162cd00` |

</details>

<details>
<summary>Review 4 Details (Rating 4/5 — Approved)</summary>

Zero blockers. All warnings flagged are pre-existing in `src/clawrium/cli/install.py:350` (unescaped Rich markup on `InstallationError`), `src/clawrium/core/install.py:678` (redundant "failed: failed" string), and removal of per-package fail messages on network-unreachable hosts (acknowledged in `00_PLAN.md`). None introduced by this diff. Non-blocking suggestions tracked for follow-up.

</details>

## Reviewer Notes

- All 1911 Python tests + 48 GUI tests pass.
- Real installer verified end-to-end on wolf-i before requesting ATX review.
- `.itx/344/00_PLAN.md` committed alongside the change per repo convention.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>