### PR TITLE
Sync issue-386-phase0-research → main (Phase 0 stragglers + Phase 1 / #380)

### DIFF
--- a/.itx/364/00_PLAN.md
+++ b/.itx/364/00_PLAN.md
@@ -42,7 +42,7 @@ flowchart TD
     subgraph Remote["Remote hosts"]
         OcHost["~/.openclaw/skills/&lt;name&gt;/"]
         HeHost["~/.hermes/skills/clawrium/&lt;name&gt;/"]
-        ZeHost["~/.zeroclaw/skills/&lt;name&gt;/<br/>(via native CLI)"]
+        ZeHost["~/.zeroclaw/workspace/skills/&lt;name&gt;/<br/>(via native CLI)"]
     end
 
     User --> CLI
@@ -117,9 +117,9 @@ flowchart TD
           ▼                       ▼                      ▼
    ┌─────────────┐         ┌────────────────┐    ┌─────────────────┐
    │  ~/.open    │         │ ~/.hermes/     │    │ ~/.zeroclaw/    │
-   │  claw/      │         │ skills/        │    │ skills/<name>/  │
-   │  skills/    │         │ clawrium/      │    │ (via native     │
-   │  <name>/    │         │ <name>/        │    │  CLI)           │
+   │  claw/      │         │ skills/        │    │ workspace/      │
+   │  skills/    │         │ clawrium/      │    │ skills/<name>/  │
+   │  <name>/    │         │ <name>/        │    │ (via native CLI)│
    └─────────────┘         └────────────────┘    └─────────────────┘
 
    skills/ catalog (this repo) — read by core/skills.py

--- a/.itx/364/00_PLAN.md
+++ b/.itx/364/00_PLAN.md
@@ -34,7 +34,7 @@ flowchart TD
     end
 
     subgraph Playbooks["platform/registry/&lt;claw&gt;/playbooks/skills_apply.yaml"]
-        OcApply["openclaw: copy +<br/>re-render openclaw.json"]
+        OcApply["openclaw: copy to<br/>~/.openclaw/skills/&lt;name&gt;/"]
         HeApply["hermes: copy to<br/>~/.hermes/skills/clawrium/"]
         ZeApply["zeroclaw: stage +<br/>zeroclaw skills install (native audit gate)"]
     end
@@ -107,10 +107,10 @@ flowchart TD
    │ skills_     │         │  skills_    │        │   skills_    │
    │ apply.yaml  │         │  apply.yaml │        │  apply.yaml  │
    │             │         │             │        │              │
-   │ copy +      │         │ copy →      │        │ stage +      │
-   │ re-render   │         │ ~/.hermes/  │        │ `zeroclaw    │
-   │ openclaw.   │         │ skills/     │        │  skills      │
-   │ json        │         │ clawrium/   │        │  install`    │
+   │ copy only   │         │ copy →      │        │ stage +      │
+   │ (auto-scan) │         │ ~/.hermes/  │        │ `zeroclaw    │
+   │             │         │ skills/     │        │  skills      │
+   │             │         │ clawrium/   │        │  install`    │
    │             │         │             │        │ (audit gate) │
    └──────┬──────┘         └──────┬──────┘        └──────┬───────┘
           │                       │                      │
@@ -142,7 +142,7 @@ Re-running any `install` / `remove` always reconciles local → remote. There is
 2. **Skill reference is `<registry>/<name>`.** Bare names rejected with `MissingRegistryPrefix` and a hint.
 3. **Local desired-state is truth.** `install` / `remove` mutate `~/.config/clawrium/agents/<agent>/skills.json` and always invoke the per-claw `skills_apply.yaml`. No short-circuit.
 4. **Per-claw mechanism follows the native idiom**:
-   - openclaw — `copy` + re-render `openclaw.json` if this fork is config-driven (phase-0 verifies)
+   - openclaw — `copy` only (Phase 0 verified auto-scan at `~/.openclaw/skills/<name>/`; no `openclaw.json` re-render)
    - hermes — `copy` to `~/.hermes/skills/clawrium/<name>/` (auto-scan)
    - zeroclaw — stage + `zeroclaw skills install <staging-path>` so the native security audit runs
 5. **Pruning is bounded** to a clawrium-owned subtree per claw. Never touches user-authored or upstream-bundled skills.
@@ -220,7 +220,7 @@ Resolution rules at install:
 
 | Phase | Scope | Exit criteria |
 |---|---|---|
-| 0 | Unblockers (no PR) | Verify whether openclaw in this fork is auto-scan or config-driven; confirm zeroclaw on-host path `~/.zeroclaw/skills/<name>/`; lock TDD normalized frontmatter that passes all three native schemas |
+| 0 | Unblockers (now closed by #386) | Verify openclaw discovery (resolved: auto-scan); confirm zeroclaw on-host path (resolved: `~/.zeroclaw/workspace/skills/<name>/`); lock normalized `_meta.yaml` shape that satisfies all three native schemas. See `.itx/364/02_PHASE0_FINDINGS.md`. |
 | 1 | Schema + core loader + namespaced catalog + TDD seed | `skills/clawrium/tdd/` validates; `skills/{openclaw,hermes,zeroclaw}/` exist with READMEs; `parse_skill_ref` + dual validator tested |
 | 2 | Desired-state store + `apply_state` entrypoint | CLI + GUI both consume one stable API; round-trip on a fake claw works in tests |
 | 3 | Per-claw `skills_apply.yaml` for all three claws | Round-trip install/remove on each claw via mocked ansible-runner; zeroclaw uses native CLI; pruning bounded |
@@ -241,7 +241,7 @@ Resolution rules at install:
 | # | Item | Default |
 |---|------|---------|
 | Q1 | Hermes namespace for clawrium skills: `~/.hermes/skills/clawrium/<name>/` | Yes |
-| Q2 | openclaw discovery: auto-scan vs config-driven | Phase 0 verifies; if config-driven, re-render `openclaw.json` |
+| Q2 | openclaw discovery: auto-scan vs config-driven | RESOLVED: auto-scan — plain file copy to `~/.openclaw/skills/<name>/`, no `openclaw.json` re-render (see `02_PHASE0_FINDINGS.md` §1) |
 | Q3 | Seed per-claw folders with one native skill in v1 | No — empty placeholders; one PR adds later |
 | Q4 | Strict refs (`<registry>/<name>`) vs auto-prefix `clawrium/` | Strict; clearer errors |
 | Q5 | zeroclaw idempotency: `zeroclaw skills install` re-runs on already-installed | Check `zeroclaw skills list` first; install only on diff |

--- a/.itx/364/02_PHASE0_FINDINGS.md
+++ b/.itx/364/02_PHASE0_FINDINGS.md
@@ -31,7 +31,10 @@ Pulled to the top because every Phase-1 reader needs these.
 4. **Q5 (zeroclaw idempotency)** — resolve as: query `zeroclaw skills
    list`, parse the slug column, install only on diff; remove only when
    the slug is present. No probe via `--check-installed` style — the
-   v0.7.5 CLI doesn't expose one.
+   v0.7.5 CLI doesn't expose one. Openclaw and Hermes don't need an
+   equivalent guard — both materialize via Ansible's `copy` module
+   (declarative; same source ⇒ no-op), so the list-first diff is a
+   zeroclaw-only concern driven by the native CLI's side-effects.
 5. **`skills_remove.yaml` cross-claw asymmetry**: zeroclaw removes
    take the source-dirname, while openclaw/hermes remove by deleting
    the directory at `<scan-path>/<name>/`. With the invariant in (3),
@@ -195,6 +198,46 @@ Installed skills (1):
    corrupts the desired-state file. State this invariant explicitly in
    `validate_skill()` error messages.
 
+## Phase 1 code-inspection prerequisites
+
+Three Phase-1 prerequisites that don't fall out of the playbook
+behavior probes above, but are visible in the current codebase. Each
+is verifiable by reading the cited file at the cited line range.
+
+1. **`AgentManifest` TypedDict has no `skills` field.**
+   `src/clawrium/core/registry.py` defines `AgentManifest` with keys
+   `agent`, `platforms`, `secrets`, `onboarding`, `workspace`,
+   `features` — no `skills`. Phase 1 must either (a) extend
+   `AgentManifest` with an optional `skills` field, or (b) keep agent
+   manifests untouched and load skill catalog state via a parallel
+   `_meta.yaml`-driven path under `core/skills.py`. Plan section
+   *Files to add / modify → Core* implies (b); call the choice
+   explicitly when Phase 1 opens.
+2. **`~/.zeroclaw/workspace/skills/` is not scaffolded by zeroclaw's
+   `install.yaml`.** The playbook creates the workspace directory and
+   the seven personality templates (SOUL/IDENTITY/USER/AGENTS/TOOLS/
+   MEMORY/HEARTBEAT) but stops there. The `skills/` subdirectory is
+   created on demand by `zeroclaw skills install` on first use (probe
+   in §2 above corroborates: no `skills/` existed under `zc-test`
+   workspace pre-install, was present post-install). Phase 3's
+   `zeroclaw/playbooks/skills_apply.yaml` must therefore tolerate
+   missing-directory state and not assume the dir exists before the
+   first skill is staged.
+3. **First reconcile against an agent with no `skills.json`
+   desired-state must be add-only.** Plan section *Architecture
+   decisions (locked) — 3* declares "Local desired-state is truth" and
+   *— 5* declares "Pruning is bounded to a clawrium-owned subtree per
+   claw." A naive Phase-3 implementation would treat a missing
+   desired-state file as "desired = []" and **prune everything** in
+   the clawrium-owned subtree on first run. Agents like `zc-test` (or
+   any agent the user managed pre-registry) may carry skill files
+   inside paths the registry will later claim. The mitigation is to
+   distinguish *first reconcile* (no `skills.json` exists yet) from
+   *subsequent reconciles*; first reconcile writes the desired-state
+   file from a scan of what's already on disk in clawrium-owned
+   paths, then exits without pruning. Phase 3 design must include
+   this branch.
+
 ## Proposed `_meta.yaml` shape for all `clawrium/` skills
 
 **This section is a design proposal, not an empirical finding.** No
@@ -244,8 +287,9 @@ license: MIT
 author: clawrium
 platforms: [linux, macos]
 
-# Cross-agent compatibility flags consumed by core/skills.py
-# check_agent_compatibility. Per the plan, clawrium/* is installable on
+# Cross-agent compatibility flags. To be consumed by a Phase 1
+# `check_agent_compatibility()` function in core/skills.py — not yet
+# implemented; Phase 1 introduces it. Per the plan, clawrium/* is installable on
 # any agent type; the flags below let a normalized skill opt out of a
 # specific claw if it can't fulfill that claw's runtime contract.
 compatibility:

--- a/.itx/364/02_PHASE0_FINDINGS.md
+++ b/.itx/364/02_PHASE0_FINDINGS.md
@@ -20,8 +20,10 @@ Pulled to the top because every Phase-1 reader needs these.
    enablement gate, not part of the discovery path — only the planned
    playbook re-render task is removed.
 2. **Use `~/.zeroclaw/workspace/skills/` everywhere** the plan currently
-   says `~/.zeroclaw/skills/`. This PR also patches the two stale path
-   references in `00_PLAN.md` (mermaid box + ASCII rendering box).
+   says `~/.zeroclaw/skills/`. This PR patches three stale path
+   references in `00_PLAN.md`: the mermaid `ZeHost` box, the ASCII
+   apply-flow rendering box, and the Phase-0 row of the *Phased
+   execution* table.
 3. **Adopt source-dirname == registry slug == `_meta.yaml.name`** as a
    hard invariant enforced at `core/skills.py` validation time.
    `zeroclaw skills list` returns the internal `name:` field, but
@@ -180,15 +182,41 @@ Installed skills (1):
 4. **`audit` is a separate subcommand.** `zeroclaw skills audit <path>`
    runs the security check without installing. The plan's "native audit
    gate" is enforced on every `install` (per the success line above), so
-   no separate audit step is needed in the apply playbook.
+   no separate audit *invocation* is needed in the apply playbook —
+   **but** the zeroclaw audit scope is opaque to clawrium (the v0.7.5
+   CLI exposes no audit-rules documentation; the probe output reports
+   only "Security audit completed successfully"). `core/skills.py
+   validate_skill()` must therefore enforce slug format (e.g.
+   `^[a-zA-Z0-9_-]+$`), path-traversal rejection, and the
+   `prerequisites.commands` allow-list **independently** at catalog
+   load time, mirroring the path-traversal check called out at
+   `00_PLAN.md:203`. The native audit is a defense-in-depth layer at
+   the zeroclaw boundary, not a substitute for clawrium-side
+   validation.
 
-5. **Idempotency check (Q5 in plan)**: `zeroclaw skills list` returns
-   the internal `name:` field, so the playbook should:
+5. **Idempotency check (Q5 in plan) — list-first guard is MANDATORY,
+   not optional.** Empirical probe:
+
+   ```
+   # First install
+   $ zeroclaw skills install /tmp/clawrium-phase0-dupprobe
+     ✓ Skill installed and audited:
+       /home/zc-test/.zeroclaw/workspace/skills/clawrium-phase0-dupprobe
+
+   # Second install (same source path)
+   $ zeroclaw skills install /tmp/clawrium-phase0-dupprobe
+     ✗ rc=1
+     stderr: Destination skill already exists:
+             /home/zc-test/.zeroclaw/workspace/skills/clawrium-phase0-dupprobe
+   ```
+
+   Duplicate install **fails** with rc=1 — the native CLI does not
+   silently overwrite. So the playbook **must**:
    - run `zeroclaw skills list` first
-   - skip `install` if the slug appears in the list
+   - skip `install` if the slug appears in the list (avoid the rc=1)
    - call `remove <slug>` (slug == source-dirname) on uninstall
 
-   The algorithm above is **only safe when** the invariant
+   The algorithm above is **only correct when** the invariant
    `slug == source-dirname == _meta.yaml.name` holds. `list` reports
    the internal name; `remove` accepts the source-dirname; these two
    strings are forced equal by adjustment (3) in the executive summary
@@ -198,45 +226,53 @@ Installed skills (1):
    corrupts the desired-state file. State this invariant explicitly in
    `validate_skill()` error messages.
 
-## Phase 1 code-inspection prerequisites
+## Phase 1 prerequisites (codebase + arch-decision derived)
 
-Three Phase-1 prerequisites that don't fall out of the playbook
-behavior probes above, but are visible in the current codebase. Each
-is verifiable by reading the cited file at the cited line range.
+Three Phase-1 prerequisites. Items 1 and 2 are visible in the current
+codebase at the cited line ranges; item 3 is *implied by* (not visible
+in) the locked architecture decisions in `00_PLAN.md`.
 
 1. **`AgentManifest` TypedDict has no `skills` field.**
-   `src/clawrium/core/registry.py` defines `AgentManifest` with keys
-   `agent`, `platforms`, `secrets`, `onboarding`, `workspace`,
-   `features` — no `skills`. Phase 1 must either (a) extend
-   `AgentManifest` with an optional `skills` field, or (b) keep agent
-   manifests untouched and load skill catalog state via a parallel
-   `_meta.yaml`-driven path under `core/skills.py`. Plan section
-   *Files to add / modify → Core* implies (b); call the choice
+   `src/clawrium/core/registry.py` defines `AgentManifest` (lines
+   143–151) with keys `agent`, `platforms`, `secrets`, `onboarding`,
+   `workspace`, `features` — no `skills`. Phase 1 must either (a)
+   extend `AgentManifest` with an optional `skills` field, or (b) keep
+   agent manifests untouched and load skill catalog state via a
+   parallel `_meta.yaml`-driven path under `core/skills.py`. Plan
+   section *Files to add / modify → Core* implies (b); call the choice
    explicitly when Phase 1 opens.
-2. **`~/.zeroclaw/workspace/skills/` is not scaffolded by zeroclaw's
-   `install.yaml`.** The playbook creates the workspace directory and
-   the seven personality templates (SOUL/IDENTITY/USER/AGENTS/TOOLS/
-   MEMORY/HEARTBEAT) but stops there. The `skills/` subdirectory is
-   created on demand by `zeroclaw skills install` on first use (probe
-   in §2 above corroborates: no `skills/` existed under `zc-test`
-   workspace pre-install, was present post-install). Phase 3's
-   `zeroclaw/playbooks/skills_apply.yaml` must therefore tolerate
-   missing-directory state and not assume the dir exists before the
-   first skill is staged.
+2. **`~/.zeroclaw/workspace/skills/` is not scaffolded by any current
+   playbook.** Zeroclaw's `install.yaml` creates only `workspace/`
+   (lines 125–131) and `state/` (lines 133–139). The seven personality
+   templates (SOUL/IDENTITY/USER/AGENTS/TOOLS/MEMORY/HEARTBEAT) are
+   rendered by `configure.yaml` (lines 56–71) via an Ansible
+   `template` loop. Neither playbook creates `workspace/skills/`; the
+   `skills/` subdirectory is created on demand by `zeroclaw skills
+   install` on first use (probe in §2 above: no `skills/` existed
+   under `zc-test` workspace pre-install, was present post-install).
+   Phase 3's `zeroclaw/playbooks/skills_apply.yaml` must therefore
+   tolerate the missing-directory state and not assume the dir exists
+   before the first skill is staged.
 3. **First reconcile against an agent with no `skills.json`
-   desired-state must be add-only.** Plan section *Architecture
-   decisions (locked) — 3* declares "Local desired-state is truth" and
-   *— 5* declares "Pruning is bounded to a clawrium-owned subtree per
-   claw." A naive Phase-3 implementation would treat a missing
-   desired-state file as "desired = []" and **prune everything** in
-   the clawrium-owned subtree on first run. Agents like `zc-test` (or
-   any agent the user managed pre-registry) may carry skill files
-   inside paths the registry will later claim. The mitigation is to
-   distinguish *first reconcile* (no `skills.json` exists yet) from
-   *subsequent reconciles*; first reconcile writes the desired-state
-   file from a scan of what's already on disk in clawrium-owned
-   paths, then exits without pruning. Phase 3 design must include
-   this branch.
+   desired-state must be add-only.** This item is **derived from**
+   `00_PLAN.md` arch decisions 3 ("Local desired-state is truth") and
+   5 ("Pruning is bounded to a clawrium-owned subtree per claw") — it
+   does not surface as code today because the desired-state machinery
+   doesn't exist yet. A naive Phase-3 implementation would treat a
+   missing desired-state file as "desired = []" and **prune
+   everything** in the clawrium-owned subtree on first run. Agents
+   like `zc-test` (or any agent the user managed pre-registry) may
+   carry skill files inside paths the registry will later claim. The
+   mitigation: distinguish *first reconcile* (no `skills.json` exists
+   yet) from *subsequent reconciles*; first reconcile writes the
+   desired-state file from a scan of what's already on disk in
+   clawrium-owned paths, then exits without pruning. Phase 3 design
+   must include this branch, and "clawrium-owned" must be a positive
+   signal (e.g., a `.clawrium-managed` marker file written at
+   `skills_apply.yaml` install time, or a catalog cross-reference) —
+   not a path-prefix heuristic, which would silently absorb any
+   user-authored directory whose name happens to match a future
+   registry slug.
 
 ## Proposed `_meta.yaml` shape for all `clawrium/` skills
 

--- a/.itx/364/02_PHASE0_FINDINGS.md
+++ b/.itx/364/02_PHASE0_FINDINGS.md
@@ -1,9 +1,59 @@
 # Issue #364 — Phase 0 Findings (Research + Test-Fleet Stand-Up)
 
-Empirical verification of the four assumptions in `00_PLAN.md` before
-implementing phases 1–6 of the Skills Registry. Numbers below come from
-`ansible-playbook` probes against the shared test fleet on host `wolf-i`
-(192.168.1.36), not from documentation.
+Empirical verification of plan-table items **Q2** (openclaw discovery)
+and **Q5** (zeroclaw idempotency) from `00_PLAN.md`, plus a worked
+proposal for the normalized `_meta.yaml` shape (Q1 / Q3 / Q4 remain
+locked as the plan states). Section 1 ("Openclaw") and section 2
+("Zeroclaw") are empirical — `ansible-playbook` output against host
+`wolf-i` (192.168.1.36). Section 3 (`_meta.yaml`) is a **design
+proposal**: no `_meta.yaml` files exist in the codebase yet; the shape
+will be validated at Phase 1 schema-implementation time.
+
+## Executive summary — net plan adjustments for Phase 1+
+
+Pulled to the top because every Phase-1 reader needs these.
+
+1. **Drop `openclaw.json` re-rendering** from openclaw's
+   `skills_apply.yaml`. Plain file copy to `~/.openclaw/skills/<name>/`
+   is sufficient. Leave the `{% if config.skills … %}` conditional in
+   `openclaw.json.j2` lines 28–32 **in place** — it's an optional
+   enablement gate, not part of the discovery path — only the planned
+   playbook re-render task is removed.
+2. **Use `~/.zeroclaw/workspace/skills/` everywhere** the plan currently
+   says `~/.zeroclaw/skills/`. This PR also patches the two stale path
+   references in `00_PLAN.md` (mermaid box + ASCII rendering box).
+3. **Adopt source-dirname == registry slug == `_meta.yaml.name`** as a
+   hard invariant enforced at `core/skills.py` validation time.
+   `zeroclaw skills list` returns the internal `name:` field, but
+   `zeroclaw skills remove` takes the *source directory name* — these
+   two strings only coincide when the invariant holds. Without it, the
+   idempotency algorithm in Phase 3 silently mis-removes skills.
+4. **Q5 (zeroclaw idempotency)** — resolve as: query `zeroclaw skills
+   list`, parse the slug column, install only on diff; remove only when
+   the slug is present. No probe via `--check-installed` style — the
+   v0.7.5 CLI doesn't expose one.
+5. **`skills_remove.yaml` cross-claw asymmetry**: zeroclaw removes
+   take the source-dirname, while openclaw/hermes remove by deleting
+   the directory at `<scan-path>/<name>/`. With the invariant in (3),
+   these are the same string; **without** it, a native skill's
+   on-disk dir name and `name:` frontmatter could diverge and the
+   remove playbook must not assume they match for non-`clawrium/`
+   skills.
+6. **Phase 1 prerequisites the plan didn't surface**: extend
+   `core/registry.py` `AgentManifest` TypedDict with an optional
+   `skills` field (currently has `agent`, `platforms`, `secrets`,
+   `onboarding`, `workspace`, `features` — no `skills`), and
+   create-on-first-use `~/.zeroclaw/workspace/skills/` (zeroclaw's
+   `install.yaml` scaffolds `workspace/` but not the `skills/`
+   subdirectory). On first reconcile against an agent with no prior
+   `skills.json` desired-state, the playbook must run **add-only** —
+   pruning activates only after the first reconciled state file exists,
+   so pre-existing user-authored skills on `zc-test`-style agents are
+   never silently wiped.
+7. **`nemoclaw` is out of Phase 1 scope.** The proposed `_meta.yaml`
+   `compatibility` map intentionally lists only openclaw, hermes,
+   zeroclaw — `nemoclaw` exists in the registry but is not part of the
+   #364 v1. Add it in a follow-up issue if/when needed.
 
 ## Openclaw discovery mode
 
@@ -52,6 +102,13 @@ Source-code references:
   automatically`) — bundled-skill side, not user skills
 
 ## Zeroclaw on-host path + CLI
+
+All zeroclaw probes below ran against the **pre-existing `zc-test`
+agent** (zeroclaw v0.7.5, same binary as the newly-installed
+`tdd-zeroclaw`). `zc-test` was chosen because its daemon was already
+up and the `skills` subcommand operates against the on-disk workspace,
+which is independent of gateway state — running the probe on the
+degraded `tdd-zeroclaw` would have produced identical results.
 
 **Answer (one correction to the plan):**
 
@@ -128,7 +185,32 @@ Installed skills (1):
    - skip `install` if the slug appears in the list
    - call `remove <slug>` (slug == source-dirname) on uninstall
 
-## Locked `_meta.yaml` shape for `clawrium/tdd`
+   The algorithm above is **only safe when** the invariant
+   `slug == source-dirname == _meta.yaml.name` holds. `list` reports
+   the internal name; `remove` accepts the source-dirname; these two
+   strings are forced equal by adjustment (3) in the executive summary
+   and enforced at `core/skills.py` validation. A `clawrium/<name>`
+   skill whose `_meta.yaml.name` differs from `<name>` must be rejected
+   at load time, otherwise the install/skip/remove cycle silently
+   corrupts the desired-state file. State this invariant explicitly in
+   `validate_skill()` error messages.
+
+## Proposed `_meta.yaml` shape for all `clawrium/` skills
+
+**This section is a design proposal, not an empirical finding.** No
+`_meta.yaml` files exist anywhere in the codebase yet. The shape below
+is grounded in observed native-frontmatter requirements (probed
+empirically and tabulated below), but its final validation lands at
+Phase 1 schema implementation. Treat the YAML at the end of this
+section as the *starting point* for Phase 1, not a frozen contract.
+
+The Hermes column in the table below comes from **runtime observation**
+of an installed Hermes skill (`/home/espresso/.hermes/skills/social-media/xurl/SKILL.md`),
+not from registry source — there is currently no skill-related
+infrastructure under `src/clawrium/platform/registry/hermes/`. The
+frontmatter shape there is the de-facto Hermes convention; Phase 1
+should re-confirm against the Hermes runtime if the materializer
+output drifts.
 
 Goal: one normalized cross-agent file the clawrium core reads
 (`load_skill` / `validate_skill`), which is then materialized into each
@@ -242,34 +324,48 @@ scope for this issue and not shown.)
 **`tdd-zeroclaw` partial-degradation note (downstream-fixable, not a
 Phase 0 blocker):**
 
-`systemctl status zeroclaw-tdd-zeroclaw.service` shows `active (running)`
-— the daemon process is up. The `degraded` label in `clm ps` reflects
-the manifest's required-secret check (`LLM_PROVIDER_URL`, `LLM_MODEL`):
-the daemon log emits `ERROR zeroclaw_runtime::daemon: Daemon component
-'gateway' failed: Unknown provider: default. Check README for supported
-providers or run zeroclaw onboard to reconfigure.` This is the same
-configure-time schema mismatch that affects the pre-existing `zc-test`
-agent and is **independent of the skills-registry work**: `zeroclaw
-skills install / list / audit / remove` operate against the on-disk
-workspace and were verified working on the same v0.7.5 binary above,
-regardless of gateway state. The zeroclaw configure-playbook ↔ v0.7.5
-TOML-schema fix is a separate platform issue.
+`systemctl status zeroclaw-tdd-zeroclaw.service` shows
+`active (running)` — the daemon process is up. The `degraded` label in
+`clm ps` comes from the manifest's required-secret check
+(`secrets.required: [LLM_PROVIDER_URL, LLM_MODEL]` in
+`zeroclaw/manifest.yaml`); the daemon log separately emits
+`ERROR zeroclaw_runtime::daemon: Daemon component 'gateway' failed:
+Unknown provider: default.` There are **two distinct issues** mashed
+together by `clm ps` here:
 
-## Net plan adjustments for Phase 1+
+- **Secret contract mismatch (the cause of the `degraded` label):**
+  the manifest declares `LLM_PROVIDER_URL` and `LLM_MODEL` as required
+  secrets, but the configure playbook writes provider values into
+  `~/.zeroclaw/config.toml` via the `[providers.models.<type>]` TOML
+  block. The systemd unit emits no `EnvironmentFile` for the agent
+  account, so those keys never reach the daemon as env vars. The
+  manifest's required-secrets contract and the configure playbook's
+  TOML-output contract are unaligned.
+- **Daemon-side schema mismatch (the cause of the daemon-log `ERROR`):**
+  the configure playbook writes `default_provider = "ollama"` and a
+  `[providers.models.ollama]` block, but zeroclaw v0.7.5's runtime
+  looks up `[providers.models.default]` (literal `default`). So even
+  if the secret contract is fixed, the daemon would still fail.
 
-1. **Drop `openclaw.json` re-rendering** from openclaw's
-   `skills_apply.yaml`. Plain file copy to `~/.openclaw/skills/<name>/`
-   is sufficient. (Plan section *Architecture decisions (locked) — 4*
-   bullet for openclaw can be replaced with `copy` only.)
-2. **Use `~/.zeroclaw/workspace/skills/` everywhere** the plan currently
-   says `~/.zeroclaw/skills/`: tables in *Per-claw mechanism* and
-   *Workflow → Remote hosts*, and the ASCII rendering box for zeroclaw.
-3. **Adopt source-dirname == registry slug** as a hard rule, so
-   zeroclaw `remove` arguments match the same string the playbook stages
-   and the same string in the `<registry>/<name>` ref. Surface this in
-   `core/skills.py` validation: reject a `clawrium/<name>` skill if its
-   `_meta.yaml.name` does not equal `<name>`.
-4. **Q5 (zeroclaw idempotency)** — resolve as: query `zeroclaw skills
-   list`, parse the slug column, install only on diff; remove only when
-   the slug is present. No probe via `--check-installed` style — the
-   v0.7.5 CLI doesn't expose one.
+Both are pre-existing platform issues (same failure on `zc-test`),
+**independent of the skills-registry work**. `zeroclaw skills install
+/ list / audit / remove` operate against the on-disk workspace and
+were verified working on the same v0.7.5 binary above, regardless of
+gateway state. **Implication for Phase 1 testing:** route the
+end-to-end skill-install integration tests against `tdd-zeroclaw` using
+the skills CLI directly (workspace path is reachable); end-to-end
+*agent-uses-skill* tests must wait until the configure ↔ v0.7.5
+alignment lands. Track the underlying fix as a separate issue.
+
+## Where Phase 1 picks this up
+
+`00_PLAN.md` in this same PR has been patched for the two stale
+zeroclaw path references (mermaid + ASCII boxes). The seven-point
+executive summary at the top of this document is the canonical
+Phase-1 hand-off list — open it side-by-side with `00_PLAN.md` § *Files
+to add / modify* when the Phase 1 issue opens.
+
+**Phase 1 integration tests** should target `wolf-i` (alias unchanged)
+with `tdd-{hermes,openclaw}` for end-to-end install/list/remove flows;
+`tdd-zeroclaw` covers the skills-CLI path only until the configure ↔
+v0.7.5 alignment fix lands separately.

--- a/.itx/380/01_EXECUTION.md
+++ b/.itx/380/01_EXECUTION.md
@@ -1,0 +1,151 @@
+# Issue #380 — Phase 1 Execution Log
+
+Scope (from issue body): `clm skill list` and `clm skill show clawrium/tdd`
+return real data from the in-repo catalog; error classes
+`MissingRegistryPrefix`, `SkillNotFound`, `ExternalSourceBlocked` exit
+non-zero with hints; schema + `parse_skill_ref` + `validate_skill`
+(dual-schema dispatch) unit-tested; `make test` + `make lint` green.
+
+Plan reference: `.itx/364/00_PLAN.md` § *Phased execution → Phase 1* and
+`.itx/364/02_PHASE0_FINDINGS.md` (which locked the `_meta.yaml` shape
+and the source-dirname == registry slug invariant).
+
+## What shipped
+
+**Catalog (repo-root `skills/`, bundled into the wheel as
+`clawrium/_skills/` via `pyproject.toml` `force-include`):**
+
+- `skills/README.md` — namespace + slug rules, authoring quickstart.
+- `skills/_schema/clawrium.schema.json` — normalized cross-agent schema.
+- `skills/_schema/native/{openclaw,hermes,zeroclaw}.schema.json` —
+  per-claw native frontmatter schemas, shaped from the upstream
+  requirements documented in `.itx/364/02_PHASE0_FINDINGS.md`.
+- `skills/clawrium/tdd/{SKILL.md,_meta.yaml}` — first cross-agent skill
+  (TDD discipline).
+- `skills/{openclaw,hermes,zeroclaw}/README.md` — registry placeholders
+  so `clm skill list --registry <claw>` returns an empty list (not
+  "registry not found").
+
+**Core (`src/clawrium/core/skills.py`):**
+
+- Error classes: `SkillError` (base), `MissingRegistryPrefix`,
+  `InvalidSkillRef`, `ExternalSourceBlocked`, `SkillNotFound`,
+  `SchemaValidationError`.
+- `parse_skill_ref(raw)` — single chokepoint. Rejection precedence:
+  empty → URL/path → bare name (with hint) → unknown registry →
+  invalid slug.
+- `list_skills([registry])` — enumerates the catalog by registry order;
+  rejects unknown registries.
+- `load_skill(ref)` — reads `_meta.yaml` (clawrium) or SKILL.md
+  frontmatter (native); raises `SkillNotFound` on missing dir/files.
+- `validate_skill(skill)` — dual-schema dispatch
+  (`clawrium/*` ↔ `_schema/clawrium.schema.json`,
+  `<claw>/*` ↔ `_schema/native/<claw>.schema.json`); also enforces the
+  `_meta.yaml.name == ref.name` invariant for `clawrium/*`.
+- Validator uses `jsonschema.Draft202012Validator` (new runtime dep).
+
+**CLI (`src/clawrium/cli/skill.py` + `src/clawrium/cli/main.py`):**
+
+- `clm skill list [--registry <r>]` — rich table; empty registry gives
+  an actionable hint pointing at `skills/<r>/<name>/`.
+- `clm skill show <registry>/<name>` — metadata table + rendered
+  SKILL.md. Catches every `SkillError` subclass and exits non-zero with
+  the matching message.
+- Top-level `skill_app` registered alongside `agent`/`host`/`provider`/
+  `integration` in `main.py`.
+
+**Tests (46 new, all passing alongside the existing 1947):**
+
+- `tests/test_core_skills.py` — parse/load/validate/list with happy and
+  error paths, including dual-schema dispatch against a tmp catalog
+  built from the in-repo schemas.
+- `tests/test_cli_skill.py` — `clm skill list`/`show` happy path, every
+  documented error path, and `--help` surface.
+
+## Verification
+
+```
+$ uv run pytest
+============================ 2004 passed in 16.31s =============================
+
+$ uv run ruff check src tests
+All checks passed!
+
+$ uv run clm skill list
+                                 Skills catalog
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Ref          ┃ Registry ┃ Description                                        ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ clawrium/tdd │ clawrium │ Test-Driven Development discipline. Drives a red → │
+│              │          │ green → refactor cycle for...                      │
+└──────────────┴──────────┴────────────────────────────────────────────────────┘
+
+$ uv run clm skill show tdd
+Error: Skill reference 'tdd' is missing a registry prefix. Use
+`<registry>/<name>` (e.g. `clawrium/tdd`). Did you mean: `clawrium/tdd`?
+$ echo $?
+1
+```
+
+## Design notes / non-obvious choices
+
+1. **Catalog is bundled into the wheel** under `clawrium/_skills/` via
+   hatch `force-include`, with a dev-mode fallback (`Path(__file__)
+   .parents[3] / "skills"`) so source checkouts work without a `pip
+   install -e .` round-trip. The package is the source of truth at
+   runtime; the repo-root location is purely for ergonomics.
+2. **Hand-rolled validator avoided** in favor of pulling in
+   `jsonschema>=4.0.0` (one new runtime dep). Rationale: the same
+   schemas will be used by `scripts/validate_skills.py` in Phase 6;
+   maintaining two implementations would risk divergence.
+3. **Bare-name hint is best-effort and degrades silently** on catalog
+   read failures, so a missing catalog never masks the underlying
+   "you forgot the registry prefix" user error.
+4. **`_short_description` swallows per-skill errors** in `clm skill list`
+   to keep the table rendering robust against one bad skill. The full
+   error surfaces via `clm skill show <ref>`.
+5. **Slug invariant** (`_meta.yaml.name == directory name`) is enforced
+   in `validate_skill` rather than `load_skill` so the loader stays
+   honest about what's on disk; validation is the gate. Required for
+   the zeroclaw remove semantics documented in
+   `.itx/364/02_PHASE0_FINDINGS.md`.
+
+## What this PR does not do
+
+Per the issue scope, this PR explicitly stops at *browsing*. Per-agent
+install/list/remove (`clm agent skill *`), desired-state files, and the
+per-claw `skills_apply.yaml` playbooks land in Phases 2–3 (issues
+#381, #382). GUI parity lands in Phase 4 (#383).
+
+## ATX Review iterations
+
+| Review | Rating | Blockers | Status | Cost | Time |
+|--------|--------|---------|--------|------|------|
+| 1 | 2/5 | B1–B6 | All fixed (B2 was a false positive) | $4.30 | 12m23s |
+| 2 | 3/5 | B6 | Test was vacuous — fixed with mocked Draft202012Validator and mixed-type-path inputs | $3.64 | 7m59s |
+| 3 | 4/5 | None | Merge gate passed | $2.01 | 6m36s |
+
+Carried to follow-up issues (out of Phase 1 scope):
+- W-new1 (CliRunner `mix_stderr` ergonomics) — repo-wide CLI test pass.
+- W1 (slug invariant extension to native registries) — Phase 2.
+- W2 / W12 / W13 / W14 (additionalProperties lockdown + SKILL.md bidi
+  sanitization) — Phase 3, before any community-contributed catalog
+  source is added.
+
+Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
+
+---
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-17T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 380 --pr-base=issue-386-phase0-research
+```
+
+</details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "fuzzyfinder>=2.1.0,<3.0.0",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
+    "jsonschema>=4.17.0,<5.0.0",
 ]
 
 [project.scripts]
@@ -37,6 +38,12 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/clawrium"]
+
+# Bundle the in-repo skills catalog into the wheel under
+# clawrium/_skills/ so installed `clm` invocations can resolve refs
+# like `clawrium/tdd` without the source tree present.
+[tool.hatch.build.targets.wheel.force-include]
+"skills" = "clawrium/_skills"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,70 @@
+# Clawrium Skills Catalog
+
+This directory is the **single source of truth** for skills installable via
+`clm` onto clawrium-managed agents. Skills are organized into four
+**registries** (namespaces). The path layout is hard-wired into
+`src/clawrium/core/skills.py` and validated in CI.
+
+```
+skills/
+├── _schema/
+│   ├── clawrium.schema.json            # cross-agent normalized shape
+│   └── native/
+│       ├── openclaw.schema.json        # openclaw SKILL.md frontmatter
+│       ├── hermes.schema.json          # hermes SKILL.md frontmatter
+│       └── zeroclaw.schema.json        # zeroclaw SKILL.md frontmatter
+├── clawrium/<name>/                    # normalized, cross-agent
+│   ├── _meta.yaml                      # required, validated against clawrium.schema.json
+│   ├── SKILL.md                        # canonical content (rendered per claw on apply)
+│   └── README.md                       # optional, human-readable docs
+├── openclaw/<name>/                    # native, openclaw-only
+│   └── SKILL.md                        # frontmatter validated against native/openclaw.schema.json
+├── hermes/<name>/                      # native, hermes-only
+│   └── SKILL.md                        # frontmatter validated against native/hermes.schema.json
+└── zeroclaw/<name>/                    # native, zeroclaw-only
+    └── SKILL.md                        # frontmatter validated against native/zeroclaw.schema.json
+```
+
+## Namespace rules
+
+| Registry    | Schema     | Install target            | Notes                                              |
+|-------------|------------|---------------------------|----------------------------------------------------|
+| `clawrium`  | clawrium   | any agent type            | normalized superset; materialized per claw on apply |
+| `openclaw`  | native     | only `openclaw` agents    | raw openclaw SKILL.md, dropped under `~/.openclaw/skills/` |
+| `hermes`    | native     | only `hermes` agents      | raw hermes SKILL.md, dropped under `~/.hermes/skills/clawrium/` |
+| `zeroclaw`  | native     | only `zeroclaw` agents    | staged + installed via `zeroclaw skills install` (audit gate) |
+
+## Skill references
+
+Skills are referenced as `<registry>/<name>` everywhere — CLI args, GUI URLs,
+desired-state files. Bare names (e.g. `tdd`) are rejected with
+`MissingRegistryPrefix` and a hint that includes the matching registries.
+
+Non-registry sources (URLs, absolute paths, tarballs) are rejected at the
+`parse_skill_ref` chokepoint with `ExternalSourceBlocked`. The only install
+source for `clm` is this in-repo tree.
+
+## Slug rules
+
+- `<name>` MUST match `^[a-z0-9][a-z0-9_-]*$` (kebab-case, no leading
+  hyphen/underscore).
+- For `clawrium/<name>`, `_meta.yaml`'s `name:` field MUST equal `<name>`
+  (the directory name). The CLI enforces this so that zeroclaw's source-
+  dirname semantics (see `.itx/364/02_PHASE0_FINDINGS.md`) stay consistent
+  with the registry slug.
+
+## Adding a new skill
+
+1. Pick the right registry.
+   - Cross-agent? Use `clawrium/`.
+   - Native to one claw and uses claw-specific frontmatter fields? Use that
+     claw's namespace.
+2. Create `skills/<registry>/<name>/SKILL.md` (and `_meta.yaml` for
+   `clawrium/`).
+3. Run `clm skill show <registry>/<name>` to confirm the catalog loader
+   accepts it.
+4. CI runs dual-schema validation on every PR; a clawrium-shaped file
+   placed under a native registry (or vice versa) will fail the build.
+
+See `docs/skills/authoring-clawrium.md` and
+`docs/skills/authoring-native.md` for full authoring guides (Phase 6).

--- a/skills/_schema/clawrium.schema.json
+++ b/skills/_schema/clawrium.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://clawrium.dev/schemas/clawrium-skill.schema.json",
+  "title": "Clawrium normalized skill (_meta.yaml)",
+  "description": "Normalized cross-agent skill descriptor. Materialized into per-claw SKILL.md frontmatter on apply. Locked in .itx/364/02_PHASE0_FINDINGS.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name", "description", "version", "compatibility"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]*$",
+      "description": "Slug. MUST equal the parent directory name under skills/clawrium/."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$"
+    },
+    "license": {"type": "string"},
+    "author": {"type": "string"},
+    "platforms": {
+      "type": "array",
+      "items": {"type": "string", "enum": ["linux", "macos", "windows"]}
+    },
+    "compatibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["openclaw", "hermes", "zeroclaw"],
+      "properties": {
+        "openclaw": {"type": "boolean"},
+        "hermes": {"type": "boolean"},
+        "zeroclaw": {"type": "boolean"}
+      }
+    },
+    "native": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "openclaw": {"type": "object"},
+        "hermes": {"type": "object"},
+        "zeroclaw": {"type": "object"}
+      }
+    },
+    "prerequisites": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "commands": {"type": "array", "items": {"type": "string"}},
+        "env": {"type": "array", "items": {"type": "string"}}
+      }
+    }
+  }
+}

--- a/skills/_schema/native/hermes.schema.json
+++ b/skills/_schema/native/hermes.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://clawrium.dev/schemas/hermes-skill.schema.json",
+  "title": "Hermes native SKILL.md frontmatter",
+  "description": "Frontmatter expected by hermes auto-scan at ~/.hermes/skills/<category>/<name>/SKILL.md.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["name", "description"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]*$"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {"type": "string"},
+    "license": {"type": "string"},
+    "author": {"type": "string"},
+    "platforms": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "prerequisites": {"type": "object"},
+    "metadata": {"type": "object"}
+  }
+}

--- a/skills/_schema/native/openclaw.schema.json
+++ b/skills/_schema/native/openclaw.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://clawrium.dev/schemas/openclaw-skill.schema.json",
+  "title": "OpenClaw native SKILL.md frontmatter",
+  "description": "Frontmatter expected by openclaw v2026.3.x auto-scan at ~/.openclaw/skills/<name>/SKILL.md. Verified against running openclaw in .itx/364/02_PHASE0_FINDINGS.md.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["name", "description"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]*$"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {"type": "string"}
+  }
+}

--- a/skills/_schema/native/zeroclaw.schema.json
+++ b/skills/_schema/native/zeroclaw.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://clawrium.dev/schemas/zeroclaw-skill.schema.json",
+  "title": "Zeroclaw native SKILL.md frontmatter",
+  "description": "Frontmatter expected by `zeroclaw skills install` v0.7.5. The source directory name is what zeroclaw uses on disk and for remove (see .itx/364/02_PHASE0_FINDINGS.md).",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["name", "description"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]*$"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {"type": "string"}
+  }
+}

--- a/skills/clawrium/tdd/SKILL.md
+++ b/skills/clawrium/tdd/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: tdd
+description: Drive a red → green → refactor cycle for the active task.
+---
+
+# TDD — Test-Driven Development
+
+When the user asks you to implement, change, or fix behavior, work in the
+red → green → refactor loop. The loop is the discipline; do not skip a step.
+
+## The loop
+
+1. **Red.** Write a single failing test that names the next behavior in the
+   smallest reasonable scope. Run the test suite (or just the new test) and
+   confirm the failure is *for the right reason* (asserts on behavior, not
+   on a missing import or typo).
+2. **Green.** Make the test pass with the *minimum* change. Resist the urge
+   to refactor neighboring code, generalize, or anticipate the next test.
+   "Minimum" means: if a literal return makes the test pass, return the
+   literal — then write the next failing test that forces the
+   generalization.
+3. **Refactor.** With the suite green, improve names, remove duplication,
+   tighten interfaces. Run the suite after every refactor step. If a
+   refactor turns the suite red, revert immediately and split it smaller.
+
+## When to break the loop
+
+- **Spike** — explore an unknown API in a throwaway branch with no tests,
+  then delete the spike and re-implement TDD-style.
+- **Bug report** — write the failing test *first* that reproduces the bug,
+  even if the production fix is one line. Without the test, the bug returns.
+- **Refactor-only** — the suite must be green at start and end; no
+  behavior changes in this mode.
+
+## Anti-patterns
+
+- Writing the implementation first then back-filling tests.
+- Writing many failing tests at once (you can't tell which one is driving).
+- Skipping the "right reason" check in step 1.
+- Refactoring while red.

--- a/skills/clawrium/tdd/_meta.yaml
+++ b/skills/clawrium/tdd/_meta.yaml
@@ -1,0 +1,29 @@
+# skills/clawrium/tdd/_meta.yaml — clawrium-internal normalized shape.
+# Phase 1 materializers (added in Phase 2/3) transform this into per-claw
+# SKILL.md frontmatter on install. Locked shape: .itx/364/02_PHASE0_FINDINGS.md.
+name: tdd
+description: >-
+  Test-Driven Development discipline. Drives a red → green → refactor
+  cycle for the active task: write a failing test, make it pass with the
+  minimum change, then refactor while green.
+version: 0.1.0
+license: MIT
+author: clawrium
+platforms: [linux, macos]
+
+compatibility:
+  openclaw: true
+  hermes: true
+  zeroclaw: true
+
+native:
+  hermes:
+    metadata:
+      hermes:
+        tags: [tdd, testing, discipline, clawrium]
+  openclaw: {}
+  zeroclaw: {}
+
+prerequisites:
+  commands: []
+  env: []

--- a/skills/hermes/README.md
+++ b/skills/hermes/README.md
@@ -1,0 +1,18 @@
+# skills/hermes/
+
+Native hermes skills. Files placed here are installable **only** onto
+agents of type `hermes`. The CLI rejects cross-claw installs with
+`IncompatibleSkillRegistry` (Phase 2).
+
+Layout:
+
+```
+skills/hermes/<name>/
+└── SKILL.md   # frontmatter validated against _schema/native/hermes.schema.json
+```
+
+A cross-agent skill belongs in `skills/clawrium/` instead — see the
+top-level [`skills/README.md`](../README.md). No native hermes skills ship
+in this initial cut; this directory is a registered registry so that
+`clm skill list --registry hermes` returns an empty list rather than a
+"registry not found" error.

--- a/skills/openclaw/README.md
+++ b/skills/openclaw/README.md
@@ -1,0 +1,18 @@
+# skills/openclaw/
+
+Native openclaw skills. Files placed here are installable **only** onto
+agents of type `openclaw`. The CLI rejects cross-claw installs with
+`IncompatibleSkillRegistry` (Phase 2).
+
+Layout:
+
+```
+skills/openclaw/<name>/
+└── SKILL.md   # frontmatter validated against _schema/native/openclaw.schema.json
+```
+
+A cross-agent skill belongs in `skills/clawrium/` instead — see the
+top-level [`skills/README.md`](../README.md). No native openclaw skills
+ship in this initial cut; this directory is a registered registry so that
+`clm skill list --registry openclaw` returns an empty list rather than a
+"registry not found" error.

--- a/skills/zeroclaw/README.md
+++ b/skills/zeroclaw/README.md
@@ -1,0 +1,24 @@
+# skills/zeroclaw/
+
+Native zeroclaw skills. Files placed here are installable **only** onto
+agents of type `zeroclaw`. The CLI rejects cross-claw installs with
+`IncompatibleSkillRegistry` (Phase 2).
+
+Layout:
+
+```
+skills/zeroclaw/<name>/
+└── SKILL.md   # frontmatter validated against _schema/native/zeroclaw.schema.json
+```
+
+Native zeroclaw installs go through `zeroclaw skills install` (v0.7.5
+audit gate). The on-disk source directory name MUST match the registry
+slug `<name>`, because `zeroclaw skills remove` keys on the source
+directory name, not the SKILL.md `name:` field — see
+[`.itx/364/02_PHASE0_FINDINGS.md`](../../.itx/364/02_PHASE0_FINDINGS.md).
+
+A cross-agent skill belongs in `skills/clawrium/` instead — see the
+top-level [`skills/README.md`](../README.md). No native zeroclaw skills
+ship in this initial cut; this directory is a registered registry so that
+`clm skill list --registry zeroclaw` returns an empty list rather than a
+"registry not found" error.

--- a/src/clawrium/cli/main.py
+++ b/src/clawrium/cli/main.py
@@ -22,6 +22,7 @@ from clawrium.cli.chat import chat as chat_command
 from clawrium.cli.host import host_app
 from clawrium.cli.integration import integration_app
 from clawrium.cli.provider import provider_app
+from clawrium.cli.skill import skill_app
 from clawrium.cli.status import status as status_command
 
 __all__ = ["app"]
@@ -167,6 +168,9 @@ app.add_typer(provider_app, name="provider")
 
 # Register integration subcommands (external service integrations)
 app.add_typer(integration_app, name="integration")
+
+# Register skill subcommands (catalog browsing)
+app.add_typer(skill_app, name="skill")
 
 
 if __name__ == "__main__":

--- a/src/clawrium/cli/skill.py
+++ b/src/clawrium/cli/skill.py
@@ -1,0 +1,192 @@
+"""`clm skill` — browse the in-repo skills catalog.
+
+Phase 1 surface: `list` (optionally filtered by `--registry`) and `show`
+(prints metadata + SKILL.md body). Per-agent install/remove lives under
+`clm agent skill` and is wired up in Phase 2.
+
+All errors raised by `clawrium.core.skills` are caught here and rendered
+as a single-line `[red]Error:[/red] …` message with a non-zero exit code,
+matching the existing `clm registry`/`clm agent` UX. The catch list is
+explicit — we never swallow `Exception`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import typer
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.markup import escape
+from rich.panel import Panel
+from rich.table import Table
+
+from clawrium.core.skills import (
+    REGISTRIES,
+    ExternalSourceBlocked,
+    InvalidSkillRef,
+    MissingRegistryPrefix,
+    SchemaValidationError,
+    SkillError,
+    SkillNotFound,
+    SkillRef,
+    list_skills,
+    load_skill,
+    parse_skill_ref,
+    validate_skill,
+)
+
+__all__ = ["skill_app"]
+
+logger = logging.getLogger(__name__)
+console = Console()
+err_console = Console(stderr=True)
+
+
+skill_app = typer.Typer(
+    name="skill",
+    help="Browse the clawrium-managed skills catalog.",
+    no_args_is_help=True,
+)
+
+
+def _exit_with_error(error: SkillError) -> None:
+    """Render a skill error to stderr and exit non-zero."""
+    err_console.print(f"[red]Error:[/red] {escape(str(error))}")
+    raise typer.Exit(code=1)
+
+
+@skill_app.command(name="list")
+def list_skills_command(
+    registry: str | None = typer.Option(
+        None,
+        "--registry",
+        "-r",
+        help=(
+            "Filter to a single registry. "
+            f"Valid values: {', '.join(REGISTRIES)}."
+        ),
+    ),
+) -> None:
+    """List skills in the catalog as a registry/name table."""
+    try:
+        refs = list_skills(registry=registry)
+    except (InvalidSkillRef, SkillNotFound) as error:
+        # SkillNotFound is raised by `_catalog_root` when neither the
+        # bundled nor the dev catalog can be located — surface that as
+        # an actionable CLI error rather than a raw traceback.
+        _exit_with_error(error)
+        return  # for type-checkers — typer.Exit raises
+
+    if not refs:
+        if registry:
+            console.print(
+                f"No skills registered under `{escape(registry)}/`. "
+                "Add one under "
+                f"[cyan]skills/{escape(registry)}/<name>/[/cyan]."
+            )
+        else:
+            console.print(
+                "No skills in the catalog. "
+                "Add one under [cyan]skills/<registry>/<name>/[/cyan]."
+            )
+        return
+
+    table = Table(title="Skills catalog")
+    table.add_column("Ref", style="cyan", no_wrap=True)
+    table.add_column("Registry", style="green")
+    table.add_column("Description")
+
+    for ref in refs:
+        description = _short_description(ref)
+        table.add_row(escape(str(ref)), escape(ref.registry), description)
+
+    console.print(table)
+
+
+@skill_app.command()
+def show(
+    skill_ref: str = typer.Argument(
+        ...,
+        metavar="REGISTRY/NAME",
+        help="Skill reference (e.g. `clawrium/tdd`). Bare names are rejected.",
+    ),
+) -> None:
+    """Show metadata + SKILL.md body for one skill."""
+    try:
+        ref = parse_skill_ref(skill_ref)
+        skill = load_skill(ref)
+        validate_skill(skill)
+    except (
+        MissingRegistryPrefix,
+        InvalidSkillRef,
+        ExternalSourceBlocked,
+        SkillNotFound,
+        SchemaValidationError,
+    ) as error:
+        _exit_with_error(error)
+        return
+
+    console.print(f"\n[bold cyan]{escape(str(skill.ref))}[/bold cyan]")
+    description = skill.metadata.get("description", "")
+    if isinstance(description, str) and description:
+        console.print(escape(description.strip()))
+    console.print()
+
+    metadata_table = Table(title="Metadata", show_header=False, expand=False)
+    metadata_table.add_column("Field", style="yellow", no_wrap=True)
+    metadata_table.add_column("Value")
+    metadata_table.add_row("registry", escape(skill.ref.registry))
+    metadata_table.add_row("name", escape(skill.ref.name))
+    for key in ("version", "license", "author"):
+        value = skill.metadata.get(key)
+        if value is not None:
+            metadata_table.add_row(key, escape(str(value)))
+
+    platforms = skill.metadata.get("platforms")
+    if isinstance(platforms, list) and platforms:
+        metadata_table.add_row(
+            "platforms", escape(", ".join(str(p) for p in platforms))
+        )
+
+    compatibility = skill.metadata.get("compatibility")
+    if isinstance(compatibility, dict):
+        compat = ", ".join(
+            f"{claw}={'yes' if flag else 'no'}"
+            for claw, flag in compatibility.items()
+        )
+        metadata_table.add_row("compatibility", escape(compat))
+    elif skill.ref.registry in {"openclaw", "hermes", "zeroclaw"}:
+        metadata_table.add_row("compatibility", skill.ref.registry)
+
+    console.print(metadata_table)
+
+    if skill.body.strip():
+        console.print(Panel(Markdown(skill.body), title="SKILL.md", expand=True))
+
+
+def _short_description(ref: SkillRef) -> str:
+    """Best-effort one-line description for the `list` table.
+
+    Failures (parse errors, schema mismatches) are degraded to a static
+    `?` so a single bad skill doesn't blow up the whole `list`. The
+    detailed error is surfaced by `clm skill show <ref>`. An empty or
+    missing description also renders as `?` — `?` and blank are
+    visually identical otherwise, and `?` signals "look at me with
+    show" more clearly.
+    """
+    try:
+        skill = load_skill(ref)
+    except SkillError as error:
+        logger.debug("Skipping description for %s: %s", ref, error)
+        return "?"
+
+    description = skill.metadata.get("description", "")
+    if not isinstance(description, str):
+        return "?"
+    one_line = " ".join(description.split())
+    if not one_line:
+        return "?"
+    if len(one_line) > 80:
+        one_line = one_line[:77] + "..."
+    return escape(one_line)

--- a/src/clawrium/core/skills.py
+++ b/src/clawrium/core/skills.py
@@ -1,0 +1,470 @@
+"""Skills catalog loader for clawrium-managed registries.
+
+Single chokepoint for resolving and validating skill references. The only
+install source recognized by `clm` is the in-repo `skills/` catalog —
+shipped inside the wheel as `clawrium/_skills/` (see `pyproject.toml`
+`force-include`) and present at the repo root for development.
+
+Reference grammar: `<registry>/<name>` where `<registry>` is one of
+{`clawrium`, `openclaw`, `hermes`, `zeroclaw`} and `<name>` matches
+`^[a-z0-9][a-z0-9_-]*$`. Bare names, URLs, and arbitrary paths are
+rejected at `parse_skill_ref` with stable error classes.
+
+Phase 1 surface: `parse_skill_ref`, `load_skill`, `validate_skill`,
+`list_skills`. Per-agent install (state file, apply playbooks) is Phases
+2–3; this module avoids any agent-mutation concerns.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+REGISTRIES: tuple[str, ...] = ("clawrium", "openclaw", "hermes", "zeroclaw")
+"""Allowed registries. Order is preserved for `clm skill list` output."""
+
+NATIVE_REGISTRIES: frozenset[str] = frozenset({"openclaw", "hermes", "zeroclaw"})
+"""Registries whose skills validate against the native (claw-specific) schema."""
+
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+"""Slug pattern for `<name>` in `<registry>/<name>` and for directory names."""
+
+_EXTERNAL_PREFIXES = (
+    "http://",
+    "https://",
+    "git+",
+    "git@",
+    "ssh://",
+    "ftp://",
+    "file://",
+)
+"""Schemes blocked at `parse_skill_ref`."""
+
+
+class SkillError(Exception):
+    """Base class for catalog-loader errors."""
+
+
+class MissingRegistryPrefix(SkillError):
+    """Raised when a skill ref omits the `<registry>/` prefix."""
+
+
+class InvalidSkillRef(SkillError):
+    """Raised when a skill ref is otherwise malformed (bad chars, empty, etc.)."""
+
+
+class ExternalSourceBlocked(SkillError):
+    """Raised when a skill ref looks like a URL or arbitrary path."""
+
+
+class SkillNotFound(SkillError):
+    """Raised when `<registry>/<name>` is not present in the catalog."""
+
+
+class SchemaValidationError(SkillError):
+    """Raised when a skill's frontmatter/meta fails its registry's schema."""
+
+
+@dataclass(frozen=True)
+class SkillRef:
+    """Parsed `<registry>/<name>` pair."""
+
+    registry: str
+    name: str
+
+    def __str__(self) -> str:
+        return f"{self.registry}/{self.name}"
+
+
+@dataclass(frozen=True)
+class Skill:
+    """Loaded skill: parsed metadata + raw SKILL.md body.
+
+    For `clawrium/*` skills, `metadata` is the parsed `_meta.yaml`. For
+    native `<claw>/*` skills, `metadata` is the SKILL.md frontmatter.
+    """
+
+    ref: SkillRef
+    path: Path
+    metadata: dict[str, Any]
+    body: str
+    skill_md_frontmatter: dict[str, Any] = field(default_factory=dict)
+
+
+def _catalog_root() -> Path:
+    """Locate the on-disk root of the `skills/` catalog.
+
+    Order of resolution:
+
+    1. Bundled inside the installed wheel as `clawrium/_skills/` (see
+       `pyproject.toml` `force-include`).
+    2. Repo root, as a sibling of `src/clawrium/` (development checkout).
+
+    The first existing path wins. We return a `Path` rather than a
+    `Traversable` so callers can do path arithmetic and `is_dir()` checks
+    without juggling two filesystem-ish APIs.
+    """
+    bundled = Path(__file__).resolve().parent.parent / "_skills"
+    if bundled.is_dir():
+        return bundled
+
+    # Repo-root fallback: clawrium-issue-380/skills/, with this file at
+    # clawrium-issue-380/src/clawrium/core/skills.py — four parents up.
+    repo_root = Path(__file__).resolve().parents[3]
+    dev = repo_root / "skills"
+    if dev.is_dir():
+        return dev
+
+    raise SkillNotFound(
+        "skills catalog not found (looked for bundled "
+        f"{bundled} and dev {dev}). "
+        "Reinstall with: `uv tool install --force clawrium`."
+    )
+
+
+def parse_skill_ref(raw: str) -> SkillRef:
+    """Parse `<registry>/<name>` into a `SkillRef`.
+
+    Rejects, in this precedence order:
+
+    - Empty or whitespace-only refs -> `InvalidSkillRef`.
+    - URLs / git+ / ssh:// / absolute paths -> `ExternalSourceBlocked`.
+    - Bare names (no `/`) -> `MissingRegistryPrefix` with a hint listing
+      every existing `<registry>/<name>` match for that name so the user
+      gets a copy-pasteable correction.
+    - Two-part refs with an unknown registry or a malformed name ->
+      `InvalidSkillRef`.
+
+    The hint cost in the bare-name branch is intentional: catalog reads
+    are cheap (`is_dir()` per registry), and a clear "did you mean
+    `clawrium/tdd`?" message is the dominant ergonomic win over a flat
+    error.
+    """
+    if raw is None or not isinstance(raw, str):
+        raise InvalidSkillRef(
+            "Skill reference must be a non-empty string of the form "
+            "`<registry>/<name>` (e.g. `clawrium/tdd`)."
+        )
+
+    candidate = raw.strip()
+    if not candidate:
+        raise InvalidSkillRef(
+            "Skill reference is empty. Expected `<registry>/<name>` "
+            "(e.g. `clawrium/tdd`)."
+        )
+
+    lowered = candidate.lower()
+    if any(lowered.startswith(prefix) for prefix in _EXTERNAL_PREFIXES):
+        raise ExternalSourceBlocked(
+            f"External skill sources are not allowed: {candidate!r}. "
+            "Skills must be referenced as `<registry>/<name>` from the "
+            "in-repo catalog (e.g. `clawrium/tdd`)."
+        )
+
+    if candidate.startswith("/") or candidate.startswith("~"):
+        raise ExternalSourceBlocked(
+            f"Path-style skill sources are not allowed: {candidate!r}. "
+            "Skills must be referenced as `<registry>/<name>` from the "
+            "in-repo catalog (e.g. `clawrium/tdd`)."
+        )
+
+    if "/" not in candidate:
+        hint = _bare_name_hint(candidate)
+        raise MissingRegistryPrefix(
+            f"Skill reference {candidate!r} is missing a registry prefix. "
+            "Use `<registry>/<name>` (e.g. `clawrium/tdd`)."
+            + (f" Did you mean: {hint}?" if hint else "")
+        )
+
+    parts = candidate.split("/")
+    if len(parts) != 2:
+        raise InvalidSkillRef(
+            f"Skill reference {candidate!r} must have exactly one `/` "
+            "separator. Use `<registry>/<name>` (e.g. `clawrium/tdd`)."
+        )
+
+    registry, name = parts
+    if registry not in REGISTRIES:
+        raise InvalidSkillRef(
+            f"Unknown registry {registry!r} in {candidate!r}. "
+            f"Allowed: {', '.join(REGISTRIES)}."
+        )
+    if not _NAME_RE.match(name):
+        raise InvalidSkillRef(
+            f"Invalid skill name {name!r} in {candidate!r}. "
+            "Names must match ^[a-z0-9][a-z0-9_-]*$."
+        )
+
+    return SkillRef(registry=registry, name=name)
+
+
+def _bare_name_hint(name: str) -> str:
+    """Return a comma-separated list of `<registry>/<name>` matches.
+
+    Used in `MissingRegistryPrefix`. Best-effort: catalog access failures
+    are swallowed so a missing catalog never masks the underlying user
+    error.
+    """
+    if not _NAME_RE.match(name):
+        return ""
+    try:
+        root = _catalog_root()
+    except SkillNotFound:
+        return ""
+
+    matches: list[str] = []
+    for registry in REGISTRIES:
+        if (root / registry / name).is_dir():
+            matches.append(f"`{registry}/{name}`")
+    return ", ".join(matches)
+
+
+def list_skills(registry: str | None = None) -> list[SkillRef]:
+    """Enumerate skills in the catalog.
+
+    `registry=None` returns refs from every registry, sorted by registry
+    (per `REGISTRIES` order) and then by name. `registry=<name>` filters
+    to a single registry; an unknown registry raises `InvalidSkillRef`.
+    """
+    if registry is not None and registry not in REGISTRIES:
+        raise InvalidSkillRef(
+            f"Unknown registry {registry!r}. Allowed: {', '.join(REGISTRIES)}."
+        )
+
+    root = _catalog_root()
+    registries: Iterable[str] = (registry,) if registry else REGISTRIES
+
+    refs: list[SkillRef] = []
+    for reg in registries:
+        reg_dir = root / reg
+        if not reg_dir.is_dir():
+            continue
+        names: list[str] = []
+        for entry in reg_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            if not _NAME_RE.match(entry.name):
+                continue
+            if not _has_skill_files(entry, reg):
+                continue
+            names.append(entry.name)
+        for name in sorted(names):
+            refs.append(SkillRef(registry=reg, name=name))
+    return refs
+
+
+def _has_skill_files(skill_dir: Path, registry: str) -> bool:
+    """Return True if `skill_dir` looks like a real skill, not a placeholder.
+
+    For `clawrium/*` we require both `_meta.yaml` and `SKILL.md` (the
+    latter is the canonical content materialized to each claw). For
+    native registries we require `SKILL.md` only.
+    """
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        return False
+    if registry == "clawrium":
+        meta = skill_dir / "_meta.yaml"
+        return meta.is_file()
+    return True
+
+
+def load_skill(ref: SkillRef | str) -> Skill:
+    """Load a skill from the catalog.
+
+    `ref` may be a pre-parsed `SkillRef` or a raw `<registry>/<name>`
+    string (in which case it is passed through `parse_skill_ref`, so
+    every error class from that function may surface here).
+    """
+    if isinstance(ref, str):
+        ref = parse_skill_ref(ref)
+
+    root = _catalog_root()
+    skill_dir = root / ref.registry / ref.name
+    if not skill_dir.is_dir():
+        raise SkillNotFound(
+            f"Skill {ref} not found. Run `clm skill list` to see available skills."
+        )
+
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        raise SkillNotFound(
+            f"Skill {ref} is missing SKILL.md at {skill_md}."
+        )
+    body, frontmatter = _split_frontmatter(skill_md.read_text())
+
+    if ref.registry == "clawrium":
+        meta_path = skill_dir / "_meta.yaml"
+        if not meta_path.is_file():
+            raise SkillNotFound(
+                f"Skill {ref} is missing _meta.yaml at {meta_path}."
+            )
+        try:
+            metadata = yaml.safe_load(meta_path.read_text()) or {}
+        except yaml.YAMLError as error:
+            raise SchemaValidationError(
+                f"Failed to parse {meta_path}: {error}"
+            ) from error
+        if not isinstance(metadata, dict):
+            raise SchemaValidationError(
+                f"{meta_path} must be a YAML mapping (got {type(metadata).__name__})."
+            )
+    else:
+        metadata = dict(frontmatter)
+
+    return Skill(
+        ref=ref,
+        path=skill_dir,
+        metadata=metadata,
+        body=body,
+        skill_md_frontmatter=frontmatter,
+    )
+
+
+def validate_skill(skill: Skill) -> None:
+    """Validate `skill.metadata` against its registry's JSON schema.
+
+    Dual-schema dispatch: `clawrium/*` validates against
+    `_schema/clawrium.schema.json`; `<claw>/*` validates against
+    `_schema/native/<claw>.schema.json`. The schema files are loaded
+    relative to `_catalog_root()` so dev and bundled installs both
+    resolve correctly.
+
+    For `clawrium/*` we additionally enforce the slug invariant
+    `metadata.name == ref.name` (the source-dirname == registry slug
+    rule from `.itx/364/02_PHASE0_FINDINGS.md` — required so that
+    zeroclaw `remove` keys line up with the registry slug downstream).
+    """
+    schema = _load_schema(skill.ref.registry)
+    _validate_against_schema(skill.metadata, schema, ref=skill.ref)
+
+    if skill.ref.registry == "clawrium":
+        if skill.metadata.get("name") != skill.ref.name:
+            raise SchemaValidationError(
+                f"Skill {skill.ref}: _meta.yaml `name` field "
+                f"({skill.metadata.get('name')!r}) must equal directory "
+                f"name ({skill.ref.name!r})."
+            )
+
+
+def _split_frontmatter(text: str) -> tuple[str, dict[str, Any]]:
+    """Split a SKILL.md into (body, frontmatter dict).
+
+    Frontmatter is the conventional `---\\n…\\n---\\n` block at the top
+    of the file. Missing frontmatter returns an empty dict and the
+    original text as the body — `validate_skill` decides whether that's
+    fatal for the registry in question.
+    """
+    if not text.startswith("---\n"):
+        return text, {}
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return text, {}
+    yaml_block = text[4:end]
+    body = text[end + len("\n---\n") :]
+    try:
+        parsed = yaml.safe_load(yaml_block) or {}
+    except yaml.YAMLError as error:
+        raise SchemaValidationError(
+            f"SKILL.md frontmatter is not valid YAML: {error}"
+        ) from error
+    if not isinstance(parsed, dict):
+        raise SchemaValidationError(
+            "SKILL.md frontmatter must be a YAML mapping."
+        )
+    return body, parsed
+
+
+def _load_schema(registry: str) -> dict[str, Any]:
+    """Load the JSON schema for `registry`. Cached via `lru_cache`-free
+    module-level dict — schemas don't change at runtime."""
+    cached = _SCHEMA_CACHE.get(registry)
+    if cached is not None:
+        return cached
+
+    root = _catalog_root() / "_schema"
+    if registry == "clawrium":
+        schema_path = root / "clawrium.schema.json"
+    else:
+        schema_path = root / "native" / f"{registry}.schema.json"
+
+    if not schema_path.is_file():
+        raise SchemaValidationError(
+            f"Schema file for registry {registry!r} not found at {schema_path}."
+        )
+    try:
+        schema = json.loads(schema_path.read_text())
+    except json.JSONDecodeError as error:
+        raise SchemaValidationError(
+            f"Schema {schema_path} is not valid JSON: {error}"
+        ) from error
+    _SCHEMA_CACHE[registry] = schema
+    return schema
+
+
+_SCHEMA_CACHE: dict[str, dict[str, Any]] = {}
+
+
+def _validate_against_schema(
+    data: dict[str, Any], schema: dict[str, Any], ref: SkillRef
+) -> None:
+    """Run jsonschema validation, translating errors into `SchemaValidationError`.
+
+    Lazy-imports `jsonschema` so this module imports cleanly even in
+    environments where the dep hasn't been installed yet (e.g. tooling
+    that imports our types but never calls the validator).
+    """
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError as error:
+        raise SchemaValidationError(
+            "jsonschema package is required for skill validation. "
+            "Install it: `uv sync` (or `pip install jsonschema`)."
+        ) from error
+
+    validator = Draft202012Validator(schema)
+    # Coerce path components to str before sorting — `absolute_path` may
+    # contain a mix of dict keys (str) and array indices (int), and
+    # `sorted()` raises TypeError on mixed-type comparisons. Stable
+    # ordering is the only thing we need here, not lexical correctness.
+    errors = sorted(
+        validator.iter_errors(data),
+        key=lambda e: [str(p) for p in e.absolute_path],
+    )
+    if not errors:
+        return
+    messages = []
+    for err in errors:
+        location = ".".join(str(p) for p in err.absolute_path) or "<root>"
+        messages.append(f"  - {location}: {err.message}")
+    raise SchemaValidationError(
+        f"Skill {ref} failed {schema.get('title', 'schema')} validation:\n"
+        + "\n".join(messages)
+    )
+
+
+__all__ = [
+    "REGISTRIES",
+    "NATIVE_REGISTRIES",
+    "Skill",
+    "SkillRef",
+    "SkillError",
+    "MissingRegistryPrefix",
+    "InvalidSkillRef",
+    "ExternalSourceBlocked",
+    "SkillNotFound",
+    "SchemaValidationError",
+    "parse_skill_ref",
+    "list_skills",
+    "load_skill",
+    "validate_skill",
+]

--- a/tests/test_cli_skill.py
+++ b/tests/test_cli_skill.py
@@ -1,0 +1,233 @@
+"""Tests for `clm skill list` and `clm skill show`."""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from clawrium.cli import skill as skill_cli
+from clawrium.cli.main import app
+from clawrium.core import skills as core_skills
+from clawrium.core.skills import Skill, SkillNotFound, SkillRef
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _reset_schema_cache():
+    """Module-level cache leaks between tests — reset on setup and teardown."""
+    core_skills._SCHEMA_CACHE.clear()
+    yield
+    core_skills._SCHEMA_CACHE.clear()
+
+
+def test_skill_list_includes_clawrium_tdd():
+    result = runner.invoke(app, ["skill", "list"])
+    assert result.exit_code == 0, result.output
+    assert "clawrium/tdd" in result.output
+    assert "Skills catalog" in result.output
+
+
+def test_skill_list_filtered_to_native_registry_is_empty():
+    result = runner.invoke(app, ["skill", "list", "--registry", "openclaw"])
+    assert result.exit_code == 0
+    assert "No skills registered" in result.output
+
+
+def test_skill_list_unknown_registry_exits_nonzero():
+    result = runner.invoke(app, ["skill", "list", "--registry", "bogus"])
+    assert result.exit_code != 0
+    assert "Unknown registry" in result.output
+
+
+def test_skill_show_real_tdd():
+    result = runner.invoke(app, ["skill", "show", "clawrium/tdd"])
+    assert result.exit_code == 0, result.output
+    assert "clawrium/tdd" in result.output
+    assert "Test-Driven Development" in result.output
+    assert "Metadata" in result.output
+    assert "SKILL.md" in result.output
+
+
+def test_skill_show_bare_name_returns_hint():
+    result = runner.invoke(app, ["skill", "show", "tdd"])
+    assert result.exit_code != 0
+    assert "missing a registry prefix" in result.output
+    # Hint should include the canonical clawrium/tdd suggestion.
+    assert "clawrium/tdd" in result.output
+
+
+def test_skill_show_external_source_blocked():
+    result = runner.invoke(app, ["skill", "show", "https://example.com/x"])
+    assert result.exit_code != 0
+    assert "External skill sources are not allowed" in result.output
+
+
+def test_skill_show_absolute_path_blocked():
+    result = runner.invoke(app, ["skill", "show", "/tmp/foo"])
+    assert result.exit_code != 0
+    assert "Path-style skill sources are not allowed" in result.output
+
+
+def test_skill_show_not_found():
+    result = runner.invoke(app, ["skill", "show", "clawrium/no-such-skill"])
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+
+
+def test_skill_show_unknown_registry_rejected():
+    result = runner.invoke(app, ["skill", "show", "bogus/whatever"])
+    assert result.exit_code != 0
+    assert "Unknown registry" in result.output
+
+
+def test_skill_list_no_args_works():
+    # No --registry filter — should enumerate everything.
+    result = runner.invoke(app, ["skill", "list"])
+    assert result.exit_code == 0
+    assert "clawrium/tdd" in result.output
+
+
+def test_skill_top_level_help_lists_subcommands():
+    result = runner.invoke(app, ["skill", "--help"])
+    assert result.exit_code == 0
+    assert "list" in result.output
+    assert "show" in result.output
+
+
+def test_skill_list_catches_missing_catalog(monkeypatch):
+    # If the catalog itself can't be located, `clm skill list` must
+    # exit non-zero with an Error: prefix — not raise a raw traceback.
+    def fake_list(registry=None):
+        raise SkillNotFound(
+            "skills catalog not found (looked for ... and ...). "
+            "Reinstall with: `uv tool install --force clawrium`."
+        )
+
+    monkeypatch.setattr(skill_cli, "list_skills", fake_list)
+    result = runner.invoke(app, ["skill", "list"])
+    assert result.exit_code != 0
+    assert "Error" in result.output
+    # Rich may soft-wrap long messages — collapse whitespace before
+    # asserting on substring presence.
+    collapsed = " ".join(result.output.split())
+    assert "skills catalog not found" in collapsed
+    # Pin the reinstall hint in the message so the W-new2 addition has
+    # a regression guard.
+    assert "uv tool install --force clawrium" in collapsed
+
+
+def test_skill_list_description_includes_real_text():
+    # Strengthens the happy-path table test: assert the actual
+    # description text reaches the rendered output, not just the ref.
+    result = runner.invoke(app, ["skill", "list"])
+    assert result.exit_code == 0
+    assert "Test-Driven Development" in result.output
+
+
+def test_skill_show_schema_validation_failure(monkeypatch, tmp_path):
+    # Drive `clm skill show` through the SchemaValidationError catch
+    # path. Builds a tmp_path catalog whose schema rejects the seed
+    # skill (here: a fake whose _meta.name disagrees with dir name).
+    skill_dir = tmp_path / "clawrium" / "bad"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "_meta.yaml").write_text(
+        "\n".join(
+            [
+                "name: not-bad",  # mismatched on purpose
+                "description: triggers slug-invariant failure",
+                "version: 0.1.0",
+                "compatibility:",
+                "  openclaw: true",
+                "  hermes: true",
+                "  zeroclaw: true",
+            ]
+        )
+        + "\n"
+    )
+    (skill_dir / "SKILL.md").write_text("---\nname: bad\ndescription: x\n---\nbody")
+
+    # Copy the real schemas in so SchemaValidationError comes from the
+    # production validator, not from a missing schema file.
+    from pathlib import Path as _P
+
+    repo_root = _P(core_skills.__file__).resolve().parents[3]
+    real_schema_root = repo_root / "skills" / "_schema"
+    dest = tmp_path / "_schema"
+    dest.mkdir()
+    (dest / "clawrium.schema.json").write_text(
+        (real_schema_root / "clawrium.schema.json").read_text()
+    )
+    (dest / "native").mkdir()
+    for native in ("openclaw", "hermes", "zeroclaw"):
+        (dest / "native" / f"{native}.schema.json").write_text(
+            (real_schema_root / "native" / f"{native}.schema.json").read_text()
+        )
+
+    monkeypatch.setattr(core_skills, "_catalog_root", lambda: tmp_path)
+    # _SCHEMA_CACHE reset is handled by the autouse fixture above.
+
+    result = runner.invoke(app, ["skill", "show", "clawrium/bad"])
+    assert result.exit_code != 0
+    assert "Error" in result.output
+    assert "directory name" in result.output  # slug-invariant message
+
+
+# --------------------------- _short_description ----------------------------
+
+
+def test_short_description_real_skill():
+    ref = SkillRef("clawrium", "tdd")
+    result = skill_cli._short_description(ref)
+    assert "Test-Driven Development" in result
+
+
+def test_short_description_swallows_skill_error(monkeypatch):
+    ref = SkillRef("clawrium", "ghost")
+
+    def fake_load(_ref):
+        raise SkillNotFound("nope")
+
+    monkeypatch.setattr(skill_cli, "load_skill", fake_load)
+    assert skill_cli._short_description(ref) == "?"
+
+
+def test_short_description_truncates_long_text(monkeypatch):
+    ref = SkillRef("clawrium", "long")
+    fake = Skill(
+        ref=ref,
+        path=None,  # type: ignore[arg-type]
+        metadata={"description": "x" * 200},
+        body="",
+        skill_md_frontmatter={},
+    )
+    monkeypatch.setattr(skill_cli, "load_skill", lambda _r: fake)
+    result = skill_cli._short_description(ref)
+    assert result.endswith("...")
+    assert len(result) <= 80
+
+
+def test_short_description_handles_non_string(monkeypatch):
+    ref = SkillRef("clawrium", "weird")
+    fake = Skill(
+        ref=ref,
+        path=None,  # type: ignore[arg-type]
+        metadata={"description": 42},
+        body="",
+        skill_md_frontmatter={},
+    )
+    monkeypatch.setattr(skill_cli, "load_skill", lambda _r: fake)
+    assert skill_cli._short_description(ref) == "?"
+
+
+def test_short_description_handles_empty_string(monkeypatch):
+    ref = SkillRef("clawrium", "empty")
+    fake = Skill(
+        ref=ref,
+        path=None,  # type: ignore[arg-type]
+        metadata={"description": "   "},
+        body="",
+        skill_md_frontmatter={},
+    )
+    monkeypatch.setattr(skill_cli, "load_skill", lambda _r: fake)
+    assert skill_cli._short_description(ref) == "?"

--- a/tests/test_core_skills.py
+++ b/tests/test_core_skills.py
@@ -1,0 +1,388 @@
+"""Tests for the skills catalog loader (parse / load / validate / list).
+
+Covers the Phase 1 exit criteria from issue #380:
+- `parse_skill_ref` raises the right error class for each bad input shape.
+- `validate_skill` dispatches on registry and validates against the
+  matching JSON schema (dual-schema dispatch).
+- `load_skill` raises `SkillNotFound` for missing entries.
+- `list_skills` enumerates the on-disk catalog and respects `--registry`.
+
+Catalog tests use a temp directory monkey-patched in as `_catalog_root`
+so they don't depend on the in-repo `skills/` tree state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from clawrium.core import skills
+from clawrium.core.skills import (
+    ExternalSourceBlocked,
+    InvalidSkillRef,
+    MissingRegistryPrefix,
+    REGISTRIES,
+    SchemaValidationError,
+    SkillNotFound,
+    SkillRef,
+    list_skills,
+    load_skill,
+    parse_skill_ref,
+    validate_skill,
+)
+
+
+# ----------------------------- parse_skill_ref ------------------------------
+
+
+def test_parse_skill_ref_happy_path():
+    ref = parse_skill_ref("clawrium/tdd")
+    assert ref == SkillRef(registry="clawrium", name="tdd")
+    assert str(ref) == "clawrium/tdd"
+
+
+@pytest.fixture(autouse=True)
+def _reset_schema_cache():
+    """Schema cache is module-level. Tests that build a fake catalog
+    in tmp_path poison the cache for whichever test runs next; clear
+    it on every setup and teardown to keep tests independent."""
+    skills._SCHEMA_CACHE.clear()
+    yield
+    skills._SCHEMA_CACHE.clear()
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "\t\n"])
+def test_parse_skill_ref_empty_rejected(raw):
+    with pytest.raises(InvalidSkillRef, match="empty|non-empty"):
+        parse_skill_ref(raw)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "http://example.com/skill.tgz",
+        "https://github.com/foo/bar",
+        "git+https://github.com/foo/bar",
+        "git@github.com:foo/bar",
+        "ssh://host/path",
+        "file:///etc/passwd",
+    ],
+)
+def test_parse_skill_ref_blocks_urls(raw):
+    with pytest.raises(ExternalSourceBlocked):
+        parse_skill_ref(raw)
+
+
+@pytest.mark.parametrize("raw", ["/abs/path", "~/relative", "/etc/passwd"])
+def test_parse_skill_ref_blocks_paths(raw):
+    with pytest.raises(ExternalSourceBlocked):
+        parse_skill_ref(raw)
+
+
+def test_parse_skill_ref_bare_name_raises_missing_prefix():
+    with pytest.raises(MissingRegistryPrefix) as excinfo:
+        parse_skill_ref("tdd")
+    # The hint should reference the canonical clawrium/tdd if it exists
+    # in the in-repo catalog. We don't assert on the hint here to keep
+    # the test independent of the catalog state; presence is verified
+    # in test_parse_skill_ref_bare_name_hints_existing_matches.
+    assert "missing a registry prefix" in str(excinfo.value)
+
+
+def test_parse_skill_ref_bare_name_hints_existing_matches():
+    # Uses the real in-repo catalog: clawrium/tdd exists, so the hint
+    # message should point to it as a copy-pasteable correction.
+    with pytest.raises(MissingRegistryPrefix) as excinfo:
+        parse_skill_ref("tdd")
+    assert "clawrium/tdd" in str(excinfo.value)
+
+
+def test_parse_skill_ref_rejects_unknown_registry():
+    with pytest.raises(InvalidSkillRef, match="Unknown registry"):
+        parse_skill_ref("nope/tdd")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "clawrium/TDD",  # uppercase
+        "clawrium/-leading",
+        "clawrium/_leading",
+        "clawrium/has spaces",
+        "clawrium/a/b",  # too many slashes
+        "clawrium/",  # empty name
+    ],
+)
+def test_parse_skill_ref_rejects_bad_names(raw):
+    with pytest.raises(InvalidSkillRef):
+        parse_skill_ref(raw)
+
+
+def test_parse_skill_ref_non_string_input():
+    with pytest.raises(InvalidSkillRef):
+        parse_skill_ref(None)  # type: ignore[arg-type]
+
+
+# ------------------------------ list_skills ---------------------------------
+
+
+def test_list_skills_includes_tdd():
+    refs = list_skills()
+    # in-repo seed must include clawrium/tdd, validated end-to-end below.
+    assert SkillRef("clawrium", "tdd") in refs
+
+
+def test_list_skills_filter_to_clawrium():
+    refs = list_skills(registry="clawrium")
+    assert all(ref.registry == "clawrium" for ref in refs)
+    assert SkillRef("clawrium", "tdd") in refs
+
+
+def test_list_skills_unknown_registry_rejected():
+    with pytest.raises(InvalidSkillRef, match="Unknown registry"):
+        list_skills(registry="bogus")
+
+
+def test_list_skills_empty_native_registries():
+    # Phase 1 ships no native skills — placeholders only. Each native
+    # registry should list cleanly as an empty result, not crash.
+    for native in ("openclaw", "hermes", "zeroclaw"):
+        refs = list_skills(registry=native)
+        assert refs == [], f"{native} should be empty in Phase 1, got {refs}"
+
+
+# ------------------------------ load_skill ----------------------------------
+
+
+def test_load_skill_real_tdd():
+    skill = load_skill("clawrium/tdd")
+    assert skill.ref == SkillRef("clawrium", "tdd")
+    assert skill.metadata.get("name") == "tdd"
+    assert "Test-Driven Development" in skill.metadata.get("description", "")
+    assert skill.body.strip().startswith("# TDD")
+
+
+def test_load_skill_missing_raises_not_found():
+    with pytest.raises(SkillNotFound):
+        load_skill("clawrium/no-such-skill")
+
+
+def test_load_skill_via_string_runs_parse_first():
+    # A URL passed to load_skill should bubble ExternalSourceBlocked
+    # from parse_skill_ref unchanged.
+    with pytest.raises(ExternalSourceBlocked):
+        load_skill("https://example.com/foo")
+
+
+# ---------------------------- validate_skill --------------------------------
+
+
+def test_validate_skill_real_tdd_passes():
+    skill = load_skill("clawrium/tdd")
+    validate_skill(skill)  # should not raise
+
+
+def test_validate_skill_enforces_slug_invariant(monkeypatch, tmp_path):
+    # Build a fake catalog where _meta.yaml's `name` disagrees with the
+    # parent directory name. validate_skill must reject this — required
+    # for downstream zeroclaw source-dirname semantics.
+    _build_fake_clawrium_skill(tmp_path, dir_name="tdd", meta_name="wrong")
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+
+    skill = load_skill("clawrium/tdd")
+    with pytest.raises(SchemaValidationError, match="must equal directory name"):
+        validate_skill(skill)
+
+
+def test_validate_skill_dual_schema_dispatch_native(monkeypatch, tmp_path):
+    # A native registry (e.g. hermes) should validate against the
+    # native/hermes.schema.json, not the clawrium schema. We build a
+    # hermes skill with frontmatter that satisfies hermes but would fail
+    # the stricter clawrium schema (no `compatibility` block).
+    _build_fake_native_skill(tmp_path, registry="hermes", name="sample")
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+
+    skill = load_skill("hermes/sample")
+    validate_skill(skill)  # uses native/hermes.schema.json — no compat block needed
+
+
+def test_validate_skill_native_rejects_missing_required(monkeypatch, tmp_path):
+    _build_fake_native_skill(
+        tmp_path,
+        registry="openclaw",
+        name="broken",
+        frontmatter={"description": "no name field"},
+    )
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+
+    skill = load_skill("openclaw/broken")
+    with pytest.raises(SchemaValidationError, match="required"):
+        validate_skill(skill)
+
+
+def test_validate_skill_clawrium_rejects_missing_compatibility(
+    monkeypatch, tmp_path
+):
+    # Clawrium schema declares `compatibility` as required; this is the
+    # rejection-direction test that the affirmative tests above don't cover.
+    # Without this, dropping `compatibility` from the schema's required
+    # list would silently pass the test suite.
+    skill_dir = tmp_path / "clawrium" / "incomplete"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "_meta.yaml").write_text(
+        "name: incomplete\ndescription: missing compat\nversion: 0.1.0\n"
+    )
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: incomplete\ndescription: missing compat\n---\n"
+    )
+    _copy_schemas(tmp_path)
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+
+    skill = load_skill("clawrium/incomplete")
+    with pytest.raises(SchemaValidationError, match="compatibility|required"):
+        validate_skill(skill)
+
+
+def test_validate_skill_zeroclaw_dispatch(monkeypatch, tmp_path):
+    # Mirror of the hermes dispatch test — guarantees the zeroclaw branch
+    # of the dual-schema dispatch is exercised at least once.
+    _build_fake_native_skill(tmp_path, registry="zeroclaw", name="zsample")
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+
+    skill = load_skill("zeroclaw/zsample")
+    validate_skill(skill)  # native/zeroclaw.schema.json — no compat block needed
+
+
+# ---------------------- _validate_against_schema sort key ------------------
+
+
+def test_validate_against_schema_sort_key_handles_mixed_paths(monkeypatch):
+    # The sort key in `_validate_against_schema` must tolerate
+    # `absolute_path` deques whose components are a mix of `str` (object
+    # keys) and `int` (array indices). The failure mode is a TypeError
+    # raised by Python's sort during `int < str` comparison — which
+    # only triggers when two errors share a common prefix but diverge
+    # at the same depth with mixed types (e.g. `['items', 'foo']` vs
+    # `['items', 0]`). We mock the validator to produce exactly that
+    # pair so the regression actually exercises the int-vs-str compare.
+    from collections import deque
+    from unittest.mock import MagicMock, patch
+
+    err_str = MagicMock()
+    err_str.absolute_path = deque(["items", "foo"])
+    err_str.message = "string-keyed branch"
+
+    err_int = MagicMock()
+    err_int.absolute_path = deque(["items", 0])
+    err_int.message = "int-indexed branch"
+
+    fake_validator = MagicMock()
+    fake_validator.iter_errors.return_value = [err_str, err_int]
+
+    # The validator is lazily imported inside `_validate_against_schema`
+    # so the patch target is the source module, not `clawrium.core.skills`.
+    with patch(
+        "jsonschema.Draft202012Validator",
+        return_value=fake_validator,
+    ):
+        with pytest.raises(SchemaValidationError) as excinfo:
+            skills._validate_against_schema(
+                data={"items": "ignored — Draft202012Validator is mocked"},
+                schema={"$schema": "x", "title": "fake"},
+                ref=SkillRef("clawrium", "anything"),
+            )
+    # Both branches must surface — confirms the sort completed and the
+    # report was assembled, not short-circuited by TypeError.
+    rendered = str(excinfo.value)
+    assert "string-keyed branch" in rendered
+    assert "int-indexed branch" in rendered
+
+
+# ------------------------------ utilities -----------------------------------
+
+
+def _build_fake_clawrium_skill(
+    root: Path, dir_name: str = "tdd", meta_name: str = "tdd"
+) -> None:
+    """Create a minimal in-tmp_path clawrium catalog containing one skill."""
+    skill_dir = root / "clawrium" / dir_name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "_meta.yaml").write_text(
+        "\n".join(
+            [
+                f"name: {meta_name}",
+                "description: fake",
+                "version: 0.1.0",
+                "compatibility:",
+                "  openclaw: true",
+                "  hermes: true",
+                "  zeroclaw: true",
+            ]
+        )
+        + "\n"
+    )
+    (skill_dir / "SKILL.md").write_text("---\nname: tdd\ndescription: fake\n---\nbody")
+    _copy_schemas(root)
+
+
+def _build_fake_native_skill(
+    root: Path,
+    registry: str,
+    name: str,
+    frontmatter: dict | None = None,
+) -> None:
+    """Create a minimal native-registry skill under `root`."""
+    assert registry in REGISTRIES and registry != "clawrium"
+    skill_dir = root / registry / name
+    skill_dir.mkdir(parents=True)
+    frontmatter = (
+        frontmatter
+        if frontmatter is not None
+        else {"name": name, "description": "fake native"}
+    )
+    lines = [f"{k}: {v}" for k, v in frontmatter.items()]
+    (skill_dir / "SKILL.md").write_text(
+        "---\n" + "\n".join(lines) + "\n---\nbody\n"
+    )
+    _copy_schemas(root)
+
+
+def _copy_schemas(root: Path) -> None:
+    """Materialize the real in-repo schemas under `root/_schema/` so
+    validation in test scenarios runs against the same files CI uses."""
+    src_schema_root = Path(skills.__file__).resolve().parents[3] / "skills" / "_schema"
+    if not src_schema_root.is_dir():
+        # Fallback for installed-only environments — should not happen
+        # during development, but keep the failure mode loud.
+        raise RuntimeError(f"Expected in-repo schemas at {src_schema_root}")
+    dest_schema = root / "_schema"
+    dest_schema.mkdir(exist_ok=True)
+    (dest_schema / "clawrium.schema.json").write_text(
+        (src_schema_root / "clawrium.schema.json").read_text()
+    )
+    native_dest = dest_schema / "native"
+    native_dest.mkdir(exist_ok=True)
+    for native in ("openclaw", "hermes", "zeroclaw"):
+        (native_dest / f"{native}.schema.json").write_text(
+            (src_schema_root / "native" / f"{native}.schema.json").read_text()
+        )
+
+
+def test_real_schemas_are_valid_json():
+    # Sanity check the schema files we ship aren't malformed — saves a
+    # confusing failure mode where validate_skill raises SchemaValidationError
+    # "schema is not valid JSON" instead of validating user data.
+    src_schema_root = Path(skills.__file__).resolve().parents[3] / "skills" / "_schema"
+    files = [
+        src_schema_root / "clawrium.schema.json",
+        src_schema_root / "native" / "openclaw.schema.json",
+        src_schema_root / "native" / "hermes.schema.json",
+        src_schema_root / "native" / "zeroclaw.schema.json",
+    ]
+    for path in files:
+        assert path.is_file(), path
+        data = json.loads(path.read_text())
+        assert isinstance(data, dict)
+        assert "$schema" in data

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -47,6 +47,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -324,6 +333,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "fuzzyfinder" },
     { name = "httpx" },
+    { name = "jsonschema" },
     { name = "msgpack" },
     { name = "packaging" },
     { name = "paramiko" },
@@ -350,6 +360,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fuzzyfinder", specifier = ">=2.1.0,<3.0.0" },
     { name = "httpx", specifier = ">=0.27,<1.0" },
+    { name = "jsonschema", specifier = ">=4.17.0,<5.0.0" },
     { name = "msgpack", specifier = ">=1.1.2" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "paramiko", specifier = ">=3.0.0" },
@@ -723,6 +734,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1298,6 +1336,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1323,6 +1375,128 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bring the `issue-386-phase0-research` branch back to `main`. PR #387 (Phase 0) merged into `main` earlier, but the branch then received post-merge cleanup commits and absorbed Phase 1 via PR #388 before being synced. This PR closes the gap.

Carries 5 commits:

| Commit | Subject |
|--------|---------|
| 81fa132 | feat(skills): #380 Phase 1 — CLI browses the in-repo catalog |
| 11ed7f7 | Merge pull request #388 from ric03uec/issue-380-cli-skill-catalog-browse |
| f759763 | chore(#364): address ATX Round 1 — clarify scope, risks, prerequisites |
| ef48943 | chore(#364): address ATX Round 2 — patch plan stragglers + add body backing |
| 96552a2 | chore(#364): address ATX Round 3 — fix attribution + add duplicate-install probe |

Phase 1 work was reviewed in PR #388 (ATX iterations 1–3, final 4/5, zero blockers).

## Testing

### Test Results
- [x] All existing tests pass (`uv run pytest` — 2004 passed)
- [x] Linter passes (`uv run ruff check src tests`)
- [x] New tests in #380 covered: parse_skill_ref errors, dual-schema dispatch, slug invariant, CLI happy/error paths, `_short_description` branches, mocked-validator regression

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (every skill ref passes through `parse_skill_ref`)
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources (`jsonschema>=4.17.0,<5.0.0`)

## Reviewer Notes

This is a sync PR rather than a feature PR — Phase 1 has already cleared ATX review under PR #388 against the predecessor branch. No code changed since that review; only the merge target moves.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)