### PR TITLE
fix(zeroclaw): align config.toml + pair handshake with v0.7.5; drop stale required secrets

### DIFF
--- a/src/clawrium/platform/registry/zeroclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/manifest.yaml
@@ -21,15 +21,16 @@ features:
   chat:
     type: zeroclaw
 
-# Secrets required for this agent (installation fails when missing)
+# Secrets for this agent. Provider URL and model are now sourced from the
+# providers system (selected during the onboarding `providers` stage and
+# rendered into ~/.zeroclaw/config.toml by configure.yaml), not from
+# per-agent secrets — keeping legacy LLM_PROVIDER_URL / LLM_MODEL keys here
+# made health.get_missing_secrets() report a permanent DEGRADED status on
+# every correctly-configured zeroclaw instance.
 secrets:
-  required:
-    - key: LLM_PROVIDER_URL
-      description: "LLM API endpoint URL (e.g., http://192.168.1.100:11434)"
-    - key: LLM_MODEL
-      description: "Model name to use (e.g., llama3, gpt-4)"
+  required: []
 
-  # Optional secrets (agent still runs without them)
+  # Optional secrets (agent still runs without them).
   optional:
     - key: LLM_API_KEY
       description: "API key for LLM provider (optional for local)"

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
@@ -214,7 +214,7 @@
     - name: Validate pairing code shape
       ansible.builtin.fail:
         msg: >-
-          /pair/code did not return a usable code field. Rotate the
+          /pair/code did not return a usable pairing_code field. Rotate the
           gateway token: clear
           agents.{{ agent_name }}.config.gateway.auth in
           ~/.config/clawrium/hosts.json, then re-run
@@ -224,18 +224,19 @@
       when:
         - zeroclaw_needs_pairing
         - pair_code_response.json is not defined
-          or pair_code_response.json.code is not defined
-          or pair_code_response.json.code | length < 1
+          or pair_code_response.json.pairing_code is not defined
+          or pair_code_response.json.pairing_code | length < 1
 
+    # ZeroClaw v0.7.5 expects the one-time code via the `X-Pairing-Code`
+    # HTTP header (per the daemon's startup banner), not a JSON body.
     - name: Exchange pairing code for bearer token
       ansible.builtin.uri:
         url: "{{ gateway_local_base }}/pair"
         method: POST
         status_code: 200
         timeout: 10
-        body_format: json
-        body:
-          code: "{{ pair_code_response.json.code }}"
+        headers:
+          X-Pairing-Code: "{{ pair_code_response.json.pairing_code }}"
         return_content: yes
       register: pair_response
       no_log: true

--- a/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
+++ b/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
@@ -36,6 +36,19 @@
 {% set personality_name = personality.name | default(agent_name | default('zeroclaw')) %}
 {% set personality_timezone = personality.timezone | default('UTC') %}
 {% set personality_style = personality.communication_style | default('direct, concise') %}
+{# Per zeroclaw v0.7.5 docs (docs/book/src/providers/configuration.md),
+   `default_provider` and `default_model` are TOP-LEVEL keys — they must
+   appear before any [section] header so TOML does not scope them under
+   the preceding table. Placing them under [gateway] caused the daemon
+   to fall back to the empty default-provider stub and crash gateway
+   startup with "Unknown provider: default". #}
+{% if provider_type in ['anthropic', 'openai', 'ollama', 'openrouter'] %}
+default_provider = "{{ toml_escape(provider_type) }}"
+{% if model_id %}
+default_model = "{{ toml_escape(model_id) }}"
+{% endif %}
+{% endif %}
+
 [gateway]
 {# Every variable interpolated into a "…" basic string passes through
    toml_escape so a hand-edited host (or future provider_type/model_id
@@ -47,11 +60,6 @@ allow_public_bind = {{ config.gateway.allow_public_bind | bool | lower }}
 require_pairing = {{ (config.gateway.require_pairing | default(true)) | bool | lower }}
 
 {% if provider_type in ['anthropic', 'openai', 'ollama', 'openrouter'] %}
-default_provider = "{{ toml_escape(provider_type) }}"
-{% if model_id %}
-default_model = "{{ toml_escape(model_id) }}"
-{% endif %}
-
 {# Section header is a bare TOML key; restrict to the allow-list above so
    no caller-supplied content reaches the header (which has its own
    escaping rules different from basic strings). The `in [...]` guard

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -648,32 +648,13 @@ def test_get_required_secrets_returns_list():
     """Test get_required_secrets returns list of SecretDefinition dicts."""
     from clawrium.core.registry import get_required_secrets
 
-    # openclaw has no required secrets (provider credentials managed separately)
-    secrets = get_required_secrets("openclaw")
-    assert isinstance(secrets, list)
-    assert len(secrets) == 0
-
-    # zeroclaw has required secrets
-    secrets = get_required_secrets("zeroclaw")
-    assert isinstance(secrets, list)
-    assert len(secrets) > 0
-    # Each secret should have key and description
-    for secret in secrets:
-        assert "key" in secret
-        assert "description" in secret
-
-
-def test_get_required_secrets_zeroclaw():
-    """Test get_required_secrets for zeroclaw returns expected secrets."""
-    from clawrium.core.registry import get_required_secrets
-
-    secrets = get_required_secrets("zeroclaw")
-
-    assert isinstance(secrets, list)
-    assert len(secrets) >= 2
-    keys = [s["key"] for s in secrets]
-    assert "LLM_PROVIDER_URL" in keys
-    assert "LLM_MODEL" in keys
+    # Neither openclaw nor zeroclaw declares required secrets: provider
+    # credentials are managed through the providers system, not per-agent
+    # secrets. The return type is still a list so callers can iterate.
+    for agent_type in ("openclaw", "zeroclaw"):
+        secrets = get_required_secrets(agent_type)
+        assert isinstance(secrets, list)
+        assert len(secrets) == 0
 
 
 def test_get_optional_secrets_returns_list():


### PR DESCRIPTION
## Summary
- Fix \`config.toml\` template: move \`default_provider\` / \`default_model\` to top level so they are not scoped under \`[gateway]\`. Daemon was crashing gateway startup with \`Unknown provider: default\` because it never saw a configured default and fell back to the auto-injected empty \`[providers.models.default]\` stub.
- Fix \`configure.yaml\` pairing tasks for zeroclaw v0.7.5 API: read \`pairing_code\` (not \`code\`) from \`GET /pair/code\`; send \`POST /pair\` with header \`X-Pairing-Code\` (not a JSON body) per the daemon's startup banner.
- Drop stale \`LLM_PROVIDER_URL\` / \`LLM_MODEL\` required-secrets from \`zeroclaw/manifest.yaml\`. Provider URL + model are sourced from the providers system (via the onboarding \`providers\` stage) and rendered into \`config.toml\`. Nothing reads these secret keys. Leaving them declared made \`clm ps\` and the topology UI permanently report \`degraded (missing: …)\` on every correctly-configured zeroclaw.

Both fixes were derived from the official zeroclaw v0.7.5 docs (\`docs/book/src/providers/configuration.md\`, README, and the daemon's own startup banner), not by guessing.

## Testing

### Test Results
- [x] All existing tests pass (\`make test\` — 2252 py + 186 js)
- [x] Linter passes (\`make lint\` — ruff + eslint)
- [x] Updated registry tests to assert the new empty required-secrets shape for both openclaw and zeroclaw

### Manual Testing
End-to-end validation against zeroclaw v0.7.5 on x86_64 (wolf-i):
1. \`clm agent install --type zeroclaw --host wolf-i --name clawrium-d01\` — clean install.
2. \`clm agent configure clawrium-d01\` — completed all four onboarding stages (providers → identity → channels → validate) without playbook failure.
3. Selected provider routes to Ollama at \`http://192.168.1.17:11434\` running \`qwen3-coder-next:q4_K_M\`.
4. Daemon paired cleanly (\`/health\` returns \`paired: true\`, gateway status \`ok\`).
5. \`clm chat clawrium-d01\` — authenticated, sent \`hello\`, received a coherent response from the model.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation: template \`toml_escape\` macro preserved on all caller-supplied values
- [x] No SQL injection / XSS / command injection surface introduced
- [x] Dependencies unchanged

## Reviewer Notes
- The template comment block still references \`v0.7.5 schema\` — the layout now matches the schema documented at \`docs/book/src/providers/configuration.md\`. Per those docs, \`default_provider\` is a top-level key whose value is the \`<name>\` of a \`[providers.models.<name>]\` sub-table; \`<name>\` can be any operator-chosen alias and \`kind\` selects the implementation. We use the kind itself as the alias (e.g. \`default_provider = "ollama"\` + \`[providers.models.ollama]\`), which is the simplest correct shape for the four provider kinds the template emits.
- \`/health/providers\` is *not* a real v0.7.5 endpoint (canonical is \`/health\`). The probe in \`configure.yaml\` happens to pass because the dashboard SPA serves an HTTP 200 on the catch-all route — so it correctly fails closed when the daemon is down, just for the wrong reason. Out of scope for this PR; flagging for a follow-up cleanup.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)