### PR TITLE
feat(skills): #382 Phase 3 — install clawrium/tdd on openclaw + zeroclaw end-to-end

### DIFF
--- a/.itx/382/01_EXECUTION.md
+++ b/.itx/382/01_EXECUTION.md
@@ -1,0 +1,393 @@
+# Issue #382 — Phase 3 Execution Log
+
+Scope (from issue body): the same `clawrium/tdd` skill must install
+on a real openclaw agent AND a real zeroclaw agent via
+`clm agent skill install`, with cross-claw parity proven. This is the
+🏁 *CLI surface complete* milestone for #364.
+
+Plan reference: `.itx/364/00_PLAN.md` § *Phased execution → Phase 3*
+and `.itx/364/02_PHASE0_FINDINGS.md` (openclaw = auto-scan, drop
+`openclaw.json` re-render; zeroclaw = native CLI wrap with audit gate,
+workspace-scoped path, source-dirname == slug).
+
+## What shipped
+
+**Per-claw materialization playbooks:**
+
+- `src/clawrium/platform/registry/openclaw/playbooks/skills_apply.yaml`
+  - Plain file-copy to `~/.openclaw/skills/<slug>/SKILL.md`. Per Phase 0
+    findings, openclaw auto-scans this path; no `openclaw.json`
+    re-render is needed.
+  - **Ownership boundary: `.clawrium-managed` sentinel file** dropped
+    inside each clawrium-installed skill dir. Pruning is the
+    intersection of (top-level dirs under `~/.openclaw/skills/` that
+    carry the sentinel) and (NOT in desired). User-authored skills are
+    invisible to the prune step. openclaw's SKILL.md scanner ignores
+    dotfiles so the sentinel is inert with respect to discovery.
+  - Atomic SKILL.md write via `ansible.builtin.copy` (tempfile +
+    rename) — safe against a concurrent openclaw daemon read.
+  - Defense-in-depth slug + agent_name regex validation inside the
+    playbook (mirrors the Python-side check).
+
+- `src/clawrium/platform/registry/zeroclaw/playbooks/skills_apply.yaml`
+  - Wraps the native `zeroclaw skills install <path>` CLI so the
+    security audit gate runs on every install. We never write directly
+    into `~/.zeroclaw/workspace/skills/`.
+  - **Ownership boundary: `~/.zeroclaw/.clawrium-managed-skills`
+    tracking file** (newline-separated slugs). Lives OUTSIDE
+    `workspace/skills/` so the audit gate doesn't scan it. The prune
+    set is `(tracked - desired) ∩ installed_on_host` — the intersection
+    with on-disk state means we never call `zeroclaw skills remove` on
+    a slug that's already been natively removed (which would error).
+  - Idempotent: `desired - installed_on_host` is the install set, so
+    a slug that's already in `~/.zeroclaw/workspace/skills/` skips
+    the audit gate (slow) on idempotent applies.
+  - Tracking file is written LAST so a mid-apply failure leaves the
+    previous ownership log intact — next apply reconverges.
+  - `argv:` form on every `ansible.builtin.command` invocation (no
+    shell parsing of slug arguments).
+
+**Core dispatch:**
+
+- `src/clawrium/core/skills_apply.py` — extended
+  `_APPLY_PLAYBOOK_BY_CLAW` with `openclaw` and `zeroclaw` entries.
+  Updated docstrings and `SkillApplyNotSupported` message; the error
+  now only fires for claw types outside `NATIVE_REGISTRIES` (a
+  defensive guard, not an expected-phase-2 path).
+
+**Tests (20 new, all passing alongside the existing 2068 → 2088 total):**
+
+- `tests/test_core_skills_apply.py`:
+  - Removed the now-obsolete `test_apply_state_openclaw_not_supported`
+    (replaced by openclaw + zeroclaw dispatch tests).
+  - Added 7 cases for openclaw + zeroclaw: empty-state apply,
+    `clawrium/tdd` staging + dispatch to the correct per-claw playbook
+    path, openclaw frontmatter NOT carrying hermes-only overrides
+    (regression guard for `materialize_for_claw`), zeroclaw routes to
+    `/zeroclaw/` not `/hermes/` or `/openclaw/`, drift-recovery
+    contract.
+
+- `tests/test_registry_skills_apply.py` (new file):
+  - Structural assertions on both new playbooks: file existence,
+    input-validation-precedes-mutation ordering,
+    `find depth: 1` pruning bound, openclaw sentinel mechanism,
+    zeroclaw native CLI wrap (not raw copy), tracking-file path is
+    outside `workspace/skills/`, tracking-file-written-last invariant,
+    `argv:` form on all commands. Tests assert YAML semantics, not
+    runtime — runtime is exercised by the unit suite (mocked
+    `ansible_runner`) and the real-host transcripts below.
+
+## Verification
+
+```
+$ make test
+============================ 2088 passed in 17.93s =============================
+gui: 88 passed (88)
+
+$ make lint
+All checks passed!
+✔ No ESLint warnings or errors
+```
+
+## Smoke test — tdd-openclaw @ wolf-i
+
+```
+$ uv run clm agent skill list tdd-openclaw
+No skills installed on tdd-openclaw. Try clm agent skill install tdd-openclaw
+clawrium/tdd.
+
+$ uv run clm agent skill install tdd-openclaw clawrium/tdd
+Installed clawrium/tdd on tdd-openclaw.
+
+$ uv run clm agent skill list tdd-openclaw
+      Skills on tdd-openclaw
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━┓
+┃ Ref          ┃ Registry ┃ Name ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━┩
+│ clawrium/tdd │ clawrium │ tdd  │
+└──────────────┴──────────┴──────┘
+```
+
+On host (`192.168.1.36`, as user `tdd-openclaw`):
+
+```
+$ ssh xclm@192.168.1.36 sudo ls -la /home/tdd-openclaw/.openclaw/skills/tdd/
+-rw-r--r--  17 May 17 11:45 .clawrium-managed   # sentinel
+-rw-r--r-- 1961 May 17 11:45 SKILL.md
+```
+
+Native openclaw discovery:
+
+```
+$ sudo -u tdd-openclaw .../openclaw skills list | grep tdd
+│ ✓ ready │ 📦 tdd │ Test-Driven Development discipline... │ openclaw-managed │
+```
+
+`openclaw-managed` is the source classification openclaw assigns to
+user-extensible auto-scan skills — confirmed in Phase 0.
+
+**Drift recovery:**
+
+```
+$ ssh xclm@192.168.1.36 sudo rm -f /home/tdd-openclaw/.openclaw/skills/tdd/SKILL.md
+
+$ uv run clm agent skill install tdd-openclaw clawrium/tdd
+clawrium/tdd was already in desired state; reconciled host. Skills now
+installed: clawrium/tdd.
+
+$ ssh xclm@192.168.1.36 sudo ls /home/tdd-openclaw/.openclaw/skills/tdd/
+.clawrium-managed
+SKILL.md   # restored
+```
+
+**Bounded pruning:**
+
+Setup: drop a user-authored skill (no sentinel) and a stray
+clawrium-managed orphan dir (sentinel present, but absent from desired
+state):
+
+```
+$ ssh xclm@192.168.1.36 'sudo ls /home/tdd-openclaw/.openclaw/skills/'
+stray-orphan          # has .clawrium-managed marker → in prune scope
+tdd                   # in desired state → kept
+user-authored-skill   # no marker → invisible to pruner
+```
+
+After re-applying (no change to desired state, but apply runs):
+
+```
+$ uv run clm agent skill install tdd-openclaw clawrium/tdd
+clawrium/tdd was already in desired state; reconciled host. Skills now
+installed: clawrium/tdd.
+
+$ ssh xclm@192.168.1.36 'sudo ls /home/tdd-openclaw/.openclaw/skills/'
+tdd                   # in desired — kept
+user-authored-skill   # no sentinel — untouched
+```
+
+`stray-orphan` was pruned (marker → in scope, not in desired);
+`user-authored-skill` was preserved exactly as we want.
+
+## Smoke test — tdd-zeroclaw @ wolf-i
+
+```
+$ uv run clm agent skill list tdd-zeroclaw
+No skills installed on tdd-zeroclaw. Try clm agent skill install tdd-zeroclaw
+clawrium/tdd.
+
+$ uv run clm agent skill install tdd-zeroclaw clawrium/tdd
+Installed clawrium/tdd on tdd-zeroclaw.
+
+$ uv run clm agent skill list tdd-zeroclaw
+      Skills on tdd-zeroclaw
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━┓
+┃ Ref          ┃ Registry ┃ Name ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━┩
+│ clawrium/tdd │ clawrium │ tdd  │
+└──────────────┴──────────┴──────┘
+```
+
+On host:
+
+```
+$ ssh xclm@192.168.1.36 sudo ls /home/tdd-zeroclaw/.zeroclaw/workspace/skills/
+tdd
+
+$ ssh xclm@192.168.1.36 sudo cat /home/tdd-zeroclaw/.zeroclaw/.clawrium-managed-skills
+tdd
+```
+
+Native zeroclaw discovery (the audit gate ran successfully):
+
+```
+$ sudo -u tdd-zeroclaw .../zeroclaw skills list
+Installed skills (1):
+  tdd v0.1.0 — Test-Driven Development discipline. Drives a red → green → refactor
+```
+
+Recall from Phase 0: zeroclaw `skills list` reads the internal
+`name:` from frontmatter, so we see `tdd` (not `clawrium/tdd`). The
+on-disk dirname is also `tdd`, matching the source-dirname == slug
+contract.
+
+**Drift recovery (native-remove out of band, then re-apply):**
+
+```
+$ sudo -u tdd-zeroclaw .../zeroclaw skills remove tdd
+  ✓ Skill 'tdd' removed.
+
+$ ssh xclm@192.168.1.36 'sudo ls /home/tdd-zeroclaw/.zeroclaw/workspace/skills/'
+(empty)
+
+$ uv run clm agent skill install tdd-zeroclaw clawrium/tdd
+clawrium/tdd was already in desired state; reconciled host. Skills now
+installed: clawrium/tdd.
+
+$ ssh xclm@192.168.1.36 'sudo ls /home/tdd-zeroclaw/.zeroclaw/workspace/skills/'
+tdd       # restored via zeroclaw skills install (audit gate ran again)
+
+$ sudo -u tdd-zeroclaw .../zeroclaw skills list
+Installed skills (1):
+  tdd v0.1.0 — Test-Driven Development discipline...
+```
+
+**Bounded pruning:**
+
+Install an out-of-band skill via the native CLI (no clawrium
+involvement), then run `remove tdd` and confirm the out-of-band skill
+survives:
+
+```
+$ sudo -u tdd-zeroclaw .../zeroclaw skills install /tmp/manual-test-skill
+  ✓ Skill installed and audited:
+    /home/tdd-zeroclaw/.zeroclaw/workspace/skills/manual-test-skill
+    (2 files scanned)
+  Security audit completed successfully.
+
+$ sudo -u tdd-zeroclaw .../zeroclaw skills list
+Installed skills (2):
+  tdd                v0.1.0 — Test-Driven Development discipline...
+  manual-test-skill  v0.1.0 — Skill installed manually out-of-band; pruning must not touch this.
+
+$ sudo cat /home/tdd-zeroclaw/.zeroclaw/.clawrium-managed-skills
+tdd                 # tracking file did not get polluted by the out-of-band install
+
+$ uv run clm agent skill remove tdd-zeroclaw clawrium/tdd
+Removed clawrium/tdd from tdd-zeroclaw.
+
+$ sudo -u tdd-zeroclaw .../zeroclaw skills list
+Installed skills (1):
+  manual-test-skill  v0.1.0 — Skill installed manually out-of-band; pruning must not touch this.
+
+$ ls /home/tdd-zeroclaw/.zeroclaw/workspace/skills/
+manual-test-skill   # out-of-band skill preserved; only tdd was pruned
+
+$ sudo cat /home/tdd-zeroclaw/.zeroclaw/.clawrium-managed-skills
+(empty)             # ownership log reconverged to match desired state
+```
+
+## Cross-claw parity proven
+
+The **same** `clawrium/tdd` skill (one normalized `_meta.yaml`, one
+catalog entry under `skills/clawrium/tdd/`) now installs end-to-end on
+all three claws:
+
+| Claw     | On-disk path                                  | Discovery mechanism           | Pruning boundary             |
+|----------|-----------------------------------------------|-------------------------------|------------------------------|
+| hermes   | `~/.hermes/skills/clawrium/tdd/`              | auto-scan (subdir namespace)  | clawrium subdir              |
+| openclaw | `~/.openclaw/skills/tdd/`                     | auto-scan (flat)              | `.clawrium-managed` sentinel |
+| zeroclaw | `~/.zeroclaw/workspace/skills/tdd/`           | native `zeroclaw skills install` (audit gate) | `~/.zeroclaw/.clawrium-managed-skills` tracking file |
+
+The normalized `_meta.yaml` shape locked in Phase 0 fed all three
+materializers without per-claw catalog edits.
+
+## Design notes / non-obvious choices
+
+1. **Sentinel vs. subdir vs. tracking file is per-claw, not uniform.**
+   Hermes already used a clawrium-owned subdir
+   (`~/.hermes/skills/clawrium/`) because hermes' skills tree is
+   category-namespaced upstream. Openclaw is flat under
+   `~/.openclaw/skills/` and has no notion of categories, so we use an
+   in-dir sentinel file. Zeroclaw's install path is dictated by the
+   native CLI (we don't write directly into `workspace/skills/`), so
+   we keep ownership info in a sibling tracking file outside the
+   skills subtree — adding files inside the source dir might surface
+   in the audit gate's "files scanned" report and looked like
+   unnecessary attack surface.
+
+2. **Tracking file is written LAST in zeroclaw apply.** If any
+   `skills install` fails (e.g., audit gate rejects), the previous
+   tracking file content is intact, and the next apply will reconverge
+   without orphaning slugs. This is the same "validate-then-mutate"
+   discipline used in `apply_state` itself.
+
+3. **`argv:` form everywhere on `ansible.builtin.command`.** Even
+   though every slug is regex-validated upstream and inside the
+   playbook, passing arguments through a shell parser is gratuitous
+   risk. The `test_zeroclaw_playbook_install_uses_argv_form_not_shell`
+   test enforces this so a future refactor can't quietly revert.
+
+4. **Prune-set ∩ installed-on-host for zeroclaw.**
+   `zeroclaw skills remove <slug>` returns non-zero for an
+   already-removed slug (Phase 0 confirmed). The intersection step
+   guarantees idempotency: if the user natively removed a skill that's
+   still in our tracking file, the next apply notices the gap, skips
+   the redundant `remove`, and the tracking file gets reconverged on
+   the final write-tracking step.
+
+5. **openclaw frontmatter has NO hermes overrides leaked into it.**
+   `materialize_for_claw(skill, "openclaw")` only lifts
+   `native.openclaw` (which is `{}` in `clawrium/tdd`). A dedicated
+   test (`test_apply_state_openclaw_materialized_skill_md_has_no_hermes_overrides`)
+   asserts this — guards against the materializer regressing into
+   "always merge `native.hermes` because that's the only override block
+   we have today".
+
+6. **No change to `apply_state` orchestration.** The dispatch table is
+   a single-line addition. All three claws share the same
+   validate-stage-dispatch-cleanup contract; the per-claw playbooks
+   carry the entire per-claw surface area. This makes future claws
+   easy to add (drop a `skills_apply.yaml`, add a dispatch entry).
+
+## Review
+
+ATX MCP (`mcp__atx__request_review`) was not available in this session
+— only Gmail/Calendar/Drive MCPs were surfaced via ToolSearch. Falling
+back to manual review with self-attestation per the
+`<manual-review-requirements>` section in `AGENTS.md`. The test fleet
+(`tdd-openclaw`, `tdd-zeroclaw`) remains available for re-running
+smoke if reviewer asks.
+
+Self-review checklist:
+- All existing tests (2068) + 20 new tests pass; GUI tests pass (88).
+- Lint clean (ruff + ESLint).
+- No hardcoded secrets / credentials.
+- Inputs validated at every layer (Python + Ansible).
+- No path-traversal vectors (regex-bounded basename joins,
+  `find depth: 1`).
+- Pruning bounded to clawrium-owned subtree on each claw — verified on
+  real hosts with adversarial fixtures.
+- Idempotent install/remove (verified on hosts).
+- Drift recovery (verified on both claws).
+- Tracking file (zeroclaw) is written last so partial failures don't
+  poison the ownership log.
+
+## What this PR does not do
+
+- **No `--force` reinstall flag.** If a clawrium-managed skill is
+  already installed on zeroclaw, `skill install` is a no-op even if
+  the catalog SKILL.md changed. Re-installing the skill requires
+  `remove` + `install`. Out of scope for Phase 3.
+- **No GUI parity.** Phase 5 adds `/api/agents/<agent>/skills`
+  routes and the agent-detail Skills tab.
+- **No catalog browser improvements.** That landed in #380.
+
+## 🏁 Milestone
+
+This phase closes the CLI surface for #364. From here:
+- `clm skill list / show`                                      — done (#380)
+- `clm agent skill list / install / remove` for hermes         — done (#381)
+- `clm agent skill list / install / remove` for openclaw       — done (#382, this PR)
+- `clm agent skill list / install / remove` for zeroclaw       — done (#382, this PR)
+
+GUI parity (Phase 5) + CI + docs (Phase 6) remain.
+
+---
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-17T12:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 382 --pr-base=issue-381-cli-skill-install-hermes
+```
+
+Execution proceeded straight through plan → implement → test → smoke
+without further user clarification. ATX MCP was unavailable; review
+fell back to manual self-attestation.
+
+</details>

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -654,6 +654,7 @@ def _sanitize_exception_text(exc: Exception, max_len: int = 500) -> str:
     cleaned = re.sub(
         "["
         "\x00-\x1f\x7f-\x9f"
+        "\u061c"             # ARABIC LETTER MARK (UAX#9 bidi format char)
         "\u200b-\u200f"      # ZWSP, ZWNJ, ZWJ, LRM, RLM
         "\u2028-\u2029"      # LINE / PARAGRAPH SEPARATOR
         "\u202a-\u202e"      # LRE, RLE, PDF, LRO, RLO

--- a/src/clawrium/core/chat_hermes.py
+++ b/src/clawrium/core/chat_hermes.py
@@ -387,6 +387,7 @@ def _extract_delta_content(chunk: Any) -> str:
 _CONTROL_CHARS_RE = re.compile(
     "["
     "\x00-\x1f\x7f-\x9f"
+    "\u061c"             # ARABIC LETTER MARK (UAX#9 bidi format char)
     "\u200b-\u200f"      # ZWSP, ZWNJ, ZWJ, LRM, RLM
     "\u2028-\u2029"      # LINE / PARAGRAPH SEPARATOR
     "\u202a-\u202e"      # LRE, RLE, PDF, LRO, RLO
@@ -406,6 +407,7 @@ _WHITESPACE_RUN_RE = re.compile(r" +")
 _ASSISTANT_TEXT_STRIP_RE = re.compile(
     "["
     "\x00-\x08\x0b-\x1f\x7f-\x9f"
+    "\u061c"             # ARABIC LETTER MARK (UAX#9 bidi format char)
     "\u200b-\u200f"      # ZWSP, ZWNJ, ZWJ, LRM, RLM
     "\u2028-\u2029"      # LINE / PARAGRAPH SEPARATOR
     "\u202a-\u202e"      # LRE, RLE, PDF, LRO, RLO

--- a/src/clawrium/core/skills_apply.py
+++ b/src/clawrium/core/skills_apply.py
@@ -17,9 +17,11 @@ is intentionally a tight orchestrator:
      clawrium-owned subtree on the host, and idempotency.
   6. Clean up the staging dir in a `finally` block.
 
-Phase 2 only wires up hermes. Other claw types raise
-`SkillApplyNotSupported` — surfaced as a clear CLI message rather than a
-traceback. Phases 3+ extend the dispatch table.
+All three native claw types are wired as of Phase 3 (#382). The
+`_APPLY_PLAYBOOK_BY_CLAW` dispatch maps each `agent_type` to its
+`skills_apply.yaml`; an `agent_type` outside `NATIVE_REGISTRIES` raises
+`SkillApplyNotSupported` so the CLI surfaces a clear "unsupported claw
+type" message rather than a missing-playbook traceback.
 """
 
 from __future__ import annotations
@@ -74,22 +76,24 @@ class SkillApplyError(SkillError):
 
 
 class SkillApplyNotSupported(SkillError):
-    """Raised when the resolved agent type has no skills_apply playbook
-    wired yet. Phase 2 wires hermes only; openclaw + zeroclaw raise this
-    so the CLI surfaces a clear "not yet supported" message instead of
-    silently no-op'ing or breaking on a missing playbook path."""
+    """Raised when the resolved agent type is outside the set of claws
+    with a `skills_apply.yaml` playbook wired into the dispatch table.
+    All three native claws (hermes/openclaw/zeroclaw) are wired as of
+    Phase 3 (#382); this remains as a defensive guard for unknown
+    agent types surfaced by future host records."""
 
 
 class AgentNotFoundError(SkillError):
     """Raised when `agent_name` does not resolve to an installed agent."""
 
 
-# Map of agent_type → per-claw skills_apply playbook name. Phase 2 only
-# wires hermes; later phases add the other two entries. Centralizing the
-# dispatch table here avoids scattering claw-type literals through the
-# CLI layer.
+# Map of agent_type → per-claw skills_apply playbook name. All three
+# native claws are wired as of Phase 3 (#382). Centralizing the dispatch
+# table here avoids scattering claw-type literals through the CLI layer.
 _APPLY_PLAYBOOK_BY_CLAW: dict[str, str] = {
     "hermes": "skills_apply.yaml",
+    "openclaw": "skills_apply.yaml",
+    "zeroclaw": "skills_apply.yaml",
 }
 
 # Same agent_name pattern enforced by every playbook + lifecycle.

--- a/src/clawrium/core/skills_apply.py
+++ b/src/clawrium/core/skills_apply.py
@@ -309,10 +309,24 @@ def _make_log_dir(agent_name: str, agent_type: str, host: dict) -> Path:
         logs_dir
         / f"skills_apply-{safe_agent_type}-{host_display}-{timestamp}"
     )
+    # Belt-and-suspenders: even after the allowlist sanitization above,
+    # assert the resolved log_dir stays inside logs_dir. Catches future
+    # regressions (e.g. if `_sanitize_for_path` is loosened) before they
+    # can reach shutil.rmtree. The user-facing error does NOT include
+    # the computed path — leaking it would tell an attacker how their
+    # traversal payload was reshaped (ATX #382 W2 / W13). Path lands at
+    # DEBUG-level only.
     resolved = log_dir.resolve()
     if not str(resolved).startswith(str(logs_dir.resolve()) + os.sep):
+        logger.debug(
+            "Rejected log_dir outside logs root: computed=%s resolved=%s root=%s",
+            log_dir,
+            resolved,
+            logs_dir.resolve(),
+        )
         raise SkillApplyError(
-            f"Log directory path escaped logs root: {log_dir}"
+            "Log directory construction failed: path safety check rejected "
+            "computed path."
         )
     log_dir.mkdir(parents=True, exist_ok=True)
     os.chmod(log_dir, 0o700)

--- a/src/clawrium/core/skills_apply.py
+++ b/src/clawrium/core/skills_apply.py
@@ -293,6 +293,11 @@ def _make_log_dir(agent_name: str, agent_type: str, host: dict) -> Path:
     e.g. `../escape` cannot traverse outside the clawrium logs dir.
     The agent_name + agent_type fields are already regex-validated
     upstream, but we still sanitize for symmetry.
+
+    Belt-and-suspenders: even after the allowlist sanitization, the
+    resolved log_dir is asserted to stay inside logs_dir. Catches
+    future regressions (e.g. if `_sanitize_for_path` is loosened)
+    before they can reach `shutil.rmtree` in the cleanup step.
     """
     logs_dir = get_config_dir() / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
@@ -304,6 +309,11 @@ def _make_log_dir(agent_name: str, agent_type: str, host: dict) -> Path:
         logs_dir
         / f"skills_apply-{safe_agent_type}-{host_display}-{timestamp}"
     )
+    resolved = log_dir.resolve()
+    if not str(resolved).startswith(str(logs_dir.resolve()) + os.sep):
+        raise SkillApplyError(
+            f"Log directory path escaped logs root: {log_dir}"
+        )
     log_dir.mkdir(parents=True, exist_ok=True)
     os.chmod(log_dir, 0o700)
     return log_dir

--- a/src/clawrium/core/skills_apply.py
+++ b/src/clawrium/core/skills_apply.py
@@ -213,6 +213,14 @@ def apply_state(agent_name: str, *, timeout: int = 60) -> ApplyResult:
         if log_dir is not None:
             _cleanup_runner_artifacts(log_dir)
 
+    # Both assignments inside the `try:` succeeded — we wouldn't reach
+    # this line otherwise (an early raise would have propagated past
+    # the `finally:` block). Asserting narrows `log_dir`'s type from
+    # `Path | None` to `Path` for the ApplyResult construction below
+    # AND documents the control-flow invariant for readers. (ATX
+    # #382 iter 4 W-new9.)
+    assert staging_dir is not None
+    assert log_dir is not None
     return ApplyResult(
         agent_name=agent_name,
         agent_type=agent_type,
@@ -256,6 +264,7 @@ def _stage_skills(agent_name: str, agent_type: str, skills: list[Skill]) -> Path
     # tempdir into `${clawrium_config}/staging/skills/`. The caller's
     # `finally` cleanup uses the return value, so a raise-before-return
     # would otherwise leave the tempdir un-referenced and un-cleaned.
+    # (ATX #382 iter 4 W-new6.)
     try:
         for skill in skills:
             frontmatter, body = materialize_for_claw(skill, agent_type)
@@ -329,10 +338,10 @@ def _make_log_dir(agent_name: str, agent_type: str, host: dict) -> Path:
             logs_dir.resolve(),
         )
         raise SkillApplyError(
-            "Log directory construction failed: path safety check rejected "
-            "computed path (likely an unsafe alias or hostname in "
-            "hosts.json). Re-register the host via "
-            "`clm host add <address> --alias <safe-name>`."
+            "Host alias or hostname contains unsafe characters that would "
+            "escape the clawrium logs directory. Update the host alias: "
+            "`clm host update <alias-or-address> --alias <safe-name>`, "
+            "then retry."
         )
     log_dir.mkdir(parents=True, exist_ok=True)
     os.chmod(log_dir, 0o700)

--- a/src/clawrium/core/skills_apply.py
+++ b/src/clawrium/core/skills_apply.py
@@ -180,10 +180,13 @@ def apply_state(agent_name: str, *, timeout: int = 60) -> ApplyResult:
 
     # Both staging and log-dir creation live inside the `try` so the
     # `finally` cleanup runs even when one of them raises mid-flight.
-    # In particular, `_stage_skills` does `mkdtemp` *then* writes
-    # per-skill SKILL.md files; an OSError on `write_text` (disk full,
-    # permissions race) would otherwise leave the tempdir under
-    # ${clawrium_config}/staging/ with no reference to clean it up.
+    # `_stage_skills` does `mkdtemp` then writes per-skill SKILL.md
+    # files; `_make_log_dir` creates the log dir then does a
+    # post-creation path-safety check that can raise. If either creator
+    # raises after creating its dir, the only reference we have is the
+    # return value — so we must capture it before any subsequent failure
+    # point. Initialize to None so the `finally:` can None-guard cleanup.
+    # (Original B-new1 hardening; consolidated with iter 3.)
     staging_dir: Path | None = None
     log_dir: Path | None = None
     try:
@@ -202,8 +205,9 @@ def apply_state(agent_name: str, *, timeout: int = 60) -> ApplyResult:
     finally:
         # Staging dir is always cleaned up — it contains rendered
         # frontmatter only (no secrets) but lingering temp dirs are
-        # noise. May be None if `_stage_skills` raised before
-        # `mkdtemp` returned.
+        # noise. May be None if `_stage_skills` raised before `mkdtemp`
+        # returned. `_cleanup_runner_artifacts` is idempotent-safe so
+        # we call it whenever `log_dir` was created.
         if staging_dir is not None:
             shutil.rmtree(staging_dir, ignore_errors=True)
         if log_dir is not None:
@@ -326,7 +330,9 @@ def _make_log_dir(agent_name: str, agent_type: str, host: dict) -> Path:
         )
         raise SkillApplyError(
             "Log directory construction failed: path safety check rejected "
-            "computed path."
+            "computed path (likely an unsafe alias or hostname in "
+            "hosts.json). Re-register the host via "
+            "`clm host add <address> --alias <safe-name>`."
         )
     log_dir.mkdir(parents=True, exist_ok=True)
     os.chmod(log_dir, 0o700)

--- a/src/clawrium/platform/registry/openclaw/playbooks/skills_apply.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/skills_apply.yaml
@@ -1,0 +1,154 @@
+---
+# OpenClaw skills_apply — reconciles clawrium-managed skills under
+# ~/.openclaw/skills/ with the clawrium desired state for one agent.
+#
+# Inputs (extravars):
+#   - agent_name:           unix user that owns the openclaw install
+#   - staging_dir:          control-machine path with one
+#                           `<name>/SKILL.md` per desired skill
+#   - desired_skill_names:  list of slug names currently in desired state
+#                           (empty list = uninstall everything we own)
+#
+# Invariants:
+#   - openclaw auto-scans `~/.openclaw/skills/<name>/SKILL.md` for
+#     user-extensible skills (per #364 Phase 0 findings). Plain file-drop
+#     is sufficient; no openclaw.json re-render is required.
+#   - Ownership boundary: every directory we create carries a
+#     `.clawrium-managed` sentinel file. Pruning only considers dirs
+#     that contain this marker, so user-authored openclaw skills under
+#     the same parent (e.g. `~/.openclaw/skills/my-custom-skill/`) are
+#     never touched. The sentinel is a dotfile and is invisible to
+#     openclaw's SKILL.md auto-scan.
+#   - Every install is idempotent: re-running with the same state
+#     re-materializes SKILL.md (drift recovery) and is otherwise a
+#     no-op aside from `changed` flags.
+#   - The openclaw daemon may concurrently read SKILL.md files. Writes
+#     stage to a tempfile in the dest dir and rename atomically
+#     (`ansible.builtin.copy`'s default).
+- hosts: all
+  become: yes
+  gather_facts: false
+  vars:
+    skills_root: "/home/{{ agent_name }}/.openclaw/skills"
+    managed_marker: ".clawrium-managed"
+  tasks:
+    - name: Validate agent_name format
+      ansible.builtin.fail:
+        msg: "Invalid agent_name format"
+      when:
+        - agent_name is not match('^[a-z][a-z0-9_-]{0,31}$')
+
+    - name: Validate desired_skill_names is a list
+      ansible.builtin.fail:
+        msg: "desired_skill_names must be a list"
+      when:
+        - desired_skill_names is not iterable
+          or desired_skill_names is string
+          or desired_skill_names is mapping
+
+    # Defense-in-depth: Python core/skills.py validates the slug pattern
+    # before each entry is written to the state file, but the playbook
+    # also enforces it so a tampered extravar can't escape skills_root
+    # via path traversal.
+    - name: Validate every desired skill name
+      ansible.builtin.fail:
+        msg: "Invalid skill name in desired_skill_names: '{{ item }}'"
+      loop: "{{ desired_skill_names }}"
+      when:
+        - item is not match('^[a-z0-9][a-z0-9_-]*$')
+
+    - name: Ensure openclaw skills root exists
+      ansible.builtin.file:
+        path: "{{ skills_root }}"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0755"
+
+    - name: List existing skill directories on host
+      ansible.builtin.find:
+        paths: "{{ skills_root }}"
+        file_type: directory
+        # depth: 1 — top-level dirs only. The find module's `depth`
+        # parameter limits the walk so we never enumerate (and thus
+        # never prune) anything deeper than this dir.
+        depth: 1
+      register: existing_skill_dirs
+
+    # Ownership detection: enumerate the marker file inside each
+    # top-level skill dir. Only dirs that carry our sentinel are
+    # candidates for pruning. User-authored skills (no marker) are
+    # invisible to this playbook.
+    - name: Detect clawrium-managed marker files
+      ansible.builtin.stat:
+        path: "{{ item.path }}/{{ managed_marker }}"
+      loop: "{{ existing_skill_dirs.files }}"
+      loop_control:
+        label: "{{ item.path | basename }}"
+      register: marker_stats
+
+    - name: Compute set of clawrium-managed skill dirnames on host
+      ansible.builtin.set_fact:
+        clawrium_managed_dirs: >-
+          {{ marker_stats.results
+             | selectattr('stat.exists', 'equalto', true)
+             | map(attribute='item.path')
+             | map('basename')
+             | list }}
+
+    - name: Compute set of skill directories to prune
+      # `extras` = (clawrium-managed names on host) - (desired names).
+      # Pruning is bounded to this intersection; we never compute a
+      # delete list from anywhere else.
+      ansible.builtin.set_fact:
+        skills_to_prune: >-
+          {{ clawrium_managed_dirs | difference(desired_skill_names) }}
+
+    - name: Prune clawrium-managed skill directories no longer in desired state
+      ansible.builtin.file:
+        path: "{{ skills_root }}/{{ item }}"
+        state: absent
+      loop: "{{ skills_to_prune }}"
+      # Each `item` is a basename of a path we just enumerated under
+      # skills_root *and* confirmed carries our sentinel. The slug regex
+      # below is a third defense-in-depth check; without it a maliciously
+      # placed sentinel inside e.g. `../foo` (impossible because basename
+      # strips traversal, but verified anyway) would still fail closed.
+      when:
+        - item is match('^[a-z0-9][a-z0-9_-]*$')
+
+    - name: Ensure per-skill directory exists for each desired skill
+      ansible.builtin.file:
+        path: "{{ skills_root }}/{{ item }}"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0755"
+      loop: "{{ desired_skill_names }}"
+
+    - name: Mark each desired skill as clawrium-managed
+      # The marker is what bounds future prune passes. Created BEFORE
+      # SKILL.md so even a partial-apply (e.g., ansible aborts between
+      # the marker task and the copy task) still produces a dir we
+      # can clean up on the next run.
+      ansible.builtin.copy:
+        dest: "{{ skills_root }}/{{ item }}/{{ managed_marker }}"
+        content: "clawrium-managed\n"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0644"
+      loop: "{{ desired_skill_names }}"
+
+    - name: Materialize SKILL.md for each desired skill
+      # `copy` writes to a tempfile in the dest dir and renames into
+      # place — atomic against a concurrent openclaw daemon read.
+      # `src` lives on the control machine inside our process-owned
+      # staging dir (0700, freshly created); Ansible reads it locally
+      # and ships the bytes.
+      ansible.builtin.copy:
+        src: "{{ staging_dir }}/{{ item }}/SKILL.md"
+        dest: "{{ skills_root }}/{{ item }}/SKILL.md"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0644"
+      loop: "{{ desired_skill_names }}"

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/skills_apply.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/skills_apply.yaml
@@ -1,0 +1,234 @@
+---
+# Zeroclaw skills_apply — reconciles clawrium-managed skills installed
+# via the native `zeroclaw skills install` CLI against the desired state
+# for one agent.
+#
+# Inputs (extravars):
+#   - agent_name:           unix user that owns the zeroclaw install
+#   - staging_dir:          control-machine path with one
+#                           `<name>/SKILL.md` per desired skill
+#   - desired_skill_names:  list of slug names currently in desired state
+#                           (empty list = uninstall everything we own)
+#
+# Invariants:
+#   - Materialization goes through `zeroclaw skills install <path>` so
+#     the binary's security audit gate runs on every install (per #364
+#     Phase 0). We never write directly under
+#     `~/.zeroclaw/workspace/skills/`.
+#   - Ownership boundary: `~/.zeroclaw/.clawrium-managed-skills` holds
+#     the newline-separated list of slugs we've installed. Pruning only
+#     considers slugs in this list — skills installed by the user out
+#     of band are never touched. The file lives OUTSIDE the
+#     `workspace/skills/` subtree so the audit gate doesn't scan it.
+#   - Source-dirname == slug == SKILL.md frontmatter `name`. Phase 0
+#     locked this contract: `zeroclaw skills remove <slug>` expects the
+#     source-dirname, which our materialization step always names with
+#     the canonical slug.
+#   - Idempotency: re-running with the same state and matching on-disk
+#     state is a no-op. Drift recovery: if a slug is in tracked + desired
+#     but absent from `~/.zeroclaw/workspace/skills/`, the install is
+#     re-run to reconverge.
+- hosts: all
+  become: yes
+  gather_facts: false
+  vars:
+    workspace_skills: "/home/{{ agent_name }}/.zeroclaw/workspace/skills"
+    tracking_file: "/home/{{ agent_name }}/.zeroclaw/.clawrium-managed-skills"
+    zeroclaw_bin: "/home/{{ agent_name }}/bin/zeroclaw"
+    remote_staging_root: "/home/{{ agent_name }}/.zeroclaw/.clawrium-stage"
+  tasks:
+    - name: Validate agent_name format
+      ansible.builtin.fail:
+        msg: "Invalid agent_name format"
+      when:
+        - agent_name is not match('^[a-z][a-z0-9_-]{0,31}$')
+
+    - name: Validate desired_skill_names is a list
+      ansible.builtin.fail:
+        msg: "desired_skill_names must be a list"
+      when:
+        - desired_skill_names is not iterable
+          or desired_skill_names is string
+          or desired_skill_names is mapping
+
+    # Defense-in-depth: Python core/skills.py validates each slug
+    # before it reaches a state file, but the playbook re-checks too
+    # so a tampered extravar can't be passed as an argument to
+    # `zeroclaw skills remove`/`install` (these accept shell-style
+    # arguments and we want zero room for command injection).
+    - name: Validate every desired skill name
+      ansible.builtin.fail:
+        msg: "Invalid skill name in desired_skill_names: '{{ item }}'"
+      loop: "{{ desired_skill_names }}"
+      when:
+        - item is not match('^[a-z0-9][a-z0-9_-]*$')
+
+    - name: Verify zeroclaw binary exists at agent's install path
+      ansible.builtin.stat:
+        path: "{{ zeroclaw_bin }}"
+      register: zeroclaw_bin_stat
+
+    - name: Fail fast if zeroclaw binary is missing
+      ansible.builtin.fail:
+        msg: >
+          zeroclaw binary not found at {{ zeroclaw_bin }}. Run
+          `clm agent install --type zeroclaw --host <host>` first.
+      when:
+        - not zeroclaw_bin_stat.stat.exists or not (zeroclaw_bin_stat.stat.executable | default(false))
+
+    - name: Ensure workspace skills root exists
+      ansible.builtin.file:
+        path: "{{ workspace_skills }}"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0755"
+
+    - name: Stat tracking file
+      ansible.builtin.stat:
+        path: "{{ tracking_file }}"
+      register: tracking_stat
+
+    - name: Read tracking file content
+      ansible.builtin.slurp:
+        src: "{{ tracking_file }}"
+      register: tracking_raw
+      when: tracking_stat.stat.exists
+
+    - name: Parse tracked slug list
+      ansible.builtin.set_fact:
+        tracked_skill_names: >-
+          {{
+            (
+              (tracking_raw.content | b64decode).splitlines()
+              if (tracking_stat.stat.exists and tracking_raw.content is defined)
+              else []
+            )
+            | map('trim')
+            | reject('equalto', '')
+            | select('match', '^[a-z0-9][a-z0-9_-]*$')
+            | list
+          }}
+
+    # Use the on-disk workspace/skills/ children as the "is installed on
+    # host" check. Phase 0 confirmed source-dirname == slug, so the
+    # dirname IS the slug we'd pass to `zeroclaw skills remove`. We
+    # don't parse `zeroclaw skills list` stdout — the format is
+    # human-oriented and version-fragile.
+    - name: List installed skill dirs in zeroclaw workspace
+      ansible.builtin.find:
+        paths: "{{ workspace_skills }}"
+        file_type: directory
+        depth: 1
+      register: installed_skill_dirs
+
+    - name: Compute set of slugs currently installed on host
+      ansible.builtin.set_fact:
+        installed_slugs: >-
+          {{ installed_skill_dirs.files
+             | map(attribute='path')
+             | map('basename')
+             | list }}
+
+    - name: Compute prune set (tracked but not desired AND still installed)
+      # Pruning is bounded to:
+      #   (slugs we've installed in a prior apply)
+      #     ∩ (slugs currently on host)
+      #     \ (desired slugs)
+      # The intersection with installed_slugs avoids "remove a slug that
+      # was already removed natively" (which would error in `zeroclaw
+      # skills remove`).
+      ansible.builtin.set_fact:
+        skills_to_prune: >-
+          {{ tracked_skill_names
+             | difference(desired_skill_names)
+             | intersect(installed_slugs) }}
+
+    - name: Uninstall clawrium-managed skills no longer in desired state
+      ansible.builtin.command:
+        argv:
+          - "{{ zeroclaw_bin }}"
+          - skills
+          - remove
+          - "{{ item }}"
+      become_user: "{{ agent_name }}"
+      loop: "{{ skills_to_prune }}"
+      # The slug regex is re-checked here as a third defense-in-depth
+      # layer — if a malformed entry somehow slipped past the earlier
+      # validate task (impossible because that task fails the play),
+      # we still refuse to pass it as a CLI argument.
+      when:
+        - item is match('^[a-z0-9][a-z0-9_-]*$')
+      register: zeroclaw_remove_results
+      changed_when: zeroclaw_remove_results.rc == 0
+
+    # Skills to install: in desired set AND not currently on host. A slug
+    # that's already installed gets skipped so we don't re-run the audit
+    # gate unnecessarily (which can be slow) and don't churn the
+    # `installed at` timestamp on idempotent applies.
+    - name: Compute install set (desired but not installed)
+      ansible.builtin.set_fact:
+        skills_to_install: >-
+          {{ desired_skill_names | difference(installed_slugs) }}
+
+    - name: Ensure remote staging root exists (0700, agent-owned)
+      ansible.builtin.file:
+        path: "{{ remote_staging_root }}"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0700"
+      when: skills_to_install | length > 0
+
+    - name: Stage per-skill source directories on host
+      # zeroclaw's `skills install <path>` reads a local-on-host path,
+      # so the control-machine staging dir must be shipped over before
+      # the install can run. One subdir per skill to install, named
+      # with the slug (source-dirname == slug per Phase 0 contract).
+      ansible.builtin.copy:
+        src: "{{ staging_dir }}/{{ item }}/"
+        dest: "{{ remote_staging_root }}/{{ item }}/"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0600"
+        directory_mode: "0700"
+      loop: "{{ skills_to_install }}"
+
+    - name: Install each new skill via native `zeroclaw skills install`
+      # The audit gate runs inside `zeroclaw skills install` and is the
+      # primary reason we wrap the native CLI rather than copy files
+      # directly into ~/.zeroclaw/workspace/skills/. A failed audit
+      # surfaces as a non-zero rc, which fails this task and aborts the
+      # play before the tracking file is updated (so we don't claim
+      # ownership of a skill the audit refused).
+      ansible.builtin.command:
+        argv:
+          - "{{ zeroclaw_bin }}"
+          - skills
+          - install
+          - "{{ remote_staging_root }}/{{ item }}"
+      become_user: "{{ agent_name }}"
+      loop: "{{ skills_to_install }}"
+      when:
+        - item is match('^[a-z0-9][a-z0-9_-]*$')
+      register: zeroclaw_install_results
+      changed_when: zeroclaw_install_results.rc == 0
+
+    - name: Clean up remote staging directory
+      # Staging contains rendered frontmatter only (no secrets), but
+      # we drop it after install to keep ~/.zeroclaw/ tidy and avoid
+      # confusing operators who run `ls` to inspect installed skills.
+      ansible.builtin.file:
+        path: "{{ remote_staging_root }}"
+        state: absent
+
+    # Write the tracking file LAST so a mid-apply failure leaves the
+    # previous tracked list intact. The next apply will re-derive
+    # state from (tracking_file ∪ on-disk skills) and reconverge.
+    - name: Update tracking file with current desired state
+      ansible.builtin.copy:
+        dest: "{{ tracking_file }}"
+        content: "{{ (desired_skill_names | join('\n')) ~ ('\n' if desired_skill_names | length > 0 else '') }}"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0600"

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/skills_apply.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/skills_apply.yaml
@@ -12,9 +12,12 @@
 #
 # Invariants:
 #   - Materialization goes through `zeroclaw skills install <path>` so
-#     the binary's security audit gate runs on every install (per #364
-#     Phase 0). We never write directly under
-#     `~/.zeroclaw/workspace/skills/`.
+#     the binary's security audit gate runs on EVERY install (per #364
+#     Phase 0 + #382 ATX review). We never write directly under
+#     `~/.zeroclaw/workspace/skills/`, and we NEVER skip the install
+#     step on already-present slugs — a skill dir present on host but
+#     not currently audited (e.g. mutated by a compromised second
+#     process between applies) must be re-audited.
 #   - Ownership boundary: `~/.zeroclaw/.clawrium-managed-skills` holds
 #     the newline-separated list of slugs we've installed. Pruning only
 #     considers slugs in this list — skills installed by the user out
@@ -24,10 +27,13 @@
 #     locked this contract: `zeroclaw skills remove <slug>` expects the
 #     source-dirname, which our materialization step always names with
 #     the canonical slug.
-#   - Idempotency: re-running with the same state and matching on-disk
-#     state is a no-op. Drift recovery: if a slug is in tracked + desired
-#     but absent from `~/.zeroclaw/workspace/skills/`, the install is
-#     re-run to reconverge.
+#   - Idempotency: `zeroclaw skills install` is itself idempotent over
+#     identical inputs (re-installs in place after audit). We rely on
+#     the native CLI's idempotency, not a pre-check that would skip the
+#     audit. Drift recovery: if a slug is absent from
+#     `~/.zeroclaw/workspace/skills/` between applies, the install
+#     restores it; if the on-disk SKILL.md drifted, the next install
+#     re-stages it and re-audits.
 - hosts: all
   become: yes
   gather_facts: false
@@ -162,15 +168,11 @@
       register: zeroclaw_remove_results
       changed_when: zeroclaw_remove_results.rc == 0
 
-    # Skills to install: in desired set AND not currently on host. A slug
-    # that's already installed gets skipped so we don't re-run the audit
-    # gate unnecessarily (which can be slow) and don't churn the
-    # `installed at` timestamp on idempotent applies.
-    - name: Compute install set (desired but not installed)
-      ansible.builtin.set_fact:
-        skills_to_install: >-
-          {{ desired_skill_names | difference(installed_slugs) }}
-
+    # Install set is ALL desired slugs — no `difference(installed_slugs)`
+    # filter. Skipping install for already-present slugs would bypass
+    # the native audit gate, which is the primary reason we wrap the
+    # native CLI (per #382 ATX B2). A re-install of an unchanged skill
+    # is the price of audit-on-every-install.
     - name: Ensure remote staging root exists (0700, agent-owned)
       ansible.builtin.file:
         path: "{{ remote_staging_root }}"
@@ -178,49 +180,59 @@
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
         mode: "0700"
-      when: skills_to_install | length > 0
+      when: desired_skill_names | length > 0
 
-    - name: Stage per-skill source directories on host
-      # zeroclaw's `skills install <path>` reads a local-on-host path,
-      # so the control-machine staging dir must be shipped over before
-      # the install can run. One subdir per skill to install, named
-      # with the slug (source-dirname == slug per Phase 0 contract).
-      ansible.builtin.copy:
-        src: "{{ staging_dir }}/{{ item }}/"
-        dest: "{{ remote_staging_root }}/{{ item }}/"
-        owner: "{{ agent_name }}"
-        group: "{{ agent_name }}"
-        mode: "0600"
-        directory_mode: "0700"
-      loop: "{{ skills_to_install }}"
+    # Wrap the stage + install steps in block/always so that even if
+    # the audit gate rejects a skill (non-zero rc from `zeroclaw skills
+    # install` aborts the play), the remote staging dir is cleaned up.
+    # Otherwise a rejected install would leave the rendered SKILL.md +
+    # `_meta.yaml` on disk at a predictable path, which is both noise
+    # and a small information-leak surface (any other user on the host
+    # would see the path exists, though not the content — 0700 perms).
+    - name: Stage + install + cleanup (always cleans up on failure)
+      block:
+        - name: Stage per-skill source directories on host
+          # zeroclaw's `skills install <path>` reads a local-on-host
+          # path, so the control-machine staging dir must be shipped
+          # over before the install can run. One subdir per desired
+          # skill, named with the slug (source-dirname == slug per
+          # Phase 0 contract).
+          ansible.builtin.copy:
+            src: "{{ staging_dir }}/{{ item }}/"
+            dest: "{{ remote_staging_root }}/{{ item }}/"
+            owner: "{{ agent_name }}"
+            group: "{{ agent_name }}"
+            mode: "0600"
+            directory_mode: "0700"
+          loop: "{{ desired_skill_names }}"
 
-    - name: Install each new skill via native `zeroclaw skills install`
-      # The audit gate runs inside `zeroclaw skills install` and is the
-      # primary reason we wrap the native CLI rather than copy files
-      # directly into ~/.zeroclaw/workspace/skills/. A failed audit
-      # surfaces as a non-zero rc, which fails this task and aborts the
-      # play before the tracking file is updated (so we don't claim
-      # ownership of a skill the audit refused).
-      ansible.builtin.command:
-        argv:
-          - "{{ zeroclaw_bin }}"
-          - skills
-          - install
-          - "{{ remote_staging_root }}/{{ item }}"
-      become_user: "{{ agent_name }}"
-      loop: "{{ skills_to_install }}"
-      when:
-        - item is match('^[a-z0-9][a-z0-9_-]*$')
-      register: zeroclaw_install_results
-      changed_when: zeroclaw_install_results.rc == 0
-
-    - name: Clean up remote staging directory
-      # Staging contains rendered frontmatter only (no secrets), but
-      # we drop it after install to keep ~/.zeroclaw/ tidy and avoid
-      # confusing operators who run `ls` to inspect installed skills.
-      ansible.builtin.file:
-        path: "{{ remote_staging_root }}"
-        state: absent
+        - name: Install each desired skill via native `zeroclaw skills install`
+          # The audit gate runs inside `zeroclaw skills install` and is
+          # the primary reason we wrap the native CLI. A failed audit
+          # surfaces as a non-zero rc, which fails this task and aborts
+          # the play before the tracking file is updated (so we don't
+          # claim ownership of a skill the audit refused).
+          ansible.builtin.command:
+            argv:
+              - "{{ zeroclaw_bin }}"
+              - skills
+              - install
+              - "{{ remote_staging_root }}/{{ item }}"
+          become_user: "{{ agent_name }}"
+          loop: "{{ desired_skill_names }}"
+          when:
+            - item is match('^[a-z0-9][a-z0-9_-]*$')
+          register: zeroclaw_install_results
+          changed_when: zeroclaw_install_results.rc == 0
+      always:
+        - name: Clean up remote staging directory
+          # Staging contains rendered frontmatter only (no secrets), but
+          # we drop it after install (success OR failure) to keep
+          # ~/.zeroclaw/ tidy and avoid leaving rejected-by-audit
+          # content at a predictable path.
+          ansible.builtin.file:
+            path: "{{ remote_staging_root }}"
+            state: absent
 
     # Write the tracking file LAST so a mid-apply failure leaves the
     # previous tracked list intact. The next apply will re-derive

--- a/tests/test_cli_agent_skill.py
+++ b/tests/test_cli_agent_skill.py
@@ -229,6 +229,7 @@ def test_bidi_chars_in_skill_error_are_stripped(monkeypatch):
     def boom(name, **_kwargs):
         raise SkillApplyError(poisoned)
 
+    _stub_agent_resolution(monkeypatch)
     monkeypatch.setattr(cli_agent_skill, "apply_state", boom)
     result = runner.invoke(
         agent_skill_app, ["install", "tdd-hermes", "clawrium/tdd"]
@@ -260,6 +261,7 @@ def test_apply_error_bidi_stripped_does_not_destroy_ordinary_diagnostics(monkeyp
     def boom(name, **_kwargs):
         raise SkillApplyError(msg)
 
+    _stub_agent_resolution(monkeypatch)
     monkeypatch.setattr(cli_agent_skill, "apply_state", boom)
     result = runner.invoke(
         agent_skill_app, ["install", "tdd-hermes", "clawrium/tdd"]

--- a/tests/test_cli_agent_skill.py
+++ b/tests/test_cli_agent_skill.py
@@ -206,6 +206,79 @@ def test_install_renders_apply_error(monkeypatch):
     assert "Permission denied" in result.output
 
 
+def test_bidi_chars_in_skill_error_are_stripped(monkeypatch):
+    """B5 regression test (ATX #382 iter 2).
+
+    `_exit_with_error` MUST pipe error text through
+    `_sanitize_exception_text` before Rich-escaping, so a remote-supplied
+    error body carrying bidi-override codepoints (e.g. RTLO at U+202E,
+    ZWSP at U+200B, ALM at U+061C) can't reach the user's terminal and
+    forge output. If a future refactor removes the sanitizer, this test
+    fails.
+
+    The non-bidi portion of the message ("Permission denied", "BUSY")
+    must survive — sanitization is non-destructive for ordinary text.
+    """
+    # Mix every bidi class our regex covers: RTLO, ZWSP, ALM, LRI.
+    poisoned = (
+        "Skills apply failed: "
+        "‮Permission​ denied "
+        "(؜BUSY⁦hidden⁩ marker)"
+    )
+
+    def boom(name, **_kwargs):
+        raise SkillApplyError(poisoned)
+
+    monkeypatch.setattr(cli_agent_skill, "apply_state", boom)
+    result = runner.invoke(
+        agent_skill_app, ["install", "tdd-hermes", "clawrium/tdd"]
+    )
+    assert result.exit_code == 1
+    # Every bidi codepoint must be absent from the rendered output.
+    for codepoint in ("‮", "​", "؜", "⁦", "⁩"):
+        assert codepoint not in result.output, (
+            f"bidi codepoint U+{ord(codepoint):04X} survived sanitization"
+        )
+    # Non-bidi portion of the message survives — the sanitizer must
+    # not be destructive to ordinary diagnostic text.
+    assert "Permission" in result.output
+    assert "denied" in result.output
+    assert "BUSY" in result.output
+
+
+def test_apply_error_bidi_stripped_does_not_destroy_ordinary_diagnostics(monkeypatch):
+    """Companion to the B5 test — confirms the sanitizer leaves a
+    real-world ansible-runner error message untouched. Hardens against
+    a future "be more aggressive" patch to the sanitizer that would
+    silently mask legitimate failures (and the user would just see
+    "Error: " with no body)."""
+    msg = (
+        "Skills apply failed (status=failed): /home/agent/.openclaw/skills "
+        "not writable by user-12345 (log: /var/log/clm-apply.log)."
+    )
+
+    def boom(name, **_kwargs):
+        raise SkillApplyError(msg)
+
+    monkeypatch.setattr(cli_agent_skill, "apply_state", boom)
+    result = runner.invoke(
+        agent_skill_app, ["install", "tdd-hermes", "clawrium/tdd"]
+    )
+    assert result.exit_code == 1
+    # Every load-bearing token survives sanitization. Normalize Rich's
+    # terminal-width line wrapping (newlines collapse to spaces) before
+    # checking — multi-word tokens may split across rendered lines.
+    flat = " ".join(result.output.split())
+    for token in (
+        "Skills apply failed",
+        "/home/agent/.openclaw/skills",
+        "not writable",
+        "user-12345",
+        "/var/log/clm-apply.log",
+    ):
+        assert token in flat, f"sanitizer stripped {token!r}"
+
+
 def test_install_renders_apply_not_supported(monkeypatch):
     _stub_agent_resolution(monkeypatch, agent_type="openclaw")
 

--- a/tests/test_core_skills_apply.py
+++ b/tests/test_core_skills_apply.py
@@ -436,19 +436,6 @@ def test_check_agent_compatibility_unknown_claw_fails_closed():
 # ---------------------------- drift recovery --------------------------------
 
 
-def test_apply_state_openclaw_message_has_no_phase_jargon(monkeypatch):
-    """`SkillApplyNotSupported` must not leak implementation-plan phase
-    numbers into user-facing CLI output. The replacement message
-    points the user at `clm agent ps` to find a supported agent."""
-    _patch_runtime(monkeypatch, agent_type="openclaw")
-    with pytest.raises(SkillApplyNotSupported) as excinfo:
-        apply_state("tdd-openclaw")
-    message = str(excinfo.value).lower()
-    assert "phase" not in message
-    assert "wires" not in message
-    assert "clm agent ps" in str(excinfo.value)
-
-
 def test_apply_state_runner_startup_failure_raises_skill_apply_error(monkeypatch):
     """Cover the previously-untested branch where `ansible_runner.run`
     itself raises during startup (e.g. missing executable, bad
@@ -857,7 +844,13 @@ def test_apply_state_dispatch_table_miss_raises_not_supported(monkeypatch):
     real bug ships."""
     _patch_runtime(monkeypatch, agent_type="hermes")
     monkeypatch.setattr(skills_apply, "_APPLY_PLAYBOOK_BY_CLAW", {})
-    with pytest.raises(SkillApplyNotSupported, match="has no playbook registered"):
+    # Message must mention the claw type (so the user can fix the
+    # mismatch) and direct them at `clm agent ps`. After the iter 1
+    # consolidation with base, the message form is "Skills install
+    # is not yet supported for <claw> agents."
+    with pytest.raises(
+        SkillApplyNotSupported, match="not yet supported for hermes"
+    ):
         apply_state("tdd-hermes")
 
 
@@ -890,40 +883,34 @@ def test_dispatch_table_entries_resolve_to_existing_playbooks():
 # ---------------------------- _make_log_dir path-safety guard (ATX iter 3) --
 
 
-class _NoopReModule:
-    """Test double for the `re` module that replaces `re.sub` with a
-    passthrough while keeping every other attribute identical. Lets a
-    test defeat the host_display allowlist sanitization step without
-    breaking other call sites that import `re` from `skills_apply` for
-    pattern matching."""
+def _bypass_sanitize_for_path(monkeypatch):
+    """Replace the `_sanitize_for_path` reference inside `skills_apply`
+    with an identity function. Defeats the allowlist sanitization step
+    so a test can prove the belt-and-suspenders resolve()-based
+    containment check is independently load-bearing.
 
-    def __init__(self, real_re):
-        self._real = real_re
-
-    def __getattr__(self, name):
-        return getattr(self._real, name)
-
-    @staticmethod
-    def sub(_pattern, _repl, value, *_args, **_kwargs):
-        # Identity — returns the raw hostile string so the allowlist
-        # cannot strip the `/` and `..` segments.
-        return str(value)
+    Patches the binding in `skills_apply` rather than in `core.reset`
+    so the helper itself remains intact for other tests in the suite
+    (the helper is also imported by `core/reset.py` callers we don't
+    want to perturb).
+    """
+    monkeypatch.setattr(
+        skills_apply, "_sanitize_for_path", lambda value: str(value)
+    )
 
 
 def test_make_log_dir_rejects_path_traversal_in_host_alias(monkeypatch):
     """W-new3: the belt-and-suspenders guard is the last defense against
     a regression that loosens the host_display sanitizer. Bypass the
-    allowlist by replacing `re.sub` (only inside the `skills_apply`
-    module) so the raw hostile alias survives, then confirm the
-    resolve()-based containment check still fires.
+    allowlist by replacing `_sanitize_for_path` (only inside the
+    `skills_apply` module) so the raw hostile alias survives, then
+    confirm the resolve()-based containment check still fires.
 
     Called directly against `_make_log_dir` (not through `apply_state`)
     so the test exercises only the guard surface, not the full
     validate→stage→dispatch pipeline.
     """
-    monkeypatch.setattr(
-        skills_apply, "re", _NoopReModule(skills_apply.re)
-    )
+    _bypass_sanitize_for_path(monkeypatch)
     hostile_host = {
         "hostname": "wolf-i",
         "alias": "../../../etc/passwd",
@@ -941,9 +928,7 @@ def test_make_log_dir_error_does_not_leak_computed_path(monkeypatch, tmp_path):
     SkillApplyError must NOT include the computed log_dir, the
     resolved variant, or the logs root — leaking these would tell an
     attacker how their traversal payload was reshaped."""
-    monkeypatch.setattr(
-        skills_apply, "re", _NoopReModule(skills_apply.re)
-    )
+    _bypass_sanitize_for_path(monkeypatch)
     hostile_host = {
         "hostname": "wolf-i",
         "alias": "../../../etc/passwd",

--- a/tests/test_core_skills_apply.py
+++ b/tests/test_core_skills_apply.py
@@ -13,12 +13,17 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import json
+
 import pytest
 import yaml
 
 from clawrium.core import skills_apply
 from clawrium.core.skills import (
+    ExternalSourceBlocked,
     IncompatibleSkillRegistry,
+    InvalidSkillRef,
+    MissingRegistryPrefix,
     NATIVE_REGISTRIES,
 )
 from clawrium.core.skills_apply import (
@@ -28,7 +33,7 @@ from clawrium.core.skills_apply import (
     apply_state,
     materialize_for_claw,
 )
-from clawrium.core.skills_state import write_state
+from clawrium.core.skills_state import state_file_path, write_state
 
 
 @pytest.fixture(autouse=True)
@@ -728,3 +733,146 @@ def test_apply_state_drift_recovery_zeroclaw(monkeypatch):
         assert call.kwargs["inventory"]["all"]["vars"]["desired_skill_names"] == [
             "tdd"
         ]
+
+
+def test_apply_state_drift_recovery_openclaw(monkeypatch):
+    """W8: parity gap fix — drift recovery must work on openclaw too,
+    not just hermes/zeroclaw. The playbook is responsible for restoring
+    SKILL.md if it was manually deleted on host; apply_state's job is
+    just to invoke it idempotently on every install/remove call."""
+    write_state("tdd-openclaw", ["clawrium/tdd"])
+    runner = _patch_runtime(monkeypatch, agent_type="openclaw")
+
+    apply_state("tdd-openclaw")
+    apply_state("tdd-openclaw")
+
+    assert runner.run.call_count == 2
+    for call in runner.run.call_args_list:
+        assert call.kwargs["inventory"]["all"]["vars"]["desired_skill_names"] == [
+            "tdd"
+        ]
+        # Drift recovery means the SAME playbook is invoked again —
+        # specifically the openclaw one, not a refactor that punts to
+        # a different claw's apply.
+        assert "/openclaw/" in call.kwargs["playbook"]
+
+
+# ---------------------------- malicious-input rejection (ATX B3) ------------
+
+
+def _write_raw_state(agent_name: str, skills: list[str]) -> None:
+    """Bypass write_state's parse_skill_ref normalization to plant a
+    hostile state file directly. Simulates a hand-edited
+    `~/.config/clawrium/agents/<agent>/skills.json` carrying entries
+    that should never have made it past `write_state`."""
+    path = state_file_path(agent_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"skills": skills}))
+
+
+@pytest.mark.parametrize(
+    "malicious_ref,expected_error",
+    [
+        # Path traversal in name component
+        ("clawrium/..", InvalidSkillRef),
+        # Path traversal across separator
+        ("../etc/passwd", (InvalidSkillRef, MissingRegistryPrefix)),
+        # Path-segment-in-name
+        ("clawrium/sub/dir", InvalidSkillRef),
+        # Shell metacharacters in name
+        ("clawrium/tdd;rm", InvalidSkillRef),
+        ("clawrium/tdd|cat", InvalidSkillRef),
+        ("clawrium/tdd&id", InvalidSkillRef),
+        ("clawrium/tdd`id`", InvalidSkillRef),
+        ("clawrium/tdd$(id)", InvalidSkillRef),
+        # Backslash / Windows-style path
+        ("clawrium\\tdd", (InvalidSkillRef, MissingRegistryPrefix)),
+        # Null byte
+        ("clawrium/tdd\x00", InvalidSkillRef),
+        # External-source URL forms
+        ("https://evil.example/skill", ExternalSourceBlocked),
+        ("file:///etc/passwd", ExternalSourceBlocked),
+        ("git+ssh://attacker.example/repo.git", ExternalSourceBlocked),
+    ],
+)
+def test_apply_state_rejects_malicious_slugs_before_dispatch(
+    monkeypatch, malicious_ref, expected_error
+):
+    """Defense-in-depth contract: hostile slugs in a hand-edited state
+    file MUST be rejected by the Python validate-before-dispatch step
+    in apply_state, not relied on the in-playbook regex re-check.
+    `runner.run` must not be invoked — any exception thrown after the
+    runner fires means the host already saw the bad input."""
+    _write_raw_state("tdd-hermes", [malicious_ref])
+    runner = _patch_runtime(monkeypatch)
+    with pytest.raises(expected_error):
+        apply_state("tdd-hermes")
+    runner.run.assert_not_called()
+
+
+def test_apply_state_rejects_malicious_slug_on_openclaw_before_dispatch(monkeypatch):
+    """Same contract as the hermes parametrized case, but routed
+    through the openclaw dispatch path so a future refactor that
+    short-circuits openclaw's compatibility check can't quietly skip
+    the slug rejection step."""
+    _write_raw_state("tdd-openclaw", ["clawrium/../etc/passwd"])
+    runner = _patch_runtime(monkeypatch, agent_type="openclaw")
+    with pytest.raises(InvalidSkillRef):
+        apply_state("tdd-openclaw")
+    runner.run.assert_not_called()
+
+
+def test_apply_state_rejects_malicious_slug_on_zeroclaw_before_dispatch(monkeypatch):
+    """Zeroclaw arm of the B3 rejection contract. Zeroclaw is the most
+    sensitive of the three because the slug is later passed to
+    `zeroclaw skills install <path>` and `zeroclaw skills remove <slug>`
+    on the host — any escape from the slug regex is reachable as a
+    command argument."""
+    _write_raw_state("tdd-zeroclaw", ["clawrium/tdd; rm -rf /"])
+    runner = _patch_runtime(monkeypatch, agent_type="zeroclaw")
+    with pytest.raises(InvalidSkillRef):
+        apply_state("tdd-zeroclaw")
+    runner.run.assert_not_called()
+
+
+# ---------------------------- dispatch-table guard (ATX B4) -----------------
+
+
+def test_apply_state_dispatch_table_miss_raises_not_supported(monkeypatch):
+    """Defensive Guard 2 (`_APPLY_PLAYBOOK_BY_CLAW.get()` → None for a
+    claw that's in `NATIVE_REGISTRIES` but missing from the dispatch
+    table). This fires in the "future claw" scenario where a developer
+    adds a claw to `NATIVE_REGISTRIES` but forgets to wire the playbook.
+    Without this test, the message and code path are dead under
+    normal config and would only surface as a confusing error after a
+    real bug ships."""
+    _patch_runtime(monkeypatch, agent_type="hermes")
+    monkeypatch.setattr(skills_apply, "_APPLY_PLAYBOOK_BY_CLAW", {})
+    with pytest.raises(SkillApplyNotSupported, match="has no playbook registered"):
+        apply_state("tdd-hermes")
+
+
+def test_dispatch_table_covers_every_native_registry():
+    """Symmetry invariant: every claw in `NATIVE_REGISTRIES` MUST have
+    an entry in `_APPLY_PLAYBOOK_BY_CLAW`. Catches the
+    "added to NATIVE_REGISTRIES but forgot the playbook" mistake at
+    development time instead of at the user's first
+    `clm agent skill install <new-claw-agent> ...`."""
+    missing = NATIVE_REGISTRIES - set(skills_apply._APPLY_PLAYBOOK_BY_CLAW)
+    assert not missing, (
+        f"NATIVE_REGISTRIES claws missing from _APPLY_PLAYBOOK_BY_CLAW: "
+        f"{sorted(missing)}"
+    )
+
+
+def test_dispatch_table_entries_resolve_to_existing_playbooks():
+    """W11: bind the Python dispatch table to the on-disk YAML files.
+    A typo in a value (`skills_apply.yml` instead of `.yaml`, or a
+    rename that misses the constant) is otherwise only caught when a
+    real apply runs — which in CI never happens."""
+    for claw, playbook_name in skills_apply._APPLY_PLAYBOOK_BY_CLAW.items():
+        playbook = skills_apply._registry_playbook_dir(claw) / playbook_name
+        assert playbook.is_file(), (
+            f"_APPLY_PLAYBOOK_BY_CLAW[{claw!r}]={playbook_name!r} does not "
+            f"resolve to an existing file at {playbook}"
+        )

--- a/tests/test_core_skills_apply.py
+++ b/tests/test_core_skills_apply.py
@@ -2,7 +2,8 @@
 
 Mocks ansible-runner and host resolution so the tests exercise the
 materialization + dispatch pipeline without touching SSH or a real
-inventory. Phase 2 only wires hermes; openclaw/zeroclaw should raise
+inventory. All three native claws (hermes/openclaw/zeroclaw) are wired
+as of Phase 3 (#382); unknown claw types still raise
 `SkillApplyNotSupported`.
 """
 
@@ -173,18 +174,6 @@ def test_apply_state_ambiguous_agent_name(monkeypatch):
     monkeypatch.setattr(skills_apply, "get_agent_by_name", raise_value_error)
     with pytest.raises(AgentNotFoundError, match="ambiguous"):
         apply_state("tdd-hermes")
-
-
-def test_apply_state_openclaw_not_supported(monkeypatch):
-    _patch_runtime(monkeypatch, agent_type="openclaw")
-    # Anchored to the parametrized claw type so a future reword that
-    # drops `openclaw` from the message (or a third raise site added
-    # elsewhere with the same generic phrase) would still surface as
-    # a real test failure.
-    with pytest.raises(
-        SkillApplyNotSupported, match=r"not yet supported for openclaw"
-    ):
-        apply_state("tdd-openclaw")
 
 
 def test_apply_state_unknown_agent_type(monkeypatch):
@@ -604,6 +593,137 @@ def test_apply_state_drift_recovery_reapplies_same_state(monkeypatch):
 
     assert runner.run.call_count == 2
     # Both invocations carry the same desired list.
+    for call in runner.run.call_args_list:
+        assert call.kwargs["inventory"]["all"]["vars"]["desired_skill_names"] == [
+            "tdd"
+        ]
+
+
+# ---------------------------- openclaw dispatch (Phase 3) -------------------
+
+
+def test_apply_state_openclaw_empty_state_runs_playbook(monkeypatch):
+    runner = _patch_runtime(monkeypatch, agent_type="openclaw")
+    result = apply_state("tdd-openclaw")
+    assert result.agent_type == "openclaw"
+    assert result.applied_skills == []
+    runner.run.assert_called_once()
+    _, kwargs = runner.run.call_args
+    extravars = kwargs["inventory"]["all"]["vars"]
+    assert extravars["agent_type"] == "openclaw"
+    assert extravars["desired_skill_names"] == []
+    # The dispatched playbook path must end at the openclaw registry's
+    # skills_apply.yaml — not hermes', not zeroclaw's.
+    playbook_arg = kwargs["playbook"]
+    assert "/openclaw/playbooks/skills_apply.yaml" in playbook_arg
+
+
+def test_apply_state_openclaw_stages_and_applies_clawrium_tdd(monkeypatch):
+    write_state("tdd-openclaw", ["clawrium/tdd"])
+    runner = _patch_runtime(monkeypatch, agent_type="openclaw")
+
+    result = apply_state("tdd-openclaw")
+
+    assert result.applied_skills == ["clawrium/tdd"]
+    _, kwargs = runner.run.call_args
+    extravars = kwargs["inventory"]["all"]["vars"]
+    assert extravars["agent_type"] == "openclaw"
+    assert extravars["desired_skill_names"] == ["tdd"]
+    staging_dir = Path(extravars["staging_dir"])
+    # apply_state cleans staging in `finally`; the dir should NOT exist
+    # by the time the call returns.
+    assert not staging_dir.exists()
+
+
+def test_apply_state_openclaw_materialized_skill_md_has_no_hermes_overrides(
+    monkeypatch,
+):
+    """When materializing for openclaw, the per-claw override block under
+    `native.hermes` in `_meta.yaml` must NOT bleed into the openclaw
+    frontmatter — only `native.openclaw` (which is `{}` for clawrium/tdd)
+    is lifted. This guards against the materializer applying the wrong
+    claw's overrides."""
+    write_state("tdd-openclaw", ["clawrium/tdd"])
+
+    captured = {}
+
+    def capture_and_succeed(**kwargs):
+        staging = Path(kwargs["inventory"]["all"]["vars"]["staging_dir"])
+        skill_md = staging / "tdd" / "SKILL.md"
+        captured["text"] = skill_md.read_text()
+        return _runner_result()
+
+    runner = _patch_runtime(monkeypatch, agent_type="openclaw")
+    runner.run.side_effect = capture_and_succeed
+
+    apply_state("tdd-openclaw")
+
+    text = captured["text"]
+    frontmatter_block, _ = text.split("\n---\n", 1)
+    frontmatter = yaml.safe_load(frontmatter_block[len("---\n"):])
+    assert frontmatter["name"] == "tdd"
+    # Hermes-specific tags must not be present in the openclaw rendering.
+    assert "metadata" not in frontmatter or "hermes" not in (
+        frontmatter.get("metadata") or {}
+    )
+
+
+# ---------------------------- zeroclaw dispatch (Phase 3) -------------------
+
+
+def test_apply_state_zeroclaw_empty_state_runs_playbook(monkeypatch):
+    runner = _patch_runtime(monkeypatch, agent_type="zeroclaw")
+    result = apply_state("tdd-zeroclaw")
+    assert result.agent_type == "zeroclaw"
+    assert result.applied_skills == []
+    runner.run.assert_called_once()
+    _, kwargs = runner.run.call_args
+    extravars = kwargs["inventory"]["all"]["vars"]
+    assert extravars["agent_type"] == "zeroclaw"
+    assert extravars["desired_skill_names"] == []
+    playbook_arg = kwargs["playbook"]
+    assert "/zeroclaw/playbooks/skills_apply.yaml" in playbook_arg
+
+
+def test_apply_state_zeroclaw_stages_and_applies_clawrium_tdd(monkeypatch):
+    write_state("tdd-zeroclaw", ["clawrium/tdd"])
+    runner = _patch_runtime(monkeypatch, agent_type="zeroclaw")
+
+    result = apply_state("tdd-zeroclaw")
+
+    assert result.applied_skills == ["clawrium/tdd"]
+    _, kwargs = runner.run.call_args
+    extravars = kwargs["inventory"]["all"]["vars"]
+    # Source-dirname == slug per Phase 0 contract — the playbook will
+    # stage under `<remote-staging>/tdd/` and pass that path to
+    # `zeroclaw skills install`.
+    assert extravars["desired_skill_names"] == ["tdd"]
+
+
+def test_apply_state_zeroclaw_dispatches_to_zeroclaw_playbook(monkeypatch):
+    """Regression guard against a future refactor that accidentally
+    points all three claws at the same playbook — we want the zeroclaw
+    invocation routed to the zeroclaw `skills_apply.yaml` so the native
+    `zeroclaw skills install` wrap (not raw file copy) runs."""
+    runner = _patch_runtime(monkeypatch, agent_type="zeroclaw")
+    apply_state("tdd-zeroclaw")
+    _, kwargs = runner.run.call_args
+    assert "/zeroclaw/" in kwargs["playbook"]
+    assert "/hermes/" not in kwargs["playbook"]
+    assert "/openclaw/" not in kwargs["playbook"]
+
+
+def test_apply_state_drift_recovery_zeroclaw(monkeypatch):
+    """Same drift-recovery contract as hermes: re-running install on a
+    state that's already set must re-invoke the playbook so the
+    playbook's idempotent install-if-missing branch runs."""
+    write_state("tdd-zeroclaw", ["clawrium/tdd"])
+    runner = _patch_runtime(monkeypatch, agent_type="zeroclaw")
+
+    apply_state("tdd-zeroclaw")
+    apply_state("tdd-zeroclaw")
+
+    assert runner.run.call_count == 2
     for call in runner.run.call_args_list:
         assert call.kwargs["inventory"]["all"]["vars"]["desired_skill_names"] == [
             "tdd"

--- a/tests/test_core_skills_apply.py
+++ b/tests/test_core_skills_apply.py
@@ -789,6 +789,14 @@ def _write_raw_state(agent_name: str, skills: list[str]) -> None:
         ("clawrium\\tdd", (InvalidSkillRef, MissingRegistryPrefix)),
         # Null byte
         ("clawrium/tdd\x00", InvalidSkillRef),
+        # Bidi-formatting codepoints — the slug regex bans these but
+        # without a unit test, a future regex loosening could let them
+        # through and reach RTLO-style output forgery in error messages
+        # AND on-host CLI args (ATX #382 W14).
+        ("clawrium/tdd‮", InvalidSkillRef),       # RIGHT-TO-LEFT OVERRIDE
+        ("clawrium/​tdd", InvalidSkillRef),       # ZERO WIDTH SPACE
+        ("clawrium/؜tdd", InvalidSkillRef),       # ARABIC LETTER MARK
+        ("clawrium/tdd⁦inject", InvalidSkillRef), # LRI
         # External-source URL forms
         ("https://evil.example/skill", ExternalSourceBlocked),
         ("file:///etc/passwd", ExternalSourceBlocked),

--- a/tests/test_core_skills_apply.py
+++ b/tests/test_core_skills_apply.py
@@ -931,7 +931,7 @@ def test_make_log_dir_rejects_path_traversal_in_host_alias(monkeypatch):
         "port": 22,
         "key_id": "wolf-i",
     }
-    with pytest.raises(SkillApplyError, match="path safety check rejected"):
+    with pytest.raises(SkillApplyError, match="unsafe characters"):
         skills_apply._make_log_dir("tdd-hermes", "hermes", hostile_host)
 
 
@@ -960,8 +960,51 @@ def test_make_log_dir_error_does_not_leak_computed_path(monkeypatch, tmp_path):
     assert "../" not in error_text
     assert str(tmp_path) not in error_text
     assert "resolved" not in error_text.lower()
-    # The friendly remediation hint still surfaces.
-    assert "clm host add" in error_text
+    # The friendly remediation hint still surfaces. Points at
+    # `clm host update` (the right command for alias mutation per
+    # ATX iter 4 W-new7), not `clm host add` (would fail with
+    # "alias already in use" since the user reached _make_log_dir,
+    # meaning the host record already exists).
+    assert "clm host update" in error_text
+
+
+def test_stage_skills_internal_failure_cleans_tempdir(monkeypatch):
+    """W-new6: `_stage_skills` materializes the staging dir via
+    `tempfile.mkdtemp` BEFORE populating it. If `materialize_for_claw`
+    or any subsequent file operation raises mid-loop, the staging dir
+    would leak — `apply_state`'s None-sentinel guard doesn't help
+    because `_stage_skills` hasn't returned yet, so `staging_dir`
+    is still None.
+
+    The fix wraps the populate loop in try/except so the dir is rmtree'd
+    before the exception propagates."""
+    captured: list[Path] = []
+    original_mkdtemp = skills_apply.tempfile.mkdtemp
+
+    def capture_mkdtemp(*args, **kwargs):
+        path = original_mkdtemp(*args, **kwargs)
+        captured.append(Path(path))
+        return path
+
+    monkeypatch.setattr(skills_apply.tempfile, "mkdtemp", capture_mkdtemp)
+
+    def boom(_skill, _claw):
+        raise RuntimeError("forced materialize failure")
+
+    monkeypatch.setattr(skills_apply, "materialize_for_claw", boom)
+
+    from clawrium.core.skills import load_skill, parse_skill_ref
+
+    skill = load_skill(parse_skill_ref("clawrium/tdd"))
+    with pytest.raises(RuntimeError, match="forced materialize failure"):
+        skills_apply._stage_skills("tdd-hermes", "hermes", [skill])
+
+    assert captured, "mkdtemp was never called"
+    staging = captured[0]
+    assert not staging.exists(), (
+        f"staging tempdir leaked at {staging} when materialize raised — "
+        "_stage_skills cleanup-on-raise regression"
+    )
 
 
 def test_make_log_dir_failure_cleans_up_staging_dir(monkeypatch, tmp_path):

--- a/tests/test_core_skills_apply.py
+++ b/tests/test_core_skills_apply.py
@@ -797,6 +797,7 @@ def _write_raw_state(agent_name: str, skills: list[str]) -> None:
         ("clawrium/​tdd", InvalidSkillRef),       # ZERO WIDTH SPACE
         ("clawrium/؜tdd", InvalidSkillRef),       # ARABIC LETTER MARK
         ("clawrium/tdd⁦inject", InvalidSkillRef), # LRI
+        ("clawrium/tdd⁩trailer", InvalidSkillRef), # PDI (W-new5)
         # External-source URL forms
         ("https://evil.example/skill", ExternalSourceBlocked),
         ("file:///etc/passwd", ExternalSourceBlocked),
@@ -884,3 +885,117 @@ def test_dispatch_table_entries_resolve_to_existing_playbooks():
             f"_APPLY_PLAYBOOK_BY_CLAW[{claw!r}]={playbook_name!r} does not "
             f"resolve to an existing file at {playbook}"
         )
+
+
+# ---------------------------- _make_log_dir path-safety guard (ATX iter 3) --
+
+
+class _NoopReModule:
+    """Test double for the `re` module that replaces `re.sub` with a
+    passthrough while keeping every other attribute identical. Lets a
+    test defeat the host_display allowlist sanitization step without
+    breaking other call sites that import `re` from `skills_apply` for
+    pattern matching."""
+
+    def __init__(self, real_re):
+        self._real = real_re
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    @staticmethod
+    def sub(_pattern, _repl, value, *_args, **_kwargs):
+        # Identity — returns the raw hostile string so the allowlist
+        # cannot strip the `/` and `..` segments.
+        return str(value)
+
+
+def test_make_log_dir_rejects_path_traversal_in_host_alias(monkeypatch):
+    """W-new3: the belt-and-suspenders guard is the last defense against
+    a regression that loosens the host_display sanitizer. Bypass the
+    allowlist by replacing `re.sub` (only inside the `skills_apply`
+    module) so the raw hostile alias survives, then confirm the
+    resolve()-based containment check still fires.
+
+    Called directly against `_make_log_dir` (not through `apply_state`)
+    so the test exercises only the guard surface, not the full
+    validate→stage→dispatch pipeline.
+    """
+    monkeypatch.setattr(
+        skills_apply, "re", _NoopReModule(skills_apply.re)
+    )
+    hostile_host = {
+        "hostname": "wolf-i",
+        "alias": "../../../etc/passwd",
+        "user": "wolf-i",
+        "port": 22,
+        "key_id": "wolf-i",
+    }
+    with pytest.raises(SkillApplyError, match="path safety check rejected"):
+        skills_apply._make_log_dir("tdd-hermes", "hermes", hostile_host)
+
+
+def test_make_log_dir_error_does_not_leak_computed_path(monkeypatch, tmp_path):
+    """W-new4: regression test for the non-leaking-path invariant
+    established in ATX iter 2 W2-residual. The user-facing
+    SkillApplyError must NOT include the computed log_dir, the
+    resolved variant, or the logs root — leaking these would tell an
+    attacker how their traversal payload was reshaped."""
+    monkeypatch.setattr(
+        skills_apply, "re", _NoopReModule(skills_apply.re)
+    )
+    hostile_host = {
+        "hostname": "wolf-i",
+        "alias": "../../../etc/passwd",
+        "user": "wolf-i",
+        "port": 22,
+        "key_id": "wolf-i",
+    }
+    with pytest.raises(SkillApplyError) as exc_info:
+        skills_apply._make_log_dir("tdd-hermes", "hermes", hostile_host)
+    error_text = str(exc_info.value)
+    # The known-revealing tokens MUST be absent from the user-facing
+    # message. They land at logger.debug only.
+    assert "/etc/passwd" not in error_text
+    assert "../" not in error_text
+    assert str(tmp_path) not in error_text
+    assert "resolved" not in error_text.lower()
+    # The friendly remediation hint still surfaces.
+    assert "clm host add" in error_text
+
+
+def test_make_log_dir_failure_cleans_up_staging_dir(monkeypatch, tmp_path):
+    """B-new1: regression test for the tempdir-leak fix.
+
+    `_stage_skills` creates a staging directory; if `_make_log_dir`
+    raises right after, the staging dir must still be cleaned up.
+    Without the None-sentinel guard, the staging dir is materialized
+    but never reaches the `try:` block so `finally:` doesn't run.
+    """
+    write_state("tdd-hermes", ["clawrium/tdd"])
+    runner = _patch_runtime(monkeypatch)
+
+    captured: dict[str, Path] = {}
+    original_stage = skills_apply._stage_skills
+
+    def capture_stage(agent_name, agent_type, skills):
+        path = original_stage(agent_name, agent_type, skills)
+        captured["staging"] = path
+        return path
+
+    def boom_log_dir(*_args, **_kwargs):
+        raise SkillApplyError("forced log_dir failure for regression test")
+
+    monkeypatch.setattr(skills_apply, "_stage_skills", capture_stage)
+    monkeypatch.setattr(skills_apply, "_make_log_dir", boom_log_dir)
+
+    with pytest.raises(SkillApplyError, match="forced log_dir failure"):
+        apply_state("tdd-hermes")
+
+    staging = captured.get("staging")
+    assert staging is not None, "_stage_skills was never called"
+    assert not staging.exists(), (
+        f"staging dir leaked at {staging} when _make_log_dir raised — "
+        "None-sentinel cleanup guard regression"
+    )
+    runner.run.assert_not_called()

--- a/tests/test_registry_skills_apply.py
+++ b/tests/test_registry_skills_apply.py
@@ -49,8 +49,39 @@ def test_zeroclaw_skills_apply_playbook_exists():
 # ---------------------------- shared invariants -----------------------------
 
 
+def _flatten_tasks(tasks: list[dict]) -> list[dict]:
+    """Flatten a tasks list, descending into `block:` / `rescue:` /
+    `always:` so structural assertions can reach tasks defined inside
+    a block/always wrapper. Order is preserved: block body first, then
+    rescue, then always — matching ansible's runtime contract for
+    "before / on error / cleanup".
+    """
+    flat: list[dict] = []
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        # A block task can be a parent (no module key, only block/always)
+        # or a regular task. If it has block/always, descend; either way
+        # also include the wrapper so its `name:` shows up in ordering.
+        if "block" in task or "always" in task or "rescue" in task:
+            flat.append(task)
+            for child in task.get("block", []) or []:
+                flat.extend(_flatten_tasks([child]))
+            for child in task.get("rescue", []) or []:
+                flat.extend(_flatten_tasks([child]))
+            for child in task.get("always", []) or []:
+                flat.extend(_flatten_tasks([child]))
+        else:
+            flat.append(task)
+    return flat
+
+
+def _all_tasks(play: dict) -> list[dict]:
+    return _flatten_tasks(play.get("tasks", []))
+
+
 def _task_names(play: dict) -> list[str]:
-    return [t.get("name", "") for t in play.get("tasks", [])]
+    return [t.get("name", "") for t in _all_tasks(play)]
 
 
 def test_openclaw_playbook_validates_inputs_before_touching_host():
@@ -75,7 +106,7 @@ def test_zeroclaw_playbook_validates_inputs_before_touching_host():
     assert "Validate every desired skill name" in names
     validate_idx = names.index("Validate every desired skill name")
     install_idx = names.index(
-        "Install each new skill via native `zeroclaw skills install`"
+        "Install each desired skill via native `zeroclaw skills install`"
     )
     assert validate_idx < install_idx
 
@@ -141,11 +172,13 @@ def test_zeroclaw_playbook_wraps_native_install_cli():
     (not raw file copies into `~/.zeroclaw/workspace/skills/`) so the
     audit runs on every install."""
     _, play = _load_playbook("zeroclaw")
+    # The install task lives inside a block/always wrapper (ATX W3) —
+    # walk the flattened list to find it.
     install_task = next(
         t
-        for t in play["tasks"]
+        for t in _all_tasks(play)
         if t.get("name")
-        == "Install each new skill via native `zeroclaw skills install`"
+        == "Install each desired skill via native `zeroclaw skills install`"
     )
     argv = install_task["ansible.builtin.command"]["argv"]
     # `argv` form prevents shell-injection through the slug; the slug
@@ -210,21 +243,54 @@ def test_zeroclaw_playbook_prune_set_intersects_installed():
     assert "desired_skill_names" in skills_to_prune
 
 
-def test_zeroclaw_playbook_install_set_skips_already_installed():
-    """Idempotency: re-running install on a slug that's already in the
-    workspace must be a no-op so the audit gate isn't re-paid every
-    apply (it's slow) and the install timestamp doesn't churn."""
+def test_zeroclaw_playbook_audit_gate_runs_for_every_desired_skill():
+    """Security contract (ATX #382 B2): `zeroclaw skills install` must
+    fire for EVERY entry in `desired_skill_names`, with no
+    `difference(installed_slugs)` filter that would skip already-present
+    slugs. Skipping would bypass the native audit gate, defeating the
+    whole reason the playbook wraps the CLI instead of doing raw file
+    copies into `~/.zeroclaw/workspace/skills/`."""
+    text, play = _load_playbook("zeroclaw")
+    install_task = next(
+        t
+        for t in _all_tasks(play)
+        if t.get("name")
+        == "Install each desired skill via native `zeroclaw skills install`"
+    )
+    # The install task must loop over the FULL desired list, not a
+    # filtered subset.
+    assert install_task["loop"] == "{{ desired_skill_names }}"
+    # Regression guard: the explicit anti-pattern that ATX B2 flagged.
+    # If a future refactor reintroduces `difference(installed_slugs)`
+    # in EXECUTABLE yaml (set_fact / when / loop), the test fails. We
+    # strip line comments (`#...`) first so the explainer comments
+    # documenting *why* we removed the filter don't false-positive.
+    non_comment = "\n".join(
+        line.split("#", 1)[0] for line in text.splitlines()
+    )
+    assert "difference(installed_slugs)" not in non_comment
+
+
+def test_zeroclaw_playbook_install_wrapped_in_block_always():
+    """Failure-mode hygiene (ATX #382 W3): stage + install must run
+    inside a `block:` with an `always:` cleanup so a rejected-by-audit
+    install never leaves the rendered SKILL.md on disk at a predictable
+    path. Mirrors the existing `configure.yaml` cleanup pattern."""
     _, play = _load_playbook("zeroclaw")
-    compute_install = next(
+    # Find the wrapper block by its name. Wrapper has `block:` and
+    # `always:` keys, no module key of its own.
+    wrapper = next(
         t
         for t in play["tasks"]
-        if t.get("name") == "Compute install set (desired but not installed)"
+        if "block" in t and "always" in t
     )
-    skills_to_install = compute_install["ansible.builtin.set_fact"][
-        "skills_to_install"
-    ]
-    assert "desired_skill_names" in skills_to_install
-    assert "difference(installed_slugs)" in skills_to_install
+    block_names = [t.get("name", "") for t in wrapper["block"]]
+    always_names = [t.get("name", "") for t in wrapper["always"]]
+    assert (
+        "Install each desired skill via native `zeroclaw skills install`"
+        in block_names
+    )
+    assert "Clean up remote staging directory" in always_names
 
 
 def test_zeroclaw_playbook_writes_tracking_file_last():
@@ -236,7 +302,7 @@ def test_zeroclaw_playbook_writes_tracking_file_last():
     names = _task_names(play)
     tracking_idx = names.index("Update tracking file with current desired state")
     install_idx = names.index(
-        "Install each new skill via native `zeroclaw skills install`"
+        "Install each desired skill via native `zeroclaw skills install`"
     )
     remove_idx = names.index(
         "Uninstall clawrium-managed skills no longer in desired state"
@@ -251,7 +317,9 @@ def test_zeroclaw_playbook_install_uses_argv_form_not_shell():
     validated, passing arguments through a shell parser is an
     unnecessary risk surface."""
     _, play = _load_playbook("zeroclaw")
-    for task in play["tasks"]:
+    # Walk the flattened task list so block/always-nested tasks are
+    # included — the install task lives inside a `block:` wrapper.
+    for task in _all_tasks(play):
         cmd = task.get("ansible.builtin.command")
         if cmd is None:
             continue

--- a/tests/test_registry_skills_apply.py
+++ b/tests/test_registry_skills_apply.py
@@ -1,0 +1,267 @@
+"""Structural tests for the per-claw skills_apply.yaml playbooks.
+
+These tests assert invariants that the safety + idempotency story for
+`clm agent skill install/remove` depends on: file existence, presence of
+the ownership boundary mechanism (hermes subdir / openclaw sentinel /
+zeroclaw tracking file), and bounded pruning. They do NOT run ansible —
+runtime behavior is exercised by `tests/test_core_skills_apply.py` with
+a mocked `ansible_runner`, and end-to-end against real hosts in the
+smoke transcripts captured under `.itx/<issue>/01_EXECUTION.md`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).parent.parent
+REGISTRY_ROOT = PROJECT_ROOT / "src" / "clawrium" / "platform" / "registry"
+
+
+def _load_playbook(claw: str) -> tuple[str, dict]:
+    """Parse the playbook and return (raw_text, first_play_dict).
+
+    An Ansible playbook file is a single YAML document whose top-level is
+    a list of plays. We unwrap to the first play because both new
+    playbooks declare exactly one.
+    """
+    path = REGISTRY_ROOT / claw / "playbooks" / "skills_apply.yaml"
+    assert path.is_file(), f"{path} must exist"
+    text = path.read_text()
+    data = yaml.safe_load(text)
+    assert isinstance(data, list), f"{path} top-level should be a list of plays"
+    assert len(data) == 1, f"{path} should declare exactly one play"
+    return text, data[0]
+
+
+# ---------------------------- existence -------------------------------------
+
+
+def test_openclaw_skills_apply_playbook_exists():
+    _load_playbook("openclaw")
+
+
+def test_zeroclaw_skills_apply_playbook_exists():
+    _load_playbook("zeroclaw")
+
+
+# ---------------------------- shared invariants -----------------------------
+
+
+def _task_names(play: dict) -> list[str]:
+    return [t.get("name", "") for t in play.get("tasks", [])]
+
+
+def test_openclaw_playbook_validates_inputs_before_touching_host():
+    """Every input that influences a filesystem path on the host must be
+    regex-validated by the playbook itself — defense-in-depth against a
+    tampered extravar bypassing the Python-side validation."""
+    _, play = _load_playbook("openclaw")
+    names = _task_names(play)
+    # Both checks must appear before any task that writes to skills_root.
+    assert "Validate agent_name format" in names
+    assert "Validate every desired skill name" in names
+    # The validation tasks must come before file-mutation tasks.
+    validate_idx = names.index("Validate every desired skill name")
+    write_idx = names.index("Materialize SKILL.md for each desired skill")
+    assert validate_idx < write_idx
+
+
+def test_zeroclaw_playbook_validates_inputs_before_touching_host():
+    _, play = _load_playbook("zeroclaw")
+    names = _task_names(play)
+    assert "Validate agent_name format" in names
+    assert "Validate every desired skill name" in names
+    validate_idx = names.index("Validate every desired skill name")
+    install_idx = names.index(
+        "Install each new skill via native `zeroclaw skills install`"
+    )
+    assert validate_idx < install_idx
+
+
+# ---------------------------- openclaw-specific -----------------------------
+
+
+def test_openclaw_playbook_writes_clawrium_managed_sentinel():
+    """Pruning safety: the playbook must drop a sentinel file inside
+    each clawrium-managed skill dir so future prune passes can
+    distinguish clawrium-owned dirs from user-authored ones under
+    `~/.openclaw/skills/`."""
+    text, play = _load_playbook("openclaw")
+    assert "managed_marker: \".clawrium-managed\"" in text
+    names = _task_names(play)
+    assert "Mark each desired skill as clawrium-managed" in names
+
+
+def test_openclaw_playbook_prunes_only_marked_dirs():
+    """The prune set is the intersection of (on-host dirs that carry our
+    sentinel) and (NOT in desired). Without the sentinel-filtering step,
+    pruning would touch user-authored skills — verify the filter exists."""
+    _, play = _load_playbook("openclaw")
+    names = _task_names(play)
+    assert "Detect clawrium-managed marker files" in names
+    assert "Compute set of clawrium-managed skill dirnames on host" in names
+    # The compute-prune task must reference clawrium_managed_dirs (the
+    # filtered set), not the raw `existing_skill_dirs.files` list.
+    compute_prune = next(
+        t
+        for t in play["tasks"]
+        if t.get("name") == "Compute set of skill directories to prune"
+    )
+    set_fact = compute_prune["ansible.builtin.set_fact"]
+    skills_to_prune = set_fact["skills_to_prune"]
+    assert "clawrium_managed_dirs" in skills_to_prune
+
+
+def test_openclaw_playbook_pruning_uses_depth_one_find():
+    """The `find` enumeration that feeds the prune set must be bounded
+    to top-level dirs. A recursive walk could enumerate (and ultimately
+    delete) files inside a user-authored skill subdir."""
+    _, play = _load_playbook("openclaw")
+    find_task = next(
+        t
+        for t in play["tasks"]
+        if t.get("name") == "List existing skill directories on host"
+    )
+    assert find_task["ansible.builtin.find"]["depth"] == 1
+
+
+def test_openclaw_playbook_skills_root_is_canonical():
+    text, _ = _load_playbook("openclaw")
+    assert 'skills_root: "/home/{{ agent_name }}/.openclaw/skills"' in text
+
+
+# ---------------------------- zeroclaw-specific -----------------------------
+
+
+def test_zeroclaw_playbook_wraps_native_install_cli():
+    """Zeroclaw's value-add is the security audit gate fronted by
+    `zeroclaw skills install <path>`. The playbook MUST invoke this CLI
+    (not raw file copies into `~/.zeroclaw/workspace/skills/`) so the
+    audit runs on every install."""
+    _, play = _load_playbook("zeroclaw")
+    install_task = next(
+        t
+        for t in play["tasks"]
+        if t.get("name")
+        == "Install each new skill via native `zeroclaw skills install`"
+    )
+    argv = install_task["ansible.builtin.command"]["argv"]
+    # `argv` form prevents shell-injection through the slug; the slug
+    # is also regex-validated upstream.
+    assert argv[1] == "skills"
+    assert argv[2] == "install"
+
+
+def test_zeroclaw_playbook_removes_via_native_cli():
+    _, play = _load_playbook("zeroclaw")
+    remove_task = next(
+        t
+        for t in play["tasks"]
+        if t.get("name")
+        == "Uninstall clawrium-managed skills no longer in desired state"
+    )
+    argv = remove_task["ansible.builtin.command"]["argv"]
+    assert argv[1] == "skills"
+    assert argv[2] == "remove"
+
+
+def test_zeroclaw_playbook_uses_workspace_skills_path():
+    """Phase 0 confirmed the on-disk install path is
+    `~/.zeroclaw/workspace/skills/` (workspace-scoped), not the
+    plan's draft `~/.zeroclaw/skills/`. Regression guard against
+    reverting to the wrong path."""
+    text, _ = _load_playbook("zeroclaw")
+    assert (
+        'workspace_skills: "/home/{{ agent_name }}/.zeroclaw/workspace/skills"'
+        in text
+    )
+
+
+def test_zeroclaw_playbook_tracking_file_outside_skills_dir():
+    """The clawrium-managed-skills tracking file must NOT live under
+    `~/.zeroclaw/workspace/skills/` — anything inside that subtree gets
+    scanned by `zeroclaw skills install`'s audit gate, which could
+    reject the unexpected file or surface false-positive findings."""
+    text, _ = _load_playbook("zeroclaw")
+    assert (
+        'tracking_file: "/home/{{ agent_name }}/.zeroclaw/.clawrium-managed-skills"'
+        in text
+    )
+    # The tracking file path must not be inside workspace/skills/.
+    assert "/workspace/skills/.clawrium" not in text
+
+
+def test_zeroclaw_playbook_prune_set_intersects_installed():
+    """`zeroclaw skills remove <slug>` errors if the slug isn't
+    currently installed. The prune set must intersect with the on-disk
+    installed list so we never `remove` a slug that's already gone."""
+    _, play = _load_playbook("zeroclaw")
+    compute_prune = next(
+        t
+        for t in play["tasks"]
+        if t.get("name")
+        == "Compute prune set (tracked but not desired AND still installed)"
+    )
+    skills_to_prune = compute_prune["ansible.builtin.set_fact"]["skills_to_prune"]
+    assert "intersect(installed_slugs)" in skills_to_prune
+    assert "tracked_skill_names" in skills_to_prune
+    assert "desired_skill_names" in skills_to_prune
+
+
+def test_zeroclaw_playbook_install_set_skips_already_installed():
+    """Idempotency: re-running install on a slug that's already in the
+    workspace must be a no-op so the audit gate isn't re-paid every
+    apply (it's slow) and the install timestamp doesn't churn."""
+    _, play = _load_playbook("zeroclaw")
+    compute_install = next(
+        t
+        for t in play["tasks"]
+        if t.get("name") == "Compute install set (desired but not installed)"
+    )
+    skills_to_install = compute_install["ansible.builtin.set_fact"][
+        "skills_to_install"
+    ]
+    assert "desired_skill_names" in skills_to_install
+    assert "difference(installed_slugs)" in skills_to_install
+
+
+def test_zeroclaw_playbook_writes_tracking_file_last():
+    """Failure-mode invariant: the tracking file is the ownership log
+    that bounds future prune passes. It must be updated AFTER all
+    install/remove operations succeed so a mid-apply failure leaves
+    the previous tracked list intact (next apply reconverges)."""
+    _, play = _load_playbook("zeroclaw")
+    names = _task_names(play)
+    tracking_idx = names.index("Update tracking file with current desired state")
+    install_idx = names.index(
+        "Install each new skill via native `zeroclaw skills install`"
+    )
+    remove_idx = names.index(
+        "Uninstall clawrium-managed skills no longer in desired state"
+    )
+    assert tracking_idx > install_idx
+    assert tracking_idx > remove_idx
+
+
+def test_zeroclaw_playbook_install_uses_argv_form_not_shell():
+    """Defense-in-depth: every external command invocation must use
+    `argv:` form, not a `cmd:` string. Even though the slug is regex-
+    validated, passing arguments through a shell parser is an
+    unnecessary risk surface."""
+    _, play = _load_playbook("zeroclaw")
+    for task in play["tasks"]:
+        cmd = task.get("ansible.builtin.command")
+        if cmd is None:
+            continue
+        # `cmd` may be a dict (with `argv` or `cmd`) or a plain string.
+        # The string form is exactly what we want to ban.
+        assert isinstance(cmd, dict), (
+            f"task {task.get('name')!r} uses shell-style `command:` — "
+            "must use argv form"
+        )
+        assert "argv" in cmd, (
+            f"task {task.get('name')!r} must use `argv:` form, "
+            "not `cmd:` string"
+        )


### PR DESCRIPTION
## Summary

Phase 3 of #364 — adds per-claw `skills_apply.yaml` for **openclaw**
and **zeroclaw**, closing the CLI surface 🏁. The same
`clawrium/tdd` skill (one normalized `_meta.yaml`) now installs
end-to-end on all three native claws via
`clm agent skill install <agent> clawrium/tdd`.

Stacked on top of `issue-381-cli-skill-install-hermes` (#389). GitHub
will auto-rebase the base to `main` once that PR merges.

- **openclaw**: plain file-copy to `~/.openclaw/skills/<slug>/`,
  per Phase 0 finding that this fork auto-scans (no
  `openclaw.json` re-render needed). Pruning is bounded by an in-dir
  `.clawrium-managed` sentinel so user-authored skills under the same
  parent are invisible to the playbook.
- **zeroclaw**: wraps native `zeroclaw skills install` so the
  security audit gate runs on **every** install (no `installed_slugs`
  filter — ATX iter 1 B2). Pruning is bounded by a
  `~/.zeroclaw/.clawrium-managed-skills` tracking file (outside
  `workspace/skills/` so it doesn't trip the audit). Prune set =
  `(tracked - desired) ∩ installed_on_host` to avoid native `remove`
  errors on already-removed slugs. Stage + install + cleanup runs
  inside a `block:/always:` so a rejected-by-audit install never
  leaks remote staging.
- Dispatch table extension in `core/skills_apply.py`. Cleanup uses
  the None-sentinel pattern so a raise from any creator
  (`_stage_skills` internal, `_make_log_dir`) leaves no tempdir
  behind.

## Testing

### Test Results
- [x] All existing tests pass (`make test`): **2119 passed** (was
      2068; +51 across 4 ATX iterations)
- [x] GUI tests pass: 88 passed
- [x] Linter passes (`make lint`): ruff + ESLint clean
- [x] New tests added for new functionality, including ATX-driven
      regression guards

### Test Coverage
- New tests: `tests/test_registry_skills_apply.py` (structural
  assertions across both playbooks) + extended
  `tests/test_core_skills_apply.py` + extended
  `tests/test_cli_agent_skill.py`.
- Files changed: 2 new playbooks, 1 dispatch update, 1 shared
  sanitizer extension (chat.py + chat_hermes.py), 3 test files
  (1 new, 2 extended), 1 execution doc.
- Coverage impact: increased — net new files and net new tests
  for the openclaw + zeroclaw apply paths, the bidi sanitization
  contract, dispatch-table guards, path-safety belt-and-suspenders.

### Manual Testing

End-to-end smoke against the Phase 0 test fleet on `wolf-i`
(192.168.1.36):

**tdd-openclaw:**
- install → `openclaw skills list` reports `tdd` as `openclaw-managed`
- drift recovery: deleted SKILL.md on host, re-ran install → restored
- bounded pruning: dropped a user-authored skill (no sentinel) and a
  stray clawrium-managed orphan (with sentinel) → re-applied →
  user-authored preserved, stray-orphan pruned

**tdd-zeroclaw:**
- install → `zeroclaw skills install` ran audit gate
  (`Security audit completed successfully`) → `zeroclaw skills list`
  reports `tdd v0.1.0`
- drift recovery: native `zeroclaw skills remove tdd` out of band, then
  re-ran install → reconverged, audit gate ran again
- bounded pruning: installed an unmanaged skill via native CLI (NOT
  tracked in `.clawrium-managed-skills`) → ran `remove tdd` →
  unmanaged skill preserved, only tdd pruned, tracking file
  reconverged to empty

Full transcripts (including all `clm`, `ssh`, and native CLI output)
are in `.itx/382/01_EXECUTION.md`.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — agent_name + every
      slug regex-validated in Python AND re-validated inside both
      playbooks (defense in depth)
- [x] No SQL injection, XSS, or command injection risks — all
      `ansible.builtin.command` invocations use `argv:` form, slug
      regex bans shell metachars (incl. bidi codepoints), paths are
      basename-joined under a fixed prefix; pruning enumeration is
      `find depth: 1`; host_display is allowlist-sanitized PLUS a
      resolve()-based containment check.
- [x] Error messages do not leak computed paths (W2/W13 contract)
- [x] Bidi/RTLO output forgery vector closed in
      `_exit_with_error` via `_sanitize_exception_text` (4-site
      contract from ATX #341 + new U+061C coverage from this PR)
- [x] Dependencies are from trusted sources — no new packages added

## ATX Review Summary

**Final Review: Rating 3.5/5 — MERGE ELIGIBLE**
**Total Cost: ~$11.66 | Total Time: ~38m across 4 iterations**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1, B2, B3, B4 | All fixed | $2.84 | 9m42s | leader, security, core-lifecycle, ansible-registry, test-coverage |
| 2 | 3/5 | B5 (new) + B1/W2/W14 residuals | All fixed | $3.31 | 10m7s | leader, security, core-lifecycle, cli-ux, ansible-registry, test-coverage |
| 3 | 2/5 | B-new1 (staging_dir leak) | Fixed | $3.37 | 11m23s | leader, security, core-lifecycle, cli-ux, test-coverage |
| 4 | **3.5/5** | **None** | **Merge eligible** | $2.64 | 8m52s | leader, security, core-lifecycle, cli-ux, test-coverage |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `cli/agent_skill.py:85-88` | `_exit_with_error` ran rich-escape but not `_sanitize_exception_text` — bidi codepoints survive | Fixed iter 1 — sanitize before escape; chat.py sanitizer wired through |
| B2 | `zeroclaw/playbooks/skills_apply.yaml` | `desired - installed_slugs` filter bypassed audit gate for already-present skills | Fixed iter 1 — install loop iterates full `desired_skill_names`; structural test enforces |
| B3 | `tests/test_core_skills_apply.py` (absent) | No Python-unit test for malicious slug rejection before playbook dispatch | Fixed iter 1 — 13-case parametrize (path traversal, shell metachars, null byte, URLs) with `runner.run.assert_not_called()` |
| B4 | `tests/test_core_skills_apply.py` (absent) | Defensive guard 2 (dispatch-table miss) untested | Fixed iter 1 — monkeypatch test + symmetry assertion |

**Warnings (high-priority fixed in iter 1):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `cli/agent_skill.py:117` | Skills table title not Rich-escaped | Fixed — `escape(agent_name)` in title |
| W2 | `core/skills_apply.py:264-267` | `host_display` used in path without validation | Fixed — allowlist-sanitize + resolve() containment check |
| W3 | `zeroclaw/playbooks/skills_apply.yaml:197-223` | Cleanup task plain, skipped on audit rejection | Fixed — `block:/always:` wrapper |
| W8 | `tests/test_core_skills_apply.py` | openclaw drift-recovery test absent | Fixed — added |
| W11 | `tests/test_registry_skills_apply.py` | Dispatch→file binding untested | Fixed — added |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B5 | `tests/test_cli_agent_skill.py` (absent) | No regression test for `_exit_with_error` bidi sanitization | Fixed iter 2 — `test_bidi_chars_in_skill_error_are_stripped` + companion preservation test |

**Residual items resolved in iter 2:**

| # | File | Warning | Action |
|---|------|---------|--------|
| B1-res | `cli/chat.py` + `core/chat_hermes.py` | Sanitizer missed U+061C (ARABIC LETTER MARK) | Fixed — added to all 3 regex sites in lockstep |
| W2-res | `core/skills_apply.py` | Path-safety error leaked computed log_dir | Fixed — message non-revealing; path lands at `logger.debug` only |
| W14 | `tests/test_core_skills_apply.py` | Malicious-slug parametrize had no bidi cases | Fixed — added U+202E, U+200B, U+061C, U+2066 |

</details>

<details>
<summary>Review 3 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B-new1 | `core/skills_apply.py:173-176` | W2 path-safety check fires before `try:`, leaking staging tempdir on raise | Fixed iter 3 — None-sentinel pattern (staging_dir/log_dir init to None, assign inside try, None-guard cleanup); regression test added |

**Warnings resolved in iter 3:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W-new2 | `core/skills_apply.py:291-294` | Path-safety error had no remediation hint | Fixed iter 3, refined iter 4 to point at correct `clm host update` command |
| W-new3 | `core/skills_apply.py:283-294` | Path-traversal guard branch untested | Fixed — `test_make_log_dir_rejects_path_traversal_in_host_alias` (defeats allowlist via `_NoopReModule`) |
| W-new4 | `core/skills_apply.py:280-293` | Non-leaking invariant unasserted | Fixed — `test_make_log_dir_error_does_not_leak_computed_path` |
| W-new5 | `tests/test_core_skills_apply.py` | U+2069 (PDI) missing from malicious-slug parametrize | Fixed — added |

</details>

<details>
<summary>Review 4 Details (Rating 3.5/5 — MERGE ELIGIBLE)</summary>

**Blocking Issues:** None.

**Warnings fixed in iter 4 polish commit:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W-new6 | `core/skills_apply.py:_stage_skills` | `mkdtemp` materializes before populate-loop; internal raise leaks tempdir (caller's None-sentinel doesn't help) | Fixed — try/except wraps loop, rmtrees on raise; regression test added |
| W-new7 | `core/skills_apply.py:_make_log_dir` | Remediation hint pointed at `clm host add` (fails on existing-host case); mechanism language | Fixed — points at `clm host update`; reframed lead to user-facing |
| W-new9 | `core/skills_apply.py:apply_state` | `log_dir` typed `Path \| None` but `ApplyResult.log_dir` expects `Path` | Fixed — `assert log_dir is not None` narrows type + documents invariant |

**Warnings tracked for follow-up (acceptable per ATX iter 4 merge checklist):**

| # | File | Warning | Disposition |
|---|------|---------|-------------|
| W-new1 | 3 CLI modules importing `_sanitize_exception_text` | Private symbol cross-module — promote to public `cli/utils.py` | Deferred — refactor across 3+ files |
| W-new8 | `core/skills_apply.py:_make_log_dir` | `mkdir`/`chmod` OSError unhandled | Deferred — minor; surfaces as raw traceback only on FS errors |
| W-new10 | `tests/test_core_skills_apply.py` | Path-traversal test covers `alias` only, not `hostname` fallback | Deferred — same code path; one branch already regression-tested |

</details>

## Reviewer Notes

- The choice of ownership-boundary mechanism is per-claw, not uniform.
  Sentinel vs. subdir vs. tracking file is documented in
  `.itx/382/01_EXECUTION.md` under "Design notes" with reasoning.
- The hermes playbook (from #381) uses a clawrium subdir namespace —
  this PR did not change it. Cross-claw consistency was considered
  and intentionally not pursued: each claw's idiom drove the choice.
- This is the last phase of CLI scope for #364. GUI parity (Phase 5)
  + CI dual-schema + docs (Phase 6) remain.

---

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>