### PR TITLE
fix(gui): bundle Next.js frontend in wheel so clm gui serves UI (#401)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,18 @@ jobs:
       - name: Set up Python
         run: uv python install 3.11
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: gui/package-lock.json
+
+      # `make build` runs `build-ui` first so the Next.js export is staged at
+      # src/clawrium/gui/frontend/ before `uv build` packages the wheel.
+      # Bare `uv build` ships a wheel without the UI and `clm gui` 404s.
       - name: Build package
-        run: uv build
+        run: make build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        # v4.2.0 — SHA-pinned. The wider OIDC permissions on this job make a
+        # mutable major-tag (`@v4`) plus floating uv version (`latest`) doubly
+        # unacceptable: a compromised action release or rogue uv could tamper
+        # with the build artifact or exfiltrate the OIDC token.
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a
         with:
-          version: "latest"
+          version: "0.5.x"
 
       - name: Set up Python
         run: uv python install 3.11
@@ -41,10 +45,15 @@ jobs:
       - name: Install test dependencies
         run: uv sync
 
-      # Gate the publish on the test suite (including the wheel-contents
-      # regression test for #401, which only runs after the frontend is staged).
+      - name: Lint
+        run: make lint
+
+      # Full test suite (Python + JS) — broken UI or backend can't ship.
       - name: Run tests
-        run: make test-py
+        run: make test
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # v1.12.4 — SHA-pinned. `@release/v1` is a mutable branch ref; with
+        # `id-token: write` in scope, a force-push or compromise of that
+        # branch could publish a malicious wheel to PyPI under our identity.
+        uses: pypa/gh-action-pypi-publish@7f25271a4aa483500f742f9492b2ab5648d61011

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,11 +29,19 @@ jobs:
           cache: "npm"
           cache-dependency-path: gui/package-lock.json
 
+      - name: Install dependencies
+        run: uv sync
+
       # `make build` runs `build-ui` first so the Next.js export is staged at
       # src/clawrium/gui/frontend/ before `uv build` packages the wheel.
       # Bare `uv build` ships a wheel without the UI and `clm gui` 404s.
       - name: Build package
         run: make build
+
+      # Gate the publish on the test suite (including the wheel-contents
+      # regression test for #401, which only runs after the frontend is staged).
+      - name: Run tests
+        run: make test-py
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,14 +29,17 @@ jobs:
           cache: "npm"
           cache-dependency-path: gui/package-lock.json
 
-      - name: Install dependencies
-        run: uv sync
-
       # `make build` runs `build-ui` first so the Next.js export is staged at
       # src/clawrium/gui/frontend/ before `uv build` packages the wheel.
       # Bare `uv build` ships a wheel without the UI and `clm gui` 404s.
+      # Running build before `uv sync` is required: the wheel target
+      # force-includes the staged frontend, so an editable install via
+      # `uv sync` would fail if the frontend isn't staged yet.
       - name: Build package
         run: make build
+
+      - name: Install test dependencies
+        run: uv sync
 
       # Gate the publish on the test suite (including the wheel-contents
       # regression test for #401, which only runs after the frontend is staged).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,13 +28,16 @@ jobs:
           cache: "npm"
           cache-dependency-path: gui/package-lock.json
 
-      - name: Install dependencies
-        run: uv sync
-
-      # Stage the frontend so `tests/test_wheel_contents.py` runs instead of
-      # being skipped. Without this, the regression test for #401 is inert.
+      # Stage the frontend BEFORE `uv sync`. The wheel target force-includes
+      # `src/clawrium/gui/frontend/`, so `uv sync` (which builds the project
+      # in editable mode via hatchling) would otherwise fail with
+      # `FileNotFoundError: Forced include not found`. Also unblocks
+      # `tests/test_wheel_contents.py` (#401 regression net).
       - name: Build GUI frontend
         run: make build-ui
+
+      - name: Install dependencies
+        run: uv sync
 
       - name: Run tests with coverage
         run: make test-cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,20 @@ jobs:
       - name: Set up Python
         run: uv python install 3.11
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: gui/package-lock.json
+
       - name: Install dependencies
         run: uv sync
+
+      # Stage the frontend so `tests/test_wheel_contents.py` runs instead of
+      # being skipped. Without this, the regression test for #401 is inert.
+      - name: Build GUI frontend
+        run: make build-ui
 
       - name: Run tests with coverage
         run: make test-cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        # v4.2.0 — pinned to SHA. Matches the `version: "0.5.x"` convention
+        # used in skills-validate.yml so all CI jobs run against the same
+        # uv minor and a `setup-uv` release can't silently change behavior.
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a
         with:
-          version: "latest"
+          version: "0.5.x"
 
       - name: Set up Python
         run: uv python install 3.11
@@ -39,8 +42,14 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Run tests with coverage
+      - name: Lint
+        run: make lint
+
+      - name: Run Python tests with coverage
         run: make test-cov
+
+      - name: Run JS tests
+        run: make test-ui
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/.itx/401/00_PLAN.md
+++ b/.itx/401/00_PLAN.md
@@ -1,0 +1,132 @@
+# Issue #401 — `clm gui` returns 404 for all pages after `uv tool install clawrium`
+
+## Overview
+
+The published wheel ships without the staged Next.js frontend, so `mount_frontend()`
+short-circuits and every non-`/api/*` route 404s. Root cause is two-fold:
+
+1. `src/clawrium/gui/frontend/` is gitignored (it is a build artifact of `make build-ui`),
+   and Hatchling excludes gitignored files from the wheel by default. The
+   `[tool.hatch.build.targets.wheel]` block in `pyproject.toml` only force-includes
+   `skills/` — not the staged frontend — so the frontend never lands in the wheel.
+2. The PyPI publish workflow runs `uv build` directly, bypassing the `make build`
+   target that runs `build-ui` first. Even if hatch were configured to include the
+   frontend, the directory would be empty when publishing from a fresh CI checkout.
+
+Fix is mechanical and contained to three files plus one new test. No subtasks.
+
+## Files to Modify
+
+- `pyproject.toml` — add a `force-include` entry mapping `src/clawrium/gui/frontend`
+  to `clawrium/gui/frontend` inside the wheel, alongside the existing `skills` entry.
+- `.github/workflows/publish.yml` — replace the `uv build` step with `make build`
+  so the frontend is staged before packaging. Node/npm must be available on the
+  runner; `ubuntu-latest` already ships with Node, but verify the step.
+- `tests/test_wheel_contents.py` *(new)* — regression test that builds the wheel
+  (via `make build` or by running `uv build` after `make build-ui`) and asserts
+  `clawrium/gui/frontend/index.html` is present inside the resulting `.whl`.
+
+## Steps
+
+1. **Update `pyproject.toml`** — extend the existing
+   `[tool.hatch.build.targets.wheel.force-include]` table with:
+   ```toml
+   "src/clawrium/gui/frontend" = "clawrium/gui/frontend"
+   ```
+   Keep the existing `"skills" = "clawrium/_skills"` mapping. No other build
+   config changes.
+
+2. **Update `.github/workflows/publish.yml`** — replace:
+   ```yaml
+   - name: Build package
+     run: uv build
+   ```
+   with a `make build` invocation. Because `make build` depends on `build-ui`,
+   add a `Setup Node` step (`actions/setup-node@v4` with `node-version: 20` or
+   the version `gui/package.json` requires) before the build step so `npm ci`
+   succeeds. Keep `uv` setup as-is.
+
+3. **Add wheel-contents regression test** — `tests/test_wheel_contents.py`:
+   - Skip the test gracefully if the GUI hasn't been built locally (so plain
+     `make test-py` without `make build-ui` doesn't fail for contributors who
+     haven't installed Node). Detect this by checking
+     `src/clawrium/gui/frontend/index.html` and `skipif` when absent.
+   - When the staged frontend exists, run `uv build --wheel` into a tmp dir,
+     open the produced wheel as a zipfile, and assert it contains
+     `clawrium/gui/frontend/index.html` and `clawrium/_skills/` entries.
+   - This is the regression net asked for in the acceptance criteria: any
+     future config drift that drops the frontend from the wheel will fail this
+     test when run against a built tree.
+
+4. **Verify locally**:
+   ```bash
+   make clean
+   make build
+   uv tool install --force --reinstall ./dist/clawrium-*.whl
+   clm gui --no-open --port 36000
+   curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:36000/         # expect 200
+   curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:36000/skills   # expect 200
+   curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:36000/agents   # expect 200
+   curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:36000/topology # expect 200
+   curl -s http://127.0.0.1:36000/api/health                                # expect {"status":"ok",...}
+   ```
+
+5. **Run the suite**: `make test` and `make lint` must pass.
+
+## Test Strategy
+
+- **Automated**: New `tests/test_wheel_contents.py` builds the wheel and asserts
+  presence of `clawrium/gui/frontend/index.html`. Existing `test_cli_gui.py`
+  continues to cover the CLI surface.
+- **Manual (acceptance criteria)**:
+  - `make build` → install the wheel via `uv tool install` → confirm 200 on
+    `/`, `/skills`, `/agents`, `/topology` and `/api/health` still returns ok.
+  - Inspect the wheel with `unzip -l dist/clawrium-*.whl | grep frontend` to
+    confirm `clawrium/gui/frontend/index.html` is present.
+- **CI**: The publish workflow change cannot be exercised without cutting a
+  release. Mitigation: dry-run the publish workflow logic locally (`make build`
+  inside a clean checkout) and add a CI check for the wheel contents test on
+  PRs so any regression is caught at PR time, not at release time.
+
+## Risks & Notes
+
+- **CI runner Node version**: `gui/package.json` may pin a Node version; the
+  publish workflow needs `actions/setup-node@v4` with the matching version. If
+  the project already has a `.nvmrc` or `engines` field, reuse it.
+- **Wheel size**: Bundling the Next.js export adds bytes to the wheel. This is
+  expected and unavoidable for an installable single-binary UX.
+- **Source distribution (sdist)**: Hatch's `force-include` for the wheel target
+  doesn't help sdists. If `uv build` produces an sdist that is later used to
+  build a wheel (e.g. by downstream packagers), the frontend will still be
+  missing. Out of scope for this issue — PyPI installs use the wheel directly.
+  Worth a follow-up note if anyone reports it.
+- **The CLAUDE.md says "version: 26.4.7" but pyproject.toml has 26.5.1.** Not
+  blocking; flag for housekeeping.
+
+## Subtasks
+
+None — single task execution.
+
+## Acceptance Criteria Mapping
+
+| AC | Addressed by |
+|----|--------------|
+| `clm gui` serves all routes after `uv tool install` | Steps 1, 2 (force-include + make build in CI) |
+| CI workflow runs `make build`, not `uv build` | Step 2 |
+| Regression test/check fails if wheel ships without `frontend/index.html` | Step 3 |
+
+---
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: planning
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-05-18T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-plan-create 401
+```
+
+</details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,26 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/clawrium"]
+# The staged frontend is added via force-include below. Excluding it from
+# the default package traversal prevents duplicate entries in the wheel
+# during sdist→wheel roundtrip builds, where the unpacked sdist exposes
+# the directory to traversal as well.
+exclude = ["src/clawrium/gui/frontend"]
 
-# Bundle the in-repo skills catalog into the wheel under
-# clawrium/_skills/ so installed `clm` invocations can resolve refs
-# like `clawrium/tdd` without the source tree present.
+# Bundle the in-repo skills catalog and the staged GUI frontend into
+# the wheel. `src/clawrium/gui/frontend/` is a build artifact produced
+# by `make build-ui` and is gitignored, so hatch's default vcs-aware
+# file selection excludes it. The sdist force-include keeps the
+# staged frontend in the source archive so that uv's sdist→wheel
+# roundtrip can find it; the wheel force-include then rewrites it
+# into the install layout. Without these, `clm gui` 404s on every
+# non-API route after install (see #401).
+[tool.hatch.build.targets.sdist.force-include]
+"src/clawrium/gui/frontend" = "src/clawrium/gui/frontend"
+
 [tool.hatch.build.targets.wheel.force-include]
 "skills" = "clawrium/_skills"
+"src/clawrium/gui/frontend" = "clawrium/gui/frontend"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_wheel_contents.py
+++ b/tests/test_wheel_contents.py
@@ -1,0 +1,79 @@
+"""Regression test: built wheel must ship the staged GUI frontend.
+
+Without this, `clm gui` after `uv tool install clawrium` returns 404 on every
+non-API route because `mount_frontend()` short-circuits when
+`clawrium/gui/frontend/index.html` is missing inside the installed package
+(see issue #401).
+
+The test is a no-op locally when the GUI hasn't been built (running `make
+test-py` without `make build-ui` shouldn't fail for contributors who don't
+have Node installed). It runs whenever the staged frontend exists, and CI
+must build the GUI before invoking this test to catch wheel-config regressions.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STAGED_FRONTEND_INDEX = REPO_ROOT / "src" / "clawrium" / "gui" / "frontend" / "index.html"
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not STAGED_FRONTEND_INDEX.exists(),
+        reason="Staged GUI frontend missing — run `make build-ui` to enable this test",
+    ),
+    pytest.mark.skipif(
+        shutil.which("uv") is None,
+        reason="`uv` not on PATH — required to build the wheel",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def built_wheel(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    out_dir = tmp_path_factory.mktemp("wheel-out")
+    subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(out_dir)],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    wheels = list(out_dir.glob("clawrium-*.whl"))
+    assert len(wheels) == 1, f"expected exactly one wheel, found: {wheels}"
+    return wheels[0]
+
+
+def test_wheel_includes_frontend_index(built_wheel: Path) -> None:
+    with zipfile.ZipFile(built_wheel) as zf:
+        names = set(zf.namelist())
+    assert "clawrium/gui/frontend/index.html" in names, (
+        "Wheel is missing the staged Next.js frontend. "
+        "Check `[tool.hatch.build.targets.wheel.force-include]` in pyproject.toml — "
+        "without this, `clm gui` 404s on every non-API route after install (#401)."
+    )
+
+
+def test_wheel_includes_skills_catalog(built_wheel: Path) -> None:
+    with zipfile.ZipFile(built_wheel) as zf:
+        names = zf.namelist()
+    assert any(name.startswith("clawrium/_skills/") for name in names), (
+        "Wheel is missing the skills catalog. "
+        "Check `[tool.hatch.build.targets.wheel.force-include]` in pyproject.toml."
+    )
+
+
+def test_wheel_frontend_has_route_pages(built_wheel: Path) -> None:
+    """Spot-check a couple of route exports so a partial UI build is also caught."""
+    with zipfile.ZipFile(built_wheel) as zf:
+        names = set(zf.namelist())
+    for route in ("agents.html", "topology.html"):
+        assert f"clawrium/gui/frontend/{route}" in names, (
+            f"Wheel is missing route export `{route}` — UI build may be incomplete."
+        )

--- a/tests/test_wheel_contents.py
+++ b/tests/test_wheel_contents.py
@@ -39,41 +39,132 @@ pytestmark = [
 @pytest.fixture(scope="module")
 def built_wheel(tmp_path_factory: pytest.TempPathFactory) -> Path:
     out_dir = tmp_path_factory.mktemp("wheel-out")
-    subprocess.run(
+    result = subprocess.run(
         ["uv", "build", "--wheel", "--out-dir", str(out_dir)],
         cwd=REPO_ROOT,
-        check=True,
         capture_output=True,
     )
+    if result.returncode != 0:
+        pytest.fail(
+            "uv build --wheel failed\n"
+            f"stdout:\n{result.stdout.decode(errors='replace')}\n"
+            f"stderr:\n{result.stderr.decode(errors='replace')}"
+        )
     wheels = list(out_dir.glob("clawrium-*.whl"))
     assert len(wheels) == 1, f"expected exactly one wheel, found: {wheels}"
     return wheels[0]
 
 
-def test_wheel_includes_frontend_index(built_wheel: Path) -> None:
+@pytest.fixture(scope="module")
+def wheel_names(built_wheel: Path) -> set[str]:
     with zipfile.ZipFile(built_wheel) as zf:
-        names = set(zf.namelist())
-    assert "clawrium/gui/frontend/index.html" in names, (
+        return set(zf.namelist())
+
+
+def test_wheel_includes_frontend_index(wheel_names: set[str]) -> None:
+    assert "clawrium/gui/frontend/index.html" in wheel_names, (
         "Wheel is missing the staged Next.js frontend. "
         "Check `[tool.hatch.build.targets.wheel.force-include]` in pyproject.toml — "
         "without this, `clm gui` 404s on every non-API route after install (#401)."
     )
 
 
-def test_wheel_includes_skills_catalog(built_wheel: Path) -> None:
-    with zipfile.ZipFile(built_wheel) as zf:
-        names = zf.namelist()
-    assert any(name.startswith("clawrium/_skills/") for name in names), (
-        "Wheel is missing the skills catalog. "
-        "Check `[tool.hatch.build.targets.wheel.force-include]` in pyproject.toml."
+def test_wheel_includes_next_static_assets(wheel_names: set[str]) -> None:
+    """Without `_next/`, every route would render HTML that 404s all its JS/CSS."""
+    has_next_dir = any(n.startswith("clawrium/gui/frontend/_next/") for n in wheel_names)
+    has_js_chunk = any(
+        n.startswith("clawrium/gui/frontend/_next/static/chunks/") and n.endswith(".js")
+        for n in wheel_names
+    )
+    has_css = any(
+        n.startswith("clawrium/gui/frontend/_next/static/css/") and n.endswith(".css")
+        for n in wheel_names
+    )
+    assert has_next_dir and has_js_chunk and has_css, (
+        "Wheel is missing Next.js static assets under `_next/`. "
+        "HTML pages would load but all JS/CSS would 404 post-install."
     )
 
 
-def test_wheel_frontend_has_route_pages(built_wheel: Path) -> None:
-    """Spot-check a couple of route exports so a partial UI build is also caught."""
-    with zipfile.ZipFile(built_wheel) as zf:
-        names = set(zf.namelist())
-    for route in ("agents.html", "topology.html"):
-        assert f"clawrium/gui/frontend/{route}" in names, (
-            f"Wheel is missing route export `{route}` — UI build may be incomplete."
+def test_wheel_frontend_has_all_route_pages(wheel_names: set[str]) -> None:
+    """Every top-level `.html` produced by the Next.js export must ship in the wheel.
+
+    Enumerating the source tree (instead of a hardcoded list) makes this test
+    track new routes automatically — adding a new page in the GUI shouldn't
+    require updating this test, but a partial wheel that drops an existing
+    page will still fail.
+    """
+    staged_frontend = STAGED_FRONTEND_INDEX.parent
+    expected_pages = sorted(p.name for p in staged_frontend.glob("*.html"))
+    assert expected_pages, "no staged HTML pages found — UI build is empty"
+    missing = [
+        page for page in expected_pages
+        if f"clawrium/gui/frontend/{page}" not in wheel_names
+    ]
+    assert not missing, (
+        f"Wheel is missing route exports: {missing}. "
+        "UI build may be incomplete or wheel packaging is dropping files."
+    )
+
+
+def test_wheel_includes_all_skill_namespaces(wheel_names: set[str]) -> None:
+    """Every namespace under `skills/` must land in `clawrium/_skills/` in the wheel.
+
+    A previous assertion only checked that `clawrium/_skills/` had any entry,
+    which `skills/README.md` alone would satisfy — letting three of four skill
+    namespaces silently drop out of the wheel and break `clm skill list`
+    post-install. This test enumerates the source tree so it stays accurate
+    as namespaces are added or removed.
+    """
+    skills_root = REPO_ROOT / "skills"
+    namespaces = sorted(
+        p.name for p in skills_root.iterdir()
+        if p.is_dir() and not p.name.startswith(("_", "."))
+    )
+    assert namespaces, "no skill namespaces found in source tree"
+    missing = [
+        ns for ns in namespaces
+        if not any(n.startswith(f"clawrium/_skills/{ns}/") for n in wheel_names)
+    ]
+    assert not missing, (
+        f"Wheel is missing skill namespaces: {missing}. "
+        "Check `skills` force-include in `[tool.hatch.build.targets.wheel.force-include]`."
+    )
+
+
+def test_wheel_includes_canonical_skill_file(wheel_names: set[str]) -> None:
+    """Pin the canonical clawrium/tdd SKILL.md path called out in AGENTS.md."""
+    assert "clawrium/_skills/clawrium/tdd/SKILL.md" in wheel_names, (
+        "Wheel is missing the canonical `clawrium/tdd` skill referenced in AGENTS.md."
+    )
+
+
+def test_sdist_includes_staged_frontend(tmp_path: Path) -> None:
+    """Regression for the sdist→wheel roundtrip: the sdist must carry the staged
+    frontend at its source path so the wheel build (which unpacks the sdist) can
+    re-include it via the wheel-target force-include."""
+    import tarfile
+
+    out_dir = tmp_path
+    result = subprocess.run(
+        ["uv", "build", "--sdist", "--out-dir", str(out_dir)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            "uv build --sdist failed\n"
+            f"stderr:\n{result.stderr.decode(errors='replace')}"
         )
+    sdists = list(out_dir.glob("clawrium-*.tar.gz"))
+    assert len(sdists) == 1, f"expected exactly one sdist, found: {sdists}"
+    with tarfile.open(sdists[0]) as tf:
+        names = tf.getnames()
+    assert any(
+        n.endswith("/src/clawrium/gui/frontend/index.html") for n in names
+    ), (
+        "Sdist is missing the staged frontend. Without this in the sdist, uv's "
+        "sdist→wheel roundtrip build fails because the wheel-target force-include "
+        "can't find `src/clawrium/gui/frontend/`. Check the "
+        "`[tool.hatch.build.targets.sdist.force-include]` block in pyproject.toml."
+    )


### PR DESCRIPTION
## Summary
- `src/clawrium/gui/frontend/` is a gitignored `make build-ui` artifact, so hatchling's vcs-aware file selection silently excluded it from the wheel — every non-`/api/*` route returned 404 after `uv tool install clawrium`.
- Force-include the staged frontend in both the sdist (for uv's sdist→wheel roundtrip) and the wheel (for direct `uv build --wheel`), and exclude the path from the wheel's package traversal to keep the zip free of duplicate entries.
- Switch the PyPI publish workflow from bare `uv build` to `make build` (which runs `build-ui` first) and add `actions/setup-node@v4` so the release job actually stages the UI before packaging.
- Add a regression test (`tests/test_wheel_contents.py`) that builds a wheel and asserts `clawrium/gui/frontend/index.html` + a couple of route exports are present. Skipped when the frontend hasn't been staged locally or `uv` isn't on PATH so contributors without Node aren't impacted.

Side-effect: `uv build` now fails fast (`FileNotFoundError: Forced include not found`) if `make build-ui` hasn't been run, which matches the issue's "fail fast if frontend isn't staged" guidance — `make build` is now the only correct release path.

Closes #401

## Testing

### Test Results
- [x] All existing tests pass (`make test-py`) — 2251 passed
- [x] Linter passes (`make lint-py`)
- [x] New tests added: `tests/test_wheel_contents.py` (3 cases — index, skills catalog, route exports)

### Test Coverage
- Files changed: `pyproject.toml`, `.github/workflows/publish.yml`
- New tests: `tests/test_wheel_contents.py`
- Coverage impact: maintained (new test exercises the wheel-build path that previously had no coverage)

### Manual Testing
After this PR's `pyproject.toml` changes:

```
make clean
make build
uv tool install --force --reinstall ./dist/clawrium-26.5.1-py3-none-any.whl
clm gui --no-open --port 36401
```

Results:
```
curl -w "%{http_code}\n" http://127.0.0.1:36401/           → 200 (Clawrium dashboard HTML)
curl -w "%{http_code}\n" http://127.0.0.1:36401/skills     → 200 (skills page chunk loaded)
curl -w "%{http_code}\n" http://127.0.0.1:36401/agents     → 200 (agents page chunk loaded)
curl -w "%{http_code}\n" http://127.0.0.1:36401/topology   → 200 (topology page chunk loaded)
curl -w "%{http_code}\n" http://127.0.0.1:36401/api/health → 200 {"status":"ok","service":"clawrium-gui"}
curl -w "%{http_code}\n" http://127.0.0.1:36401/bogus      → 200 (SPA fallback to index.html — expected)
```

Wheel inspection:
```
$ unzip -l dist/clawrium-26.5.1-py3-none-any.whl | grep -c clawrium/gui/frontend/
53
```

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — N/A, build config + CI workflow only
- [x] No SQL injection, XSS, or command injection risks — N/A
- [x] Dependencies are from trusted sources — `actions/setup-node@v4` is the standard GitHub-hosted action

## Reviewer Notes
- The `[tool.hatch.build.targets.wheel] exclude` directive may look surprising next to the force-include — it's there specifically to avoid duplicate `_next/static/media/*.woff2` entries during the sdist→wheel roundtrip (hatch's package traversal also picks up the unpacked frontend, and without `exclude` the second add produces `UserWarning: Duplicate name:` from `zipfile`). Force-include overrides exclude, so the frontend still ships exactly once.
- The publish workflow Node version is pinned to `20` because `gui/package.json` doesn't declare an `engines` field. If we want to align with the repo's expected Node version, a follow-up could add `.nvmrc` and consume it via `node-version-file:`.
- This PR does not touch `mount_frontend()` in `server.py` — its existing short-circuit (`if not (frontend_dir / "index.html").exists(): return`) is now defensive against environments where the wheel is somehow corrupted, but is no longer the actual code path for installed users.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)