### PR TITLE
fix(zeroclaw): always re-pair after any lifecycle operation

### DIFF
--- a/.itx/437/00_PLAN.md
+++ b/.itx/437/00_PLAN.md
@@ -1,0 +1,63 @@
+# Issue #437 — Plan
+
+The full implementation plan is in the issue body (#437). This file logs the
+execution against that plan. The acceptance criteria from #437 are the
+contract; the file structure below is the execution trace.
+
+## Implementation Outline
+
+1. Extract pair handshake to reusable task file
+   - New: `src/clawrium/platform/registry/zeroclaw/playbooks/tasks/pair.yaml`
+   - Four tasks: request `/pair/code` → validate → POST `/pair` → validate
+   - Sets cacheable fact `zeroclaw_gateway_token`
+
+2. Refactor `configure.yaml`
+   - Delete `Determine whether re-pairing is required` set_fact
+   - Replace inlined pair handshake with `include_tasks: tasks/pair.yaml`
+   - Remove all `zeroclaw_needs_pairing` / `force_repair` / `existing_gateway_token`
+     references
+   - Update success message (no more "existing token reused" branch)
+
+3. Refactor `lifecycle.py`
+   - Drop `existing_gateway_token` / `force_repair` block in `configure_agent`
+   - Add zeroclaw branch in `restart_agent` that runs a new `restart.yaml`
+     playbook, extracts the gateway token fact, and updates hosts.json atomically
+   - Drop unconditional `restart_agent` call from `sync_agent`
+   - Add `_emit_gateway_token_rotated` helper used at every write site that
+     persists a new gateway.auth value
+
+4. New playbook: `restart.yaml` for zeroclaw
+   - `systemctl restart` → wait for `/health/providers` → `include_tasks: tasks/pair.yaml`
+
+5. `cli/chat.py` transparent reconnect on 401
+   - Catch `ChatAuthenticationError`, reload hosts.json, compare bearer
+   - If different, reconnect once; if identical, surface the existing error
+
+6. CLI: surface `gateway_token_rotated` events
+   - Extend `_print_configure_warnings` (or sibling) to render the structured
+     rotation event as a yellow notice
+
+7. Tests
+   - Remove tests pinned to `existing_gateway_token` / `force_repair`
+   - Add post-condition tests: install / configure / sync / restart all leave
+     `hosts.json.gateway.auth` equal to the daemon's enforced bearer
+   - Add chat reconnect unit test
+
+8. Docs
+   - Update `AGENTS.md` with "Gateway token lifecycle" section
+   - Remove stale ATX B3 comment block
+
+## Prompt Log
+
+### Execute
+
+**Stage**: execute
+**Skill**: /itx-execute
+**Timestamp**: 2026-05-19T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 437
+```
+
+**Output**: Implementation of always-repair invariant for zeroclaw lifecycle.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,31 @@ clm ps
 - Project Board: https://github.com/users/ric03uec/projects/1
 - Version: 26.4.7
 
+## Gateway Token Lifecycle (zeroclaw)
+
+The zeroclaw gateway authenticates `clm chat` sessions with a bearer token
+the daemon mints via a `/pair/code` → `/pair` loopback handshake. The
+daemon does not persist that bearer across systemd restarts, so the only
+way for `clm` to guarantee `hosts.json.gateway.auth` equals the bearer the
+daemon will enforce on the next request is to **always re-pair** on every
+lifecycle op that touches the daemon.
+
+Rules (issue #437):
+
+- `clm agent configure`, `clm agent sync`, and `clm agent restart` all
+  mint a fresh bearer and overwrite `hosts.json.gateway.auth` atomically.
+- There is no idempotent-skip path. Do not add a `--no-rotate` flag —
+  branching here is the bug the original ATX Round 1 B3 code introduced.
+- Remote `clm chat` sessions (running on a different machine than the one
+  that ran the lifecycle op) will get a clean 401 on their next request.
+  They must reconnect — that's the documented trade-off.
+- Local `clm chat` reconnects transparently: on 401 it reloads
+  `hosts.json` once, compares the bearer in memory vs disk, and rebuilds
+  the backend with the fresh token if they differ.
+- A single `gateway_token_rotated` event is emitted from `lifecycle.py`
+  whenever the bearer is overwritten. The CLI renders it as a yellow
+  notice during `configure`/`sync`/`restart`.
+
 ## Tech Stack
 
 - **CLI**: Python + Typer

--- a/docs/agent-support/zeroclaw.md
+++ b/docs/agent-support/zeroclaw.md
@@ -217,18 +217,15 @@ agents.<agent-name>.config.gateway.auth = "<bearer-token>"
 agents.<agent-name>.config.gateway.url  = "ws://<agent-host>:42617/ws/chat"
 ```
 
-Re-running `clm agent configure <agent-name>` **reuses** the persisted token by default — live chat sessions stay valid. See [Rotating the gateway token](#rotating-the-gateway-token) below for the rotation workaround (no Typer flag exists yet; rotation is driven through an Ansible extra-var).
+Re-running `clm agent configure <agent-name>` (or `sync` or `restart`) **always re-pairs** and overwrites the persisted token (issue #437). Live chat sessions on **other machines** must reconnect on their next message — `clm chat` on the local machine reloads `hosts.json` automatically on a 401 and reconnects transparently. See [Gateway token lifecycle](#gateway-token-lifecycle) below for the full contract.
 
 A non-fatal warning is surfaced when the post-configure readiness probe (`GET /health/providers`) returns 401: the gateway is reachable but the provider credentials likely mismatch the API key supplied in `config.toml`. Re-run with the correct key.
 
-#### Rotating the gateway token
+#### Gateway token lifecycle
 
-The pairing token can be invalidated and re-minted, but `clm agent configure` does not yet surface a Typer flag for this. Today, the rotation flow is:
+The zeroclaw daemon mints its bearer through a loopback `/pair/code` → `/pair` handshake. The daemon does not persist that bearer across systemd restarts, so `clm` enforces a single invariant: every lifecycle op (`install`, `configure`, `sync`, `restart`) ends with a fresh pair handshake and an atomic write to `hosts.json.gateway.auth`. There is no idempotent-skip path and no `force_repair` opt-out — branching here was the cause of issue #437.
 
-1. Edit `~/.config/clawrium/hosts.json` and clear `agents.<agent-name>.config.gateway.auth` (set it to an empty string or delete the key).
-2. Re-run `clm agent configure <agent-name>`. The configure playbook detects the missing token and runs a fresh `GET /pair/code` → `POST /pair` handshake.
-
-Alternatively, if you are scripting against the playbook directly, pass `force_repair=true` as an Ansible extra-var — the configure playbook honors it and forces the mint path. This bypasses the higher-level CLI; live chat sessions using the previous token will fail at their next message.
+Trade-off (accepted): every `sync`/`restart` invalidates in-flight chat sessions on other machines. The CLI emits a single `gateway_token_rotated` yellow notice when this happens, including the agent name so you know which remote sessions need to reconnect.
 
 ### 3. Use the WebSocket chat surface
 
@@ -306,7 +303,7 @@ ZeroClaw's threat model is **trusted LAN**, parity with the upstream daemon's de
 - **The bearer token traverses the network in cleartext on `ws://` connections.** The pairing handshake itself happens loopback-only inside the configure playbook, so the code/token never leave the agent host during minting — but every subsequent `clm chat` carries the token in an `Authorization` header over plain WebSocket. Fine on a trusted LAN; **not fine** over an untrusted network. `core/chat_zeroclaw.py` warns once per session when the destination is non-loopback (`_warn_if_token_in_cleartext`). For production / untrusted networks, terminate TLS at a reverse proxy (Caddy / nginx) and use a `wss://` URL; clm does not run that proxy itself.
 - **A plain `ssh -L 42617:…` tunnel does not redirect `clm chat`.** `clm chat` rebuilds the gateway URL from the host record's primary address in `hosts.json` (see [Off-host access from the control machine](#off-host-access-from-the-control-machine) above). For ad-hoc verification, point a raw client (`wscat`, `websocat`) at the tunnelled loopback instead; for persistent overlay-network access, register the overlay address via `clm host address add` + `set-primary` so `clm chat` dials it directly.
 - **Tokens persist to `hosts.json` on the control machine.** Treat the file like any other credential store; review its permissions (it is not chmod-0600 by default) and avoid checking it into version control. On a multi-user control machine, tighten the file mode manually.
-- **Re-configure preserves the existing token by default.** clm only mints a fresh token when `force_repair` is supplied via Ansible extra-vars (see [Rotating the gateway token](#rotating-the-gateway-token)). There is no Typer flag for this yet — rotate by clearing the stored token first.
+- **Re-configure always re-mints the bearer (issue #437).** `clm agent configure`/`sync`/`restart` overwrite `config.gateway.auth` on every run. Local `clm chat` reloads the token transparently on 401; remote sessions must reconnect. See [Gateway token lifecycle](#gateway-token-lifecycle).
 - **Server-supplied text is BIDI / control-char sanitized before rendering.** `core/chat_zeroclaw.py` routes every visible field from server frames through `sanitize_server_text` (which strips C0/C1 controls, zero-width codepoints, BIDI overrides U+202A–U+202E and U+2066–U+2069, line/paragraph separators, and the word-joiner). Rich-markup escaping is handled separately by the CLI render layer, not by this sanitizer.
 - **`approval_request` frames tear down the session.** Inline tool approval is not implemented; the client closes the WebSocket and raises a remediation error pointing operators at `~/.zeroclaw/config.toml`. Pre-approve or disable tools at the agent host before invoking them. See [Use the WebSocket chat surface](#3-use-the-websocket-chat-surface) for the full frame envelope.
 - **Treat `config.toml` as an audited surface.** clm only emits `[gateway]`, `[providers.models.<name>]`, and `[personality]`. Any block manually added (e.g. `[integrations]`, `[hardware]`) is honored by the daemon but **invisible to `clm`** — `clm agent configure` will not validate it and `clm` cannot detect drift between renders and manual edits.
@@ -319,7 +316,7 @@ ZeroClaw's threat model is **trusted LAN**, parity with the upstream daemon's de
 - **Workspace personality is operator-owned after first configure.** Every workspace template renders with `force: no`. After the initial seed, the daemon and the operator (via `clm agent memory edit`) are the only writers.
 - **`BOOTSTRAP.md` is runtime-generated and self-deletes.** Do not expect to see it in `clm agent memory show`. It only exists between first daemon start and the daemon's own bootstrap cleanup.
 - **`clm chat` requires the daemon to be running.** The CLI does not run the runtime in-process; it speaks to the systemd-managed daemon. If `systemctl status zeroclaw-<name>` is `inactive (dead)`, `clm chat` will fail to connect.
-- **Re-installing preserves the gateway token.** `install.py`'s `preserved_gateway` carry-over keeps `config.gateway.auth` across reinstalls, so re-running install does not break live chat sessions. Re-running `configure` follows the same rule — see [Rotating the gateway token](#rotating-the-gateway-token) for the explicit rotation path.
+- **Re-installing preserves the gateway token; configure/sync/restart do not.** `install.py`'s `preserved_gateway` carry-over keeps `config.gateway.auth` across reinstalls because install itself does not re-pair. Lifecycle ops that touch the running daemon (`configure`, `sync`, `restart`) always re-pair — see [Gateway token lifecycle](#gateway-token-lifecycle).
 
 ---
 
@@ -374,14 +371,14 @@ Both pairing steps validate their responses; failure modes:
 - `GET /pair/code` returned non-200, or a body missing the `code` field → daemon is up but pairing endpoint is disabled. Check the journal for upstream errors.
 - `POST /pair` returned non-200, or a token shorter than 16 chars → the code expired or was already consumed.
 
-Recovery is a token rotation — see [Rotating the gateway token](#rotating-the-gateway-token). Tl;dr: clear `agents.<agent-name>.config.gateway.auth` from `hosts.json`, then re-run `clm agent configure <agent-name>`. The empty token triggers a fresh `GET /pair/code` → `POST /pair` cycle. Existing chat sessions using the old token will fail at the next message.
+Recovery: re-run `clm agent configure <agent-name>` — every configure run unconditionally mints a fresh token (see [Gateway token lifecycle](#gateway-token-lifecycle)). If `/pair/code` still fails, check the journal for upstream errors and restart the daemon (`clm agent restart <agent-name>`), which also re-pairs.
 
 </details>
 
 <details>
 <summary><strong><code>clm chat</code> fails after a reinstall</strong></summary>
 
-`install.py preserved_gateway` carries `config.gateway.auth` across reinstalls so this is rare. If it happens, the most likely cause is a manual edit to `hosts.json` between install and chat. Rotate the token (clear `gateway.auth` and re-run `clm agent configure <agent-name>` — see [Rotating the gateway token](#rotating-the-gateway-token)) to mint a fresh token aligned with the rebuilt daemon state.
+`install.py preserved_gateway` carries `config.gateway.auth` across reinstalls so this is rare. If it happens, run `clm agent configure <agent-name>` — every configure unconditionally re-pairs (see [Gateway token lifecycle](#gateway-token-lifecycle)) and brings `hosts.json` into agreement with the rebuilt daemon state.
 
 </details>
 

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -117,10 +117,39 @@ def ps(
     status_command(host=host)
 
 
-def _print_configure_warnings(_stage: str, message: str) -> None:
+def _print_configure_warnings(stage: str, message: str) -> None:
     """on_event callback for configure_agent that surfaces WARNING-prefixed
-    messages to the terminal so silent lifecycle gaps (e.g. an integration
-    with an unknown type) become visible during `clm agent configure`."""
+    messages and structured lifecycle events to the terminal so silent
+    lifecycle gaps (e.g. an integration with an unknown type, or an
+    operator-visible token rotation) become visible during `clm agent
+    configure`/`sync`/`restart`."""
+    if stage == "gateway_token_rotated":
+        # Issue #437: structured rotation event. Payload is JSON with
+        # agent_key + old/new token prefixes + reason. Decode best-effort
+        # — a malformed payload still surfaces, just without the agent
+        # name.
+        agent_label: str | None = None
+        try:
+            payload = json.loads(message)
+            if isinstance(payload, dict):
+                raw_key = payload.get("agent_key")
+                if isinstance(raw_key, str) and raw_key:
+                    agent_label = raw_key
+        except (json.JSONDecodeError, TypeError):
+            pass
+        if agent_label:
+            console.print(
+                f"  [yellow]Gateway token rotated for "
+                f"{rich_escape(agent_label)}. Active chat sessions on "
+                f"other machines will need to reconnect.[/yellow]"
+            )
+        else:
+            console.print(
+                "  [yellow]Gateway token rotated. Active chat sessions on "
+                "other machines will need to reconnect.[/yellow]"
+            )
+        return
+
     if message.startswith("WARNING:"):
         # Escape `message` before embedding in a Rich markup span — the
         # lifecycle warning interpolates `integration_type` from

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -2343,6 +2343,8 @@ def start(
                 console.print(f"  [dim]{message}[/dim]")
             elif stage == "start":
                 console.print(f"  {message}")
+            elif stage == "gateway_token_rotated":
+                _print_configure_warnings(stage, message)
 
         try:
             if installed_name in host_data.get("agents", {}):
@@ -2476,6 +2478,11 @@ def restart(
         def on_event(stage: str, message: str) -> None:
             if stage in ("validate", "restart"):
                 console.print(f"  [dim]{message}[/dim]")
+            elif stage == "gateway_token_rotated":
+                # ATX W3: route structured rotation events through the
+                # shared renderer so the operator sees the yellow notice
+                # documented in AGENTS.md instead of raw JSON.
+                _print_configure_warnings(stage, message)
             else:
                 console.print(f"  {message}")
 
@@ -2552,6 +2559,10 @@ def sync(
             # configure stage gets dim, sync stage gets normal
             if stage == "configure":
                 console.print(f"  [dim]{message}[/dim]")
+            elif stage == "gateway_token_rotated":
+                # ATX W3: structured rotation events get the yellow
+                # notice from the shared renderer, not raw JSON.
+                _print_configure_warnings(stage, message)
             else:
                 console.print(f"  {message}")
 
@@ -2568,13 +2579,13 @@ def sync(
             raise typer.Exit(code=1)
 
         if result["success"]:
-            if workspace:
-                console.print("[green]✓[/green] Workspace synced (no restart)")
-            else:
-                console.print(
-                    "[green]✓[/green] Configuration synced and agent restarted"
-                )
-                console.print("  Run 'clm agent ps' to check status")
+            # Issue #437 / ATX W9: sync no longer orchestrates a restart;
+            # the daemon-side restart fires via the configure playbook's
+            # notify handler only when config.toml or the systemd
+            # drop-in actually changed. Drop the misleading "agent
+            # restarted" string.
+            console.print("[green]✓[/green] Configuration synced")
+            console.print("  Run 'clm agent ps' to check status")
         else:
             console.print(f"[red]✗[/red] Failed to sync agent: {result['error']}")
             raise typer.Exit(code=1)

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -2278,7 +2278,10 @@ def remove(
         if result["success"]:
             console.print("[green]✓[/green] Agent removed successfully")
         else:
-            console.print(f"[red]✗[/red] Failed to remove agent: {result['error']}")
+            console.print(
+                f"[red]✗[/red] Failed to remove agent: "
+                f"{rich_escape(result['error'] or '')}"
+            )
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
@@ -2370,7 +2373,10 @@ def start(
             console.print("[green]✓[/green] Agent started successfully")
             console.print("  Run 'clm agent ps' to check status")
         else:
-            console.print(f"[red]✗[/red] Failed to start agent: {result['error']}")
+            console.print(
+                f"[red]✗[/red] Failed to start agent: "
+                f"{rich_escape(result['error'] or '')}"
+            )
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
@@ -2439,7 +2445,10 @@ def stop(
         if result["success"]:
             console.print("[green]✓[/green] Agent stopped successfully")
         else:
-            console.print(f"[red]✗[/red] Failed to stop agent: {result['error']}")
+            console.print(
+                f"[red]✗[/red] Failed to stop agent: "
+                f"{rich_escape(result['error'] or '')}"
+            )
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
@@ -2504,7 +2513,10 @@ def restart(
             console.print("[green]✓[/green] Agent restarted successfully")
             console.print("  Run 'clm agent ps' to check status")
         else:
-            console.print(f"[red]✗[/red] Failed to restart agent: {result['error']}")
+            console.print(
+                f"[red]✗[/red] Failed to restart agent: "
+                f"{rich_escape(result['error'] or '')}"
+            )
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
@@ -2587,7 +2599,10 @@ def sync(
             console.print("[green]✓[/green] Configuration synced")
             console.print("  Run 'clm agent ps' to check status")
         else:
-            console.print(f"[red]✗[/red] Failed to sync agent: {result['error']}")
+            console.print(
+                f"[red]✗[/red] Failed to sync agent: "
+                f"{rich_escape(result['error'] or '')}"
+            )
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -207,6 +207,12 @@ def chat(
                     chat_type=chat_type,
                 )
             )
+            if attempted_reconnect:
+                # ATX W7: only confirm success after the retry actually
+                # succeeded (no further auth error during the inner loop).
+                console.print(
+                    "[dim]Gateway token rotated; reconnected.[/dim]"
+                )
             break
         except ChatAuthenticationError as exc:
             # Issue #437: zeroclaw lifecycle ops always rotate the bearer.
@@ -225,8 +231,11 @@ def chat(
                 if reloaded_backend is not None:
                     backend = reloaded_backend
                     attempted_reconnect = True
+                    # ATX W7: tentative — the second asyncio.run might
+                    # also raise. Promote to the documented confirmation
+                    # only after the retry actually breaks the loop.
                     console.print(
-                        "[dim]Gateway token rotated; reconnected.[/dim]"
+                        "[dim]Gateway token rotated — retrying...[/dim]"
                     )
                     continue
             console.print(

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -195,102 +195,125 @@ def chat(
     else:
         console.print("Type /exit or press Ctrl+D to end the chat session.")
 
-    try:
-        asyncio.run(
-            _chat_loop(
-                backend=backend,
-                session_key=session,
-                response_timeout_seconds=timeout,
-                idle_timeout_seconds=idle_timeout,
-                chat_type=chat_type,
+    attempted_reconnect = False
+    while True:
+        try:
+            asyncio.run(
+                _chat_loop(
+                    backend=backend,
+                    session_key=session,
+                    response_timeout_seconds=timeout,
+                    idle_timeout_seconds=idle_timeout,
+                    chat_type=chat_type,
+                )
             )
-        )
-    except ChatAuthenticationError as exc:
-        console.print(
-            f"[red]Authentication failed:[/red] {rich_escape(_sanitize_exception_text(exc))}"
-        )
-        if chat_type in ("openai", "zeroclaw"):
-            console.print(
-                f"Token mismatch. Re-run 'clm agent configure {rich_escape(str(canonical_name))}'."
-            )
-        raise typer.Exit(code=1)
-    except ChatConnectionError as exc:
-        console.print(
-            f"[red]Connection failed:[/red] {rich_escape(_sanitize_exception_text(exc))}"
-        )
-        if chat_type == "openai":
-            # The backend uses two distinct ChatConnectionError messages:
-            # - "Failed to reach hermes at <url>" for connect-refused / DNS
-            # - "Timed out waiting for hermes response after Ns" for timeouts
-            # A genuine timeout means the service is up but slow; the right
-            # remediation is `--timeout`, not `systemctl`.
-            if str(exc).startswith("Timed out"):
-                console.print(
-                    f"Try a higher --timeout value (current: {timeout}s)."
+            break
+        except ChatAuthenticationError as exc:
+            # Issue #437: zeroclaw lifecycle ops always rotate the bearer.
+            # If a sync/restart/configure rotated the token in another
+            # shell while this session was open, the in-memory bearer is
+            # stale. Reload hosts.json once; if the on-disk bearer
+            # differs, rebuild the backend with the fresh token and
+            # resume. Identical bearer ⇒ genuine pairing failure, fall
+            # through to the existing error path.
+            if chat_type == "zeroclaw" and not attempted_reconnect:
+                reloaded_backend = _try_reload_zeroclaw_bearer(
+                    agent_name=agent_name,
+                    current_bearer=_current_bearer_for_backend(backend),
+                    response_timeout_seconds=timeout,
                 )
-            else:
-                console.print(
-                    f"Check 'systemctl --user status hermes-{rich_escape(str(canonical_name))}' on the agent host."
-                )
-                # Legacy install hint: persisted bind still on loopback means the
-                # opportunistic 127.0.0.1 → 0.0.0.0 migration in lifecycle hasn't
-                # run for this agent yet. Re-running configure flips it.
-                api_server = (
-                    agent_record.get("config", {}).get("api_server")
-                    if isinstance(agent_record.get("config"), dict)
-                    else None
-                )
-                if (
-                    isinstance(api_server, dict)
-                    and api_server.get("host") == "127.0.0.1"
-                ):
+                if reloaded_backend is not None:
+                    backend = reloaded_backend
+                    attempted_reconnect = True
                     console.print(
-                        f"Legacy bind detected (127.0.0.1). "
-                        f"Re-run 'clm agent configure {rich_escape(str(canonical_name))}' "
-                        f"to bind a reachable interface."
+                        "[dim]Gateway token rotated; reconnected.[/dim]"
                     )
-        elif chat_type == "zeroclaw":
-            # ATX Round 1 W6 / Round 2 W8: distinguish three connection
-            # failure modes. `chat_zeroclaw.py` emits three word-stable
-            # ChatConnectionError messages:
-            #
-            #   "Timed out connecting to ZeroClaw gateway at <url>"
-            #       -> TCP handshake never completed; firewall / wrong
-            #          port / host down. A higher --timeout won't help
-            #          because the connect path doesn't honor request
-            #          timeout. Route to a reachability hint.
-            #
-            #   "Timed out waiting for ZeroClaw response after Ns"
-            #       -> Connection succeeded but the agent is slow.
-            #          Route to the --timeout hint.
-            #
-            #   "Failed to reach ZeroClaw gateway at <url>: <reason>"
-            #       -> Connect failed immediately (OSError). Same as
-            #          connect-timeout: reachability hint.
-            # ATX Round 3 W2: use the shared constant exported by the
-            # zeroclaw backend so reworded exception messages can't
-            # silently misroute the hint.
-            msg = str(exc)
-            if msg.startswith(ZEROCLAW_RECV_TIMEOUT_MSG_PREFIX):
+                    continue
+            console.print(
+                f"[red]Authentication failed:[/red] {rich_escape(_sanitize_exception_text(exc))}"
+            )
+            if chat_type in ("openai", "zeroclaw"):
                 console.print(
-                    f"Try a higher --timeout value (current: {timeout}s)."
+                    f"Token mismatch. Re-run 'clm agent configure {rich_escape(str(canonical_name))}'."
                 )
+            raise typer.Exit(code=1)
+        except ChatConnectionError as exc:
+            console.print(
+                f"[red]Connection failed:[/red] {rich_escape(_sanitize_exception_text(exc))}"
+            )
+            if chat_type == "openai":
+                # The backend uses two distinct ChatConnectionError messages:
+                # - "Failed to reach hermes at <url>" for connect-refused / DNS
+                # - "Timed out waiting for hermes response after Ns" for timeouts
+                # A genuine timeout means the service is up but slow; the right
+                # remediation is `--timeout`, not `systemctl`.
+                if str(exc).startswith("Timed out"):
+                    console.print(
+                        f"Try a higher --timeout value (current: {timeout}s)."
+                    )
+                else:
+                    console.print(
+                        f"Check 'systemctl --user status hermes-{rich_escape(str(canonical_name))}' on the agent host."
+                    )
+                    # Legacy install hint: persisted bind still on loopback means the
+                    # opportunistic 127.0.0.1 → 0.0.0.0 migration in lifecycle hasn't
+                    # run for this agent yet. Re-running configure flips it.
+                    api_server = (
+                        agent_record.get("config", {}).get("api_server")
+                        if isinstance(agent_record.get("config"), dict)
+                        else None
+                    )
+                    if (
+                        isinstance(api_server, dict)
+                        and api_server.get("host") == "127.0.0.1"
+                    ):
+                        console.print(
+                            f"Legacy bind detected (127.0.0.1). "
+                            f"Re-run 'clm agent configure {rich_escape(str(canonical_name))}' "
+                            f"to bind a reachable interface."
+                        )
+            elif chat_type == "zeroclaw":
+                # ATX Round 1 W6 / Round 2 W8: distinguish three connection
+                # failure modes. `chat_zeroclaw.py` emits three word-stable
+                # ChatConnectionError messages:
+                #
+                #   "Timed out connecting to ZeroClaw gateway at <url>"
+                #       -> TCP handshake never completed; firewall / wrong
+                #          port / host down. A higher --timeout won't help
+                #          because the connect path doesn't honor request
+                #          timeout. Route to a reachability hint.
+                #
+                #   "Timed out waiting for ZeroClaw response after Ns"
+                #       -> Connection succeeded but the agent is slow.
+                #          Route to the --timeout hint.
+                #
+                #   "Failed to reach ZeroClaw gateway at <url>: <reason>"
+                #       -> Connect failed immediately (OSError). Same as
+                #          connect-timeout: reachability hint.
+                # ATX Round 3 W2: use the shared constant exported by the
+                # zeroclaw backend so reworded exception messages can't
+                # silently misroute the hint.
+                msg = str(exc)
+                if msg.startswith(ZEROCLAW_RECV_TIMEOUT_MSG_PREFIX):
+                    console.print(
+                        f"Try a higher --timeout value (current: {timeout}s)."
+                    )
+                else:
+                    console.print(
+                        f"Verify the agent host is reachable and re-run "
+                        f"'clm agent configure {rich_escape(str(canonical_name))}' "
+                        f"if the pairing token is stale."
+                    )
             else:
                 console.print(
-                    f"Verify the agent host is reachable and re-run "
-                    f"'clm agent configure {rich_escape(str(canonical_name))}' "
-                    f"if the pairing token is stale."
+                    "Verify the host is online and the recorded gateway URL/token are current (re-run configure/install if needed)."
                 )
-        else:
+            raise typer.Exit(code=1)
+        except ChatProtocolError as exc:
             console.print(
-                "Verify the host is online and the recorded gateway URL/token are current (re-run configure/install if needed)."
+                f"[red]Protocol error:[/red] {rich_escape(_sanitize_exception_text(exc))}"
             )
-        raise typer.Exit(code=1)
-    except ChatProtocolError as exc:
-        console.print(
-            f"[red]Protocol error:[/red] {rich_escape(_sanitize_exception_text(exc))}"
-        )
-        raise typer.Exit(code=1)
+            raise typer.Exit(code=1)
 
 
 async def _chat_loop(
@@ -471,6 +494,66 @@ def _build_openclaw_backend(
         device_private_key=gateway.get("device_private_key"),
         timeout_seconds=response_timeout_seconds,
     )
+
+
+def _current_bearer_for_backend(backend: ChatBackend) -> str | None:
+    """Return the bearer the backend will send on its next request.
+
+    Reads `_auth_token` (the SecretStr field both OpenClaw and ZeroClaw
+    backends use). Returns None if the backend type doesn't expose one;
+    callers treat None as "cannot compare" and skip the reconnect path.
+    """
+    auth = getattr(backend, "_auth_token", None)
+    if auth is None:
+        return None
+    # SecretStr exposes get_secret_value()
+    getter = getattr(auth, "get_secret_value", None)
+    if callable(getter):
+        try:
+            return getter()
+        except Exception:
+            return None
+    return None
+
+
+def _try_reload_zeroclaw_bearer(
+    agent_name: str,
+    current_bearer: str | None,
+    response_timeout_seconds: float,
+) -> ChatBackend | None:
+    """Reload hosts.json for a zeroclaw agent and rebuild the backend if
+    the on-disk bearer differs from `current_bearer`.
+
+    Returns a fresh ChatBackend when reconnect should proceed, or None
+    when the on-disk bearer matches (genuine pairing failure) or the
+    reload itself failed (treat as "cannot transparently recover").
+    """
+    if current_bearer is None:
+        return None
+    try:
+        resolved = get_agent_by_name(agent_name)
+    except (HostsFileCorruptedError, ValueError):
+        return None
+    if not resolved:
+        return None
+    host_record, _agent_type, agent_record = resolved
+    disk_bearer = (
+        agent_record.get("config", {}).get("gateway", {}).get("auth")
+        if isinstance(agent_record.get("config"), dict)
+        else None
+    )
+    if not isinstance(disk_bearer, str) or not disk_bearer.strip():
+        return None
+    if disk_bearer == current_bearer:
+        return None
+    try:
+        return _build_zeroclaw_backend(
+            agent_record=agent_record,
+            host_record=host_record,
+            response_timeout_seconds=response_timeout_seconds,
+        )
+    except ValueError:
+        return None
 
 
 def _build_zeroclaw_backend(

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -64,6 +64,45 @@ ALIAS_TO_CANONICAL = {
 }
 
 
+def _token_prefix(token: str | None) -> str:
+    """Return first 8 chars of a token for logging; "" if absent."""
+    if not isinstance(token, str):
+        return ""
+    return token.strip()[:8]
+
+
+def _emit_gateway_token_rotated(
+    on_event: Callable[[str, str], None] | None,
+    agent_key: str,
+    old_token: str | None,
+    new_token: str | None,
+    reason: str,
+) -> None:
+    """Emit a structured `gateway_token_rotated` event.
+
+    Issue #437: single emit site whenever any lifecycle op writes a new
+    value to hosts.json.gateway.auth. Suppressed on first mint (no prior
+    token) because that's an install, not a rotation.
+    """
+    if not isinstance(new_token, str) or not new_token.strip():
+        return
+    old_clean = old_token.strip() if isinstance(old_token, str) else ""
+    new_clean = new_token.strip()
+    if not old_clean or old_clean == new_clean:
+        return
+    payload = json.dumps(
+        {
+            "agent_key": agent_key,
+            "old_token_prefix": _token_prefix(old_clean),
+            "new_token_prefix": _token_prefix(new_clean),
+            "reason": reason,
+        }
+    )
+    if on_event is not None:
+        on_event("gateway_token_rotated", payload)
+    logger.info("gateway_token_rotated %s", payload)
+
+
 def get_host_private_key(key_id: str) -> Path | None:
     """Resolve host SSH key path.
 
@@ -530,7 +569,213 @@ def restart_agent(
     )
     start_result["operation"] = "restart"
 
+    # Issue #437: zeroclaw daemon does not persist its bearer across
+    # systemd restarts. The just-restarted daemon will mint a fresh token
+    # on the next pair handshake. Re-pair now and overwrite hosts.json so
+    # the operator-visible invariant ("hosts.json.gateway.auth equals the
+    # bearer the daemon will enforce") holds across restarts.
+    if start_result["success"] and _resolve_agent_type(claw_name) == "zeroclaw":
+        repair_success, repair_error = _zeroclaw_repair_after_restart(
+            hostname,
+            agent_name=agent_name,
+            on_event=on_event,
+        )
+        if not repair_success:
+            return {
+                "success": False,
+                "agent": target,
+                "host": hostname,
+                "operation": "restart",
+                "pid": start_result.get("pid"),
+                "started_at": start_result.get("started_at"),
+                "error": f"Re-pair after restart failed: {repair_error}",
+            }
+
     return start_result
+
+
+def _extract_zeroclaw_gateway_facts(
+    artifacts_dir: Path,
+) -> tuple[str | None, str | None]:
+    """Read `zeroclaw_gateway_token` and `zeroclaw_gateway_url` out of an
+    ansible-runner fact_cache directory.
+
+    Returns (token, url); either may be None if the playbook did not emit
+    the fact (e.g. it failed before reaching the set_fact task).
+    """
+    fact_cache_dir = artifacts_dir / "fact_cache"
+    if not fact_cache_dir.exists():
+        return None, None
+
+    for fact_file in fact_cache_dir.glob("*"):
+        try:
+            with open(fact_file) as fh:
+                facts = json.load(fh)
+        except (json.JSONDecodeError, IOError) as exc:
+            logger.debug("Skipping fact file %s: %s", fact_file, exc)
+            continue
+        payload = facts.get("__payload__")
+        if not isinstance(payload, str) or not payload:
+            continue
+        try:
+            parsed = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+
+        token_raw = parsed.get("zeroclaw_gateway_token")
+        url_raw = parsed.get("zeroclaw_gateway_url")
+        if isinstance(token_raw, dict):
+            token_raw = token_raw.get("value")
+        if isinstance(url_raw, dict):
+            url_raw = url_raw.get("value")
+        if isinstance(token_raw, str):
+            token_raw = token_raw.strip()
+        if isinstance(url_raw, str):
+            url_raw = url_raw.strip()
+        if token_raw and url_raw:
+            return token_raw, url_raw
+    return None, None
+
+
+def _zeroclaw_repair_after_restart(
+    hostname: str,
+    agent_name: str | None,
+    on_event: Callable[[str, str], None] | None,
+) -> tuple[bool, str | None]:
+    """Run the zeroclaw restart playbook to re-pair and persist the new
+    bearer to hosts.json.
+
+    Returns (success, error_message). Emits a `gateway_token_rotated`
+    event with reason="restart" when the token actually changed.
+    """
+
+    def emit(stage: str, message: str) -> None:
+        if on_event:
+            on_event(stage, message)
+        logger.info("[%s] %s", stage, message)
+
+    host = get_host(hostname)
+    if not host:
+        return False, f"Host '{hostname}' not found"
+
+    target = agent_name or "zeroclaw"
+    resolved = _resolve_agent_record(host, target, expected_type="zeroclaw")
+    if not resolved:
+        return False, f"Agent '{target}' not installed on '{hostname}'"
+    agent_key, _agent_type, agent_record = resolved
+    unix_agent_name = agent_record.get("agent_name") or agent_key
+
+    gateway_cfg = agent_record.get("config", {}).get("gateway") or {}
+    gateway_port = gateway_cfg.get("port")
+    if not isinstance(gateway_port, int) or gateway_port <= 0:
+        return (
+            False,
+            f"Gateway port missing from hosts.json for {agent_key}. "
+            f"Re-run `clm agent configure {agent_key}`.",
+        )
+
+    key_id = host.get("key_id") or hostname
+    ssh_key = get_host_private_key(key_id)
+    if not ssh_key:
+        return False, "SSH key not found"
+
+    playbook_path = _get_lifecycle_playbook_path("zeroclaw", "restart")
+    if not playbook_path.exists():
+        return False, f"Restart playbook not found: {playbook_path}"
+
+    inventory = {
+        "all": {
+            "hosts": {
+                host["hostname"]: {
+                    "ansible_user": host.get("user", "xclm"),
+                    "ansible_port": host.get("port", 22),
+                    "ansible_ssh_private_key_file": str(ssh_key),
+                }
+            },
+            "vars": {
+                "agent_name": unix_agent_name,
+                "agent_type": "zeroclaw",
+                "config": {"gateway": {"port": gateway_port}},
+            },
+        }
+    }
+
+    logs_dir = _get_logs_dir()
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    host_display = host.get("alias") or host.get("key_id") or hostname
+    operation_log_dir = (
+        logs_dir / f"restart-pair-zeroclaw-{host_display}-{timestamp}"
+    )
+    operation_log_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(operation_log_dir, 0o700)
+
+    emit("restart", "Re-pairing zeroclaw after restart...")
+
+    try:
+        result = ansible_runner.run(
+            private_data_dir=str(operation_log_dir),
+            inventory=inventory,
+            playbook=str(playbook_path),
+            quiet=True,
+            timeout=180,
+        )
+
+        if result.status == "timeout":
+            return False, "Re-pair after restart timed out"
+        if result.status != "successful":
+            error_msg = f"Re-pair playbook failed: {result.status}"
+            for event in result.events:
+                if event.get("event") == "runner_on_failed":
+                    event_data = event.get("event_data", {})
+                    res = event_data.get("res", {})
+                    if "msg" in res:
+                        error_msg = res["msg"]
+                        break
+                    if "stderr" in res:
+                        error_msg = res["stderr"]
+                        break
+            return False, error_msg
+
+        artifacts_dir = Path(result.config.artifact_dir)
+        new_token, new_url = _extract_zeroclaw_gateway_facts(artifacts_dir)
+        if not new_token or not new_url:
+            return (
+                False,
+                "Re-pair playbook succeeded but pairing token was not "
+                f"captured. Re-run `clm agent configure {agent_key}` and "
+                f"check `journalctl --unit zeroclaw-{agent_key}`.",
+            )
+
+        old_token = agent_record.get("config", {}).get("gateway", {}).get("auth")
+
+        def updater(h: dict) -> dict:
+            agents = h.setdefault("agents", {})
+            record = agents.setdefault(agent_key, {})
+            config = record.setdefault("config", {})
+            gateway = config.setdefault("gateway", {})
+            gateway["auth"] = new_token
+            gateway["url"] = new_url
+            return h
+
+        if not update_host(host["hostname"], updater):
+            return (
+                False,
+                f"Re-pair succeeded but failed to update hosts.json for "
+                f"{agent_key} on {hostname}",
+            )
+
+        _emit_gateway_token_rotated(
+            on_event, agent_key, old_token, new_token, "restart"
+        )
+        emit("restart", "Pairing token refreshed")
+        return True, None
+
+    except Exception as exc:
+        return False, str(exc)
+    finally:
+        _cleanup_ansible_artifacts(operation_log_dir)
 
 
 def sync_agent(
@@ -540,16 +785,20 @@ def sync_agent(
     workspace_only: bool = False,
     on_event: Callable[[str, str], None] | None = None,
 ) -> LifecycleResult:
-    """Sync configuration and optionally restart an agent instance.
+    """Sync configuration to an agent instance.
 
-    Orchestrates: configure_agent -> restart_agent (unless workspace_only).
-    This is a single command to ensure an agent is running the latest configuration.
+    Issue #437: sync now equals configure. The previous configure → restart
+    orchestration created token divergence on every sync because restart did
+    not re-pair. Now configure always re-pairs (and the playbook's
+    notify-driven restart fires whenever config.toml or the systemd drop-in
+    actually changed), so the explicit restart step is redundant and unsafe.
 
     Args:
         hostname: Hostname or alias of target host
         claw_name: Type of agent to sync (e.g., "openclaw")
         agent_name: Optional specific instance name
-        workspace_only: If True, only sync workspace files without restarting
+        workspace_only: Accepted for backwards compat; sync no longer
+            performs a separate restart, so the flag is informational
         on_event: Optional callback for progress events
 
     Returns:
@@ -564,7 +813,6 @@ def sync_agent(
     target = agent_name or claw_name
     emit("sync", f"Syncing {target} on {hostname}...")
 
-    # Validate host and agent exist
     host = get_host(hostname)
     if not host:
         raise LifecycleError(f"Host '{hostname}' not found")
@@ -574,8 +822,6 @@ def sync_agent(
         raise LifecycleError(f"Agent '{target}' not installed on '{hostname}'")
     agent_key, agent_type, claw_record = resolved
 
-    # Check onboarding state - agent must be past PENDING to sync
-    # This allows syncing during onboarding (e.g., after identity stage)
     onboarding = claw_record.get("onboarding", {})
     state_value = onboarding.get("state", "pending")
 
@@ -590,16 +836,6 @@ def sync_agent(
             f"Run 'clm agent configure {agent_key}' first."
         )
 
-    # Auto-coerce workspace_only=True for non-READY states
-    # start_agent() enforces state==READY, so restart would fail
-    if state != OnboardingState.READY and not workspace_only:
-        workspace_only = True
-        emit(
-            "sync",
-            f"Note: Agent not fully onboarded (state={state_value}), syncing workspace only",
-        )
-
-    # Get existing config to re-apply
     existing_config = claw_record.get("config", {})
     if not existing_config:
         raise LifecycleError(
@@ -607,7 +843,6 @@ def sync_agent(
             f"Run 'clm agent configure {agent_key}' first."
         )
 
-    # Step 1: Configure agent (sync config files)
     emit("sync", f"Configuring {agent_key}...")
     config_success, config_error = configure_agent(
         hostname,
@@ -615,6 +850,7 @@ def sync_agent(
         existing_config,
         agent_name=agent_key,
         on_event=on_event,
+        reason="sync",
     )
 
     if not config_success:
@@ -628,50 +864,6 @@ def sync_agent(
             "error": f"Configure failed: {config_error}",
         }
 
-    # Step 2: Restart agent (unless workspace_only)
-    if workspace_only:
-        emit("sync", f"Workspace sync complete for {agent_key} (no restart)")
-        return {
-            "success": True,
-            "agent": agent_key,
-            "host": hostname,
-            "operation": "sync",
-            "pid": None,
-            "started_at": None,
-            "error": None,
-        }
-
-    # Wrap in try/except to maintain LifecycleResult return contract
-    emit("sync", f"Restarting {agent_key}...")
-    try:
-        restart_result = restart_agent(
-            hostname,
-            agent_type,
-            agent_name=agent_key,
-            on_event=on_event,
-        )
-    except LifecycleError as e:
-        return {
-            "success": False,
-            "agent": agent_key,
-            "host": hostname,
-            "operation": "sync",
-            "pid": None,
-            "started_at": None,
-            "error": f"Restart failed: {e}",
-        }
-
-    if not restart_result["success"]:
-        return {
-            "success": False,
-            "agent": agent_key,
-            "host": hostname,
-            "operation": "sync",
-            "pid": None,
-            "started_at": None,
-            "error": f"Restart failed: {restart_result['error']}",
-        }
-
     emit("sync", f"Sync complete for {agent_key}")
 
     return {
@@ -679,8 +871,8 @@ def sync_agent(
         "agent": agent_key,
         "host": hostname,
         "operation": "sync",
-        "pid": restart_result.get("pid"),
-        "started_at": restart_result.get("started_at"),
+        "pid": None,
+        "started_at": None,
         "error": None,
     }
 
@@ -692,6 +884,7 @@ def configure_agent(
     agent_name: str | None = None,
     extra_vars: dict | None = None,
     on_event: Callable[[str, str], None] | None = None,
+    reason: str = "configure",
 ) -> tuple[bool, str | None]:
     """Configure an agent instance on a remote host.
 
@@ -1150,54 +1343,9 @@ def configure_agent(
         "integrations": integrations_data,
     }
 
-    # ZeroClaw idempotent re-configure (ATX Round 1 B3): pass any
-    # existing bearer token in via Ansible vars so the configure playbook
-    # can skip the pairing handshake when already paired. Without this
-    # every configure call would mint a fresh token and silently
-    # invalidate any in-flight `clm chat` WebSocket.
-    if resolved_type == "zeroclaw":
-        existing_gateway = agent_record.get("config", {}).get("gateway") or {}
-        existing_token = existing_gateway.get("auth")
-        # ATX Round 2 W5: keep the Python-side threshold consistent with
-        # the playbook's `length >= 16` check. A 1-15 char hand-edited
-        # token would otherwise be passed in but silently rejected by the
-        # playbook, causing an opaque re-pair.
-        if (
-            isinstance(existing_token, str)
-            and len(existing_token.strip()) >= 16
-        ):
-            ansible_vars["existing_gateway_token"] = existing_token.strip()
-        else:
-            # ATX Round 3 W5 / Round 4 B1: when a too-short token
-            # forces a re-pair, surface that explicitly so the operator
-            # can tell whether any live `clm chat` sessions are about
-            # to break. Suppressed when there is no token at all
-            # (first configure) — that's the normal mint path, not an
-            # unexpected re-pair.
-            #
-            # Must use the `WARNING:` prefix + stage="configure" pattern
-            # (mirrors the integration-type warning at lifecycle.py:1046)
-            # so cli/agent.py's `_print_configure_warnings` callback
-            # routes the message to the user. The callback dispatches
-            # on the `WARNING:` prefix; a `stage="warn"` event with a
-            # different prefix is silently dropped at the terminal.
-            if isinstance(existing_token, str) and existing_token.strip():
-                warning_msg = (
-                    f"WARNING: Existing gateway token for {agent_key} "
-                    f"is shorter than 16 characters — treating as "
-                    f"absent. A new pairing handshake will be performed "
-                    f"and any live `clm chat {agent_key}` session will "
-                    f"need to reconnect."
-                )
-                emit("configure", warning_msg)
-                logger.warning(warning_msg)
-            ansible_vars["existing_gateway_token"] = ""
-        # `force_repair` flows in via extra_vars when the CLI surfaces
-        # an explicit rotation flag; default false so normal reconfigures
-        # are idempotent. ATX Round 2 S1: direct assignment — `setdefault`
-        # on a freshly constructed dict reads as a guard that doesn't
-        # exist in practice.
-        ansible_vars["force_repair"] = False
+    # Issue #437: zeroclaw always re-pairs on configure. No skip path,
+    # no existing_gateway_token, no force_repair. The token in hosts.json
+    # is overwritten with whatever the playbook's pair handshake mints.
 
     # Merge extra_vars (not persisted to hosts.json)
     if extra_vars:
@@ -1387,6 +1535,20 @@ def configure_agent(
             existing_gateway["auth"] = zc_gateway_token
             existing_gateway["url"] = zc_gateway_url
             config_data["gateway"] = existing_gateway
+
+            # Issue #437: emit structured rotation event when the bearer
+            # in hosts.json is about to be overwritten with a different
+            # token. Suppressed on first-time mint (no prior token).
+            prior_token = (
+                agent_record.get("config", {}).get("gateway", {}).get("auth")
+            )
+            _emit_gateway_token_rotated(
+                on_event,
+                agent_key,
+                prior_token,
+                zc_gateway_token,
+                reason,
+            )
 
         # B2: Only update hosts.json after Ansible succeeds
         emit("configure", "Saving configuration to hosts.json...")

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -100,7 +100,13 @@ def _emit_gateway_token_rotated(
     )
     if on_event is not None:
         on_event("gateway_token_rotated", payload)
-    logger.info("gateway_token_rotated %s", payload)
+    # ATX W6: do NOT log the 8-char token prefixes — that's 50% of the
+    # 16-char minimum bearer secret and application logs may be shipped
+    # to centralized aggregators or readable by accounts without
+    # hosts.json access. Log only the audit-relevant fields.
+    logger.info(
+        "gateway_token_rotated agent=%s reason=%s", agent_key, reason
+    )
 
 
 def get_host_private_key(key_id: str) -> Path | None:
@@ -361,6 +367,7 @@ def start_agent(
     agent_name: str | None = None,
     force: bool = False,
     on_event: Callable[[str, str], None] | None = None,
+    repair_reason: str = "start",
 ) -> LifecycleResult:
     """Start an agent instance on a remote host.
 
@@ -435,6 +442,29 @@ def start_agent(
     )
 
     emit("start", f"Started {agent_key} successfully")
+
+    # Issue #437 / ATX W1: zeroclaw daemon does not persist bearer state
+    # across systemd starts. Always re-pair after a cold start so
+    # hosts.json.gateway.auth agrees with the token the daemon will
+    # enforce on the next request. restart_agent reuses this path via
+    # its stop -> start sequence (repair_reason="restart").
+    if _resolve_agent_type(claw_name) == "zeroclaw":
+        repair_success, repair_error = _zeroclaw_repair_after_start(
+            hostname,
+            agent_name=agent_name,
+            on_event=on_event,
+            reason=repair_reason,
+        )
+        if not repair_success:
+            return {
+                "success": False,
+                "agent": agent_key,
+                "host": hostname,
+                "operation": "start",
+                "pid": None,
+                "started_at": now,
+                "error": f"Re-pair after start failed: {repair_error}",
+            }
 
     return {
         "success": True,
@@ -564,33 +594,21 @@ def restart_agent(
             "error": f"Stop failed: {stop_result['error']}",
         }
 
+    # Issue #437: pass repair_reason="restart" so the structured rotation
+    # event identifies the originating op. start_agent re-pairs for
+    # zeroclaw on every cold start; restart inherits that for free.
     start_result = start_agent(
-        hostname, claw_name, agent_name=agent_name, on_event=on_event
+        hostname,
+        claw_name,
+        agent_name=agent_name,
+        on_event=on_event,
+        repair_reason="restart",
     )
     start_result["operation"] = "restart"
-
-    # Issue #437: zeroclaw daemon does not persist its bearer across
-    # systemd restarts. The just-restarted daemon will mint a fresh token
-    # on the next pair handshake. Re-pair now and overwrite hosts.json so
-    # the operator-visible invariant ("hosts.json.gateway.auth equals the
-    # bearer the daemon will enforce") holds across restarts.
-    if start_result["success"] and _resolve_agent_type(claw_name) == "zeroclaw":
-        repair_success, repair_error = _zeroclaw_repair_after_restart(
-            hostname,
-            agent_name=agent_name,
-            on_event=on_event,
+    if not start_result["success"] and start_result.get("error"):
+        start_result["error"] = start_result["error"].replace(
+            "Re-pair after start failed", "Re-pair after restart failed"
         )
-        if not repair_success:
-            return {
-                "success": False,
-                "agent": target,
-                "host": hostname,
-                "operation": "restart",
-                "pid": start_result.get("pid"),
-                "started_at": start_result.get("started_at"),
-                "error": f"Re-pair after restart failed: {repair_error}",
-            }
-
     return start_result
 
 
@@ -639,16 +657,19 @@ def _extract_zeroclaw_gateway_facts(
     return None, None
 
 
-def _zeroclaw_repair_after_restart(
+def _zeroclaw_repair_after_start(
     hostname: str,
     agent_name: str | None,
     on_event: Callable[[str, str], None] | None,
+    reason: str = "start",
 ) -> tuple[bool, str | None]:
     """Run the zeroclaw restart playbook to re-pair and persist the new
-    bearer to hosts.json.
+    bearer to hosts.json. Called from `start_agent` (and thus `restart_agent`,
+    which goes through start).
 
     Returns (success, error_message). Emits a `gateway_token_rotated`
-    event with reason="restart" when the token actually changed.
+    event with the given `reason` (default "start", "restart" when
+    invoked via restart_agent) only after the disk write succeeds.
     """
 
     def emit(stage: str, message: str) -> None:
@@ -666,6 +687,18 @@ def _zeroclaw_repair_after_restart(
         return False, f"Agent '{target}' not installed on '{hostname}'"
     agent_key, _agent_type, agent_record = resolved
     unix_agent_name = agent_record.get("agent_name") or agent_key
+
+    # ATX W4: parity with configure_agent's validation guard. Defends
+    # against future Ansible tasks that exec shell/command from
+    # agent_name; current pair.yaml uses only uri/fail/set_fact so this
+    # is preventative, not currently exploitable.
+    if not re.match(r"^[a-z][a-z0-9_-]{0,31}$", unix_agent_name):
+        return (
+            False,
+            f"Invalid agent_name format: '{unix_agent_name}'. Must start "
+            "with lowercase letter and contain only lowercase letters, "
+            "digits, hyphens, underscores (max 32 chars)",
+        )
 
     gateway_cfg = agent_record.get("config", {}).get("gateway") or {}
     gateway_port = gateway_cfg.get("port")
@@ -767,9 +800,9 @@ def _zeroclaw_repair_after_restart(
             )
 
         _emit_gateway_token_rotated(
-            on_event, agent_key, old_token, new_token, "restart"
+            on_event, agent_key, old_token, new_token, reason
         )
-        emit("restart", "Pairing token refreshed")
+        emit(reason, "Pairing token refreshed")
         return True, None
 
     except Exception as exc:
@@ -1427,6 +1460,7 @@ def configure_agent(
         # corrupting hosts.json silently.
         zc_gateway_token: str | None = None
         zc_gateway_url: str | None = None
+        prior_zc_token: str | None = None
         if resolved_type == "zeroclaw":
             try:
                 artifacts_dir = Path(result.config.artifact_dir)
@@ -1536,18 +1570,13 @@ def configure_agent(
             existing_gateway["url"] = zc_gateway_url
             config_data["gateway"] = existing_gateway
 
-            # Issue #437: emit structured rotation event when the bearer
-            # in hosts.json is about to be overwritten with a different
-            # token. Suppressed on first-time mint (no prior token).
-            prior_token = (
+            # Capture the prior token now; the rotation event is emitted
+            # AFTER `update_host` succeeds below (ATX W2 — emitting before
+            # the write means a failed write would still surface the
+            # yellow "rotated" notice while hosts.json still holds the
+            # old bearer, contradicting the invariant).
+            prior_zc_token = (
                 agent_record.get("config", {}).get("gateway", {}).get("auth")
-            )
-            _emit_gateway_token_rotated(
-                on_event,
-                agent_key,
-                prior_token,
-                zc_gateway_token,
-                reason,
             )
 
         # B2: Only update hosts.json after Ansible succeeds
@@ -1633,6 +1662,17 @@ def configure_agent(
             return (
                 False,
                 f"Configuration applied but failed to update local state for {agent_key} on {hostname}",
+            )
+
+        # ATX W2: rotation event fires only after the disk write
+        # succeeded. Suppressed on first mint (prior token absent).
+        if resolved_type == "zeroclaw" and zc_gateway_token:
+            _emit_gateway_token_rotated(
+                on_event,
+                agent_key,
+                prior_zc_token,
+                zc_gateway_token,
+                reason,
             )
 
         emit("configure", f"Successfully configured {agent_key}")

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -141,6 +141,19 @@ def _get_logs_dir() -> Path:
     return logs_dir
 
 
+def _safe_host_display(host: dict, hostname: str) -> str:
+    """Return a filesystem-safe host display string for log dir naming.
+
+    ATX W-SEC-3: an alias like `../etc` or `my/box` would otherwise turn
+    the operation log directory into a traversal target. Substitute any
+    char outside `[A-Za-z0-9_.-]` with `_`. Empty / all-bad-char input
+    falls back to "host".
+    """
+    raw = host.get("alias") or host.get("key_id") or hostname or ""
+    sanitized = re.sub(r"[^A-Za-z0-9_.-]", "_", raw)
+    return sanitized or "host"
+
+
 def _cleanup_ansible_artifacts(operation_log_dir: Path) -> None:
     """Clean up ansible-runner artifacts that may contain secrets.
 
@@ -319,7 +332,7 @@ def _run_lifecycle_playbook(
 
     logs_dir = _get_logs_dir()
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    host_display = host.get("alias") or host.get("key_id") or hostname
+    host_display = _safe_host_display(host, hostname)
     operation_log_dir = (
         logs_dir / f"{operation}-{agent_type}-{host_display}-{timestamp}"
     )
@@ -441,17 +454,23 @@ def start_agent(
         },
     )
 
-    emit("start", f"Started {agent_key} successfully")
-
     # Issue #437 / ATX W1: zeroclaw daemon does not persist bearer state
     # across systemd starts. Always re-pair after a cold start so
     # hosts.json.gateway.auth agrees with the token the daemon will
     # enforce on the next request. restart_agent reuses this path via
     # its stop -> start sequence (repair_reason="restart").
     if _resolve_agent_type(claw_name) == "zeroclaw":
+        # ATX W-SEC-2: do NOT emit "Started successfully" until the
+        # repair completes. An operator who ctrl-C's between the success
+        # line and the silent-but-still-running repair would otherwise
+        # be left with a stale hosts.json bearer.
+        emit("start", f"Daemon started; pairing {agent_key}...")
+        # ATX W-NEW-2: pass the resolved agent_key, not the raw caller
+        # parameter, so the helper's _resolve_agent_record always sees a
+        # canonical instance key.
         repair_success, repair_error = _zeroclaw_repair_after_start(
             hostname,
-            agent_name=agent_name,
+            agent_name=agent_key,
             on_event=on_event,
             reason=repair_reason,
         )
@@ -465,6 +484,8 @@ def start_agent(
                 "started_at": now,
                 "error": f"Re-pair after start failed: {repair_error}",
             }
+
+    emit("start", f"Started {agent_key} successfully")
 
     return {
         "success": True,
@@ -737,14 +758,18 @@ def _zeroclaw_repair_after_start(
 
     logs_dir = _get_logs_dir()
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    host_display = host.get("alias") or host.get("key_id") or hostname
+    host_display = _safe_host_display(host, hostname)
     operation_log_dir = (
         logs_dir / f"restart-pair-zeroclaw-{host_display}-{timestamp}"
     )
     operation_log_dir.mkdir(parents=True, exist_ok=True)
     os.chmod(operation_log_dir, 0o700)
 
-    emit("restart", "Re-pairing zeroclaw after restart...")
+    # ATX W-NEW-1: stage uses the actual reason so the start/restart
+    # CLI handlers (which dispatch by stage name) render the progress
+    # line instead of silently swallowing a hardcoded "restart" stage
+    # during a "start" op.
+    emit(reason, f"Re-pairing zeroclaw after {reason}...")
 
     try:
         result = ansible_runner.run(
@@ -1400,7 +1425,7 @@ def configure_agent(
     # Set up logging
     logs_dir = _get_logs_dir()
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    host_display = host.get("alias") or host.get("key_id") or hostname
+    host_display = _safe_host_display(host, hostname)
     operation_log_dir = (
         logs_dir / f"configure-{resolved_type}-{host_display}-{timestamp}"
     )

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -146,12 +146,14 @@ def _safe_host_display(host: dict, hostname: str) -> str:
 
     ATX W-SEC-3: an alias like `../etc` or `my/box` would otherwise turn
     the operation log directory into a traversal target. Substitute any
-    char outside `[A-Za-z0-9_.-]` with `_`. Empty / all-bad-char input
-    falls back to "host".
+    char outside `[A-Za-z0-9_.-]` with `_`. Empty / all-bad-char (i.e.
+    sanitized to only `_`) input falls back to "host".
     """
     raw = host.get("alias") or host.get("key_id") or hostname or ""
     sanitized = re.sub(r"[^A-Za-z0-9_.-]", "_", raw)
-    return sanitized or "host"
+    if not sanitized or set(sanitized) == {"_"}:
+        return "host"
+    return sanitized
 
 
 def _cleanup_ansible_artifacts(operation_log_dir: Path) -> None:

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
@@ -251,124 +251,14 @@
           `clm agent configure {{ agent_name }}` if needed.
       when: health_probe.status == 401
 
-    # ATX B3: skip the pairing handshake when configure_agent already
-    # passed an existing bearer token from hosts.json. The persisted
-    # token remains valid across configure runs by default — rotate by
-    # clearing agents.<n>.config.gateway.auth in hosts.json and
-    # re-running configure (or passing force_repair=true as a playbook
-    # extra-var when scripting against ansible-runner directly). The
-    # token is echoed back as a cacheable fact so configure_agent's
-    # fact-extraction path always finds it (skip and mint paths emit
-    # the same fact).
-    #
-    # `existing_gateway_token` and `force_repair` are top-level Ansible
-    # vars passed in by configure_agent via extra_vars (see
-    # core/lifecycle.py `_zeroclaw_extra_vars`). They are `default('')` /
-    # `default(false)` so a fresh configure (no persisted token) takes
-    # the mint path automatically.
-    - name: Determine whether re-pairing is required
-      ansible.builtin.set_fact:
-        zeroclaw_needs_pairing: >-
-          {{ (force_repair | default(false) | bool)
-             or (existing_gateway_token | default('') | length < 16) }}
-
-    # Pairing handshake (mint path) — two-step:
-    #   1. GET /pair/code     -> daemon emits a one-shot pairing code
-    #   2. POST /pair {code:} -> daemon mints a bearer token bound to that code
-    # Both calls are loopback so the code/token never traverses the LAN.
-    # `no_log: true` on every step so the credentials never reach Ansible
-    # logs even at -vvv (ATX B4 + W8).
-    - name: Request pairing code
-      ansible.builtin.uri:
-        url: "{{ gateway_local_base }}/pair/code"
-        method: GET
-        status_code: 200
-        timeout: 10
-        return_content: yes
-      register: pair_code_response
-      no_log: true
-      when: zeroclaw_needs_pairing
-
-    # ATX Round 3 B_new1: do NOT set `no_log: true` on this fail task.
-    # The msg body is pure template-literal text (`agent_name`, `agent_type`
-    # — both safe to log) and contains the operator-facing rotation
-    # instructions. With `no_log: true`, Ansible would replace the msg
-    # with "the output has been hidden" and the operator would never see
-    # the recovery path at the exact moment they need it. The original
-    # ATX B4 concern (registered var from a `no_log: true` task leaking
-    # into logs) does not apply here because we never reference
-    # pair_code_response.json fields inside the msg.
-    - name: Validate pairing code shape
-      ansible.builtin.fail:
-        msg: >-
-          /pair/code did not return a usable pairing_code field. Rotate the
-          gateway token: clear
-          agents.{{ agent_name }}.config.gateway.auth in
-          ~/.config/clawrium/hosts.json, then re-run
-          `clm agent configure {{ agent_name }}`. See the ZeroClaw
-          docs section "Rotating the gateway token". Daemon logs:
-          `journalctl --unit {{ agent_type }}-{{ agent_name }}`.
-      when:
-        - zeroclaw_needs_pairing
-        - pair_code_response.json is not defined
-          or pair_code_response.json.pairing_code is not defined
-          or pair_code_response.json.pairing_code | length < 1
-
-    # ZeroClaw v0.7.5 expects the one-time code via the `X-Pairing-Code`
-    # HTTP header (per the daemon's startup banner), not a JSON body.
-    - name: Exchange pairing code for bearer token
-      ansible.builtin.uri:
-        url: "{{ gateway_local_base }}/pair"
-        method: POST
-        status_code: 200
-        timeout: 10
-        headers:
-          X-Pairing-Code: "{{ pair_code_response.json.pairing_code }}"
-        return_content: yes
-      register: pair_response
-      no_log: true
-      when: zeroclaw_needs_pairing
-
-    # ATX Round 3 B_new1: same rationale as the Validate-pairing-code
-    # task above — keep this fail visible. The msg never references
-    # `pair_response.json.token`; only `agent_name`/`agent_type`.
-    - name: Validate bearer token shape
-      ansible.builtin.fail:
-        msg: >-
-          /pair did not return a usable token. Rotate the gateway
-          token: clear agents.{{ agent_name }}.config.gateway.auth in
-          ~/.config/clawrium/hosts.json, then re-run
-          `clm agent configure {{ agent_name }}`. See the ZeroClaw
-          docs section "Rotating the gateway token". Daemon logs:
-          `journalctl --unit {{ agent_type }}-{{ agent_name }}`.
-      when:
-        - zeroclaw_needs_pairing
-        - pair_response.json is not defined
-          or pair_response.json.token is not defined
-          or pair_response.json.token | length < 16
-
-    # Resolve the final bearer-token value: freshly minted on the mint
-    # path, echoed-back from hosts.json on the skip path. Surfaced via a
-    # single set_fact below so the fact-emission task is identical for
-    # both branches.
-    - name: Resolve effective gateway bearer token
-      ansible.builtin.set_fact:
-        effective_gateway_token: >-
-          {{ pair_response.json.token if zeroclaw_needs_pairing
-             else existing_gateway_token }}
-      no_log: true
-
-    # Emit gateway token + URL as cacheable host facts. configure_agent()
-    # reads them out of artifacts/<run>/fact_cache and persists them to
-    # hosts.json under agents.<n>.config.gateway.{auth,url}. Mirrors the
-    # OpenClaw fact-emission pattern in install.py:307-316. `no_log: true`
-    # so the value isn't echoed at -vvv (ATX W8).
-    - name: Save gateway credentials as cacheable facts
-      ansible.builtin.set_fact:
-        zeroclaw_gateway_token: "{{ effective_gateway_token }}"
-        zeroclaw_gateway_url: "ws://{{ ansible_host }}:{{ gateway_port }}/ws/chat"
-        cacheable: true
-      no_log: true
+    # Always re-pair (issue #437). The daemon does not persist bearer
+    # state across restarts, so the only way to make hosts.json
+    # structurally agree with the daemon is to mint a fresh token on
+    # every configure run. The trade-off (in-flight `clm chat` sessions
+    # on other machines need to reconnect) is accepted in exchange for
+    # eliminating the silent divergence class entirely.
+    - name: Run zeroclaw pair handshake
+      ansible.builtin.include_tasks: tasks/pair.yaml
 
     # Discord-config verification (#422). Confirms the bot token + an
     # allowlist landed in config.toml when Discord is enabled. grep -q so
@@ -402,8 +292,7 @@
         msg: |
           ZeroClaw agent '{{ agent_name }}' configured with provider
           '{{ config.provider.type }}'.
-          Pairing: {{ 'fresh token minted' if zeroclaw_needs_pairing
-                      else 'existing token reused (clear agents.' ~ agent_name ~ '.config.gateway.auth in ~/.config/clawrium/hosts.json and re-run to rotate)' }}.
+          Pairing: fresh token minted (issue #437 — every lifecycle op re-pairs).
           Service: {{ agent_type }}-{{ agent_name }}.service (active)
 
   handlers:

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/restart.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/restart.yaml
@@ -13,8 +13,12 @@
 # startup, so the old token in hosts.json no longer matches whatever the
 # daemon will enforce).
 
+# ATX W-SEC-4: no `become: yes` — every task in this play (the
+# /health/providers probe + the included pair.yaml handshake) hits
+# loopback HTTP only. Privilege escalation here would broaden blast
+# radius for zero benefit; if a future task needs root, add `become`
+# at the task level (not the play level).
 - hosts: all
-  become: yes
   vars:
     gateway_port: "{{ config.gateway.port }}"
     gateway_local_base: "http://127.0.0.1:{{ gateway_port }}"

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/restart.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/restart.yaml
@@ -1,0 +1,35 @@
+---
+# Re-pair playbook for zeroclaw restart (issue #437).
+#
+# The systemd restart itself happens in start.yaml / stop.yaml (driven by
+# lifecycle.restart_agent's stop -> start path). This playbook runs *after*
+# the daemon is back up: it waits for /health/providers to respond, then
+# performs the pair handshake. The new bearer token is emitted as a
+# cacheable host fact so lifecycle.restart_agent can persist it to
+# hosts.json under agents.<n>.config.gateway.auth.
+#
+# Without this step, a `clm agent restart zeroclaw-…` would silently
+# invalidate hosts.json's bearer (the daemon mints a fresh token on
+# startup, so the old token in hosts.json no longer matches whatever the
+# daemon will enforce).
+
+- hosts: all
+  become: yes
+  vars:
+    gateway_port: "{{ config.gateway.port }}"
+    gateway_local_base: "http://127.0.0.1:{{ gateway_port }}"
+  tasks:
+    - name: Probe /health/providers
+      ansible.builtin.uri:
+        url: "{{ gateway_local_base }}/health/providers"
+        method: GET
+        status_code: [200, 401]
+        timeout: 5
+      register: health_probe
+      retries: 30
+      delay: 2
+      until: health_probe.status in [200, 401]
+      no_log: true
+
+    - name: Run zeroclaw pair handshake
+      ansible.builtin.include_tasks: tasks/pair.yaml

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/tasks/pair.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/tasks/pair.yaml
@@ -1,0 +1,82 @@
+---
+# Reusable pair-handshake task file (issue #437).
+#
+# Every lifecycle op that brings the zeroclaw daemon up MUST include this
+# file. There is no skip path. The daemon does not persist bearer state across
+# restarts, so the operator-visible invariant is "hosts.json.gateway.auth
+# equals the bearer the daemon will enforce on the next request" — and that
+# can only be guaranteed by always re-minting.
+#
+# Inputs:
+#   - gateway_local_base: http://127.0.0.1:<port> (set by including playbook)
+#   - ansible_host, gateway_port (used to emit zeroclaw_gateway_url fact)
+#   - agent_name, agent_type (used in failure messages)
+#
+# Outputs (cacheable host facts; configure_agent / restart_agent read these
+# out of artifacts/<run>/fact_cache):
+#   - zeroclaw_gateway_token: bearer token minted by /pair
+#   - zeroclaw_gateway_url:   ws://<host>:<port>/ws/chat
+
+- name: Request pairing code
+  ansible.builtin.uri:
+    url: "{{ gateway_local_base }}/pair/code"
+    method: GET
+    status_code: 200
+    timeout: 10
+    return_content: yes
+  register: pair_code_response
+  no_log: true
+
+# Do NOT set `no_log: true` on this fail task. The msg body is pure
+# template-literal text (`agent_name`, `agent_type` — both safe to log) and
+# contains the operator-facing rotation instructions. The original ATX B4
+# concern (registered var from a `no_log: true` task leaking into logs)
+# does not apply here because we never reference pair_code_response.json
+# fields inside the msg.
+- name: Validate pairing code shape
+  ansible.builtin.fail:
+    msg: >-
+      /pair/code did not return a usable pairing_code field. Daemon logs:
+      `journalctl --unit {{ agent_type }}-{{ agent_name }}`. Re-run
+      `clm agent configure {{ agent_name }}` after fixing the daemon.
+  when:
+    - pair_code_response.json is not defined
+      or pair_code_response.json.pairing_code is not defined
+      or pair_code_response.json.pairing_code | length < 1
+
+# ZeroClaw v0.7.5 expects the one-time code via the `X-Pairing-Code` HTTP
+# header (per the daemon's startup banner), not a JSON body.
+- name: Exchange pairing code for bearer token
+  ansible.builtin.uri:
+    url: "{{ gateway_local_base }}/pair"
+    method: POST
+    status_code: 200
+    timeout: 10
+    headers:
+      X-Pairing-Code: "{{ pair_code_response.json.pairing_code }}"
+    return_content: yes
+  register: pair_response
+  no_log: true
+
+- name: Validate bearer token shape
+  ansible.builtin.fail:
+    msg: >-
+      /pair did not return a usable token. Daemon logs:
+      `journalctl --unit {{ agent_type }}-{{ agent_name }}`. Re-run
+      `clm agent configure {{ agent_name }}` after fixing the daemon.
+  when:
+    - pair_response.json is not defined
+      or pair_response.json.token is not defined
+      or pair_response.json.token | length < 16
+
+# Emit gateway token + URL as cacheable host facts. The Python caller reads
+# them out of artifacts/<run>/fact_cache and persists them to hosts.json
+# under agents.<n>.config.gateway.{auth,url}. Mirrors the OpenClaw
+# fact-emission pattern in install.py:307-316. `no_log: true` so the value
+# isn't echoed at -vvv.
+- name: Save gateway credentials as cacheable facts
+  ansible.builtin.set_fact:
+    zeroclaw_gateway_token: "{{ pair_response.json.token }}"
+    zeroclaw_gateway_url: "ws://{{ ansible_host }}:{{ gateway_port }}/ws/chat"
+    cacheable: true
+  no_log: true

--- a/tests/test_cli_agent_lifecycle.py
+++ b/tests/test_cli_agent_lifecycle.py
@@ -416,28 +416,19 @@ class TestAgentSync:
         ]
         hosts_file.write_text(json.dumps(hosts_data, indent=2))
 
+        # Issue #437 / ATX W9: sync no longer calls restart_agent, so the
+        # dead restart_agent mock is removed and the success string drops
+        # the misleading "agent restarted" suffix.
         with patch(
             "clawrium.core.lifecycle.configure_agent",
             return_value=(True, None),
         ):
-            with patch(
-                "clawrium.core.lifecycle.restart_agent",
-                return_value={
-                    "success": True,
-                    "agent": "assistant",
-                    "host": "192.168.1.100",
-                    "operation": "restart",
-                    "pid": None,
-                    "started_at": "2026-04-14T12:00:00Z",
-                    "error": None,
-                },
-            ):
-                result = runner.invoke(app, ["agent", "sync", "assistant"])
+            result = runner.invoke(app, ["agent", "sync", "assistant"])
 
         assert result.exit_code == 0
         assert "Syncing agent" in result.output
-        # Updated success message
-        assert "Configuration synced and agent restarted" in result.output
+        assert "Configuration synced" in result.output
+        assert "agent restarted" not in result.output
 
     def test_sync_configure_failure(self, isolated_config: Path, tmp_path: Path):
         """Sync fails when configure step fails."""
@@ -569,11 +560,11 @@ class TestAgentSync:
                 )
 
         assert result.exit_code == 0
-        assert "Syncing workspace for" in result.output
-        assert "Workspace synced (no restart)" in result.output
-        # Configure should be called
+        # Issue #437: sync always reports "Configuration synced" now; the
+        # --workspace flag is preserved on the CLI surface but the
+        # output is the same since sync no longer orchestrates a restart.
+        assert "Configuration synced" in result.output
         mock_configure.assert_called_once()
-        # Restart should NOT be called
         mock_restart.assert_not_called()
 
     def test_sync_does_not_call_restart_agent(

--- a/tests/test_cli_agent_lifecycle.py
+++ b/tests/test_cli_agent_lifecycle.py
@@ -480,8 +480,11 @@ class TestAgentSync:
         assert "Failed to sync" in result.output
         assert "Configure failed" in result.output
 
-    def test_sync_restart_failure(self, isolated_config: Path, tmp_path: Path):
-        """Sync fails when restart step fails."""
+    def test_sync_configure_failure_after_always_repair(
+        self, isolated_config: Path, tmp_path: Path
+    ):
+        """Issue #437: sync no longer calls restart; failure paths now
+        come from configure (which performs the always-pair step)."""
         hosts_file = isolated_config / "hosts.json"
         isolated_config.mkdir(parents=True, exist_ok=True)
 
@@ -513,25 +516,13 @@ class TestAgentSync:
 
         with patch(
             "clawrium.core.lifecycle.configure_agent",
-            return_value=(True, None),
+            return_value=(False, "Configure error"),
         ):
-            with patch(
-                "clawrium.core.lifecycle.restart_agent",
-                return_value={
-                    "success": False,
-                    "agent": "assistant",
-                    "host": "192.168.1.100",
-                    "operation": "restart",
-                    "pid": None,
-                    "started_at": None,
-                    "error": "Restart error",
-                },
-            ):
-                result = runner.invoke(app, ["agent", "sync", "assistant"])
+            result = runner.invoke(app, ["agent", "sync", "assistant"])
 
         assert result.exit_code == 1
         assert "Failed to sync" in result.output
-        assert "Restart failed" in result.output
+        assert "Configure failed" in result.output
 
     def test_sync_with_workspace_flag_skips_restart(
         self, isolated_config: Path, tmp_path: Path
@@ -585,10 +576,12 @@ class TestAgentSync:
         # Restart should NOT be called
         mock_restart.assert_not_called()
 
-    def test_sync_without_workspace_flag_calls_restart(
+    def test_sync_does_not_call_restart_agent(
         self, isolated_config: Path, tmp_path: Path
     ):
-        """B4/B6 fix: Sync without --workspace flag calls restart_agent with correct args."""
+        """Issue #437: `clm agent sync` no longer orchestrates a
+        separate restart. configure handles re-pair + handler-driven
+        restart in one shot."""
         hosts_file = isolated_config / "hosts.json"
         isolated_config.mkdir(parents=True, exist_ok=True)
 
@@ -623,25 +616,10 @@ class TestAgentSync:
             return_value=(True, None),
         ) as mock_configure:
             with patch(
-                "clawrium.core.lifecycle.restart_agent",
-                return_value={
-                    "success": True,
-                    "agent": "assistant",
-                    "host": "192.168.1.100",
-                    "operation": "restart",
-                    "pid": None,
-                    "started_at": "2026-04-14T12:00:00Z",
-                    "error": None,
-                },
+                "clawrium.core.lifecycle.restart_agent"
             ) as mock_restart:
                 result = runner.invoke(app, ["agent", "sync", "assistant"])
 
         assert result.exit_code == 0
-        # Configure should be called
         mock_configure.assert_called_once()
-        # B6 fix: Verify restart_agent called with correct arguments
-        mock_restart.assert_called_once()
-        call_args = mock_restart.call_args
-        assert call_args.args[0] == "192.168.1.100"  # hostname
-        assert call_args.args[1] == "openclaw"  # agent_type
-        assert call_args.kwargs.get("agent_name") == "assistant"
+        mock_restart.assert_not_called()

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -447,6 +447,52 @@ def test_chat_zeroclaw_loop_guard_stops_on_second_401(monkeypatch):
     assert "Authentication failed" in result.output
 
 
+def test_chat_zeroclaw_treats_corrupted_hosts_as_genuine_401(monkeypatch):
+    """ATX W-COV-5: when reloading hosts.json during the 401 recovery
+    path raises HostsFileCorruptedError, treat the 401 as genuine —
+    surface 'Authentication failed' and exit 1, do not retry."""
+    host = {"hostname": "192.168.1.100", "alias": "server1"}
+    agent_initial = {
+        "agent_name": "zer-test",
+        "config": {
+            "gateway": {
+                "url": "ws://192.168.1.100:40123/ws/chat",
+                "auth": "stable-bearer-zzzzz",
+                "port": 40123,
+            }
+        },
+    }
+
+    call_log = {"count": 0}
+
+    def get_agent_by_name(_name: str):
+        call_log["count"] += 1
+        if call_log["count"] == 1:
+            return host, "zeroclaw", agent_initial
+        raise HostsFileCorruptedError("hosts.json malformed")
+
+    monkeypatch.setattr("clawrium.cli.chat.get_agent_by_name", get_agent_by_name)
+    monkeypatch.setattr(
+        "clawrium.cli.chat._resolve_chat_type", lambda _agent_type: "zeroclaw"
+    )
+
+    run_call_count = {"n": 0}
+
+    def fake_asyncio_run(coro):
+        coro.close()
+        run_call_count["n"] += 1
+        raise ChatAuthenticationError("401")
+
+    monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
+
+    result = runner.invoke(app, ["chat", "zer-test", "--idle-timeout", "0"])
+
+    assert result.exit_code == 1
+    # No retry — only the initial attempt.
+    assert run_call_count["n"] == 1
+    assert "Authentication failed" in result.output
+
+
 def test_chat_zeroclaw_does_not_reconnect_when_disk_bearer_unchanged(monkeypatch):
     """Issue #437: an authentic 401 (disk bearer matches in-memory) must
     surface the existing 'Authentication failed' error rather than

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -9,7 +9,7 @@ from typer.testing import CliRunner
 
 from clawrium.cli import chat as chat_module
 from clawrium.cli.main import app
-from clawrium.core.chat import ChatProtocolError
+from clawrium.core.chat import ChatAuthenticationError, ChatProtocolError
 from clawrium.core.hosts import HostsFileCorruptedError
 
 
@@ -320,6 +320,116 @@ def test_chat_invokes_async_loop(monkeypatch):
     assert called.get("called") is True
     assert called.get("response_timeout_seconds") == 30.0
     assert called.get("idle_timeout_seconds") == 0.0
+
+
+def test_chat_zeroclaw_reconnects_on_401_when_disk_bearer_rotated(monkeypatch):
+    """Issue #437: when ChatAuthenticationError fires and hosts.json has a
+    new bearer (e.g. another shell ran `clm agent sync`), the chat REPL
+    rebuilds the backend with the fresh token and resumes once."""
+    host = {"hostname": "192.168.1.100", "alias": "server1"}
+    agent_initial = {
+        "agent_name": "zer-test",
+        "config": {
+            "gateway": {
+                "url": "ws://192.168.1.100:40123/ws/chat",
+                "auth": "stale-bearer-token-zzzzz",
+                "port": 40123,
+            }
+        },
+    }
+    agent_rotated = {
+        "agent_name": "zer-test",
+        "config": {
+            "gateway": {
+                "url": "ws://192.168.1.100:40123/ws/chat",
+                "auth": "fresh-bearer-token-zzzzz",
+                "port": 40123,
+            }
+        },
+    }
+
+    # Sequence: first lookup returns the stale token (used to build the
+    # initial backend); the reload during 401 handling returns the
+    # rotated record. Use an iterator so each call advances.
+    call_log = {"count": 0}
+
+    def get_agent_by_name(_name: str):
+        call_log["count"] += 1
+        if call_log["count"] == 1:
+            return host, "zeroclaw", agent_initial
+        return host, "zeroclaw", agent_rotated
+
+    monkeypatch.setattr("clawrium.cli.chat.get_agent_by_name", get_agent_by_name)
+
+    # `_resolve_chat_type` reads from the manifest registry — short
+    # circuit by stubbing the manifest loader.
+    monkeypatch.setattr(
+        "clawrium.cli.chat._resolve_chat_type", lambda _agent_type: "zeroclaw"
+    )
+
+    run_call_count = {"n": 0}
+
+    def fake_asyncio_run(coro):
+        coro.close()
+        run_call_count["n"] += 1
+        if run_call_count["n"] == 1:
+            raise ChatAuthenticationError("401 gateway rejected the bearer")
+        # Second call: success path.
+        return None
+
+    monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
+
+    result = runner.invoke(
+        app,
+        ["chat", "zer-test", "--idle-timeout", "0"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert run_call_count["n"] == 2
+    assert "Gateway token rotated; reconnected." in result.output
+
+
+def test_chat_zeroclaw_does_not_reconnect_when_disk_bearer_unchanged(monkeypatch):
+    """Issue #437: an authentic 401 (disk bearer matches in-memory) must
+    surface the existing 'Authentication failed' error rather than
+    silently looping."""
+    host = {"hostname": "192.168.1.100", "alias": "server1"}
+    agent_record = {
+        "agent_name": "zer-test",
+        "config": {
+            "gateway": {
+                "url": "ws://192.168.1.100:40123/ws/chat",
+                "auth": "same-stale-bearer-zzzzz",
+                "port": 40123,
+            }
+        },
+    }
+    monkeypatch.setattr(
+        "clawrium.cli.chat.get_agent_by_name",
+        lambda _name: (host, "zeroclaw", agent_record),
+    )
+    monkeypatch.setattr(
+        "clawrium.cli.chat._resolve_chat_type", lambda _agent_type: "zeroclaw"
+    )
+
+    run_call_count = {"n": 0}
+
+    def fake_asyncio_run(coro):
+        coro.close()
+        run_call_count["n"] += 1
+        raise ChatAuthenticationError("401 gateway rejected the bearer")
+
+    monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
+
+    result = runner.invoke(
+        app,
+        ["chat", "zer-test", "--idle-timeout", "0"],
+    )
+
+    assert result.exit_code == 1
+    assert run_call_count["n"] == 1
+    assert "Authentication failed" in result.output
+    assert "Gateway token rotated; reconnected." not in result.output
 
 
 def test_chat_invokes_async_loop_with_default_timeouts(monkeypatch):

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -389,6 +389,64 @@ def test_chat_zeroclaw_reconnects_on_401_when_disk_bearer_rotated(monkeypatch):
     assert "Gateway token rotated; reconnected." in result.output
 
 
+def test_chat_zeroclaw_loop_guard_stops_on_second_401(monkeypatch):
+    """ATX B1: the `attempted_reconnect` flag must cap retries at one.
+    If the second `asyncio.run` also raises ChatAuthenticationError
+    (e.g. the freshly-rotated bearer was ALSO immediately rotated by a
+    third actor), exit with code 1 — do not try a third connect."""
+    host = {"hostname": "192.168.1.100", "alias": "server1"}
+    agent_v1 = {
+        "agent_name": "zer-test",
+        "config": {
+            "gateway": {
+                "url": "ws://192.168.1.100:40123/ws/chat",
+                "auth": "stale-bearer-v1-zzzzz",
+                "port": 40123,
+            }
+        },
+    }
+    agent_v2 = {
+        "agent_name": "zer-test",
+        "config": {
+            "gateway": {
+                "url": "ws://192.168.1.100:40123/ws/chat",
+                "auth": "still-rotates-v2-zzzzz",
+                "port": 40123,
+            }
+        },
+    }
+
+    call_log = {"count": 0}
+
+    def get_agent_by_name(_name: str):
+        call_log["count"] += 1
+        return host, "zeroclaw", agent_v1 if call_log["count"] == 1 else agent_v2
+
+    monkeypatch.setattr("clawrium.cli.chat.get_agent_by_name", get_agent_by_name)
+    monkeypatch.setattr(
+        "clawrium.cli.chat._resolve_chat_type", lambda _agent_type: "zeroclaw"
+    )
+
+    run_call_count = {"n": 0}
+
+    def fake_asyncio_run(coro):
+        coro.close()
+        run_call_count["n"] += 1
+        # Both attempts raise auth — emulates a token that keeps rotating
+        # under us. Loop-guard must prevent a third attempt.
+        raise ChatAuthenticationError("401")
+
+    monkeypatch.setattr("clawrium.cli.chat.asyncio.run", fake_asyncio_run)
+
+    result = runner.invoke(app, ["chat", "zer-test", "--idle-timeout", "0"])
+
+    # The CLI must exit 1, must have tried exactly 2 connects (initial
+    # + 1 reconnect, no third), and must surface the final auth error.
+    assert result.exit_code == 1
+    assert run_call_count["n"] == 2
+    assert "Authentication failed" in result.output
+
+
 def test_chat_zeroclaw_does_not_reconnect_when_disk_bearer_unchanged(monkeypatch):
     """Issue #437: an authentic 401 (disk bearer matches in-memory) must
     surface the existing 'Authentication failed' error rather than

--- a/tests/test_configure_claw.py
+++ b/tests/test_configure_claw.py
@@ -794,16 +794,13 @@ class TestConfigureZeroclawFactExtraction:
         assert gateway["auth"] == "wrapped-bearer-token-xyz"
 
 
-class TestConfigureZeroclawIdempotentRepair:
-    """ATX Round 1 B3: re-running configure on an already-paired zeroclaw
-    must NOT re-pair (which would invalidate the live token). The
-    configure playbook receives `existing_gateway_token` from configure_agent
-    and skips the /pair/code → /pair handshake when it's non-empty."""
+class TestConfigureZeroclawAlwaysRepair:
+    """Issue #437: configure_agent for zeroclaw always mints a fresh
+    bearer. The previous idempotent-skip path is gone — `existing_gateway_token`
+    / `force_repair` are no longer plumbed through the inventory."""
 
-    def test_existing_token_passed_to_playbook_as_ansible_var(self, tmp_path: Path):
-        """Verify configure_agent forwards the persisted token into the
-        Ansible vars so the playbook can take its idempotent skip path."""
-        host = {
+    def _build_host_with_existing_token(self, token: str = "x" * 32) -> dict:
+        return {
             "hostname": "test-host",
             "key_id": "test",
             "agent_name": "xclm",
@@ -813,14 +810,16 @@ class TestConfigureZeroclawIdempotentRepair:
                     "type": "zeroclaw",
                     "config": {
                         "gateway": {
-                            "auth": "existing-paired-token-from-prior-configure",
+                            "auth": token,
                             "url": "ws://test-host:40000/ws/chat",
                         }
                     },
                 }
             },
         }
-        config_data = {
+
+    def _build_config(self) -> dict:
+        return {
             "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
             "provider": {
                 "name": "test-provider",
@@ -829,18 +828,20 @@ class TestConfigureZeroclawIdempotentRepair:
             },
         }
 
+    def _run_configure(self, host: dict, config_data: dict, tmp_path: Path,
+                       *, fact_token: str = "freshly-minted-token-1234567890",
+                       on_event=None, extra_vars=None):
         key_path = tmp_path / "key"
         key_path.write_text("key")
         playbook = tmp_path / "configure.yaml"
         playbook.write_text("---\n")
 
-        # Set up fact cache so fact extraction also succeeds.
         artifacts_dir = tmp_path / "artifacts"
         fact_cache_dir = artifacts_dir / "fact_cache"
         fact_cache_dir.mkdir(parents=True)
         (fact_cache_dir / "test-host").write_text(json.dumps({
             "__payload__": json.dumps({
-                "zeroclaw_gateway_token": "existing-paired-token-from-prior-configure",
+                "zeroclaw_gateway_token": fact_token,
                 "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
             }),
         }))
@@ -850,7 +851,7 @@ class TestConfigureZeroclawIdempotentRepair:
         mock_runner.events = []
         mock_runner.config.artifact_dir = str(artifacts_dir)
 
-        captured: dict[str, object] = {}
+        captured: dict = {}
 
         def capture_run(*, inventory, **_kwargs):
             captured["inventory"] = inventory
@@ -878,462 +879,82 @@ class TestConfigureZeroclawIdempotentRepair:
                                 return_value="",
                             ):
                                 success, error = configure_agent(
-                                    "test-host", "zeroclaw", config_data
-                                )
-
-        assert success is True, error
-        # The existing token is passed to the playbook so it can skip pairing.
-        ansible_vars = captured["inventory"]["all"]["vars"]
-        assert ansible_vars["existing_gateway_token"] == (
-            "existing-paired-token-from-prior-configure"
-        )
-        assert ansible_vars["force_repair"] is False
-
-    def test_force_repair_true_forwarded_to_playbook(self, tmp_path: Path):
-        """ATX Round 2 W7: explicit `force_repair=True` via `extra_vars`
-        must reach the playbook so the operator can rotate the bearer
-        token. Without this test, dropping the `update(extra_vars)` call
-        in configure_agent would silently neuter the rotation path."""
-        host = {
-            "hostname": "test-host",
-            "key_id": "test",
-            "agent_name": "xclm",
-            "port": 22,
-            "agents": {
-                "zer-test": {
-                    "type": "zeroclaw",
-                    "config": {
-                        "gateway": {
-                            "auth": "existing-paired-token-from-prior-configure",
-                            "url": "ws://test-host:40000/ws/chat",
-                        }
-                    },
-                }
-            },
-        }
-        config_data = {
-            "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
-            "provider": {
-                "name": "test-provider",
-                "type": "anthropic",
-                "default_model": "claude-sonnet-4-5",
-            },
-        }
-
-        key_path = tmp_path / "key"
-        key_path.write_text("key")
-        playbook = tmp_path / "configure.yaml"
-        playbook.write_text("---\n")
-
-        artifacts_dir = tmp_path / "artifacts"
-        fact_cache_dir = artifacts_dir / "fact_cache"
-        fact_cache_dir.mkdir(parents=True)
-        (fact_cache_dir / "test-host").write_text(json.dumps({
-            "__payload__": json.dumps({
-                "zeroclaw_gateway_token": "fresh-bearer-token-after-repair",
-                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
-            }),
-        }))
-
-        mock_runner = MagicMock()
-        mock_runner.status = "successful"
-        mock_runner.events = []
-        mock_runner.config.artifact_dir = str(artifacts_dir)
-
-        captured: dict[str, object] = {}
-
-        def capture_run(*, inventory, **_kwargs):
-            captured["inventory"] = inventory
-            return mock_runner
-
-        with patch("clawrium.core.lifecycle.get_host", return_value=host):
-            with patch(
-                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
-                return_value=playbook,
-            ):
-                with patch(
-                    "clawrium.core.lifecycle.get_host_private_key",
-                    return_value=key_path,
-                ):
-                    with patch(
-                        "clawrium.core.lifecycle.ansible_runner.run",
-                        side_effect=capture_run,
-                    ):
-                        with patch(
-                            "clawrium.core.lifecycle.update_host",
-                            return_value=True,
-                        ):
-                            with patch(
-                                "clawrium.core.providers.get_provider_api_key",
-                                return_value="",
-                            ):
-                                success, error = configure_agent(
-                                    "test-host",
-                                    "zeroclaw",
+                                    "test-host", "zeroclaw",
                                     config_data,
-                                    extra_vars={"force_repair": True},
+                                    on_event=on_event,
+                                    extra_vars=extra_vars,
                                 )
+        return success, error, captured
 
+    def test_no_existing_gateway_token_in_inventory(self, tmp_path: Path):
+        """`existing_gateway_token` and `force_repair` MUST NOT appear in
+        the Ansible inventory. The playbook no longer reads them — leaving
+        them in would be confusing and would let a stale skip-path sneak
+        back in via extra_vars."""
+        host = self._build_host_with_existing_token()
+        success, error, captured = self._run_configure(
+            host, self._build_config(), tmp_path
+        )
         assert success is True, error
         ansible_vars = captured["inventory"]["all"]["vars"]
-        assert ansible_vars["force_repair"] is True
+        assert "existing_gateway_token" not in ansible_vars
+        assert "force_repair" not in ansible_vars
 
-    def test_empty_token_on_first_configure_passes_empty_string(self, tmp_path: Path):
-        """ATX Round 2 W7: a first-time configure (no persisted gateway
-        block) MUST pass `existing_gateway_token=""` so the playbook
-        takes the mint path. This pins the contract that the empty
-        string — not absence or None — is the signal."""
-        host = {
-            "hostname": "test-host",
-            "key_id": "test",
-            "agent_name": "xclm",
-            "port": 22,
-            "agents": {"zer-test": {"type": "zeroclaw"}},  # no config.gateway
-        }
-        config_data = {
-            "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
-            "provider": {
-                "name": "test-provider",
-                "type": "anthropic",
-                "default_model": "claude-sonnet-4-5",
-            },
-        }
-
-        key_path = tmp_path / "key"
-        key_path.write_text("key")
-        playbook = tmp_path / "configure.yaml"
-        playbook.write_text("---\n")
-
-        artifacts_dir = tmp_path / "artifacts"
-        fact_cache_dir = artifacts_dir / "fact_cache"
-        fact_cache_dir.mkdir(parents=True)
-        (fact_cache_dir / "test-host").write_text(json.dumps({
-            "__payload__": json.dumps({
-                "zeroclaw_gateway_token": "freshly-minted-token-on-first-configure",
-                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
-            }),
-        }))
-
-        mock_runner = MagicMock()
-        mock_runner.status = "successful"
-        mock_runner.events = []
-        mock_runner.config.artifact_dir = str(artifacts_dir)
-
-        captured: dict[str, object] = {}
-
-        def capture_run(*, inventory, **_kwargs):
-            captured["inventory"] = inventory
-            return mock_runner
-
-        with patch("clawrium.core.lifecycle.get_host", return_value=host):
-            with patch(
-                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
-                return_value=playbook,
-            ):
-                with patch(
-                    "clawrium.core.lifecycle.get_host_private_key",
-                    return_value=key_path,
-                ):
-                    with patch(
-                        "clawrium.core.lifecycle.ansible_runner.run",
-                        side_effect=capture_run,
-                    ):
-                        with patch(
-                            "clawrium.core.lifecycle.update_host",
-                            return_value=True,
-                        ):
-                            with patch(
-                                "clawrium.core.providers.get_provider_api_key",
-                                return_value="",
-                            ):
-                                success, error = configure_agent(
-                                    "test-host", "zeroclaw", config_data
-                                )
-
+    def test_fresh_token_overwrites_existing_in_config_data(self, tmp_path: Path):
+        """After configure runs, config_data['gateway']['auth'] must hold
+        the fact-cache token, not the prior persisted one."""
+        host = self._build_host_with_existing_token(token="old-token-" + "a" * 22)
+        config_data = self._build_config()
+        success, error, _ = self._run_configure(
+            host, config_data, tmp_path,
+            fact_token="brand-new-token-after-pair-zxy",
+        )
         assert success is True, error
-        ansible_vars = captured["inventory"]["all"]["vars"]
-        assert ansible_vars["existing_gateway_token"] == ""
+        assert config_data["gateway"]["auth"] == "brand-new-token-after-pair-zxy"
 
-    def test_short_existing_token_treated_as_absent(self, tmp_path: Path):
-        """ATX Round 2 W5: a 1-15-char persisted token must be treated
-        as absent (the playbook's `length >= 16` gate would reject it
-        anyway). Without this guard, the Python side passes a too-short
-        token through and the playbook silently re-pairs, surprising the
-        operator."""
-        host = {
-            "hostname": "test-host",
-            "key_id": "test",
-            "agent_name": "xclm",
-            "port": 22,
-            "agents": {
-                "zer-test": {
-                    "type": "zeroclaw",
-                    "config": {
-                        "gateway": {
-                            # 15 characters — one short of the 16-char floor.
-                            "auth": "shortenedtokenz",
-                            "url": "ws://test-host:40000/ws/chat",
-                        }
-                    },
-                }
-            },
-        }
-        config_data = {
-            "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
-            "provider": {
-                "name": "test-provider",
-                "type": "anthropic",
-                "default_model": "claude-sonnet-4-5",
-            },
-        }
-
-        key_path = tmp_path / "key"
-        key_path.write_text("key")
-        playbook = tmp_path / "configure.yaml"
-        playbook.write_text("---\n")
-
-        artifacts_dir = tmp_path / "artifacts"
-        fact_cache_dir = artifacts_dir / "fact_cache"
-        fact_cache_dir.mkdir(parents=True)
-        (fact_cache_dir / "test-host").write_text(json.dumps({
-            "__payload__": json.dumps({
-                "zeroclaw_gateway_token": "freshly-paired-bearer-token-1234",
-                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
-            }),
-        }))
-
-        mock_runner = MagicMock()
-        mock_runner.status = "successful"
-        mock_runner.events = []
-        mock_runner.config.artifact_dir = str(artifacts_dir)
-
-        captured: dict[str, object] = {}
-
-        def capture_run(*, inventory, **_kwargs):
-            captured["inventory"] = inventory
-            return mock_runner
-
-        with patch("clawrium.core.lifecycle.get_host", return_value=host):
-            with patch(
-                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
-                return_value=playbook,
-            ):
-                with patch(
-                    "clawrium.core.lifecycle.get_host_private_key",
-                    return_value=key_path,
-                ):
-                    with patch(
-                        "clawrium.core.lifecycle.ansible_runner.run",
-                        side_effect=capture_run,
-                    ):
-                        with patch(
-                            "clawrium.core.lifecycle.update_host",
-                            return_value=True,
-                        ):
-                            with patch(
-                                "clawrium.core.providers.get_provider_api_key",
-                                return_value="",
-                            ):
-                                success, error = configure_agent(
-                                    "test-host", "zeroclaw", config_data
-                                )
-
-        assert success is True, error
-        ansible_vars = captured["inventory"]["all"]["vars"]
-        # 15-char token is filtered to "" by configure_agent so the
-        # playbook takes the mint path.
-        assert ansible_vars["existing_gateway_token"] == ""
-
-    def test_short_existing_token_emits_warning_via_on_event(self, tmp_path: Path):
-        """ATX Round 5 W-1: when a sub-16-char token forces a re-pair,
-        the warning MUST flow through on_event with stage='configure'
-        and a `WARNING:` prefix — that's the only shape `cli/agent.py`'s
-        `_print_configure_warnings` callback surfaces to the terminal.
-        Pre-fix, the path emitted via stage='warn' which the callback
-        silently dropped (the user re-paired and broke their live
-        `clm chat` with zero indication)."""
-        host = {
-            "hostname": "test-host",
-            "key_id": "test",
-            "agent_name": "xclm",
-            "port": 22,
-            "agents": {
-                "zer-test": {
-                    "type": "zeroclaw",
-                    "config": {
-                        "gateway": {
-                            # 15 chars — under the 16-char floor.
-                            "auth": "shortenedtokenz",
-                            "url": "ws://test-host:40000/ws/chat",
-                        }
-                    },
-                }
-            },
-        }
-        config_data = {
-            "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
-            "provider": {
-                "name": "test-provider",
-                "type": "anthropic",
-                "default_model": "claude-sonnet-4-5",
-            },
-        }
-
-        key_path = tmp_path / "key"
-        key_path.write_text("key")
-        playbook = tmp_path / "configure.yaml"
-        playbook.write_text("---\n")
-
-        artifacts_dir = tmp_path / "artifacts"
-        fact_cache_dir = artifacts_dir / "fact_cache"
-        fact_cache_dir.mkdir(parents=True)
-        (fact_cache_dir / "test-host").write_text(json.dumps({
-            "__payload__": json.dumps({
-                "zeroclaw_gateway_token": "freshly-paired-bearer-token-1234",
-                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
-            }),
-        }))
-
-        mock_runner = MagicMock()
-        mock_runner.status = "successful"
-        mock_runner.events = []
-        mock_runner.config.artifact_dir = str(artifacts_dir)
-
+    def test_rotation_event_emitted_when_token_changes(self, tmp_path: Path):
+        """When the just-minted bearer differs from the persisted one,
+        configure_agent must emit a single stage='gateway_token_rotated'
+        event carrying a JSON payload with the agent_key + reason."""
+        host = self._build_host_with_existing_token(token="stable-old-token-zzz")
         events: list[tuple[str, str]] = []
 
         def on_event(stage: str, message: str) -> None:
             events.append((stage, message))
 
-        with patch("clawrium.core.lifecycle.get_host", return_value=host):
-            with patch(
-                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
-                return_value=playbook,
-            ):
-                with patch(
-                    "clawrium.core.lifecycle.get_host_private_key",
-                    return_value=key_path,
-                ):
-                    with patch(
-                        "clawrium.core.lifecycle.ansible_runner.run",
-                        return_value=mock_runner,
-                    ):
-                        with patch(
-                            "clawrium.core.lifecycle.update_host",
-                            return_value=True,
-                        ):
-                            with patch(
-                                "clawrium.core.providers.get_provider_api_key",
-                                return_value="",
-                            ):
-                                success, error = configure_agent(
-                                    "test-host",
-                                    "zeroclaw",
-                                    config_data,
-                                    on_event=on_event,
-                                )
-
-        assert success is True, error
-        short_token_warnings = [
-            (s, m) for s, m in events
-            if s == "configure"
-            and m.startswith("WARNING:")
-            and "shorter than 16" in m
-        ]
-        assert short_token_warnings, (
-            f"Expected a stage='configure' / 'WARNING:'-prefixed event "
-            f"about the short token; saw {events!r}"
+        success, error, _ = self._run_configure(
+            host, self._build_config(), tmp_path,
+            fact_token="brand-new-token-rotation-zxy",
+            on_event=on_event,
         )
-        # The user-facing message must reference the agent so they know
-        # which session needs to reconnect.
-        assert "zer-test" in short_token_warnings[0][1]
+        assert success is True, error
+        rotation_events = [m for s, m in events if s == "gateway_token_rotated"]
+        assert len(rotation_events) == 1
+        payload = json.loads(rotation_events[0])
+        assert payload["agent_key"] == "zer-test"
+        assert payload["reason"] == "configure"
 
-    def test_token_of_exactly_16_chars_passes_through(self, tmp_path: Path):
-        """ATX Round 3 W9: a token at the 16-char boundary must pass
-        through unchanged (this is the positive boundary of the W5
-        guard). Pre-fix, an off-by-one (`> 16` instead of `>= 16`)
-        would silently re-pair every 16-char token; this test fails
-        if the comparison drifts."""
-        sixteen_char_token = "a" * 16
+    def test_rotation_event_not_emitted_on_first_mint(self, tmp_path: Path):
+        """When there is no prior token (first configure), the rotation
+        event must be suppressed — that's an install, not a rotation."""
         host = {
             "hostname": "test-host",
             "key_id": "test",
             "agent_name": "xclm",
             "port": 22,
-            "agents": {
-                "zer-test": {
-                    "type": "zeroclaw",
-                    "config": {
-                        "gateway": {
-                            "auth": sixteen_char_token,
-                            "url": "ws://test-host:40000/ws/chat",
-                        }
-                    },
-                }
-            },
+            "agents": {"zer-test": {"type": "zeroclaw"}},
         }
-        config_data = {
-            "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
-            "provider": {
-                "name": "test-provider",
-                "type": "anthropic",
-                "default_model": "claude-sonnet-4-5",
-            },
-        }
+        events: list[tuple[str, str]] = []
 
-        key_path = tmp_path / "key"
-        key_path.write_text("key")
-        playbook = tmp_path / "configure.yaml"
-        playbook.write_text("---\n")
+        def on_event(stage: str, message: str) -> None:
+            events.append((stage, message))
 
-        artifacts_dir = tmp_path / "artifacts"
-        fact_cache_dir = artifacts_dir / "fact_cache"
-        fact_cache_dir.mkdir(parents=True)
-        (fact_cache_dir / "test-host").write_text(json.dumps({
-            "__payload__": json.dumps({
-                "zeroclaw_gateway_token": sixteen_char_token,
-                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
-            }),
-        }))
-
-        mock_runner = MagicMock()
-        mock_runner.status = "successful"
-        mock_runner.events = []
-        mock_runner.config.artifact_dir = str(artifacts_dir)
-
-        captured: dict[str, object] = {}
-
-        def capture_run(*, inventory, **_kwargs):
-            captured["inventory"] = inventory
-            return mock_runner
-
-        with patch("clawrium.core.lifecycle.get_host", return_value=host):
-            with patch(
-                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
-                return_value=playbook,
-            ):
-                with patch(
-                    "clawrium.core.lifecycle.get_host_private_key",
-                    return_value=key_path,
-                ):
-                    with patch(
-                        "clawrium.core.lifecycle.ansible_runner.run",
-                        side_effect=capture_run,
-                    ):
-                        with patch(
-                            "clawrium.core.lifecycle.update_host",
-                            return_value=True,
-                        ):
-                            with patch(
-                                "clawrium.core.providers.get_provider_api_key",
-                                return_value="",
-                            ):
-                                success, error = configure_agent(
-                                    "test-host", "zeroclaw", config_data
-                                )
-
+        success, error, _ = self._run_configure(
+            host, self._build_config(), tmp_path, on_event=on_event,
+        )
         assert success is True, error
-        ansible_vars = captured["inventory"]["all"]["vars"]
-        assert ansible_vars["existing_gateway_token"] == sixteen_char_token
+        assert not [e for e in events if e[0] == "gateway_token_rotated"]
+
 
 
 class TestOpenClawTemplate:

--- a/tests/test_configure_claw.py
+++ b/tests/test_configure_claw.py
@@ -112,6 +112,95 @@ class TestConfigureClaw:
         assert success is False
         assert "failed to update local state" in error
 
+    def test_no_rotation_event_emitted_when_update_host_fails_with_prior_token(self, tmp_path: Path):
+        """ATX W-COV-3: when configure's hosts.json write fails AFTER
+        the pair handshake minted a new token, the rotation event must
+        NOT be emitted — that's the W2 ordering invariant. Without this
+        test, moving the emit back before the write would silently
+        regress."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "zer-test": {
+                    "type": "zeroclaw",
+                    "config": {
+                        "gateway": {
+                            "auth": "stable-prior-token-zzzzzzz",
+                            "url": "ws://test-host:40000/ws/chat",
+                        }
+                    },
+                }
+            },
+        }
+        config_data = {
+            "gateway": {"host": "0.0.0.0", "port": 40000, "allow_public_bind": True},
+            "provider": {
+                "name": "test-provider",
+                "type": "anthropic",
+                "default_model": "claude-sonnet-4-5",
+            },
+        }
+
+        key_path = tmp_path / "key"
+        key_path.write_text("key")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        artifacts_dir = tmp_path / "artifacts"
+        fact_cache_dir = artifacts_dir / "fact_cache"
+        fact_cache_dir.mkdir(parents=True)
+        (fact_cache_dir / "test-host").write_text(json.dumps({
+            "__payload__": json.dumps({
+                "zeroclaw_gateway_token": "freshly-minted-token-but-not-persisted",
+                "zeroclaw_gateway_url": "ws://test-host:40000/ws/chat",
+            }),
+        }))
+
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+        mock_runner.config.artifact_dir = str(artifacts_dir)
+
+        events: list[tuple[str, str]] = []
+
+        def on_event(stage: str, message: str) -> None:
+            events.append((stage, message))
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.get_host_private_key",
+                    return_value=key_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        return_value=mock_runner,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle.update_host",
+                            return_value=False,
+                        ):
+                            with patch(
+                                "clawrium.core.providers.get_provider_api_key",
+                                return_value="",
+                            ):
+                                success, _ = configure_agent(
+                                    "test-host", "zeroclaw", config_data,
+                                    on_event=on_event,
+                                )
+
+        assert success is False
+        rotation = [m for s, m in events if s == "gateway_token_rotated"]
+        assert not rotation, (
+            f"rotation event leaked despite update_host failure: {rotation!r}"
+        )
+
     def test_returns_false_when_playbook_missing(self, tmp_path: Path):
         """Test that missing configure playbook is detected."""
         host = {

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -510,6 +510,208 @@ class TestZeroclawRepairAfterStart:
         assert success is False
         assert "Invalid agent_name" in error
 
+    def test_returns_failure_when_fact_cache_empty(self, tmp_path: Path):
+        """ATX W-COV-2: playbook reports successful but the fact cache
+        is empty — the pair token never made it back to clm. This is
+        the exact timing window the always-repair invariant must
+        surface as a failure, not silently leave hosts.json stale."""
+        host = self._host()
+        artifacts_dir = tmp_path / "artifacts"
+        (artifacts_dir / "fact_cache").mkdir(parents=True)
+        # No fact files written → extractor returns (None, None).
+        runner = MagicMock()
+        runner.status = "successful"
+        runner.events = []
+        runner.config.artifact_dir = str(artifacts_dir)
+
+        success, error = self._run_repair(host, tmp_path, runner=runner)
+        assert success is False
+        assert "pairing token was not captured" in error
+
+    def test_returns_failure_when_gateway_port_missing(self, tmp_path: Path):
+        """ATX W-COV-4: hosts.json record without config.gateway.port
+        must surface a clear error rather than building an invalid
+        Ansible inventory."""
+        host = self._host()
+        host["agents"]["zer-test"]["config"]["gateway"] = {"auth": "x" * 32}
+        runner, _ = self._setup_repair_runner(tmp_path, "any-token")
+        success, error = self._run_repair(host, tmp_path, runner=runner)
+        assert success is False
+        assert "Gateway port missing" in error
+
+    def test_no_rotation_event_emitted_when_update_host_fails(self, tmp_path: Path):
+        """ATX W-COV-3: the rotation event must NOT fire if the disk
+        write fails — that's the exact ordering invariant W2 fixed in
+        configure_agent. Pin the same invariant for the restart path."""
+        host = self._host()
+        runner, _ = self._setup_repair_runner(tmp_path, "would-be-new-token")
+        events: list[tuple[str, str]] = []
+
+        def on_event(stage: str, message: str) -> None:
+            events.append((stage, message))
+
+        success, _ = self._run_repair(
+            host, tmp_path, runner=runner,
+            update_host_result=False, on_event=on_event,
+        )
+        assert success is False
+        rotation = [m for s, m in events if s == "gateway_token_rotated"]
+        assert not rotation, f"rotation event leaked despite write failure: {rotation!r}"
+
+
+class TestStartAgentZeroclawRepairWiring:
+    """ATX W-COV-1: exercise the start_agent → _zeroclaw_repair_after_start
+    branch through a real `start_agent` call (the helper is unit-tested
+    in TestZeroclawRepairAfterStart; this class pins the wiring)."""
+
+    def _zeroclaw_host(self) -> dict:
+        return {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "zer-test": {
+                    "type": "zeroclaw",
+                    "agent_name": "zerot",
+                    "onboarding": {"state": "ready"},
+                    "config": {"gateway": {"port": 40000, "auth": "x" * 32}},
+                }
+            },
+        }
+
+    def test_start_zeroclaw_invokes_repair_with_reason_start(self, tmp_path: Path):
+        host = self._zeroclaw_host()
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook_path = tmp_path / "start.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ):
+                with patch(
+                    "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                    return_value=playbook_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        return_value=mock_runner,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle._update_agent_runtime",
+                            return_value=True,
+                        ):
+                            with patch(
+                                "clawrium.core.lifecycle.get_config_dir",
+                                return_value=tmp_path,
+                            ):
+                                with patch(
+                                    "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+                                    return_value=(True, None),
+                                ) as mock_repair:
+                                    result = start_agent("192.168.1.100", "zeroclaw")
+
+        assert result["success"] is True
+        mock_repair.assert_called_once()
+        kwargs = mock_repair.call_args.kwargs
+        assert kwargs.get("reason") == "start"
+        # ATX W-NEW-2: helper receives resolved agent_key (not raw param)
+        assert kwargs.get("agent_name") == "zer-test"
+
+    def test_start_zeroclaw_returns_failure_when_repair_fails(self, tmp_path: Path):
+        host = self._zeroclaw_host()
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook_path = tmp_path / "start.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ):
+                with patch(
+                    "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                    return_value=playbook_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        return_value=mock_runner,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle._update_agent_runtime",
+                            return_value=True,
+                        ):
+                            with patch(
+                                "clawrium.core.lifecycle.get_config_dir",
+                                return_value=tmp_path,
+                            ):
+                                with patch(
+                                    "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+                                    return_value=(False, "pair failed"),
+                                ):
+                                    result = start_agent("192.168.1.100", "zeroclaw")
+
+        assert result["success"] is False
+        assert "Re-pair after start failed" in result["error"]
+        assert "pair failed" in result["error"]
+
+    def test_start_openclaw_does_not_invoke_zeroclaw_repair(self, tmp_path: Path):
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "opc-test": {
+                    "type": "openclaw",
+                    "onboarding": {"state": "ready"},
+                }
+            },
+        }
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook_path = tmp_path / "start.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+        mock_runner = MagicMock()
+        mock_runner.status = "successful"
+        mock_runner.events = []
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ):
+                with patch(
+                    "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                    return_value=playbook_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        return_value=mock_runner,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle._update_agent_runtime",
+                            return_value=True,
+                        ):
+                            with patch(
+                                "clawrium.core.lifecycle.get_config_dir",
+                                return_value=tmp_path,
+                            ):
+                                with patch(
+                                    "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+                                ) as mock_repair:
+                                    result = start_agent("192.168.1.100", "openclaw")
+
+        assert result["success"] is True
+        mock_repair.assert_not_called()
+
 
 class TestRestartAgentZeroclawWiring:
     """Issue #437: `restart_agent` for zeroclaw drives the re-pair through

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -341,13 +341,14 @@ class TestRestartClaw:
         assert result["operation"] == "restart"
 
 
-class TestRestartAgentZeroclawRepair:
-    """Issue #437: `restart_agent` for zeroclaw must re-pair after the
-    systemd restart and atomically update `hosts.json.gateway.auth`.
-    Without this, hosts.json keeps the old token while the daemon enforces
-    a freshly-minted one, breaking `clm chat` on the next call."""
+class TestZeroclawRepairAfterStart:
+    """Issue #437: `_zeroclaw_repair_after_start` re-pairs after any
+    systemd-level start of the zeroclaw daemon and atomically updates
+    `hosts.json.gateway.auth`. Tested directly so the failure modes
+    (playbook failure, update_host failure) are exercised without
+    going through the full start_agent stack."""
 
-    def _host(self) -> dict:
+    def _host(self, auth: str = "old-token-zzzzz") -> dict:
         return {
             "hostname": "192.168.1.100",
             "key_id": "test",
@@ -358,116 +359,174 @@ class TestRestartAgentZeroclawRepair:
                     "type": "zeroclaw",
                     "agent_name": "zerot",
                     "onboarding": {"state": "ready"},
-                    "config": {"gateway": {"port": 40000, "auth": "old-token-zzzzz"}},
+                    "config": {"gateway": {"port": 40000, "auth": auth}},
                 }
             },
         }
 
-    def test_zeroclaw_restart_invokes_repair_and_updates_hosts_json(self, tmp_path: Path):
-        host = self._host()
-        key_path = tmp_path / "test_key"
-        key_path.write_text("key")
-        playbook_path = tmp_path / "restart.yaml"
-        playbook_path.write_text("---\n- hosts: all\n")
-
+    def _setup_repair_runner(self, tmp_path: Path, token: str) -> tuple[MagicMock, Path]:
         artifacts_dir = tmp_path / "artifacts"
         fact_cache_dir = artifacts_dir / "fact_cache"
         fact_cache_dir.mkdir(parents=True)
         (fact_cache_dir / "192.168.1.100").write_text(
             json.dumps({
                 "__payload__": json.dumps({
-                    "zeroclaw_gateway_token": "fresh-after-restart-zzzzz",
+                    "zeroclaw_gateway_token": token,
                     "zeroclaw_gateway_url": "ws://192.168.1.100:40000/ws/chat",
                 })
             })
         )
-        repair_runner = MagicMock()
-        repair_runner.status = "successful"
-        repair_runner.events = []
-        repair_runner.config.artifact_dir = str(artifacts_dir)
+        runner = MagicMock()
+        runner.status = "successful"
+        runner.events = []
+        runner.config.artifact_dir = str(artifacts_dir)
+        return runner, artifacts_dir
 
+    def _run_repair(self, host: dict, tmp_path: Path, *,
+                    runner: MagicMock, update_host_result=True,
+                    update_host_capture: dict | None = None,
+                    reason: str = "restart",
+                    on_event=None):
+        key_path = tmp_path / "test_key"
+        key_path.write_text("key")
+        playbook_path = tmp_path / "restart.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+
+        def update_host_side_effect(_hostname: str, updater) -> bool:
+            if update_host_capture is not None:
+                h = {"hostname": "192.168.1.100", "agents": dict(host["agents"])}
+                update_host_capture["updated"] = updater(h)
+            return update_host_result
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle.get_host_private_key",
+                return_value=key_path,
+            ):
+                with patch(
+                    "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                    return_value=playbook_path,
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.ansible_runner.run",
+                        return_value=runner,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle.update_host",
+                            side_effect=update_host_side_effect,
+                        ):
+                            with patch(
+                                "clawrium.core.lifecycle.get_config_dir",
+                                return_value=tmp_path,
+                            ):
+                                from clawrium.core.lifecycle import (
+                                    _zeroclaw_repair_after_start,
+                                )
+                                return _zeroclaw_repair_after_start(
+                                    "192.168.1.100",
+                                    agent_name="zer-test",
+                                    on_event=on_event,
+                                    reason=reason,
+                                )
+
+    def test_happy_path_updates_hosts_json_and_emits_rotation(self, tmp_path: Path):
+        host = self._host()
+        runner, _ = self._setup_repair_runner(tmp_path, "fresh-after-restart-zzzzz")
+        capture: dict = {}
         events: list[tuple[str, str]] = []
 
         def on_event(stage: str, message: str) -> None:
             events.append((stage, message))
 
-        captured_update: dict = {}
-
-        def update_host_capture(_hostname: str, updater) -> bool:
-            h = {"hostname": "192.168.1.100", "agents": host["agents"].copy()}
-            captured_update["updated"] = updater(h)
-            return True
-
-        with patch("clawrium.core.lifecycle.get_host", return_value=host):
-            with patch(
-                "clawrium.core.lifecycle.stop_agent",
-                return_value={
-                    "success": True, "agent": "zer-test", "host": "192.168.1.100",
-                    "operation": "stop", "pid": None, "started_at": None, "error": None,
-                },
-            ):
-                with patch(
-                    "clawrium.core.lifecycle.start_agent",
-                    return_value={
-                        "success": True, "agent": "zer-test", "host": "192.168.1.100",
-                        "operation": "start", "pid": None,
-                        "started_at": "2026-05-19T00:00:00Z", "error": None,
-                    },
-                ):
-                    with patch(
-                        "clawrium.core.lifecycle.get_host_private_key",
-                        return_value=key_path,
-                    ):
-                        with patch(
-                            "clawrium.core.lifecycle._get_lifecycle_playbook_path",
-                            return_value=playbook_path,
-                        ):
-                            with patch(
-                                "clawrium.core.lifecycle.ansible_runner.run",
-                                return_value=repair_runner,
-                            ):
-                                with patch(
-                                    "clawrium.core.lifecycle.update_host",
-                                    side_effect=update_host_capture,
-                                ):
-                                    with patch(
-                                        "clawrium.core.lifecycle.get_config_dir",
-                                        return_value=tmp_path,
-                                    ):
-                                        result = restart_agent(
-                                            "192.168.1.100", "zeroclaw",
-                                            on_event=on_event,
-                                        )
-
-        assert result["success"] is True
-        # The repair updater overwrote the bearer in hosts.json.
-        updated = captured_update["updated"]
-        new_auth = (
-            updated["agents"]["zer-test"]["config"]["gateway"]["auth"]
+        success, error = self._run_repair(
+            host, tmp_path,
+            runner=runner,
+            update_host_capture=capture,
+            reason="restart",
+            on_event=on_event,
         )
+        assert success is True, error
+        new_auth = capture["updated"]["agents"]["zer-test"]["config"]["gateway"]["auth"]
         assert new_auth == "fresh-after-restart-zzzzz"
-
-        # And it emitted exactly one rotation event with reason="restart".
         rotation = [m for s, m in events if s == "gateway_token_rotated"]
         assert len(rotation) == 1
         payload = json.loads(rotation[0])
         assert payload["agent_key"] == "zer-test"
         assert payload["reason"] == "restart"
 
-    def test_zeroclaw_restart_fails_when_repair_playbook_fails(self, tmp_path: Path):
+    def test_reason_start_propagates_into_event_payload(self, tmp_path: Path):
         host = self._host()
-        key_path = tmp_path / "test_key"
-        key_path.write_text("key")
-        playbook_path = tmp_path / "restart.yaml"
-        playbook_path.write_text("---\n- hosts: all\n")
+        runner, _ = self._setup_repair_runner(tmp_path, "fresh-after-start-zzzzz")
+        events: list[tuple[str, str]] = []
 
-        repair_runner = MagicMock()
-        repair_runner.status = "failed"
-        repair_runner.events = [
+        def on_event(stage: str, message: str) -> None:
+            events.append((stage, message))
+
+        success, _ = self._run_repair(
+            host, tmp_path, runner=runner, reason="start", on_event=on_event,
+        )
+        assert success is True
+        rotation = [m for s, m in events if s == "gateway_token_rotated"]
+        assert json.loads(rotation[0])["reason"] == "start"
+
+    def test_returns_failure_when_playbook_fails(self, tmp_path: Path):
+        host = self._host()
+        runner = MagicMock()
+        runner.status = "failed"
+        runner.events = [
             {"event": "runner_on_failed",
              "event_data": {"res": {"msg": "pair handshake exploded"}}}
         ]
+        success, error = self._run_repair(host, tmp_path, runner=runner)
+        assert success is False
+        assert "pair handshake exploded" in error
 
+    def test_returns_failure_when_update_host_returns_false(self, tmp_path: Path):
+        """ATX W8: the exact divergence #437 fixes — playbook succeeds but
+        hosts.json never gets written. Must surface as a failure."""
+        host = self._host()
+        runner, _ = self._setup_repair_runner(tmp_path, "fresh-but-not-persisted")
+        success, error = self._run_repair(
+            host, tmp_path, runner=runner, update_host_result=False,
+        )
+        assert success is False
+        assert "failed to update hosts.json" in error
+
+    def test_returns_failure_when_playbook_times_out(self, tmp_path: Path):
+        host = self._host()
+        runner = MagicMock()
+        runner.status = "timeout"
+        runner.events = []
+        success, error = self._run_repair(host, tmp_path, runner=runner)
+        assert success is False
+        assert "timed out" in error.lower()
+
+    def test_rejects_invalid_agent_name(self, tmp_path: Path):
+        """ATX W4: parity with configure_agent's validation guard."""
+        host = self._host()
+        host["agents"]["zer-test"]["agent_name"] = "INVALID/name"
+        runner, _ = self._setup_repair_runner(tmp_path, "any-token")
+        success, error = self._run_repair(host, tmp_path, runner=runner)
+        assert success is False
+        assert "Invalid agent_name" in error
+
+
+class TestRestartAgentZeroclawWiring:
+    """Issue #437: `restart_agent` for zeroclaw drives the re-pair through
+    `start_agent(repair_reason='restart')`. Verify the wiring without
+    exercising the underlying playbook (covered by
+    TestZeroclawRepairAfterStart)."""
+
+    def test_restart_calls_start_agent_with_repair_reason_restart(self, tmp_path: Path):
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "zer-test": {"type": "zeroclaw", "onboarding": {"state": "ready"}},
+            },
+        }
         with patch("clawrium.core.lifecycle.get_host", return_value=host):
             with patch(
                 "clawrium.core.lifecycle.stop_agent",
@@ -483,29 +542,13 @@ class TestRestartAgentZeroclawRepair:
                         "operation": "start", "pid": None,
                         "started_at": "2026-05-19T00:00:00Z", "error": None,
                     },
-                ):
-                    with patch(
-                        "clawrium.core.lifecycle.get_host_private_key",
-                        return_value=key_path,
-                    ):
-                        with patch(
-                            "clawrium.core.lifecycle._get_lifecycle_playbook_path",
-                            return_value=playbook_path,
-                        ):
-                            with patch(
-                                "clawrium.core.lifecycle.ansible_runner.run",
-                                return_value=repair_runner,
-                            ):
-                                with patch(
-                                    "clawrium.core.lifecycle.get_config_dir",
-                                    return_value=tmp_path,
-                                ):
-                                    result = restart_agent(
-                                        "192.168.1.100", "zeroclaw"
-                                    )
+                ) as mock_start:
+                    result = restart_agent("192.168.1.100", "zeroclaw")
 
-        assert result["success"] is False
-        assert "Re-pair" in result["error"]
+        assert result["success"] is True
+        assert result["operation"] == "restart"
+        kwargs = mock_start.call_args.kwargs
+        assert kwargs.get("repair_reason") == "restart"
 
 
 class TestRemoveClaw:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -17,6 +17,7 @@ from clawrium.core.lifecycle import (
     _run_lifecycle_playbook,
     _resolve_agent_record,
     _cleanup_ansible_artifacts,
+    _safe_host_display,
 )
 
 
@@ -559,6 +560,33 @@ class TestZeroclawRepairAfterStart:
         assert not rotation, f"rotation event leaked despite write failure: {rotation!r}"
 
 
+class TestSafeHostDisplay:
+    """ATX W-R3-1: `_safe_host_display` is a path-traversal guard used at
+    three log-dir construction sites. Pin the documented edge cases so
+    a regex widening that re-opens traversal fails a test."""
+
+    def test_traversal_alias_is_sanitized(self):
+        assert _safe_host_display({"alias": "../etc"}, "h") == ".._etc"
+
+    def test_slash_in_alias_is_sanitized(self):
+        assert _safe_host_display({"alias": "my/box"}, "h") == "my_box"
+
+    def test_empty_inputs_fall_back_to_host(self):
+        assert _safe_host_display({}, "") == "host"
+
+    def test_all_bad_chars_fall_back_to_host(self):
+        assert _safe_host_display({"alias": "///"}, "h") == "host"
+
+    def test_falls_back_to_key_id_when_no_alias(self):
+        assert _safe_host_display({"key_id": "kev"}, "192.168.1.1") == "kev"
+
+    def test_falls_back_to_hostname_when_neither_alias_nor_key_id(self):
+        assert _safe_host_display({}, "192.168.1.1") == "192.168.1.1"
+
+    def test_preserves_safe_chars(self):
+        assert _safe_host_display({"alias": "Foo-bar_1.2"}, "h") == "Foo-bar_1.2"
+
+
 class TestStartAgentZeroclawRepairWiring:
     """ATX W-COV-1: exercise the start_agent → _zeroclaw_repair_after_start
     branch through a real `start_agent` call (the helper is unit-tested
@@ -614,7 +642,15 @@ class TestStartAgentZeroclawRepairWiring:
                                     "clawrium.core.lifecycle._zeroclaw_repair_after_start",
                                     return_value=(True, None),
                                 ) as mock_repair:
-                                    result = start_agent("192.168.1.100", "zeroclaw")
+                                    sentinel_events: list[tuple[str, str]] = []
+
+                                    def sentinel_on_event(stage: str, msg: str) -> None:
+                                        sentinel_events.append((stage, msg))
+
+                                    result = start_agent(
+                                        "192.168.1.100", "zeroclaw",
+                                        on_event=sentinel_on_event,
+                                    )
 
         assert result["success"] is True
         mock_repair.assert_called_once()
@@ -622,6 +658,9 @@ class TestStartAgentZeroclawRepairWiring:
         assert kwargs.get("reason") == "start"
         # ATX W-NEW-2: helper receives resolved agent_key (not raw param)
         assert kwargs.get("agent_name") == "zer-test"
+        # ATX W-R3-2: on_event forwarded so the rotation notice reaches
+        # the CLI handler. Identity check — must be the same callable.
+        assert kwargs.get("on_event") is sentinel_on_event
 
     def test_start_zeroclaw_returns_failure_when_repair_fails(self, tmp_path: Path):
         host = self._zeroclaw_host()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,5 +1,6 @@
 """Tests for claw lifecycle management module."""
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -338,6 +339,173 @@ class TestRestartClaw:
 
         assert result["success"] is True
         assert result["operation"] == "restart"
+
+
+class TestRestartAgentZeroclawRepair:
+    """Issue #437: `restart_agent` for zeroclaw must re-pair after the
+    systemd restart and atomically update `hosts.json.gateway.auth`.
+    Without this, hosts.json keeps the old token while the daemon enforces
+    a freshly-minted one, breaking `clm chat` on the next call."""
+
+    def _host(self) -> dict:
+        return {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "zer-test": {
+                    "type": "zeroclaw",
+                    "agent_name": "zerot",
+                    "onboarding": {"state": "ready"},
+                    "config": {"gateway": {"port": 40000, "auth": "old-token-zzzzz"}},
+                }
+            },
+        }
+
+    def test_zeroclaw_restart_invokes_repair_and_updates_hosts_json(self, tmp_path: Path):
+        host = self._host()
+        key_path = tmp_path / "test_key"
+        key_path.write_text("key")
+        playbook_path = tmp_path / "restart.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+
+        artifacts_dir = tmp_path / "artifacts"
+        fact_cache_dir = artifacts_dir / "fact_cache"
+        fact_cache_dir.mkdir(parents=True)
+        (fact_cache_dir / "192.168.1.100").write_text(
+            json.dumps({
+                "__payload__": json.dumps({
+                    "zeroclaw_gateway_token": "fresh-after-restart-zzzzz",
+                    "zeroclaw_gateway_url": "ws://192.168.1.100:40000/ws/chat",
+                })
+            })
+        )
+        repair_runner = MagicMock()
+        repair_runner.status = "successful"
+        repair_runner.events = []
+        repair_runner.config.artifact_dir = str(artifacts_dir)
+
+        events: list[tuple[str, str]] = []
+
+        def on_event(stage: str, message: str) -> None:
+            events.append((stage, message))
+
+        captured_update: dict = {}
+
+        def update_host_capture(_hostname: str, updater) -> bool:
+            h = {"hostname": "192.168.1.100", "agents": host["agents"].copy()}
+            captured_update["updated"] = updater(h)
+            return True
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle.stop_agent",
+                return_value={
+                    "success": True, "agent": "zer-test", "host": "192.168.1.100",
+                    "operation": "stop", "pid": None, "started_at": None, "error": None,
+                },
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.start_agent",
+                    return_value={
+                        "success": True, "agent": "zer-test", "host": "192.168.1.100",
+                        "operation": "start", "pid": None,
+                        "started_at": "2026-05-19T00:00:00Z", "error": None,
+                    },
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.get_host_private_key",
+                        return_value=key_path,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                            return_value=playbook_path,
+                        ):
+                            with patch(
+                                "clawrium.core.lifecycle.ansible_runner.run",
+                                return_value=repair_runner,
+                            ):
+                                with patch(
+                                    "clawrium.core.lifecycle.update_host",
+                                    side_effect=update_host_capture,
+                                ):
+                                    with patch(
+                                        "clawrium.core.lifecycle.get_config_dir",
+                                        return_value=tmp_path,
+                                    ):
+                                        result = restart_agent(
+                                            "192.168.1.100", "zeroclaw",
+                                            on_event=on_event,
+                                        )
+
+        assert result["success"] is True
+        # The repair updater overwrote the bearer in hosts.json.
+        updated = captured_update["updated"]
+        new_auth = (
+            updated["agents"]["zer-test"]["config"]["gateway"]["auth"]
+        )
+        assert new_auth == "fresh-after-restart-zzzzz"
+
+        # And it emitted exactly one rotation event with reason="restart".
+        rotation = [m for s, m in events if s == "gateway_token_rotated"]
+        assert len(rotation) == 1
+        payload = json.loads(rotation[0])
+        assert payload["agent_key"] == "zer-test"
+        assert payload["reason"] == "restart"
+
+    def test_zeroclaw_restart_fails_when_repair_playbook_fails(self, tmp_path: Path):
+        host = self._host()
+        key_path = tmp_path / "test_key"
+        key_path.write_text("key")
+        playbook_path = tmp_path / "restart.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+
+        repair_runner = MagicMock()
+        repair_runner.status = "failed"
+        repair_runner.events = [
+            {"event": "runner_on_failed",
+             "event_data": {"res": {"msg": "pair handshake exploded"}}}
+        ]
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle.stop_agent",
+                return_value={
+                    "success": True, "agent": "zer-test", "host": "192.168.1.100",
+                    "operation": "stop", "pid": None, "started_at": None, "error": None,
+                },
+            ):
+                with patch(
+                    "clawrium.core.lifecycle.start_agent",
+                    return_value={
+                        "success": True, "agent": "zer-test", "host": "192.168.1.100",
+                        "operation": "start", "pid": None,
+                        "started_at": "2026-05-19T00:00:00Z", "error": None,
+                    },
+                ):
+                    with patch(
+                        "clawrium.core.lifecycle.get_host_private_key",
+                        return_value=key_path,
+                    ):
+                        with patch(
+                            "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                            return_value=playbook_path,
+                        ):
+                            with patch(
+                                "clawrium.core.lifecycle.ansible_runner.run",
+                                return_value=repair_runner,
+                            ):
+                                with patch(
+                                    "clawrium.core.lifecycle.get_config_dir",
+                                    return_value=tmp_path,
+                                ):
+                                    result = restart_agent(
+                                        "192.168.1.100", "zeroclaw"
+                                    )
+
+        assert result["success"] is False
+        assert "Re-pair" in result["error"]
 
 
 class TestRemoveClaw:
@@ -833,8 +1001,9 @@ class TestSyncAgent:
         mock_configure.assert_called_once()
         mock_restart.assert_not_called()
 
-    def test_returns_failure_when_restart_fails(self):
-        """B9: Sync fails when restart step fails after configure succeeds."""
+    def test_does_not_call_restart_agent(self):
+        """Issue #437: sync no longer orchestrates a separate restart.
+        configure handles re-pairing + handler-driven restart in one shot."""
         host = {
             "hostname": "192.168.1.100",
             "key_id": "test",
@@ -863,112 +1032,85 @@ class TestSyncAgent:
                 return_value=(True, None),
             ) as mock_configure:
                 with patch(
-                    "clawrium.core.lifecycle.restart_agent",
-                    return_value={
-                        "success": False,
-                        "agent": "opc-work",
-                        "host": "192.168.1.100",
-                        "operation": "restart",
-                        "pid": None,
-                        "started_at": None,
-                        "error": "Restart error",
-                    },
-                ):
-                    result = sync_agent("192.168.1.100", "openclaw")
-
-        assert result["success"] is False
-        assert "Restart failed" in result["error"]
-        assert result["operation"] == "sync"
-        # Confirm configure was called (intermediate step ran)
-        mock_configure.assert_called_once()
-
-    def test_returns_failure_when_restart_raises_exception(self):
-        """B2: Sync catches LifecycleError from restart and returns result."""
-        host = {
-            "hostname": "192.168.1.100",
-            "key_id": "test",
-            "agent_name": "xclm",
-            "port": 22,
-            "agents": {
-                "opc-work": {
-                    "type": "openclaw",
-                    "onboarding": {"state": "ready"},
-                    "config": {
-                        "gateway": {"port": 40000},
-                        "provider": {
-                            "name": "test",
-                            "type": "ollama",
-                            "endpoint": "http://localhost:11434",
-                            "default_model": "llama3",
-                        },
-                    },
-                }
-            },
-        }
-
-        with patch("clawrium.core.lifecycle.get_host", return_value=host):
-            with patch(
-                "clawrium.core.lifecycle.configure_agent",
-                return_value=(True, None),
-            ):
-                with patch(
-                    "clawrium.core.lifecycle.restart_agent",
-                    side_effect=LifecycleError("Restart exception"),
-                ):
-                    result = sync_agent("192.168.1.100", "openclaw")
-
-        assert result["success"] is False
-        assert "Restart failed" in result["error"]
-        assert "Restart exception" in result["error"]
-        assert result["operation"] == "sync"
-
-    def test_returns_success_on_successful_sync(self):
-        """Sync succeeds when all steps succeed."""
-        host = {
-            "hostname": "192.168.1.100",
-            "key_id": "test",
-            "agent_name": "xclm",
-            "port": 22,
-            "agents": {
-                "opc-work": {
-                    "type": "openclaw",
-                    "onboarding": {"state": "ready"},
-                    "config": {
-                        "gateway": {"port": 40000},
-                        "provider": {
-                            "name": "test",
-                            "type": "ollama",
-                            "endpoint": "http://localhost:11434",
-                            "default_model": "llama3",
-                        },
-                    },
-                }
-            },
-        }
-
-        with patch("clawrium.core.lifecycle.get_host", return_value=host):
-            with patch(
-                "clawrium.core.lifecycle.configure_agent",
-                return_value=(True, None),
-            ):
-                with patch(
-                    "clawrium.core.lifecycle.restart_agent",
-                    return_value={
-                        "success": True,
-                        "agent": "opc-work",
-                        "host": "192.168.1.100",
-                        "operation": "restart",
-                        "pid": 1234,
-                        "started_at": "2026-04-14T12:00:00Z",
-                        "error": None,
-                    },
-                ):
+                    "clawrium.core.lifecycle.restart_agent"
+                ) as mock_restart:
                     result = sync_agent("192.168.1.100", "openclaw")
 
         assert result["success"] is True
         assert result["operation"] == "sync"
+        mock_configure.assert_called_once()
+        # Issue #437: restart is no longer orchestrated by sync.
+        mock_restart.assert_not_called()
+
+    def test_returns_success_on_successful_sync(self):
+        """Sync succeeds when configure succeeds."""
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "opc-work": {
+                    "type": "openclaw",
+                    "onboarding": {"state": "ready"},
+                    "config": {
+                        "gateway": {"port": 40000},
+                        "provider": {
+                            "name": "test",
+                            "type": "ollama",
+                            "endpoint": "http://localhost:11434",
+                            "default_model": "llama3",
+                        },
+                    },
+                }
+            },
+        }
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle.configure_agent",
+                return_value=(True, None),
+            ):
+                result = sync_agent("192.168.1.100", "openclaw")
+
+        assert result["success"] is True
+        assert result["operation"] == "sync"
         assert result["agent"] == "opc-work"
-        assert result["pid"] == 1234
+
+    def test_sync_passes_reason_sync_to_configure(self):
+        """Issue #437: sync calls configure_agent with reason='sync' so
+        the rotation event payload identifies the originating op."""
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "opc-work": {
+                    "type": "openclaw",
+                    "onboarding": {"state": "ready"},
+                    "config": {
+                        "gateway": {"port": 40000},
+                        "provider": {
+                            "name": "test",
+                            "type": "ollama",
+                            "endpoint": "http://localhost:11434",
+                            "default_model": "llama3",
+                        },
+                    },
+                }
+            },
+        }
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host):
+            with patch(
+                "clawrium.core.lifecycle.configure_agent",
+                return_value=(True, None),
+            ) as mock_configure:
+                sync_agent("192.168.1.100", "openclaw")
+
+        kwargs = mock_configure.call_args.kwargs
+        assert kwargs.get("reason") == "sync"
 
     def test_sync_agent_by_explicit_name(self):
         """W7: Test sync with explicit agent_name parameter."""
@@ -999,21 +1141,9 @@ class TestSyncAgent:
                 "clawrium.core.lifecycle.configure_agent",
                 return_value=(True, None),
             ):
-                with patch(
-                    "clawrium.core.lifecycle.restart_agent",
-                    return_value={
-                        "success": True,
-                        "agent": "opc-work",
-                        "host": "192.168.1.100",
-                        "operation": "restart",
-                        "pid": None,
-                        "started_at": "2026-04-14T12:00:00Z",
-                        "error": None,
-                    },
-                ):
-                    result = sync_agent(
-                        "192.168.1.100", "openclaw", agent_name="opc-work"
-                    )
+                result = sync_agent(
+                    "192.168.1.100", "openclaw", agent_name="opc-work"
+                )
 
         assert result["success"] is True
         assert result["agent"] == "opc-work"
@@ -1052,28 +1182,14 @@ class TestSyncAgent:
                 "clawrium.core.lifecycle.configure_agent",
                 return_value=(True, None),
             ):
-                with patch(
-                    "clawrium.core.lifecycle.restart_agent",
-                    return_value={
-                        "success": True,
-                        "agent": "opc-work",
-                        "host": "192.168.1.100",
-                        "operation": "restart",
-                        "pid": None,
-                        "started_at": "2026-04-14T12:00:00Z",
-                        "error": None,
-                    },
-                ):
-                    result = sync_agent("192.168.1.100", "openclaw", on_event=on_event)
+                result = sync_agent("192.168.1.100", "openclaw", on_event=on_event)
 
         assert result["success"] is True
-        # W8: Assert sync events were emitted with proper count/ordering
         sync_events = [e for e in events if e[0] == "sync"]
-        # Should have at least 4 sync events: Syncing, Configuring, Restarting, complete
-        assert len(sync_events) >= 4
-        # First should be "Syncing..."
+        # Issue #437: sync now emits 3 events — "Syncing", "Configuring",
+        # "Sync complete" (the explicit "Restarting" step is gone).
+        assert len(sync_events) >= 3
         assert "Syncing" in sync_events[0][1]
-        # Last should be "Sync complete"
         assert "complete" in sync_events[-1][1].lower()
 
     def test_workspace_only_skips_restart(self):

--- a/website/docs/agent-support/zeroclaw.md
+++ b/website/docs/agent-support/zeroclaw.md
@@ -217,18 +217,15 @@ agents.<agent-name>.config.gateway.auth = "<bearer-token>"
 agents.<agent-name>.config.gateway.url  = "ws://<agent-host>:42617/ws/chat"
 ```
 
-Re-running `clm agent configure <agent-name>` **reuses** the persisted token by default — live chat sessions stay valid. See [Rotating the gateway token](#rotating-the-gateway-token) below for the rotation workaround (no Typer flag exists yet; rotation is driven through an Ansible extra-var).
+Re-running `clm agent configure <agent-name>` (or `sync` or `restart`) **always re-pairs** and overwrites the persisted token (issue #437). Live chat sessions on **other machines** must reconnect on their next message — `clm chat` on the local machine reloads `hosts.json` automatically on a 401 and reconnects transparently. See [Gateway token lifecycle](#gateway-token-lifecycle) below for the full contract.
 
 A non-fatal warning is surfaced when the post-configure readiness probe (`GET /health/providers`) returns 401: the gateway is reachable but the provider credentials likely mismatch the API key supplied in `config.toml`. Re-run with the correct key.
 
-#### Rotating the gateway token
+#### Gateway token lifecycle
 
-The pairing token can be invalidated and re-minted, but `clm agent configure` does not yet surface a Typer flag for this. Today, the rotation flow is:
+The zeroclaw daemon mints its bearer through a loopback `/pair/code` → `/pair` handshake. The daemon does not persist that bearer across systemd restarts, so `clm` enforces a single invariant: every lifecycle op (`install`, `configure`, `sync`, `restart`) ends with a fresh pair handshake and an atomic write to `hosts.json.gateway.auth`. There is no idempotent-skip path and no `force_repair` opt-out — branching here was the cause of issue #437.
 
-1. Edit `~/.config/clawrium/hosts.json` and clear `agents.<agent-name>.config.gateway.auth` (set it to an empty string or delete the key).
-2. Re-run `clm agent configure <agent-name>`. The configure playbook detects the missing token and runs a fresh `GET /pair/code` → `POST /pair` handshake.
-
-Alternatively, if you are scripting against the playbook directly, pass `force_repair=true` as an Ansible extra-var — the configure playbook honors it and forces the mint path. This bypasses the higher-level CLI; live chat sessions using the previous token will fail at their next message.
+Trade-off (accepted): every `sync`/`restart` invalidates in-flight chat sessions on other machines. The CLI emits a single `gateway_token_rotated` yellow notice when this happens, including the agent name so you know which remote sessions need to reconnect.
 
 ### 3. Use the WebSocket chat surface
 
@@ -306,7 +303,7 @@ ZeroClaw's threat model is **trusted LAN**, parity with the upstream daemon's de
 - **The bearer token traverses the network in cleartext on `ws://` connections.** The pairing handshake itself happens loopback-only inside the configure playbook, so the code/token never leave the agent host during minting — but every subsequent `clm chat` carries the token in an `Authorization` header over plain WebSocket. Fine on a trusted LAN; **not fine** over an untrusted network. `core/chat_zeroclaw.py` warns once per session when the destination is non-loopback (`_warn_if_token_in_cleartext`). For production / untrusted networks, terminate TLS at a reverse proxy (Caddy / nginx) and use a `wss://` URL; clm does not run that proxy itself.
 - **A plain `ssh -L 42617:…` tunnel does not redirect `clm chat`.** `clm chat` rebuilds the gateway URL from the host record's primary address in `hosts.json` (see [Off-host access from the control machine](#off-host-access-from-the-control-machine) above). For ad-hoc verification, point a raw client (`wscat`, `websocat`) at the tunnelled loopback instead; for persistent overlay-network access, register the overlay address via `clm host address add` + `set-primary` so `clm chat` dials it directly.
 - **Tokens persist to `hosts.json` on the control machine.** Treat the file like any other credential store; review its permissions (it is not chmod-0600 by default) and avoid checking it into version control. On a multi-user control machine, tighten the file mode manually.
-- **Re-configure preserves the existing token by default.** clm only mints a fresh token when `force_repair` is supplied via Ansible extra-vars (see [Rotating the gateway token](#rotating-the-gateway-token)). There is no Typer flag for this yet — rotate by clearing the stored token first.
+- **Re-configure always re-mints the bearer (issue #437).** `clm agent configure`/`sync`/`restart` overwrite `config.gateway.auth` on every run. Local `clm chat` reloads the token transparently on 401; remote sessions must reconnect. See [Gateway token lifecycle](#gateway-token-lifecycle).
 - **Server-supplied text is BIDI / control-char sanitized before rendering.** `core/chat_zeroclaw.py` routes every visible field from server frames through `sanitize_server_text` (which strips C0/C1 controls, zero-width codepoints, BIDI overrides U+202A–U+202E and U+2066–U+2069, line/paragraph separators, and the word-joiner). Rich-markup escaping is handled separately by the CLI render layer, not by this sanitizer.
 - **`approval_request` frames tear down the session.** Inline tool approval is not implemented; the client closes the WebSocket and raises a remediation error pointing operators at `~/.zeroclaw/config.toml`. Pre-approve or disable tools at the agent host before invoking them. See [Use the WebSocket chat surface](#3-use-the-websocket-chat-surface) for the full frame envelope.
 - **Treat `config.toml` as an audited surface.** clm only emits `[gateway]`, `[providers.models.<name>]`, and `[personality]`. Any block manually added (e.g. `[integrations]`, `[hardware]`) is honored by the daemon but **invisible to `clm`** — `clm agent configure` will not validate it and `clm` cannot detect drift between renders and manual edits.
@@ -319,7 +316,7 @@ ZeroClaw's threat model is **trusted LAN**, parity with the upstream daemon's de
 - **Workspace personality is operator-owned after first configure.** Every workspace template renders with `force: no`. After the initial seed, the daemon and the operator (via `clm agent memory edit`) are the only writers.
 - **`BOOTSTRAP.md` is runtime-generated and self-deletes.** Do not expect to see it in `clm agent memory show`. It only exists between first daemon start and the daemon's own bootstrap cleanup.
 - **`clm chat` requires the daemon to be running.** The CLI does not run the runtime in-process; it speaks to the systemd-managed daemon. If `systemctl status zeroclaw-<name>` is `inactive (dead)`, `clm chat` will fail to connect.
-- **Re-installing preserves the gateway token.** `install.py`'s `preserved_gateway` carry-over keeps `config.gateway.auth` across reinstalls, so re-running install does not break live chat sessions. Re-running `configure` follows the same rule — see [Rotating the gateway token](#rotating-the-gateway-token) for the explicit rotation path.
+- **Re-installing preserves the gateway token; configure/sync/restart do not.** `install.py`'s `preserved_gateway` carry-over keeps `config.gateway.auth` across reinstalls because install itself does not re-pair. Lifecycle ops that touch the running daemon (`configure`, `sync`, `restart`) always re-pair — see [Gateway token lifecycle](#gateway-token-lifecycle).
 
 ---
 
@@ -374,14 +371,14 @@ Both pairing steps validate their responses; failure modes:
 - `GET /pair/code` returned non-200, or a body missing the `code` field → daemon is up but pairing endpoint is disabled. Check the journal for upstream errors.
 - `POST /pair` returned non-200, or a token shorter than 16 chars → the code expired or was already consumed.
 
-Recovery is a token rotation — see [Rotating the gateway token](#rotating-the-gateway-token). Tl;dr: clear `agents.<agent-name>.config.gateway.auth` from `hosts.json`, then re-run `clm agent configure <agent-name>`. The empty token triggers a fresh `GET /pair/code` → `POST /pair` cycle. Existing chat sessions using the old token will fail at the next message.
+Recovery: re-run `clm agent configure <agent-name>` — every configure run unconditionally mints a fresh token (see [Gateway token lifecycle](#gateway-token-lifecycle)). If `/pair/code` still fails, check the journal for upstream errors and restart the daemon (`clm agent restart <agent-name>`), which also re-pairs.
 
 </details>
 
 <details>
 <summary><strong><code>clm chat</code> fails after a reinstall</strong></summary>
 
-`install.py preserved_gateway` carries `config.gateway.auth` across reinstalls so this is rare. If it happens, the most likely cause is a manual edit to `hosts.json` between install and chat. Rotate the token (clear `gateway.auth` and re-run `clm agent configure <agent-name>` — see [Rotating the gateway token](#rotating-the-gateway-token)) to mint a fresh token aligned with the rebuilt daemon state.
+`install.py preserved_gateway` carries `config.gateway.auth` across reinstalls so this is rare. If it happens, run `clm agent configure <agent-name>` — every configure unconditionally re-pairs (see [Gateway token lifecycle](#gateway-token-lifecycle)) and brings `hosts.json` into agreement with the rebuilt daemon state.
 
 </details>
 


### PR DESCRIPTION
## Summary

- Every lifecycle op that touches the zeroclaw daemon (`install`, `configure`, `sync`, `restart`, `start`) now ends with a fresh `/pair/code` → `/pair` handshake and an atomic write to `hosts.json.gateway.auth`. The idempotent-skip branch is gone.
- `cli/chat.py` reloads `hosts.json` on a 401 and reconnects transparently when the on-disk bearer rotated under it; loop-guard caps retry at one.
- Structured `gateway_token_rotated` event emitted from one site; CLI renders it as a yellow notice during `configure`/`sync`/`restart`/`start`.

Closes #437

## ATX Review Summary

**Final Review: Rating 4/5** — Merge unblocked.
**Total: 3 rounds, $10.74 cost, ~31m wall time, 5 specialist agents**

| Round | Rating | Blocking | Status | Cost | Agents |
|-------|--------|----------|--------|------|--------|
| 1 | 2/5 | B1, W1-W9 | All addressed in commit 4eb3a8b | $3.76 | leader, test-coverage, cli-ux, core-lifecycle, ansible-registry, security |
| 2 | 3/5 | None (11 warnings: W-NEW-1,2; W-SEC-1-4; W-COV-1-5) | All addressed in commit cdc57e4 | $3.26 | same |
| 3 | **4/5** | **None** (2 follow-up warnings: W-R3-1, W-R3-2) | **Both addressed in commit 3b0001d** | $3.73 | all 5 specialists |

> Note: ATX does not expose model information per agent.

<details>
<summary>Round 1 Details (Rating 2/5)</summary>

**Blocking Issues**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_cli_chat.py` | `attempted_reconnect` loop guard untested — could regress to infinite loop | Fixed — added `test_chat_zeroclaw_loop_guard_stops_on_second_401` |

**Warnings**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `playbooks/start.yaml` | Missing re-pair after daemon start | Fixed — repair moved into `start_agent`; `restart_agent` inherits via `repair_reason="restart"` kwarg |
| W2 | `lifecycle.py:1545` | Rotation event emitted before `update_host` write | Fixed — emit only after disk write returns True |
| W3 | `cli/agent.py:2477` | Restart/sync inline on_event printed raw JSON for rotation events | Fixed — both dispatch to `_print_configure_warnings` |
| W4 | `lifecycle.py:668` | Missing `agent_name` regex validation in repair helper | Fixed — parity with `configure_agent` |
| W5 | `lifecycle.py:637` | Bearer not validated for charset/max-length before disk write | Deferred to follow-up issue |
| W6 | `lifecycle.py:103` | 8-char token prefix logged at INFO | Fixed — prefixes dropped from log line; still in structured payload |
| W7 | `cli/chat.py:228` | "Reconnected" printed before retry outcome | Fixed — tentative "retrying..." before; "reconnected" only after success |
| W8 | `tests/test_lifecycle.py` | `update_host=False` and timeout paths untested | Fixed — added both tests |
| W9 | `test_cli_agent_lifecycle.py:386` | Dead `restart_agent` mock + misleading "agent restarted" CLI message | Fixed — mock removed, CLI message updated to "Configuration synced" |

</details>

<details>
<summary>Round 2 Details (Rating 3/5)</summary>

**Warnings** (11 new, no blockers)

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W-NEW-1 | `lifecycle.py:747` | Hardcoded `emit('restart', ...)` in repair helper silently swallowed during `start` op | Fixed — `emit(reason, ...)` so stage matches the originating op |
| W-NEW-2 | `lifecycle.py:454` | Raw `agent_name` (possibly None) passed instead of resolved `agent_key` | Fixed — pass `agent_key` |
| W-SEC-1 | `cli/agent.py × 5` | Rich markup injection via unescaped `result['error']` | Fixed — `rich_escape` at remove/start/stop/restart/sync sites |
| W-SEC-2 | `lifecycle.py:444` | "Started successfully" emitted before repair completes | Fixed — pre-repair "Daemon started; pairing..."; success only after repair |
| W-SEC-3 | `lifecycle.py:740` | `host_display` unsanitized in `Path` construction (3 sites) | Fixed — `_safe_host_display()` helper |
| W-SEC-4 | `playbooks/restart.yaml:4` | Unnecessary `become: yes` on loopback-only play | Fixed — removed |
| W-COV-1 | `lifecycle.py:451` | `start_agent → repair` wiring untested through real `start_agent` | Fixed — `TestStartAgentZeroclawRepairWiring` (3 tests including negative parity) |
| W-COV-2 | `lifecycle.py:776` | Empty-fact-cache timing window uncovered | Fixed — `test_returns_failure_when_fact_cache_empty` |
| W-COV-3 | `test_configure_claw.py` | No assertion that rotation event is suppressed when write fails | Fixed — assertion added in both repair-helper and configure-agent tests |
| W-COV-4 | `lifecycle.py:704` | Gateway-port-missing branch never exercised | Fixed — `test_returns_failure_when_gateway_port_missing` |
| W-COV-5 | `cli/chat.py:362` | `HostsFileCorruptedError` during reconnect not tested | Fixed — `test_chat_zeroclaw_treats_corrupted_hosts_as_genuine_401` |

</details>

<details>
<summary>Round 3 Details (Rating 4/5 — Merge unblocked)</summary>

**Round 2 Verification — All 11 Confirmed Resolved ✅** (per specialist verdicts)

**Warnings** (2 new, non-blocking — addressed anyway)

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W-R3-1 | `tests/test_lifecycle.py` | `_safe_host_display` has zero direct tests | Fixed — `TestSafeHostDisplay` with 7 cases; helper hardened to fall back to `"host"` when sanitized result is all underscores |
| W-R3-2 | `tests/test_lifecycle.py:619` | `on_event` forwarding not asserted in start_agent wiring test | Fixed — identity-check on forwarded callback added |

**Per-agent ratings:** ansible-registry 5/5, cli-ux 4/5, security 4/5, core-lifecycle 4/5, test-coverage 3/5 → aggregate 4/5.

**Deferred (out of scope, tracked separately):** W5 (token charset validation), S1-S7 suggestions.

</details>

## Testing

### Test Results
- [x] All Python tests pass (`make test`) — 2317 passed, 14 skipped
- [x] Linter passes (`make lint`)
- [x] New tests added covering: always-repair invariant for configure/sync/start/restart, transparent chat reconnect with loop guard, fact-cache failure modes, host-display sanitization

### Manual Testing
The fix targets the exact repro flow in #437 (sync → chat 401 → can't recover without manually clearing `hosts.json`). Verified locally that:
- A fresh configure does **not** emit a rotation event (suppressed on first mint).
- A second configure emits one rotation event with `reason='configure'`.
- `sync` runs configure with `reason='sync'` and does not orchestrate a restart.
- `restart` re-pairs via `start_agent(repair_reason='restart')`.
- The chat reconnect path uses exactly one retry; on second 401 it exits 1 with the existing auth-failed error.

### Security Checklist
- [x] No hardcoded secrets or credentials — token capture and storage paths unchanged (still loopback handshake, still `no_log: true` on every pair step)
- [x] Input validation for user-provided data — `_safe_host_display` guards path construction; `unix_agent_name` regex validation in repair helper matches `configure_agent`
- [x] No SQL injection, XSS, or command injection risks — `rich_escape` applied to all five CLI error-display sites
- [x] Dependencies are from trusted sources — no new dependencies
- [x] Privilege scope tightened — `become: yes` removed from `restart.yaml` (loopback-only play)

## Trade-off (documented in AGENTS.md)

Every `sync` / `restart` / `start` now invalidates in-flight `clm chat` sessions on other machines. The local machine reconnects transparently. Remote sessions get a clean 401 they must handle. This is the trade-off the original ATX Round 1 B3 code was specifically trying to dodge — this PR reverses that: **correctness over convenience.** The new `gateway_token_rotated` yellow notice tells the operator exactly which agent rotated so they know which remote sessions to expect.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>