### PR TITLE
feat(skills): #385 Phase 6 — contributor safety net (docs + CI dual-schema validation)

### DIFF
--- a/.github/workflows/skills-validate.yml
+++ b/.github/workflows/skills-validate.yml
@@ -8,6 +8,10 @@ name: Skills Validate
 # The job is intentionally narrow: it only runs the dual-schema catalog
 # validator (scripts/validate_skills.py) plus the fixture-based unit
 # tests for it. The full test suite still runs in test.yml.
+#
+# The path filter intentionally lists skills/** (which implicitly
+# covers skills/_schema/**), the validator, the core loader the
+# validator imports, the validator's own tests, and this workflow.
 
 on:
   push:
@@ -37,14 +41,28 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          # Pin to a specific minor for reproducibility — a new uv
+          # major release should not break a re-run of the same commit.
+          version: "0.5.x"
+          # Cache the uv download dir keyed on uv.lock so re-runs skip
+          # the cold-download of dependencies.
+          enable-cache: true
 
       - name: Set up Python
-        run: uv python install 3.11
+        # Pin to the package's declared support floor (>=3.10 in
+        # pyproject.toml). Testing the floor catches 3.10-specific
+        # regressions before they ship; the test.yml workflow can
+        # cover the newer interpreter separately.
+        run: uv python install 3.10
 
       - name: Install dependencies
         run: uv sync
 
+      # The validator step MUST run before the fixture tests. If the
+      # validator fails, GitHub Actions skips the next step by default
+      # (the desired behaviour — a broken catalog should fail loudly
+      # rather than have its diagnostic masked by an unrelated test
+      # report). Do not add `if: always()` to the test step.
       - name: Validate skills catalog
         run: uv run python scripts/validate_skills.py
 

--- a/.github/workflows/skills-validate.yml
+++ b/.github/workflows/skills-validate.yml
@@ -1,0 +1,52 @@
+name: Skills Validate
+
+# Phase 6 contributor safety net (issue #385). A new contributor drops a
+# skill into skills/<registry>/<name>/, opens a PR, and this workflow
+# catches schema mistakes (path traversal, schema mismatch, missing
+# required fields) before maintainer review.
+#
+# The job is intentionally narrow: it only runs the dual-schema catalog
+# validator (scripts/validate_skills.py) plus the fixture-based unit
+# tests for it. The full test suite still runs in test.yml.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - "scripts/validate_skills.py"
+      - "src/clawrium/core/skills.py"
+      - "tests/test_validate_skills_script.py"
+      - ".github/workflows/skills-validate.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - "scripts/validate_skills.py"
+      - "src/clawrium/core/skills.py"
+      - "tests/test_validate_skills_script.py"
+      - ".github/workflows/skills-validate.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Validate skills catalog
+        run: uv run python scripts/validate_skills.py
+
+      - name: Run validator fixture tests
+        run: uv run pytest tests/test_validate_skills_script.py -v

--- a/.github/workflows/skills-validate.yml
+++ b/.github/workflows/skills-validate.yml
@@ -31,6 +31,13 @@ on:
       - "tests/test_validate_skills_script.py"
       - ".github/workflows/skills-validate.yml"
 
+# Least-privilege: this job only needs to read the checkout and run
+# tests — no writes to PR, issues, or releases. Explicit declaration
+# prevents future repo-wide default changes from granting the runner
+# extra scopes silently.
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -56,7 +63,10 @@ jobs:
         run: uv python install 3.10
 
       - name: Install dependencies
-        run: uv sync
+        # --frozen rejects any lock-file drift in the PR — same locked
+        # dependency set the contributor saw locally must be what CI
+        # validates.
+        run: uv sync --frozen
 
       # The validator step MUST run before the fixture tests. If the
       # validator fails, GitHub Actions skips the next step by default

--- a/.itx/385/01_EXECUTION.md
+++ b/.itx/385/01_EXECUTION.md
@@ -1,0 +1,111 @@
+# Issue #385 — Phase 6 Execution Log
+
+Phase 6 of parent #364: contributor safety net (docs + CI dual-schema
+validation) plus the final acceptance sweep across all three claws.
+
+## Scope shipped
+
+**CI validator + workflow**
+- `scripts/validate_skills.py` — dual-schema validator that walks
+  `skills/`, validates every skill against its registry's schema, and
+  enforces path-traversal + schema-mismatch guards. Importable from
+  tests; runnable directly for local dev.
+- `.github/workflows/skills-validate.yml` — runs on PRs that touch
+  `skills/`, the validator, the schemas, or the validator's tests.
+
+**Tests**
+- `tests/test_validate_skills_script.py` — 13 fixture tests covering
+  the happy path, the four path-traversal vectors, the three
+  schema-mismatch vectors, the missing-file cases, and the
+  invariant that the real in-repo catalog always validates.
+
+**Docs**
+- `docs/skills/index.md`, `docs/skills/authoring-clawrium.md`,
+  `docs/skills/authoring-native.md` — repo-rooted authoring guides.
+- `website/docs/skills/intro.md`, `website/docs/skills/authoring.md` —
+  user-facing site mirror (registered in `website/sidebars.ts`).
+- `AGENTS.md` — quickstart now includes
+  `clm agent skill install <agent-name> clawrium/tdd`.
+
+## Final acceptance sweep — CLI + GUI on tdd-* fleet
+
+Host: `wolf-i` (192.168.1.36). Phase 0 fleet (from
+`.itx/364/02_PHASE0_FINDINGS.md`).
+
+### CLI
+
+```text
+$ uv run clm skill list
+clawrium/tdd  clawrium  Test-Driven Development discipline …
+
+$ uv run clm agent skill install tdd-openclaw clawrium/tdd
+Installed clawrium/tdd on tdd-openclaw.
+$ uv run clm agent skill install tdd-hermes clawrium/tdd
+Installed clawrium/tdd on tdd-hermes.
+$ uv run clm agent skill install tdd-zeroclaw clawrium/tdd
+Installed clawrium/tdd on tdd-zeroclaw.
+
+$ uv run clm agent skill list tdd-openclaw
+clawrium/tdd  clawrium  tdd
+$ uv run clm agent skill list tdd-hermes
+clawrium/tdd  clawrium  tdd
+$ uv run clm agent skill list tdd-zeroclaw
+clawrium/tdd  clawrium  tdd
+
+$ uv run clm agent skill remove tdd-openclaw clawrium/tdd
+Removed clawrium/tdd from tdd-openclaw.
+$ uv run clm agent skill remove tdd-hermes clawrium/tdd
+Removed clawrium/tdd from tdd-hermes.
+$ uv run clm agent skill remove tdd-zeroclaw clawrium/tdd
+Removed clawrium/tdd from tdd-zeroclaw.
+```
+
+Post-remove `clm agent skill list <agent>` returned "No skills
+installed on …" for each of the three.
+
+### GUI (FastAPI surface backing the dashboard)
+
+```text
+GET  /api/skills                                  → 200, clawrium/tdd in payload
+POST /api/agents/tdd-openclaw/skills/clawrium/tdd → {"success":true,"changed":true,"installed":["clawrium/tdd"]}
+POST /api/agents/tdd-hermes/skills/clawrium/tdd   → {"success":true,"changed":true,"installed":["clawrium/tdd"]}
+POST /api/agents/tdd-zeroclaw/skills/clawrium/tdd → {"success":true,"changed":true,"installed":["clawrium/tdd"]}
+
+GET /api/agents/tdd-openclaw/skills → installed=[clawrium/tdd], available=[…]
+GET /api/agents/tdd-hermes/skills   → installed=[clawrium/tdd], available=[…]
+GET /api/agents/tdd-zeroclaw/skills → installed=[clawrium/tdd], available=[…]
+
+DELETE /api/agents/tdd-openclaw/skills/clawrium/tdd → {"success":true,"changed":true,"installed":[]}
+DELETE /api/agents/tdd-hermes/skills/clawrium/tdd   → {"success":true,"changed":true,"installed":[]}
+DELETE /api/agents/tdd-zeroclaw/skills/clawrium/tdd → {"success":true,"changed":true,"installed":[]}
+```
+
+GUI server started with `uv run clm gui --port 9999` and stopped after
+the sweep.
+
+## Verification
+
+- `make test` → 2126 Python + 115 GUI tests pass.
+- `make lint` → ruff + next lint clean.
+- `python scripts/validate_skills.py` → ok against the real catalog.
+
+## PR
+
+Stacked on top of `issue-384-gui-skill-install-all-claws` (parent's
+Phase 5 PR), per `/itx:execute 385 --pr-base=issue-384-gui-skill-install-all-claws`.
+
+---
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-17T12:35:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 385 --pr-base=issue-384-gui-skill-install-all-claws
+```
+
+</details>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,10 @@ clm agent install --type openclaw --host mybox
 clm agent configure <agent-name>
 clm agent start <agent-name>
 
+# Install a skill onto the agent (catalog: skills/)
+clm skill list
+clm agent skill install <agent-name> clawrium/tdd
+
 # Check fleet status
 clm ps
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ clm agent start <agent-name>
 
 # Install a skill onto the agent (catalog: skills/)
 clm skill list
+clm skill show clawrium/tdd       # Inspect a skill before installing
 clm agent skill install <agent-name> clawrium/tdd
 
 # Check fleet status

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,8 @@ clm ps
 - **Agent**: An AI assistant instance (zeroclaw, nemoclaw, or openclaw)
 - **Agent Type**: The specific AI assistant implementation (e.g., zeroclaw, nemoclaw, openclaw)
 - **Agent Name**: The unique identifier for an installed agent instance
-- **Registry**: Platform-defined agent types with versions, dependencies, and templates
+- **Agent Registry**: Platform-defined agent types with versions, dependencies, and templates
+- **Skill Registry**: A namespace under `skills/` from which skills can be installed onto an agent (`clawrium`, `openclaw`, `hermes`, `zeroclaw`). Skills are referenced as `<skill-registry>/<name>` (e.g. `clawrium/tdd`). Distinct from the Agent Registry.
 
 ## Resources
 
@@ -109,10 +110,10 @@ Trigger with: `/itx:execute 35 in a subtree` or `/itx:execute 35 --worktree`
 New Issue → /itx:triage → /itx:plan-create → /itx:plan-scaffold → /itx:execute → /itx:verify → /itx:review-pr → Merge
 ```
 
-### Skills
+### Workflow Commands
 
-| Skill | Purpose |
-|-------|---------|
+| Command | Purpose |
+|---------|---------|
 | `/itx:bug-new` | Create bug issue (asks for customer outcome) |
 | `/itx:issue-new` | Create feature issue (asks for customer outcome) |
 | `/itx:triage` | Review unlabeled issues |

--- a/docs/skills/authoring-clawrium.md
+++ b/docs/skills/authoring-clawrium.md
@@ -79,9 +79,10 @@ top-level keys are rejected (`additionalProperties: false`).
 
 The SKILL.md is the canonical content the agent sees. The frontmatter
 at the top of this file is **not** the source of truth — the apply
-playbook re-renders frontmatter from `_meta.yaml` for each claw. The
-SKILL.md you check in only needs minimal frontmatter (`name` +
-`description`) and the body:
+playbook re-renders frontmatter from `_meta.yaml` for each claw, and
+the validator does not enforce SKILL.md frontmatter under `clawrium/`.
+By convention, include `name:` and `description:` so the file is
+readable standalone, but the body is what matters:
 
 ```markdown
 ---
@@ -115,7 +116,7 @@ specific rule violated. Common ones:
 | `must equal directory name`              | Make `_meta.yaml.name` match the dirname  |
 | `missing required _meta.yaml`            | Add the file (clawrium skills require it) |
 | `clawrium-only keys`                     | You're under a native registry — move it  |
-| `failed clawrium-skill schema`           | Read the message; usually a typo / type   |
+| `failed Clawrium normalized skill (_meta.yaml) validation` | Read the per-field message; usually a typo or wrong type |
 | `violates the slug rule`                 | Rename the directory to kebab-case        |
 
 Then run the test suite:

--- a/docs/skills/authoring-clawrium.md
+++ b/docs/skills/authoring-clawrium.md
@@ -1,0 +1,144 @@
+# Authoring a `clawrium/` skill
+
+Use the `clawrium/` registry when the same behaviour should be available
+on every kind of claw (openclaw, hermes, zeroclaw). The skill is
+authored once in a normalized `_meta.yaml` shape; the per-claw apply
+playbooks materialize the right native frontmatter at install time.
+
+This guide walks through adding a new `clawrium/<name>/` skill end to
+end. The CI validator (`scripts/validate_skills.py`) is the contract —
+if your skill passes validation locally, it will pass in CI.
+
+## 1. Pick a name
+
+The `<name>` is a kebab-case slug. Slug rule (enforced by the validator
+and by `parse_skill_ref`):
+
+```
+^[a-z0-9][a-z0-9_-]*$
+```
+
+The directory name and `_meta.yaml`'s `name:` field MUST be identical.
+This invariant is required for zeroclaw's `skills install`/`remove`
+semantics (the source-dirname is what the native CLI uses on disk —
+see `.itx/364/02_PHASE0_FINDINGS.md`).
+
+## 2. Create the directory
+
+```
+skills/clawrium/<name>/
+├── _meta.yaml      # required — validated against clawrium.schema.json
+├── SKILL.md        # required — canonical content shipped to every claw
+└── README.md       # optional — human-facing rationale, links
+```
+
+## 3. Author `_meta.yaml`
+
+The normalized shape:
+
+```yaml
+# skills/clawrium/<name>/_meta.yaml
+name: <name>              # MUST equal the directory name
+description: >-
+  One-line elevator pitch. Surfaces in `clm skill list` and the GUI.
+version: 0.1.0            # semver (jsonschema-enforced)
+license: MIT              # optional, surfaces in hermes metadata
+author: clawrium          # optional
+platforms: [linux, macos] # optional; informational
+
+# Required. Maps each claw type to whether this skill can run there.
+# `false` makes the install fail closed on that claw, even though
+# clawrium/* is otherwise installable on any agent type.
+compatibility:
+  openclaw: true
+  hermes: true
+  zeroclaw: true
+
+# Optional. Per-claw frontmatter overrides merged verbatim into the
+# native SKILL.md on install. Use this for claw-specific metadata
+# that doesn't belong in the cross-agent normalized shape.
+native:
+  hermes:
+    metadata:
+      hermes:
+        tags: [tdd, testing, discipline]
+  openclaw: {}
+  zeroclaw: {}
+
+# Optional. Surfaced to each claw's runtime so it can warn the user
+# about a missing executable or env var before the skill runs.
+prerequisites:
+  commands: []
+  env: []
+```
+
+Validated against `skills/_schema/clawrium.schema.json`. Unknown
+top-level keys are rejected (`additionalProperties: false`).
+
+## 4. Author `SKILL.md`
+
+The SKILL.md is the canonical content the agent sees. The frontmatter
+at the top of this file is **not** the source of truth — the apply
+playbook re-renders frontmatter from `_meta.yaml` for each claw. The
+SKILL.md you check in only needs minimal frontmatter (`name` +
+`description`) and the body:
+
+```markdown
+---
+name: <name>
+description: One-line elevator pitch.
+---
+
+# Skill body
+
+Markdown prose, examples, and any inline tool-use hints the claw should
+read at runtime.
+```
+
+## 5. Validate locally
+
+```bash
+python scripts/validate_skills.py
+```
+
+Expected output on success:
+
+```
+ok: skills catalog at .../skills validates
+```
+
+If the validator reports a failure, it prints the file path and the
+specific rule violated. Common ones:
+
+| Failure message                          | Fix                                       |
+|------------------------------------------|-------------------------------------------|
+| `must equal directory name`              | Make `_meta.yaml.name` match the dirname  |
+| `missing required _meta.yaml`            | Add the file (clawrium skills require it) |
+| `clawrium-only keys`                     | You're under a native registry — move it  |
+| `failed clawrium-skill schema`           | Read the message; usually a typo / type   |
+| `violates the slug rule`                 | Rename the directory to kebab-case        |
+
+Then run the test suite:
+
+```bash
+make test
+```
+
+## 6. Smoke-test against a real claw
+
+A clawrium-authored skill is only "done" when it installs and runs on
+every claw it claims compatibility with. From a checkout pointing at
+your dev fleet:
+
+```bash
+clm agent skill install <openclaw-agent> clawrium/<name>
+clm agent skill install <hermes-agent>   clawrium/<name>
+clm agent skill install <zeroclaw-agent> clawrium/<name>
+```
+
+Confirm each agent's native `skills list` shows the new skill.
+
+## 7. Open the PR
+
+CI runs the same validator and the fixture-based unit tests. If both
+pass and a maintainer reviews, the skill ships in the next release.

--- a/docs/skills/authoring-clawrium.md
+++ b/docs/skills/authoring-clawrium.md
@@ -11,8 +11,9 @@ if your skill passes validation locally, it will pass in CI.
 
 ## 1. Pick a name
 
-The `<name>` is a kebab-case slug. Slug rule (enforced by the validator
-and by `parse_skill_ref`):
+The `<name>` is a lowercase slug (hyphens and underscores both
+allowed). Slug rule (enforced by the validator and by
+`parse_skill_ref`):
 
 ```
 ^[a-z0-9][a-z0-9_-]*$
@@ -115,9 +116,9 @@ specific rule violated. Common ones:
 |------------------------------------------|-------------------------------------------|
 | `must equal directory name`              | Make `_meta.yaml.name` match the dirname  |
 | `missing required _meta.yaml`            | Add the file (clawrium skills require it) |
-| `clawrium-only keys`                     | You're under a native registry — move it  |
+| `missing required SKILL.md`              | Add the file alongside `_meta.yaml`       |
 | `failed Clawrium normalized skill (_meta.yaml) validation` | Read the per-field message; usually a typo or wrong type |
-| `violates the slug rule`                 | Rename the directory to kebab-case        |
+| `violates the slug rule`                 | Rename the directory to lowercase letters, digits, `-`, `_` |
 
 Then run the test suite:
 

--- a/docs/skills/authoring-native.md
+++ b/docs/skills/authoring-native.md
@@ -119,6 +119,13 @@ The validator checks:
 - `name:` field equals the directory name.
 - No `_meta.yaml` in the skill directory.
 
+Then run the test suite — the validator fixture tests run alongside
+the rest of the suite:
+
+```bash
+make test
+```
+
 ## Smoke-test against the real claw
 
 A native skill must be installed and exercised on a real agent of the

--- a/docs/skills/authoring-native.md
+++ b/docs/skills/authoring-native.md
@@ -1,0 +1,132 @@
+# Authoring a native skill
+
+Use a native registry (`openclaw/`, `hermes/`, `zeroclaw/`) when the
+skill depends on that claw's specific frontmatter fields and can't be
+expressed in the cross-agent `clawrium/` normalized shape.
+
+A native skill is installable **only** on agents of the matching type.
+Attempting to install a `hermes/<name>` skill onto an openclaw agent
+fails with `IncompatibleSkillRegistry` at the CLI/API boundary — no
+silent skip, no partial install.
+
+## When to choose native over clawrium
+
+Choose **native** when:
+
+- The skill needs hermes-only `metadata` keys (e.g. `tags`,
+  `homepage`, `upstream_skill`).
+- The skill needs openclaw-only frontmatter (e.g. `allowed-tools`).
+- The skill needs zeroclaw-only fields not part of the normalized
+  shape.
+- The behaviour is fundamentally claw-specific (e.g. wraps a native
+  CLI flag that no other claw has).
+
+Choose **clawrium** when the behaviour is portable and you'd write the
+same prose for every claw.
+
+## Layout
+
+```
+skills/<claw>/<name>/
+├── SKILL.md      # required — frontmatter is the source of truth
+└── README.md     # optional
+```
+
+**No `_meta.yaml`.** A `_meta.yaml` under a native registry is a hard
+failure in the CI validator — it almost always means a contributor
+copy-pasted a clawrium skill into the wrong namespace.
+
+## SKILL.md frontmatter
+
+The frontmatter is whatever the underlying claw expects. The catalog
+schemas are intentionally lenient (`additionalProperties: true`) so a
+forward-compatible field added by a claw upstream doesn't immediately
+break CI — but the validator still requires:
+
+| Field         | Required | Notes                                |
+|---------------|:--------:|--------------------------------------|
+| `name`        | ✅       | MUST equal the directory name        |
+| `description` | ✅       | One-line elevator pitch              |
+| `version`     | optional | Surfaces in the claw's `skills list` |
+
+Plus: clawrium-only keys (`compatibility`, `native`) are **rejected**
+in native frontmatter. They have no meaning outside the cross-agent
+shape and their presence usually signals a misplaced clawrium skill.
+
+### openclaw example
+
+```markdown
+---
+name: code-review
+description: Walk a pull request and flag style issues.
+version: 0.2.0
+---
+
+# Code Review
+
+When the user pastes a diff, walk it hunk by hunk and surface…
+```
+
+### hermes example
+
+```markdown
+---
+name: code-review
+description: Walk a pull request and flag style issues.
+version: 0.2.0
+license: MIT
+metadata:
+  hermes:
+    tags: [review, code-quality]
+    homepage: https://example.com/code-review
+---
+
+# Code Review
+
+...
+```
+
+### zeroclaw example
+
+```markdown
+---
+name: code-review
+description: Walk a pull request and flag style issues.
+version: 0.2.0
+---
+
+# Code Review
+
+...
+```
+
+Note: zeroclaw uses the **source directory name** as the install key
+on disk. The directory name and `name:` field MUST match — the
+validator enforces this.
+
+## Validate locally
+
+```bash
+python scripts/validate_skills.py
+```
+
+The validator checks:
+
+- Slug rule on the directory name.
+- No symlinks in the skill tree.
+- Frontmatter validates against the per-claw native schema.
+- Frontmatter does NOT contain clawrium-only keys.
+- `name:` field equals the directory name.
+- No `_meta.yaml` in the skill directory.
+
+## Smoke-test against the real claw
+
+A native skill must be installed and exercised on a real agent of the
+matching type. The clawrium GUI's `Skills` tab on the agent detail
+filters the installable list to `clawrium/*` + the matching `<claw>/*`,
+so you can confirm the install/list/remove round-trip there as well.
+
+## Open the PR
+
+CI runs `scripts/validate_skills.py` plus the fixture tests in
+`tests/test_validate_skills_script.py`. Both must pass.

--- a/docs/skills/authoring-native.md
+++ b/docs/skills/authoring-native.md
@@ -110,14 +110,17 @@ validator enforces this.
 python scripts/validate_skills.py
 ```
 
-The validator checks:
+Common failures and their fixes:
 
-- Slug rule on the directory name.
-- No symlinks in the skill tree.
-- Frontmatter validates against the per-claw native schema.
-- Frontmatter does NOT contain clawrium-only keys.
-- `name:` field equals the directory name.
-- No `_meta.yaml` in the skill directory.
+| Failure message                                | Fix                                                       |
+|------------------------------------------------|-----------------------------------------------------------|
+| `missing required SKILL.md`                    | Add the file; native skills are SKILL.md only             |
+| `_meta.yaml is only valid under skills/clawrium/` | Delete the `_meta.yaml`, or move the skill to `clawrium/` |
+| `clawrium-only keys ['compatibility'...]`      | Remove `compatibility:` / `native:` from the frontmatter   |
+| `must equal directory name`                    | Make `name:` match the directory name                     |
+| `violates the slug rule`                       | Rename the directory to lowercase letters, digits, `-`, `_` |
+| `symlinks are not allowed`                     | Inline the file; no symlinks anywhere in the catalog       |
+| `YAML frontmatter block`                       | Add a `---\n…\n---` frontmatter at the top of `SKILL.md`   |
 
 Then run the test suite — the validator fixture tests run alongside
 the rest of the suite:

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,0 +1,108 @@
+# Skills Catalog
+
+Clawrium ships a curated catalog of **skills** that any agent in your
+fleet can install with one command. A skill is a directory of
+behaviour-shaping prompts and metadata that the underlying claw
+discovers at runtime — Test-Driven Development discipline, code-review
+guardrails, security-audit playbooks, and so on.
+
+Skills are sourced **only** from the in-repo `skills/` tree. There is no
+URL install, no arbitrary path install, no third-party registry. The
+catalog is the source of truth, and CI gates every change against a
+dual-schema validator (see [Authoring guides](#authoring) below).
+
+## Quick start
+
+```bash
+# Browse the catalog
+clm skill list
+
+# Inspect a skill before installing
+clm skill show clawrium/tdd
+
+# Install onto an agent
+clm agent skill install my-agent clawrium/tdd
+
+# List skills installed on an agent
+clm agent skill list my-agent
+
+# Remove a skill
+clm agent skill remove my-agent clawrium/tdd
+```
+
+The GUI mirrors the same surface under `Agents → <agent> → Skills`
+and a top-level `Skills` catalog page.
+
+## Registries
+
+The catalog is split into four **registries** (namespaces). The split
+determines which agents can install a given skill and which JSON schema
+its descriptor is validated against.
+
+| Registry   | Install target          | Schema                            |
+|------------|-------------------------|-----------------------------------|
+| `clawrium` | any agent type          | `_schema/clawrium.schema.json`    |
+| `openclaw` | only `openclaw` agents  | `_schema/native/openclaw.schema.json` |
+| `hermes`   | only `hermes` agents    | `_schema/native/hermes.schema.json`   |
+| `zeroclaw` | only `zeroclaw` agents  | `_schema/native/zeroclaw.schema.json` |
+
+Skills are referenced everywhere as `<registry>/<name>` — CLI args, GUI
+URLs, and desired-state files. Bare names (`tdd`) are rejected with a
+hint that suggests the matching `<registry>/<name>`.
+
+### When to use `clawrium/`
+
+Use the `clawrium/` registry when the skill is behaviour you want
+available on **every** kind of claw. The normalized `_meta.yaml` shape
+is materialized into each native frontmatter format on install — a
+single source file ends up on disk as openclaw-shaped SKILL.md on an
+openclaw agent, hermes-shaped on a hermes agent, and zeroclaw-shaped
+(via `zeroclaw skills install`) on a zeroclaw agent.
+
+### When to use a native registry
+
+Use `openclaw/`, `hermes/`, or `zeroclaw/` when the skill depends on
+that claw's specific frontmatter fields (e.g. hermes-only `metadata`
+keys, openclaw allowed-tools lists). Native skills are installable
+**only** on agents of the matching type. Attempting to install a
+`hermes/<name>` skill on an openclaw agent fails with
+`IncompatibleSkillRegistry`.
+
+## Authoring
+
+| Guide | Use when |
+|-------|----------|
+| [Authoring clawrium skills](authoring-clawrium.md) | Cross-agent skill — works on every claw |
+| [Authoring native skills](authoring-native.md)     | Skill specific to one claw's frontmatter |
+
+Every PR that touches `skills/` runs `scripts/validate_skills.py` in CI
+([skills-validate.yml](https://github.com/ric03uec/clawrium/blob/main/.github/workflows/skills-validate.yml))
+to catch:
+
+- Slug-rule violations (path-traversal guard).
+- Symlinks inside the catalog.
+- Schema mismatches (a clawrium `_meta.yaml` mis-placed under a native
+  registry, or clawrium-only frontmatter keys in a native SKILL.md).
+- Missing required fields on `_meta.yaml` or SKILL.md frontmatter.
+- The clawrium "directory name == `_meta.yaml.name`" invariant
+  (required for zeroclaw's source-dirname install/remove semantics —
+  see `.itx/364/02_PHASE0_FINDINGS.md`).
+
+Run the same checks locally before pushing:
+
+```bash
+python scripts/validate_skills.py
+```
+
+## On-host materialization
+
+| Claw     | Install location                              | Mechanism                                  |
+|----------|-----------------------------------------------|--------------------------------------------|
+| openclaw | `~/.openclaw/skills/<name>/SKILL.md`          | file copy (auto-scan)                      |
+| hermes   | `~/.hermes/skills/clawrium/<name>/SKILL.md`   | file copy (auto-scan)                      |
+| zeroclaw | `~/.zeroclaw/workspace/skills/<name>/`        | staged + `zeroclaw skills install` (audit) |
+
+Re-running `clm agent skill install` is the recovery for drift. There
+is no separate `reconcile` command — the local desired-state file at
+`~/.config/clawrium/agents/<agent>/skills.json` is truth, and every
+install/remove re-applies it end-to-end.

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,5 +1,14 @@
 # Skills Catalog
 
+<!--
+  Repo-rooted docs live in docs/skills/. The user-facing site mirror
+  lives at website/docs/skills/ and is a condensed variant: the two
+  trees are kept semantically in sync but are not structurally
+  identical (this file → intro.md; authoring-clawrium.md +
+  authoring-native.md → authoring.md). Update both when changing
+  catalog rules.
+-->
+
 Clawrium ships a curated catalog of **skills** that any agent in your
 fleet can install with one command. A skill is a directory of
 behaviour-shaping prompts and metadata that the underlying claw

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -70,17 +70,15 @@ from pathlib import Path
 
 import yaml
 
-from clawrium.core import skills as core_skills
 from clawrium.core.skills import (
-    NATIVE_REGISTRIES,
     REGISTRIES,
     SchemaValidationError,
-    Skill,
     SkillRef,
     _NAME_RE,
     _load_schema,
     _split_frontmatter,
     _validate_against_schema,
+    clear_schema_cache,
 )
 
 
@@ -249,7 +247,15 @@ def _validate_native_skill(
         )
         return failures
 
-    body, frontmatter = _split_frontmatter(skill_md.read_text())
+    try:
+        body, frontmatter = _split_frontmatter(skill_md.read_text())
+    except SchemaValidationError as error:
+        # _split_frontmatter raises when YAML is invalid OR when the
+        # frontmatter parses to a non-mapping (e.g. a list or scalar).
+        # Catch here so a single broken contributor SKILL.md surfaces
+        # as a normal failure entry, not an unhandled traceback in CI.
+        failures.append(ValidationFailure(skill_md, str(error)))
+        return failures
     if not frontmatter:
         failures.append(
             ValidationFailure(
@@ -300,6 +306,17 @@ def _validate_registry(
         return failures
 
     for entry in sorted(registry_root.iterdir()):
+        # Symlink check MUST come first: `Path.is_file()` follows
+        # symlinks, so a `README.md -> /etc/passwd` link would slip past
+        # the `is_file()` branch and `continue` before this guard ever
+        # ran. Mirrors the ordering in `_validate_unexpected_registries`.
+        if entry.is_symlink():
+            failures.append(
+                ValidationFailure(
+                    entry, "registry-level symlinks are not allowed"
+                )
+            )
+            continue
         if entry.is_file():
             # README.md or similar registry-level docs are allowed; any
             # other top-level file is suspicious enough to flag.
@@ -313,13 +330,6 @@ def _validate_registry(
                         ),
                     )
                 )
-            continue
-        if entry.is_symlink():
-            failures.append(
-                ValidationFailure(
-                    entry, "registry-level symlinks are not allowed"
-                )
-            )
             continue
         if not _NAME_RE.match(entry.name):
             failures.append(
@@ -386,11 +396,24 @@ def _validate_unexpected_registries(
 
 def validate_catalog(catalog_root: Path) -> list[ValidationFailure]:
     """Run every validation rule on `catalog_root` and return the
-    aggregated failure list. An empty list means the catalog is clean."""
+    aggregated failure list. An empty list means the catalog is clean.
+
+    Note on schema resolution: the JSON schemas live with the
+    ``clawrium.core.skills`` module (installed via the package, or at
+    the repo root for development). The validator does NOT honour a
+    custom ``_schema/`` directory under ``catalog_root`` — it always
+    resolves against the schemas the core loader resolves against. In
+    practice this is what you want: every catalog the validator sees
+    should agree with the loader's schemas, and CI runs against the
+    same checkout so the two roots are the same tree. The fixture
+    helper ``_write_schemas`` in the test suite re-creates the
+    schemas under ``tmp_path`` only so the fixture *looks* like a
+    well-formed catalog; the schema content is never read.
+    """
     # Schemas are cached at module level by the core loader. Tests that
     # validate multiple fixture catalogs in the same process need a
     # clean slate; production CI only runs once so the cost is moot.
-    core_skills._SCHEMA_CACHE.clear()
+    clear_schema_cache()
 
     failures: list[ValidationFailure] = []
     failures.extend(_validate_unexpected_registries(catalog_root))
@@ -439,6 +462,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     for failure in failures:
         print(failure.render(root), file=sys.stderr)
+    # Trailing summary mirrors the ok path so the last visible line in
+    # a long CI log is actionable, not a bullet point that scrolls the
+    # header off-screen. Pytest and ruff both do this.
+    print(
+        f"FAILED — {len(failures)} error(s). Fix the above, then "
+        "re-run: python scripts/validate_skills.py",
+        file=sys.stderr,
+    )
     return 1
 
 

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -89,6 +89,19 @@ from clawrium.core.skills import (
 _CLAWRIUM_ONLY_KEYS: frozenset[str] = frozenset({"compatibility", "native"})
 
 
+class _InternalValidationError(Exception):
+    """Raised when validation cannot start because the catalog's own
+    schema files are missing or malformed.
+
+    This is distinct from `SchemaValidationError`, which fires when a
+    *skill* fails validation — those are contributor-fixable and surface
+    as `ValidationFailure` entries with exit code 1. An
+    `_InternalValidationError` means the validator itself can't do its
+    job (corrupt repo state, partial install, schema file deleted) and
+    surfaces as exit code 2 per the module-level contract.
+    """
+
+
 @dataclass
 class ValidationFailure:
     """One catalog-level validation error.
@@ -107,6 +120,21 @@ class ValidationFailure:
         except ValueError:
             rel = self.path
         return f"  - {rel}: {self.message}"
+
+
+def _safe_load_schema(registry: str) -> dict:
+    """Wrap `_load_schema` so a missing or corrupt schema file becomes an
+    `_InternalValidationError` (exit code 2) instead of leaking
+    `SchemaValidationError` (which is the contributor-fixable, exit-1
+    surface). Without this wrap a partial install or a deleted
+    `_schema/*.json` would crash the validator with an uncaught
+    exception."""
+    try:
+        return _load_schema(registry)
+    except SchemaValidationError as error:
+        raise _InternalValidationError(
+            f"schema for registry {registry!r} could not be loaded: {error}"
+        ) from error
 
 
 def _is_within(path: Path, root: Path) -> bool:
@@ -194,7 +222,7 @@ def _validate_clawrium_skill(
             )
         ]
 
-    schema = _load_schema("clawrium")
+    schema = _safe_load_schema("clawrium")
     try:
         _validate_against_schema(metadata, schema, ref=ref)
     except SchemaValidationError as error:
@@ -264,7 +292,7 @@ def _validate_native_skill(
         )
         return failures
 
-    schema = _load_schema(ref.registry)
+    schema = _safe_load_schema(ref.registry)
     try:
         _validate_against_schema(frontmatter, schema, ref=ref)
     except SchemaValidationError as error:
@@ -447,10 +475,23 @@ def main(argv: list[str] | None = None) -> int:
 
     root = (args.catalog_root or _default_catalog_root()).resolve()
     if not root.is_dir():
-        print(f"error: catalog root not found: {root}", file=sys.stderr)
+        print(
+            f"error: catalog root not found: {root}\n"
+            "hint: run `python scripts/validate_skills.py` with no args "
+            "to auto-detect the repo-root skills/, or verify the path "
+            "you passed.",
+            file=sys.stderr,
+        )
         return 2
 
-    failures = validate_catalog(root)
+    try:
+        failures = validate_catalog(root)
+    except _InternalValidationError as error:
+        # The validator itself can't run (missing/corrupt schema, etc.).
+        # Exit code 2 — matches the contract documented in the module
+        # docstring and signals "not contributor-fixable" to CI.
+        print(f"error: internal validation failure: {error}", file=sys.stderr)
+        return 2
     if not failures:
         print(f"ok: skills catalog at {root} validates")
         return 0

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Catalog validator for the in-repo `skills/` tree.
+
+Used by:
+
+- `.github/workflows/skills-validate.yml` — runs on every PR that touches
+  `skills/`, `scripts/validate_skills.py`, or the schemas under
+  `skills/_schema/`.
+- Local contributors — `python scripts/validate_skills.py` before pushing.
+
+What it checks (each failure is collected; the script exits non-zero with
+a full report rather than bailing on the first error):
+
+1. **Slug rules.** Every skill directory name matches
+   ``^[a-z0-9][a-z0-9_-]*$``. Anything else (incl. `..`, dotfiles, names
+   with slashes after normalization) is rejected as a *path-traversal*
+   guard. The same rule applies to registry directories: only the four
+   names in :data:`clawrium.core.skills.REGISTRIES` are allowed.
+2. **No symlinks.** Skills must be plain files / dirs under `skills/`.
+   A symlink pointing outside the tree is a covert path-traversal vector
+   even when its name passes the slug rule.
+3. **Required files.** `clawrium/<name>/` needs both `_meta.yaml` and
+   `SKILL.md`. `<claw>/<name>/` needs `SKILL.md`. Missing files are a
+   hard failure (vs. the loader's "silently skip" behavior, which is the
+   right default at runtime but not in CI).
+4. **Dual schema.** `clawrium/*` validates against
+   `_schema/clawrium.schema.json`. `<claw>/*` validates against
+   `_schema/native/<claw>.schema.json`. Dispatches via
+   :func:`clawrium.core.skills.validate_skill`.
+5. **Schema-mismatch fixtures rejected.** A clawrium-shaped layout
+   placed under a native registry (e.g. `_meta.yaml` exists, or
+   frontmatter has clawrium-only `compatibility` block) is rejected:
+   the native registry's SKILL.md is the source of truth and the loader
+   only reads `_meta.yaml` under `clawrium/`. Similarly, a clawrium
+   skill whose `_meta.yaml.name` doesn't match the directory name is
+   rejected (the source-dirname == registry-slug invariant from
+   `.itx/364/02_PHASE0_FINDINGS.md`).
+
+The script keeps a tight dependency surface: only the in-repo
+`clawrium.core.skills` module + `pyyaml` + `jsonschema` (both already
+required by the package itself). It does not import the CLI or the GUI.
+
+Exit codes
+----------
+
+- ``0`` — every skill in every registry validates.
+- ``1`` — at least one validation error. Full report goes to stderr.
+- ``2`` — internal failure (e.g. catalog root missing, schema file
+  unreadable) — surfaces as a CI failure, not a contributor-fixable
+  one.
+
+Usage
+-----
+
+::
+
+    python scripts/validate_skills.py              # validates skills/ at repo root
+    python scripts/validate_skills.py path/to/skills
+
+The second form is used by the test suite to point the validator at a
+fixture tree without monkey-patching `_catalog_root`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from clawrium.core import skills as core_skills
+from clawrium.core.skills import (
+    NATIVE_REGISTRIES,
+    REGISTRIES,
+    SchemaValidationError,
+    Skill,
+    SkillRef,
+    _NAME_RE,
+    _load_schema,
+    _split_frontmatter,
+    _validate_against_schema,
+)
+
+
+# Clawrium-only frontmatter keys that must NOT appear in a native SKILL.md.
+# Their presence under skills/<claw>/ signals a copy-paste from a clawrium
+# skill — surface the mismatch loudly instead of letting the lenient
+# native schema (additionalProperties: true) silently accept it.
+_CLAWRIUM_ONLY_KEYS: frozenset[str] = frozenset({"compatibility", "native"})
+
+
+@dataclass
+class ValidationFailure:
+    """One catalog-level validation error.
+
+    `path` is the on-disk location closest to the problem (a skill
+    directory, schema file, or registry root). `message` is the
+    contributor-facing diagnostic.
+    """
+
+    path: Path
+    message: str
+
+    def render(self, root: Path) -> str:
+        try:
+            rel = self.path.relative_to(root)
+        except ValueError:
+            rel = self.path
+        return f"  - {rel}: {self.message}"
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """Return True if `path` resolves to a location inside `root`.
+
+    Both arguments are resolved to absolute paths first so symlinks
+    pointing outside the catalog are caught even when the link itself
+    lives inside it.
+    """
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _check_no_symlinks(skill_dir: Path, root: Path) -> list[ValidationFailure]:
+    """Walk `skill_dir` and flag any symlink — even one that resolves
+    back inside `root`. Skills are a flat content directory; there's no
+    legitimate reason for a symlink in this tree."""
+    failures: list[ValidationFailure] = []
+    for entry in skill_dir.rglob("*"):
+        if entry.is_symlink():
+            failures.append(
+                ValidationFailure(
+                    path=entry,
+                    message=(
+                        "symlinks are not allowed in the skills catalog "
+                        "(path-traversal guard); resolve and inline the file"
+                    ),
+                )
+            )
+            continue
+        # Defense-in-depth: a regular file whose resolved path escapes
+        # the catalog should never happen (the symlink check above
+        # already catches it), but check anyway so a future bug in the
+        # symlink probe doesn't silently let an escape through.
+        if not _is_within(entry, root):
+            failures.append(
+                ValidationFailure(
+                    path=entry,
+                    message="path resolves outside the skills catalog root",
+                )
+            )
+    return failures
+
+
+def _validate_clawrium_skill(
+    skill_dir: Path, ref: SkillRef
+) -> list[ValidationFailure]:
+    """Validate a `clawrium/<name>/` skill.
+
+    Requires `_meta.yaml` + `SKILL.md`. `_meta.yaml.name` MUST equal
+    the directory name (Phase 0 finding: zeroclaw `skills install`/`remove`
+    use the source dirname, so the slug and the meta name must agree).
+    """
+    failures: list[ValidationFailure] = []
+    meta_path = skill_dir / "_meta.yaml"
+    skill_md = skill_dir / "SKILL.md"
+
+    if not meta_path.is_file():
+        failures.append(
+            ValidationFailure(skill_dir, "missing required _meta.yaml")
+        )
+    if not skill_md.is_file():
+        failures.append(
+            ValidationFailure(skill_dir, "missing required SKILL.md")
+        )
+    if failures:
+        return failures
+
+    try:
+        metadata = yaml.safe_load(meta_path.read_text()) or {}
+    except yaml.YAMLError as error:
+        return [
+            ValidationFailure(
+                meta_path, f"_meta.yaml is not valid YAML: {error}"
+            )
+        ]
+    if not isinstance(metadata, dict):
+        return [
+            ValidationFailure(
+                meta_path,
+                f"_meta.yaml must be a YAML mapping (got {type(metadata).__name__})",
+            )
+        ]
+
+    schema = _load_schema("clawrium")
+    try:
+        _validate_against_schema(metadata, schema, ref=ref)
+    except SchemaValidationError as error:
+        failures.append(ValidationFailure(meta_path, str(error)))
+
+    if metadata.get("name") != ref.name:
+        failures.append(
+            ValidationFailure(
+                meta_path,
+                (
+                    f"_meta.yaml `name` ({metadata.get('name')!r}) must equal "
+                    f"directory name ({ref.name!r}) — the slug invariant from "
+                    ".itx/364/02_PHASE0_FINDINGS.md"
+                ),
+            )
+        )
+    return failures
+
+
+def _validate_native_skill(
+    skill_dir: Path, ref: SkillRef
+) -> list[ValidationFailure]:
+    """Validate a `<claw>/<name>/` skill.
+
+    Native skills are SKILL.md only — frontmatter validates against the
+    claw-specific schema. A `_meta.yaml` in this directory is a
+    schema-mismatch (copy-paste from a clawrium skill) and is rejected.
+    Frontmatter keys reserved for the clawrium-normalized shape
+    (``compatibility``, ``native``) are also rejected because the native
+    schema is `additionalProperties: true` and would otherwise silently
+    accept them.
+    """
+    failures: list[ValidationFailure] = []
+    skill_md = skill_dir / "SKILL.md"
+
+    if (skill_dir / "_meta.yaml").is_file():
+        failures.append(
+            ValidationFailure(
+                skill_dir / "_meta.yaml",
+                (
+                    "_meta.yaml is only valid under skills/clawrium/ — a "
+                    "native skill's frontmatter lives in SKILL.md itself"
+                ),
+            )
+        )
+
+    if not skill_md.is_file():
+        failures.append(
+            ValidationFailure(skill_dir, "missing required SKILL.md")
+        )
+        return failures
+
+    body, frontmatter = _split_frontmatter(skill_md.read_text())
+    if not frontmatter:
+        failures.append(
+            ValidationFailure(
+                skill_md, "SKILL.md must start with a YAML frontmatter block"
+            )
+        )
+        return failures
+
+    schema = _load_schema(ref.registry)
+    try:
+        _validate_against_schema(frontmatter, schema, ref=ref)
+    except SchemaValidationError as error:
+        failures.append(ValidationFailure(skill_md, str(error)))
+
+    bad_keys = sorted(_CLAWRIUM_ONLY_KEYS & frontmatter.keys())
+    if bad_keys:
+        failures.append(
+            ValidationFailure(
+                skill_md,
+                (
+                    f"native SKILL.md frontmatter contains clawrium-only "
+                    f"keys {bad_keys!r} — move the skill under "
+                    f"skills/clawrium/ if you need them, or remove the keys"
+                ),
+            )
+        )
+
+    if frontmatter.get("name") != ref.name:
+        failures.append(
+            ValidationFailure(
+                skill_md,
+                (
+                    f"SKILL.md frontmatter `name` ({frontmatter.get('name')!r}) "
+                    f"must equal directory name ({ref.name!r})"
+                ),
+            )
+        )
+    return failures
+
+
+def _validate_registry(
+    registry: str, registry_root: Path, catalog_root: Path
+) -> list[ValidationFailure]:
+    failures: list[ValidationFailure] = []
+    if not registry_root.is_dir():
+        # README-only registries (e.g. an empty native namespace) are
+        # legitimate during early adoption — the README is not a skill.
+        return failures
+
+    for entry in sorted(registry_root.iterdir()):
+        if entry.is_file():
+            # README.md or similar registry-level docs are allowed; any
+            # other top-level file is suspicious enough to flag.
+            if entry.name not in {"README.md", ".gitkeep"}:
+                failures.append(
+                    ValidationFailure(
+                        entry,
+                        (
+                            "unexpected file at registry root; skills live in "
+                            "their own subdirectory"
+                        ),
+                    )
+                )
+            continue
+        if entry.is_symlink():
+            failures.append(
+                ValidationFailure(
+                    entry, "registry-level symlinks are not allowed"
+                )
+            )
+            continue
+        if not _NAME_RE.match(entry.name):
+            failures.append(
+                ValidationFailure(
+                    entry,
+                    (
+                        f"directory name {entry.name!r} violates the slug rule "
+                        "^[a-z0-9][a-z0-9_-]*$ (path-traversal guard)"
+                    ),
+                )
+            )
+            continue
+
+        ref = SkillRef(registry=registry, name=entry.name)
+        failures.extend(_check_no_symlinks(entry, catalog_root))
+        if registry == "clawrium":
+            failures.extend(_validate_clawrium_skill(entry, ref))
+        else:
+            failures.extend(_validate_native_skill(entry, ref))
+
+    return failures
+
+
+def _validate_unexpected_registries(
+    catalog_root: Path,
+) -> list[ValidationFailure]:
+    """Flag top-level entries under `skills/` that aren't a known registry,
+    a schema directory, or an allowlisted docs file."""
+    failures: list[ValidationFailure] = []
+    allowed_files = {"README.md"}
+    allowed_dirs = set(REGISTRIES) | {"_schema"}
+    for entry in sorted(catalog_root.iterdir()):
+        if entry.is_symlink():
+            failures.append(
+                ValidationFailure(
+                    entry, "catalog-root symlinks are not allowed"
+                )
+            )
+            continue
+        if entry.is_file():
+            if entry.name not in allowed_files:
+                failures.append(
+                    ValidationFailure(
+                        entry,
+                        (
+                            "unexpected file at skills/ root; only README.md "
+                            "is allowed alongside the registries"
+                        ),
+                    )
+                )
+            continue
+        if entry.name not in allowed_dirs:
+            failures.append(
+                ValidationFailure(
+                    entry,
+                    (
+                        f"unexpected top-level directory {entry.name!r}; "
+                        f"allowed: {', '.join(sorted(allowed_dirs))}"
+                    ),
+                )
+            )
+    return failures
+
+
+def validate_catalog(catalog_root: Path) -> list[ValidationFailure]:
+    """Run every validation rule on `catalog_root` and return the
+    aggregated failure list. An empty list means the catalog is clean."""
+    # Schemas are cached at module level by the core loader. Tests that
+    # validate multiple fixture catalogs in the same process need a
+    # clean slate; production CI only runs once so the cost is moot.
+    core_skills._SCHEMA_CACHE.clear()
+
+    failures: list[ValidationFailure] = []
+    failures.extend(_validate_unexpected_registries(catalog_root))
+    for registry in REGISTRIES:
+        registry_root = catalog_root / registry
+        failures.extend(
+            _validate_registry(registry, registry_root, catalog_root)
+        )
+    return failures
+
+
+def _default_catalog_root() -> Path:
+    """Resolve the in-repo skills/ tree. CI checks out the repo at root,
+    so we walk up from this file: scripts/validate_skills.py -> repo
+    root -> skills/."""
+    return Path(__file__).resolve().parent.parent / "skills"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate the in-repo skills/ catalog.",
+    )
+    parser.add_argument(
+        "catalog_root",
+        nargs="?",
+        type=Path,
+        default=None,
+        help="Path to a skills/ directory (default: repo-root skills/).",
+    )
+    args = parser.parse_args(argv)
+
+    root = (args.catalog_root or _default_catalog_root()).resolve()
+    if not root.is_dir():
+        print(f"error: catalog root not found: {root}", file=sys.stderr)
+        return 2
+
+    failures = validate_catalog(root)
+    if not failures:
+        print(f"ok: skills catalog at {root} validates")
+        return 0
+
+    print(
+        f"error: {len(failures)} skill catalog validation "
+        f"failure(s) under {root}:",
+        file=sys.stderr,
+    )
+    for failure in failures:
+        print(failure.render(root), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -506,6 +506,12 @@ def main(argv: list[str] | None = None) -> int:
         # Exit code 2 — matches the contract documented in the module
         # docstring and signals "not contributor-fixable" to CI.
         print(f"error: internal validation failure: {error}", file=sys.stderr)
+        print(
+            "hint: check that skills/_schema/ is intact and readable; "
+            "reinstall the package (`uv sync` or `uv tool install --force "
+            "clawrium`) if schema files are missing or corrupt.",
+            file=sys.stderr,
+        )
         return 2
     if not failures:
         print(f"ok: skills catalog at {root} validates")

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -74,11 +74,19 @@ from clawrium.core.skills import (
     REGISTRIES,
     SchemaValidationError,
     SkillRef,
+    clear_schema_cache,
+)
+
+# The four names below are intentionally underscored — they're private
+# to `clawrium.core.skills` and don't appear in its `__all__`. We reuse
+# them here as a cross-module contract so this script and the runtime
+# loader stay in lockstep on parsing/schema semantics. Any rename in
+# `skills.py` must touch this import block too.
+from clawrium.core.skills import (  # noqa: PLC2701  (private import is deliberate)
     _NAME_RE,
     _load_schema,
     _split_frontmatter,
     _validate_against_schema,
-    clear_schema_cache,
 )
 
 
@@ -123,15 +131,22 @@ class ValidationFailure:
 
 
 def _safe_load_schema(registry: str) -> dict:
-    """Wrap `_load_schema` so a missing or corrupt schema file becomes an
-    `_InternalValidationError` (exit code 2) instead of leaking
-    `SchemaValidationError` (which is the contributor-fixable, exit-1
-    surface). Without this wrap a partial install or a deleted
-    `_schema/*.json` would crash the validator with an uncaught
-    exception."""
+    """Wrap `_load_schema` so any schema-side failure surfaces as an
+    `_InternalValidationError` (exit code 2) instead of leaking through
+    as `SchemaValidationError` (exit 1, contributor-fixable) or as a
+    raw `OSError` (Python's default exit 1).
+
+    Catches:
+    - `SchemaValidationError`: missing file *or* corrupt JSON, raised
+      explicitly by the core loader.
+    - `OSError` and subclasses (`PermissionError`, `FileNotFoundError`):
+      raceable between the loader's `is_file()` probe and the
+      `read_text()` call, or surfaceable on partial installs / chroot
+      mounts. Without this we'd exit 1 with an unhandled traceback.
+    """
     try:
         return _load_schema(registry)
-    except SchemaValidationError as error:
+    except (SchemaValidationError, OSError) as error:
         raise _InternalValidationError(
             f"schema for registry {registry!r} could not be loaded: {error}"
         ) from error

--- a/src/clawrium/core/skills.py
+++ b/src/clawrium/core/skills.py
@@ -379,8 +379,10 @@ def check_agent_compatibility(skill: Skill, agent_type: str) -> None:
       ``IncompatibleSkillRegistry``. The catalog author must list each
       claw they intend to support — silent "absent means anywhere" was
       rejected during planning because it makes drift hard to debug
-      ("why did install succeed but the skill never run?"). Unknown
-      agent types fail closed too.
+      ("why did install succeed but the skill never run?"). The
+      `clawrium.schema.json` also requires the map (and all three claw
+      entries inside it), so a missing key represents a malformed skill.
+      Unknown agent types fail closed too.
     - ``<claw>/<name>`` (native): must match ``agent_type`` exactly.
       Cross-claw native installs are a hard error because the SKILL.md
       is already in a per-claw frontmatter shape.
@@ -603,4 +605,13 @@ __all__ = [
     "check_agent_compatibility",
     "clear_schema_cache",
     "materialize_for_claw",
+    # The four names below are private (leading underscore) but
+    # intentionally exported as a stable surface for
+    # `scripts/validate_skills.py` to reuse the loader's parsing /
+    # schema-validation primitives. Renaming any of them requires
+    # updating that script in lockstep.
+    "_NAME_RE",
+    "_load_schema",
+    "_split_frontmatter",
+    "_validate_against_schema",
 ]

--- a/src/clawrium/core/skills.py
+++ b/src/clawrium/core/skills.py
@@ -534,6 +534,18 @@ def _load_schema(registry: str) -> dict[str, Any]:
 _SCHEMA_CACHE: dict[str, dict[str, Any]] = {}
 
 
+def clear_schema_cache() -> None:
+    """Reset the module-level schema cache.
+
+    Exported so callers (notably ``scripts/validate_skills.py`` and the
+    test suite) don't have to poke at the private ``_SCHEMA_CACHE``
+    name. Used when the same process validates more than one catalog
+    root in sequence — without a reset, a fixture catalog with a
+    stale schema would receive a hit from the previous run.
+    """
+    _SCHEMA_CACHE.clear()
+
+
 def _validate_against_schema(
     data: dict[str, Any], schema: dict[str, Any], ref: SkillRef
 ) -> None:
@@ -589,5 +601,6 @@ __all__ = [
     "load_skill",
     "validate_skill",
     "check_agent_compatibility",
+    "clear_schema_cache",
     "materialize_for_claw",
 ]

--- a/src/clawrium/core/skills.py
+++ b/src/clawrium/core/skills.py
@@ -605,13 +605,9 @@ __all__ = [
     "check_agent_compatibility",
     "clear_schema_cache",
     "materialize_for_claw",
-    # The four names below are private (leading underscore) but
-    # intentionally exported as a stable surface for
-    # `scripts/validate_skills.py` to reuse the loader's parsing /
-    # schema-validation primitives. Renaming any of them requires
-    # updating that script in lockstep.
-    "_NAME_RE",
-    "_load_schema",
-    "_split_frontmatter",
-    "_validate_against_schema",
 ]
+# Note: `scripts/validate_skills.py` imports a handful of underscored
+# helpers from this module by explicit name (`_NAME_RE`, `_load_schema`,
+# `_split_frontmatter`, `_validate_against_schema`). They stay private
+# (no `__all__` entry — adding underscored names there would falsely
+# signal a public API), but renames must touch that script in lockstep.

--- a/tests/test_core_skills.py
+++ b/tests/test_core_skills.py
@@ -47,10 +47,15 @@ def test_parse_skill_ref_happy_path():
 def _reset_schema_cache():
     """Schema cache is module-level. Tests that build a fake catalog
     in tmp_path poison the cache for whichever test runs next; clear
-    it on every setup and teardown to keep tests independent."""
-    skills._SCHEMA_CACHE.clear()
+    it on every setup and teardown to keep tests independent.
+
+    Uses the public `clear_schema_cache()` helper rather than poking at
+    the private `_SCHEMA_CACHE` name — keeps the fixture working if the
+    cache implementation ever changes (e.g. swaps to functools.lru_cache).
+    """
+    skills.clear_schema_cache()
     yield
-    skills._SCHEMA_CACHE.clear()
+    skills.clear_schema_cache()
 
 
 @pytest.mark.parametrize("raw", ["", "   ", "\t\n"])
@@ -368,6 +373,79 @@ def _copy_schemas(root: Path) -> None:
         (native_dest / f"{native}.schema.json").write_text(
             (src_schema_root / "native" / f"{native}.schema.json").read_text()
         )
+
+
+def test_load_skill_rejects_malformed_meta_yaml(monkeypatch, tmp_path):
+    """`load_skill` catches `yaml.YAMLError` and re-raises as
+    `SchemaValidationError`. Without this test the YAMLError branch is
+    0-coverage and a future refactor that drops the wrap would surface
+    a raw stack trace to CLI / GUI callers instead of a fixable error."""
+    skill_dir = tmp_path / "clawrium" / "tdd"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "_meta.yaml").write_text("key: [unclosed\n")
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: tdd\ndescription: fake\n---\nbody"
+    )
+    _copy_schemas(tmp_path)
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+
+    with pytest.raises(SchemaValidationError, match="Failed to parse"):
+        load_skill("clawrium/tdd")
+
+
+def test_load_skill_rejects_non_mapping_meta_yaml(monkeypatch, tmp_path):
+    """`_meta.yaml` that parses to a YAML list (or scalar) — the
+    isinstance check sits next to the YAMLError handler and shares the
+    same risk if dropped."""
+    skill_dir = tmp_path / "clawrium" / "tdd"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "_meta.yaml").write_text("- item1\n- item2\n")
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: tdd\ndescription: fake\n---\nbody"
+    )
+    _copy_schemas(tmp_path)
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+
+    with pytest.raises(SchemaValidationError, match="YAML mapping"):
+        load_skill("clawrium/tdd")
+
+
+def test_load_schema_missing_file_raises(monkeypatch, tmp_path):
+    """`_load_schema` raises `SchemaValidationError` when the on-disk
+    schema is absent. Catalog readers (e.g. the validate_skills.py CI
+    script) rely on the *class* of the exception to map to exit code 2,
+    so the contract needs a direct test."""
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+    # No _schema/ at all → both clawrium and native lookups fail.
+    with pytest.raises(SchemaValidationError, match="Schema file"):
+        skills._load_schema("clawrium")
+    with pytest.raises(SchemaValidationError, match="Schema file"):
+        skills._load_schema("hermes")
+
+
+def test_load_schema_corrupt_json_raises(monkeypatch, tmp_path):
+    schema_dir = tmp_path / "_schema"
+    schema_dir.mkdir()
+    (schema_dir / "clawrium.schema.json").write_text("{not json")
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+
+    with pytest.raises(SchemaValidationError, match="not valid JSON"):
+        skills._load_schema("clawrium")
+
+
+def test_clear_schema_cache_empties_cache(monkeypatch, tmp_path):
+    """Round-trip: populate the cache via a real `_load_schema` call,
+    then prove `clear_schema_cache()` actually empties it. Without this
+    the autouse fixture pretends to do work without anyone verifying
+    it does."""
+    _copy_schemas(tmp_path)
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+    skills.clear_schema_cache()
+    assert skills._SCHEMA_CACHE == {}
+    skills._load_schema("clawrium")
+    assert "clawrium" in skills._SCHEMA_CACHE
+    skills.clear_schema_cache()
+    assert skills._SCHEMA_CACHE == {}
 
 
 def test_real_schemas_are_valid_json():

--- a/tests/test_validate_skills_script.py
+++ b/tests/test_validate_skills_script.py
@@ -539,7 +539,7 @@ def test_native_skill_schema_violation_rejected(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_main_exit_0_on_valid_catalog(tmp_path):
+def test_main_exit_0_on_valid_catalog(tmp_path, capsys):
     _build_fixture(tmp_path)
     skill = tmp_path / "clawrium" / "tdd"
     skill.mkdir()
@@ -547,7 +547,11 @@ def test_main_exit_0_on_valid_catalog(tmp_path):
     (skill / "SKILL.md").write_text(_VALID_SKILL_MD)
 
     rc = validate_skills_mod.main([str(tmp_path)])
+    captured = capsys.readouterr()
     assert rc == 0
+    # The "ok:" stdout message is part of the CI contract — a silent
+    # success or a message routed to stderr should fail this test.
+    assert "ok:" in captured.out
 
 
 def test_main_exit_1_on_invalid_catalog(tmp_path, capsys):
@@ -570,13 +574,132 @@ def test_main_exit_2_on_missing_root(tmp_path, capsys):
     assert "catalog root not found" in captured.err
 
 
-def test_main_uses_default_catalog_root_for_real_repo(monkeypatch, capsys):
+def test_main_uses_default_catalog_root_for_real_repo(capsys):
     """`main` with no argv falls back to `_default_catalog_root()`, which
     encodes the assumption that the script lives at repo-root/scripts/.
     Run it against the actual repo to pin that assumption."""
     rc = validate_skills_mod.main([])
     captured = capsys.readouterr()
     assert rc == 0, captured.err
+
+
+# ---------------------------------------------------------------------------
+# Internal validation errors (schema-file failures) — exit code 2
+# ---------------------------------------------------------------------------
+
+
+def test_main_exit_2_on_missing_schema_file(tmp_path, capsys):
+    """If a registry's schema file is deleted post-install, the loader
+    raises `SchemaValidationError`. The validator wraps that into
+    `_InternalValidationError` so the CI contract (exit 2 for
+    not-contributor-fixable failures) holds — exit 1 would mis-signal
+    a fixable skill error."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "clawrium" / "tdd"
+    skill.mkdir()
+    (skill / "_meta.yaml").write_text(_VALID_META)
+    (skill / "SKILL.md").write_text(_VALID_SKILL_MD)
+    # Remove the clawrium schema after the fixture is built.
+    (tmp_path / "_schema" / "clawrium.schema.json").unlink()
+
+    # Patch _load_schema to read from the fixture root so the deletion
+    # actually matters (the production loader resolves to the package
+    # _schema dir, which is unaffected by this fixture).
+    from clawrium.core import skills as core_skills
+
+    real_load = validate_skills_mod._load_schema  # captured before patch
+    schema_dir = tmp_path / "_schema"
+
+    def _fixture_load(registry: str):
+        if registry == "clawrium":
+            path = schema_dir / "clawrium.schema.json"
+        else:
+            path = schema_dir / "native" / f"{registry}.schema.json"
+        if not path.is_file():
+            from clawrium.core.skills import SchemaValidationError as SVE
+            raise SVE(f"Schema file for registry {registry!r} not found at {path}.")
+        import json
+        return json.loads(path.read_text())
+
+    validate_skills_mod._load_schema = _fixture_load
+    # _safe_load_schema closes over the module name, so patch through it
+    # by reaching back into the module namespace.
+    try:
+        rc = validate_skills_mod.main([str(tmp_path)])
+    finally:
+        validate_skills_mod._load_schema = real_load
+        core_skills._SCHEMA_CACHE.clear()
+
+    captured = capsys.readouterr()
+    assert rc == 2, captured.err
+    assert "internal validation failure" in captured.err
+    assert "schema for registry" in captured.err
+
+
+def test_native_skill_invalid_yaml_syntax_rejected(tmp_path):
+    """A SKILL.md with frontmatter that fails YAML parse (not just a
+    non-mapping shape) must surface as a normal failure entry — the
+    `yaml.YAMLError` branch in `_split_frontmatter` is otherwise
+    uncovered by `test_native_frontmatter_as_list_rejected` which only
+    exercises the non-mapping branch."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "openclaw" / "demo"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        dedent(
+            """\
+            ---
+            name: demo
+            description: [unclosed
+            ---
+
+            # Body
+            """
+        )
+    )
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(failures, "SKILL.md", "not valid YAML"), failures
+
+
+@pytest.mark.parametrize("clawrium_key", ["compatibility", "native"])
+def test_clawrium_only_keys_in_native_frontmatter_rejected_each(
+    tmp_path, clawrium_key
+):
+    """Cover each entry in `_CLAWRIUM_ONLY_KEYS` independently — without
+    the parametrized variant, dropping `native` (or any other key) from
+    the frozenset would not break a single test."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "hermes" / "demo"
+    skill.mkdir()
+    block_lines = {
+        "compatibility": (
+            "compatibility:\n"
+            "  openclaw: true\n"
+            "  hermes: true\n"
+            "  zeroclaw: true\n"
+        ),
+        "native": (
+            "native:\n"
+            "  hermes:\n"
+            "    metadata: {}\n"
+        ),
+    }[clawrium_key]
+    (skill / "SKILL.md").write_text(
+        "---\n"
+        "name: demo\n"
+        "description: A native skill with a stray clawrium-only block.\n"
+        + block_lines
+        + "---\n\n# Body\n"
+    )
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(failures, "SKILL.md", "clawrium-only keys"), failures
+    # Defence-in-depth: the specific key name must surface in the
+    # message, not just the generic "clawrium-only" phrase.
+    assert any(
+        clawrium_key in failure.message for failure in failures
+    ), failures
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate_skills_script.py
+++ b/tests/test_validate_skills_script.py
@@ -636,6 +636,32 @@ def test_main_exit_2_on_missing_schema_file(tmp_path, capsys):
     assert "schema for registry" in captured.err
 
 
+def test_main_exit_2_on_permission_error_reading_schema(
+    tmp_path, monkeypatch, capsys
+):
+    """A `PermissionError` (or any `OSError`) bubbling out of
+    `_load_schema` during `schema_path.read_text()` is contractually
+    an *internal* failure (exit 2), not a contributor-fixable skill
+    error (exit 1). Pin that by patching `_load_schema` to raise
+    `PermissionError` directly."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "clawrium" / "tdd"
+    skill.mkdir()
+    (skill / "_meta.yaml").write_text(_VALID_META)
+    (skill / "SKILL.md").write_text(_VALID_SKILL_MD)
+
+    def _raise_permission(_registry: str):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(validate_skills_mod, "_load_schema", _raise_permission)
+
+    rc = validate_skills_mod.main([str(tmp_path)])
+    captured = capsys.readouterr()
+    assert rc == 2, captured.err
+    assert "internal validation failure" in captured.err
+    assert "Permission denied" in captured.err
+
+
 def test_native_skill_invalid_yaml_syntax_rejected(tmp_path):
     """A SKILL.md with frontmatter that fails YAML parse (not just a
     non-mapping shape) must surface as a normal failure entry — the

--- a/tests/test_validate_skills_script.py
+++ b/tests/test_validate_skills_script.py
@@ -21,6 +21,8 @@ import sys
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
+
 
 # scripts/validate_skills.py is not a package — import it via importlib
 # so we can call validate_catalog() directly. The CI workflow exercises
@@ -121,16 +123,20 @@ def test_valid_catalog_passes(tmp_path):
     assert validate_catalog(tmp_path) == []
 
 
-def test_native_skill_passes(tmp_path):
+@pytest.mark.parametrize("registry", ["openclaw", "hermes", "zeroclaw"])
+def test_native_skill_passes(tmp_path, registry):
+    """The happy path for every native registry. Catches per-claw schema
+    regressions (e.g. an accidental edit to zeroclaw.schema.json that
+    leaves the other two unaffected)."""
     _build_fixture(tmp_path)
-    skill = tmp_path / "openclaw" / "demo"
+    skill = tmp_path / registry / "demo"
     skill.mkdir()
     (skill / "SKILL.md").write_text(
         dedent(
-            """\
+            f"""\
             ---
             name: demo
-            description: An openclaw-native demo skill.
+            description: A {registry}-native demo skill.
             ---
 
             # Body
@@ -138,6 +144,14 @@ def test_native_skill_passes(tmp_path):
         )
     )
 
+    assert validate_catalog(tmp_path) == []
+
+
+def test_empty_catalog_passes(tmp_path):
+    """skills/_schema/ but no registry directories should validate.
+    Exercises the early-return in `_validate_registry` when a
+    registry root doesn't exist on disk."""
+    _write_schemas(tmp_path)
     assert validate_catalog(tmp_path) == []
 
 
@@ -335,11 +349,10 @@ def test_missing_required_field_rejected(tmp_path):
     (skill / "SKILL.md").write_text(_VALID_SKILL_MD)
 
     failures = validate_catalog(tmp_path)
-    # jsonschema renders the missing-required diagnostic via the schema
-    # title; the contributor-facing message is the full schema error.
-    assert any(
-        "compatibility" in failure.message for failure in failures
-    ), failures
+    # Pin both path and message so a future refactor that mis-attributes
+    # the failure to SKILL.md (or to some unrelated file that happens to
+    # mention `compatibility`) still trips this test.
+    assert _has_failure(failures, "_meta.yaml", "compatibility"), failures
 
 
 def test_missing_skill_md_rejected(tmp_path):
@@ -353,6 +366,34 @@ def test_missing_skill_md_rejected(tmp_path):
     assert _has_failure(failures, "tdd", "missing required SKILL.md"), failures
 
 
+def test_missing_meta_yaml_rejected(tmp_path):
+    """Symmetric counterpart to test_missing_skill_md_rejected. Without
+    this test, a refactor that drops the _meta.yaml guard in
+    _validate_clawrium_skill would pass the full suite even though the
+    catalog would silently accept SKILL.md-only clawrium skills."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "clawrium" / "tdd"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(_VALID_SKILL_MD)
+    # Intentionally no _meta.yaml.
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(failures, "tdd", "missing required _meta.yaml"), failures
+
+
+def test_native_skill_missing_skill_md_rejected(tmp_path):
+    """Native-registry counterpart to test_missing_skill_md_rejected.
+    Covers the missing-SKILL.md branch in _validate_native_skill which
+    the clawrium-path test does not exercise."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "openclaw" / "demo"
+    skill.mkdir()
+    # Intentionally no SKILL.md.
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(failures, "demo", "missing required SKILL.md"), failures
+
+
 def test_missing_frontmatter_in_native_rejected(tmp_path):
     _build_fixture(tmp_path)
     skill = tmp_path / "hermes" / "demo"
@@ -363,6 +404,179 @@ def test_missing_frontmatter_in_native_rejected(tmp_path):
     assert _has_failure(
         failures, "SKILL.md", "YAML frontmatter block"
     ), failures
+
+
+def test_native_frontmatter_as_list_rejected(tmp_path):
+    """SKILL.md frontmatter that parses to a YAML list (or any non-
+    mapping) used to crash the validator with an uncaught
+    SchemaValidationError. The validator must surface this as a
+    normal failure entry instead."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "hermes" / "demo"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        dedent(
+            """\
+            ---
+            - item1
+            - item2
+            ---
+
+            # Body
+            """
+        )
+    )
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(failures, "SKILL.md", "YAML mapping"), failures
+
+
+def test_meta_yaml_invalid_yaml_rejected(tmp_path):
+    _build_fixture(tmp_path)
+    skill = tmp_path / "clawrium" / "tdd"
+    skill.mkdir()
+    (skill / "_meta.yaml").write_text("key: [unclosed")
+    (skill / "SKILL.md").write_text(_VALID_SKILL_MD)
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(failures, "_meta.yaml", "not valid YAML"), failures
+
+
+def test_meta_yaml_non_dict_rejected(tmp_path):
+    _build_fixture(tmp_path)
+    skill = tmp_path / "clawrium" / "tdd"
+    skill.mkdir()
+    (skill / "_meta.yaml").write_text("- item1\n- item2\n")
+    (skill / "SKILL.md").write_text(_VALID_SKILL_MD)
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(
+        failures, "_meta.yaml", "must be a YAML mapping"
+    ), failures
+
+
+def test_registry_level_symlink_rejected(tmp_path):
+    """A skill directory that is itself a symlink (not just a symlink
+    *inside* a skill dir) is a separate path-traversal vector. The
+    symlink check in _validate_registry must fire before the
+    is_file()/is_dir() branches that would otherwise follow the link."""
+    _build_fixture(tmp_path)
+    target = tmp_path / "_real_skill"
+    target.mkdir()
+    evil = tmp_path / "clawrium" / "evil"
+    evil.symlink_to(target)
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(
+        failures, "evil", "registry-level symlinks are not allowed"
+    ), failures
+
+
+def test_registry_root_symlink_to_file_rejected(tmp_path):
+    """`Path.is_file()` follows symlinks. Before B2 was fixed, a
+    `README.md -> /etc/passwd` symlink would slip past the
+    `is_file()` branch and `continue` before the symlink check ever
+    ran. Pin the ordering with an explicit test."""
+    _build_fixture(tmp_path)
+    target = tmp_path / "outside"
+    target.write_text("decoy")
+    evil = tmp_path / "clawrium" / "README.md"
+    evil.symlink_to(target)
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(
+        failures, "README.md", "registry-level symlinks are not allowed"
+    ), failures
+
+
+def test_catalog_root_symlink_rejected(tmp_path):
+    _build_fixture(tmp_path)
+    evil = tmp_path / "evil-link"
+    evil.symlink_to("/etc")
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(
+        failures, "evil-link", "catalog-root symlinks are not allowed"
+    ), failures
+
+
+def test_unexpected_file_at_registry_root_rejected(tmp_path):
+    _build_fixture(tmp_path)
+    (tmp_path / "clawrium" / "stray.txt").write_text("oops")
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(
+        failures, "stray.txt", "unexpected file at registry root"
+    ), failures
+
+
+def test_native_skill_schema_violation_rejected(tmp_path):
+    """A native SKILL.md with a wrong-shape required field (description
+    failing minLength) must surface a schema validation failure rather
+    than slip past on the lenient `additionalProperties: true` schema."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "hermes" / "demo"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        dedent(
+            """\
+            ---
+            name: demo
+            description: ''
+            ---
+
+            # Body
+            """
+        )
+    )
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(failures, "SKILL.md", "description"), failures
+
+
+# ---------------------------------------------------------------------------
+# main() — exit-code contract (the CI entry point)
+# ---------------------------------------------------------------------------
+
+
+def test_main_exit_0_on_valid_catalog(tmp_path):
+    _build_fixture(tmp_path)
+    skill = tmp_path / "clawrium" / "tdd"
+    skill.mkdir()
+    (skill / "_meta.yaml").write_text(_VALID_META)
+    (skill / "SKILL.md").write_text(_VALID_SKILL_MD)
+
+    rc = validate_skills_mod.main([str(tmp_path)])
+    assert rc == 0
+
+
+def test_main_exit_1_on_invalid_catalog(tmp_path, capsys):
+    _build_fixture(tmp_path)
+    (tmp_path / "clawrium" / ".hidden").mkdir()
+
+    rc = validate_skills_mod.main([str(tmp_path)])
+    captured = capsys.readouterr()
+    assert rc == 1
+    # Both the header and the trailing FAILED summary should reach
+    # stderr so the last visible line in CI logs is actionable.
+    assert "violation" in captured.err.lower() or "slug rule" in captured.err
+    assert "FAILED" in captured.err
+
+
+def test_main_exit_2_on_missing_root(tmp_path, capsys):
+    rc = validate_skills_mod.main([str(tmp_path / "does-not-exist")])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "catalog root not found" in captured.err
+
+
+def test_main_uses_default_catalog_root_for_real_repo(monkeypatch, capsys):
+    """`main` with no argv falls back to `_default_catalog_root()`, which
+    encodes the assumption that the script lives at repo-root/scripts/.
+    Run it against the actual repo to pin that assumption."""
+    rc = validate_skills_mod.main([])
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_validate_skills_script.py
+++ b/tests/test_validate_skills_script.py
@@ -658,6 +658,48 @@ def test_main_exit_2_on_permission_error_reading_schema(
     rc = validate_skills_mod.main([str(tmp_path)])
     captured = capsys.readouterr()
     assert rc == 2, captured.err
+    # Pin every layer of the diagnostic so a regression that drops any
+    # one of them (the wrapper prefix, the registry-name interpolation,
+    # the underlying OSError detail) still fails this test.
+    assert "internal validation failure" in captured.err
+    assert "schema for registry" in captured.err
+    assert "Permission denied" in captured.err
+    assert "hint:" in captured.err
+    # A success message on stdout would mean main() printed "ok:" before
+    # the exception fired — covers any future ordering regression.
+    assert captured.out == ""
+
+
+def test_main_exit_2_on_permission_error_for_native_registry(
+    tmp_path, monkeypatch, capsys
+):
+    """Native-registry counterpart of the clawrium-path test. Without
+    this the OSError → exit-2 propagation through `_validate_native_skill
+    → _validate_registry → validate_catalog → main` is untested."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "openclaw" / "demo"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        dedent(
+            """\
+            ---
+            name: demo
+            description: An openclaw-native demo.
+            ---
+
+            # Body
+            """
+        )
+    )
+
+    def _raise_permission(_registry: str):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(validate_skills_mod, "_load_schema", _raise_permission)
+
+    rc = validate_skills_mod.main([str(tmp_path)])
+    captured = capsys.readouterr()
+    assert rc == 2, captured.err
     assert "internal validation failure" in captured.err
     assert "Permission denied" in captured.err
 

--- a/tests/test_validate_skills_script.py
+++ b/tests/test_validate_skills_script.py
@@ -1,0 +1,381 @@
+"""Tests for `scripts/validate_skills.py` — the CI catalog validator.
+
+Phase 6 exit criterion: "CI rejects invalid-fixture PR; accepts
+valid-fixture PR." These tests express that contract directly by
+building fixture catalogs in `tmp_path` and running the validator
+against them. The real `skills/` tree is exercised by the
+`make test` integration check below.
+
+Each fixture is the smallest possible catalog that still triggers the
+exact failure we care about. We assert on:
+
+- A non-empty failure list (the validator reports the issue).
+- The specific failure message substring (so a future regression that
+  silently swallows the check fails this test, not just refactors).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+
+# scripts/validate_skills.py is not a package — import it via importlib
+# so we can call validate_catalog() directly. The CI workflow exercises
+# the `__main__` path separately via `python scripts/validate_skills.py`.
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent / "scripts" / "validate_skills.py"
+)
+_spec = importlib.util.spec_from_file_location("validate_skills", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+validate_skills_mod = importlib.util.module_from_spec(_spec)
+sys.modules["validate_skills"] = validate_skills_mod
+_spec.loader.exec_module(validate_skills_mod)
+
+validate_catalog = validate_skills_mod.validate_catalog
+ValidationFailure = validate_skills_mod.ValidationFailure
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_schemas(root: Path) -> None:
+    """Copy the real `_schema/` tree into a fixture catalog. Validator
+    behavior depends on the actual schemas — re-defining them inline
+    would let drift in the production schemas silently break this test
+    suite."""
+    real_schema = (
+        Path(__file__).resolve().parent.parent / "skills" / "_schema"
+    )
+    schema_dir = root / "_schema"
+    schema_dir.mkdir(parents=True, exist_ok=True)
+    (schema_dir / "clawrium.schema.json").write_text(
+        (real_schema / "clawrium.schema.json").read_text()
+    )
+    native_dir = schema_dir / "native"
+    native_dir.mkdir(exist_ok=True)
+    for claw in ("openclaw", "hermes", "zeroclaw"):
+        (native_dir / f"{claw}.schema.json").write_text(
+            (real_schema / "native" / f"{claw}.schema.json").read_text()
+        )
+
+
+def _empty_registries(root: Path) -> None:
+    for reg in ("clawrium", "openclaw", "hermes", "zeroclaw"):
+        (root / reg).mkdir(parents=True, exist_ok=True)
+
+
+def _build_fixture(root: Path) -> None:
+    _write_schemas(root)
+    _empty_registries(root)
+
+
+def _has_failure(
+    failures: list[ValidationFailure], path_part: str, message_part: str
+) -> bool:
+    return any(
+        path_part in str(failure.path) and message_part in failure.message
+        for failure in failures
+    )
+
+
+_VALID_META = dedent(
+    """\
+    name: tdd
+    description: A test skill.
+    version: 0.1.0
+    compatibility:
+      openclaw: true
+      hermes: true
+      zeroclaw: true
+    """
+)
+_VALID_SKILL_MD = dedent(
+    """\
+    ---
+    name: tdd
+    description: A test skill.
+    ---
+
+    # Body
+    """
+)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_valid_catalog_passes(tmp_path):
+    _build_fixture(tmp_path)
+    skill = tmp_path / "clawrium" / "tdd"
+    skill.mkdir()
+    (skill / "_meta.yaml").write_text(_VALID_META)
+    (skill / "SKILL.md").write_text(_VALID_SKILL_MD)
+
+    assert validate_catalog(tmp_path) == []
+
+
+def test_native_skill_passes(tmp_path):
+    _build_fixture(tmp_path)
+    skill = tmp_path / "openclaw" / "demo"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        dedent(
+            """\
+            ---
+            name: demo
+            description: An openclaw-native demo skill.
+            ---
+
+            # Body
+            """
+        )
+    )
+
+    assert validate_catalog(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Path-traversal fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_path_traversal_via_bad_dirname_rejected(tmp_path):
+    """A directory whose name fails the slug rule (incl. leading dots
+    and dot-segments) is rejected before any file read. Even though
+    Path() would never resolve `..` literally as a child entry, the
+    same regex catches `evil-..` style attempts as well."""
+    _build_fixture(tmp_path)
+    # We can't literally create a directory named ".." (it resolves up),
+    # but the slug rule catches the broader class of forbidden names:
+    # dotfiles, dot-prefixed dirs, and anything not matching kebab-case.
+    (tmp_path / "clawrium" / ".hidden").mkdir()
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(
+        failures, ".hidden", "violates the slug rule"
+    ), failures
+
+
+def test_path_traversal_via_symlink_rejected(tmp_path):
+    """A symlink inside a skill directory is rejected regardless of
+    where it points. Skills are flat content; symlinks are not."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "clawrium" / "tdd"
+    skill.mkdir()
+    (skill / "_meta.yaml").write_text(_VALID_META)
+    (skill / "SKILL.md").write_text(_VALID_SKILL_MD)
+
+    # The symlink target itself is benign (/etc/hostname); the rule is
+    # "no symlinks at all," so target choice is irrelevant to the test.
+    evil = skill / "leak"
+    evil.symlink_to("/etc/hostname")
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(failures, "leak", "symlinks are not allowed"), failures
+
+
+def test_unexpected_top_level_directory_rejected(tmp_path):
+    """Anything at skills/ root that isn't `_schema`, a known registry,
+    or README.md is rejected — keeps the catalog tree from accumulating
+    drive-by directories."""
+    _build_fixture(tmp_path)
+    (tmp_path / "external").mkdir()
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(failures, "external", "unexpected top-level"), failures
+
+
+# ---------------------------------------------------------------------------
+# Schema-mismatch fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_meta_yaml_under_native_registry_rejected(tmp_path):
+    """A `_meta.yaml` under skills/<claw>/ is the classic schema-mismatch
+    signal — a clawrium-shaped skill mis-placed under a native registry.
+    The validator surfaces this even if the SKILL.md frontmatter alone
+    would have passed the lenient native schema."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "openclaw" / "demo"
+    skill.mkdir()
+    (skill / "_meta.yaml").write_text(_VALID_META)
+    (skill / "SKILL.md").write_text(
+        dedent(
+            """\
+            ---
+            name: demo
+            description: An openclaw demo with a stray _meta.yaml.
+            ---
+
+            # Body
+            """
+        )
+    )
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(
+        failures,
+        "_meta.yaml",
+        "only valid under skills/clawrium/",
+    ), failures
+
+
+def test_clawrium_keys_in_native_frontmatter_rejected(tmp_path):
+    """Native schemas are `additionalProperties: true`. If we did NOT
+    explicitly reject clawrium-only keys, a contributor could paste a
+    clawrium frontmatter under skills/zeroclaw/ and have it silently
+    pass — defeating the dual-schema guarantee."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "zeroclaw" / "demo"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        dedent(
+            """\
+            ---
+            name: demo
+            description: A zeroclaw skill with a stray compatibility block.
+            compatibility:
+              openclaw: true
+              hermes: true
+              zeroclaw: true
+            ---
+
+            # Body
+            """
+        )
+    )
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(
+        failures,
+        "SKILL.md",
+        "clawrium-only keys",
+    ), failures
+
+
+def test_clawrium_name_mismatch_rejected(tmp_path):
+    """The source-dirname == registry-slug invariant (Phase 0 finding).
+    Zeroclaw uses the source dirname for `remove`; if `_meta.yaml.name`
+    drifts from the directory name, downstream uninstalls break."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "clawrium" / "tdd"
+    skill.mkdir()
+    (skill / "_meta.yaml").write_text(
+        dedent(
+            """\
+            name: not-tdd
+            description: Mismatched name.
+            version: 0.1.0
+            compatibility:
+              openclaw: true
+              hermes: true
+              zeroclaw: true
+            """
+        )
+    )
+    (skill / "SKILL.md").write_text(_VALID_SKILL_MD)
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(
+        failures,
+        "_meta.yaml",
+        "must equal directory name",
+    ), failures
+
+
+def test_native_skill_name_mismatch_rejected(tmp_path):
+    _build_fixture(tmp_path)
+    skill = tmp_path / "hermes" / "demo"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        dedent(
+            """\
+            ---
+            name: wrong
+            description: Mismatched name.
+            ---
+
+            # Body
+            """
+        )
+    )
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(
+        failures,
+        "SKILL.md",
+        "must equal directory name",
+    ), failures
+
+
+def test_missing_required_field_rejected(tmp_path):
+    """Schema-required keys (e.g. clawrium `compatibility`) must trip
+    the dual-schema validator. This is the same code path that
+    runtime `validate_skill` exercises — we just confirm it surfaces
+    from the validator script too."""
+    _build_fixture(tmp_path)
+    skill = tmp_path / "clawrium" / "tdd"
+    skill.mkdir()
+    (skill / "_meta.yaml").write_text(
+        dedent(
+            """\
+            name: tdd
+            description: Missing compatibility.
+            version: 0.1.0
+            """
+        )
+    )
+    (skill / "SKILL.md").write_text(_VALID_SKILL_MD)
+
+    failures = validate_catalog(tmp_path)
+    # jsonschema renders the missing-required diagnostic via the schema
+    # title; the contributor-facing message is the full schema error.
+    assert any(
+        "compatibility" in failure.message for failure in failures
+    ), failures
+
+
+def test_missing_skill_md_rejected(tmp_path):
+    _build_fixture(tmp_path)
+    skill = tmp_path / "clawrium" / "tdd"
+    skill.mkdir()
+    (skill / "_meta.yaml").write_text(_VALID_META)
+    # Intentionally no SKILL.md.
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(failures, "tdd", "missing required SKILL.md"), failures
+
+
+def test_missing_frontmatter_in_native_rejected(tmp_path):
+    _build_fixture(tmp_path)
+    skill = tmp_path / "hermes" / "demo"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("# No frontmatter\n")
+
+    failures = validate_catalog(tmp_path)
+    assert _has_failure(
+        failures, "SKILL.md", "YAML frontmatter block"
+    ), failures
+
+
+# ---------------------------------------------------------------------------
+# Integration: the real catalog must always validate
+# ---------------------------------------------------------------------------
+
+
+def test_real_in_repo_catalog_validates():
+    """The actual skills/ tree at repo root validates. This guards
+    against schema regressions slipping past PR review — if a real
+    skill is broken, this test fails before CI even runs the workflow."""
+    real_root = Path(__file__).resolve().parent.parent / "skills"
+    assert validate_catalog(real_root) == [], (
+        "The in-repo skills/ catalog does not validate. "
+        "Run `python scripts/validate_skills.py` for the full report."
+    )

--- a/website/docs/skills/authoring.md
+++ b/website/docs/skills/authoring.md
@@ -126,9 +126,11 @@ Common ones:
 |------------------------------------------|--------------------------------------------|
 | `must equal directory name`              | Make `name:` match the dirname             |
 | `missing required _meta.yaml`            | clawrium skill is missing the file         |
+| `missing required SKILL.md`              | Add the file alongside `_meta.yaml`        |
+| `failed Clawrium normalized skill (_meta.yaml) validation` | Read the per-field message; usually a typo or wrong type in `_meta.yaml` |
 | `_meta.yaml is only valid under skills/clawrium/` | Move the skill or delete the file |
 | `clawrium-only keys`                     | Remove `compatibility:`/`native:` keys     |
-| `violates the slug rule`                 | Rename the directory to kebab-case         |
+| `violates the slug rule`                 | Rename the directory to lowercase letters, digits, `-`, `_` |
 | `symlinks are not allowed`               | Inline the file, no symlinks               |
 
 Run the test suite too:

--- a/website/docs/skills/authoring.md
+++ b/website/docs/skills/authoring.md
@@ -1,0 +1,161 @@
+---
+sidebar_position: 2
+description: Add a new skill to the Clawrium catalog with the dual-schema validator and CI safety net.
+keywords: [skills, authoring, schema, validator, ci, clawrium, openclaw, hermes, zeroclaw]
+---
+
+# Authoring Skills
+
+Skills are added by dropping a directory into the in-repo
+`skills/<registry>/<name>/` tree, opening a PR, and letting the CI
+validator gate the schema. This page covers both flavours
+side-by-side. The repository
+[`docs/skills/`](https://github.com/ric03uec/clawrium/tree/main/docs/skills)
+guides go deeper on each.
+
+## Choose a registry
+
+| You're adding…                                  | Registry         |
+|-------------------------------------------------|------------------|
+| Behaviour that should run on every claw         | `clawrium/`      |
+| openclaw-specific frontmatter (e.g. allowed-tools) | `openclaw/`   |
+| hermes-specific metadata (tags, homepage)       | `hermes/`        |
+| zeroclaw-specific frontmatter                   | `zeroclaw/`      |
+
+A native skill (`<claw>/<name>`) is installable **only** on agents of
+the matching type. A `clawrium/<name>` skill is installable on any
+agent whose entry in the skill's `compatibility:` map is truthy.
+
+## Slug rule
+
+The skill directory name (and `name:` field in `_meta.yaml` /
+frontmatter) must match:
+
+```
+^[a-z0-9][a-z0-9_-]*$
+```
+
+The directory name and the `name:` field MUST be identical. This is
+the source-dirname == registry-slug invariant required for zeroclaw's
+`skills install`/`remove` CLI to round-trip cleanly (see Phase 0
+findings in `.itx/364/02_PHASE0_FINDINGS.md`).
+
+## `clawrium/<name>/` — cross-agent
+
+Layout:
+
+```
+skills/clawrium/<name>/
+├── _meta.yaml      # required — validated against clawrium.schema.json
+├── SKILL.md        # required — canonical content
+└── README.md       # optional
+```
+
+Minimum `_meta.yaml`:
+
+```yaml
+name: <name>
+description: One-line elevator pitch.
+version: 0.1.0
+compatibility:
+  openclaw: true
+  hermes: true
+  zeroclaw: true
+```
+
+Minimum `SKILL.md`:
+
+```markdown
+---
+name: <name>
+description: One-line elevator pitch.
+---
+
+# Skill body...
+```
+
+## `<claw>/<name>/` — native
+
+Layout:
+
+```
+skills/<claw>/<name>/
+├── SKILL.md        # required — frontmatter is the source of truth
+└── README.md       # optional
+```
+
+**No `_meta.yaml`.** A `_meta.yaml` under a native registry is a hard
+failure in the validator (almost always a misplaced clawrium skill).
+
+Minimum `SKILL.md`:
+
+```markdown
+---
+name: <name>
+description: One-line elevator pitch.
+---
+
+# Skill body...
+```
+
+Forbidden in native frontmatter:
+
+- `compatibility:` — clawrium-only.
+- `native:` — clawrium-only (per-claw override map for the cross-agent
+  shape).
+
+The native schemas are otherwise lenient (`additionalProperties: true`)
+so a claw can add new frontmatter fields upstream without breaking CI.
+
+## Validate locally
+
+```bash
+python scripts/validate_skills.py
+```
+
+Expected output on success:
+
+```
+ok: skills catalog at .../skills validates
+```
+
+Failures print the offending file path and the specific rule violated.
+Common ones:
+
+| Failure message                          | Fix                                        |
+|------------------------------------------|--------------------------------------------|
+| `must equal directory name`              | Make `name:` match the dirname             |
+| `missing required _meta.yaml`            | clawrium skill is missing the file         |
+| `_meta.yaml is only valid under skills/clawrium/` | Move the skill or delete the file |
+| `clawrium-only keys`                     | Remove `compatibility:`/`native:` keys     |
+| `violates the slug rule`                 | Rename the directory to kebab-case         |
+| `symlinks are not allowed`               | Inline the file, no symlinks               |
+
+Run the test suite too:
+
+```bash
+make test
+```
+
+## Smoke-test against a real claw
+
+Before merging, exercise the install/list/remove round-trip against a
+real agent. For a `clawrium/<name>` skill, this means three agents
+(one per claw); for a `<claw>/<name>` native skill, one agent of the
+matching type.
+
+```bash
+clm agent skill install <agent> <registry>/<name>
+clm agent skill list    <agent>
+clm agent skill remove  <agent> <registry>/<name>
+```
+
+The web dashboard's **Agents → `<agent>` → Skills** tab covers the
+same flow.
+
+## CI
+
+[`skills-validate.yml`](https://github.com/ric03uec/clawrium/blob/main/.github/workflows/skills-validate.yml)
+runs `scripts/validate_skills.py` plus the fixture-based unit tests on
+every PR that touches the catalog. The full test suite still runs in
+the main `test.yml` workflow.

--- a/website/docs/skills/intro.md
+++ b/website/docs/skills/intro.md
@@ -1,0 +1,122 @@
+---
+sidebar_position: 1
+description: Browse and install vetted skills onto any agent in your Clawrium fleet.
+keywords: [skills, registry, clawrium, openclaw, hermes, zeroclaw, install]
+---
+
+# Skills
+
+Clawrium ships a curated **skills catalog** that any agent in your
+fleet can install with one command. A skill is a directory of
+behaviour-shaping prompts and metadata that the underlying claw
+discovers at runtime — Test-Driven Development discipline, code-review
+guardrails, security-audit playbooks.
+
+Skills are sourced **only** from the in-repo `skills/` tree. There is no
+URL install, no arbitrary-path install, no third-party registry. The
+catalog is the source of truth, and every PR runs a dual-schema
+validator in CI.
+
+## Quick start
+
+```bash
+# Browse the catalog
+clm skill list
+
+# Inspect a skill before installing
+clm skill show clawrium/tdd
+
+# Install onto an agent
+clm agent skill install my-agent clawrium/tdd
+
+# List skills installed on an agent
+clm agent skill list my-agent
+
+# Remove a skill
+clm agent skill remove my-agent clawrium/tdd
+```
+
+The web dashboard mirrors the same surface under **Agents → `<agent>`
+→ Skills**, plus a top-level **Skills** catalog page for browse.
+
+## Registries
+
+The catalog is split into four **registries** (namespaces). The split
+determines which agents can install a given skill and which JSON
+schema its descriptor validates against.
+
+| Registry   | Install target          | Schema                              |
+|------------|-------------------------|-------------------------------------|
+| `clawrium` | any agent type          | `clawrium.schema.json`              |
+| `openclaw` | only `openclaw` agents  | `native/openclaw.schema.json`       |
+| `hermes`   | only `hermes` agents    | `native/hermes.schema.json`         |
+| `zeroclaw` | only `zeroclaw` agents  | `native/zeroclaw.schema.json`       |
+
+Skills are referenced as `<registry>/<name>` everywhere — CLI args,
+GUI URLs, desired-state files. Bare names (`tdd`) are rejected with a
+hint that suggests the matching `<registry>/<name>`.
+
+### `clawrium/` — cross-agent
+
+Use the `clawrium/` registry when the skill is behaviour you want
+available on **every** kind of claw. The normalized `_meta.yaml` shape
+is materialized into each native frontmatter format at install time —
+a single source file ends up on disk as openclaw-shaped SKILL.md on an
+openclaw agent, hermes-shaped on a hermes agent, and zeroclaw-shaped
+(via `zeroclaw skills install`) on a zeroclaw agent.
+
+### `openclaw/`, `hermes/`, `zeroclaw/` — native
+
+Use a native registry when the skill needs that claw's specific
+frontmatter fields. Native skills are installable **only** on agents
+of the matching type — `clm agent skill install` fails fast if you try
+to mix them.
+
+## On-host install path
+
+| Claw     | On-host location                              | Mechanism                                  |
+|----------|-----------------------------------------------|--------------------------------------------|
+| openclaw | `~/.openclaw/skills/<name>/SKILL.md`          | file copy (auto-scan)                      |
+| hermes   | `~/.hermes/skills/clawrium/<name>/SKILL.md`   | file copy (auto-scan)                      |
+| zeroclaw | `~/.zeroclaw/workspace/skills/<name>/`        | staged + `zeroclaw skills install` (audit) |
+
+Re-running `clm agent skill install` is the drift recovery — the local
+desired-state file at
+`~/.config/clawrium/agents/<agent>/skills.json` is the source of truth,
+and every install/remove re-applies it end-to-end. There is no separate
+`reconcile` command.
+
+## Authoring
+
+See the [authoring guide](authoring.md) for the full step-by-step on
+adding a new skill to the catalog. The short version:
+
+1. Pick a registry (`clawrium/` if cross-agent, otherwise the native
+   registry).
+2. Create `skills/<registry>/<name>/` with `SKILL.md` (and `_meta.yaml`
+   for `clawrium/`).
+3. Run `python scripts/validate_skills.py` locally.
+4. Open a PR. CI re-runs the validator on every push.
+
+## CI safety net
+
+The
+[`skills-validate.yml`](https://github.com/ric03uec/clawrium/blob/main/.github/workflows/skills-validate.yml)
+workflow runs on every PR that touches the catalog. It catches:
+
+- **Path-traversal**: directory names that violate the slug rule,
+  symlinks inside the tree, unexpected top-level files/dirs.
+- **Schema mismatch**: a clawrium `_meta.yaml` mis-placed under a
+  native registry, or clawrium-only frontmatter keys in a native
+  SKILL.md.
+- **Missing required fields** on `_meta.yaml` or SKILL.md frontmatter
+  (per-registry JSON schema).
+- The clawrium "directory name == `_meta.yaml.name`" invariant —
+  required so that zeroclaw's source-dirname install/remove semantics
+  stay consistent with the registry slug.
+
+Run the same checks locally before pushing:
+
+```bash
+python scripts/validate_skills.py
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -38,6 +38,15 @@ const sidebars: SidebarsConfig = {
     'web-dashboard',
     {
       type: 'category',
+      label: 'Skills',
+      collapsed: true,
+      items: [
+        'skills/intro',
+        'skills/authoring',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Scenarios',
       collapsed: true,
       items: [


### PR DESCRIPTION
## Summary

Phase 6 of parent #364. Closes the loop: every Phase 1–5 surface stays correct under contributor edits because CI now gates the catalog.

- `scripts/validate_skills.py` — dual-schema catalog validator. Walks `skills/<registry>/<name>/`, validates each skill against its registry's JSON schema, enforces the slug rule as a path-traversal guard, rejects symlinks anywhere in the tree, and catches schema mismatches the lenient native schemas would otherwise let through (`_meta.yaml` under a native registry, clawrium-only frontmatter keys like `compatibility`/`native` in a native SKILL.md).
- `.github/workflows/skills-validate.yml` — runs the validator + its fixture tests on every PR that touches `skills/`, the schemas, or the validator itself. Least-privilege `permissions: contents: read`, `uv sync --frozen` against `uv.lock`, pinned setup-uv `0.5.x`, Python 3.10 (the declared support floor in `pyproject.toml`).
- `tests/test_validate_skills_script.py` — 36 fixture tests expressing the Phase 6 contract (CI rejects invalid fixtures, accepts valid ones), plus exit-code 0/1/2 contract tests on `main()` and integration tests against the real catalog.
- `docs/skills/{index,authoring-clawrium,authoring-native}.md`, `website/docs/skills/{intro,authoring}.md` (registered in `sidebars.ts`), and `AGENTS.md` quickstart update.

Stacked on top of `issue-384-gui-skill-install-all-claws`.

## Testing

### Test Results
- [x] All existing tests pass (\`make test\`) — 2154 pytest + 115 vitest
- [x] Linter passes (\`make lint\`) — ruff + next lint clean
- [x] New tests added for new functionality — `tests/test_validate_skills_script.py` (36 cases) and 5 new tests in `tests/test_core_skills.py`

### Manual Testing

Final acceptance sweep on Phase 0 fleet (`wolf-i` / 192.168.1.36), all three `tdd-*` agents, both surfaces. CLI: `clm skill list`, then install / list / remove × 3 claws. GUI (FastAPI surface): \`GET /api/skills\`, then \`POST\`/\`GET\`/\`DELETE /api/agents/<agent>/skills/clawrium/tdd\` × 3 claws. All round-trips clean. Full transcript: \`.itx/385/01_EXECUTION.md\`.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — validator enforces slug rule (\`^[a-z0-9][a-z0-9_-]*$\`) on every skill directory name; rejects symlinks at registry root, inside skills, and at catalog root; rejects unexpected top-level entries
- [x] No SQL injection, XSS, or command injection risks — validator is pure-Python, reads files only, never shells out
- [x] Dependencies are from trusted sources — relies on existing `pyyaml` + `jsonschema`

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: ~$9.5 | Total Time: ~30m | 4 iterations**

| Review | Rating | Blocking Issues | Status | Agents |
|--------|--------|-----------------|--------|--------|
| 1 | 2/5 | B1–B7 (7) | All fixed in iter1 | core-lifecycle, cli-ux, ansible-registry, test-coverage |
| 2 | 2/5 | NB1–NB4 (4) | All fixed in iter2 | leader + 4 specialists (security skipped iter1, present iter2) |
| 3 | 3/5 | 0 at B-level (NB1 partial, NB2 wrong-mechanism flagged) | Fixed in iter3 | leader + 3 specialists |
| 4 | **4/5** | **0** | **Ready** | security, core-lifecycle, ansible-registry, leader |

> **Note**: ATX does not expose model information per agent. CLI-UX and test-coverage reviewers hit max-turns in iter3; their iter1/iter2 findings were fully addressed and not regressed.

<details>
<summary>Review 1 Details (Rating 2/5) — B1–B7 blockers</summary>

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `scripts/validate_skills.py:252` | `_split_frontmatter` raised uncaught `SchemaValidationError` for list/scalar frontmatter | Fixed — wrapped in try/except, surfaces as `ValidationFailure` |
| B2 | `scripts/validate_skills.py:303–317` | Security: `is_file()` follows symlinks → registry-root symlink bypass | Fixed — symlink check moved before `is_file()` (mirrors `_validate_unexpected_registries`) |
| B3 | `tests/test_validate_skills_script.py` | `main()` untested — exit-code 0/1/2 contract unverified | Fixed — `test_main_exit_0/1/2*` added |
| B4 | `tests/test_validate_skills_script.py` | Missing `_meta.yaml` branch untested | Fixed — `test_missing_meta_yaml_rejected` |
| B5 | `tests/test_validate_skills_script.py` | Native-missing-`SKILL.md` branch untested | Fixed — `test_native_skill_missing_skill_md_rejected` |
| B6 | `docs/skills/authoring-clawrium.md:110` | Docs cited wrong error substring (`failed clawrium-skill schema`) | Fixed — substring updated to actual `failed Clawrium normalized skill (_meta.yaml) validation` |
| B7 | `.github/workflows/skills-validate.yml:34` | CI pinned 3.11 but pyproject declares `>=3.10` (support floor untested) | Fixed — pinned to 3.10 |

Iter1 also addressed W1–W12 (uv version pin, cache, `clear_schema_cache()` export, fixture using public API, slug-as-symlink test, catalog-root symlink test, invalid-YAML/non-dict `_meta.yaml` tests, tighter assertion, softened docs language, AGENTS.md quickstart sync, native `make test` step) and S1–S6 (unused imports, FAILED summary line, parameterized native registries, empty-catalog test, sync-convention doc comment, step-ordering CI comment).

</details>

<details>
<summary>Review 2 Details (Rating 2/5) — NB1–NB4 + 14 warnings</summary>

All iter1 fixes confirmed correct. New blockers surfaced under deeper analysis:

| # | File | Issue | Resolution |
|---|------|-------|------------|
| NB1 | `scripts/validate_skills.py:197,267` | `_load_schema()` outside try/except — could leak `SchemaValidationError` past the exit-2 contract | Fixed — new `_InternalValidationError` + `_safe_load_schema` wrapper; iter3+iter4 widened to also catch `OSError` |
| NB2 | `scripts/validate_skills.py:73–81` | Script imported four private symbols not in `__all__` — silent break on rename | First fixed by adding to `__all__` (iter2); iter3 reverted to correct mechanism — names stay private, contract comment moved to import site, `__all__` stays clean |
| NB3 | `_split_frontmatter` yaml.YAMLError branch 0-covered | Fixed — `test_native_skill_invalid_yaml_syntax_rejected` |
| NB4 | `load_skill` yaml.YAMLError branch 0-covered | Fixed — `test_load_skill_rejects_malformed_meta_yaml` + non-mapping counterpart |

Warnings: workflow `permissions: contents: read`, `uv sync --frozen`, docstring corrections (`check_agent_compatibility` defaults closed), stdout assertion on `test_main_exit_0`, autouse fixture uses `clear_schema_cache()`, parameterized clawrium-only-key test over both `compatibility` and `native`, dropped unused `monkeypatch` param, `_load_schema` missing/corrupt tests, `clear_schema_cache` round-trip test, slug-rule wording correction ("lowercase, hyphens/underscores"), removed unreachable doc table row, added missing schema-error row to website guide, converted native guide bullets to a failure table, AGENTS.md disambiguation: "Agent Registry" vs new "Skill Registry"; Development Workflow section renamed to "Workflow Commands".

NW2 (SHA-pin third-party actions) deferred — rest of the repo uses tag pins; tracked as a separate hardening pass. NW15 (hardcoded `/home/{{ agent_name }}` in apply playbooks) is pre-existing in `#381`/`#382`.

</details>

<details>
<summary>Review 3 Details (Rating 3/5) — NB1 partial, NB2 wrong-mechanism</summary>

No B-level blockers, but two iter2 fixes flagged as not-cleanly-resolved:

- **NB1 partial** — `_safe_load_schema` only caught `SchemaValidationError`, not `OSError`. A `PermissionError` between `is_file()` and `read_text()` would still exit 1. **Fixed in iter4** — `except (SchemaValidationError, OSError)`, new test `test_main_exit_2_on_permission_error_reading_schema`.
- **NB2 wrong mechanism** — putting underscored names in `__all__` widened the perceived public API. `__all__` only affects star-imports; the script imports by explicit name. **Fixed in iter4** — names removed from `__all__`, contract comment moved to the validator's import site.

Two warnings the reviewer attributed to iter3 turned out to be pre-existing in files from `#381`/`#382` (staging_dir orphan in `skills_apply.py`, `InvalidSkillRef` reuse in `skills_state.py`) — out of scope for #385.

</details>

<details>
<summary>Review 4 Details (Rating 4/5) — Ready</summary>

NB1 + NB2 both confirmed resolved across all responding specialists. Zero blocking issues. Three cheap warnings:

- **W1** — `_InternalValidationError` exit-2 branch in `main()` was the only error path without a `hint:` line. **Fixed** — added a follow-up hint pointing at `skills/_schema/` integrity and a remediation command.
- **W2** — `test_main_exit_2_on_permission_error_reading_schema` asserted only the bare `PermissionError` text. **Fixed** — now pins the wrapper prefix, the registry-name interpolation, the underlying OSError detail, the hint line, and asserts empty stdout.
- **W3** — Native-registry OSError propagation chain (`_validate_native_skill → _validate_registry → validate_catalog → main`) untested for the exit-2 path. **Fixed** — added `test_main_exit_2_on_permission_error_for_native_registry`.

Non-blocking suggestions (S1–S4) acknowledged in code via per-callsite comments and stdout assertions.

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>