### PR TITLE
[DO NOT MERGE] D3 CI test — verify skills-validate.yml catches broken skill

### DIFF
--- a/skills/clawrium/tdd/_meta.yaml
+++ b/skills/clawrium/tdd/_meta.yaml
@@ -1,29 +1,25 @@
-# skills/clawrium/tdd/_meta.yaml — clawrium-internal normalized shape.
-# Phase 1 materializers (added in Phase 2/3) transform this into per-claw
-# SKILL.md frontmatter on install. Locked shape: .itx/364/02_PHASE0_FINDINGS.md.
 name: tdd
-description: >-
-  Test-Driven Development discipline. Drives a red → green → refactor
-  cycle for the active task: write a failing test, make it pass with the
-  minimum change, then refactor while green.
 version: 0.1.0
 license: MIT
 author: clawrium
-platforms: [linux, macos]
-
+platforms:
+- linux
+- macos
 compatibility:
   openclaw: true
   hermes: true
   zeroclaw: true
-
 native:
   hermes:
     metadata:
       hermes:
-        tags: [tdd, testing, discipline, clawrium]
+        tags:
+        - tdd
+        - testing
+        - discipline
+        - clawrium
   openclaw: {}
   zeroclaw: {}
-
 prerequisites:
   commands: []
   env: []


### PR DESCRIPTION
Throwaway draft PR for #364 e2e validation Phase D3.

Removes the required 'description' field from `skills/clawrium/tdd/_meta.yaml` to confirm the skills-validate.yml workflow correctly rejects invalid catalog state.

**Expected**: CI fails.
**Cleanup**: this PR + branch will be deleted as soon as CI completes.
