### PR TITLE
fix(zeroclaw): retune runtime budgets for coding-agent workloads

### DIFF
--- a/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
+++ b/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
@@ -93,20 +93,26 @@ timezone = "{{ toml_escape(personality_timezone) }}"
 communication_style = "{{ toml_escape(personality_style) }}"
 
 {# --- Agent runtime knobs --------------------------------------------------
-   Pin the daemon's tool-loop + context budgets explicitly rather than
-   relying on upstream defaults. Defaults (per binary strings):
-     max_tool_iterations = 10
-     max_context_tokens  = 32000
-   These are too tight for typical clm workflows where one user message
-   triggers several git_operations + shell calls (e.g. branch + commit
-   + push + gh pr create is 8–12 turns minimum). When the cap hits, the
-   daemon emits a `Max iterations reached` warning and the model often
-   misattributes the truncation as a policy block on the next turn,
-   poisoning conversation history. Larger budget here eliminates the
-   misattribution failure mode entirely. #}
+   Pin the daemon's tool-loop + context budgets above their default
+   coding-hostile values. Verified defaults from
+   crates/zeroclaw-config/src/schema.rs L3342-3422 @ v0.7.5:
+     max_tool_iterations    = 10
+     max_context_tokens     = 32000
+     max_tool_result_chars  = 50000
+     max_history_messages   = 50
+     keep_tool_context_turns = 2
+   A real coding cycle (plan → edit → test → fix → re-test → commit →
+   push → gh pr create) routinely needs 60–100 tool calls, holds AGENTS.md
+   + several source files + diff output in context at once, and re-reads
+   files many turns later. The upstream defaults truncate mid-task and
+   the model misattributes the truncation as a policy block, poisoning
+   history. Values below give a TDD/PR workflow room to breathe. #}
 [agent]
-max_tool_iterations = 30
-max_context_tokens = 100000
+max_tool_iterations = 200
+max_context_tokens = 180000
+max_tool_result_chars = 200000
+max_history_messages = 200
+keep_tool_context_turns = 8
 
 {# --- Discord channel (#422) -----------------------------------------------
    ZeroClaw v0.7.5 schema per docs/book/src/channels/chat-others.md:
@@ -189,8 +195,17 @@ draft_update_interval_ms = {{ _discord.get('draft_update_interval_ms') | int }}
 
 [autonomy]
 level = "supervised"
-approval_timeout_secs = 300
 workspace_only = true
+{# v0.7.5 AutonomyConfig defaults (schema.rs L5820-5942) are sized for a
+   light-touch personal assistant, not a coding agent:
+     max_actions_per_hour   = 20    → ~one tool call every 3 minutes
+     max_cost_per_day_cents = 500   → $5/day, exhausted by one Opus session
+     shell_timeout_secs     = 60    → kills `cargo build`, long test suites
+   Bump all three to coding-appropriate ceilings. These are *ceilings*,
+   not floors — actual usage is driven by the conversation. #}
+max_actions_per_hour = 1000
+max_cost_per_day_cents = 50000
+shell_timeout_secs = 600
 {# Explicit broad developer allowlist. v0.7.5 treats
    `allowed_commands = []` as deny-all rather than permissive (the
    upstream doc only specifies the non-empty case). Positive list
@@ -299,4 +314,36 @@ auto_approve = [
   "escalate_to_human",
   # Tool catalog (read-only)
   "tool_search",
+]
+
+{# --- Pacing / loop detection ---------------------------------------------
+   v0.7.5 PacingConfig defaults (crates/zeroclaw-config/src/schema.rs
+   L3481-3547):
+     loop_detection_enabled     = true
+     loop_detection_window_size = 20
+     loop_detection_max_repeats = 3
+   With max_repeats=3 in a 20-call window, the daemon blocks any tool
+   that returns identical results 4 times — even with different args.
+   That tripped the runtime in production on routine coding cadence
+   (re-running `pytest -x` between fixes, re-reading the same file
+   across edits, `git status` between commits):
+     `zeroclaw_runtime::agent::loop_: loop detector blocked tool call
+      tool=shell msg=Blocked: tool 'shell' called 6 times with different
+      arguments but identical results`
+   loop_ignore_tools is the surgical knob — listed tools never trip
+   the detector regardless of window/max_repeats. Restricted to the
+   high-repeat, low-risk surface (shell, file_read, search tools);
+   web_fetch / http_request / git_operations remain detected because
+   repeated identical results from those almost always indicate genuine
+   pathology. #}
+[pacing]
+loop_detection_enabled = true
+loop_detection_window_size = 40
+loop_detection_max_repeats = 12
+loop_ignore_tools = [
+  "shell",
+  "file_read",
+  "file_list",
+  "content_search",
+  "glob_search",
 ]

--- a/tests/test_configure_zeroclaw.py
+++ b/tests/test_configure_zeroclaw.py
@@ -655,17 +655,20 @@ class TestChannelsDiscordBlock:
 
 class TestAgentBlock:
     """[agent] pins the daemon's tool-loop + context budgets above their
-    too-tight defaults (10 iterations / 32k tokens), which were causing
-    multi-step PR workflows to hit `Max iterations reached` and poison
-    the conversation history with phantom-block hallucinations."""
+    coding-hostile defaults (10 iters / 32k ctx / 50k tool-result / 50
+    history / 2 turns retained). Verified against
+    crates/zeroclaw-config/src/schema.rs L3342-3422 @ v0.7.5."""
 
     def test_agent_block_pins_iteration_and_context_budgets(self):
         rendered = _render_with_channels_and_integrations(
             provider={"type": "anthropic", "default_model": "m"},
         )
         assert "[agent]" in rendered
-        assert "max_tool_iterations = 30" in rendered
-        assert "max_context_tokens = 100000" in rendered
+        assert "max_tool_iterations = 200" in rendered
+        assert "max_context_tokens = 180000" in rendered
+        assert "max_tool_result_chars = 200000" in rendered
+        assert "max_history_messages = 200" in rendered
+        assert "keep_tool_context_turns = 8" in rendered
 
 
 class TestAutonomyBlock:
@@ -679,8 +682,15 @@ class TestAutonomyBlock:
         )
         assert "[autonomy]" in rendered
         assert 'level = "supervised"' in rendered
-        assert "approval_timeout_secs = 300" in rendered
         assert "workspace_only = true" in rendered
+        # Coding-agent ceilings (v0.7.5 defaults are 20/hr, $5/day, 60s).
+        assert "max_actions_per_hour = 1000" in rendered
+        assert "max_cost_per_day_cents = 50000" in rendered
+        assert "shell_timeout_secs = 600" in rendered
+        # approval_timeout_secs is NOT a recognized AutonomyConfig field in
+        # v0.7.5 (schema.rs L5820-5942) — silently ignored by the daemon.
+        # Asserted absent so future templates don't reintroduce it.
+        assert "approval_timeout_secs" not in rendered
         # Explicit broad developer allowlist. v0.7.5 treats `[]` as
         # deny-all (vs. the doc's implied permissive), so we enumerate.
         # Spot-check representative entries from each category — the
@@ -765,6 +775,45 @@ class TestAutonomyBlock:
             },
         )
         assert "GITHUB_TOKEN_TEAM_A_GH" in rendered
+
+
+class TestPacingBlock:
+    """[pacing] loosens the loop detector from its coding-hostile default
+    (max_repeats=3 in a 20-call window) and exempts the high-repeat,
+    low-risk tool surface (shell, file_read, search tools). Verified
+    against crates/zeroclaw-config/src/schema.rs L3481-3547 @ v0.7.5."""
+
+    def test_pacing_block_renders_with_loosened_thresholds(self):
+        rendered = _render_with_channels_and_integrations(
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert "[pacing]" in rendered
+        assert "loop_detection_enabled = true" in rendered
+        assert "loop_detection_window_size = 40" in rendered
+        assert "loop_detection_max_repeats = 12" in rendered
+
+    def test_pacing_block_exempts_high_repeat_low_risk_tools(self):
+        rendered = _render_with_channels_and_integrations(
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        # Surgical exemption — repeats on these tools are normal coding
+        # cadence (re-running tests, re-reading edited files, grep loops).
+        import re
+        m = re.search(
+            r"loop_ignore_tools\s*=\s*\[(.*?)\]", rendered, re.DOTALL
+        )
+        assert m is not None, "loop_ignore_tools list not rendered"
+        block = m.group(1)
+        for tool in ["shell", "file_read", "file_list",
+                     "content_search", "glob_search"]:
+            assert f'"{tool}"' in block, f"{tool} missing from loop_ignore_tools"
+        # Network + git ops stay detected — repeated identical results
+        # there almost always indicate genuine pathology.
+        for tool in ["web_fetch", "http_request", "git_operations"]:
+            assert f'"{tool}"' not in block, (
+                f"{tool} must NOT be in loop_ignore_tools — repeated "
+                f"identical results are a pathology signal for it"
+            )
 
 
 class TestSystemdDropIn:


### PR DESCRIPTION
## Summary

- Loosens zeroclaw v0.7.5 runtime budgets across `[agent]`, `[autonomy]`, and a **new** `[pacing]` block so the daemon stops killing iterative coding work.
- Drops a bogus `approval_timeout_secs` line from `[autonomy]` — verified against upstream schema, that field does not exist on `AutonomyConfig` and was being silently ignored.
- Adds a surgical `loop_ignore_tools` exemption for the high-repeat / low-risk tool surface (shell, file_read, search tools). Network and git-ops tools remain detected because repeated identical results there are pathology, not coding cadence.

## Background

Observed in production on `clawrium-d01`:
```
zeroclaw_runtime::agent::loop_: loop detector blocked tool call
  tool=shell msg=Blocked: tool 'shell' called 6 times with different
  arguments but identical results
```
The agent then **fabricated** a `Rate limited. Retrying in a moment...` reply rather than surfacing the real cause. With default `loop_detection_max_repeats = 3` in a 20-call window, any TDD loop (`pytest -x` after each fix, re-reading edited files, `git status` between commits) trips the detector by the 4th identical-result call.

## What changed

All values verified against [`crates/zeroclaw-config/src/schema.rs` @ v0.7.5](https://github.com/zeroclaw-labs/zeroclaw/blob/v0.7.5/crates/zeroclaw-config/src/schema.rs):

### `[agent]` (schema.rs L3342-3422)
| Key | Default | New | Rationale |
|---|---|---|---|
| `max_tool_iterations` | 10 | 200 | A real PR cycle (plan → edit → test → fix → re-test → commit → push → gh pr create) runs 60-100 calls |
| `max_context_tokens` | 32000 | 180000 | Anthropic models support 200K; use the budget |
| `max_tool_result_chars` | 50000 | 200000 | `grep -rn` / test output / file dumps exceed 50K on real codebases |
| `max_history_messages` | 50 | 200 | 50 ≈ 25 turns; a coding session passes that |
| `keep_tool_context_turns` | 2 | 8 | Earlier file reads need to stay readable while editing later |

### `[autonomy]` (schema.rs L5820-5942)
| Key | Default | New | Rationale |
|---|---|---|---|
| `max_actions_per_hour` | 20 | 1000 | Default = ~1 call every 3 min, gasses out a TDD session in ~30 min |
| `max_cost_per_day_cents` | 500 | 50000 | $5/day → $500/day ceiling. Still a ceiling, not a target |
| `shell_timeout_secs` | 60 | 600 | `cargo build` / large `pytest` exceed 60s |

**Dropped**: `approval_timeout_secs = 300` — not a field on `AutonomyConfig` in v0.7.5; was silently ignored. Test now asserts it stays out.

### `[pacing]` — NEW (schema.rs L3481-3547)
| Key | Default | New |
|---|---|---|
| `loop_detection_enabled` | true | true (kept on — a stuck agent burning paid calls is worse than a false-block) |
| `loop_detection_window_size` | 20 | 40 |
| `loop_detection_max_repeats` | 3 | 12 |
| `loop_ignore_tools` | `[]` | `[shell, file_read, file_list, content_search, glob_search]` |

`loop_ignore_tools` is the surgical knob — listed tools never trip the detector regardless of window/max_repeats. Restricted to the high-repeat, low-risk surface. Web/HTTP/git-ops deliberately omitted.

## Testing

### Test Results
- [x] All existing tests pass (`make test` — 2302 Python + 186 GUI tests)
- [x] Linter passes (`make lint` — ruff + ESLint clean)
- [x] New tests added:
  - `TestAgentBlock.test_agent_block_pins_iteration_and_context_budgets` — extended for all 5 budget knobs
  - `TestAutonomyBlock.test_autonomy_block_always_renders` — asserts new ceilings + `approval_timeout_secs` absent
  - `TestPacingBlock.test_pacing_block_renders_with_loosened_thresholds`
  - `TestPacingBlock.test_pacing_block_exempts_high_repeat_low_risk_tools` — positive + negative assertions on `loop_ignore_tools` membership

### Test Coverage
- Files changed: `src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2`, `tests/test_configure_zeroclaw.py`
- New tests: 2 (`TestPacingBlock` class)
- Coverage impact: maintained/increased — every new TOML key has a matching positive assertion

### Manual Testing
Pending post-merge: `clm agent configure <name>` on clawrium-d01 followed by an iterative coding session to confirm the loop detector no longer trips. Will follow up in this PR or as a comment on the issue if anomalies surface.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — N/A (constants only)
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources — no new deps

## Reviewer Notes

- All key names + defaults are quoted against upstream `schema.rs` at the `v0.7.5` tag, not master. The upstream master branch has in-flight work ([#2152](https://github.com/zeroclaw-labs/zeroclaw/issues/2152) proposes additional loop-detector keys) that does **not** apply to v0.7.5.
- The `[pacing]` block is rendered unconditionally. If a future profile / per-agent override is desired (e.g. `--profile chat` to restore tighter defaults for non-coding agents), that's a separate change — explicitly deferred per current scope.
- Out of scope: ATX-flagged `tmp/` PII issue, `auto_approve` security review, `gh auth setup-git` test coverage. Track separately.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)