### PR TITLE
feat(zeroclaw): wire Discord channel + GitHub integration end-to-end

### DIFF
--- a/.itx/422/00_PLAN.md
+++ b/.itx/422/00_PLAN.md
@@ -1,0 +1,38 @@
+# Issue #422: Operators can drive zeroclaw onboarding for Discord and GitHub the same way as hermes
+
+URL: https://github.com/ric03uec/clawrium/issues/422
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: issue-creation
+**Skill**: /itx:issue-new
+**Timestamp**: 2026-05-18
+**Model**: claude-opus-4-7
+
+```prompt
+then add support for both discord and github integration for zeroclaw first
+the same way its there for hermes. follow official documentation of zeroclaw.
+i will test it
+
+[follow-up: "is aid read the documentation and find the right location. this
+is not a opinon, you have to follow standards. add a task to udpate website
+and documentation as well. update plan after doing your research"]
+```
+
+### Clarifications captured
+
+- **Process**: Full `/itx:*` workflow — issue first, then plan-create, plan-scaffold, execute.
+- **`[autonomy]` block**: Full upstream-default block + token names (not partial table) — avoids relying on undocumented daemon merge behavior.
+- **Outcome statement**: "Operators can drive zeroclaw onboarding for Discord and GitHub the same way as hermes" (selected over agent-perspective and parity-emphasis alternatives).
+- **Out of scope for this issue**: Slack on zeroclaw, GitHub MCP server, auto-installing `gh`, multi-agent Discord per host.
+
+### Upstream-doc citations driving the design (zeroclaw v0.7.5)
+
+- `docs/book/src/channels/chat-others.md` — Discord TOML schema (keys: `enabled`, `bot_token`, `allowed_guilds`, `allowed_users`, `reply_to_mentions_only`, `draft_update_interval_ms`).
+- `docs/book/src/security/sandboxing.md` — `[autonomy] shell_env_passthrough` allowlist is the only documented path for exposing env vars to shell tools.
+- `docs/book/src/security/autonomy.md` — full `[autonomy]` block schema; explicit rule that `_TOKEN`/`_SECRET`/`_PASSWORD`/`API_KEY` patterns are auto-blocked.
+- `docs/book/src/ops/service.md` — systemd `Environment=` directive is the only documented daemon-env mechanism (no `EnvironmentFile=`).
+- Full `docs/book/src/SUMMARY.md` + tree listing — no native `[integrations]` block in zeroclaw v0.7.5.
+
+</details>

--- a/docs/agent-support/channels/discord.md
+++ b/docs/agent-support/channels/discord.md
@@ -1,6 +1,6 @@
 # Discord
 
-**Status:** ✅ Supported (OpenClaw only)
+**Status:** ✅ Supported on OpenClaw, Hermes, and ZeroClaw (each uses a different on-disk shape — see the agent-specific sections below).
 
 Discord channel allows your agent to operate as a bot in Discord servers.
 
@@ -238,6 +238,105 @@ Re-run `clm agent configure <name> --stage channels`, pick `discord` again, and 
 ### Non-interactive flags (Hermes)
 
 Planned for a follow-up — interactive is the supported path in this release. For automation today, drive `clm agent configure --stage channels` via expect/pexpect, or set the values directly in `hosts.json` + `secrets.json` and re-run the stage to trigger a re-render.
+
+---
+
+## ZeroClaw Configuration
+
+ZeroClaw consumes Discord credentials via **inline TOML**, not env vars. The bot token lives directly in `~/.zeroclaw/config.toml` under `[channels.discord]`, mode 0600. This differs from Hermes (env-based) and OpenClaw (env-based). Source of truth: zeroclaw upstream `docs/book/src/channels/chat-others.md` (v0.7.5).
+
+### Schema rendered by clm
+
+The clm-managed `[channels.discord]` block uses **only** the keys documented in zeroclaw v0.7.5:
+
+| TOML key | Source field in `hosts.json` `channels.discord.*` | Notes |
+|---|---|---|
+| `enabled = true` | always emitted when `enabled` is true and the bot token is hydrated | gating |
+| `bot_token = "..."` | hydrated from `secrets.json` `DISCORD_BOT_TOKEN` by `lifecycle.configure_agent` | inline TOML, never persisted in `hosts.json` |
+| `allowed_users = [...]` | `allowed_users` | empty array if unset |
+| `allowed_guilds = [...]` | `allowed_guilds` | empty array if unset; zeroclaw-specific (no hermes equivalent) |
+| `reply_to_mentions_only` | `require_mention` | renamed to match the upstream key |
+| `draft_update_interval_ms` | `draft_update_interval_ms` | optional — defaults handled by the daemon when omitted |
+
+### Hermes-side fields with no ZeroClaw equivalent
+
+These wizard inputs land in `hosts.json` but are **not** rendered into `~/.zeroclaw/config.toml`:
+
+- `home_channel`, `home_channel_name`, `home_channel_thread_id` — no upstream zeroclaw concept of a "home" channel.
+- `allow_all_users` — zeroclaw uses an empty `allowed_users = []` array to mean "allow everyone"; the boolean has no direct upstream representation.
+- `allowed_channels` — zeroclaw's upstream `allowed_destinations` is the nearest concept but is documented only generically (`channels/overview.md`), not under the Discord-specific schema; clm does not emit it pending a confirmed mapping.
+
+If you set any of these via the wizard for a zeroclaw agent, they persist to `hosts.json` for forward compatibility but have no runtime effect.
+
+### Interactive setup (ZeroClaw)
+
+```bash
+clm agent configure <zeroclaw-name> --stage channels
+```
+
+Prompts:
+
+| Prompt | Field |
+|---|---|
+| `Confirm CLI channel` | always-on; sets `confirm_cli = true` |
+| `Enable Discord channel (optional)` | persists `channels.discord.enabled` in `hosts.json` |
+| `Discord bot token` (masked) | persists to `secrets.json` as `DISCORD_BOT_TOKEN` |
+| `Allowed Discord user IDs` | `allowed_users` list |
+| `Allowed guild IDs` (optional) | `allowed_guilds` list |
+| `Reply to mentions only?` | `require_mention` → rendered as `reply_to_mentions_only` |
+
+`clm` then runs the configure playbook, which re-renders `~/.zeroclaw/config.toml` with the `[channels.discord]` block, restarts `zeroclaw-<name>.service`, and verifies the block landed by grepping for `^bot_token =` in the file.
+
+### Resulting on-disk shape (ZeroClaw)
+
+```toml
+[channels.discord]
+enabled = true
+bot_token = "MTIzNDU2Nzg5MDEyMzQ1Njc4Cg.G..."
+allowed_guilds = ["987654321098765432"]
+allowed_users = ["740723459344302120"]
+reply_to_mentions_only = true
+draft_update_interval_ms = 750
+```
+
+In `hosts.json` (agents.`<name>`.config.channels.discord):
+
+```json
+{
+  "enabled": true,
+  "allowed_users": ["740723459344302120"],
+  "allowed_guilds": ["987654321098765432"],
+  "require_mention": true
+}
+```
+
+`bot_token` is **never** stored in `hosts.json` — only `secrets.json` (mode 0600).
+
+### Removal (ZeroClaw)
+
+Re-run `clm agent configure <name> --stage channels` and answer **No** to "Enable Discord channel?". On the next render, the `[channels.discord]` block disappears from `config.toml` and the daemon stops listening on Discord on restart. To also wipe the persisted token, manually remove the `DISCORD_BOT_TOKEN` entry from `secrets.json`.
+
+### ZeroClaw-specific troubleshooting
+
+<details>
+<summary><strong>Bot connects but doesn't reply to my messages</strong></summary>
+
+1. Confirm your Discord user ID is in `~/.zeroclaw/config.toml` under `[channels.discord]` `allowed_users` — empty array means **allow all users** (zeroclaw upstream convention), but if you populated it with other IDs, yours must be in the list.
+2. If `reply_to_mentions_only = true`, the bot only responds when @-mentioned.
+3. Check the Discord Developer Portal: the bot must have `Message Content Intent` and `Server Members Intent` enabled (zeroclaw upstream requirement).
+
+</details>
+
+<details>
+<summary><strong>Bot didn't connect after configure</strong></summary>
+
+```bash
+ssh <agent-host> "sudo journalctl -u zeroclaw-<name>.service -n 200 --no-pager | grep -iE 'discord|channel'"
+```
+
+If the daemon logged a token error, rotate the bot token in the Discord Developer Portal and re-run `clm agent configure <name> --stage channels` to push the new value.
+
+</details>
 
 ---
 

--- a/docs/agent-support/integrations/github.md
+++ b/docs/agent-support/integrations/github.md
@@ -1,27 +1,8 @@
 # GitHub
 
-**Status:** 🚧 In Development
+**Status:** ✅ Supported on Hermes and ZeroClaw (#419, #422). 📋 Planned for OpenClaw.
 
-GitHub integration allows agents to interact with repositories, pull requests, and issues.
-
----
-
-## Planned Features
-
-- **PR Reviews:** Comment on pull requests
-- **Issue Management:** Read and create issues
-- **Code Search:** Search repositories
-- **Actions:** Trigger and monitor workflows
-- **Webhooks:** React to GitHub events
-- **Notifications:** Summarize activity
-
-## Timeline
-
-**Target:** Q2 2026
-
-**Milestone:** [SEA (Secondary Engagement & Automation)](https://github.com/ric03uec/clawrium/milestones)
-
-Track progress: [GitHub Issue #TBD](https://github.com/ric03uec/clawrium/issues)
+GitHub integration allows agents to clone repos, open pull requests, comment on issues, and search code from inside the agent's shell tool. The credential is a Personal Access Token (classic) or a fine-grained token — see [Create Fine-Grained Token for One Repo](#create-fine-grained-token-for-one-repo) below.
 
 ---
 
@@ -109,29 +90,89 @@ The key difference from classic tokens: fine-grained tokens let you scope to spe
 
 ---
 
-## Alternatives (Current Workaround)
+## How clm Wires GitHub to Each Agent Type
 
-Until native integration is available:
+### Hermes — env vars in `~/.hermes/.env`
 
-1. **CLI Tools:** Use `gh` CLI in agent scripts
-   ```bash
-   clm chat my-agent
-   # In chat: Run "gh issue list --repo myorg/myrepo"
-   ```
+Hermes natively reads `GITHUB_TOKEN` from its environment. `clm agent integration add <hermes> <gh-name>` followed by `clm agent sync <hermes>` renders the following into `~/.hermes/.env` (mode 0600):
 
-2. **API via curl:** Make direct API calls
-   ```bash
-   curl -H "Authorization: token $GITHUB_TOKEN" \
-        https://api.github.com/repos/myorg/myrepo/issues
-   ```
+```env
+GITHUB_TOKEN_WORK_GH='ghp_...'
+GITHUB_TOKEN='ghp_...'      # tracks the alphabetically-last github integration
+```
 
-3. **MCP Tools:** (Coming Q2 2026) Use GitHub MCP server
+`clm` then runs `gh auth login --with-token` as the agent user (soft dep — skipped if `gh` is not on the host). See [hermes/playbooks/configure.yaml](https://github.com/ric03uec/clawrium/blob/main/src/clawrium/platform/registry/hermes/playbooks/configure.yaml) lines 118–145.
+
+### ZeroClaw — two layers, both required
+
+ZeroClaw's shell tool **auto-strips** any env var matching `_TOKEN` / `_SECRET` / `_PASSWORD` / `API_KEY` patterns unless explicitly listed in `[autonomy] shell_env_passthrough`. Source: zeroclaw v0.7.5 `docs/book/src/security/sandboxing.md` and `security/autonomy.md`. So GitHub credentials need to land in **two** places:
+
+| Layer | Where | What it enables |
+|---|---|---|
+| 1. systemd `Environment=` drop-in | `/etc/systemd/system/zeroclaw-<name>.service.d/10-clm-env.conf` | The daemon process and all child processes (including the shell tool) inherit `GITHUB_TOKEN` from systemd. |
+| 2. `[autonomy] shell_env_passthrough` | `~/.zeroclaw/config.toml` | The agent's sandboxed shell tool sees the token. Without this, layer 1 alone is invisible to `gh`/`git push` inside chat. |
+
+Both layers are populated automatically by `clm agent sync <zeroclaw>` after `clm agent integration add`. The drop-in template is `src/clawrium/platform/registry/zeroclaw/templates/clm-env.conf.j2`; the autonomy block lives in `config.toml.j2`. Re-running `clm agent sync` re-renders both atomically and triggers a single service restart (daemon_reload + restart, handled by the configure playbook's restart handler).
+
+Like hermes, a `gh auth login --with-token` is run as the agent user when `gh` is present on the host — convenience only; the env-var path works without it.
+
+```toml
+# Rendered in ~/.zeroclaw/config.toml when github integrations are assigned:
+[autonomy]
+level = "supervised"
+approval_timeout_secs = 300
+workspace_only = true
+allowed_commands = ["git", "cargo", "grep", "find", "ls", "cat"]
+forbidden_commands = ["shutdown", "reboot", "mkfs"]
+forbidden_paths = ["/etc", "/sys", "/boot", "~/.ssh", "~/.aws"]
+shell_env_passthrough = ["PATH", "HOME", "USER", "LANG", "GITHUB_TOKEN_WORK_GH", "GITHUB_TOKEN"]
+```
+
+```ini
+# Rendered in /etc/systemd/system/zeroclaw-<name>.service.d/10-clm-env.conf:
+[Service]
+Environment=GITHUB_TOKEN_WORK_GH="ghp_..."
+Environment=GITHUB_TOKEN="ghp_..."
+```
+
+### Verifying the wiring (ZeroClaw)
+
+```bash
+# On the agent host:
+systemctl show -p Environment zeroclaw-<name>      # should list GITHUB_TOKEN
+grep -E '^shell_env_passthrough' ~/.zeroclaw/config.toml
+# From clm:
+clm chat <name>
+> Run: echo $GITHUB_TOKEN          # should print the token
+> Run: gh auth status              # should print "Logged in to github.com" if gh is installed
+```
 
 ---
 
-## Vote for Priority
+## Multi-Account Support
 
-Add a 👍 reaction to [the GitHub integration issue](https://github.com/ric03uec/clawrium/issues) to help prioritize.
+Both hermes and zeroclaw support multiple github integrations on a single agent:
+
+```bash
+clm integration add work-gh --type github
+clm integration add personal-gh --type github
+clm agent integration add my-agent work-gh
+clm agent integration add my-agent personal-gh
+clm agent sync my-agent
+```
+
+The agent then has `GITHUB_TOKEN_WORK_GH` and `GITHUB_TOKEN_PERSONAL_GH` available, plus a bare `GITHUB_TOKEN` set to the alphabetically-last integration (deterministic — uses Jinja's `dictsort`).
+
+---
+
+## OpenClaw (Not Yet Supported)
+
+OpenClaw does not yet consume GitHub credentials. Use a hermes or zeroclaw agent for GitHub workflows, or follow the workaround below for OpenClaw-only fleets.
+
+## Workaround for OpenClaw
+
+1. **CLI Tools:** Manually `gh auth login` on the OpenClaw host outside of clm.
+2. **API via curl:** Make direct API calls inside chat using a hard-coded token (not recommended for production).
 
 ---
 

--- a/docs/agent-support/zeroclaw.md
+++ b/docs/agent-support/zeroclaw.md
@@ -64,8 +64,8 @@ ZeroClaw's only chat surface is the daemon's own WebSocket endpoint at `GET /ws/
 |---------|:------:|-------|
 | **clm `chat <zeroclaw-name>`** | ✅ | Connects to `ws://<host>:42617/ws/chat` with `Authorization: Bearer <paired-token>`. See [Use the WebSocket chat surface](#3-use-the-websocket-chat-surface). |
 | **OpenAI-compatible HTTP API** | ❌ | Not exposed by upstream ZeroClaw. Use [Hermes](hermes.md) when an OpenAI-style HTTP endpoint is required. |
-| **Discord** | ❌ | Not supported (use [OpenClaw](openclaw.md) or [Hermes](hermes.md)). |
-| **Slack** | ❌ | Not supported (use [OpenClaw](openclaw.md) or [Hermes](hermes.md)). |
+| **[Discord](channels/discord.md)** | ✅ | Native — rendered as `[channels.discord]` in `config.toml`. Bot token is **inline TOML**, not env-based (differs from hermes). Schema follows zeroclaw v0.7.5 upstream: `bot_token`, `allowed_guilds`, `allowed_users`, `reply_to_mentions_only`, `draft_update_interval_ms`. Configure via `clm agent configure <name> --stage channels`. |
+| **Slack** | ❌ | Not supported (use [OpenClaw](openclaw.md) or [Hermes](hermes.md)). Tracked as a follow-up. |
 | **Web / WhatsApp / Telegram / Email / Matrix** | ❌ | Not supported. |
 
 ---
@@ -85,7 +85,8 @@ ZeroClaw's only chat surface is the daemon's own WebSocket endpoint at `GET /ws/
 | **Onboarding wizard** | ✅ | 4 stages: `providers` (required) → `identity` (auto-skipped) → `channels` (required, CLI confirm) → `validate` (3 local checks: agent install record, provider config + API key, provider connectivity). |
 | **Personality block in `config.toml`** | ✅ | `[personality]` with `name`, `timezone`, `communication_style` defaults; rendered with `force: no` semantics through Ansible's template default — re-running configure preserves the file because `notify` only fires when content actually changes. |
 | **Bootstrap file (`BOOTSTRAP.md`)** | ✅ | **Not rendered by clm.** The ZeroClaw daemon generates `BOOTSTRAP.md` on first boot and self-deletes it after use. Never appears in `clm agent memory show`. |
-| **Integrations (GitHub / Jira / GitLab / Linear / Notion)** | 📋 | Deferred. Upstream ZeroClaw supports an `[integrations]` block; clm does not emit it in this iteration. Tracked as a follow-up to #112. |
+| **[GitHub integration](integrations/github.md)** | ✅ | Two-layer wiring (#422): tokens land in a systemd drop-in (`/etc/systemd/system/zeroclaw-<name>.service.d/10-clm-env.conf`) so the daemon's environment has `GITHUB_TOKEN`, AND in `[autonomy] shell_env_passthrough` in `config.toml` so the agent's shell tool can actually see them (required: zeroclaw auto-strips `_TOKEN`-pattern vars unless explicitly allow-listed). `gh auth login --with-token` runs as a soft-dep convenience when `gh` is on the host. |
+| **Jira / GitLab / Linear / Notion integrations** | 📋 | Deferred. No native consumer in zeroclaw v0.7.5; would require either a `[mcp.servers]` block (potential future path) or per-integration env passthrough. Tracked as a follow-up. |
 | **Hardware support (GPIO / serial / debug probes)** | 📋 | Deferred. |
 | **Tunnel providers (Cloudflare / Tailscale / Ngrok / custom)** | 📋 | Deferred. Reach the gateway over your own SSH tunnel or LAN. |
 | **Encrypted secrets (ChaCha20-Poly1305)** | 📋 | Deferred. |
@@ -143,7 +144,7 @@ The wizard walks through:
 |-------|----------|
 | **providers** | Required. Pick from your registered clm providers; clm validates connectivity via `provider_test`. |
 | **identity** | Auto-skipped. ZeroClaw manages its own identity through the workspace MD files (`SOUL.md`, `IDENTITY.md`, …) which clm renders below — there is no separate identity wizard. |
-| **channels** | Required. The wizard presents `cli`, `discord`, and `slack` for all agent types — pick `cli` for ZeroClaw. `discord` / `slack` are selectable but **non-functional** on ZeroClaw; only the CLI path (`clm chat`) routes to the WebSocket gateway. |
+| **channels** | Required. ZeroClaw confirms the always-on CLI channel and offers a `discord` opt-in. Selecting `discord` prompts for the bot token (persists to `secrets.json` as `DISCORD_BOT_TOKEN`) plus optional allowlists; clm renders the result as `[channels.discord]` in `~/.zeroclaw/config.toml`. Slack remains unsupported on ZeroClaw — use [Hermes](hermes.md) or [OpenClaw](openclaw.md) for Slack. |
 | **validate** | Local validation only, three steps for zeroclaw: (1) agent install record, (2) provider config + API key, (3) provider connectivity. The control-machine SOUL.md check is skipped — zeroclaw owns its identity through `~/.zeroclaw/workspace/` on the agent host, not under `~/.config/clawrium/agents/zeroclaw/`. The playbook's own post-render readiness probe (`GET /health/providers`) is separate from this stage. The manifest's `binary_check` task (`zeroclaw --version`) is not dispatched yet — remote version verification is planned. |
 
 Configure renders TWO things on the agent host, then runs the pairing handshake against the freshly started daemon.
@@ -410,7 +411,7 @@ The render is idempotent (force: no), so this is safe to run against a partially
 
 The following are explicitly out of scope for issue #112 and tracked as separate follow-ups:
 
-- **Integrations** — GitHub, GitLab, Atlassian (Jira + Confluence), Linear, Notion. Upstream ZeroClaw supports an `[integrations]` block; clm does not emit it in this iteration.
+- **Non-GitHub integrations** — GitLab, Atlassian (Jira + Confluence), Linear, Notion. Tracked as follow-ups; the upstream `[mcp.servers]` block is the most likely landing pad. GitHub is supported as of #422 — see the Feature Support table above.
 - **Hardware** — GPIO, serial, debug-probe support.
 - **Tunnel providers** — Cloudflare Tunnel, Tailscale, Ngrok, custom tunnels. Use SSH tunneling in the meantime.
 - **Encrypted secrets** — ChaCha20-Poly1305 secret encryption is upstream-only for now.

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -740,8 +740,14 @@ def _run_channels_stage(
     """
     from clawrium.core.secrets import get_instance_key, set_instance_secret
 
-    # All agent types support cli, discord, and slack channels.
-    channels = ["cli", "discord", "slack"]
+    # Channel menu per agent type. ZeroClaw v0.7.5 has no native Slack
+    # channel (#422), so we filter Slack out for zeroclaw. Hermes + OpenClaw
+    # remain on the full 3-channel menu. This guard MUST stay in sync with
+    # the docs: docs/agent-support/zeroclaw.md says Slack is unsupported.
+    if claw_type == "zeroclaw":
+        channels = ["cli", "discord"]
+    else:
+        channels = ["cli", "discord", "slack"]
 
     console.print("[bold]Select default channel:[/bold]")
     for i, ch in enumerate(channels, 1):
@@ -886,6 +892,114 @@ def _run_channels_stage(
                 discord_cfg["allowed_channels"] = allowed_channels
 
             channels_config = {"discord": discord_cfg}
+        elif claw_type == "zeroclaw":
+            # ZeroClaw shape (#422): flat TOML keys per zeroclaw v0.7.5 docs
+            # (docs/book/src/channels/chat-others.md):
+            #   [channels.discord]
+            #   enabled, bot_token, allowed_guilds, allowed_users,
+            #   reply_to_mentions_only, draft_update_interval_ms
+            # The CLI collects the persistable fields here; `bot_token` is
+            # stored in secrets.json below and hydrated into config.toml by
+            # lifecycle.configure_agent before the playbook runs. No
+            # home_channel / allow_all_users / allowed_channels concepts
+            # upstream — we deliberately don't prompt for them so users
+            # following the docs don't get surprised when those fields don't
+            # take effect.
+            allowed_users_raw = typer.prompt(
+                "Allowed Discord user IDs (comma-separated; empty = allow all)",
+                default="",
+                show_default=False,
+            )
+            allowed_users_raw = (allowed_users_raw or "").strip()
+            allowed_users = []
+            if allowed_users_raw:
+                ids = [
+                    s.strip() for s in allowed_users_raw.split(",") if s.strip()
+                ]
+                # ATX Round 3 B1: comma-only input (`,` or `, ,`) is truthy
+                # after strip but `ids` resolves to []. Without this guard
+                # the agent silently becomes an open bot with no operator
+                # feedback. Mirrors the hermes guard at line ~815.
+                if not ids:
+                    console.print(
+                        "[red]Error:[/red] No valid user IDs parsed from "
+                        "input. Enter 17-19 digit IDs separated by commas, "
+                        "or leave the field empty for an open bot."
+                    )
+                    return False
+                for uid in ids:
+                    if not re.match(r"^\d{17,19}$", uid):
+                        console.print(
+                            f"[red]Error:[/red] Invalid user ID "
+                            f"'{rich_escape(uid)}' (17-19 digits required)"
+                        )
+                        return False
+                allowed_users = ids
+            else:
+                console.print(
+                    "[yellow]Note:[/yellow] empty allowed_users means the "
+                    "bot will respond to every user it can see — zeroclaw's "
+                    "upstream convention for an open bot."
+                )
+
+            allowed_guilds_raw = typer.prompt(
+                "Allowed guild IDs (comma-separated, Enter for any guild)",
+                default="",
+                show_default=False,
+            )
+            allowed_guilds_raw = (allowed_guilds_raw or "").strip()
+            allowed_guilds = []
+            if allowed_guilds_raw:
+                gids = [
+                    s.strip()
+                    for s in allowed_guilds_raw.split(",")
+                    if s.strip()
+                ]
+                # Symmetric B1 guard for guilds — comma-only input must fail
+                # loudly rather than silently allow any guild.
+                if not gids:
+                    console.print(
+                        "[red]Error:[/red] No valid guild IDs parsed from "
+                        "input. Enter 17-19 digit IDs separated by commas, "
+                        "or leave the field empty for any guild."
+                    )
+                    return False
+                for gid in gids:
+                    if not re.match(r"^\d{17,19}$", gid):
+                        console.print(
+                            f"[red]Error:[/red] Invalid guild ID "
+                            f"'{rich_escape(gid)}' (17-19 digits required)"
+                        )
+                        return False
+                allowed_guilds = gids
+            else:
+                # ATX Round 3 W4: empty allowed_guilds means any Discord
+                # server can host the bot — symmetric warning to the
+                # allowed_users empty-case note above.
+                console.print(
+                    "[yellow]Note:[/yellow] empty allowed_guilds means the "
+                    "bot is reachable from any Discord server it joins."
+                )
+
+            # `require_mention` is the clm-side knob; lifecycle/config.toml.j2
+            # translates it to upstream `reply_to_mentions_only`. Default
+            # true is intentional security hardening — more restrictive than
+            # the zeroclaw v0.7.5 default for new bots. ATX Round 3 S1.
+            # Wording aligned to hermes prompt for mixed-fleet operators
+            # (Round 3 W2).
+            require_mention = typer.confirm(
+                "Require @mention to respond?", default=True
+            )
+
+            zc_discord_cfg: dict = {
+                "enabled": True,
+                "allowed_users": allowed_users,
+                "require_mention": require_mention,
+            }
+            if allowed_guilds:
+                zc_discord_cfg["allowed_guilds"] = allowed_guilds
+
+            channels_config = {"discord": zc_discord_cfg}
         else:
             # Prompt for guild ID with validation
             guild_id = typer.prompt("Discord server (guild) ID")
@@ -941,12 +1055,19 @@ def _run_channels_stage(
             canonical_hostname, claw_type, installed_name or claw_type
         )
 
-        # For hermes, configure_agent's hydration block reads
+        # For hermes AND zeroclaw, configure_agent's hydration block reads
         # DISCORD_BOT_TOKEN from secrets.json BEFORE running the ansible
-        # playbook (the playbook needs the token to render .env). So the
-        # secret must be persisted first. For openclaw the sync uses the
-        # ansible-vars passthrough and W4 keeps the "sync first" order.
-        if claw_type == "hermes":
+        # playbook (hermes renders it into .env; zeroclaw renders it inline
+        # into config.toml's [channels.discord]). So the secret must be
+        # persisted first. ATX Round 3 B2: pre-Round-3 the guard was
+        # hermes-only and zeroclaw fell into the post-sync store branch,
+        # which deadlocked every first configure because lifecycle.
+        # configure_agent returned `(False, "DISCORD_BOT_TOKEN missing")`
+        # before the token was ever stored.
+        #
+        # For openclaw the sync uses the ansible-vars passthrough and the
+        # original W4 ordering (sync first, then store) is preserved.
+        if claw_type in ("hermes", "zeroclaw"):
             set_instance_secret(
                 instance_key, "DISCORD_BOT_TOKEN", bot_token, "Discord bot token"
             )
@@ -966,8 +1087,9 @@ def _run_channels_stage(
             return False
 
         # Store bot token as secret only after successful sync (W4) — for
-        # openclaw/zeroclaw. Hermes already stored it above.
-        if claw_type != "hermes":
+        # openclaw. Hermes and zeroclaw stored it above (their playbooks
+        # need the token DURING the sync, not after).
+        if claw_type not in ("hermes", "zeroclaw"):
             set_instance_secret(
                 instance_key, "DISCORD_BOT_TOKEN", bot_token, "Discord bot token"
             )

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -815,55 +815,21 @@ def configure_agent(
                 "key": api_server_key,
             }
 
-        # Hermes Discord: merge persisted channels.discord shape from hosts.json
-        # with anything passed in config_data, then hydrate the bot token from
-        # secrets.json. Mirrors the api_server.key pattern. If discord is not
-        # enabled this block is a no-op — .env.j2 emits no DISCORD_* lines.
+        # Hermes Slack: merge persisted channels.slack shape from hosts.json
+        # with anything passed in config_data, then hydrate the bot/app tokens
+        # from secrets.json. Mirrors the Discord hydration pattern.
+        #
+        # Discord hydration moved out of this hermes-only branch to a sibling
+        # block below (#422) so zeroclaw can share it; Slack stays hermes-only
+        # because zeroclaw v0.7.5 has no native Slack channel. The
+        # persisted_channels/incoming_channels locals below feed only Slack.
         persisted_channels = agent_record.get("config", {}).get("channels") or {}
         if not isinstance(persisted_channels, dict):
             persisted_channels = {}
-        persisted_discord = persisted_channels.get("discord") or {}
-        if not isinstance(persisted_discord, dict):
-            persisted_discord = {}
-
         incoming_channels = config_data.get("channels") or {}
         if not isinstance(incoming_channels, dict):
             incoming_channels = {}
-        incoming_discord = incoming_channels.get("discord") or {}
-        if not isinstance(incoming_discord, dict):
-            incoming_discord = {}
 
-        # Merge persisted onto incoming so an explicit caller-provided field
-        # wins, but fields the caller didn't set (e.g. _sync_provider_config
-        # only carrying provider) inherit from hosts.json.
-        merged_discord = {**persisted_discord, **incoming_discord}
-
-        if merged_discord.get("enabled"):
-            discord_secret = get_instance_secrets(instance_key).get(
-                "DISCORD_BOT_TOKEN"
-            )
-            discord_token = (
-                discord_secret.get("value")
-                if isinstance(discord_secret, dict)
-                else None
-            )
-            if not isinstance(discord_token, str) or len(discord_token) < 50:
-                return (
-                    False,
-                    "Discord enabled for this agent but DISCORD_BOT_TOKEN is "
-                    "missing or invalid in secrets.json. Re-run "
-                    "'clm agent configure <name> --stage channels' to set it.",
-                )
-            merged_discord["bot_token"] = discord_token
-
-        if persisted_discord or incoming_discord:
-            merged_channels = {**persisted_channels, **incoming_channels}
-            merged_channels["discord"] = merged_discord
-            config_data["channels"] = merged_channels
-
-        # Hermes Slack: merge persisted channels.slack shape from hosts.json
-        # with anything passed in config_data, then hydrate the bot/app tokens
-        # from secrets.json. Mirrors the Discord hydration pattern above.
         persisted_slack = persisted_channels.get("slack") or {}
         if not isinstance(persisted_slack, dict):
             persisted_slack = {}
@@ -916,6 +882,71 @@ def configure_agent(
             if not isinstance(current_channels, dict):
                 current_channels = {}
             current_channels["slack"] = merged_slack
+            config_data["channels"] = current_channels
+
+    # Discord channel hydration (#422). Shared between hermes and zeroclaw —
+    # both consume the same DISCORD_BOT_TOKEN secrets.json entry, the only
+    # difference is downstream: hermes renders DISCORD_BOT_TOKEN into .env
+    # via .env.j2 while zeroclaw renders bot_token = "<token>" into config.toml
+    # via config.toml.j2's [channels.discord] block. The hydration is identical.
+    #
+    # Gated on Discord being present in either persisted or incoming config
+    # before any get_instance_key call so a configure for a non-Discord agent
+    # with an unusable agent_name (e.g. the invalid-claw-user test path) still
+    # falls through to the validation block below.
+    if resolved_type in ("hermes", "zeroclaw"):
+        discord_persisted_channels = (
+            agent_record.get("config", {}).get("channels") or {}
+        )
+        if not isinstance(discord_persisted_channels, dict):
+            discord_persisted_channels = {}
+        discord_persisted = discord_persisted_channels.get("discord") or {}
+        if not isinstance(discord_persisted, dict):
+            discord_persisted = {}
+
+        discord_incoming_channels = config_data.get("channels") or {}
+        if not isinstance(discord_incoming_channels, dict):
+            discord_incoming_channels = {}
+        discord_incoming = discord_incoming_channels.get("discord") or {}
+        if not isinstance(discord_incoming, dict):
+            discord_incoming = {}
+
+        if discord_persisted or discord_incoming:
+            # Persisted onto incoming so an explicit caller-provided field
+            # wins, but fields the caller didn't set (e.g.
+            # _sync_provider_config only carrying provider) inherit from
+            # hosts.json.
+            discord_merged = {**discord_persisted, **discord_incoming}
+
+            if discord_merged.get("enabled"):
+                discord_instance_key = get_instance_key(
+                    host["hostname"], resolved_type, unix_agent_name
+                )
+                discord_secret = get_instance_secrets(discord_instance_key).get(
+                    "DISCORD_BOT_TOKEN"
+                )
+                discord_token = (
+                    discord_secret.get("value")
+                    if isinstance(discord_secret, dict)
+                    else None
+                )
+                if (
+                    not isinstance(discord_token, str)
+                    or len(discord_token) < 50
+                ):
+                    return (
+                        False,
+                        "Discord enabled for this agent but DISCORD_BOT_TOKEN "
+                        "is missing or invalid in secrets.json. Re-run "
+                        "'clm agent configure <name> --stage channels' to set "
+                        "it.",
+                    )
+                discord_merged["bot_token"] = discord_token
+
+            current_channels = config_data.get("channels") or {}
+            if not isinstance(current_channels, dict):
+                current_channels = {}
+            current_channels["discord"] = discord_merged
             config_data["channels"] = current_channels
 
     # Validate config data before running Ansible
@@ -1383,13 +1414,19 @@ def configure_agent(
                     api_server_persisted = dict(persisted_config["api_server"])
                     api_server_persisted.pop("key", None)
                     persisted_config["api_server"] = api_server_persisted
-                # B3 invariant for Discord: bot_token lives in secrets.json
-                # only. Mirror the api_server.key strip so re-persisting
-                # config_data doesn't leak the token back into hosts.json.
-                # Defense in depth: if channels is an unexpected type, drop
-                # it entirely rather than risk leaking a misplaced token.
-                channels_persisted = persisted_config.get("channels")
+
+            # B3 invariant for Discord: bot_token lives in secrets.json only,
+            # never in hosts.json. Applies to both hermes (DISCORD_BOT_TOKEN
+            # hydrated into .env via .env.j2) and zeroclaw (#422 — token
+            # hydrated into config.toml's [channels.discord]). Without this
+            # strip, the bot_token roundtrips: hydrated → persisted → read
+            # back into existing_config on next configure → re-hydrated, etc.
+            # ATX B1 finding. Slack inclusion is hermes-only in practice but
+            # the pop is idempotent on absent keys so leaving it covers both
+            # agent types in one branch.
+            if resolved_type in ("hermes", "zeroclaw"):
                 if "channels" in persisted_config:
+                    channels_persisted = persisted_config.get("channels")
                     if isinstance(channels_persisted, dict):
                         channels_persisted = dict(channels_persisted)
                         discord_persisted = channels_persisted.get("discord")

--- a/src/clawrium/platform/registry/zeroclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/manifest.yaml
@@ -34,6 +34,8 @@ secrets:
   optional:
     - key: LLM_API_KEY
       description: "API key for LLM provider (optional for local)"
+    - key: DISCORD_BOT_TOKEN
+      description: "Discord bot token (only when [channels.discord] is enabled)"
 
 # Onboarding workflow configuration
 onboarding:
@@ -56,13 +58,26 @@ onboarding:
 
     channels:
       required: true
-      description: "Configure communication channel"
+      description: "Configure communication channels (cli always on; discord optional)"
       tasks:
         - id: confirm_cli
           name: "Confirm CLI channel"
           type: confirm
           message: "ZeroClaw will use CLI for communication"
           default: true
+        - id: select_discord
+          name: "Enable Discord channel (optional)"
+          type: confirm
+          message: "Enable Discord messaging for this agent?"
+          default: false
+        # When select_discord=yes, the CLI prompts interactively for the bot
+        # token, allowed-user IDs, optional allowed-guild allowlist, and
+        # reply-to-mentions-only toggle. Token persists to secrets.json under
+        # DISCORD_BOT_TOKEN; the rest land in hosts.json under
+        # config.channels.discord and are rendered into ~/.zeroclaw/config.toml
+        # as a [channels.discord] table (zeroclaw v0.7.5 docs/book/src/channels/
+        # chat-others.md). Note: bot_token lives in TOML inline — zeroclaw does
+        # not consume DISCORD_BOT_TOKEN as an env var.
 
     validate:
       description: "Verify installation"

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
@@ -90,6 +90,69 @@
         enabled: yes
         daemon_reload: yes
 
+    # systemd drop-in directory (#422). Hosts the clm-managed Environment=
+    # overlay without touching the install.yaml-dropped unit file. Drop-ins
+    # are the systemd-standard mechanism per `man systemd.unit` "Drop-In".
+    - name: Ensure systemd drop-in directory exists for zeroclaw service
+      ansible.builtin.file:
+        path: "/etc/systemd/system/{{ agent_type }}-{{ agent_name }}.service.d"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    # Render the GitHub-integration drop-in. The template emits an empty
+    # [Service] block when no github integrations are assigned — systemd
+    # treats that as a no-op overlay. Mode 0600 because the file contains
+    # the GITHUB_TOKEN verbatim (read-only to root; systemd is started as
+    # root so this is fine). notify the restart handler so the drop-in is
+    # picked up before /health/providers is probed.
+    - name: Render zeroclaw GitHub-integration systemd drop-in
+      ansible.builtin.template:
+        src: "{{ template_path }}/clm-env.conf.j2"
+        dest: "/etc/systemd/system/{{ agent_type }}-{{ agent_name }}.service.d/10-clm-env.conf"
+        owner: root
+        group: root
+        mode: "0600"
+        force: yes
+      no_log: true
+      notify: Restart zeroclaw service
+
+    # GitHub CLI authentication block (#422, mirrors hermes configure.yaml).
+    # `gh` is a soft dependency: when absent, the Environment= drop-in above
+    # still wires GITHUB_TOKEN so skills calling the GitHub REST API
+    # directly continue to work. `changed_when: false` keeps the task
+    # idempotent — re-running configure against an authenticated host
+    # reports `ok` rather than `changed`.
+    - name: GitHub CLI authentication block
+      when: integrations is defined
+      block:
+        - name: Check if gh CLI is installed
+          ansible.builtin.command: which gh
+          register: gh_check
+          changed_when: false
+          failed_when: false
+
+        - name: Authenticate gh CLI for each github integration
+          ansible.builtin.command:
+            argv:
+              - gh
+              - auth
+              - login
+              - --with-token
+            stdin: "{{ item.value.GITHUB_TOKEN }}"
+          become: yes
+          become_user: "{{ agent_name }}"
+          no_log: true
+          changed_when: false
+          when:
+            - gh_check.rc == 0
+            - item.value.type == 'github'
+            - item.value.GITHUB_TOKEN is defined
+          loop: "{{ integrations | dict2items }}"
+          loop_control:
+            label: "{{ item.key }}"
+
     # Apply pending restart (from the template task) before the readiness
     # probe so /health is observing the just-rendered config, not the
     # previous incarnation.
@@ -282,6 +345,33 @@
         zeroclaw_gateway_url: "ws://{{ ansible_host }}:{{ gateway_port }}/ws/chat"
         cacheable: true
       no_log: true
+
+    # Discord-config verification (#422). Confirms the bot token + an
+    # allowlist landed in config.toml when Discord is enabled. grep -q so
+    # we get a clean exit status without leaking the rendered key into logs.
+    # Uses dict.get() pattern (not attribute access) so undefined keys
+    # don't error under Ansible 2.20+'s strict Jinja mode.
+    - name: Verify config.toml contains bot_token when Discord enabled
+      ansible.builtin.command:
+        cmd: grep -qE '^bot_token\s*=' "/home/{{ agent_name }}/.zeroclaw/config.toml"
+      register: discord_token_check
+      changed_when: false
+      failed_when: discord_token_check.rc != 0
+      no_log: true
+      when:
+        - config.channels is defined
+        - config.channels.discord is defined
+        - config.channels.discord.enabled | default(false)
+
+    # Autonomy block always renders, so the grep is unconditional. This
+    # catches a Jinja regression that drops the block (which would silently
+    # disable shell_env_passthrough → tools lose GITHUB_TOKEN, _SECRET, etc.).
+    - name: Verify config.toml renders [autonomy] block with shell_env_passthrough
+      ansible.builtin.command:
+        cmd: grep -qE '^shell_env_passthrough\s*=' "/home/{{ agent_name }}/.zeroclaw/config.toml"
+      register: autonomy_check
+      changed_when: false
+      failed_when: autonomy_check.rc != 0
 
     - name: Display configure success
       ansible.builtin.debug:

--- a/src/clawrium/platform/registry/zeroclaw/templates/clm-env.conf.j2
+++ b/src/clawrium/platform/registry/zeroclaw/templates/clm-env.conf.j2
@@ -1,0 +1,53 @@
+# Managed by clawrium (clm). Do not edit by hand — re-render with
+# `clm agent configure {{ agent_name | default('<name>') }}`.
+#
+# systemd drop-in (#422). Loaded into the zeroclaw-<name>.service unit
+# at /etc/systemd/system/zeroclaw-<name>.service.d/10-clm-env.conf so the
+# install-time unit (install.yaml) stays untouched. Drop-ins are the
+# systemd-standard override mechanism per `man systemd.unit`.
+#
+# Why this layer is required: zeroclaw v0.7.5 docs/book/src/security/
+# sandboxing.md states that the agent shell tool inherits ONLY env vars
+# explicitly listed in `[autonomy] shell_env_passthrough`. But that
+# allowlist is per-tool — the daemon process itself reads from the
+# systemd-supplied environment. So GitHub tokens need to land in BOTH
+# places: here (so the daemon has them at all) and in shell_env_passthrough
+# inside config.toml (so the shell tool can see them).
+#
+# Per-name vars (GITHUB_TOKEN_<NAME>) support multi-account setups; the
+# bare GITHUB_TOKEN is set to the alphabetically-last github integration
+# for back-compat with skills/CLIs that hard-code that name. `dictsort`
+# makes the choice deterministic regardless of dict insertion order.
+# Mirrors hermes/.env.j2:115-122.
+{# Shell-safe quoting for systemd. systemd Environment= parses the RHS as
+   POSIX-shell-like with double-quotes — embedded double quotes and backslashes
+   must be escaped. POSIX-style single-quote escape (used by hermes) does NOT
+   apply here because systemd does its own un-quoting before exposing the value.
+   See systemd.exec(5) "Environment=".
+
+   ATX Round 1 W3 — newline injection defense: per systemd.exec(5), an
+   embedded newline in a quoted Environment= value terminates the directive
+   and the rest of the token is parsed as a new systemd statement. A
+   malformed GITHUB_TOKEN containing a literal `\n` could inject e.g.
+   `Environment=PATH=/evil`. Strip CR/LF before quoting — github PATs never
+   contain newlines so this drops only malicious-or-corrupted input. #}
+{%- macro systemd_quote(value) -%}
+"{{ value | string
+   | replace('\r', '')
+   | replace('\n', '')
+   | replace('\\', '\\\\')
+   | replace('"', '\\"') }}"
+{%- endmacro -%}
+[Service]
+{# `default({}, true)` (boolean=true) coerces both undefined AND falsy values
+   (None, []) to the empty dict — plain `default({})` would let None through
+   and crash on the length call. Mirrors hermes .env.j2:111-114. #}
+{% set _integrations = integrations | default({}, true) %}
+{% if _integrations | length > 0 %}
+{% for _name, _integration in _integrations | dictsort %}
+{% if _integration.type == 'github' and _integration.GITHUB_TOKEN is defined %}
+Environment=GITHUB_TOKEN_{{ _name | upper | replace('-', '_') | regex_replace('[^A-Z0-9_]', '') }}={{ systemd_quote(_integration.GITHUB_TOKEN) }}
+Environment=GITHUB_TOKEN={{ systemd_quote(_integration.GITHUB_TOKEN) }}
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
+++ b/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
@@ -127,11 +127,16 @@ allowed_users = []
 {% endif %}
 {# require_mention is the hermes-side knob; upstream calls it
    reply_to_mentions_only. Same semantics — translate verbatim.
-   ATX Round 3 W3: default `true` to match the CLI prompt's default. The
-   prior `false` default silently turned mention-gated bots into ambient
-   responders on any reconfigure of a hosts.json record predating the
-   field's introduction. #}
-reply_to_mentions_only = {{ (_discord.get('require_mention') | default(true)) | bool | lower }}
+   ATX Round 3 W3 + Round 4 B1-R4: default `true` to match the CLI
+   prompt's default, applied via dict.get(key, default) at the Python
+   level rather than `| default(true)` — Jinja2's default() filter only
+   fires on Undefined, NOT on None, and dict.get() returns None for
+   missing keys. A `_discord.get('require_mention') | default(true)`
+   form silently rendered `false` for any legacy hosts.json record
+   predating the field, turning mention-gated bots into ambient
+   responders — exactly the safety regression Round 3 W3 was meant to
+   prevent. #}
+reply_to_mentions_only = {{ _discord.get('require_mention', true) | bool | lower }}
 {% if _discord.get('draft_update_interval_ms') %}
 draft_update_interval_ms = {{ _discord.get('draft_update_interval_ms') | int }}
 {% endif %}

--- a/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
+++ b/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
@@ -91,3 +91,86 @@ api_key = "{{ toml_escape(provider_api_key) }}"
 name = "{{ toml_escape(personality_name) }}"
 timezone = "{{ toml_escape(personality_timezone) }}"
 communication_style = "{{ toml_escape(personality_style) }}"
+
+{# --- Discord channel (#422) -----------------------------------------------
+   ZeroClaw v0.7.5 schema per docs/book/src/channels/chat-others.md:
+     [channels.discord]
+     enabled, bot_token, allowed_guilds, allowed_users,
+     reply_to_mentions_only, draft_update_interval_ms
+   bot_token is inline TOML (NOT an env var) — distinct from hermes which
+   reads DISCORD_BOT_TOKEN from .env. The token is hydrated into
+   config.channels.discord.bot_token by lifecycle.configure_agent before this
+   template runs (mirrors the hermes hydration path; same secrets.json key
+   DISCORD_BOT_TOKEN).
+
+   Hermes-wizard fields with no upstream zeroclaw equivalent are dropped
+   silently here: home_channel, home_channel_name, home_channel_thread_id,
+   allow_all_users, allowed_channels. They land in hosts.json under
+   channels.discord.* but never reach config.toml.
+#}
+{% set _channels = config.channels | default({}) %}
+{% set _discord = _channels.get('discord', {}) if _channels else {} %}
+{% if _discord.get('enabled') and _discord.get('bot_token') %}
+
+[channels.discord]
+enabled = true
+bot_token = "{{ toml_escape(_discord.get('bot_token')) }}"
+{% if _discord.get('allowed_guilds') %}
+allowed_guilds = [{% for guild in _discord.get('allowed_guilds') %}"{{ toml_escape(guild) }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+{% else %}
+allowed_guilds = []
+{% endif %}
+{% if _discord.get('allowed_users') %}
+allowed_users = [{% for user in _discord.get('allowed_users') %}"{{ toml_escape(user) }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+{% else %}
+allowed_users = []
+{% endif %}
+{# require_mention is the hermes-side knob; upstream calls it
+   reply_to_mentions_only. Same semantics — translate verbatim.
+   ATX Round 3 W3: default `true` to match the CLI prompt's default. The
+   prior `false` default silently turned mention-gated bots into ambient
+   responders on any reconfigure of a hosts.json record predating the
+   field's introduction. #}
+reply_to_mentions_only = {{ (_discord.get('require_mention') | default(true)) | bool | lower }}
+{% if _discord.get('draft_update_interval_ms') %}
+draft_update_interval_ms = {{ _discord.get('draft_update_interval_ms') | int }}
+{% endif %}
+{% endif %}
+
+{# --- Autonomy block (#422) ------------------------------------------------
+   Rendered every configure so the daemon's autonomy posture is a known
+   quantity rather than relying on whatever defaults the binary picked up.
+   Values mirror docs/book/src/security/autonomy.md verbatim for v0.7.5.
+
+   shell_env_passthrough is the ONLY documented mechanism for exposing env
+   vars to the shell tool (security/sandboxing.md). The defaults below
+   replicate the upstream-doc example exactly; per-integration token names
+   are appended so credentials wired via the systemd Environment= drop-in
+   (configure.yaml) actually reach the agent's shell tool.
+
+   Without this block, secret-pattern env vars (matching _TOKEN, _SECRET,
+   _PASSWORD, API_KEY) are auto-stripped by the sandbox even if the daemon
+   has them in its environment. Explicit allowlisting is mandatory — globs
+   are NOT supported, so every GITHUB_TOKEN_<NAME> needs its own entry. #}
+{% set _integrations = integrations | default({}, true) %}
+{% set _passthrough = ['PATH', 'HOME', 'USER', 'LANG'] %}
+{% set _github_seen = namespace(any=false) %}
+{% for _name, _integration in _integrations | dictsort %}
+{% if _integration.type == 'github' and _integration.GITHUB_TOKEN is defined %}
+{% set _slug = _name | upper | replace('-', '_') | regex_replace('[^A-Z0-9_]', '') %}
+{% set _ = _passthrough.append('GITHUB_TOKEN_' ~ _slug) %}
+{% set _github_seen.any = true %}
+{% endif %}
+{% endfor %}
+{% if _github_seen.any %}
+{% set _ = _passthrough.append('GITHUB_TOKEN') %}
+{% endif %}
+
+[autonomy]
+level = "supervised"
+approval_timeout_secs = 300
+workspace_only = true
+allowed_commands = ["git", "cargo", "grep", "find", "ls", "cat"]
+forbidden_commands = ["shutdown", "reboot", "mkfs"]
+forbidden_paths = ["/etc", "/sys", "/boot", "~/.ssh", "~/.aws"]
+shell_env_passthrough = [{% for _entry in _passthrough %}"{{ _entry }}"{% if not loop.last %}, {% endif %}{% endfor %}]

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -3258,3 +3258,394 @@ class TestRunChannelsStageHermesSlack:
         # And the hermes-only flat fields are NOT injected.
         assert "allowed_users" not in s
         assert "home_channel" not in s
+
+class TestRunChannelsStageZeroclaw:
+    """#422 — zeroclaw-specific channel-stage behavior.
+
+    Two ATX Round 2 blockers covered:
+      - B_new1: Slack is filtered from the channel menu (zeroclaw has no
+        native Slack support; offering it contradicts docs).
+      - B_new2: Discord selection produces the FLAT shape expected by
+        config.toml.j2's [channels.discord] block, NOT the OpenClaw nested
+        (guilds/allowFrom/groupPolicy) shape.
+    """
+
+    _VALID_TOKEN = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMw"
+
+    def test_zeroclaw_channel_menu_excludes_slack(self, isolated_config: Path):
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        result = runner.invoke(
+            app,
+            ["agent", "configure", "assistant", "--stage", "channels"],
+            input="1\n",
+            env=os.environ,
+        )
+
+        # ATX Round 3 W8: assert exit code so the test doesn't pass on a
+        # crash that prints the menu and then dies after.
+        assert result.exit_code == 0, (
+            f"configure exited non-zero ({result.exit_code}); output:\n"
+            f"{result.output}"
+        )
+
+        out = result.output.lower()
+        assert "cli" in out
+        assert "discord" in out
+        # B_new1: slack must NOT appear in the zeroclaw menu.
+        assert "slack" not in out, (
+            "Slack offered to zeroclaw user but zeroclaw v0.7.5 has no "
+            "native Slack channel. See docs/agent-support/zeroclaw.md."
+        )
+
+    def test_zeroclaw_discord_produces_flat_config_shape(
+        self, isolated_config: Path
+    ):
+        """B_new2: the Discord branch for zeroclaw must produce the flat
+        config shape (allowed_users, allowed_guilds, require_mention)
+        consumed by config.toml.j2 — NOT the OpenClaw nested shape (guilds,
+        allowFrom, groupPolicy)."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        synced: list[dict] = []
+
+        def capture_sync(_host, _claw, channels_config, _name):
+            synced.append(channels_config)
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.cli.agent._sync_channel_config", side_effect=capture_sync),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,                             # Pick discord (option 2 in cli/discord menu)
+                self._VALID_TOKEN,             # Bot token
+                "740723459344302120",          # Allowed user IDs
+                "987654321098765432",          # Allowed guild IDs
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "zeroclaw", False, "assistant"
+            )
+
+        assert result is True, "zeroclaw discord configure must succeed"
+        assert len(synced) == 1, "channel config must be synced once"
+
+        cfg = synced[0]["discord"]
+        # Flat shape — config.toml.j2 reads these exact keys.
+        assert cfg["enabled"] is True
+        assert cfg["allowed_users"] == ["740723459344302120"]
+        assert cfg["allowed_guilds"] == ["987654321098765432"]
+        assert cfg["require_mention"] is True
+
+        # OpenClaw nested keys MUST NOT appear (would silently disable the
+        # template's [channels.discord] block because bot_token gate fails
+        # when the shape is wrong).
+        assert "guilds" not in cfg
+        assert "allowFrom" not in cfg
+        assert "groupPolicy" not in cfg
+        assert "token" not in cfg
+
+        # Hermes-only fields with no zeroclaw equivalent — must NOT leak.
+        assert "home_channel" not in cfg
+        assert "home_channel_name" not in cfg
+        assert "allow_all_users" not in cfg
+        assert "allowed_channels" not in cfg
+
+    def test_zeroclaw_discord_empty_allowed_users_renders_open_bot(
+        self, isolated_config: Path
+    ):
+        """ZeroClaw's upstream convention: empty allowed_users = allow all.
+        The CLI must accept an empty allowlist for zeroclaw (no required-
+        field error — that's the hermes convention) and emit a warning so
+        the operator knows."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        synced: list[dict] = []
+
+        def capture_sync(_host, _claw, channels_config, _name):
+            synced.append(channels_config)
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=False),
+            patch("clawrium.cli.agent._sync_channel_config", side_effect=capture_sync),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,                             # discord
+                self._VALID_TOKEN,             # bot token
+                "",                            # empty allowed users
+                "",                            # empty allowed guilds
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "zeroclaw", False, "assistant"
+            )
+
+        assert result is True
+        assert synced[0]["discord"]["allowed_users"] == []
+        assert "allowed_guilds" not in synced[0]["discord"]
+        # ATX Round 3 W6: assert require_mention propagates the
+        # typer.confirm return value. Without this, a silent regression
+        # could flip the mention-gating behavior without test failure.
+        assert synced[0]["discord"]["require_mention"] is False
+
+    def test_zeroclaw_discord_rejects_malformed_user_id(
+        self, isolated_config: Path
+    ):
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.cli.agent._sync_channel_config"),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,                             # discord
+                self._VALID_TOKEN,             # bot token
+                "not-a-valid-id",              # malformed
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "zeroclaw", False, "assistant"
+            )
+
+        assert result is False
+
+    def test_zeroclaw_discord_rejects_mid_list_invalid_user_id(
+        self, isolated_config: Path
+    ):
+        """ATX Round 3 W5: validation must walk the entire list and fail on
+        any malformed ID, not just the first one. Catches a regression where
+        only `ids[0]` is validated."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.cli.agent._sync_channel_config"),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,                                            # discord
+                self._VALID_TOKEN,                            # bot token
+                "740723459344302120,not-a-valid-id",          # valid + invalid
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "zeroclaw", False, "assistant"
+            )
+
+        assert result is False
+
+    def test_zeroclaw_discord_rejects_comma_only_user_input(
+        self, isolated_config: Path
+    ):
+        """ATX Round 3 B1: comma-only input (`,` or `, ,`) is truthy after
+        strip but parses to an empty ID list. Without the explicit guard
+        this collapses silently into open-bot mode with no operator
+        feedback."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.cli.agent._sync_channel_config"),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,                                            # discord
+                self._VALID_TOKEN,                            # bot token
+                ", , ,",                                      # comma-only
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "zeroclaw", False, "assistant"
+            )
+
+        assert result is False, (
+            "Comma-only allowed_users input silently passed — would have "
+            "produced an open bot with no operator feedback."
+        )
+
+    def test_zeroclaw_discord_rejects_comma_only_guild_input(
+        self, isolated_config: Path
+    ):
+        """ATX Round 4 B4: symmetric to the user-side comma-only guard.
+        Without the explicit ids-empty check on the guild list, `, , ,`
+        would silently emit `allowed_guilds = []` (any-guild) with no
+        operator feedback — a security-relevant regression."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.cli.agent._sync_channel_config"),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,                                            # discord
+                self._VALID_TOKEN,                            # bot token
+                "740723459344302120",                         # valid user
+                ", , ,",                                      # comma-only guild
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "zeroclaw", False, "assistant"
+            )
+
+        assert result is False, (
+            "Comma-only allowed_guilds input silently passed — would have "
+            "produced an any-guild bot with no operator feedback."
+        )
+
+    def test_zeroclaw_discord_rejects_malformed_guild_id(
+        self, isolated_config: Path
+    ):
+        """ATX Round 3 W7: guild-ID validation has its own loop — needs its
+        own negative-path coverage."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.cli.agent._sync_channel_config"),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,                                            # discord
+                self._VALID_TOKEN,                            # bot token
+                "740723459344302120",                         # valid user
+                "abc-not-numeric",                            # malformed guild
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "zeroclaw", False, "assistant"
+            )
+
+        assert result is False
+
+    def test_zeroclaw_discord_pre_sync_token_storage_avoids_deadlock(
+        self, isolated_config: Path
+    ):
+        """ATX Round 3 B2: DISCORD_BOT_TOKEN must be stored BEFORE
+        `_sync_channel_config` is called for zeroclaw — `lifecycle.
+        configure_agent` reads the secret from secrets.json before the
+        playbook runs and returns False if missing. Without pre-sync
+        storage, every first configure deadlocks.
+
+        Spy on the call ordering: `set_instance_secret` must fire before
+        `_sync_channel_config` for claw_type='zeroclaw'."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        call_order: list[str] = []
+
+        def capture_secret(_ik, _k, _v, _d):
+            call_order.append("set_instance_secret")
+
+        def capture_sync(*_args, **_kwargs):
+            call_order.append("sync_channel_config")
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch(
+                "clawrium.cli.agent._sync_channel_config", side_effect=capture_sync
+            ),
+            patch(
+                "clawrium.core.secrets.set_instance_secret",
+                side_effect=capture_secret,
+            ),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,
+                self._VALID_TOKEN,
+                "740723459344302120",
+                "",
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "zeroclaw", False, "assistant"
+            )
+
+        assert result is True
+        # Token store MUST come first for zeroclaw.
+        assert call_order == ["set_instance_secret", "sync_channel_config"], (
+            f"Wrong call order for zeroclaw — got {call_order}. "
+            "Token must be stored BEFORE sync so lifecycle.configure_agent's "
+            "hydration block can find it (ATX Round 3 B2 deadlock)."
+        )
+

--- a/tests/test_configure_claw.py
+++ b/tests/test_configure_claw.py
@@ -2847,3 +2847,275 @@ class TestConfigureTimeoutBudget:
         assert timeout == 60, (
             f"Openclaw must keep the legacy 60s configure budget, got {timeout}"
         )
+
+
+# ---------------------------------------------------------------------------
+# #422 — zeroclaw Discord hydration via lifecycle.configure_agent
+# ---------------------------------------------------------------------------
+
+
+class TestZeroclawDiscordHydration:
+    """`configure_agent` must hydrate `DISCORD_BOT_TOKEN` from secrets.json
+    onto `config_data['channels']['discord']['bot_token']` for zeroclaw
+    just like it does for hermes (#422). The hydration block lives outside
+    the hermes-only api_server branch so both agent types share it.
+    """
+
+    def _make_host(self, discord_persisted: dict | None) -> dict:
+        agent_config: dict = {
+            "provider": {
+                "name": "p",
+                "type": "anthropic",
+                "default_model": "claude-sonnet-4-5",
+            },
+            "gateway": {"host": "0.0.0.0", "port": 40000},
+        }
+        if discord_persisted is not None:
+            agent_config["channels"] = {"discord": discord_persisted}
+        return {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "zc-test": {
+                    "type": "zeroclaw",
+                    "agent_name": "zc-test",
+                    "config": agent_config,
+                }
+            },
+        }
+
+    def _setup_fact_cache(self, tmp_path: Path) -> Path:
+        """ZeroClaw configure reads pairing facts after Ansible runs. Provide
+        a token so the playbook's fact-extraction path succeeds and we can
+        focus on the hydration block under test."""
+        artifacts_dir = tmp_path / "artifacts"
+        fact_cache_dir = artifacts_dir / "fact_cache"
+        fact_cache_dir.mkdir(parents=True)
+        (fact_cache_dir / "test-host").write_text(json.dumps({
+            "__payload__": json.dumps({
+                "zeroclaw_gateway_token": "paired-bearer-token",
+                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+            }),
+        }))
+        return artifacts_dir
+
+    def _run_zeroclaw_configure(
+        self,
+        host: dict,
+        tmp_path: Path,
+        secrets: dict,
+    ) -> tuple[bool, str | None, dict]:
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+        artifacts_dir = self._setup_fact_cache(tmp_path)
+
+        captured: dict = {}
+
+        def fake_run(**kwargs):
+            captured["inventory"] = kwargs["inventory"]
+            m = MagicMock()
+            m.status = "successful"
+            m.events = []
+            m.config.artifact_dir = str(artifacts_dir)
+            return m
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ),
+            patch(
+                "clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run
+            ),
+            patch("clawrium.core.lifecycle.update_host", return_value=True),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets", return_value=secrets
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host",
+                "zeroclaw",
+                {
+                    "provider": {
+                        "name": "p",
+                        "type": "anthropic",
+                        "default_model": "claude-sonnet-4-5",
+                    },
+                    "gateway": {"host": "0.0.0.0", "port": 40000},
+                },
+                agent_name="zc-test",
+            )
+
+        return success, error, captured
+
+    def _discord_secrets_entry(self, token: str) -> dict:
+        return {
+            "DISCORD_BOT_TOKEN": {
+                "key": "DISCORD_BOT_TOKEN",
+                "value": token,
+                "created_at": "2026-05-18T00:00:00+00:00",
+                "updated_at": "2026-05-18T00:00:00+00:00",
+                "description": "Discord bot token",
+            }
+        }
+
+    def test_discord_token_hydrated_for_zeroclaw(self, tmp_path: Path):
+        """The bot_token from secrets.json lands on
+        config_data['channels']['discord']['bot_token'] before the playbook
+        runs — same path as hermes, just a different downstream consumer
+        (config.toml.j2 instead of .env.j2)."""
+        token = "B" * 64
+        host = self._make_host(
+            discord_persisted={
+                "enabled": True,
+                "allowed_users": ["740723459344302120"],
+                "allowed_guilds": ["123"],
+                "require_mention": True,
+            }
+        )
+        secrets = self._discord_secrets_entry(token)
+
+        success, error, captured = self._run_zeroclaw_configure(
+            host, tmp_path, secrets
+        )
+        assert success is True, error
+        sent = captured["inventory"]["all"]["vars"]["config"]
+        assert sent["channels"]["discord"]["bot_token"] == token
+        # Persisted shape merged onto config_data even though the caller
+        # only passed provider/gateway.
+        assert sent["channels"]["discord"]["allowed_users"] == [
+            "740723459344302120"
+        ]
+        assert sent["channels"]["discord"]["allowed_guilds"] == ["123"]
+
+    def test_discord_disabled_does_not_hydrate_zeroclaw(self, tmp_path: Path):
+        """No channels.discord block in hosts.json → no hydration, no error
+        even if DISCORD_BOT_TOKEN happens to exist in secrets.json."""
+        host = self._make_host(discord_persisted=None)
+        secrets = self._discord_secrets_entry("B" * 64)
+
+        success, error, captured = self._run_zeroclaw_configure(
+            host, tmp_path, secrets
+        )
+        assert success is True, error
+        sent = captured["inventory"]["all"]["vars"]["config"]
+        assert "channels" not in sent or "discord" not in sent.get(
+            "channels", {}
+        ) or "bot_token" not in sent["channels"].get("discord", {})
+
+    def test_discord_enabled_without_token_rejected_zeroclaw(self, tmp_path: Path):
+        """`enabled = true` with no DISCORD_BOT_TOKEN in secrets.json must
+        return (False, error) — same failure mode as hermes."""
+        host = self._make_host(discord_persisted={"enabled": True})
+        secrets = {}  # No DISCORD_BOT_TOKEN at all.
+
+        success, error, _ = self._run_zeroclaw_configure(host, tmp_path, secrets)
+        assert success is False
+        assert "DISCORD_BOT_TOKEN" in (error or "")
+
+    def test_discord_short_token_rejected_zeroclaw(self, tmp_path: Path):
+        """Bot tokens shorter than 50 chars are rejected; mirrors hermes
+        validation."""
+        host = self._make_host(discord_persisted={"enabled": True})
+        secrets = self._discord_secrets_entry("short-token")
+
+        success, error, _ = self._run_zeroclaw_configure(host, tmp_path, secrets)
+        assert success is False
+        assert "DISCORD_BOT_TOKEN" in (error or "")
+
+    def test_discord_bot_token_stripped_from_hosts_json_zeroclaw(
+        self, tmp_path: Path
+    ):
+        """ATX Round 1 B1: zeroclaw must mirror hermes's strip-before-persist
+        behavior so bot_token never lands in hosts.json. Without this, the
+        token roundtrips: hydrated → persisted → read into existing_config →
+        re-hydrated, defeating the B3 invariant that bot_token lives in
+        secrets.json only."""
+        token = "B" * 64
+        host = self._make_host(
+            discord_persisted={
+                "enabled": True,
+                "allowed_users": ["740723459344302120"],
+                "require_mention": True,
+            }
+        )
+        secrets = self._discord_secrets_entry(token)
+
+        captured_update: dict = {}
+
+        def fake_update_host(_hostname, updater_fn):
+            # Run the updater on a deepcopy of the host so the captured
+            # post-strip shape reflects what would be written to disk.
+            from copy import deepcopy
+
+            mutated = updater_fn(deepcopy(host))
+            captured_update["host"] = mutated
+            return True
+
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+        artifacts_dir = self._setup_fact_cache(tmp_path)
+
+        def fake_run(**_kwargs):
+            m = MagicMock()
+            m.status = "successful"
+            m.events = []
+            m.config.artifact_dir = str(artifacts_dir)
+            return m
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ),
+            patch(
+                "clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run
+            ),
+            patch(
+                "clawrium.core.lifecycle.update_host", side_effect=fake_update_host
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets", return_value=secrets
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host",
+                "zeroclaw",
+                {
+                    "provider": {
+                        "name": "p",
+                        "type": "anthropic",
+                        "default_model": "claude-sonnet-4-5",
+                    },
+                    "gateway": {"host": "0.0.0.0", "port": 40000},
+                },
+                agent_name="zc-test",
+            )
+
+        assert success is True, error
+        persisted = captured_update["host"]["agents"]["zc-test"]["config"]
+        # The Discord block must be persisted (so re-configure can find it)
+        # but bot_token MUST be stripped — only secrets.json holds it.
+        assert "channels" in persisted
+        assert "discord" in persisted["channels"]
+        assert persisted["channels"]["discord"]["enabled"] is True
+        assert "bot_token" not in persisted["channels"]["discord"], (
+            f"bot_token leaked into hosts.json for zeroclaw — "
+            f"persisted shape: {persisted['channels']['discord']}"
+        )
+        # Other persisted fields survive the strip (idempotency check).
+        assert persisted["channels"]["discord"]["allowed_users"] == [
+            "740723459344302120"
+        ]

--- a/tests/test_configure_zeroclaw.py
+++ b/tests/test_configure_zeroclaw.py
@@ -357,3 +357,318 @@ class TestPersonalityBlock:
                 f"TOML injection succeeded via personality.{field} — "
                 f"payload broke out of basic string: {line!r}"
             )
+
+
+# ---------------------------------------------------------------------------
+# #422 — [channels.discord], [autonomy], and clm-env.conf.j2 rendering
+# ---------------------------------------------------------------------------
+
+
+import re as _re422  # noqa: E402  (test-section import, kept local)
+
+
+def _ansible_regex_replace(value, pattern, replacement=""):
+    """Ansible's `regex_replace` filter, reimplemented for the bare-Jinja
+    test renderer (same pattern as tests/test_hermes_configure.py:23-29)."""
+    return _re422.sub(pattern, replacement, str(value))
+
+
+def _render_with_channels_and_integrations(
+    *,
+    channels: dict | None = None,
+    integrations: dict | None = None,
+    provider: dict | None = None,
+    provider_api_key: str = "sk-test",
+) -> str:
+    """Render config.toml.j2 with the #422 extensions wired in.
+
+    Mirrors the production Ansible env: registers `bool` + `regex_replace`
+    filters so the [autonomy] block's per-integration env-var name
+    construction matches what the configure playbook actually produces.
+    """
+    env = Environment(loader=FileSystemLoader(str(ZEROCLAW_TEMPLATES)))
+    env.filters["bool"] = _ansible_bool
+    env.filters["regex_replace"] = _ansible_regex_replace
+    template = env.get_template("config.toml.j2")
+    config = {"gateway": dict(_GATEWAY_DEFAULTS)}
+    if provider is not None:
+        config["provider"] = provider
+    if channels is not None:
+        config["channels"] = channels
+    return template.render(
+        config=config,
+        provider_api_key=provider_api_key,
+        integrations=integrations or {},
+    )
+
+
+def _render_systemd_dropin(integrations: dict | None) -> str:
+    """Render the clm-env.conf.j2 drop-in with the supplied integrations dict."""
+    env = Environment(
+        loader=FileSystemLoader(str(ZEROCLAW_TEMPLATES)),
+        keep_trailing_newline=True,
+    )
+    env.filters["regex_replace"] = _ansible_regex_replace
+    template = env.get_template("clm-env.conf.j2")
+    return template.render(integrations=integrations or {}, agent_name="zc1")
+
+
+class TestChannelsDiscordBlock:
+    """[channels.discord] is the upstream-documented v0.7.5 schema —
+    docs/book/src/channels/chat-others.md. Only keys listed in that doc
+    may appear in the rendered TOML.
+    """
+
+    def test_no_discord_block_when_disabled(self):
+        rendered = _render_with_channels_and_integrations(
+            channels={"discord": {"enabled": False}},
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert "[channels.discord]" not in rendered
+
+    def test_no_discord_block_when_token_missing(self):
+        """`enabled = true` without a hydrated bot_token must not render —
+        the playbook's verify_bot_token grep would fail, but the template
+        is the first defense."""
+        rendered = _render_with_channels_and_integrations(
+            channels={"discord": {"enabled": True}},
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert "[channels.discord]" not in rendered
+
+    def test_discord_block_emits_upstream_fields(self):
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": "DUMMY_BOT_TOKEN_VALUE",
+                    "allowed_users": ["123456789012345678"],
+                    "allowed_guilds": ["987654321098765432"],
+                    "require_mention": True,
+                    "draft_update_interval_ms": 750,
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert "[channels.discord]" in rendered
+        assert "enabled = true" in rendered
+        assert 'bot_token = "DUMMY_BOT_TOKEN_VALUE"' in rendered
+        assert 'allowed_users = ["123456789012345678"]' in rendered
+        assert 'allowed_guilds = ["987654321098765432"]' in rendered
+        # require_mention (hermes naming) → reply_to_mentions_only (upstream).
+        assert "reply_to_mentions_only = true" in rendered
+        assert "draft_update_interval_ms = 750" in rendered
+
+    def test_discord_block_drops_hermes_only_fields(self):
+        """home_channel, home_channel_name, allow_all_users, allowed_channels
+        have no zeroclaw upstream equivalent and must NOT leak into the
+        rendered TOML — the daemon would reject the file or silently ignore."""
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": "DUMMY",
+                    "home_channel": "111",
+                    "home_channel_name": "general",
+                    "home_channel_thread_id": "222",
+                    "allow_all_users": True,
+                    "allowed_channels": ["333"],
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert "home_channel" not in rendered
+        assert "allow_all_users" not in rendered
+        assert "allowed_channels" not in rendered
+
+    def test_discord_bot_token_toml_escaped(self):
+        """Tokens with embedded quotes/backslashes must be escaped so they
+        cannot break out of the TOML basic string and inject `[autonomy]`
+        overrides below."""
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": 'tok"with"quote\\and\\bs',
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert 'bot_token = "tok\\"with\\"quote\\\\and\\\\bs"' in rendered
+
+
+class TestAutonomyBlock:
+    """[autonomy] is always rendered (no gate). The default block mirrors
+    docs/book/src/security/autonomy.md verbatim. shell_env_passthrough is
+    extended when github integrations are assigned."""
+
+    def test_autonomy_block_always_renders(self):
+        rendered = _render_with_channels_and_integrations(
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert "[autonomy]" in rendered
+        assert 'level = "supervised"' in rendered
+        assert "approval_timeout_secs = 300" in rendered
+        assert "workspace_only = true" in rendered
+        assert (
+            'allowed_commands = ["git", "cargo", "grep", "find", "ls", "cat"]'
+            in rendered
+        )
+        assert 'forbidden_commands = ["shutdown", "reboot", "mkfs"]' in rendered
+        assert (
+            'forbidden_paths = ["/etc", "/sys", "/boot", "~/.ssh", "~/.aws"]'
+            in rendered
+        )
+
+    def test_shell_env_passthrough_defaults_to_upstream_four(self):
+        rendered = _render_with_channels_and_integrations(
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        # Without github integrations, only the 4 upstream-default vars.
+        assert (
+            'shell_env_passthrough = ["PATH", "HOME", "USER", "LANG"]' in rendered
+        )
+
+    def test_shell_env_passthrough_appends_github_token_names(self):
+        rendered = _render_with_channels_and_integrations(
+            provider={"type": "anthropic", "default_model": "m"},
+            integrations={
+                "work-gh": {"type": "github", "GITHUB_TOKEN": "ghp_DUMMY1"},
+                "personal-gh": {"type": "github", "GITHUB_TOKEN": "ghp_DUMMY2"},
+            },
+        )
+        # Defaults still present + per-name + canonical at the end (so the
+        # bare GITHUB_TOKEN tracks the last integration alphabetically:
+        # `work-gh` > `personal-gh` → bare entry follows GITHUB_TOKEN_WORK_GH).
+        assert "PATH" in rendered
+        assert "GITHUB_TOKEN_PERSONAL_GH" in rendered
+        assert "GITHUB_TOKEN_WORK_GH" in rendered
+        # The canonical GITHUB_TOKEN entry must be present (after the per-name
+        # entries per template construction).
+        assert _re422.search(
+            r'shell_env_passthrough\s*=\s*\[[^\]]*"GITHUB_TOKEN"', rendered
+        ), f"GITHUB_TOKEN missing from shell_env_passthrough: {rendered}"
+
+    def test_shell_env_passthrough_excludes_non_github_integrations(self):
+        """An assigned atlassian integration must NOT add its credential
+        names to the autonomy allowlist — that table is GitHub-specific."""
+        rendered = _render_with_channels_and_integrations(
+            provider={"type": "anthropic", "default_model": "m"},
+            integrations={
+                "atl": {
+                    "type": "atlassian",
+                    "ATLASSIAN_API_TOKEN": "atl_DUMMY",
+                    "ATLASSIAN_EMAIL": "a@b.c",
+                    "ATLASSIAN_URL": "https://x.atlassian.net",
+                },
+            },
+        )
+        assert "ATLASSIAN_API_TOKEN" not in rendered
+        assert "GITHUB_TOKEN" not in rendered
+
+    def test_github_integration_name_sanitized_for_env_var(self):
+        """Names with hyphens/uppercase must end up uppercase + underscored.
+        Defense-in-depth: any char outside [A-Z0-9_] is stripped, mirroring
+        hermes .env.j2:118."""
+        rendered = _render_with_channels_and_integrations(
+            provider={"type": "anthropic", "default_model": "m"},
+            integrations={
+                "team-a-gh": {"type": "github", "GITHUB_TOKEN": "ghp_X"},
+            },
+        )
+        assert "GITHUB_TOKEN_TEAM_A_GH" in rendered
+
+
+class TestSystemdDropIn:
+    """clm-env.conf.j2 lands at /etc/systemd/system/zeroclaw-<n>.service.d/
+    and must emit one canonical `Environment=GITHUB_TOKEN=` line plus a
+    per-name line per github integration. Shell-quote semantics differ
+    from hermes (.env files use single-quotes; systemd Environment= uses
+    double-quotes)."""
+
+    def test_dropin_is_empty_service_block_without_integrations(self):
+        rendered = _render_systemd_dropin(integrations={})
+        # systemd accepts a `[Service]` header with no directives as a no-op
+        # overlay. Confirm we never emit Environment= when no github integrations.
+        assert "[Service]" in rendered
+        assert "Environment=" not in rendered
+
+    def test_dropin_emits_per_name_and_canonical_lines(self):
+        rendered = _render_systemd_dropin(
+            integrations={
+                "work-gh": {"type": "github", "GITHUB_TOKEN": "ghp_WORK"},
+                "personal-gh": {"type": "github", "GITHUB_TOKEN": "ghp_PERSONAL"},
+            },
+        )
+        # Both per-name entries.
+        assert 'Environment=GITHUB_TOKEN_WORK_GH="ghp_WORK"' in rendered
+        assert 'Environment=GITHUB_TOKEN_PERSONAL_GH="ghp_PERSONAL"' in rendered
+        # Canonical GITHUB_TOKEN tracks the dictsort-last integration
+        # (work-gh > personal-gh alphabetically).
+        canonical_lines = [
+            line
+            for line in rendered.splitlines()
+            if line.startswith('Environment=GITHUB_TOKEN="')
+        ]
+        # Two integrations → two canonical lines (one per loop iteration);
+        # the last one wins at systemd's level. Mirrors hermes .env.j2.
+        assert len(canonical_lines) == 2
+        # Final canonical entry must be from the alphabetically-last name.
+        assert canonical_lines[-1] == 'Environment=GITHUB_TOKEN="ghp_WORK"'
+
+    def test_dropin_quote_escaping_systemd_style(self):
+        """Tokens with embedded double-quotes or backslashes must be escaped
+        with backslash-double-quote / double-backslash so systemd's
+        Environment= parser doesn't terminate the value early."""
+        rendered = _render_systemd_dropin(
+            integrations={
+                "gh": {
+                    "type": "github",
+                    "GITHUB_TOKEN": 'tok"with"quote\\and\\bs',
+                },
+            },
+        )
+        assert (
+            'Environment=GITHUB_TOKEN="tok\\"with\\"quote\\\\and\\\\bs"'
+            in rendered
+        )
+
+    def test_dropin_skips_non_github_integrations(self):
+        rendered = _render_systemd_dropin(
+            integrations={
+                "atl": {
+                    "type": "atlassian",
+                    "ATLASSIAN_API_TOKEN": "atl_DUMMY",
+                },
+            },
+        )
+        assert "Environment=" not in rendered
+
+    def test_dropin_strips_newline_injection_attempts(self):
+        """ATX Round 1 W3: per systemd.exec(5), an embedded `\\n` inside a
+        quoted Environment= value terminates the directive and the rest is
+        parsed as a new systemd statement — a vector to inject e.g.
+        `Environment=PATH=/evil`. The systemd_quote macro must strip CR/LF
+        before quoting so a malformed token cannot smuggle in extra
+        directives. github PATs never contain newlines so this drops only
+        malicious-or-corrupted input."""
+        rendered = _render_systemd_dropin(
+            integrations={
+                "gh": {
+                    "type": "github",
+                    "GITHUB_TOKEN": "ghp_real\nEnvironment=PATH=/evil\nthe_rest",
+                },
+            },
+        )
+        # The injection attempt must NOT appear as a new directive.
+        for line in rendered.splitlines():
+            stripped = line.strip()
+            assert not stripped.startswith("Environment=PATH="), (
+                f"systemd-directive injection succeeded via newline in "
+                f"GITHUB_TOKEN: {line!r}"
+            )
+        # The token (stripped of its newlines) lands on a single line.
+        assert (
+            'Environment=GITHUB_TOKEN="ghp_realEnvironment=PATH=/evilthe_rest"'
+            in rendered
+        )

--- a/tests/test_configure_zeroclaw.py
+++ b/tests/test_configure_zeroclaw.py
@@ -44,6 +44,16 @@ def _ansible_bool(v):
     return bool(v)
 
 
+def _ansible_regex_replace_top(value, pattern, replacement=""):
+    """Module-level mirror of ansible.builtin.filter.regex_replace, used by
+    `_render()`. The #422 section below defines an identical helper for the
+    bigger renderers — both registered with the same filter name in their
+    respective env instances so the test renderer matches production."""
+    import re as _re_mod
+
+    return _re_mod.sub(pattern, replacement, str(value))
+
+
 def _render(
     provider: dict | None,
     provider_api_key: str = "",
@@ -53,6 +63,13 @@ def _render(
     """Render `config.toml.j2` with the given provider block."""
     env = Environment(loader=FileSystemLoader(str(ZEROCLAW_TEMPLATES)))
     env.filters["bool"] = _ansible_bool
+    # ATX Round 5 W2: register regex_replace here too. The template's
+    # [autonomy] block calls regex_replace inside the integrations loop.
+    # _render() never passes integrations today so it's not exercised, but
+    # keeping the test-renderer's filter set in sync with the production
+    # ansible env avoids a future opaque TemplateAssertionError. Mirrors
+    # _render_with_channels_and_integrations() at line ~376.
+    env.filters["regex_replace"] = _ansible_regex_replace_top
     template = env.get_template("config.toml.j2")
     config = {"gateway": dict(_GATEWAY_DEFAULTS)}
     if provider is not None:
@@ -507,6 +524,100 @@ class TestChannelsDiscordBlock:
             "Legacy hosts.json record rendered reply_to_mentions_only=false "
             "— this is the ATX Round 4 B1-R4 safety regression. The CLI "
             "default is True; the template must match."
+        )
+
+    def test_discord_bot_token_newline_toml_injection_blocked(self):
+        """ATX Round 5 W1: parallel to the api_key control-char test. A
+        bot_token containing `\\n` + a fake TOML statement must NOT break
+        out of the basic string into the next [section]. The toml_escape
+        macro encodes \\r/\\n/\\t today, but without an explicit test a
+        future macro refactor could drop a branch and leave bot_token
+        injectable while the api_key test still passes."""
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": 'tok\ninjected_key = "evil"\nok',
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        # The encoded payload must appear inside the bot_token line, not
+        # as a top-level injected TOML statement.
+        assert (
+            'bot_token = "tok\\ninjected_key = \\"evil\\"\\nok"' in rendered
+        )
+        # No injected top-level key.
+        for line in rendered.splitlines():
+            assert not line.strip().startswith("injected_key"), (
+                f"TOML injection succeeded via bot_token newline payload: "
+                f"{line!r}"
+            )
+
+    def test_discord_allowed_users_array_elements_toml_escaped(self):
+        """ATX Round 5 W6: array elements must also pass through
+        toml_escape. A regression dropping the macro on the loop body
+        would let a quote-bearing ID break out of the array."""
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": "DUMMY",
+                    "allowed_users": ['98765"evil', "740723459344302120"],
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        # Escaped quote inside the array element.
+        assert '"98765\\"evil"' in rendered
+        # No raw injection landing outside the string.
+        for line in rendered.splitlines():
+            assert not line.strip().startswith("evil"), (
+                f"allowed_users element broke out of TOML basic string: "
+                f"{line!r}"
+            )
+
+    def test_discord_allowed_guilds_array_elements_toml_escaped(self):
+        """ATX Round 5 W6 (symmetric to allowed_users)."""
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": "DUMMY",
+                    "allowed_guilds": ['11111"evil', "987654321098765432"],
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert '"11111\\"evil"' in rendered
+        for line in rendered.splitlines():
+            assert not line.strip().startswith("evil"), (
+                f"allowed_guilds element broke out of TOML basic string: "
+                f"{line!r}"
+            )
+
+    def test_discord_draft_update_interval_zero_omitted(self):
+        """ATX Round 5 W5: integer `0` is falsy in Jinja2/Python so the
+        current `{% if _discord.get('draft_update_interval_ms') %}` guard
+        silently drops a zero value. This test pins that behavior so any
+        future change to treat `0` as a real value (e.g., real-time
+        updates) is a conscious decision, not a silent semantic flip.
+        Operators relying on this should be aware: zeroclaw's daemon
+        applies its compiled-in default when the key is absent."""
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": "DUMMY",
+                    "draft_update_interval_ms": 0,
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert "draft_update_interval_ms" not in rendered, (
+            "Zero value for draft_update_interval_ms is currently dropped "
+            "by the falsy-check; if intentional, document. If not, treat "
+            "0 as a valid configured value."
         )
 
     def test_discord_explicit_false_require_mention_renders_false(self):

--- a/tests/test_configure_zeroclaw.py
+++ b/tests/test_configure_zeroclaw.py
@@ -481,6 +481,51 @@ class TestChannelsDiscordBlock:
         assert "allow_all_users" not in rendered
         assert "allowed_channels" not in rendered
 
+    def test_discord_legacy_record_defaults_reply_to_mentions_to_true(self):
+        """ATX Round 4 B1-R4: a hosts.json record predating the
+        require_mention field (the dict has `enabled` + `bot_token` but no
+        require_mention) MUST render `reply_to_mentions_only = true`.
+
+        The fragile form `_discord.get('require_mention') | default(true)`
+        silently rendered `false` because dict.get returns None for missing
+        keys and Jinja's default() only fires on Undefined. dict.get(key,
+        default) applies the default at the Python level, bypassing the
+        filter entirely."""
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": "DUMMY_LEGACY_TOKEN_VALUE",
+                    # NB: require_mention deliberately absent — simulating a
+                    # legacy hosts.json record written before the field was
+                    # added in #422.
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert "reply_to_mentions_only = true" in rendered, (
+            "Legacy hosts.json record rendered reply_to_mentions_only=false "
+            "— this is the ATX Round 4 B1-R4 safety regression. The CLI "
+            "default is True; the template must match."
+        )
+
+    def test_discord_explicit_false_require_mention_renders_false(self):
+        """Counterpart to the legacy-default test: an explicit `False` value
+        must NOT be overridden to `True`. This catches the alternative
+        `| default(true, boolean=True)` form, which would clobber explicit
+        opt-outs."""
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": "DUMMY",
+                    "require_mention": False,
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert "reply_to_mentions_only = false" in rendered
+
     def test_discord_bot_token_toml_escaped(self):
         """Tokens with embedded quotes/backslashes must be escaped so they
         cannot break out of the TOML basic string and inject `[autonomy]`

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -944,13 +944,20 @@ def test_load_manifest_zeroclaw_with_onboarding():
     # Should not have tasks when auto_skip is true
     assert "tasks" not in identity or len(identity.get("tasks", [])) == 0
 
-    # Validate channels stage uses confirm type
+    # Validate channels stage: cli always-on (default true) + discord optional
+    # (default false). Discord was added in #422 so zeroclaw could mirror the
+    # hermes wizard's Discord opt-in step.
     channels = stages["channels"]
     assert channels["required"] is True
     assert "tasks" in channels
-    assert len(channels["tasks"]) == 1
-    assert channels["tasks"][0]["type"] == "confirm"
-    assert channels["tasks"][0]["default"] is True
+    assert len(channels["tasks"]) == 2
+    task_by_id = {t["id"]: t for t in channels["tasks"]}
+    assert "confirm_cli" in task_by_id
+    assert task_by_id["confirm_cli"]["type"] == "confirm"
+    assert task_by_id["confirm_cli"]["default"] is True
+    assert "select_discord" in task_by_id
+    assert task_by_id["select_discord"]["type"] == "confirm"
+    assert task_by_id["select_discord"]["default"] is False
 
     # Validate validate stage structure
     validate = stages["validate"]

--- a/website/docs/agent-support/channels/discord.md
+++ b/website/docs/agent-support/channels/discord.md
@@ -1,6 +1,6 @@
 # Discord
 
-**Status:** ✅ Supported (OpenClaw only)
+**Status:** ✅ Supported on OpenClaw, Hermes, and ZeroClaw (each uses a different on-disk shape — see the agent-specific sections below).
 
 Discord channel allows your agent to operate as a bot in Discord servers.
 
@@ -238,6 +238,105 @@ Re-run `clm agent configure <name> --stage channels`, pick `discord` again, and 
 ### Non-interactive flags (Hermes)
 
 Planned for a follow-up — interactive is the supported path in this release. For automation today, drive `clm agent configure --stage channels` via expect/pexpect, or set the values directly in `hosts.json` + `secrets.json` and re-run the stage to trigger a re-render.
+
+---
+
+## ZeroClaw Configuration
+
+ZeroClaw consumes Discord credentials via **inline TOML**, not env vars. The bot token lives directly in `~/.zeroclaw/config.toml` under `[channels.discord]`, mode 0600. This differs from Hermes (env-based) and OpenClaw (env-based). Source of truth: zeroclaw upstream `docs/book/src/channels/chat-others.md` (v0.7.5).
+
+### Schema rendered by clm
+
+The clm-managed `[channels.discord]` block uses **only** the keys documented in zeroclaw v0.7.5:
+
+| TOML key | Source field in `hosts.json` `channels.discord.*` | Notes |
+|---|---|---|
+| `enabled = true` | always emitted when `enabled` is true and the bot token is hydrated | gating |
+| `bot_token = "..."` | hydrated from `secrets.json` `DISCORD_BOT_TOKEN` by `lifecycle.configure_agent` | inline TOML, never persisted in `hosts.json` |
+| `allowed_users = [...]` | `allowed_users` | empty array if unset |
+| `allowed_guilds = [...]` | `allowed_guilds` | empty array if unset; zeroclaw-specific (no hermes equivalent) |
+| `reply_to_mentions_only` | `require_mention` | renamed to match the upstream key |
+| `draft_update_interval_ms` | `draft_update_interval_ms` | optional — defaults handled by the daemon when omitted |
+
+### Hermes-side fields with no ZeroClaw equivalent
+
+These wizard inputs land in `hosts.json` but are **not** rendered into `~/.zeroclaw/config.toml`:
+
+- `home_channel`, `home_channel_name`, `home_channel_thread_id` — no upstream zeroclaw concept of a "home" channel.
+- `allow_all_users` — zeroclaw uses an empty `allowed_users = []` array to mean "allow everyone"; the boolean has no direct upstream representation.
+- `allowed_channels` — zeroclaw's upstream `allowed_destinations` is the nearest concept but is documented only generically (`channels/overview.md`), not under the Discord-specific schema; clm does not emit it pending a confirmed mapping.
+
+If you set any of these via the wizard for a zeroclaw agent, they persist to `hosts.json` for forward compatibility but have no runtime effect.
+
+### Interactive setup (ZeroClaw)
+
+```bash
+clm agent configure <zeroclaw-name> --stage channels
+```
+
+Prompts:
+
+| Prompt | Field |
+|---|---|
+| `Confirm CLI channel` | always-on; sets `confirm_cli = true` |
+| `Enable Discord channel (optional)` | persists `channels.discord.enabled` in `hosts.json` |
+| `Discord bot token` (masked) | persists to `secrets.json` as `DISCORD_BOT_TOKEN` |
+| `Allowed Discord user IDs` | `allowed_users` list |
+| `Allowed guild IDs` (optional) | `allowed_guilds` list |
+| `Reply to mentions only?` | `require_mention` → rendered as `reply_to_mentions_only` |
+
+`clm` then runs the configure playbook, which re-renders `~/.zeroclaw/config.toml` with the `[channels.discord]` block, restarts `zeroclaw-<name>.service`, and verifies the block landed by grepping for `^bot_token =` in the file.
+
+### Resulting on-disk shape (ZeroClaw)
+
+```toml
+[channels.discord]
+enabled = true
+bot_token = "MTIzNDU2Nzg5MDEyMzQ1Njc4Cg.G..."
+allowed_guilds = ["987654321098765432"]
+allowed_users = ["740723459344302120"]
+reply_to_mentions_only = true
+draft_update_interval_ms = 750
+```
+
+In `hosts.json` (agents.`<name>`.config.channels.discord):
+
+```json
+{
+  "enabled": true,
+  "allowed_users": ["740723459344302120"],
+  "allowed_guilds": ["987654321098765432"],
+  "require_mention": true
+}
+```
+
+`bot_token` is **never** stored in `hosts.json` — only `secrets.json` (mode 0600).
+
+### Removal (ZeroClaw)
+
+Re-run `clm agent configure <name> --stage channels` and answer **No** to "Enable Discord channel?". On the next render, the `[channels.discord]` block disappears from `config.toml` and the daemon stops listening on Discord on restart. To also wipe the persisted token, manually remove the `DISCORD_BOT_TOKEN` entry from `secrets.json`.
+
+### ZeroClaw-specific troubleshooting
+
+<details>
+<summary><strong>Bot connects but doesn't reply to my messages</strong></summary>
+
+1. Confirm your Discord user ID is in `~/.zeroclaw/config.toml` under `[channels.discord]` `allowed_users` — empty array means **allow all users** (zeroclaw upstream convention), but if you populated it with other IDs, yours must be in the list.
+2. If `reply_to_mentions_only = true`, the bot only responds when @-mentioned.
+3. Check the Discord Developer Portal: the bot must have `Message Content Intent` and `Server Members Intent` enabled (zeroclaw upstream requirement).
+
+</details>
+
+<details>
+<summary><strong>Bot didn't connect after configure</strong></summary>
+
+```bash
+ssh <agent-host> "sudo journalctl -u zeroclaw-<name>.service -n 200 --no-pager | grep -iE 'discord|channel'"
+```
+
+If the daemon logged a token error, rotate the bot token in the Discord Developer Portal and re-run `clm agent configure <name> --stage channels` to push the new value.
+
+</details>
 
 ---
 

--- a/website/docs/agent-support/integrations/github.md
+++ b/website/docs/agent-support/integrations/github.md
@@ -1,27 +1,8 @@
 # GitHub
 
-**Status:** 🚧 In Development
+**Status:** ✅ Supported on Hermes and ZeroClaw (#419, #422). 📋 Planned for OpenClaw.
 
-GitHub integration allows agents to interact with repositories, pull requests, and issues.
-
----
-
-## Planned Features
-
-- **PR Reviews:** Comment on pull requests
-- **Issue Management:** Read and create issues
-- **Code Search:** Search repositories
-- **Actions:** Trigger and monitor workflows
-- **Webhooks:** React to GitHub events
-- **Notifications:** Summarize activity
-
-## Timeline
-
-**Target:** Q2 2026
-
-**Milestone:** [SEA (Secondary Engagement & Automation)](https://github.com/ric03uec/clawrium/milestones)
-
-Track progress: [GitHub Issue #TBD](https://github.com/ric03uec/clawrium/issues)
+GitHub integration allows agents to clone repos, open pull requests, comment on issues, and search code from inside the agent's shell tool. The credential is a Personal Access Token (classic) or a fine-grained token — see [Create Fine-Grained Token for One Repo](#create-fine-grained-token-for-one-repo) below.
 
 ---
 
@@ -109,29 +90,89 @@ The key difference from classic tokens: fine-grained tokens let you scope to spe
 
 ---
 
-## Alternatives (Current Workaround)
+## How clm Wires GitHub to Each Agent Type
 
-Until native integration is available:
+### Hermes — env vars in `~/.hermes/.env`
 
-1. **CLI Tools:** Use `gh` CLI in agent scripts
-   ```bash
-   clm chat my-agent
-   # In chat: Run "gh issue list --repo myorg/myrepo"
-   ```
+Hermes natively reads `GITHUB_TOKEN` from its environment. `clm agent integration add <hermes> <gh-name>` followed by `clm agent sync <hermes>` renders the following into `~/.hermes/.env` (mode 0600):
 
-2. **API via curl:** Make direct API calls
-   ```bash
-   curl -H "Authorization: token $GITHUB_TOKEN" \
-        https://api.github.com/repos/myorg/myrepo/issues
-   ```
+```env
+GITHUB_TOKEN_WORK_GH='ghp_...'
+GITHUB_TOKEN='ghp_...'      # tracks the alphabetically-last github integration
+```
 
-3. **MCP Tools:** (Coming Q2 2026) Use GitHub MCP server
+`clm` then runs `gh auth login --with-token` as the agent user (soft dep — skipped if `gh` is not on the host). See [hermes/playbooks/configure.yaml](https://github.com/ric03uec/clawrium/blob/main/src/clawrium/platform/registry/hermes/playbooks/configure.yaml) lines 118–145.
+
+### ZeroClaw — two layers, both required
+
+ZeroClaw's shell tool **auto-strips** any env var matching `_TOKEN` / `_SECRET` / `_PASSWORD` / `API_KEY` patterns unless explicitly listed in `[autonomy] shell_env_passthrough`. Source: zeroclaw v0.7.5 `docs/book/src/security/sandboxing.md` and `security/autonomy.md`. So GitHub credentials need to land in **two** places:
+
+| Layer | Where | What it enables |
+|---|---|---|
+| 1. systemd `Environment=` drop-in | `/etc/systemd/system/zeroclaw-<name>.service.d/10-clm-env.conf` | The daemon process and all child processes (including the shell tool) inherit `GITHUB_TOKEN` from systemd. |
+| 2. `[autonomy] shell_env_passthrough` | `~/.zeroclaw/config.toml` | The agent's sandboxed shell tool sees the token. Without this, layer 1 alone is invisible to `gh`/`git push` inside chat. |
+
+Both layers are populated automatically by `clm agent sync <zeroclaw>` after `clm agent integration add`. The drop-in template is `src/clawrium/platform/registry/zeroclaw/templates/clm-env.conf.j2`; the autonomy block lives in `config.toml.j2`. Re-running `clm agent sync` re-renders both atomically and triggers a single service restart (daemon_reload + restart, handled by the configure playbook's restart handler).
+
+Like hermes, a `gh auth login --with-token` is run as the agent user when `gh` is present on the host — convenience only; the env-var path works without it.
+
+```toml
+# Rendered in ~/.zeroclaw/config.toml when github integrations are assigned:
+[autonomy]
+level = "supervised"
+approval_timeout_secs = 300
+workspace_only = true
+allowed_commands = ["git", "cargo", "grep", "find", "ls", "cat"]
+forbidden_commands = ["shutdown", "reboot", "mkfs"]
+forbidden_paths = ["/etc", "/sys", "/boot", "~/.ssh", "~/.aws"]
+shell_env_passthrough = ["PATH", "HOME", "USER", "LANG", "GITHUB_TOKEN_WORK_GH", "GITHUB_TOKEN"]
+```
+
+```ini
+# Rendered in /etc/systemd/system/zeroclaw-<name>.service.d/10-clm-env.conf:
+[Service]
+Environment=GITHUB_TOKEN_WORK_GH="ghp_..."
+Environment=GITHUB_TOKEN="ghp_..."
+```
+
+### Verifying the wiring (ZeroClaw)
+
+```bash
+# On the agent host:
+systemctl show -p Environment zeroclaw-<name>      # should list GITHUB_TOKEN
+grep -E '^shell_env_passthrough' ~/.zeroclaw/config.toml
+# From clm:
+clm chat <name>
+> Run: echo $GITHUB_TOKEN          # should print the token
+> Run: gh auth status              # should print "Logged in to github.com" if gh is installed
+```
 
 ---
 
-## Vote for Priority
+## Multi-Account Support
 
-Add a 👍 reaction to [the GitHub integration issue](https://github.com/ric03uec/clawrium/issues) to help prioritize.
+Both hermes and zeroclaw support multiple github integrations on a single agent:
+
+```bash
+clm integration add work-gh --type github
+clm integration add personal-gh --type github
+clm agent integration add my-agent work-gh
+clm agent integration add my-agent personal-gh
+clm agent sync my-agent
+```
+
+The agent then has `GITHUB_TOKEN_WORK_GH` and `GITHUB_TOKEN_PERSONAL_GH` available, plus a bare `GITHUB_TOKEN` set to the alphabetically-last integration (deterministic — uses Jinja's `dictsort`).
+
+---
+
+## OpenClaw (Not Yet Supported)
+
+OpenClaw does not yet consume GitHub credentials. Use a hermes or zeroclaw agent for GitHub workflows, or follow the workaround below for OpenClaw-only fleets.
+
+## Workaround for OpenClaw
+
+1. **CLI Tools:** Manually `gh auth login` on the OpenClaw host outside of clm.
+2. **API via curl:** Make direct API calls inside chat using a hard-coded token (not recommended for production).
 
 ---
 

--- a/website/docs/agent-support/zeroclaw.md
+++ b/website/docs/agent-support/zeroclaw.md
@@ -64,8 +64,8 @@ ZeroClaw's only chat surface is the daemon's own WebSocket endpoint at `GET /ws/
 |---------|:------:|-------|
 | **clm `chat <zeroclaw-name>`** | ✅ | Connects to `ws://<host>:42617/ws/chat` with `Authorization: Bearer <paired-token>`. See [Use the WebSocket chat surface](#3-use-the-websocket-chat-surface). |
 | **OpenAI-compatible HTTP API** | ❌ | Not exposed by upstream ZeroClaw. Use [Hermes](hermes.md) when an OpenAI-style HTTP endpoint is required. |
-| **Discord** | ❌ | Not supported (use [OpenClaw](openclaw.md) or [Hermes](hermes.md)). |
-| **Slack** | ❌ | Not supported (use [OpenClaw](openclaw.md) or [Hermes](hermes.md)). |
+| **[Discord](channels/discord.md)** | ✅ | Native — rendered as `[channels.discord]` in `config.toml`. Bot token is **inline TOML**, not env-based (differs from hermes). Schema follows zeroclaw v0.7.5 upstream: `bot_token`, `allowed_guilds`, `allowed_users`, `reply_to_mentions_only`, `draft_update_interval_ms`. Configure via `clm agent configure <name> --stage channels`. |
+| **Slack** | ❌ | Not supported (use [OpenClaw](openclaw.md) or [Hermes](hermes.md)). Tracked as a follow-up. |
 | **Web / WhatsApp / Telegram / Email / Matrix** | ❌ | Not supported. |
 
 ---
@@ -85,7 +85,8 @@ ZeroClaw's only chat surface is the daemon's own WebSocket endpoint at `GET /ws/
 | **Onboarding wizard** | ✅ | 4 stages: `providers` (required) → `identity` (auto-skipped) → `channels` (required, CLI confirm) → `validate` (3 local checks: agent install record, provider config + API key, provider connectivity). |
 | **Personality block in `config.toml`** | ✅ | `[personality]` with `name`, `timezone`, `communication_style` defaults; rendered with `force: no` semantics through Ansible's template default — re-running configure preserves the file because `notify` only fires when content actually changes. |
 | **Bootstrap file (`BOOTSTRAP.md`)** | ✅ | **Not rendered by clm.** The ZeroClaw daemon generates `BOOTSTRAP.md` on first boot and self-deletes it after use. Never appears in `clm agent memory show`. |
-| **Integrations (GitHub / Jira / GitLab / Linear / Notion)** | 📋 | Deferred. Upstream ZeroClaw supports an `[integrations]` block; clm does not emit it in this iteration. Tracked as a follow-up to #112. |
+| **[GitHub integration](integrations/github.md)** | ✅ | Two-layer wiring (#422): tokens land in a systemd drop-in (`/etc/systemd/system/zeroclaw-<name>.service.d/10-clm-env.conf`) so the daemon's environment has `GITHUB_TOKEN`, AND in `[autonomy] shell_env_passthrough` in `config.toml` so the agent's shell tool can actually see them (required: zeroclaw auto-strips `_TOKEN`-pattern vars unless explicitly allow-listed). `gh auth login --with-token` runs as a soft-dep convenience when `gh` is on the host. |
+| **Jira / GitLab / Linear / Notion integrations** | 📋 | Deferred. No native consumer in zeroclaw v0.7.5; would require either a `[mcp.servers]` block (potential future path) or per-integration env passthrough. Tracked as a follow-up. |
 | **Hardware support (GPIO / serial / debug probes)** | 📋 | Deferred. |
 | **Tunnel providers (Cloudflare / Tailscale / Ngrok / custom)** | 📋 | Deferred. Reach the gateway over your own SSH tunnel or LAN. |
 | **Encrypted secrets (ChaCha20-Poly1305)** | 📋 | Deferred. |
@@ -143,7 +144,7 @@ The wizard walks through:
 |-------|----------|
 | **providers** | Required. Pick from your registered clm providers; clm validates connectivity via `provider_test`. |
 | **identity** | Auto-skipped. ZeroClaw manages its own identity through the workspace MD files (`SOUL.md`, `IDENTITY.md`, …) which clm renders below — there is no separate identity wizard. |
-| **channels** | Required. The wizard presents `cli`, `discord`, and `slack` for all agent types — pick `cli` for ZeroClaw. `discord` / `slack` are selectable but **non-functional** on ZeroClaw; only the CLI path (`clm chat`) routes to the WebSocket gateway. |
+| **channels** | Required. ZeroClaw confirms the always-on CLI channel and offers a `discord` opt-in. Selecting `discord` prompts for the bot token (persists to `secrets.json` as `DISCORD_BOT_TOKEN`) plus optional allowlists; clm renders the result as `[channels.discord]` in `~/.zeroclaw/config.toml`. Slack remains unsupported on ZeroClaw — use [Hermes](hermes.md) or [OpenClaw](openclaw.md) for Slack. |
 | **validate** | Local validation only, three steps for zeroclaw: (1) agent install record, (2) provider config + API key, (3) provider connectivity. The control-machine SOUL.md check is skipped — zeroclaw owns its identity through `~/.zeroclaw/workspace/` on the agent host, not under `~/.config/clawrium/agents/zeroclaw/`. The playbook's own post-render readiness probe (`GET /health/providers`) is separate from this stage. The manifest's `binary_check` task (`zeroclaw --version`) is not dispatched yet — remote version verification is planned. |
 
 Configure renders TWO things on the agent host, then runs the pairing handshake against the freshly started daemon.
@@ -410,7 +411,7 @@ The render is idempotent (force: no), so this is safe to run against a partially
 
 The following are explicitly out of scope for issue #112 and tracked as separate follow-ups:
 
-- **Integrations** — GitHub, GitLab, Atlassian (Jira + Confluence), Linear, Notion. Upstream ZeroClaw supports an `[integrations]` block; clm does not emit it in this iteration.
+- **Non-GitHub integrations** — GitLab, Atlassian (Jira + Confluence), Linear, Notion. Tracked as follow-ups; the upstream `[mcp.servers]` block is the most likely landing pad. GitHub is supported as of #422 — see the Feature Support table above.
 - **Hardware** — GPIO, serial, debug-probe support.
 - **Tunnel providers** — Cloudflare Tunnel, Tailscale, Ngrok, custom tunnels. Use SSH tunneling in the meantime.
 - **Encrypted secrets** — ChaCha20-Poly1305 secret encryption is upstream-only for now.


### PR DESCRIPTION
## Summary

Wire native Discord channel + GitHub integration into zeroclaw, following zeroclaw v0.7.5 upstream contract (TOML-based channel config, `[autonomy] shell_env_passthrough`, systemd `Environment=` drop-in) rather than copying hermes's env-based conventions verbatim.

Closes #422.

End-to-end smoke verified with dummy `bot_token` + two github integrations: `~/.zeroclaw/config.toml` renders the expected `[channels.discord]` (upstream-only fields) + `[autonomy]` (full block with extended `shell_env_passthrough`), and the systemd drop-in renders the expected `Environment=GITHUB_TOKEN*` lines. No atlassian credentials leak into either output.

## Testing

### Test Results
- [x] All existing tests pass (`make test` — 2293 py + 186 gui green, +33 new)
- [x] Linter passes (`make lint`)
- [x] New tests cover: select_discord task in manifest; `[channels.discord]` upstream-schema render with hermes-only field drop; full `[autonomy]` block; `GITHUB_TOKEN` + per-name passthrough; clm-env.conf.j2 per-name + canonical `Environment=` lines + CR/LF injection defense; lifecycle Discord hydration for zeroclaw; B3-invariant strip-before-persist for zeroclaw; CLI flat-shape Discord config; slack-filter in zeroclaw menu; malformed/comma-only user/guild input rejection; pre-sync token-store ordering (deadlock prevention).

### Test Coverage
- Files changed: 14 (5 code, 4 tests, 5 docs)
- New tests: TestZeroclawDiscordHydration (5), TestChannelsDiscordBlock (4), TestAutonomyBlock (5), TestSystemdDropIn (5), TestRunChannelsStageZeroclaw (8) — 27 total in 4 classes + scattered single tests
- Coverage impact: increased

### Manual Testing
The repo owner will exercise on a live zeroclaw target after merge:
1. `clm agent configure clawrium-d01 --stage channels` → Discord opt-in → token persists → `~/.zeroclaw/config.toml` shows `[channels.discord]` with `bot_token`; daemon `journalctl` shows Discord connect.
2. `clm integration add clawrium-gh --type github && clm agent integration add clawrium-d01 clawrium-gh && clm agent sync clawrium-d01` → drop-in present at `/etc/systemd/system/zeroclaw-clawrium-d01.service.d/10-clm-env.conf` → `systemctl show -p Environment zeroclaw-clawrium-d01` shows `GITHUB_TOKEN` → `~/.zeroclaw/config.toml` shows `GITHUB_TOKEN` in `shell_env_passthrough` → from `clm chat clawrium-d01`, `gh auth status` returns ok.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — 17-19 digit ID regex on user/guild IDs; comma-only input rejected (ATX Round 3 B1, Round 4 B4); CR/LF strip on tokens (ATX Round 1 W3); `toml_escape` on all interpolated values
- [x] No SQL injection, XSS, or command injection risks — `argv:` form for `gh auth`; systemd drop-in uses static directives; B3 invariant (bot_token never in hosts.json) enforced for zeroclaw
- [x] Dependencies are from trusted sources — `gh` is a soft dependency only

## Reviewer Notes

**Upstream-doc-driven design decisions:**
- Discord bot_token is **inline TOML in `config.toml`**, not env-based — zeroclaw v0.7.5 `docs/book/src/channels/chat-others.md`. Differs from hermes.
- GitHub credentials need **two layers**: systemd `Environment=` drop-in (so daemon has them) PLUS `[autonomy] shell_env_passthrough` allow-listing (so the shell tool can see them, since zeroclaw auto-strips `_TOKEN`-pattern env vars per `security/sandboxing.md` + `security/autonomy.md`).
- Full `[autonomy]` block is rendered unconditionally — operator chose this over a partial table to avoid relying on undocumented daemon merge behavior.

**Mapping from hermes wizard fields to zeroclaw upstream:**
- `require_mention` → `reply_to_mentions_only` (renamed; same semantics)
- `home_channel*`, `allow_all_users`, `allowed_channels` → dropped silently (no upstream zeroclaw equivalent)
- Empty `allowed_users` = open bot (zeroclaw upstream convention; warned at prompt time)
- Empty `allowed_guilds` = any guild (symmetric warning added in Round 3)

## ATX Review Summary

**Final Review: Rating 2/5** — see commit body for the four-round per-issue table. The Round 4 rating did not lift to 3+ because:
1. ATX Round 4 expanded scope beyond the diff (B1/B2/B3/B5 audit unrelated `rich_escape` gaps and a pre-existing `_sync_provider_config` test gap). Those are valid observations but pre-existing — recommended as follow-up issues.
2. The cli-ux specialist that found the actionable issues in Rounds 1–3 hit max-turns and was skipped on Round 4, leaving only auditors that found out-of-scope items.

**Total Cost: ~$0.50 | Total Time: ~80m across 4 rounds**

| Review | Rating | Blocking Issues (in-scope) | Status | Agents |
|--------|--------|----------------------------|--------|--------|
| 1 | 2/5 | B1 (bot_token leak), B2 (pre-existing OOS), B3 (pre-existing OOS) | B1 fixed; B2/B3 cited OOS | core-lifecycle, security, test-coverage, cli-ux |
| 2 | 2/5 | B_new1 (slack in menu), B_new2 (zeroclaw CLI branch missing) | Both fixed | cli-ux |
| 3 | 2/5 | B1 (comma-only open-bot), B2 (chicken-and-egg deadlock) | Both fixed | cli-ux, security, test-coverage |
| 4 | 2/5 | B1/B2/B3 (OOS rich_escape pre-existing), B4 (guild test gap), B5 (OOS pre-existing) | B4 fixed; B1/B2/B3/B5 cited OOS | ansible-registry, security, test-coverage (cli-ux max-turns) |

<details>
<summary>Round 4 out-of-scope blockers (recommended follow-ups)</summary>

**B1/B2/B3**: `result['error']` from Ansible runner is printed via `console.print()` without `rich_escape()` in remove/start/stop/restart/sync commands and in `_run_identity_stage` / `_run_edit_config` error-return paths. Pre-existing in main; not touched by this PR. Recommend filing as a security-hardening follow-up.

**B5**: `_sync_provider_config` zeroclaw branch (`allow_public_bind` vs `bind`) has zero test coverage across the file. Pre-existing; recommend filing as a coverage follow-up.

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
