### PR TITLE
feat(skills): #384 Phase 5 — GUI install/list/remove on all three real claws

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"d8ce4ec6-4fbf-4375-b01a-6baece045adb","pid":2590861,"procStart":"50185760","acquiredAt":1779050755062}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"d8ce4ec6-4fbf-4375-b01a-6baece045adb","pid":2590861,"procStart":"50185760","acquiredAt":1779050755062}

--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,6 @@ gui/.next/
 *.tsbuildinfo
 src/clawrium/gui/frontend/
 .claude/worktrees/
+
+# Scheduled-task internal state (ScheduleWakeup runtime lock)
+.claude/scheduled_tasks.lock

--- a/.itx/384/01_EXECUTION.md
+++ b/.itx/384/01_EXECUTION.md
@@ -1,0 +1,241 @@
+# Issue #384 — Phase 5 Execution Log
+
+Scope (from issue body): mirror Phases 2–3 (CLI per-agent install/list/
+remove) in the GUI. Real install on all three claws via browser, drift
+recovery, cross-surface parity with `clm agent skill list`.
+
+Plan reference: `.itx/364/00_PLAN.md` § *Files to add → GUI backend
+(agents.py extension), GUI frontend (Skills tab + filtered picker)*.
+
+## What shipped
+
+**Backend (`src/clawrium/gui/routes/agents.py`):**
+
+- `GET /api/agents/{agent_key}/skills` — returns `{ agent_name,
+  agent_type, installed[], available[] }`. `available` is the catalog
+  filtered to "installable on this claw type": `clawrium/*` whose
+  `_meta.yaml.compatibility[<claw>] = true` plus the matching
+  `<claw>/*` native registry. The filter lives in
+  `_is_compatible_for_agent_type` and fail-closes on any catalog
+  error — same rule `check_agent_compatibility` uses.
+- `POST /api/agents/{agent_key}/skills/{registry}/{skill}` — installs.
+  Mutates desired state via `add_skill`, then always invokes
+  `apply_state(agent_name)`. Re-installing an already-installed skill
+  is the documented drift-recovery path — `changed: false` but the
+  playbook still runs.
+- `DELETE /api/agents/{agent_key}/skills/{registry}/{skill}` — removes.
+  Same idempotency rule: removing an absent skill is a no-op state
+  mutation but the playbook still runs to prune any orphan host
+  directory.
+- `SkillError` → HTTP status mapping (`_skill_error_status`):
+
+  | Error class                                               | Status |
+  |-----------------------------------------------------------|--------|
+  | `AgentNotFoundError`, `SkillNotFound`                     | 404    |
+  | `MissingRegistryPrefix`, `ExternalSourceBlocked`,         |        |
+  |   `InvalidSkillRef`, `IncompatibleSkillRegistry`,         |        |
+  |   `SchemaValidationError`, `SkillApplyNotSupported`       | 422    |
+  | `SkillApplyError`                                         | 502    |
+
+  502 (not 500) is deliberate: a failed ansible/SSH run is an
+  upstream-host failure, not a server bug — the GUI should treat it
+  as transient and let the user retry. The CLI surfaces these as
+  `SkillApplyError`; the GUI maps them to a Bad-Gateway category so
+  the alert-banner text is meaningful.
+
+**Frontend types / api / hooks (`gui/src/lib/`, `gui/src/hooks/`):**
+
+- `types.ts`: `AgentSkillRow`, `AgentSkills`,
+  `AgentSkillMutationResponse`.
+- `api.ts`: `getAgentSkills`, `installAgentSkill`, `removeAgentSkill`.
+- `hooks/use-skills.ts`: `useAgentSkills`, `useInstallAgentSkill`,
+  `useRemoveAgentSkill` — react-query mutations invalidate the
+  `["agent-skills", agentKey]` query key so the installed-list and
+  available-picker both re-render after install/remove.
+
+**Frontend (`gui/src/components/agent-detail/skills-tab.tsx`):**
+
+- Replaced the placeholder card with a real Skills tab:
+  - "Installed Skills" card lists each row with a registry badge,
+    `ref`, version, description preview, and a per-row **Remove**
+    button.
+  - "Install skill" button opens a modal with the **filtered picker**.
+    The picker subtracts already-installed refs so the user can't try
+    to "install" a duplicate, and renders an empty-state hint
+    pointing at the right catalog directory when nothing is available
+    (e.g. a claw type with no native skills + no clawrium skills marked
+    compatible).
+  - Mutation errors render inline as a `role="alert"` banner above
+    the cards, so the user sees the failure without losing context.
+- `tab-nav.tsx`: renamed the tab label from "Skills & Tools" to
+  "Skills". The "& Tools" half referenced the now-removed integrations
+  placeholder card; no integrations work happens in this PR.
+
+**Tests:**
+
+- `tests/test_gui_agent_skills_routes.py` (15 tests):
+  - GET: 404 on unknown agent, payload shape, available filtering by
+    each claw (hermes/openclaw/zeroclaw), empty-state passthrough.
+  - POST: state mutation + apply, idempotency, 404 on unknown agent,
+    422 on `ExternalSourceBlocked`, 422 on `IncompatibleSkillRegistry`,
+    502 on `SkillApplyError`.
+  - DELETE: state mutation + apply, idempotency on no-op, 404, 422.
+- `gui/src/components/agent-detail/skills-tab.test.tsx` (9 tests):
+  loading state, error state with retry, empty-state hint, installed
+  rows, picker filtering, picker hides installed, install + remove
+  mutations invoked with `{agentKey, registry, name}`, inline error
+  rendering.
+
+## Verification
+
+```
+$ make test
+============================ 2113 passed in 19.62s =============================
+ Test Files  13 passed (13)
+      Tests  115 passed (115)
+
+$ make lint
+uv run ruff check src tests
+All checks passed!
+✔ No ESLint warnings or errors
+```
+
+(2113 pytest + 115 vitest. Phase 4 baseline was 2098 + 106; this PR
+adds 15 backend + 9 vitest tests.)
+
+## Real smoke-test transcript
+
+Test fleet (Phase 0): all three running on `wolf-i` (192.168.1.36).
+Agent names: `tdd-hermes`, `tdd-openclaw`, `tdd-zeroclaw`.
+
+GUI server: `uv run uvicorn clawrium.gui.server:app --port 38384`.
+
+### tdd-hermes (hermes — file-drop to `~/.hermes/skills/clawrium/`)
+
+```
+$ curl -X POST .../api/agents/tdd-hermes/skills/clawrium/tdd
+{"success":true,"agent_name":"tdd-hermes","ref":"clawrium/tdd",
+ "changed":true,"installed":["clawrium/tdd"]}
+
+$ ssh wolf-i 'sudo ls /home/tdd-hermes/.hermes/skills/clawrium/'
+tdd
+
+$ ssh wolf-i 'sudo head -3 /home/tdd-hermes/.hermes/skills/clawrium/tdd/SKILL.md'
+---
+name: tdd
+description: 'Test-Driven Development discipline. ...'
+
+# Cross-surface parity:
+$ clm agent skill list tdd-hermes
+       Skills on tdd-hermes
+┃ Ref          ┃ Registry ┃ Name ┃
+│ clawrium/tdd │ clawrium │ tdd  │
+
+# Drift recovery (delete on host, re-POST → file restored):
+$ ssh wolf-i 'sudo rm -rf /home/tdd-hermes/.hermes/skills/clawrium/tdd'
+$ curl -X POST .../skills/clawrium/tdd
+{"changed":false,"installed":["clawrium/tdd"]}     # state unchanged, but...
+$ ssh wolf-i 'sudo ls /home/tdd-hermes/.hermes/skills/clawrium/tdd/'
+SKILL.md                                            # ...host reconciled
+
+$ curl -X DELETE .../skills/clawrium/tdd
+{"changed":true,"installed":[]}
+$ ssh wolf-i 'sudo ls /home/tdd-hermes/.hermes/skills/clawrium/'
+(empty)
+```
+
+### tdd-openclaw (openclaw — file-drop to `~/.openclaw/skills/`)
+
+```
+$ curl -X POST .../api/agents/tdd-openclaw/skills/clawrium/tdd
+{"success":true,"changed":true,"installed":["clawrium/tdd"]}
+
+$ ssh wolf-i 'sudo ls /home/tdd-openclaw/.openclaw/skills/'
+tdd
+
+# Drift recovery: same pattern — file restored on re-POST.
+# DELETE: directory pruned.
+```
+
+### tdd-zeroclaw (zeroclaw — native `zeroclaw skills install` to `~/.zeroclaw/workspace/skills/`)
+
+```
+$ curl -X POST .../api/agents/tdd-zeroclaw/skills/clawrium/tdd
+{"success":true,"changed":true,"installed":["clawrium/tdd"]}
+
+$ ssh wolf-i 'sudo find /home/tdd-zeroclaw/.zeroclaw -name "SKILL.md"'
+/home/tdd-zeroclaw/.zeroclaw/workspace/skills/tdd/SKILL.md
+
+# zeroclaw's path differs from the other claws — the native CLI puts
+# files under workspace/skills/ (Phase 0 finding). The clawrium GUI
+# route is agnostic; whatever the per-claw playbook produces is what
+# the host sees.
+```
+
+All three claws: install → host materialization confirmed, CLI
+parity confirmed via `clm agent skill list`, drift recovery confirmed
+(delete on host → re-POST → file restored), remove confirmed
+(host directory pruned).
+
+Browser visual smoke: `/tmp/skills-smoke/agent-detail-tdd-hermes.png`
+shows the agent-detail page rendering with the new **Skills** tab in
+the navigation row. Tab interaction itself is covered by the vitest
+suite for `skills-tab.tsx` — chrome-headless `--screenshot` doesn't
+fire React onClick handlers, so the interactive flow (click Install →
+modal opens → pick row → install fires → row appears under Installed)
+is asserted in `skills-tab.test.tsx`. That's the same pattern Phase 4
+used in `.itx/383/01_EXECUTION.md`.
+
+## Decisions worth noting
+
+1. **Filtered picker on the server, not the client.** `available` is
+   already filtered to "compatible with this claw" before the GUI sees
+   it. Reasoning: keeps the compatibility-resolution logic
+   (`check_agent_compatibility` + native-registry-self-match) in one
+   place — Python — so a future change to the rule doesn't have to be
+   mirrored in TypeScript. The frontend only does set-subtraction
+   (available minus installed) to hide duplicates from the picker.
+
+2. **502 for apply failures.** A `SkillApplyError` is a host/SSH
+   failure, not a server bug. Mapping it to 500 would conflate "your
+   request is fine but the host is unreachable" with "this server is
+   broken". 502 (Bad Gateway) gives the GUI a clean signal to render a
+   retry-able banner and lets log monitors that page on 5xx ignore
+   transient host blips by status alone.
+
+3. **`changed: false` does not imply "did nothing"**. The API returns
+   `changed` so the UI can render "already installed; host
+   reconciled" vs "newly installed" copy if it wants to, but the
+   apply playbook runs unconditionally on every POST/DELETE. The
+   drift-recovery contract (CLI Phase 2/3) is preserved in the GUI.
+
+4. **Tab label rename.** `"Skills & Tools"` → `"Skills"`. The
+   placeholder Skills tab contained a separate "Integrations"
+   sub-card, which is why the original label had `& Tools`. With
+   integrations living on its own sidebar page (#373), the per-agent
+   tab is now skills-only. Single-word label avoids the misleading
+   ampersand.
+
+## What's NOT in this PR
+
+- Per-agent **integrations** management. The Phase 5 scope is skills
+  only. Integrations stays on the dedicated `/integrations` page.
+- Docs / CI / end-to-end multi-skill fixtures. That's Phase 6 (#385+).
+- Deep-linking the active tab via `?tab=skills` querystring. Would be
+  useful for support handoffs but the issue scope doesn't call for it.
+
+---
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: execution
+**Skill**: /itx-execute
+**Timestamp**: 2026-05-17T19:30:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 384 --pr-base=issue-383-gui-skill-catalog-browse
+```
+
+</details>

--- a/gui/src/components/agent-detail/skills-tab.test.tsx
+++ b/gui/src/components/agent-detail/skills-tab.test.tsx
@@ -151,8 +151,9 @@ describe("SkillsTab", () => {
     agentSkillsState.data = makeAgentSkills();
     render(<SkillsTab agentKey="tdd-hermes" />);
     fireEvent.click(screen.getByRole("button", { name: /Install skill/ }));
+    // Per-row picker button is labeled "Install <ref>" (ATX-1 W7).
     fireEvent.click(
-      screen.getAllByRole("button", { name: /^Install$/ })[0],
+      screen.getByRole("button", { name: /Install clawrium\/tdd/ }),
     );
     await waitFor(() =>
       expect(installMutation.mutateAsync).toHaveBeenCalledWith({
@@ -163,7 +164,49 @@ describe("SkillsTab", () => {
     );
   });
 
-  it("calls remove mutation with parsed registry+name", async () => {
+  it("calls remove mutation only after the confirm step", async () => {
+    // ATX-1 B2: destructive Remove is a two-step. First click arms the
+    // confirm/cancel pair; the mutation only fires on the Confirm click.
+    agentSkillsState.data = makeAgentSkills({
+      installed: [
+        {
+          ref: "clawrium/tdd",
+          registry: "clawrium",
+          name: "tdd",
+          description: "TDD discipline.",
+          version: "0.1.0",
+        },
+      ],
+    });
+    render(<SkillsTab agentKey="tdd-hermes" />);
+
+    // Step 1: clicking "Remove" must NOT call the mutation.
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Remove clawrium\/tdd$/ }),
+    );
+    expect(removeMutation.mutateAsync).not.toHaveBeenCalled();
+
+    // The confirm/cancel pair is now rendered, labelled with the ref.
+    expect(
+      screen.getByRole("group", {
+        name: /Confirm removal of clawrium\/tdd/,
+      }),
+    ).toBeInTheDocument();
+
+    // Step 2: confirm.
+    fireEvent.click(
+      screen.getByRole("button", { name: /Confirm remove clawrium\/tdd/ }),
+    );
+    await waitFor(() =>
+      expect(removeMutation.mutateAsync).toHaveBeenCalledWith({
+        agentKey: "tdd-hermes",
+        registry: "clawrium",
+        name: "tdd",
+      }),
+    );
+  });
+
+  it("cancels the remove confirmation without firing the mutation", () => {
     agentSkillsState.data = makeAgentSkills({
       installed: [
         {
@@ -177,15 +220,16 @@ describe("SkillsTab", () => {
     });
     render(<SkillsTab agentKey="tdd-hermes" />);
     fireEvent.click(
-      screen.getByRole("button", { name: /Remove clawrium\/tdd/ }),
+      screen.getByRole("button", { name: /^Remove clawrium\/tdd$/ }),
     );
-    await waitFor(() =>
-      expect(removeMutation.mutateAsync).toHaveBeenCalledWith({
-        agentKey: "tdd-hermes",
-        registry: "clawrium",
-        name: "tdd",
-      }),
+    fireEvent.click(
+      screen.getByRole("button", { name: /Cancel remove clawrium\/tdd/ }),
     );
+    expect(removeMutation.mutateAsync).not.toHaveBeenCalled();
+    // Confirmation UI is gone; the original Remove button is back.
+    expect(
+      screen.getByRole("button", { name: /^Remove clawrium\/tdd$/ }),
+    ).toBeInTheDocument();
   });
 
   it("surfaces install errors inline", async () => {
@@ -196,10 +240,53 @@ describe("SkillsTab", () => {
     render(<SkillsTab agentKey="tdd-hermes" />);
     fireEvent.click(screen.getByRole("button", { name: /Install skill/ }));
     fireEvent.click(
-      screen.getAllByRole("button", { name: /^Install$/ })[0],
+      screen.getAllByRole("button", { name: /Install clawrium\/tdd/ })[0],
     );
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent(/host unreachable/);
+    });
+  });
+
+  it("surfaces remove errors inline", async () => {
+    // ATX-1 W9: handleRemove has the same catch path as handleInstall;
+    // assert the error banner fires for the destructive path too.
+    agentSkillsState.data = makeAgentSkills({
+      installed: [
+        {
+          ref: "clawrium/tdd",
+          registry: "clawrium",
+          name: "tdd",
+          description: "TDD discipline.",
+          version: "0.1.0",
+        },
+      ],
+    });
+    removeMutation.mutateAsync = vi
+      .fn()
+      .mockRejectedValue(new Error("ansible timeout"));
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Remove clawrium\/tdd$/ }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /Confirm remove clawrium\/tdd/ }),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/ansible timeout/);
+    });
+  });
+
+  it("closes the install picker after a successful install", async () => {
+    // ATX-1 W9: post-install modal-close path was previously uncovered.
+    agentSkillsState.data = makeAgentSkills();
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    fireEvent.click(screen.getByRole("button", { name: /Install skill/ }));
+    expect(screen.getByTestId("modal")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /Install clawrium\/tdd/ })[0],
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
     });
   });
 });

--- a/gui/src/components/agent-detail/skills-tab.test.tsx
+++ b/gui/src/components/agent-detail/skills-tab.test.tsx
@@ -79,17 +79,17 @@ describe("SkillsTab", () => {
     removeMutation.isPending = false;
   });
 
-  it("renders the loading skeleton with assistive-tech attributes", () => {
-    // ATX-2 W1: assert the a11y attributes themselves, not just the
-    // presence of the testid — a regression that dropped role=status
-    // or aria-busy would still pass a presence-only check.
+  it("renders the live region with role=status and aria-busy=true while loading", () => {
+    // ATX-3 W1/W2: the live region lives at the SkillsTab root (not
+    // inside the skeleton) so it can announce *both* the load start
+    // and the transition to loaded. Assert role=status + aria-busy
+    // are wired and the announcement text matches the load state.
     agentSkillsState.isLoading = true;
     render(<SkillsTab agentKey="tdd-hermes" />);
-    const node = screen.getByTestId("skills-loading");
-    expect(node).toHaveAttribute("role", "status");
-    expect(node).toHaveAttribute("aria-busy", "true");
-    expect(node).toHaveAttribute("aria-live", "polite");
-    expect(node).toHaveAttribute("aria-label", "Loading skills");
+    const live = screen.getByRole("status", { name: /Skills tab status/ });
+    expect(live).toHaveAttribute("aria-busy", "true");
+    expect(live).toHaveTextContent("Loading skills…");
+    expect(screen.getByTestId("skills-loading")).toBeInTheDocument();
   });
 
   it("renders an error state with a retry control", () => {
@@ -291,37 +291,11 @@ describe("SkillsTab", () => {
     ).toBeInTheDocument();
   });
 
-  it("dismisses the confirm group on Escape", () => {
+  it("dismisses the confirm group on Escape from the Confirm button", () => {
     // ATX-2 B2b: Escape on the inline confirm group must cancel.
-    agentSkillsState.data = makeAgentSkills({
-      installed: [
-        {
-          ref: "clawrium/tdd",
-          registry: "clawrium",
-          name: "tdd",
-          description: "TDD discipline.",
-          version: "0.1.0",
-        },
-      ],
-    });
-    render(<SkillsTab agentKey="tdd-hermes" />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /^Remove clawrium\/tdd$/ }),
-    );
-    const group = screen.getByRole("group", {
-      name: /Confirm removal of clawrium\/tdd/,
-    });
-    fireEvent.keyDown(group, { key: "Escape" });
-    expect(
-      screen.queryByRole("group", {
-        name: /Confirm removal of clawrium\/tdd/,
-      }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("focuses the Confirm button on Remove→confirming transition", () => {
-    // ATX-2 B2a: focus must move so keyboard / SR users notice the
-    // state change.
+    // ATX-3 W4: fire Escape on the *focused* Confirm button so the
+    // event-bubble path is exercised, not a synthetic group keydown
+    // that would bypass any accidentally-added child stopPropagation.
     agentSkillsState.data = makeAgentSkills({
       installed: [
         {
@@ -340,7 +314,75 @@ describe("SkillsTab", () => {
     const confirmBtn = screen.getByRole("button", {
       name: /Confirm remove clawrium\/tdd/,
     });
-    expect(confirmBtn).toHaveFocus();
+    fireEvent.keyDown(confirmBtn, { key: "Escape" });
+    expect(
+      screen.queryByRole("group", {
+        name: /Confirm removal of clawrium\/tdd/,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("focuses the Confirm button on Remove→confirming transition", async () => {
+    // ATX-2 B2a: focus must move so keyboard / SR users notice the
+    // state change. S1: waitFor so a future requestAnimationFrame
+    // delay doesn't silently make this assertion vacuous.
+    agentSkillsState.data = makeAgentSkills({
+      installed: [
+        {
+          ref: "clawrium/tdd",
+          registry: "clawrium",
+          name: "tdd",
+          description: "TDD discipline.",
+          version: "0.1.0",
+        },
+      ],
+    });
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Remove clawrium\/tdd$/ }),
+    );
+    const confirmBtn = screen.getByRole("button", {
+      name: /Confirm remove clawrium\/tdd/,
+    });
+    await waitFor(() => expect(confirmBtn).toHaveFocus());
+  });
+
+  it("dismisses the confirm group when a concurrent mutation disables the row", () => {
+    // ATX-3 W3: assert the disabled→confirming-cleanup effect, which
+    // is the only thing standing between "two mutations in flight"
+    // and "user sees a stuck disabled Confirm button they cannot
+    // escape from".
+    agentSkillsState.data = makeAgentSkills({
+      installed: [
+        {
+          ref: "clawrium/tdd",
+          registry: "clawrium",
+          name: "tdd",
+          description: "TDD discipline.",
+          version: "0.1.0",
+        },
+      ],
+    });
+    const { rerender } = render(<SkillsTab agentKey="tdd-hermes" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Remove clawrium\/tdd$/ }),
+    );
+    expect(
+      screen.getByRole("group", { name: /Confirm removal of clawrium\/tdd/ }),
+    ).toBeInTheDocument();
+
+    // Concurrent install fires — the row disables. The effect must
+    // collapse the confirm group back to the resting Remove button.
+    installMutation.isPending = true;
+    rerender(<SkillsTab agentKey="tdd-hermes" />);
+    expect(
+      screen.queryByRole("group", {
+        name: /Confirm removal of clawrium\/tdd/,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^Remove clawrium\/tdd$/ }),
+    ).toBeDisabled();
   });
 
   it("closes the install picker after a successful install", async () => {

--- a/gui/src/components/agent-detail/skills-tab.test.tsx
+++ b/gui/src/components/agent-detail/skills-tab.test.tsx
@@ -1,0 +1,205 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import type { AgentSkills } from "@/lib/types";
+
+// Mocked hook state — each test resets the slots in beforeEach.
+const agentSkillsState: {
+  data: AgentSkills | undefined;
+  isLoading: boolean;
+  error: unknown;
+  refetch: () => void;
+} = { data: undefined, isLoading: false, error: null, refetch: vi.fn() };
+
+const installMutation = {
+  mutateAsync: vi.fn(),
+  isPending: false,
+};
+const removeMutation = {
+  mutateAsync: vi.fn(),
+  isPending: false,
+};
+
+vi.mock("@/hooks", () => ({
+  useAgentSkills: () => agentSkillsState,
+  useInstallAgentSkill: () => installMutation,
+  useRemoveAgentSkill: () => removeMutation,
+}));
+
+vi.mock("@/components/ui/modal", () => ({
+  Modal: ({
+    open,
+    title,
+    children,
+    footer,
+  }: {
+    open: boolean;
+    title: string;
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+  }) =>
+    open ? (
+      <div data-testid="modal">
+        <p>{title}</p>
+        {children}
+        {footer}
+      </div>
+    ) : null,
+}));
+
+import { SkillsTab } from "./skills-tab";
+
+function makeAgentSkills(overrides: Partial<AgentSkills> = {}): AgentSkills {
+  return {
+    agent_name: "tdd-hermes",
+    agent_type: "hermes",
+    installed: [],
+    available: [
+      {
+        ref: "clawrium/tdd",
+        registry: "clawrium",
+        name: "tdd",
+        description: "TDD discipline.",
+        version: "0.1.0",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("SkillsTab", () => {
+  beforeEach(() => {
+    agentSkillsState.data = undefined;
+    agentSkillsState.isLoading = false;
+    agentSkillsState.error = null;
+    agentSkillsState.refetch = vi.fn();
+    installMutation.mutateAsync = vi.fn().mockResolvedValue({});
+    installMutation.isPending = false;
+    removeMutation.mutateAsync = vi.fn().mockResolvedValue({});
+    removeMutation.isPending = false;
+  });
+
+  it("renders the loading skeleton while fetching", () => {
+    agentSkillsState.isLoading = true;
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    expect(screen.getByTestId("skills-loading")).toBeInTheDocument();
+  });
+
+  it("renders an error state with a retry control", () => {
+    agentSkillsState.error = new Error("boom");
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    expect(screen.getByText(/Failed to load skills/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Retry/ }));
+    expect(agentSkillsState.refetch).toHaveBeenCalled();
+  });
+
+  it("shows the empty-state hint when nothing is installed", () => {
+    agentSkillsState.data = makeAgentSkills();
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    expect(screen.getByText(/No skills installed yet/i)).toBeInTheDocument();
+  });
+
+  it("renders installed skills with Remove buttons", () => {
+    agentSkillsState.data = makeAgentSkills({
+      installed: [
+        {
+          ref: "clawrium/tdd",
+          registry: "clawrium",
+          name: "tdd",
+          description: "TDD discipline.",
+          version: "0.1.0",
+        },
+      ],
+    });
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    expect(screen.getByText("clawrium/tdd")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Remove clawrium\/tdd/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the install picker filtered to compatible skills", () => {
+    agentSkillsState.data = makeAgentSkills();
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    fireEvent.click(screen.getByRole("button", { name: /Install skill/ }));
+    const modal = screen.getByTestId("modal");
+    expect(modal).toBeInTheDocument();
+    // The picker shows the available skill that isn't yet installed.
+    expect(modal.textContent).toContain("clawrium/tdd");
+  });
+
+  it("hides already-installed skills from the picker", () => {
+    agentSkillsState.data = makeAgentSkills({
+      installed: [
+        {
+          ref: "clawrium/tdd",
+          registry: "clawrium",
+          name: "tdd",
+          description: "TDD discipline.",
+          version: "0.1.0",
+        },
+      ],
+    });
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    // The Install button disables when nothing is available beyond installed.
+    expect(
+      screen.getByRole("button", { name: /Install skill/ }),
+    ).toBeDisabled();
+  });
+
+  it("calls install mutation with parsed registry+name", async () => {
+    agentSkillsState.data = makeAgentSkills();
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    fireEvent.click(screen.getByRole("button", { name: /Install skill/ }));
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /^Install$/ })[0],
+    );
+    await waitFor(() =>
+      expect(installMutation.mutateAsync).toHaveBeenCalledWith({
+        agentKey: "tdd-hermes",
+        registry: "clawrium",
+        name: "tdd",
+      }),
+    );
+  });
+
+  it("calls remove mutation with parsed registry+name", async () => {
+    agentSkillsState.data = makeAgentSkills({
+      installed: [
+        {
+          ref: "clawrium/tdd",
+          registry: "clawrium",
+          name: "tdd",
+          description: "TDD discipline.",
+          version: "0.1.0",
+        },
+      ],
+    });
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Remove clawrium\/tdd/ }),
+    );
+    await waitFor(() =>
+      expect(removeMutation.mutateAsync).toHaveBeenCalledWith({
+        agentKey: "tdd-hermes",
+        registry: "clawrium",
+        name: "tdd",
+      }),
+    );
+  });
+
+  it("surfaces install errors inline", async () => {
+    agentSkillsState.data = makeAgentSkills();
+    installMutation.mutateAsync = vi
+      .fn()
+      .mockRejectedValue(new Error("host unreachable"));
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    fireEvent.click(screen.getByRole("button", { name: /Install skill/ }));
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /^Install$/ })[0],
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/host unreachable/);
+    });
+  });
+});

--- a/gui/src/components/agent-detail/skills-tab.test.tsx
+++ b/gui/src/components/agent-detail/skills-tab.test.tsx
@@ -79,10 +79,17 @@ describe("SkillsTab", () => {
     removeMutation.isPending = false;
   });
 
-  it("renders the loading skeleton while fetching", () => {
+  it("renders the loading skeleton with assistive-tech attributes", () => {
+    // ATX-2 W1: assert the a11y attributes themselves, not just the
+    // presence of the testid — a regression that dropped role=status
+    // or aria-busy would still pass a presence-only check.
     agentSkillsState.isLoading = true;
     render(<SkillsTab agentKey="tdd-hermes" />);
-    expect(screen.getByTestId("skills-loading")).toBeInTheDocument();
+    const node = screen.getByTestId("skills-loading");
+    expect(node).toHaveAttribute("role", "status");
+    expect(node).toHaveAttribute("aria-busy", "true");
+    expect(node).toHaveAttribute("aria-live", "polite");
+    expect(node).toHaveAttribute("aria-label", "Loading skills");
   });
 
   it("renders an error state with a retry control", () => {
@@ -247,9 +254,12 @@ describe("SkillsTab", () => {
     });
   });
 
-  it("surfaces remove errors inline", async () => {
-    // ATX-1 W9: handleRemove has the same catch path as handleInstall;
-    // assert the error banner fires for the destructive path too.
+  it("surfaces remove errors inline and resets confirming state", async () => {
+    // ATX-1 W9 + ATX-2 W9: handleRemove has the same catch path as
+    // handleInstall, AND after a failed mutation the row must drop
+    // back to the un-armed state — otherwise the user is stuck staring
+    // at Confirm/Cancel with no way to retry the Remove from the
+    // resting state.
     agentSkillsState.data = makeAgentSkills({
       installed: [
         {
@@ -274,6 +284,63 @@ describe("SkillsTab", () => {
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent(/ansible timeout/);
     });
+    // The mutation handler clears `confirming` synchronously when the
+    // Confirm button fires, so the resting "Remove" button is back.
+    expect(
+      screen.getByRole("button", { name: /^Remove clawrium\/tdd$/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("dismisses the confirm group on Escape", () => {
+    // ATX-2 B2b: Escape on the inline confirm group must cancel.
+    agentSkillsState.data = makeAgentSkills({
+      installed: [
+        {
+          ref: "clawrium/tdd",
+          registry: "clawrium",
+          name: "tdd",
+          description: "TDD discipline.",
+          version: "0.1.0",
+        },
+      ],
+    });
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Remove clawrium\/tdd$/ }),
+    );
+    const group = screen.getByRole("group", {
+      name: /Confirm removal of clawrium\/tdd/,
+    });
+    fireEvent.keyDown(group, { key: "Escape" });
+    expect(
+      screen.queryByRole("group", {
+        name: /Confirm removal of clawrium\/tdd/,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("focuses the Confirm button on Remove→confirming transition", () => {
+    // ATX-2 B2a: focus must move so keyboard / SR users notice the
+    // state change.
+    agentSkillsState.data = makeAgentSkills({
+      installed: [
+        {
+          ref: "clawrium/tdd",
+          registry: "clawrium",
+          name: "tdd",
+          description: "TDD discipline.",
+          version: "0.1.0",
+        },
+      ],
+    });
+    render(<SkillsTab agentKey="tdd-hermes" />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Remove clawrium\/tdd$/ }),
+    );
+    const confirmBtn = screen.getByRole("button", {
+      name: /Confirm remove clawrium\/tdd/,
+    });
+    expect(confirmBtn).toHaveFocus();
   });
 
   it("closes the install picker after a successful install", async () => {

--- a/gui/src/components/agent-detail/skills-tab.tsx
+++ b/gui/src/components/agent-detail/skills-tab.tsx
@@ -56,8 +56,19 @@ export function SkillsTab({ agentKey }: SkillsTabProps) {
   );
 
   if (isLoading) {
+    // ATX-1 B1: skeleton must announce itself to assistive tech.
+    // role=status + aria-live=polite makes screen readers report
+    // "Loading skills…" when the tab becomes active; the sr-only span
+    // gives them text to read since the pulsing divs carry no content.
     return (
-      <div className="space-y-3 p-4" data-testid="skills-loading">
+      <div
+        className="space-y-3 p-4"
+        data-testid="skills-loading"
+        role="status"
+        aria-live="polite"
+        aria-label="Loading skills"
+      >
+        <span className="sr-only">Loading skills…</span>
         <div className="bg-surface rounded-xl border border-default h-20 animate-pulse" />
         <div className="bg-surface rounded-xl border border-default h-20 animate-pulse" />
       </div>
@@ -146,7 +157,11 @@ export function SkillsTab({ agentKey }: SkillsTabProps) {
             the catalog.
           </div>
         ) : (
-          <ul className="divide-y divide-default border border-default rounded-lg overflow-hidden">
+          <ul
+            className="divide-y divide-default border border-default rounded-lg overflow-hidden"
+            role="list"
+            aria-label="Installed skills"
+          >
             {data.installed.map((row) => (
               <InstalledRow
                 key={row.ref}
@@ -188,6 +203,12 @@ function InstalledRow({
   onRemove: (registry: string, name: string) => void;
   disabled: boolean;
 }) {
+  // ATX-1 B2: remove is destructive (re-running install brings the host
+  // back in sync, but the desired-state file is mutated immediately).
+  // First click arms the confirm/cancel pair instead of firing the
+  // mutation directly. Confirm button carries the skill ref in its
+  // accessible name so a screen-reader scan can't conflate two rows.
+  const [confirming, setConfirming] = useState(false);
   const canRemove = !!row.registry && !!row.name;
   return (
     <li className="flex items-start gap-3 px-4 py-3">
@@ -207,15 +228,43 @@ function InstalledRow({
           </p>
         ) : null}
       </div>
-      <Button
-        variant="danger"
-        size="sm"
-        onClick={() => canRemove && onRemove(row.registry!, row.name!)}
-        disabled={disabled || !canRemove}
-        aria-label={`Remove ${row.ref}`}
-      >
-        Remove
-      </Button>
+      {confirming ? (
+        <div className="flex items-center gap-2" role="group" aria-label={`Confirm removal of ${row.ref}`}>
+          <span className="text-xs text-secondary">Remove {row.ref}?</span>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={() => {
+              if (canRemove) {
+                onRemove(row.registry!, row.name!);
+                setConfirming(false);
+              }
+            }}
+            disabled={disabled || !canRemove}
+            aria-label={`Confirm remove ${row.ref}`}
+          >
+            Confirm
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setConfirming(false)}
+            aria-label={`Cancel remove ${row.ref}`}
+          >
+            Cancel
+          </Button>
+        </div>
+      ) : (
+        <Button
+          variant="danger"
+          size="sm"
+          onClick={() => setConfirming(true)}
+          disabled={disabled || !canRemove}
+          aria-label={`Remove ${row.ref}`}
+        >
+          Remove
+        </Button>
+      )}
     </li>
   );
 }
@@ -270,6 +319,7 @@ function SkillPicker({
             size="sm"
             onClick={() => row.registry && row.name && onPick(row.registry, row.name)}
             disabled={pending || !row.registry || !row.name}
+            aria-label={`Install ${row.ref}`}
           >
             Install
           </Button>

--- a/gui/src/components/agent-detail/skills-tab.tsx
+++ b/gui/src/components/agent-detail/skills-tab.tsx
@@ -55,13 +55,58 @@ export function SkillsTab({ agentKey }: SkillsTabProps) {
     [data?.available, installedRefs],
   );
 
+  // ATX-3 W1: the live region is rendered unconditionally at the
+  // SkillsTab root so that the transition from loading → loaded shows
+  // up as a DOM *mutation* (which is what NVDA / JAWS / VoiceOver
+  // actually announce). When the load completes the text flips from
+  // "Loading skills…" to "Skills loaded." once, then clears.
+  const [justLoaded, setJustLoaded] = useState(false);
+  const wasLoadingRef = useRef(isLoading);
+  useEffect(() => {
+    if (wasLoadingRef.current && !isLoading && !error) {
+      setJustLoaded(true);
+      const t = setTimeout(() => setJustLoaded(false), 1500);
+      wasLoadingRef.current = false;
+      return () => clearTimeout(t);
+    }
+    if (isLoading) wasLoadingRef.current = true;
+  }, [isLoading, error]);
+
+  const liveRegion = (
+    <div
+      // role=status implies aria-live=polite per WAI-ARIA §5.3.1, so
+      // we don't set aria-live explicitly (ATX-3 W2). aria-busy
+      // tracks the load state so ATs that honor it can suppress
+      // partial reads of the subtree below.
+      role="status"
+      aria-busy={isLoading}
+      aria-label="Skills tab status"
+      className="sr-only"
+    >
+      {isLoading ? "Loading skills…" : justLoaded ? "Skills loaded." : ""}
+    </div>
+  );
+
   if (isLoading) {
-    return <SkillsLoading />;
+    return (
+      <div className="space-y-3 p-4" data-testid="skills-tab">
+        {liveRegion}
+        <div
+          data-testid="skills-loading"
+          aria-hidden="true"
+          className="space-y-3"
+        >
+          <div className="bg-surface rounded-xl border border-default h-20 animate-pulse" />
+          <div className="bg-surface rounded-xl border border-default h-20 animate-pulse" />
+        </div>
+      </div>
+    );
   }
 
   if (error || !data) {
     return (
-      <div className="p-4">
+      <div className="p-4" data-testid="skills-tab">
+        {liveRegion}
         <Card padding="md">
           <p className="text-sm text-red-600">
             Failed to load skills for this agent.
@@ -103,6 +148,7 @@ export function SkillsTab({ agentKey }: SkillsTabProps) {
 
   return (
     <div className="space-y-6 p-4" data-testid="skills-tab">
+      {liveRegion}
       {actionError ? (
         <div
           role="alert"
@@ -178,33 +224,6 @@ export function SkillsTab({ agentKey }: SkillsTabProps) {
   );
 }
 
-function SkillsLoading() {
-  // ATX-2 B1: live-region timing — NVDA / JAWS / VoiceOver only
-  // announce live-region content on DOM *mutations*, not initial
-  // paint. Mount the announcement text in a useEffect so it lands as
-  // a mutation after first render. aria-busy="true" lets ATs that
-  // honor it suppress reads of the still-loading subtree.
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-  return (
-    <div
-      className="space-y-3 p-4"
-      data-testid="skills-loading"
-      role="status"
-      aria-busy="true"
-      aria-live="polite"
-      aria-label="Loading skills"
-    >
-      {mounted ? <span className="sr-only">Loading skills…</span> : null}
-      <div className="bg-surface rounded-xl border border-default h-20 animate-pulse" />
-      <div className="bg-surface rounded-xl border border-default h-20 animate-pulse" />
-    </div>
-  );
-}
-
-
 function InstalledRow({
   row,
   onRemove,
@@ -258,12 +277,15 @@ function InstalledRow({
           className="flex items-center gap-2"
           role="group"
           aria-label={`Confirm removal of ${row.ref}`}
-          // ATX-2 B2b: ARIA APG requires confirm patterns to support
-          // Escape. The native <dialog> handles this for the picker
-          // modal; this inline group needs an explicit handler.
+          // ATX-2 B2b + ATX-3 W5: ARIA APG requires confirm patterns
+          // to support Escape. The native <dialog> handles this for
+          // the picker modal; this inline group needs an explicit
+          // handler. preventDefault (not stopPropagation) — we're
+          // saying "I handled this Escape" without silencing
+          // ancestor JS listeners (toasts, command palettes, etc.).
           onKeyDown={(e) => {
             if (e.key === "Escape") {
-              e.stopPropagation();
+              e.preventDefault();
               setConfirming(false);
             }
           }}
@@ -273,10 +295,14 @@ function InstalledRow({
             ref={confirmRef}
             variant="danger"
             size="sm"
+            // S4: confirming is cleared SYNCHRONOUSLY here (before
+            // the async mutation fires), so an Escape key arriving
+            // mid-mutation cannot race the removal — the group is
+            // already gone. Don't move this to onSettled / onSuccess.
             onClick={() => {
               if (canRemove) {
-                onRemove(row.registry!, row.name!);
                 setConfirming(false);
+                onRemove(row.registry!, row.name!);
               }
             }}
             disabled={disabled || !canRemove}

--- a/gui/src/components/agent-detail/skills-tab.tsx
+++ b/gui/src/components/agent-detail/skills-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
@@ -56,23 +56,7 @@ export function SkillsTab({ agentKey }: SkillsTabProps) {
   );
 
   if (isLoading) {
-    // ATX-1 B1: skeleton must announce itself to assistive tech.
-    // role=status + aria-live=polite makes screen readers report
-    // "Loading skills…" when the tab becomes active; the sr-only span
-    // gives them text to read since the pulsing divs carry no content.
-    return (
-      <div
-        className="space-y-3 p-4"
-        data-testid="skills-loading"
-        role="status"
-        aria-live="polite"
-        aria-label="Loading skills"
-      >
-        <span className="sr-only">Loading skills…</span>
-        <div className="bg-surface rounded-xl border border-default h-20 animate-pulse" />
-        <div className="bg-surface rounded-xl border border-default h-20 animate-pulse" />
-      </div>
-    );
+    return <SkillsLoading />;
   }
 
   if (error || !data) {
@@ -194,6 +178,33 @@ export function SkillsTab({ agentKey }: SkillsTabProps) {
   );
 }
 
+function SkillsLoading() {
+  // ATX-2 B1: live-region timing — NVDA / JAWS / VoiceOver only
+  // announce live-region content on DOM *mutations*, not initial
+  // paint. Mount the announcement text in a useEffect so it lands as
+  // a mutation after first render. aria-busy="true" lets ATs that
+  // honor it suppress reads of the still-loading subtree.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  return (
+    <div
+      className="space-y-3 p-4"
+      data-testid="skills-loading"
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      aria-label="Loading skills"
+    >
+      {mounted ? <span className="sr-only">Loading skills…</span> : null}
+      <div className="bg-surface rounded-xl border border-default h-20 animate-pulse" />
+      <div className="bg-surface rounded-xl border border-default h-20 animate-pulse" />
+    </div>
+  );
+}
+
+
 function InstalledRow({
   row,
   onRemove,
@@ -210,6 +221,20 @@ function InstalledRow({
   // accessible name so a screen-reader scan can't conflate two rows.
   const [confirming, setConfirming] = useState(false);
   const canRemove = !!row.registry && !!row.name;
+  // ATX-2 B2a: focus the Confirm button when the row enters the
+  // confirming state — without this a keyboard user has no indication
+  // that anything happened on the first click.
+  const confirmRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (confirming) confirmRef.current?.focus();
+  }, [confirming]);
+  // ATX-2 W3: if a concurrent install/remove disables the row while a
+  // confirm is open, drop back to the un-armed state so the user
+  // doesn't see a stuck/disabled Confirm button.
+  useEffect(() => {
+    if (disabled && confirming) setConfirming(false);
+  }, [disabled, confirming]);
+
   return (
     <li className="flex items-start gap-3 px-4 py-3">
       <RegistryBadge registry={row.registry} />
@@ -229,9 +254,23 @@ function InstalledRow({
         ) : null}
       </div>
       {confirming ? (
-        <div className="flex items-center gap-2" role="group" aria-label={`Confirm removal of ${row.ref}`}>
+        <div
+          className="flex items-center gap-2"
+          role="group"
+          aria-label={`Confirm removal of ${row.ref}`}
+          // ATX-2 B2b: ARIA APG requires confirm patterns to support
+          // Escape. The native <dialog> handles this for the picker
+          // modal; this inline group needs an explicit handler.
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.stopPropagation();
+              setConfirming(false);
+            }
+          }}
+        >
           <span className="text-xs text-secondary">Remove {row.ref}?</span>
           <Button
+            ref={confirmRef}
             variant="danger"
             size="sm"
             onClick={() => {

--- a/gui/src/components/agent-detail/skills-tab.tsx
+++ b/gui/src/components/agent-detail/skills-tab.tsx
@@ -1,45 +1,280 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
+import {
+  useAgentSkills,
+  useInstallAgentSkill,
+  useRemoveAgentSkill,
+} from "@/hooks";
+import type { AgentSkillRow } from "@/lib/types";
 
 interface SkillsTabProps {
   agentKey: string;
 }
 
-export function SkillsTab({ agentKey }: SkillsTabProps) {
-  // Skills and integrations are not yet exposed via the core API.
-  // This tab shows a placeholder until the backend endpoints are added.
+const REGISTRY_BADGES: Record<string, { label: string; color: string }> = {
+  clawrium: { label: "CLW", color: "bg-blue-100 text-blue-700" },
+  openclaw: { label: "OC", color: "bg-emerald-100 text-emerald-700" },
+  hermes: { label: "HE", color: "bg-violet-100 text-violet-700" },
+  zeroclaw: { label: "ZC", color: "bg-amber-100 text-amber-700" },
+};
+
+function RegistryBadge({ registry }: { registry: string | null }) {
+  const badge = registry
+    ? REGISTRY_BADGES[registry]
+    : { label: "??", color: "bg-gray-100 text-gray-700" };
+  const safe = badge ?? { label: "??", color: "bg-gray-100 text-gray-700" };
   return (
-    <div className="space-y-6 p-4">
-      <Card padding="md">
-        <h3 className="text-sm font-semibold text-primary-text mb-4">
-          Installed Skills
-        </h3>
-        <div className="flex items-center justify-center py-8 text-muted text-sm">
-          <p>
-            Skill management will be available in a future update.
-            <br />
-            <span className="text-xs">
-              Use <code className="bg-surface px-1 py-0.5 rounded">clm agent skill</code> in the CLI.
-            </span>
+    <span
+      className={`inline-flex items-center justify-center w-10 h-7 rounded text-[10px] font-bold ${safe.color}`}
+    >
+      {safe.label}
+    </span>
+  );
+}
+
+export function SkillsTab({ agentKey }: SkillsTabProps) {
+  const { data, isLoading, error, refetch } = useAgentSkills(agentKey);
+  const installMutation = useInstallAgentSkill();
+  const removeMutation = useRemoveAgentSkill();
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const installedRefs = useMemo(
+    () => new Set((data?.installed ?? []).map((row) => row.ref)),
+    [data?.installed],
+  );
+
+  const installable = useMemo(
+    () =>
+      (data?.available ?? []).filter((row) => !installedRefs.has(row.ref)),
+    [data?.available, installedRefs],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3 p-4" data-testid="skills-loading">
+        <div className="bg-surface rounded-xl border border-default h-20 animate-pulse" />
+        <div className="bg-surface rounded-xl border border-default h-20 animate-pulse" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="p-4">
+        <Card padding="md">
+          <p className="text-sm text-red-600">
+            Failed to load skills for this agent.
           </p>
+          <p className="mt-2 text-xs text-muted">
+            {error instanceof Error ? error.message : "Unknown error."}
+          </p>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="mt-3"
+            onClick={() => refetch()}
+          >
+            Retry
+          </Button>
+        </Card>
+      </div>
+    );
+  }
+
+  const handleInstall = async (registry: string, name: string) => {
+    setActionError(null);
+    try {
+      await installMutation.mutateAsync({ agentKey, registry, name });
+      setPickerOpen(false);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Install failed");
+    }
+  };
+
+  const handleRemove = async (registry: string, name: string) => {
+    setActionError(null);
+    try {
+      await removeMutation.mutateAsync({ agentKey, registry, name });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Remove failed");
+    }
+  };
+
+  return (
+    <div className="space-y-6 p-4" data-testid="skills-tab">
+      {actionError ? (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+        >
+          {actionError}
         </div>
-      </Card>
+      ) : null}
 
       <Card padding="md">
-        <h3 className="text-sm font-semibold text-primary-text mb-4">
-          Integrations
-        </h3>
-        <div className="flex items-center justify-center py-8 text-muted text-sm">
-          <p>
-            Integration management will be available in a future update.
-            <br />
-            <span className="text-xs">
-              Use <code className="bg-surface px-1 py-0.5 rounded">clm agent integration</code> in the CLI.
-            </span>
-          </p>
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h3 className="text-sm font-semibold text-primary-text">
+              Installed Skills
+            </h3>
+            <p className="mt-1 text-xs text-muted">
+              Skills currently installed on{" "}
+              <code className="bg-surface px-1 rounded">{data.agent_name}</code>{" "}
+              ({data.agent_type}).
+            </p>
+          </div>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => setPickerOpen(true)}
+            disabled={installable.length === 0}
+          >
+            Install skill
+          </Button>
         </div>
+
+        {data.installed.length === 0 ? (
+          <div className="py-8 text-center text-sm text-muted">
+            No skills installed yet. Click{" "}
+            <span className="font-medium">Install skill</span> to add one from
+            the catalog.
+          </div>
+        ) : (
+          <ul className="divide-y divide-default border border-default rounded-lg overflow-hidden">
+            {data.installed.map((row) => (
+              <InstalledRow
+                key={row.ref}
+                row={row}
+                onRemove={handleRemove}
+                disabled={removeMutation.isPending || installMutation.isPending}
+              />
+            ))}
+          </ul>
+        )}
       </Card>
+
+      <Modal
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        title={`Install skill on ${data.agent_name}`}
+        footer={
+          <Button variant="secondary" onClick={() => setPickerOpen(false)}>
+            Close
+          </Button>
+        }
+      >
+        <SkillPicker
+          installable={installable}
+          onPick={handleInstall}
+          pending={installMutation.isPending}
+        />
+      </Modal>
     </div>
+  );
+}
+
+function InstalledRow({
+  row,
+  onRemove,
+  disabled,
+}: {
+  row: AgentSkillRow;
+  onRemove: (registry: string, name: string) => void;
+  disabled: boolean;
+}) {
+  const canRemove = !!row.registry && !!row.name;
+  return (
+    <li className="flex items-start gap-3 px-4 py-3">
+      <RegistryBadge registry={row.registry} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-medium text-primary-text">
+            {row.ref}
+          </span>
+          {row.version ? (
+            <span className="text-xs text-muted">v{row.version}</span>
+          ) : null}
+        </div>
+        {row.description ? (
+          <p className="mt-0.5 text-xs text-secondary line-clamp-2">
+            {row.description}
+          </p>
+        ) : null}
+      </div>
+      <Button
+        variant="danger"
+        size="sm"
+        onClick={() => canRemove && onRemove(row.registry!, row.name!)}
+        disabled={disabled || !canRemove}
+        aria-label={`Remove ${row.ref}`}
+      >
+        Remove
+      </Button>
+    </li>
+  );
+}
+
+function SkillPicker({
+  installable,
+  onPick,
+  pending,
+}: {
+  installable: AgentSkillRow[];
+  onPick: (registry: string, name: string) => void;
+  pending: boolean;
+}) {
+  if (installable.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-muted">
+        No compatible skills available to install. Add one to{" "}
+        <code className="bg-surface px-1 rounded">skills/clawrium/</code> or{" "}
+        the matching native registry, then refresh.
+      </p>
+    );
+  }
+  return (
+    <ul
+      className="divide-y divide-default border border-default rounded-lg overflow-hidden"
+      role="list"
+      aria-label="Compatible skills"
+    >
+      {installable.map((row) => (
+        <li
+          key={row.ref}
+          className="flex items-start gap-3 px-4 py-3"
+        >
+          <RegistryBadge registry={row.registry} />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-sm font-medium text-primary-text">
+                {row.ref}
+              </span>
+              {row.version ? (
+                <span className="text-xs text-muted">v{row.version}</span>
+              ) : null}
+            </div>
+            {row.description ? (
+              <p className="mt-0.5 text-xs text-secondary line-clamp-2">
+                {row.description}
+              </p>
+            ) : null}
+          </div>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => row.registry && row.name && onPick(row.registry, row.name)}
+            disabled={pending || !row.registry || !row.name}
+          >
+            Install
+          </Button>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/gui/src/components/agent-detail/tab-nav.tsx
+++ b/gui/src/components/agent-detail/tab-nav.tsx
@@ -3,7 +3,7 @@
 const TABS = [
   { id: "chat", label: "Chat" },
   { id: "configuration", label: "Configuration" },
-  { id: "skills", label: "Skills & Tools" },
+  { id: "skills", label: "Skills" },
   { id: "memory", label: "Memory" },
   { id: "logs", label: "Logs" },
 ] as const;

--- a/gui/src/components/ui/modal.test.tsx
+++ b/gui/src/components/ui/modal.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { Modal } from "./modal";
+
+// jsdom does not implement HTMLDialogElement.showModal / close. Stub
+// them so the Modal's open/close effects can run without throwing.
+// This shim is intentionally minimal: it flips an "open" attribute so
+// querying by role="dialog" works the same way browsers expose it via
+// the dialog tag. ATX-3 B1 wants real-Modal coverage; without these
+// stubs jsdom raises "Not implemented: HTMLDialogElement.prototype.showModal".
+beforeEach(() => {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function showModal(this: HTMLDialogElement) {
+      this.setAttribute("open", "");
+    };
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function close(this: HTMLDialogElement) {
+      this.removeAttribute("open");
+      this.dispatchEvent(new Event("close"));
+    };
+  }
+});
+
+describe("Modal a11y", () => {
+  it("renders the <dialog> with aria-modal and aria-labelledby wired to the heading", () => {
+    // ATX-3 B1: every other test mocks Modal as a <div>; the real
+    // dialog/aria wiring is dark without this test. A regression that
+    // dropped aria-modal or unlinked aria-labelledby would otherwise
+    // pass every existing suite.
+    render(
+      <Modal open onClose={vi.fn()} title="Install skill on tdd-hermes">
+        body
+      </Modal>,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.tagName).toBe("DIALOG");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+
+    // aria-labelledby must point at the rendered <h2>, so a SR reads
+    // the title when the dialog opens.
+    const labelId = dialog.getAttribute("aria-labelledby");
+    expect(labelId).toBeTruthy();
+    const heading = document.getElementById(labelId as string);
+    expect(heading).not.toBeNull();
+    expect(heading).toHaveTextContent("Install skill on tdd-hermes");
+  });
+
+  it("the ✕ button has an accessible name (not the raw glyph)", () => {
+    // ATX-1 W5 (acknowledged in Review 3): the close button is the
+    // only way out via mouse — must be readable by a screen reader.
+    render(
+      <Modal open onClose={vi.fn()} title="t">
+        body
+      </Modal>,
+    );
+    expect(
+      screen.getByRole("button", { name: /Close dialog/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("invokes onClose when the close button fires", () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open onClose={onClose} title="t">
+        body
+      </Modal>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Close dialog/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/gui/src/components/ui/modal.tsx
+++ b/gui/src/components/ui/modal.tsx
@@ -43,6 +43,11 @@ export function Modal({ open, onClose, title, children, footer }: ModalProps) {
     <dialog
       ref={dialogRef}
       aria-labelledby={titleId}
+      // ATX-2 B3: VoiceOver / older JAWS use virtual-cursor navigation
+      // that ignores <dialog>'s native focus trap, so background DOM
+      // is still readable. aria-modal="true" is the explicit signal
+      // those assistive techs honor.
+      aria-modal="true"
       className="backdrop:bg-black/40 rounded-xl border border-default shadow-xl p-0 max-w-lg w-full"
       onClick={(e) => {
         if (e.target === dialogRef.current) onClose();

--- a/gui/src/components/ui/modal.tsx
+++ b/gui/src/components/ui/modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useId, useRef } from "react";
 
 interface ModalProps {
   open: boolean;
@@ -12,6 +12,10 @@ interface ModalProps {
 
 export function Modal({ open, onClose, title, children, footer }: ModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  // ATX-1 W5: pair the <dialog> with a stable id so screen readers
+  // announce the title via aria-labelledby. useId is stable across
+  // renders + SSR-safe; one id per modal instance.
+  const titleId = useId();
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -38,6 +42,7 @@ export function Modal({ open, onClose, title, children, footer }: ModalProps) {
   return (
     <dialog
       ref={dialogRef}
+      aria-labelledby={titleId}
       className="backdrop:bg-black/40 rounded-xl border border-default shadow-xl p-0 max-w-lg w-full"
       onClick={(e) => {
         if (e.target === dialogRef.current) onClose();
@@ -46,9 +51,12 @@ export function Modal({ open, onClose, title, children, footer }: ModalProps) {
       <div className="p-6">
         {/* Header */}
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-primary-text">{title}</h2>
+          <h2 id={titleId} className="text-lg font-semibold text-primary-text">
+            {title}
+          </h2>
           <button
             onClick={onClose}
+            aria-label="Close dialog"
             className="text-muted hover:text-secondary p-1 rounded"
           >
             ✕

--- a/gui/src/hooks/index.ts
+++ b/gui/src/hooks/index.ts
@@ -12,4 +12,10 @@ export {
   useUpdateIntegrationCredentials,
   useDeleteIntegration,
 } from "./use-integrations";
-export { useSkills, useSkill } from "./use-skills";
+export {
+  useSkills,
+  useSkill,
+  useAgentSkills,
+  useInstallAgentSkill,
+  useRemoveAgentSkill,
+} from "./use-skills";

--- a/gui/src/hooks/use-skills.ts
+++ b/gui/src/hooks/use-skills.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 
 // Skills catalog is read from the in-repo filesystem and only changes
@@ -20,5 +20,45 @@ export function useSkill(registry: string | null, name: string | null) {
     queryFn: () => api.getSkill(registry!, name!),
     enabled: !!registry && !!name,
     staleTime: SKILLS_STALE_MS,
+  });
+}
+
+export function useAgentSkills(agentKey: string | null) {
+  return useQuery({
+    queryKey: ["agent-skills", agentKey],
+    queryFn: () => api.getAgentSkills(agentKey as string),
+    enabled: !!agentKey,
+  });
+}
+
+interface AgentSkillMutationVars {
+  agentKey: string;
+  registry: string;
+  name: string;
+}
+
+export function useInstallAgentSkill() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ agentKey, registry, name }: AgentSkillMutationVars) =>
+      api.installAgentSkill(agentKey, registry, name),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({
+        queryKey: ["agent-skills", vars.agentKey],
+      });
+    },
+  });
+}
+
+export function useRemoveAgentSkill() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ agentKey, registry, name }: AgentSkillMutationVars) =>
+      api.removeAgentSkill(agentKey, registry, name),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({
+        queryKey: ["agent-skills", vars.agentKey],
+      });
+    },
   });
 }

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -223,6 +223,26 @@ export const api = {
     request<SkillDetail>(
       `/skills/${encodeURIComponent(registry)}/${encodeURIComponent(name)}`,
     ),
+
+  // Per-agent skills (Phase 5). Same encodeURIComponent guard as
+  // getSkill above — defense in depth on top of the backend's
+  // identifier regex.
+  getAgentSkills: (key: string) =>
+    request<AgentSkills>(`/agents/${encodeURIComponent(key)}/skills`),
+  installAgentSkill: (key: string, registry: string, name: string) =>
+    request<AgentSkillMutationResponse>(
+      `/agents/${encodeURIComponent(key)}/skills/${encodeURIComponent(
+        registry,
+      )}/${encodeURIComponent(name)}`,
+      { method: "POST" },
+    ),
+  removeAgentSkill: (key: string, registry: string, name: string) =>
+    request<AgentSkillMutationResponse>(
+      `/agents/${encodeURIComponent(key)}/skills/${encodeURIComponent(
+        registry,
+      )}/${encodeURIComponent(name)}`,
+      { method: "DELETE" },
+    ),
 };
 
 // Type imports (re-exported from types.ts for convenience)
@@ -252,4 +272,6 @@ import type {
   IntegrationCredentialsUpdate,
   SkillsCatalog,
   SkillDetail,
+  AgentSkills,
+  AgentSkillMutationResponse,
 } from "./types";

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -337,3 +337,29 @@ export interface SkillDetail {
   body: string;
   compatibility: SkillCompatibility;
 }
+
+// Per-agent skills (Phase 5). Both installed and available rows reuse
+// SkillSummary but allow `registry`/`name` to be null on installed rows
+// when the state file carries a ref that no longer parses.
+export interface AgentSkillRow {
+  ref: string;
+  registry: SkillRegistry | null;
+  name: string | null;
+  description: string | null;
+  version: string | null;
+}
+
+export interface AgentSkills {
+  agent_name: string;
+  agent_type: string;
+  installed: AgentSkillRow[];
+  available: AgentSkillRow[];
+}
+
+export interface AgentSkillMutationResponse {
+  success: boolean;
+  agent_name: string;
+  ref: string;
+  changed: boolean;
+  installed: string[];
+}

--- a/src/clawrium/core/skills.py
+++ b/src/clawrium/core/skills.py
@@ -375,10 +375,12 @@ def check_agent_compatibility(skill: Skill, agent_type: str) -> None:
     Compatibility rules (locked in `.itx/364/00_PLAN.md`):
 
     - ``clawrium/<name>``: read the ``compatibility`` map in `_meta.yaml`.
-      Default-true if the key is missing (a normalized skill is meant to
-      run anywhere); explicit ``false`` fails closed. Unknown agent
-      types fail closed too — better a clear error than a "silently
-      installed and never invoked" surprise.
+      **Fail-closed**: missing key OR explicit ``false`` raises
+      ``IncompatibleSkillRegistry``. The catalog author must list each
+      claw they intend to support — silent "absent means anywhere" was
+      rejected during planning because it makes drift hard to debug
+      ("why did install succeed but the skill never run?"). Unknown
+      agent types fail closed too.
     - ``<claw>/<name>`` (native): must match ``agent_type`` exactly.
       Cross-claw native installs are a hard error because the SKILL.md
       is already in a per-claw frontmatter shape.

--- a/src/clawrium/gui/routes/agents.py
+++ b/src/clawrium/gui/routes/agents.py
@@ -37,6 +37,7 @@ from clawrium.core.secrets import (
 )
 from clawrium.core.skills import (
     NATIVE_REGISTRIES,
+    REGISTRIES,
     ExternalSourceBlocked,
     IncompatibleSkillRegistry,
     InvalidSkillRef,
@@ -44,6 +45,7 @@ from clawrium.core.skills import (
     SchemaValidationError,
     SkillError,
     SkillNotFound,
+    check_agent_compatibility,
     list_skills,
     load_skill,
     parse_skill_ref,
@@ -291,27 +293,60 @@ def _skill_error_status(error: SkillError) -> int:
     return 500
 
 
+# SkillApplyError messages from core.skills_apply embed absolute paths
+# (log_dir, playbook_path) and remote stderr — useful for the CLI's local
+# error surface but not safe to ship in an HTTP body that a browser or
+# upstream proxy may cache/log. ATX-1 B1: replace the detail string with
+# a generic message for SkillApplyError; the full text is logged for
+# operator debugging only.
+_SKILL_APPLY_GENERIC_DETAIL = (
+    "Skills apply failed on host. Check server logs for details."
+)
+
+
+def _skill_error_detail(error: SkillError) -> str:
+    """Detail string to ship in the HTTPException body.
+
+    All ``SkillError`` subclasses except ``SkillApplyError`` are
+    user-actionable input/catalog problems — the message itself is the
+    fix hint, so we surface it verbatim. ``SkillApplyError`` is the only
+    class that can carry filesystem paths or remote stderr; that one is
+    redacted to a fixed string and the original message goes to the
+    server log.
+    """
+    if isinstance(error, SkillApplyError):
+        logger.warning("skills apply failed: %s", error)
+        return _SKILL_APPLY_GENERIC_DETAIL
+    return str(error)
+
+
 def _is_compatible_for_agent_type(reg: str, name: str, agent_type: str) -> bool:
     """Decide if a catalog skill is installable on a given claw type.
 
-    Mirrors ``core.skills.check_agent_compatibility``: native registries
-    must match the claw exactly; ``clawrium/*`` consults the skill's
-    ``compatibility`` map. We swallow ``SkillError`` and return False so
-    a broken catalog row never widens the install picker — fail closed,
-    same rule the CLI uses.
+    ATX-1 W2: delegate to ``check_agent_compatibility`` instead of
+    reimplementing the rule. Any future tweak to the compatibility
+    semantics (e.g. how missing keys are treated) now applies to both
+    the CLI and GUI from one place.
+
+    Fast paths kept for the picker's perf budget:
+      - Unknown source registry → false without loading anything.
+      - Native registry whose name doesn't match the claw → false
+        without loading (a native skill can never run on another claw,
+        no need to read SKILL.md to decide).
+
+    Loader failures swallow to false so a single bad catalog row
+    cannot widen the install picker on the user's screen.
     """
-    if reg in NATIVE_REGISTRIES:
-        return reg == agent_type
-    if reg != "clawrium":
+    if reg not in REGISTRIES:
+        return False
+    if reg in NATIVE_REGISTRIES and reg != agent_type:
         return False
     try:
         skill = load_skill(parse_skill_ref(f"{reg}/{name}"))
+        check_agent_compatibility(skill, agent_type)
     except SkillError:
         return False
-    raw = skill.metadata.get("compatibility") or {}
-    if not isinstance(raw, dict):
-        return False
-    return bool(raw.get(agent_type, False))
+    return True
 
 
 def _list_available_for_agent_type(agent_type: str) -> list[dict[str, object]]:
@@ -464,9 +499,10 @@ def _install_or_remove(
 
     raw_ref = f"{registry}/{skill}"
     try:
-        # parse_skill_ref runs first so a malformed ref surfaces as 422
-        # before we touch the state file.
-        parse_skill_ref(raw_ref)
+        # add_skill / remove_skill both call parse_skill_ref as their
+        # first operation, so a malformed ref short-circuits with 422
+        # before any state mutation. (W4: dropped the redundant pre-call
+        # that ATX flagged as dead code.)
         if action == "install":
             _new_state, changed = add_skill(agent_name, raw_ref)
         else:
@@ -475,7 +511,7 @@ def _install_or_remove(
     except SkillError as error:
         raise HTTPException(
             status_code=_skill_error_status(error),
-            detail=str(error),
+            detail=_skill_error_detail(error),
         ) from error
 
     return {

--- a/src/clawrium/gui/routes/agents.py
+++ b/src/clawrium/gui/routes/agents.py
@@ -35,6 +35,30 @@ from clawrium.core.secrets import (
     get_instance_secrets,
     set_instance_secret,
 )
+from clawrium.core.skills import (
+    NATIVE_REGISTRIES,
+    ExternalSourceBlocked,
+    IncompatibleSkillRegistry,
+    InvalidSkillRef,
+    MissingRegistryPrefix,
+    SchemaValidationError,
+    SkillError,
+    SkillNotFound,
+    list_skills,
+    load_skill,
+    parse_skill_ref,
+)
+from clawrium.core.skills_apply import (
+    AgentNotFoundError,
+    SkillApplyError,
+    SkillApplyNotSupported,
+    apply_state,
+)
+from clawrium.core.skills_state import (
+    add_skill,
+    read_state,
+    remove_skill,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -229,6 +253,264 @@ async def get_agent_logs(
     # bug (KeyError/TypeError/...) shouldn't masquerade as "service unavailable".
 
     return {"logs": log_lines}
+
+
+# --- Skills endpoints ---
+
+
+def _skill_error_status(error: SkillError) -> int:
+    """Map a ``SkillError`` subclass to an HTTP status code.
+
+    ``SkillApplyError`` is the only "remote failed" class; everything else
+    is a client-side input or catalog problem and maps to 422/404. ATX
+    review wanted explicit failure isolation: a broken playbook run
+    surfaces as 502 (upstream/host failed) so the GUI doesn't mistake
+    "your input is bad" for "the host is down".
+    """
+    if isinstance(error, AgentNotFoundError):
+        return 404
+    if isinstance(error, SkillNotFound):
+        return 404
+    if isinstance(error, SkillApplyError):
+        return 502
+    if isinstance(error, SkillApplyNotSupported):
+        return 422
+    if isinstance(
+        error,
+        (
+            MissingRegistryPrefix,
+            ExternalSourceBlocked,
+            InvalidSkillRef,
+            IncompatibleSkillRegistry,
+            SchemaValidationError,
+        ),
+    ):
+        return 422
+    # Defensive: a future SkillError subclass surfaces as 500 with a
+    # bounded message so it isn't silently treated as a client error.
+    return 500
+
+
+def _is_compatible_for_agent_type(reg: str, name: str, agent_type: str) -> bool:
+    """Decide if a catalog skill is installable on a given claw type.
+
+    Mirrors ``core.skills.check_agent_compatibility``: native registries
+    must match the claw exactly; ``clawrium/*`` consults the skill's
+    ``compatibility`` map. We swallow ``SkillError`` and return False so
+    a broken catalog row never widens the install picker — fail closed,
+    same rule the CLI uses.
+    """
+    if reg in NATIVE_REGISTRIES:
+        return reg == agent_type
+    if reg != "clawrium":
+        return False
+    try:
+        skill = load_skill(parse_skill_ref(f"{reg}/{name}"))
+    except SkillError:
+        return False
+    raw = skill.metadata.get("compatibility") or {}
+    if not isinstance(raw, dict):
+        return False
+    return bool(raw.get(agent_type, False))
+
+
+def _list_available_for_agent_type(agent_type: str) -> list[dict[str, object]]:
+    """Return catalog skills installable on ``agent_type``, summarized.
+
+    Used to populate the install picker on the agent-detail Skills tab.
+    """
+    try:
+        refs = list_skills()
+    except SkillError as error:
+        logger.warning("skills catalog unavailable: %s", error)
+        return []
+    available: list[dict[str, object]] = []
+    for ref in refs:
+        if not _is_compatible_for_agent_type(ref.registry, ref.name, agent_type):
+            continue
+        description: str | None = None
+        version: str | None = None
+        try:
+            skill = load_skill(ref)
+        except SkillError:
+            # Bad catalog row — surface the ref so the user still sees
+            # something in the picker, but null out the optional fields.
+            pass
+        else:
+            raw_desc = skill.metadata.get("description")
+            if isinstance(raw_desc, str) and raw_desc.strip():
+                description = " ".join(raw_desc.split())
+            raw_ver = skill.metadata.get("version")
+            if raw_ver is not None:
+                version = str(raw_ver)
+        available.append(
+            {
+                "ref": str(ref),
+                "registry": ref.registry,
+                "name": ref.name,
+                "description": description,
+                "version": version,
+            }
+        )
+    return available
+
+
+@router.get("/{agent_key}/skills")
+async def list_agent_skills(agent_key: str):
+    """List installed skills + available-to-install skills for an agent.
+
+    Returns:
+
+    ```
+    {
+      "agent_name": "tdd-hermes",
+      "agent_type": "hermes",
+      "installed": [{"ref": "clawrium/tdd", ...}, ...],
+      "available": [{"ref": "clawrium/tdd", ...}, ...]
+    }
+    ```
+
+    ``installed`` is the local desired-state file's view — the same view
+    ``clm agent skill list`` shows. The agent-detail Skills tab merges
+    these in the UI, so the response keeps them separate to keep the
+    payload close to the underlying data.
+    """
+    resolved = await asyncio.to_thread(_resolve_agent, agent_key)
+    if not resolved:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
+
+    _host_record, agent_type, agent_record = resolved
+    agent_name = agent_record.get("agent_name") or agent_key
+
+    def _build() -> dict[str, object]:
+        try:
+            installed_refs = read_state(agent_name)
+        except SkillError as error:
+            logger.warning(
+                "skills state unreadable for %s: %s", agent_name, error
+            )
+            installed_refs = []
+        installed: list[dict[str, object]] = []
+        for raw_ref in installed_refs:
+            try:
+                ref = parse_skill_ref(raw_ref)
+            except SkillError:
+                # State file has an entry that no longer validates — show
+                # the bare ref so the user can remove it.
+                installed.append(
+                    {
+                        "ref": raw_ref,
+                        "registry": None,
+                        "name": None,
+                        "description": None,
+                        "version": None,
+                    }
+                )
+                continue
+            description: str | None = None
+            version: str | None = None
+            try:
+                skill = load_skill(ref)
+            except SkillError:
+                pass
+            else:
+                raw_desc = skill.metadata.get("description")
+                if isinstance(raw_desc, str) and raw_desc.strip():
+                    description = " ".join(raw_desc.split())
+                raw_ver = skill.metadata.get("version")
+                if raw_ver is not None:
+                    version = str(raw_ver)
+            installed.append(
+                {
+                    "ref": str(ref),
+                    "registry": ref.registry,
+                    "name": ref.name,
+                    "description": description,
+                    "version": version,
+                }
+            )
+        available = _list_available_for_agent_type(agent_type)
+        return {
+            "agent_name": agent_name,
+            "agent_type": agent_type,
+            "installed": installed,
+            "available": available,
+        }
+
+    return await asyncio.to_thread(_build)
+
+
+def _install_or_remove(
+    agent_key: str,
+    registry: str,
+    skill: str,
+    *,
+    action: str,
+) -> dict[str, object]:
+    """Shared body for POST/DELETE; runs synchronously inside a thread.
+
+    Resolves the agent, mutates desired state, then unconditionally calls
+    ``apply_state`` — same drift-recovery contract the CLI uses. Returns
+    a payload with the post-apply installed skills so the frontend can
+    update its cache without an extra round-trip.
+    """
+    resolved = _resolve_agent(agent_key)
+    if not resolved:
+        raise HTTPException(
+            status_code=404, detail=f"Agent '{agent_key}' not found"
+        )
+    _host_record, _agent_type, agent_record = resolved
+    agent_name = agent_record.get("agent_name") or agent_key
+
+    raw_ref = f"{registry}/{skill}"
+    try:
+        # parse_skill_ref runs first so a malformed ref surfaces as 422
+        # before we touch the state file.
+        parse_skill_ref(raw_ref)
+        if action == "install":
+            _new_state, changed = add_skill(agent_name, raw_ref)
+        else:
+            _new_state, changed = remove_skill(agent_name, raw_ref)
+        result = apply_state(agent_name)
+    except SkillError as error:
+        raise HTTPException(
+            status_code=_skill_error_status(error),
+            detail=str(error),
+        ) from error
+
+    return {
+        "success": True,
+        "agent_name": agent_name,
+        "ref": raw_ref,
+        "changed": changed,
+        "installed": list(result.applied_skills),
+    }
+
+
+@router.post("/{agent_key}/skills/{registry}/{skill}")
+async def install_agent_skill(agent_key: str, registry: str, skill: str):
+    """Install ``<registry>/<skill>`` on ``agent_key``.
+
+    Idempotent: re-installing an already-installed skill is a no-op
+    state mutation, but the apply playbook still runs to reconcile any
+    on-host drift (matches the CLI semantics).
+    """
+    return await asyncio.to_thread(
+        _install_or_remove, agent_key, registry, skill, action="install"
+    )
+
+
+@router.delete("/{agent_key}/skills/{registry}/{skill}")
+async def remove_agent_skill(agent_key: str, registry: str, skill: str):
+    """Remove ``<registry>/<skill>`` from ``agent_key``.
+
+    Idempotent: removing a skill that wasn't in desired state still
+    runs the apply playbook so any orphan on-host directory is pruned
+    (matches the CLI semantics).
+    """
+    return await asyncio.to_thread(
+        _install_or_remove, agent_key, registry, skill, action="remove"
+    )
 
 
 # --- Internal helpers ---

--- a/src/clawrium/gui/routes/agents.py
+++ b/src/clawrium/gui/routes/agents.py
@@ -328,11 +328,19 @@ def _is_compatible_for_agent_type(reg: str, name: str, agent_type: str) -> bool:
     semantics (e.g. how missing keys are treated) now applies to both
     the CLI and GUI from one place.
 
-    Fast paths kept for the picker's perf budget:
-      - Unknown source registry → false without loading anything.
-      - Native registry whose name doesn't match the claw → false
-        without loading (a native skill can never run on another claw,
-        no need to read SKILL.md to decide).
+    Short-circuits (no I/O) for two cases that cannot ever be
+    compatible:
+      - Unknown source registry → false.
+      - Native registry whose name doesn't match the claw → false (a
+        native skill can never run on another claw).
+
+    Everything else — `clawrium/*` and `<claw>/*` matching the claw —
+    falls through to ``load_skill`` + ``check_agent_compatibility``.
+    The picker scan is therefore O(n) ``load_skill`` calls bounded by
+    the catalog size for compatible registries; a follow-up could
+    cache loaded skills per request if catalogs grow large (ATX-2 W4
+    flagged the cost but the present picker scans <10 skills, so the
+    cache is deferred).
 
     Loader failures swallow to false so a single bad catalog row
     cannot widen the install picker on the user's screen.

--- a/tests/test_gui_agent_skills_routes.py
+++ b/tests/test_gui_agent_skills_routes.py
@@ -245,26 +245,49 @@ def test_install_422_on_unsupported_claw_type(monkeypatch):
 
     Without this, the route could silently regress to 500 on an unknown
     claw type and the existing 200/422/502 tests would still pass.
+    ATX-2 W6 also requires asserting the detail string is the original
+    message, not the redacted ``Check server logs…`` text — that path
+    is reserved for the genuine apply-failure class.
     """
     _stub_resolved(monkeypatch)
-    _stub_apply(
-        monkeypatch,
-        raises=SkillApplyNotSupported("Skills apply for 'nemoclaw' has no playbook"),
-    )
+    detail = "Skills apply for 'nemoclaw' has no playbook"
+    _stub_apply(monkeypatch, raises=SkillApplyNotSupported(detail))
     with pytest.raises(HTTPException) as exc:
         _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
     assert exc.value.status_code == 422
+    assert detail in str(exc.value.detail)
+    assert "Check server logs" not in str(exc.value.detail)
 
 
 def test_remove_422_on_unsupported_claw_type(monkeypatch):
     _stub_resolved(monkeypatch)
-    _stub_apply(
-        monkeypatch,
-        raises=SkillApplyNotSupported("Skills apply for 'nemoclaw' has no playbook"),
-    )
+    detail = "Skills apply for 'nemoclaw' has no playbook"
+    _stub_apply(monkeypatch, raises=SkillApplyNotSupported(detail))
     with pytest.raises(HTTPException) as exc:
         _run(agents_route.remove_agent_skill("tdd-hermes", "clawrium", "tdd"))
     assert exc.value.status_code == 422
+    assert detail in str(exc.value.detail)
+    assert "Check server logs" not in str(exc.value.detail)
+
+
+def test_remove_502_on_apply_error(monkeypatch):
+    """ATX-2 W7: mirror the install-side path-scrubbing assertion on
+    the DELETE side so the redaction can't regress only for removes.
+    """
+    _stub_resolved(monkeypatch)
+    write_state("tdd-hermes", ["clawrium/tdd"])
+    raw_msg = (
+        "Skills apply failed (status=failed): host unreachable "
+        "(log: /home/op/.config/clawrium/logs/skills_apply-x)."
+    )
+    _stub_apply(monkeypatch, raises=SkillApplyError(raw_msg))
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.remove_agent_skill("tdd-hermes", "clawrium", "tdd"))
+    assert exc.value.status_code == 502
+    assert "/home/op/.config/clawrium/logs" not in str(exc.value.detail)
+    assert "Check server logs" in str(exc.value.detail)
+    # Desired state mutation is preserved on failure (W3 contract).
+    assert read_state("tdd-hermes") == []
 
 
 def test_install_422_on_incompatible_claw(monkeypatch):

--- a/tests/test_gui_agent_skills_routes.py
+++ b/tests/test_gui_agent_skills_routes.py
@@ -24,9 +24,14 @@ from typing import Any
 import pytest
 from fastapi import HTTPException
 
+from clawrium.core.skills import (
+    ExternalSourceBlocked,
+    parse_skill_ref,
+)
 from clawrium.core.skills_apply import (
     ApplyResult,
     SkillApplyError,
+    SkillApplyNotSupported,
 )
 from clawrium.core.skills_state import read_state, write_state
 from clawrium.gui.routes import agents as agents_route
@@ -194,9 +199,20 @@ def test_install_404_when_agent_missing(monkeypatch):
     assert exc.value.status_code == 404
 
 
-def test_install_422_on_external_source_ref(monkeypatch):
-    """A ref like ``http:/bad`` must be rejected before we touch state
-    or apply_state. parse_skill_ref raises ExternalSourceBlocked."""
+def test_install_422_on_unknown_registry(monkeypatch):
+    """An unknown registry token (``http:``, ``bogus``, …) routed through
+    the path-parameter form fails inside ``parse_skill_ref`` with
+    ``InvalidSkillRef`` — *not* ``ExternalSourceBlocked``. The route maps
+    both to 422 the same way; the test is renamed (ATX-1 W8) to match
+    the actual exception class so a future reader doesn't think this
+    line exercises the external-source guard.
+
+    ``ExternalSourceBlocked`` is unreachable from a path-parameter
+    request because the FastAPI router forbids a path segment from
+    containing ``/`` or ``://`` — see
+    ``test_external_source_blocked_at_parser_level`` for the direct
+    parser test of that boundary.
+    """
     _stub_resolved(monkeypatch)
     # apply_state must NOT be called — assert by raising if it is.
     monkeypatch.setattr(
@@ -204,6 +220,50 @@ def test_install_422_on_external_source_ref(monkeypatch):
     )
     with pytest.raises(HTTPException) as exc:
         _run(agents_route.install_agent_skill("tdd-hermes", "http:", "bad"))
+    assert exc.value.status_code == 422
+
+
+def test_external_source_blocked_at_parser_level():
+    """Direct parser test for the security boundary the GUI relies on.
+
+    ATX-1 W8 flagged that the path-param route can't reach
+    ``ExternalSourceBlocked`` (FastAPI strips the protocol delimiter).
+    The actual guard lives in ``parse_skill_ref``; this asserts it
+    fires for url-shaped inputs.
+    """
+    for ref in (
+        "https://evil.example/skill",
+        "http://evil.example/skill",
+        "git+https://evil.example/skill",
+    ):
+        with pytest.raises(ExternalSourceBlocked):
+            parse_skill_ref(ref)
+
+
+def test_install_422_on_unsupported_claw_type(monkeypatch):
+    """ATX-1 B3: cover the ``SkillApplyNotSupported`` → 422 mapping.
+
+    Without this, the route could silently regress to 500 on an unknown
+    claw type and the existing 200/422/502 tests would still pass.
+    """
+    _stub_resolved(monkeypatch)
+    _stub_apply(
+        monkeypatch,
+        raises=SkillApplyNotSupported("Skills apply for 'nemoclaw' has no playbook"),
+    )
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
+    assert exc.value.status_code == 422
+
+
+def test_remove_422_on_unsupported_claw_type(monkeypatch):
+    _stub_resolved(monkeypatch)
+    _stub_apply(
+        monkeypatch,
+        raises=SkillApplyNotSupported("Skills apply for 'nemoclaw' has no playbook"),
+    )
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.remove_agent_skill("tdd-hermes", "clawrium", "tdd"))
     assert exc.value.status_code == 422
 
 
@@ -234,12 +294,20 @@ def test_install_422_on_incompatible_claw(monkeypatch):
 
 def test_install_502_on_apply_error(monkeypatch):
     _stub_resolved(monkeypatch)
-    _stub_apply(
-        monkeypatch, raises=SkillApplyError("host unreachable: timed out")
+    # Reproduces the exact message shape core.skills_apply ships — embeds
+    # a log dir absolute path so the test fails if we ever stop redacting.
+    raw_msg = (
+        "Skills apply failed (status=failed): host unreachable: "
+        "/tmp/nope (log: /home/op/.config/clawrium/logs/skills_apply-x)."
     )
+    _stub_apply(monkeypatch, raises=SkillApplyError(raw_msg))
     with pytest.raises(HTTPException) as exc:
         _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
     assert exc.value.status_code == 502
+    # ATX-1 B1: 502 detail must NOT echo the original path-bearing message.
+    assert "/home/op/.config/clawrium/logs" not in str(exc.value.detail)
+    assert "/tmp/nope" not in str(exc.value.detail)
+    assert "Check server logs" in str(exc.value.detail)
     # State should still reflect the user's intent — apply failures
     # don't roll back desired state; the user will retry.
     assert read_state("tdd-hermes") == ["clawrium/tdd"]
@@ -293,7 +361,122 @@ def test_remove_422_on_malformed_ref(monkeypatch):
     assert exc.value.status_code == 422
 
 
+# ---------- Documented behavior on apply failure ------------------------------
+
+
+def test_state_is_not_rolled_back_on_apply_failure(monkeypatch):
+    """ATX-1 W3 documents the design choice (carried over from the CLI):
+    on apply failure the desired-state mutation is *kept*, so the user
+    can retry the apply without re-typing the ref. This test pins the
+    behavior so any future change to "validate-before-write" is
+    deliberate, not accidental.
+    """
+    _stub_resolved(monkeypatch)
+    _stub_apply(monkeypatch, raises=SkillApplyError("host unreachable"))
+    with pytest.raises(HTTPException):
+        _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
+    assert read_state("tdd-hermes") == ["clawrium/tdd"]
+
+
+# ---------- _is_compatible_for_agent_type unit tests --------------------------
+
+
+@pytest.mark.parametrize(
+    "registry,name,agent_type,expected",
+    [
+        # Native registry, claw match: drop through to load+validate.
+        ("hermes", "ANY", "hermes", False),  # no real hermes/ANY skill → loader fails-closed
+        # Native registry, claw mismatch: short-circuit false without loading.
+        ("hermes", "anything", "openclaw", False),
+        ("openclaw", "anything", "zeroclaw", False),
+        # Unknown source registry: short-circuit false.
+        ("not-a-registry", "tdd", "hermes", False),
+        # clawrium/tdd is the seed skill — compatible with every native claw.
+        ("clawrium", "tdd", "hermes", True),
+        ("clawrium", "tdd", "openclaw", True),
+        ("clawrium", "tdd", "zeroclaw", True),
+        # Unknown agent type fails closed via check_agent_compatibility.
+        ("clawrium", "tdd", "nemoclaw", False),
+        # Catalog row that doesn't exist fails closed at load_skill.
+        ("clawrium", "missing-skill", "hermes", False),
+    ],
+)
+def test_is_compatible_for_agent_type_matrix(
+    registry: str, name: str, agent_type: str, expected: bool
+):
+    """ATX-1 B5/W2: every branch of the filter — including the
+    fail-closed paths — is covered with a direct unit test, not just
+    inferred via the route-level happy path."""
+    assert (
+        agents_route._is_compatible_for_agent_type(registry, name, agent_type)
+        is expected
+    )
+
+
+# ---------- _skill_error_status mapping table ---------------------------------
+
+
+def test_skill_error_status_table():
+    """Pin every concrete ``SkillError`` subclass → status code so a
+    future subclass added without wiring stays loud (defaults to 500
+    via the fallback branch)."""
+    from clawrium.core.skills import (
+        InvalidSkillRef,
+        MissingRegistryPrefix,
+        SchemaValidationError,
+    )
+    from clawrium.core.skills_apply import (
+        AgentNotFoundError,
+        SkillApplyError,
+        SkillApplyNotSupported,
+    )
+
+    cases: list[tuple[Exception, int]] = [
+        (AgentNotFoundError("a"), 404),
+        (SkillNotFoundLike(), 404),  # SkillNotFound — see helper below
+        (SkillApplyError("x"), 502),
+        (SkillApplyNotSupported("x"), 422),
+        (MissingRegistryPrefix("x"), 422),
+        (ExternalSourceBlocked("x"), 422),
+        (InvalidSkillRef("x"), 422),
+        (IncompatibleSkillRegistryLike(), 422),
+        (SchemaValidationError("x"), 422),
+    ]
+    for error, expected in cases:
+        assert agents_route._skill_error_status(error) == expected, error
+
+
+def test_skill_error_status_falls_back_to_500_for_unknown_subclass():
+    """A subclass added later without wiring should not silently
+    register as a client error — fallback is 500."""
+    from clawrium.core.skills import SkillError
+
+    class _NovelSkillError(SkillError):
+        pass
+
+    assert agents_route._skill_error_status(_NovelSkillError("x")) == 500
+
+
 # ---------- Helpers -----------------------------------------------------------
+
+
+# Cannot construct SkillNotFound / IncompatibleSkillRegistry with the
+# bare base-class init in some refactors; alias them at the import site
+# so the table above stays declarative.
+from clawrium.core.skills import (  # noqa: E402
+    IncompatibleSkillRegistry,
+    SkillNotFound,
+)
+
+
+class SkillNotFoundLike(SkillNotFound):
+    def __init__(self) -> None:
+        super().__init__("skill x not in catalog")
+
+
+class IncompatibleSkillRegistryLike(IncompatibleSkillRegistry):
+    def __init__(self) -> None:
+        super().__init__("not compatible")
 
 
 def _raises_if_called(label: str):

--- a/tests/test_gui_agent_skills_routes.py
+++ b/tests/test_gui_agent_skills_routes.py
@@ -286,7 +286,10 @@ def test_remove_502_on_apply_error(monkeypatch):
     assert exc.value.status_code == 502
     assert "/home/op/.config/clawrium/logs" not in str(exc.value.detail)
     assert "Check server logs" in str(exc.value.detail)
-    # Desired state mutation is preserved on failure (W3 contract).
+    # Remove already mutated desired-state before apply_state ran;
+    # an apply failure does not restore the removed ref — the user
+    # retries with a fresh `clm agent skill install` if they want it
+    # back. (ATX-3 S3 clarifies the W3 contract on the delete side.)
     assert read_state("tdd-hermes") == []
 
 

--- a/tests/test_gui_agent_skills_routes.py
+++ b/tests/test_gui_agent_skills_routes.py
@@ -1,0 +1,303 @@
+"""Tests for the per-agent skills GUI routes (Phase 5).
+
+Covers the exit gates from issue #384:
+
+- ``GET /api/agents/{agent}/skills`` returns ``installed`` + ``available``
+  arrays, with ``available`` filtered by the resolved ``agent_type``
+  (clawrium-cross-agent + matching native registry only).
+- ``POST /api/agents/{agent}/skills/{registry}/{skill}`` mutates desired
+  state and dispatches ``apply_state``; idempotent on the no-op path.
+- ``DELETE`` mirrors POST: state cleanup + unconditional apply.
+- Error mapping: 404 unknown agent, 422 malformed ref, 502 on apply
+  failure, 422 on incompatible-claw install.
+
+We mock ``apply_state`` to avoid real ansible/SSH, and ``_resolve_agent``
+to keep the test independent of the user's ``hosts.json``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from clawrium.core.skills_apply import (
+    ApplyResult,
+    SkillApplyError,
+)
+from clawrium.core.skills_state import read_state, write_state
+from clawrium.gui.routes import agents as agents_route
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Per-test XDG_CONFIG_HOME so the desired-state file is fresh."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _stub_resolved(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    agent_name: str = "tdd-hermes",
+    agent_type: str = "hermes",
+    hostname: str = "wolf-i",
+    resolved: bool = True,
+) -> dict[str, Any]:
+    """Stub _resolve_agent. Returns the agent_record dict for assertions."""
+    agent_record = {"agent_name": agent_name}
+    host_record = {"hostname": hostname}
+
+    def fake(_key: str):
+        if not resolved:
+            return None
+        return (host_record, agent_type, agent_record)
+
+    monkeypatch.setattr(agents_route, "_resolve_agent", fake)
+    return agent_record
+
+
+def _stub_apply(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    agent_type: str = "hermes",
+    applied: list[str] | None = None,
+    raises: Exception | None = None,
+) -> list[str]:
+    """Stub apply_state with a recorder that respects current desired state."""
+    calls: list[str] = []
+
+    def fake(agent_name: str, **_kwargs):
+        calls.append(agent_name)
+        if raises is not None:
+            raise raises
+        return ApplyResult(
+            agent_name=agent_name,
+            agent_type=agent_type,
+            hostname="wolf-i",
+            applied_skills=applied
+            if applied is not None
+            else read_state(agent_name),
+            log_dir=Path("/tmp/fake-log"),
+        )
+
+    monkeypatch.setattr(agents_route, "apply_state", fake)
+    return calls
+
+
+# ---------- GET /api/agents/{agent}/skills ----------------------------------
+
+
+def test_list_returns_404_when_agent_not_resolved(monkeypatch):
+    _stub_resolved(monkeypatch, resolved=False)
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.list_agent_skills("ghost"))
+    assert exc.value.status_code == 404
+
+
+def test_list_includes_installed_and_available_for_hermes(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+    write_state("tdd-hermes", ["clawrium/tdd"])
+
+    result = _run(agents_route.list_agent_skills("tdd-hermes"))
+
+    assert result["agent_name"] == "tdd-hermes"
+    assert result["agent_type"] == "hermes"
+
+    installed_refs = [row["ref"] for row in result["installed"]]
+    assert installed_refs == ["clawrium/tdd"]
+    # Installed row carries summary metadata so the UI can render the
+    # description without a second round-trip.
+    tdd_row = result["installed"][0]
+    assert tdd_row["registry"] == "clawrium"
+    assert tdd_row["name"] == "tdd"
+    assert tdd_row["description"]
+    assert tdd_row["version"]
+
+    # Available picker is filtered to clawrium/* + matching <claw>/*.
+    available_registries = {row["registry"] for row in result["available"]}
+    # hermes claw → no openclaw/zeroclaw native entries leak in.
+    assert "openclaw" not in available_registries
+    assert "zeroclaw" not in available_registries
+    # clawrium/tdd is universally compatible so it must show up.
+    available_refs = {row["ref"] for row in result["available"]}
+    assert "clawrium/tdd" in available_refs
+
+
+def test_list_filters_available_to_openclaw_only(monkeypatch):
+    _stub_resolved(monkeypatch, agent_name="tdd-openclaw", agent_type="openclaw")
+    result = _run(agents_route.list_agent_skills("tdd-openclaw"))
+
+    for row in result["available"]:
+        assert row["registry"] in {"clawrium", "openclaw"}, row
+
+
+def test_list_filters_available_to_zeroclaw_only(monkeypatch):
+    _stub_resolved(monkeypatch, agent_name="tdd-zeroclaw", agent_type="zeroclaw")
+    result = _run(agents_route.list_agent_skills("tdd-zeroclaw"))
+
+    for row in result["available"]:
+        assert row["registry"] in {"clawrium", "zeroclaw"}, row
+
+
+def test_list_handles_empty_desired_state(monkeypatch):
+    _stub_resolved(monkeypatch)
+    result = _run(agents_route.list_agent_skills("tdd-hermes"))
+    assert result["installed"] == []
+    assert any(r["ref"] == "clawrium/tdd" for r in result["available"])
+
+
+# ---------- POST /api/agents/{agent}/skills/{registry}/{skill} ---------------
+
+
+def test_install_writes_state_and_calls_apply(monkeypatch):
+    _stub_resolved(monkeypatch)
+    calls = _stub_apply(monkeypatch, applied=["clawrium/tdd"])
+
+    result = _run(
+        agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd")
+    )
+
+    assert result["success"] is True
+    assert result["ref"] == "clawrium/tdd"
+    assert result["changed"] is True
+    assert result["installed"] == ["clawrium/tdd"]
+    assert calls == ["tdd-hermes"]
+    assert read_state("tdd-hermes") == ["clawrium/tdd"]
+
+
+def test_install_is_idempotent_but_still_applies(monkeypatch):
+    """Re-installing an already-installed skill is the documented drift
+    recovery path — state is unchanged but the playbook still runs."""
+    _stub_resolved(monkeypatch)
+    write_state("tdd-hermes", ["clawrium/tdd"])
+    calls = _stub_apply(monkeypatch, applied=["clawrium/tdd"])
+
+    result = _run(
+        agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd")
+    )
+
+    assert result["changed"] is False
+    assert calls == ["tdd-hermes"], "apply_state must run on re-install"
+
+
+def test_install_404_when_agent_missing(monkeypatch):
+    _stub_resolved(monkeypatch, resolved=False)
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.install_agent_skill("ghost", "clawrium", "tdd"))
+    assert exc.value.status_code == 404
+
+
+def test_install_422_on_external_source_ref(monkeypatch):
+    """A ref like ``http:/bad`` must be rejected before we touch state
+    or apply_state. parse_skill_ref raises ExternalSourceBlocked."""
+    _stub_resolved(monkeypatch)
+    # apply_state must NOT be called — assert by raising if it is.
+    monkeypatch.setattr(
+        agents_route, "apply_state", _raises_if_called("apply_state")
+    )
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.install_agent_skill("tdd-hermes", "http:", "bad"))
+    assert exc.value.status_code == 422
+
+
+def test_install_422_on_incompatible_claw(monkeypatch):
+    """Installing a hermes-native skill on an openclaw agent must surface
+    as 422 (IncompatibleSkillRegistry) — caught inside apply_state's
+    pre-check, not on the host."""
+    _stub_resolved(monkeypatch, agent_name="tdd-openclaw", agent_type="openclaw")
+    write_state("tdd-openclaw", [])
+
+    # Real apply_state will refuse: write the state then let the real
+    # code path validate. But we don't want a real run — supply a fake
+    # apply_state that raises IncompatibleSkillRegistry.
+    from clawrium.core.skills import IncompatibleSkillRegistry
+
+    def fake(_name: str, **_kw):
+        raise IncompatibleSkillRegistry(
+            "Skill 'hermes/foo' from registry 'hermes' is not installable "
+            "on openclaw agents."
+        )
+
+    monkeypatch.setattr(agents_route, "apply_state", fake)
+
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.install_agent_skill("tdd-openclaw", "hermes", "foo"))
+    assert exc.value.status_code == 422
+
+
+def test_install_502_on_apply_error(monkeypatch):
+    _stub_resolved(monkeypatch)
+    _stub_apply(
+        monkeypatch, raises=SkillApplyError("host unreachable: timed out")
+    )
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
+    assert exc.value.status_code == 502
+    # State should still reflect the user's intent — apply failures
+    # don't roll back desired state; the user will retry.
+    assert read_state("tdd-hermes") == ["clawrium/tdd"]
+
+
+# ---------- DELETE /api/agents/{agent}/skills/{registry}/{skill} -------------
+
+
+def test_remove_drops_state_and_calls_apply(monkeypatch):
+    _stub_resolved(monkeypatch)
+    write_state("tdd-hermes", ["clawrium/tdd"])
+    calls = _stub_apply(monkeypatch, applied=[])
+
+    result = _run(
+        agents_route.remove_agent_skill("tdd-hermes", "clawrium", "tdd")
+    )
+
+    assert result["success"] is True
+    assert result["changed"] is True
+    assert result["installed"] == []
+    assert calls == ["tdd-hermes"]
+    assert read_state("tdd-hermes") == []
+
+
+def test_remove_is_idempotent_on_missing_skill(monkeypatch):
+    _stub_resolved(monkeypatch)
+    calls = _stub_apply(monkeypatch, applied=[])
+
+    result = _run(
+        agents_route.remove_agent_skill("tdd-hermes", "clawrium", "tdd")
+    )
+
+    assert result["changed"] is False
+    assert calls == ["tdd-hermes"], "apply_state must run even on no-op remove"
+
+
+def test_remove_404_when_agent_missing(monkeypatch):
+    _stub_resolved(monkeypatch, resolved=False)
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.remove_agent_skill("ghost", "clawrium", "tdd"))
+    assert exc.value.status_code == 404
+
+
+def test_remove_422_on_malformed_ref(monkeypatch):
+    _stub_resolved(monkeypatch)
+    monkeypatch.setattr(
+        agents_route, "apply_state", _raises_if_called("apply_state")
+    )
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.remove_agent_skill("tdd-hermes", "bogus", "tdd"))
+    assert exc.value.status_code == 422
+
+
+# ---------- Helpers -----------------------------------------------------------
+
+
+def _raises_if_called(label: str):
+    def _raise(*_args, **_kwargs):
+        raise AssertionError(f"{label} should not have been called")
+
+    return _raise


### PR DESCRIPTION
Stacked on top of #391 (issue-383-gui-skill-catalog-browse).

## Summary
- Real per-agent skills management in the GUI: GET/POST/DELETE under `/api/agents/{agent}/skills/{registry}/{skill}`, backed by the same `core.skills_state` + `apply_state` pipeline the CLI uses (Phases 2–3).
- Agent-detail **Skills** tab: real installed-skills list with per-row two-step Remove (confirm/cancel) + an Install modal with a server-side filtered picker (`clawrium/*` whose `compatibility[<claw>]: true` plus the matching native registry only).
- Apply failures surface as **502** (Bad Gateway), not 500 — a host-unreachable run is an upstream failure, not a server bug. Detail strings are redacted (no log_dir paths) and the full message is logged server-side only.

## Real smoke on all three running claws (wolf-i)
All three flows pass end-to-end against the Phase 0 fleet — install, drift recovery (delete on host → re-POST restores), remove, and cross-surface parity (`clm agent skill list` reflects browser-initiated installs).

| Claw | On-host path | Install | Drift recovery | Remove |
|---|---|---|---|---|
| tdd-hermes (hermes) | `~/.hermes/skills/clawrium/tdd/SKILL.md` | ✅ 200 | ✅ `changed:false`, file restored | ✅ dir pruned |
| tdd-openclaw (openclaw) | `~/.openclaw/skills/tdd/SKILL.md` | ✅ 200 | ✅ `changed:false`, file restored | ✅ dir pruned |
| tdd-zeroclaw (zeroclaw) | `~/.zeroclaw/workspace/skills/tdd/SKILL.md` (native CLI) | ✅ 200 | ✅ `changed:false`, file restored | ✅ dir pruned |

Full curl transcripts and per-claw paths in `.itx/384/01_EXECUTION.md`.

## Testing
- [x] All existing tests pass (`make test`): 2129 pytest + 124 vitest
- [x] Linter passes (`make lint`)
- [x] New tests: 31 backend (`tests/test_gui_agent_skills_routes.py`), 15 vitest for SkillsTab + 3 for Modal a11y
- [x] Manual smoke on all three real claws (transcripts above + execution log)

### Test Coverage
- Backend: GET 404/200, POST install/idempotent/422 (unknown registry, unsupported claw, incompatible claw)/502 (path-scrubbed), DELETE remove/idempotent/422/502 + parametrized `_skill_error_status` table + parametrized `_is_compatible_for_agent_type` matrix + direct `ExternalSourceBlocked` parser test + state-survives-apply-failure pin.
- Vitest: loading live region, error+retry, empty state, installed rows, picker filtering, picker hides installed, install/remove mutation flows, two-step Remove with focus + Escape + concurrent-disable cleanup, inline error rendering for both flows, modal aria-modal + aria-labelledby + close-button accessible name.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation: `parse_skill_ref` runs first on every install/remove (inside `add_skill`/`remove_skill`) so malformed refs short-circuit before state mutation. `ExternalSourceBlocked` boundary covered by direct parser test.
- [x] No SQL/XSS/command-injection risks: routes return JSON, no shell exec; on-host writes happen inside the per-claw playbooks already audited in Phases 2–3.
- [x] `SkillApplyError` details (which embed log paths) are scrubbed before reaching the HTTP response body.
- [x] Dependencies: no new deps added.

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $8.95 | Total Time: ≈40 min | Agents: leader, cli-ux-reviewer, security-reviewer, core-lifecycle-reviewer, test-coverage-reviewer**

| Review | Rating | Blocking Issues | Status | Cost | Commit |
|--------|--------|-----------------|--------|------|--------|
| 1 | 2/5 | B1, B2, B3 | All fixed | $3.01 | `00de26b` reviewed → fix in `00df607` |
| 2 | 2/5 | B1, B2a, B2b, B3 (new a11y nits found in R1 fixes) | All fixed | $1.97 | `00df607` reviewed → fix in `bb46184` |
| 3 | 3/5 | B1 (missing modal.test.tsx) | All fixed | $2.49 | `bb46184` reviewed → fix in `a273117` |
| 4 | **4/5** | None | **READY TO MERGE** | $1.47 | `a273117` reviewed; clean |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 2/5 → 00df607)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `skills-tab.tsx:60` | Loading skeleton invisible to screen readers — no role/aria-live/sr-only text | Fixed — added `role="status" aria-live="polite" aria-label="Loading skills"` + sr-only text |
| B2 | `skills-tab.tsx:213` | Destructive Remove fires immediately, no confirmation | Fixed — two-step inline Confirm/Cancel with per-row aria-labels |
| B3 | `_skill_error_status` | `SkillApplyNotSupported → 422` has zero test coverage | Fixed — added `test_install/remove_422_on_unsupported_claw_type` |

**Warnings (Resolved in this round):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `skills_apply.py` + `agents.py:478` | Filesystem paths leak into 502 response body | Fixed — added `_skill_error_detail` redaction; full message logged server-side only |
| W2 | `agents.py:294-314` | `_is_compatible_for_agent_type` reimplements `check_agent_compatibility` | Fixed — delegate to core helper with native fast-paths |
| W3 | `agents.py:470-474` | State pollution on 422 | Documented via dedicated test (pre-existing CLI design) |
| W4 | `tab-nav.tsx` | ARIA tabs pattern missing | Deferred to follow-up (existing component scope) |
| W5 | `modal.tsx` | Missing `aria-labelledby` + close-button accessible name | Fixed — `useId()` + `aria-labelledby` + `aria-label="Close dialog"` |
| W6 | `skills-tab.tsx:149` | Installed `<ul>` missing `role=list` | Fixed |
| W7 | `skills-tab.tsx:268` | Picker Install buttons share identical accessible name | Fixed — per-row `aria-label={`Install ${ref}`}` |
| W8 | `test_gui_agent_skills_routes.py:197` | Wrong exception class in test | Fixed — renamed test + added direct `ExternalSourceBlocked` parser test |
| W9 | `skills-tab.test.tsx` | Modal close + remove-error path untested | Fixed — added 3 vitest tests |

</details>

<details>
<summary>Review 2 Details (Rating 2/5 → bb46184)</summary>

**Blocking Issues (all new — found in Review 1 fixes):**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `skills-tab.tsx (SkillsLoading)` | Live-region timing flaw — sr-only span at initial paint isn't announced; aria-busy absent | Fixed — useEffect-delayed sr-only mount + `aria-busy="true"` |
| B2a | `skills-tab.tsx:258` | Focus lost on Remove→confirming transition | Fixed — `useEffect` focuses Confirm button on state change |
| B2b | `skills-tab.tsx:231` | No Escape-key dismiss on confirming group | Fixed — `onKeyDown` handler with `Escape` |
| B3 | `modal.tsx:43` | `aria-modal="true"` absent — VoiceOver virtual cursor bypasses dialog focus trap | Fixed — `aria-modal="true"` added |

**Warnings (Resolved in this round):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `skills-tab.test.tsx` | Skeleton test only checks presence, not attributes | Fixed — assertion on role/aria-busy/aria-live/aria-label |
| W3 | `skills-tab.tsx:234` | `confirming` state not reset on disabled transition | Fixed — `useEffect` resets when disabled flips true |
| W4 | `agents.py:344-349` | Native-matching skills now incur 2 `load_skill` calls per scan | Acknowledged — docstring corrected; cost bounded by clawrium+matching-native count |
| W5 | `core/skills.py:378` | `check_agent_compatibility` docstring vs code divergence | Fixed — docstring corrected to match fail-closed code |
| W6 | `test_gui_agent_skills_routes.py:243` | B3 tests assert status only, not detail message | Fixed — assert detail is original message, not redacted string |
| W7 | `test_gui_agent_skills_routes.py` | Missing `test_remove_502_on_apply_error` | Fixed |
| W9 | `skills-tab.test.tsx:250` | Remove-error test doesn't assert `confirming` resets | Fixed |

</details>

<details>
<summary>Review 3 Details (Rating 3/5 → a273117)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `modal.tsx` | `aria-modal` + `aria-labelledby` fixes have zero test coverage (every test mocks Modal) | Fixed — added `modal.test.tsx` rendering the real Modal with jsdom showModal/close shim |

**Warnings (Resolved in this round):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `skills-tab.tsx:181` | aria-busy unmounts on load — no "loaded" announcement | Fixed — hoisted live region to SkillsTab root; transitions Loading→"Skills loaded." |
| W2 | `skills-tab.tsx:195` | redundant `aria-live="polite"` (implied by role=status) | Fixed — removed; left comment citing WAI-ARIA §5.3.1 |
| W3 | `skills-tab.tsx:234` | concurrent-disable cleanup effect untested | Fixed — new vitest with rerender + `installMutation.isPending=true` |
| W4 | `skills-tab.test.tsx:314` | Escape fired on group div, not focused Confirm button | Fixed — fires on confirm button so bubble path is exercised |
| W5 | `skills-tab.tsx:266` | `stopPropagation()` is broader than necessary | Fixed — `preventDefault()` instead |

**Suggestions (Addressed):**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | wrap focus assertion in `waitFor` | Fixed |
| S3 | misleading DELETE-state comment | Fixed |
| S4 | document synchronous `setConfirming(false)` | Comment added |

</details>

<details>
<summary>Review 4 Details (Rating 4/5 — READY TO MERGE)</summary>

**Blocking Issues:** None

**Warnings (Acknowledged, deferred to follow-up):**

| # | File | Warning | Status |
|---|------|---------|--------|
| W1 | `modal.test.tsx` | Native `close`-event listener path untested | Out-of-scope — file follow-up issue |
| W2 | `skills-tab.test.tsx` | `Skills loaded.` live-region transition path untested | Out-of-scope — file follow-up issue |

**Suggestions (Acknowledged):**

| # | Suggestion | Status |
|---|------------|--------|
| S1 | `labelId as string` → `labelId!` | Acknowledged |
| S2 | jsdom shim teardown | Acknowledged |
| S3 | backdrop-click path test | Out-of-scope — follow-up |
| S4 | error-message length/URL bounding (pre-existing) | Out-of-scope — follow-up |
| S5 | lock-file content audit | Acknowledged — clean per ATX |

**Per-specialist ratings (Review 4):** test-coverage 4/5, cli-ux 4/5, security 4/5, core-lifecycle 5/5.

</details>

## Reviewer Notes
- Base of this PR is `issue-383-gui-skill-catalog-browse`. Once #391 merges, GitHub auto-rebases this onto `main`.
- Tab label was `"Skills & Tools"` → renamed to `"Skills"`. The placeholder Skills tab contained an integrations sub-card; integrations now lives on its own sidebar page (#373).
- Four ATX review iterations cleared the merge bar. Final rating 4/5, zero blockers. Two remaining warnings are real regression risks on a11y features (close-event listener test, Skills-loaded transition test) but do not block ship per ATX.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)