### PR TITLE
feat(skills): hermes/{release-watcher,blog-author} for maurice (#404)

### DIFF
--- a/skills/hermes/blog-author/SKILL.md
+++ b/skills/hermes/blog-author/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: blog-author
+description: Watch ric03uec/clawrium release tags; draft a short blog post per user-visible feature as a PR against blog/.
+version: 0.1.0
+license: MIT
+author: clawrium
+platforms: [linux, macos]
+metadata:
+  cadence: "every 30 minutes"
+  trigger: "poll"
+  outputs: ["pull-request"]
+---
+
+# blog-author
+
+Poll `ric03uec/clawrium` release tags every 30 minutes. For each new
+tag, draft a short blog post per user-visible feature and open a PR
+against `blog/`. The post is a draft for human review and editing —
+**never** publish on your own.
+
+## Inputs
+
+- `gh release list --repo ric03uec/clawrium --limit 5` and the
+  per-release `gh release view <tag> --json body,tagName,publishedAt`.
+- The diff between the previous tag and this one for surface area
+  context: `git log <prev>..<tag>` and selective `git show` on
+  commits the release notes call out.
+- Existing scenarios under `scenarios/` — the post must reference at
+  least one runnable snippet (see "Output" below).
+- Memory key `blog-author:tagged` — release tags already drafted.
+
+## Triage rule — what gets a post
+
+Each user-visible feature in the release notes gets its **own** post.
+Bundled posts produce shallow writeups; split aggressively.
+
+A change qualifies if it falls into one of:
+
+- New `clm` command, option, or workflow.
+- New agent type, integration, channel, or skill.
+- New GUI route or page.
+- Behavior change a user would notice on upgrade.
+
+Skip:
+
+- Internal refactors, dependency bumps, test changes.
+- Documentation-only or scenario-only edits.
+- Security fixes — let the maintainer write those by hand.
+
+## Output — PR
+
+For each qualifying feature, open a PR against `main` titled:
+
+`blog: <tag> — <feature one-liner>`
+
+The PR adds **one** file: `blog/<YYYY>-<MM>-<DD>-<slug>.md`.
+
+Required front-matter:
+
+```yaml
+---
+title: <feature one-liner>
+date: <YYYY-MM-DD from release publishedAt>
+tag: <release tag>
+status: draft
+author: maurice
+---
+```
+
+Required structure (short — aim for ~250–400 words):
+
+1. **What changed** — one paragraph in engineer voice.
+2. **Why** — one paragraph, lifted/condensed from the release notes
+   or linked issue. No marketing fluff.
+3. **Try it** — at least one runnable snippet from `scenarios/` or
+   built from the actual CLI signatures in `src/clawrium/cli/`. The
+   snippet **must work** on a fresh clawrium install at this tag.
+4. **Links** — release notes URL, the primary PR(s).
+
+Add the tag to `blog-author:tagged` only after the PR opens cleanly.
+
+## Hard constraints
+
+- One feature, one post, one PR. No combined posts.
+- Snippet runnability is non-negotiable: if you can't find a valid
+  scenario or construct one from real CLI signatures, drop the post
+  rather than fabricate commands.
+- Never merge your own PRs.
+- Never push to `main` directly. PR target is `main`; branch name is
+  `blog/<tag>-<slug>`.
+- Never publish (move out of `status: draft`). Human edits drive that.
+
+## Voice
+
+- Engineer to engineer. Same rules as `daily-digest`: no marketing
+  copy, no hedging, no flattery, emoji only when informational.
+- First-person plural ("we shipped") is fine. Avoid first-person
+  singular — these are project posts, not personal essays.
+
+## Anti-patterns
+
+- Lifting whole paragraphs from the release notes. Rewrite for the
+  blog's reader, who has not seen the changelog.
+- Padding to a minimum word count. 250 words is enough if the
+  feature is small. Cut, do not stretch.
+- Inventing CLI commands or option names. Read the real source.

--- a/skills/hermes/release-watcher/SKILL.md
+++ b/skills/hermes/release-watcher/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: release-watcher
+description: Watch upstream *Claw releases and clawrium discussions; surface top 3 feature candidates to Devashish via Discord DM for approve/skip.
+version: 0.1.0
+license: MIT
+author: clawrium
+platforms: [linux, macos]
+metadata:
+  cadence: "daily"
+  trigger: "cron"
+  outputs: ["discord-dm", "github-issue"]
+---
+
+# release-watcher
+
+Once per day, scan upstream `*Claw` releases and the
+`ric03uec/clawrium` GitHub Discussions for feature ideas that could
+land in clawrium. Surface the top 3 candidates to Devashish via Discord
+DM with an approve / skip pattern. On approval, file a GitHub issue.
+
+## Inputs
+
+- Releases (last 7 days, GitHub API):
+  - `openclaw/openclaw` releases
+  - `zeroclaw/zeroclaw` releases
+  - `nousresearch/hermes` releases
+  - Any additional supported `*Claw` repos listed in
+    `platform/registry/*/manifest.yaml` (look up dynamically; don't
+    hardcode).
+- `gh api repos/ric03uec/clawrium/discussions` — open discussions
+  updated in the last 7 days, sorted by reaction count.
+- Memory key `release-watcher:seen` — release tag IDs already
+  presented, so candidates don't repeat across days.
+
+## Scoring
+
+Pick the 3 candidates that score highest on:
+
+1. **User-facing**: does this change something a clawrium user would
+   directly touch (CLI, GUI, agent behavior, install flow)?
+2. **Fits clawrium's surface**: matches an existing primitive
+   (agent type, integration, channel, skill) rather than introducing
+   a new top-level concept.
+3. **Cheap to land**: rough fit in an afternoon's work, not a quarter.
+
+Skip:
+
+- Pure internal refactors in the upstream project.
+- Features that depend on infrastructure clawrium does not have
+  (custom kernels, GPU sharding, etc.).
+- Anything already covered by an open issue (check before suggesting).
+
+## Output — Discord DM
+
+Send a single DM to user `740723459344302120` (Devashish) in the
+project guild. **Slack is not used** — the original issue proposed
+Slack DM for this flow; release-watcher uses Discord DM in the same
+guild instead.
+
+Format:
+
+```
+Release watch — <YYYY-MM-DD> — 3 candidates
+
+1. <project> <tag> — <one-line rationale>
+   <link>
+
+2. <project> <tag> — <one-line rationale>
+   <link>
+
+3. <project> <tag> — <one-line rationale>
+   <link>
+
+Reply: `approve 1 2` to file issues, `skip all`, or `skip 3` to drop
+the third while keeping 1+2 in tomorrow's pool.
+```
+
+Wait up to 24 hours for a reply. If no reply by next run, treat as
+`skip all` and move on — do not nag.
+
+## On approval
+
+For each approved candidate, create a GitHub issue on
+`ric03uec/clawrium`:
+
+- Title: `<verb> <feature> from <project> <tag>`
+- Body: link to the upstream release notes + the one-line rationale.
+- Labels: best-effort `type:*` and `area:*` from the candidate
+  description. Do **not** apply `agent-ready`.
+- Assign no one — Devashish chooses the owner later.
+
+Append the candidate's release tag to `release-watcher:seen`.
+
+## Hard constraints
+
+- One DM per day. If nothing crosses the bar, send a one-liner:
+  "Release watch — quiet day, no candidates." Silence reads as broken.
+- Do not file issues without an explicit `approve N` from Devashish.
+- Never apply the `agent-ready` label (PAT-blocked).
+- Discussions are read-only here — do not post a comment in the
+  discussion thread itself.
+
+## Anti-patterns
+
+- Presenting 5 candidates because they all "look promising." 3 is the
+  cap; rank harder.
+- Re-presenting yesterday's `skip` items the next day. Use the
+  memory key.
+- Filing an issue then immediately self-assigning a triage label.
+  Triage is `issue-triage`'s job; let that skill run on the new
+  issue.


### PR DESCRIPTION
## Summary
- Adds two more native hermes skills for maurice (completes the 5-skill set for #376):
  - `release-watcher` — daily DM to Devashish with top-3 upstream candidates from `*Claw` releases + clawrium Discussions; approve/skip flow files labeled issues. Discord DM in place of Slack (per #376 planning).
  - `blog-author` — 30-min poll for new ric03uec/clawrium release tags; drafts a short post per user-visible feature as a PR against `blog/` in `status: draft`. Snippets must come from real CLI signatures.

## Testing

### Test Results
- [x] Each `SKILL.md` validates against `skills/_schema/native/hermes.schema.json`
- [x] Lint not applicable — Markdown only, no source code changes
- [x] Install verification deferred to follow-up: `clm agent skill install maurice hermes/<name>` + `clm agent skill list maurice` shows 5/5

### Test Coverage
- Files changed: 2 new files under `skills/hermes/`
- New tests: N/A (config-only)
- Coverage impact: unchanged

### Manual Testing
\`\`\`
ok hermes/release-watcher
ok hermes/blog-author
\`\`\`

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] No injection vectors (markdown only)
- [x] Skills explicitly disclaim `agent-ready` label and direct push to `main` — enforced by PAT scope
- [x] Dependencies unchanged

## Reviewer Notes
Configuration-only PR per parent #376 instruction. ATX skipped intentionally.

Closes #404
Refs #376

Co-Authored-By: Claude <noreply@anthropic.com>