### PR TITLE
feat(skills): hermes/{issue-triage,daily-digest,docs-sync} for maurice (#403)

### DIFF
--- a/skills/hermes/daily-digest/SKILL.md
+++ b/skills/hermes/daily-digest/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: daily-digest
+description: Post a daily engineer-tone summary of the last 24h of activity on ric03uec/clawrium to Discord.
+version: 0.1.0
+license: MIT
+author: clawrium
+platforms: [linux, macos]
+metadata:
+  cadence: "daily"
+  trigger: "cron"
+  outputs: ["discord-message"]
+---
+
+# daily-digest
+
+Once per day, summarize what happened on `ric03uec/clawrium` in the
+last 24 hours and post it to the project's home Discord channel.
+
+## Inputs (last 24h, in `ric03uec/clawrium`)
+
+- Merged PRs — title, number, author, one-line summary you derive from
+  the PR body.
+- Issues opened — title, number, current labels.
+- Issues closed — title, number, the closing PR if any.
+- Your own run logs from the previous day (memory keyed
+  `daily-digest:last-run`). Use it to avoid repeating the same items.
+
+Commands:
+
+```bash
+gh pr list --repo ric03uec/clawrium --state merged --search \
+  "merged:>$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)" \
+  --json number,title,author,body
+gh issue list --repo ric03uec/clawrium --state open --search \
+  "created:>$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)" \
+  --json number,title,labels
+gh issue list --repo ric03uec/clawrium --state closed --search \
+  "closed:>$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)" \
+  --json number,title,closedByPullRequestsReferences
+```
+
+## Output
+
+A single Discord message in the home channel, structured as:
+
+```
+**clawrium digest — <YYYY-MM-DD>**
+
+**Shipped (N)**
+- #<num> <title> — <one-line summary>
+
+**Opened (N)**
+- #<num> <title> — <labels>
+
+**Closed (N)**
+- #<num> <title> — closed by #<pr>
+
+Quiet day: <only if nothing material happened>
+```
+
+Send via the hermes Discord channel adapter (the agent already has the
+home channel id bound). Do **not** open a thread; the message is the
+unit.
+
+## Voice
+
+- Engineer to engineer. No marketing copy ("exciting", "robust",
+  "delights"), no hedging through verbosity.
+- Emoji only when it encodes information (✅ for a green CI run that
+  unblocks a release; 🔒 for a security fix). Skip them for flair.
+- Past tense for shipped; present tense for state ("Open: 14").
+- If a single PR did the heavy lifting, say so explicitly — don't
+  level the slope.
+
+## Hard constraints
+
+- One message per day. Idempotent — re-runs within the same day update
+  rather than duplicate (track the last-message id in skill memory).
+- Never `@here` or `@everyone`.
+- If 0 PRs merged and 0 issues opened or closed, post a one-line
+  "Quiet day on clawrium." entry — silence reads as "the bot is
+  broken."
+
+## Anti-patterns
+
+- Paraphrasing each PR body into a paragraph. One line per PR.
+- Listing internal refactors that did not change user-visible
+  behavior. Group them: "+ 4 internal cleanups (#a, #b, #c, #d)".
+- Restating yesterday's items. Use the run log to dedup.

--- a/skills/hermes/docs-sync/SKILL.md
+++ b/skills/hermes/docs-sync/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: docs-sync
+description: Detect user-visible changes from the last 24h of commits on main and propose doc and scenario updates as PRs.
+version: 0.1.0
+license: MIT
+author: clawrium
+platforms: [linux, macos]
+metadata:
+  cadence: "daily"
+  trigger: "cron"
+  outputs: ["pull-request"]
+---
+
+# docs-sync
+
+Once per day, find code changes that altered user-visible behavior and
+propose corresponding updates to `docs/` and `scenarios/`. The goal is
+that anyone running the documented commands or following the scenarios
+hits the same surface real users hit today.
+
+## Inputs
+
+- `git log --since='24 hours ago' --first-parent main` for the commit
+  set (first-parent skips merge-squash internals when present).
+- `git diff <prev>..<head>` per logical change.
+- The current state of `docs/` and `scenarios/`.
+
+## Triage rule — what counts as "user-visible"
+
+Include a change in scope when **any** of the following is true:
+
+- Adds, renames, removes, or changes the signature of a `clm` CLI
+  command or option (`src/clawrium/cli/`).
+- Changes a documented config path or env var.
+- Changes an installation, configuration, or onboarding stage.
+- Changes a GUI route, control, or visible label.
+- Changes output of a `clm ps`-style status command in a way a user
+  would notice.
+
+Exclude pure refactors, test-only changes, dependency bumps that do
+not change observable behavior, and internal log strings.
+
+## Output
+
+For each cluster of related changes, open **one** PR titled:
+
+`docs(<area>): sync with <one-line behavior change>`
+
+PR contents:
+
+- Doc edits limited to the surface that actually changed.
+- Scenario updates limited to scenarios the change actually breaks.
+- **Hard cap: 2 new scenarios per run.** Prefer updating an existing
+  scenario over adding a new one. If you would exceed the cap, leave
+  a TODO comment in the PR body listing the deferred scenarios.
+
+## Hard constraints
+
+- Do not edit `docs/` purely for tone or grammar — out of scope.
+- Do not touch `AGENTS.md`, `CLAUDE.md`, or `.itx/` from this skill.
+- If the diff is unclear, open the PR anyway with `[draft]` in the
+  title and request input from the author of the originating commit
+  (one short PR-body line: "@<author> — please confirm the
+  user-facing wording").
+- Never merge your own PRs. The PR opens against `main` and waits for
+  human review.
+
+## Anti-patterns
+
+- Bulk-updating every doc that mentions a renamed term. Touch only the
+  paths the diff actually changes.
+- Inventing scenarios that the code doesn't exercise. Scenarios must
+  be runnable on a fresh checkout.
+- Producing one mega-PR for a day's worth of changes. One PR per
+  logical doc unit, even if that means three PRs in a single run.

--- a/skills/hermes/issue-triage/SKILL.md
+++ b/skills/hermes/issue-triage/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: issue-triage
+description: Triage new and updated GitHub issues on ric03uec/clawrium — apply type/complexity/area labels and draft a planning file.
+version: 0.1.0
+license: MIT
+author: clawrium
+platforms: [linux, macos]
+metadata:
+  cadence: "every 10 minutes"
+  trigger: "poll"
+  outputs: ["labels", "pull-request"]
+---
+
+# issue-triage
+
+Triage incoming work on `ric03uec/clawrium`. Run on a 10-minute poll cycle.
+The loop is: find issues that need triage → read them carefully → apply
+labels → draft a planning file as a PR.
+
+## Inputs
+
+For each candidate issue:
+
+- Title and body.
+- Current labels (skip if `needs-triage` is absent or the issue already
+  has a `type:*` label).
+- The repo's `LABELS.md` for the allowed taxonomy. **Do not invent labels.**
+
+Candidates are issues opened or updated in the last 15 minutes (giving
+the poll a 5-minute overlap so nothing is missed during a slow run). Use:
+
+```bash
+gh issue list --repo ric03uec/clawrium \
+  --search "sort:updated-desc updated:>$(date -u -d '15 minutes ago' +%Y-%m-%dT%H:%M:%SZ)" \
+  --json number,title,body,labels,updatedAt
+```
+
+## Output
+
+- Apply labels from the taxonomy in `LABELS.md`. At minimum: one
+  `type:*`, one `complexity:*`, one `area:*`. Add `needs-review` when
+  the issue lacks a clear Definition of Done.
+- Open a PR adding `.itx/active/<issue-number>/plan.md` with a one-page
+  scaffold (Outcome / Approach / Files / Risk). Title:
+  `chore(triage): draft plan for #<n>`. Body links to the issue.
+
+## Hard constraints
+
+- **Never** apply the `agent-ready` label. The PAT denies it; even if it
+  did not, this label is a human decision.
+- **Never** push directly to `main` or merge a PR. PRs target `main`
+  with a feature branch named `triage/<issue-number>-<slug>`.
+- If the issue body is empty or one sentence, label `needs-review` and
+  leave a single short comment asking for Outcome + Definition of Done.
+  Do not invent requirements.
+- If `LABELS.md` is missing or unreadable, stop and post a `[ITX-STUCK]`
+  comment on the issue rather than guessing label names.
+
+## Anti-patterns
+
+- Re-labeling issues that already have a `type:*` label — assume a
+  human or earlier triage decided. Touch only the missing dimensions.
+- Drafting an `.itx/active/<n>/plan.md` that exceeds one page. The plan
+  is a starting point for `/itx:plan-create`, not a substitute for it.
+- Commenting on the issue with summaries of the body. The body is the
+  source of truth; do not paraphrase it back.


### PR DESCRIPTION
## Summary
- Adds three native hermes skills under `skills/hermes/` for maurice (provisioned in #402):
  - `issue-triage` — 10-min poll; applies `type:*`/`complexity:*`/`area:*` labels; drafts `.itx/active/<n>/plan.md` as PR
  - `daily-digest` — once-daily Discord summary of last 24h activity; engineer voice
  - `docs-sync` — daily PRs proposing doc and scenario updates from user-visible changes (max 2 new scenarios per run)

## Testing

### Test Results
- [x] Each `SKILL.md` validates against `skills/_schema/native/hermes.schema.json` (verified locally with `jsonschema` directly against frontmatter)
- [x] Lint not applicable — Markdown only, no source code changes
- [x] Install verification deferred to follow-up commit after merge: `clm agent skill install maurice hermes/<name>` for each + `clm agent skill list maurice` shows 5/5

### Test Coverage
- Files changed: 3 new files under `skills/hermes/`
- New tests: N/A (config files — existing `validate_skills.py` test pipeline picks them up on next CI run)
- Coverage impact: unchanged

### Manual Testing
Schema validation tested locally:
\`\`\`
ok hermes/issue-triage
ok hermes/daily-digest
ok hermes/docs-sync
\`\`\`

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] No SQL/XSS/command injection vectors (markdown content)
- [x] Skills explicitly disclaim `agent-ready` label and direct push to `main` — enforced by PAT scope
- [x] Dependencies unchanged

## Reviewer Notes
Configuration-only PR per parent #376 instruction (no executable code). ATX review intentionally skipped — these are agent-behavior prompts, not runtime code.

Closes #403
Refs #376

Co-Authored-By: Claude <noreply@anthropic.com>