### PR TITLE
ui: sidebar/topology/providers revamp

### DIFF
--- a/gui/src/components/topology/provider-node.test.tsx
+++ b/gui/src/components/topology/provider-node.test.tsx
@@ -45,6 +45,7 @@ function renderNode(data: Partial<ProviderNodeData>) {
     name: "p",
     type: "ollama",
     endpoint: null,
+    model: null,
     agentCount: 1,
     unconfigured: false,
     ...data,
@@ -154,6 +155,16 @@ describe("ProviderNode", () => {
   it("falls back to 'Provider' label when type is null", () => {
     renderNode({ name: "Unconfigured", type: null, unconfigured: true });
     expect(screen.getByText("Provider")).toBeInTheDocument();
+  });
+
+  it("shows the model sub-line when model is truthy", () => {
+    renderNode({ model: "z-ai/glm-5" });
+    expect(screen.getByText("z-ai/glm-5")).toBeInTheDocument();
+  });
+
+  it("hides the model sub-line when model is null", () => {
+    const { container } = renderNode({ model: null });
+    expect(container.textContent).not.toMatch(/z-ai\/glm-5/);
   });
 
   it("shows the endpoint sub-line when endpoint is truthy", () => {

--- a/gui/src/components/topology/provider-node.tsx
+++ b/gui/src/components/topology/provider-node.tsx
@@ -14,6 +14,7 @@ export function ProviderNode({ data }: NodeProps) {
     name,
     type,
     endpoint,
+    model,
     agentCount,
     unconfigured,
     hostGpuVendor,
@@ -80,6 +81,16 @@ export function ProviderNode({ data }: NodeProps) {
       >
         {name}
       </div>
+
+      {/* Model (if present) */}
+      {model && (
+        <div
+          className="text-[10px] text-secondary truncate mt-0.5"
+          title={model}
+        >
+          {model}
+        </div>
+      )}
 
       {/* Endpoint (if present) */}
       {endpoint && (

--- a/gui/src/components/topology/topology-graph.test.ts
+++ b/gui/src/components/topology/topology-graph.test.ts
@@ -301,25 +301,37 @@ describe("computeTopology", () => {
     }
   });
 
-  it("attaches the agent model name as the edge label", () => {
+  it("exposes the provider model on the provider node data", () => {
     const data = makeData([
       {
         hostname: "h",
         agents: [makeAgent({ agent_key: "a1", model: "claude-sonnet-4-6" })],
       },
     ]);
-    const { edges } = computeTopology(data);
-    const agentEdge = edges.find(
-      (e) => e.source === "agent-a1" && e.target.startsWith("provider-")
+    const { nodes } = computeTopology(data);
+    const providerNode = nodes.find((n) => n.type === "provider");
+    expect((providerNode!.data as { model: string | null }).model).toBe(
+      "claude-sonnet-4-6"
     );
-    expect(agentEdge?.label).toBe("claude-sonnet-4-6");
   });
 
-  it("omits the edge label when the agent has no model set", () => {
+  it("leaves provider model null when the agent has no model set", () => {
     const data = makeData([
       {
         hostname: "h",
         agents: [makeAgent({ agent_key: "a1", model: "" })],
+      },
+    ]);
+    const { nodes } = computeTopology(data);
+    const providerNode = nodes.find((n) => n.type === "provider");
+    expect((providerNode!.data as { model: string | null }).model).toBeNull();
+  });
+
+  it("never attaches a label to the agent→provider edge", () => {
+    const data = makeData([
+      {
+        hostname: "h",
+        agents: [makeAgent({ agent_key: "a1", model: "claude-sonnet-4-6" })],
       },
     ]);
     const { edges } = computeTopology(data);

--- a/gui/src/components/topology/topology-graph.ts
+++ b/gui/src/components/topology/topology-graph.ts
@@ -30,6 +30,7 @@ export interface ProviderNodeData {
   name: string;
   type: string | null;
   endpoint: string | null;
+  model: string | null;
   agentCount: number;
   unconfigured: boolean;
   hostGpuVendor?: string | null;
@@ -161,6 +162,7 @@ export function computeTopology(
   providerOrder.forEach((pKey, idx) => {
     const acc = providerMap.get(pKey)!;
     const providerNodeId = `provider-${pKey}`;
+    const providerModel = acc.agents.find((a) => a.model)?.model ?? null;
     nodes.push({
       id: providerNodeId,
       type: "provider",
@@ -170,6 +172,7 @@ export function computeTopology(
         name: acc.name,
         type: acc.type,
         endpoint: acc.endpoint,
+        model: providerModel,
         agentCount: acc.agents.length,
         unconfigured: acc.unconfigured,
         hostGpuVendor: acc.hostGpuVendor,
@@ -178,7 +181,7 @@ export function computeTopology(
     });
 
     // Edges: agent → provider
-    acc.agents.forEach(({ agentKey, model }) => {
+    acc.agents.forEach(({ agentKey }) => {
       const stroke = acc.unconfigured ? "#94A3B8" : "#475569";
       edges.push({
         id: `edge-${agentKey}-${pKey}`,
@@ -198,18 +201,6 @@ export function computeTopology(
           width: 14,
           height: 14,
         },
-        ...(model
-          ? {
-              label: model,
-              labelStyle: {
-                fontSize: 9,
-                fill: "var(--text-secondary)",
-                opacity: 0.7,
-              },
-              labelBgStyle: { fill: "#FFFFFF", fillOpacity: 0.7 },
-              labelBgPadding: [3, 1] as [number, number],
-            }
-          : {}),
       });
     });
   });


### PR DESCRIPTION
## Summary

UI revamp covering the sidebar, topology graph, and providers page, including local-inference accelerator branding (NVIDIA/AMD) and the topology node layout.

Commits on this branch:
- `feat(gui): sidebar/topology/providers UI revamp + Ollama accelerator_vendor`
- `fix(gui): address ATX Round 1 blockers (B2–B5)`
- `feat(gui): stack accelerator badge under Ollama logo in ProviderCard`
- `feat(gui): move model name from edge label into provider card`

The latest commit moves the model name from a floating edge label onto the provider card, between the provider name and the endpoint. The agent→provider edge is now a clean line with just an arrowhead. The agent card is unchanged.

## Testing

### Test Results
- [x] All existing tests pass (208 UI tests, `npx vitest run`)
- [x] Linter passes (`npx next lint --dir src`)
- [x] Typecheck clean (`npx tsc --noEmit`)
- [x] New tests added for provider model line and edge-label removal

### Test Coverage
- Files changed: `provider-node.tsx`, `provider-node.test.tsx`, `topology-graph.ts`, `topology-graph.test.ts`
- New tests: 3 cases (model line shown/hidden; edge never carries a label)

### Manual Testing
Visually verified the topology canvas in the dev server: model name now renders inside the provider card (e.g., `z-ai/glm-5`, `nemotron-cascade-2:30b-a3b-q4_K_M`), and the agent→provider arrows are unlabeled.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] No new user-provided input paths
- [x] No SQL / XSS / command-injection surface
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)