### PR TITLE
docs(itx): add planning doc for issue #413 (clm agent pt)

### DIFF
--- a/.itx/413/00_PLAN.md
+++ b/.itx/413/00_PLAN.md
@@ -1,0 +1,31 @@
+# Issue #413: User can run agent-native commands on remote hosts without SSH using `clm agent pt`
+
+URL: https://github.com/ric03uec/clawrium/issues/413
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: issue-creation
+**Skill**: /itx:issue-new
+**Timestamp**: 2026-05-18
+**Model**: claude-opus-4-7
+
+```prompt
+Create a new feature request. Add support for a CLI command, called CLM agent PT
+options. PT stands for pass through. This is a way for users to send agent
+specific commands to the agent without logging into the host machine. This is
+there to support native commands on the agents without getting SSH access to
+the host. Users might need to configure Hermes, Zeroclaw or Openclaw based on
+the respective agent's CLI. This option is not supported right now, but the
+passthrough option in CLM will allow users to do that.
+```
+
+### Clarifications captured
+
+- **Syntax**: `clm agent pt <name> -- <cmd>` (Unix `--` separator convention)
+- **Output**: Stream live (stdout/stderr) to local terminal
+- **Interactivity**: Non-interactive only in v1 (no TTY)
+- **Agent types in v1**: hermes, zeroclaw, openclaw (nemoclaw out of scope)
+- **Exit code propagation**: Required (must propagate remote exit code as `clm` exit code)
+
+</details>


### PR DESCRIPTION
## Summary
- Adds `.itx/413/00_PLAN.md` capturing the customer outcome, clarifications, and v1 scope for the new `clm agent pt <name> -- <cmd>` passthrough command.
- Docs-only change. No production code touched.

Refs #413

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — N/A, docs-only change
- [x] Linter passes (`make lint`) — N/A, docs-only change
- [x] New tests added for new functionality — N/A, docs-only change

### Test Coverage
- Files changed: `.itx/413/00_PLAN.md` (new file)
- New tests: N/A
- Coverage impact: N/A

### Manual Testing
- Verified markdown renders correctly in the issue thread context.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — N/A
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources — no new deps

## Reviewer Notes
ATX review skipped because this PR contains no executable code — only a planning artifact. The implementation PR for #413 will go through the full ATX flow.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)