### PR TITLE
docs(skills): on-host troubleshooting + agent-user clarification (#364 e2e findings)

### DIFF
--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -111,7 +111,102 @@ python scripts/validate_skills.py
 | hermes   | `~/.hermes/skills/clawrium/<name>/SKILL.md`   | file copy (auto-scan)                      |
 | zeroclaw | `~/.zeroclaw/workspace/skills/<name>/`        | staged + `zeroclaw skills install` (audit) |
 
+**The `~` above refers to the agent unix user's home**, not the
+operator's home on the control machine. Each agent installed via
+`clm agent install` runs as its own dedicated user named after the
+agent (e.g. `tdd-hermes` runs as user `tdd-hermes`, with files under
+`/home/tdd-hermes/`). To SSH-verify after a CLI install, switch users
+on the remote host:
+
+```bash
+# As the management user (typically xclm), drop into the agent user
+sudo -u tdd-hermes ls /home/tdd-hermes/.hermes/skills/clawrium/tdd/
+```
+
 Re-running `clm agent skill install` is the recovery for drift. There
 is no separate `reconcile` command — the local desired-state file at
 `~/.config/clawrium/agents/<agent>/skills.json` is truth, and every
 install/remove re-applies it end-to-end.
+
+## Ownership boundaries
+
+Pruning never touches user-authored or upstream-bundled skills. Each
+claw uses a different marker so a future apply can distinguish
+clawrium-managed dirs from anything else:
+
+| Claw     | Marker                                                                                  |
+|----------|-----------------------------------------------------------------------------------------|
+| openclaw | `.clawrium-managed` sentinel file inside each clawrium-installed skill dir              |
+| hermes   | Implicit — clawrium skills live under the dedicated `~/.hermes/skills/clawrium/` subdir |
+| zeroclaw | `~/.zeroclaw/.clawrium-managed-skills` (newline-separated slugs, outside `skills/`)     |
+
+If you see a clawrium-installed skill that the prune logic is failing
+to recognize, check that its marker is intact.
+
+## Troubleshooting
+
+### `clm agent skill install` reports success but the file isn't where I expect
+
+The `~` in the on-host paths is the **agent user's** home, not yours.
+A common source of confusion when verifying via SSH as the management
+user (`xclm` by default):
+
+```bash
+# Wrong — checking your own home (or the management user's home)
+ssh wolf-i 'ls ~/.hermes/skills/clawrium/tdd/'
+
+# Right — switch to the agent user
+ssh wolf-i 'sudo -u tdd-hermes ls /home/tdd-hermes/.hermes/skills/clawrium/tdd/'
+```
+
+### `clm agent remove` doesn't clean up the local skill state
+
+Known limitation: `~/.config/clawrium/agents/<name>/skills.json` is
+left behind when you `clm agent remove <name>`. If you re-install
+under the same name later, the leftover state is benign (an empty
+`{"skills": []}` array), but clean it explicitly if you want a clean
+slate:
+
+```bash
+rm -rf ~/.config/clawrium/agents/<name>
+```
+
+### Local end-to-end smoke test
+
+After making a change to a `skills/clawrium/<name>/` or per-claw
+playbook, exercise the full round-trip against a real agent before
+opening a PR:
+
+```bash
+# 1. Install — should report success
+clm agent skill install <agent> clawrium/<name>
+
+# 2. List — should show it
+clm agent skill list <agent>
+
+# 3. Verify on host (substitute the agent's unix user)
+ssh <host> "sudo -u <agent-user> ls -la /home/<agent-user>/<claw-skill-path>"
+
+# 4. Idempotent re-install — should report "already in desired state"
+clm agent skill install <agent> clawrium/<name>
+
+# 5. Drift recovery — delete on host, re-install reconverges
+ssh <host> "sudo -u <agent-user> rm -rf /home/<agent-user>/<claw-skill-path>"
+clm agent skill install <agent> clawrium/<name>
+
+# 6. Remove — should clean up and report success
+clm agent skill remove <agent> clawrium/<name>
+```
+
+### Local validator exit code
+
+`scripts/validate_skills.py` exits **0 on success, 1 on validation
+failure**. When checking the exit code in a script, do not pipe stdout
+through `tail` / `head` — those overwrite `$?` with the pipe element's
+exit. Use:
+
+```bash
+python scripts/validate_skills.py; echo "exit=$?"
+# or
+python scripts/validate_skills.py > /tmp/out.log; echo "exit=$?"
+```

--- a/website/docs/skills/intro.md
+++ b/website/docs/skills/intro.md
@@ -80,11 +80,46 @@ to mix them.
 | hermes   | `~/.hermes/skills/clawrium/<name>/SKILL.md`   | file copy (auto-scan)                      |
 | zeroclaw | `~/.zeroclaw/workspace/skills/<name>/`        | staged + `zeroclaw skills install` (audit) |
 
+:::note
+The `~` above is the **agent unix user's** home, not the operator's.
+Each agent installed via `clm agent install` runs as its own dedicated
+user named after the agent (so an agent named `tdd-hermes` runs as
+user `tdd-hermes` with files under `/home/tdd-hermes/`). To SSH-verify
+after install, switch users on the remote host with
+`sudo -u <agent-name> ls /home/<agent-name>/...`.
+:::
+
 Re-running `clm agent skill install` is the drift recovery — the local
 desired-state file at
 `~/.config/clawrium/agents/<agent>/skills.json` is the source of truth,
 and every install/remove re-applies it end-to-end. There is no separate
 `reconcile` command.
+
+## Troubleshooting
+
+### Install reports success but the file isn't where I expect
+
+Common pitfall — the `~` in the on-host paths is the **agent user's**
+home, not yours. When verifying via SSH:
+
+```bash
+# Wrong — checks the management user's home
+ssh wolf-i 'ls ~/.hermes/skills/clawrium/tdd/'
+
+# Right — switch to the agent user
+ssh wolf-i 'sudo -u tdd-hermes ls /home/tdd-hermes/.hermes/skills/clawrium/tdd/'
+```
+
+### `clm agent remove` leaves the skill state file behind
+
+Known limitation: `~/.config/clawrium/agents/<name>/skills.json` is
+left behind when you `clm agent remove <name>`. Harmless on re-install
+(the file contains an empty array) but clean it explicitly if you want
+a clean slate:
+
+```bash
+rm -rf ~/.config/clawrium/agents/<name>
+```
 
 ## Authoring
 


### PR DESCRIPTION
## Summary

Doc updates that came out of end-to-end validation of #364 against the real test fleet (`tdd-hermes`, `tdd-openclaw`, `tdd-zeroclaw` on `wolf-i`). No code changes — only `docs/skills/index.md` and `website/docs/skills/intro.md`.

## What changed

**Both files**:
- Clarify that `~` in the on-host install paths is the **agent user's** home, not the operator's. Each agent runs as its own unix user named after the agent (e.g. `tdd-hermes` runs as user `tdd-hermes` under `/home/tdd-hermes/`). Include the `sudo -u <agent-name>` recipe for SSH verification.

**`docs/skills/index.md`** (the comprehensive repo-rooted doc):
- New "Ownership boundaries" section — how each claw distinguishes clawrium-managed dirs from user-authored ones (openclaw `.clawrium-managed` sentinel, hermes namespace subdir, zeroclaw `.clawrium-managed-skills` tracking file).
- New "Troubleshooting" section covering:
  - Agent-user vs operator-user confusion (wrong vs right SSH commands)
  - Known limitation: `clm agent remove` leaves `~/.config/clawrium/agents/<name>/skills.json` behind. Harmless on re-install but worth knowing.
  - Local end-to-end smoke-test recipe (install / list / SSH verify / idempotent re-install / drift recovery / remove)
  - `scripts/validate_skills.py` exit-code semantics, with a warning that piping stdout through `tail` masks the script's `$?`.

**`website/docs/skills/intro.md`** (user-facing site mirror, kept condensed per the in-doc note about the trees being semantically synced but not structurally identical):
- Agent-user clarification in a Docusaurus `:::note` callout
- Condensed troubleshooting covering the two most common gotchas

## Why now

I ran a clean-room reinstall (delete + reinstall agents, wipe state, re-run all 33 CLI scenarios + 26 browser-driven scenarios + Phase 6 CI workflow against a deliberately broken fixture). Two findings stood out as doc gaps every operator would hit:

1. Hours debugging "the install said success but I can't find the file" — because I was SSHing as the management user and looking under that user's `~/`, not the agent user's home.
2. Confusion when a re-installed agent appeared to "remember" prior skill state — because `clm agent remove` doesn't touch the desired-state directory.

## Verification

- `make test` → 2230 passed
- `make lint` → clean
- `cd website && npm run build` → clean rebuild, no warnings beyond the pre-existing vscode-languageserver-types one
- Both pages render correctly

## Out of scope (filed separately or flagged in #364 e2e summary)

- Fixing `clm agent remove` to also clean up the skill state dir — feature/bug, not docs
- Adding a top-level "troubleshooting" page to the website nav — orthogonal
- Recovering pyproject version bump for next PyPI release — release-ops, not docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)