### PR TITLE
fix(skills): pre-remove desired+installed slugs before zeroclaw native install

### DIFF
--- a/src/clawrium/platform/registry/zeroclaw/playbooks/skills_apply.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/skills_apply.yaml
@@ -27,13 +27,18 @@
 #     locked this contract: `zeroclaw skills remove <slug>` expects the
 #     source-dirname, which our materialization step always names with
 #     the canonical slug.
-#   - Idempotency: `zeroclaw skills install` is itself idempotent over
-#     identical inputs (re-installs in place after audit). We rely on
-#     the native CLI's idempotency, not a pre-check that would skip the
-#     audit. Drift recovery: if a slug is absent from
-#     `~/.zeroclaw/workspace/skills/` between applies, the install
-#     restores it; if the on-disk SKILL.md drifted, the next install
-#     re-stages it and re-audits.
+#   - Idempotency: zeroclaw v0.7.5's `skills install` is NOT
+#     overwrite-idempotent — it errors with "Destination skill already
+#     exists" when the slug is already present under
+#     `~/.zeroclaw/workspace/skills/`. We work around this by
+#     pre-removing any slug that is both desired and currently
+#     installed BEFORE running the install loop. The install loop then
+#     always runs against a clean destination so the audit gate runs
+#     on every apply. Drift recovery: if a slug is absent from
+#     `~/.zeroclaw/workspace/skills/` between applies, the pre-remove
+#     is a no-op (intersect is empty) and the install restores it; if
+#     the on-disk SKILL.md drifted, the pre-remove discards the drifted
+#     copy and the install re-stages + re-audits.
 - hosts: all
   become: yes
   gather_facts: false
@@ -181,6 +186,30 @@
         group: "{{ agent_name }}"
         mode: "0700"
       when: desired_skill_names | length > 0
+
+    # Pre-remove already-installed desired skills. zeroclaw v0.7.5's
+    # `skills install` is NOT overwrite-idempotent — it errors with
+    # "Destination skill already exists" when the slug is already in
+    # `~/.zeroclaw/workspace/skills/`. Without this step the second
+    # apply for an unchanged desired-state fails. Discovered by E2E
+    # validation of #364 against tdd-zeroclaw on wolf-i.
+    #
+    # We only remove slugs present in BOTH desired and installed —
+    # the unconditional install loop below then runs the audit gate
+    # on a clean destination, preserving "audit on every apply".
+    - name: Pre-remove desired-and-installed slugs for clean re-install
+      ansible.builtin.command:
+        argv:
+          - "{{ zeroclaw_bin }}"
+          - skills
+          - remove
+          - "{{ item }}"
+      become_user: "{{ agent_name }}"
+      loop: "{{ desired_skill_names | intersect(installed_slugs) }}"
+      when:
+        - item is match('^[a-z0-9][a-z0-9_-]*$')
+      register: zeroclaw_preremove_results
+      changed_when: zeroclaw_preremove_results.rc == 0
 
     # Wrap the stage + install steps in block/always so that even if
     # the audit gate rejects a skill (non-zero rc from `zeroclaw skills

--- a/tests/test_registry_skills_apply.py
+++ b/tests/test_registry_skills_apply.py
@@ -200,6 +200,51 @@ def test_zeroclaw_playbook_removes_via_native_cli():
     assert argv[2] == "remove"
 
 
+def test_zeroclaw_playbook_preremoves_desired_and_installed_slugs():
+    """zeroclaw v0.7.5's `skills install` is NOT overwrite-idempotent:
+    if the destination dir under `~/.zeroclaw/workspace/skills/` already
+    exists, the install errors with "Destination skill already exists".
+
+    The playbook works around this by removing slugs that are present
+    in BOTH desired_skill_names AND installed_slugs before the install
+    loop runs — so the install always lands on a clean destination
+    while preserving the "audit on every apply" intent.
+
+    Regression guard: E2E validation of #364 against tdd-zeroclaw on
+    wolf-i caught the bug; the second apply for an unchanged desired
+    state failed before this pre-remove was added."""
+    _, play = _load_playbook("zeroclaw")
+    preremove = next(
+        t
+        for t in play["tasks"]
+        if t.get("name")
+        == "Pre-remove desired-and-installed slugs for clean re-install"
+    )
+    argv = preremove["ansible.builtin.command"]["argv"]
+    assert argv[1:3] == ["skills", "remove"], argv
+    # Loop must be the intersection of desired and installed — not
+    # all desired (would error on first-install for new slugs) and
+    # not all installed (that's the prune step's job).
+    assert "desired_skill_names | intersect(installed_slugs)" in preremove["loop"]
+
+
+def test_zeroclaw_playbook_preremove_runs_before_install_loop():
+    """Pre-remove must execute BEFORE the stage+install block —
+    otherwise the install would still error on already-present slugs."""
+    _, play = _load_playbook("zeroclaw")
+    task_names = [t.get("name") for t in play["tasks"] if t.get("name")]
+    preremove_idx = task_names.index(
+        "Pre-remove desired-and-installed slugs for clean re-install"
+    )
+    stage_block_idx = task_names.index(
+        "Stage + install + cleanup (always cleans up on failure)"
+    )
+    assert preremove_idx < stage_block_idx, (
+        "Pre-remove must run before the stage+install block, "
+        f"got preremove_idx={preremove_idx} stage_block_idx={stage_block_idx}"
+    )
+
+
 def test_zeroclaw_playbook_uses_workspace_skills_path():
     """Phase 0 confirmed the on-disk install path is
     `~/.zeroclaw/workspace/skills/` (workspace-scoped), not the

--- a/tests/test_registry_skills_apply.py
+++ b/tests/test_registry_skills_apply.py
@@ -222,10 +222,24 @@ def test_zeroclaw_playbook_preremoves_desired_and_installed_slugs():
     )
     argv = preremove["ansible.builtin.command"]["argv"]
     assert argv[1:3] == ["skills", "remove"], argv
-    # Loop must be the intersection of desired and installed — not
-    # all desired (would error on first-install for new slugs) and
-    # not all installed (that's the prune step's job).
-    assert "desired_skill_names | intersect(installed_slugs)" in preremove["loop"]
+    # Loop must be EXACTLY the intersection of desired and installed —
+    # not all desired (would error on first-install for new slugs) and
+    # not all installed (that's the prune step's job). Exact match
+    # guards against a mutated expression that appends extra filters.
+    assert (
+        preremove["loop"]
+        == "{{ desired_skill_names | intersect(installed_slugs) }}"
+    )
+    # Per-iteration regex guard: defense-in-depth so a tampered
+    # extravar that bypassed the earlier validate task still can't
+    # be passed as `zeroclaw skills remove <slug>`.
+    when_clauses = preremove.get("when")
+    assert when_clauses is not None, "pre-remove must have a `when:` guard"
+    when_str = " ".join(when_clauses) if isinstance(when_clauses, list) else when_clauses
+    assert "match('^[a-z0-9][a-z0-9_-]*$')" in when_str, when_str
+    # Must run as the agent user (zeroclaw is single-user-scoped — the
+    # binary won't find the right config.toml as root).
+    assert preremove.get("become_user") == "{{ agent_name }}"
 
 
 def test_zeroclaw_playbook_preremove_runs_before_install_loop():


### PR DESCRIPTION
## Summary
E2E validation of #364 against `tdd-zeroclaw` on `wolf-i` caught a real idempotency bug. The second `clm agent skill install <agent> <skill>` for an unchanged desired state fails because zeroclaw v0.7.5's native `skills install` errors when the destination directory already exists (no `--force` flag).

## Root cause
The playbook design assumed `zeroclaw skills install` was overwrite-idempotent:
> Idempotency: `zeroclaw skills install` is itself idempotent over identical inputs (re-installs in place after audit).

It isn't:
```
Error: failed to install local skill source: /home/tdd-zeroclaw/.zeroclaw/.clawrium-stage/tdd
Caused by:
    Destination skill already exists: /home/tdd-zeroclaw/.zeroclaw/workspace/skills/tdd
```

## Fix
Add a `Pre-remove desired-and-installed slugs for clean re-install` task that removes slugs present in BOTH `desired_skill_names` AND `installed_slugs` before the existing stage+install block runs. The install loop then always lands on a clean destination, preserving the "audit on every apply" intent (we still call the native CLI for every desired skill).

The intersection is essential:
- Not all desired (would error trying to remove not-yet-installed slugs on first install)
- Not all installed (that's the existing "Uninstall clawrium-managed skills no longer in desired state" prune task)

## Tests added
- `test_zeroclaw_playbook_preremoves_desired_and_installed_slugs` — asserts pre-remove task exists, invokes `skills remove`, loops `desired_skill_names | intersect(installed_slugs)`
- `test_zeroclaw_playbook_preremove_runs_before_install_loop` — asserts pre-remove runs before stage+install block

## E2E verification on wolf-i (after fix)
| # | Scenario | Result |
|---|---|---|
| Z2 | `clm agent skill install tdd-zeroclaw clawrium/tdd` | ✓ Installed |
| Z3 | Native `zeroclaw skills list` shows `tdd v0.1.0` | ✓ |
| Z5 | `clm agent skill list tdd-zeroclaw` shows `clawrium/tdd` | ✓ |
| Z6 | Idempotent install (repeat Z2) | ✓ (was failing pre-fix) |
| Z7 | Drift recovery: `zeroclaw skills remove tdd` then re-install | ✓ (was failing pre-fix) |
| Z8 | `clm agent skill remove tdd-zeroclaw clawrium/tdd` | ✓ |
| Z9 | Native list empty + workspace clean | ✓ |

## Verification
- `make test` — 2230 passed
- `make lint` — clean

Refs #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)