### PR TITLE
Add plan for issue 435: clawctl rename + kubectl-style UX

### DIFF
--- a/.itx/435/00_PLAN.md
+++ b/.itx/435/00_PLAN.md
@@ -1,0 +1,16 @@
+# Issue #435 — User can use clawctl with kubectl-style UX across the fleet
+
+GitHub: https://github.com/ric03uec/clawrium/issues/435
+
+## Issue Creation
+
+**Stage**: issue-creation
+**Skill**: /itx:issue-new
+**Timestamp**: 2026-05-20T03:40:46Z
+**Model**: claude-opus-4-7
+
+```prompt
+change the cli from clm to clawctl and align the cli output format with kubectl format. make sure all the commands can be run using cli only and the gui wiring is using the same commaands. this issue is about doing a sweep of the cli surface and stnandardizing it across the board for a cleaner ux
+```
+
+**Output**: Created GitHub issue #435 covering (1) rename `clm` → `clawctl`, (2) kubectl-style verb-noun grammar + `-o yaml|json|wide` output, and (3) wiring the GUI through `clawctl` so CLI is the single source of truth.


### PR DESCRIPTION
## Summary
- Adds `.itx/435/00_PLAN.md` capturing the prompt log for issue #435
- Documents the scope: rename `clm` → `clawctl`, kubectl-style command grammar/output, and routing the GUI through `clawctl`

Refs #435

## Testing

### Test Results
- [x] Docs-only change; no code touched
- [x] No tests required

### Manual Testing
N/A — markdown artifact only.

### Security Checklist
- [x] No secrets
- [x] No code paths affected

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)