### PR TITLE
fix(zeroclaw): handle daemon's locked-pair state in pair handshake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,13 @@ classifiers = [
 dependencies = [
     "typer>=0.12.0",
     "rich>=14.0.0",
-    # ATX #445 NW1: pin below 3.x. `res.censored` is an internal
-    # callback contract (ansible_runner/display_callback/...), not a
-    # documented public API. A 3.0 rename would silently no-op the
-    # bearer-leak guard at lifecycle.py:~360/808/1517 with no test
-    # failure. Bump deliberately when 3.x is vetted.
+    # ATX #445 NW1 / iter-3 S2: pin below 3.x. `res.censored` is an
+    # internal callback contract (ansible_runner/display_callback/...),
+    # not a documented public API; a 3.0 rename would silently no-op the
+    # bearer-leak guard with no test failure. Call sites:
+    # lifecycle.py:_run_lifecycle_playbook (~L360),
+    # _zeroclaw_repair_after_start (~L808),
+    # configure_agent (~L1525). Bump deliberately when 3.x is vetted.
     "ansible-runner>=2.4.0,<3",
     "paramiko>=3.0.0",
     "pyyaml>=6.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawrium"
-version = "26.5.1"
+version = "26.5.2"
 description = "CLI tool for managing AI assistant fleets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,12 @@ classifiers = [
 dependencies = [
     "typer>=0.12.0",
     "rich>=14.0.0",
-    "ansible-runner>=2.4.0",
+    # ATX #445 NW1: pin below 3.x. `res.censored` is an internal
+    # callback contract (ansible_runner/display_callback/...), not a
+    # documented public API. A 3.0 rename would silently no-op the
+    # bearer-leak guard at lifecycle.py:~360/808/1517 with no test
+    # failure. Bump deliberately when 3.x is vetted.
+    "ansible-runner>=2.4.0,<3",
     "paramiko>=3.0.0",
     "pyyaml>=6.0.0",
     "packaging>=24.0",

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -732,6 +732,11 @@ def _zeroclaw_repair_after_start(
             f"Gateway port missing from hosts.json for {agent_key}. "
             f"Re-run `clm agent configure {agent_key}`.",
         )
+    # Issue #445: the playbook's locked-pair branch (tasks/pair.yaml) calls
+    # POST /api/pairing/initiate with this bearer when /pair/code returns
+    # null. Empty string is acceptable on the fresh-boot branch since
+    # /pair/code will return a usable code and the locked branch never fires.
+    existing_gateway_auth = gateway_cfg.get("auth") or ""
 
     key_id = host.get("key_id") or hostname
     ssh_key = get_host_private_key(key_id)
@@ -754,7 +759,12 @@ def _zeroclaw_repair_after_start(
             "vars": {
                 "agent_name": unix_agent_name,
                 "agent_type": "zeroclaw",
-                "config": {"gateway": {"port": gateway_port}},
+                "config": {
+                    "gateway": {
+                        "port": gateway_port,
+                        "auth": existing_gateway_auth,
+                    }
+                },
             },
         }
     }

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -367,10 +367,14 @@ def _run_lifecycle_playbook(
                     # in its 401 body.
                     if res.get("censored"):
                         continue
-                    if "msg" in res:
+                    # ATX #445 iter-3 NW4: `if "msg" in res` would fire on a
+                    # `{"msg": None}` entry and set error_msg = None, leaking
+                    # an empty error string up the stack. Use `is not None`
+                    # so the loop falls through to stderr / generic prefix.
+                    if res.get("msg") is not None:
                         error_msg = res["msg"]
                         break
-                    if "stderr" in res:
+                    if res.get("stderr") is not None:
                         error_msg = res["stderr"]
                         break
             return False, error_msg
@@ -815,10 +819,14 @@ def _zeroclaw_repair_after_start(
                     # in its 401 body.
                     if res.get("censored"):
                         continue
-                    if "msg" in res:
+                    # ATX #445 iter-3 NW4: `if "msg" in res` would fire on a
+                    # `{"msg": None}` entry and set error_msg = None, leaking
+                    # an empty error string up the stack. Use `is not None`
+                    # so the loop falls through to stderr / generic prefix.
+                    if res.get("msg") is not None:
                         error_msg = res["msg"]
                         break
-                    if "stderr" in res:
+                    if res.get("stderr") is not None:
                         error_msg = res["stderr"]
                         break
             return False, error_msg
@@ -1262,10 +1270,14 @@ def configure_agent(
     # /api/pairing/initiate with, instead of sending `Bearer ` (empty) and
     # getting a 401 the operator can't decode.
     #
-    # ATX iter-2 NS1: runs BEFORE the gateway port validation below so the
-    # injection cannot create a `{"gateway": {"auth": ""}}` block that
-    # silently bypasses the port check (the existing `if config_data.get
-    # ("gateway")` guard is falsy for both an absent key and an empty dict).
+    # ATX iter-2 NS1 (clarified in iter-3 S1): runs BEFORE the gateway port
+    # validation below. The injection populates config_data["gateway"] so
+    # the `if config_data.get("gateway")` guard at the validation block
+    # becomes truthy and the port check FIRES with a clean
+    # "Incomplete gateway config — missing: port" error. In the old
+    # position (after validation), a caller that omitted the gateway key
+    # left that guard falsy — the port check was silently skipped and the
+    # failure surfaced later as a confusing Ansible error.
     if resolved_type == "zeroclaw":
         gw_block = config_data.setdefault("gateway", {})
         if not gw_block.get("auth"):
@@ -1521,10 +1533,14 @@ def configure_agent(
                     # in its 401 body.
                     if res.get("censored"):
                         continue
-                    if "msg" in res:
+                    # ATX #445 iter-3 NW4: `if "msg" in res` would fire on a
+                    # `{"msg": None}` entry and set error_msg = None, leaking
+                    # an empty error string up the stack. Use `is not None`
+                    # so the loop falls through to stderr / generic prefix.
+                    if res.get("msg") is not None:
                         error_msg = res["msg"]
                         break
-                    if "stderr" in res:
+                    if res.get("stderr") is not None:
                         error_msg = res["stderr"]
                         break
             return False, error_msg

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -360,6 +360,13 @@ def _run_lifecycle_playbook(
                 if event.get("event") == "runner_on_failed":
                     event_data = event.get("event_data", {})
                     res = event_data.get("res", {})
+                    # ATX #445 W1: a `no_log: true` task that fails surfaces
+                    # `{"censored": "..."}` in res; skip it so we don't read
+                    # `msg`/`stderr` keys that may carry the bearer if a
+                    # debug-mode daemon echoes the Authorization header back
+                    # in its 401 body.
+                    if res.get("censored"):
+                        continue
                     if "msg" in res:
                         error_msg = res["msg"]
                         break
@@ -801,6 +808,13 @@ def _zeroclaw_repair_after_start(
                 if event.get("event") == "runner_on_failed":
                     event_data = event.get("event_data", {})
                     res = event_data.get("res", {})
+                    # ATX #445 W1: a `no_log: true` task that fails surfaces
+                    # `{"censored": "..."}` in res; skip it so we don't read
+                    # `msg`/`stderr` keys that may carry the bearer if a
+                    # debug-mode daemon echoes the Authorization header back
+                    # in its 401 body.
+                    if res.get("censored"):
+                        continue
                     if "msg" in res:
                         error_msg = res["msg"]
                         break
@@ -1399,6 +1413,23 @@ def configure_agent(
             f"Invalid agent_name format: '{unix_agent_name}'. Must start with lowercase letter and contain only lowercase letters, digits, hyphens, underscores (max 32 chars)",
         )
 
+    # Issue #445 B1: defensive bearer injection for zeroclaw configure. The
+    # CLI paths in cli/agent.py already copy `existing_gateway["auth"]` into
+    # config_data when present, but callers that build config_data from
+    # scratch (e.g. _run_identity_stage at agent.py:639) won't. Mirror the
+    # pattern from _zeroclaw_repair_after_start (line 739) so the playbook's
+    # locked-pair branch in tasks/pair.yaml has a Bearer to authenticate
+    # /api/pairing/initiate with, instead of sending `Bearer ` (empty) and
+    # getting a 401 the operator can't decode.
+    if resolved_type == "zeroclaw":
+        gw_block = config_data.setdefault("gateway", {})
+        if not gw_block.get("auth"):
+            record_auth = (
+                agent_record.get("config", {}).get("gateway", {}).get("auth")
+                or ""
+            )
+            gw_block["auth"] = record_auth
+
     # Build Ansible inventory with API key passed directly
     ansible_vars = {
         "agent_name": unix_agent_name,
@@ -1478,6 +1509,13 @@ def configure_agent(
                 if event.get("event") == "runner_on_failed":
                     event_data = event.get("event_data", {})
                     res = event_data.get("res", {})
+                    # ATX #445 W1: a `no_log: true` task that fails surfaces
+                    # `{"censored": "..."}` in res; skip it so we don't read
+                    # `msg`/`stderr` keys that may carry the bearer if a
+                    # debug-mode daemon echoes the Authorization header back
+                    # in its 401 body.
+                    if res.get("censored"):
+                        continue
                     if "msg" in res:
                         error_msg = res["msg"]
                         break

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -1253,6 +1253,28 @@ def configure_agent(
             if not config_data["provider"].get("endpoint"):
                 return False, "Ollama provider requires 'endpoint' field"
 
+    # Issue #445 B1: defensive bearer injection for zeroclaw configure. The
+    # CLI paths in cli/agent.py already copy `existing_gateway["auth"]` into
+    # config_data when present, but callers that build config_data from
+    # scratch (e.g. _run_identity_stage at agent.py:639) won't. Mirror the
+    # pattern from _zeroclaw_repair_after_start (line 739) so the playbook's
+    # locked-pair branch in tasks/pair.yaml has a Bearer to authenticate
+    # /api/pairing/initiate with, instead of sending `Bearer ` (empty) and
+    # getting a 401 the operator can't decode.
+    #
+    # ATX iter-2 NS1: runs BEFORE the gateway port validation below so the
+    # injection cannot create a `{"gateway": {"auth": ""}}` block that
+    # silently bypasses the port check (the existing `if config_data.get
+    # ("gateway")` guard is falsy for both an absent key and an empty dict).
+    if resolved_type == "zeroclaw":
+        gw_block = config_data.setdefault("gateway", {})
+        if not gw_block.get("auth"):
+            record_auth = (
+                agent_record.get("config", {}).get("gateway", {}).get("auth")
+                or ""
+            )
+            gw_block["auth"] = record_auth
+
     # Validate required gateway fields
     required_gateway_fields = ["port"]
     if config_data.get("gateway"):
@@ -1412,23 +1434,6 @@ def configure_agent(
             False,
             f"Invalid agent_name format: '{unix_agent_name}'. Must start with lowercase letter and contain only lowercase letters, digits, hyphens, underscores (max 32 chars)",
         )
-
-    # Issue #445 B1: defensive bearer injection for zeroclaw configure. The
-    # CLI paths in cli/agent.py already copy `existing_gateway["auth"]` into
-    # config_data when present, but callers that build config_data from
-    # scratch (e.g. _run_identity_stage at agent.py:639) won't. Mirror the
-    # pattern from _zeroclaw_repair_after_start (line 739) so the playbook's
-    # locked-pair branch in tasks/pair.yaml has a Bearer to authenticate
-    # /api/pairing/initiate with, instead of sending `Bearer ` (empty) and
-    # getting a 401 the operator can't decode.
-    if resolved_type == "zeroclaw":
-        gw_block = config_data.setdefault("gateway", {})
-        if not gw_block.get("auth"):
-            record_auth = (
-                agent_record.get("config", {}).get("gateway", {}).get("auth")
-                or ""
-            )
-            gw_block["auth"] = record_auth
 
     # Build Ansible inventory with API key passed directly
     ansible_vars = {

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -371,11 +371,14 @@ def _run_lifecycle_playbook(
                     # `{"msg": None}` entry and set error_msg = None, leaking
                     # an empty error string up the stack. Use `is not None`
                     # so the loop falls through to stderr / generic prefix.
-                    if res.get("msg") is not None:
-                        error_msg = res["msg"]
+                    # ATX iter-4 S-F: symmetric `.get` access on both lines.
+                    msg = res.get("msg")
+                    if msg is not None:
+                        error_msg = msg
                         break
-                    if res.get("stderr") is not None:
-                        error_msg = res["stderr"]
+                    stderr = res.get("stderr")
+                    if stderr is not None:
+                        error_msg = stderr
                         break
             return False, error_msg
 
@@ -823,11 +826,14 @@ def _zeroclaw_repair_after_start(
                     # `{"msg": None}` entry and set error_msg = None, leaking
                     # an empty error string up the stack. Use `is not None`
                     # so the loop falls through to stderr / generic prefix.
-                    if res.get("msg") is not None:
-                        error_msg = res["msg"]
+                    # ATX iter-4 S-F: symmetric `.get` access on both lines.
+                    msg = res.get("msg")
+                    if msg is not None:
+                        error_msg = msg
                         break
-                    if res.get("stderr") is not None:
-                        error_msg = res["stderr"]
+                    stderr = res.get("stderr")
+                    if stderr is not None:
+                        error_msg = stderr
                         break
             return False, error_msg
 
@@ -1537,11 +1543,14 @@ def configure_agent(
                     # `{"msg": None}` entry and set error_msg = None, leaking
                     # an empty error string up the stack. Use `is not None`
                     # so the loop falls through to stderr / generic prefix.
-                    if res.get("msg") is not None:
-                        error_msg = res["msg"]
+                    # ATX iter-4 S-F: symmetric `.get` access on both lines.
+                    msg = res.get("msg")
+                    if msg is not None:
+                        error_msg = msg
                         break
-                    if res.get("stderr") is not None:
-                        error_msg = res["stderr"]
+                    stderr = res.get("stderr")
+                    if stderr is not None:
+                        error_msg = stderr
                         break
             return False, error_msg
 

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/tasks/pair.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/tasks/pair.yaml
@@ -66,6 +66,14 @@
 # ATX B2: surface 401/503 as actionable operator messages BEFORE the
 # resolved_pairing_code set_fact runs, so the operator sees the right
 # remediation instead of a generic "pairing code" failure downstream.
+#
+# ATX iter-2 NW2: `no_log: true` even though the current msg references
+# only `initiate_response.status` (safe). Defends against a future template
+# edit that adds `initiate_response.json` or `.content` to the msg — those
+# would otherwise leak the daemon's 401 body, which may echo back the
+# Authorization header in a debug-mode daemon. Keep the fail-msg visible to
+# the operator via the LifecycleResult error string; no_log only suppresses
+# Ansible's own callback echo, not the fail itself.
 - name: Validate locked-branch initiate response
   ansible.builtin.fail:
     msg: >-
@@ -80,6 +88,7 @@
       {% else %}POST /api/pairing/initiate returned an unexpected status
       {{ initiate_response.status }} — see daemon logs.
       {% endif %}
+  no_log: true
   when:
     - initiate_response is defined
     - initiate_response.status is defined

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/tasks/pair.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/tasks/pair.yaml
@@ -67,13 +67,18 @@
 # resolved_pairing_code set_fact runs, so the operator sees the right
 # remediation instead of a generic "pairing code" failure downstream.
 #
-# ATX iter-2 NW2: `no_log: true` even though the current msg references
-# only `initiate_response.status` (safe). Defends against a future template
-# edit that adds `initiate_response.json` or `.content` to the msg — those
-# would otherwise leak the daemon's 401 body, which may echo back the
-# Authorization header in a debug-mode daemon. Keep the fail-msg visible to
-# the operator via the LifecycleResult error string; no_log only suppresses
-# Ansible's own callback echo, not the fail itself.
+# ATX iter-3 NB2: this task MUST NOT carry `no_log: true`. The
+# lifecycle.py censored-event handler (W1) skips events where
+# `res.censored` is set, which silently swallows the operator-actionable
+# branching this msg encodes. The current msg references only
+# `initiate_response.status` (an int — safe to log) plus the constants
+# `agent_name` and `agent_type`. Future editors:
+#
+#   WARNING: do NOT reference `initiate_response.json` or
+#   `initiate_response.content` in this msg. A debug-mode daemon may echo
+#   the Authorization header back in its 401 body; templating that into
+#   the msg would leak the bearer through the fail-msg path that bypasses
+#   no_log.
 - name: Validate locked-branch initiate response
   ansible.builtin.fail:
     msg: >-
@@ -88,7 +93,6 @@
       {% else %}POST /api/pairing/initiate returned an unexpected status
       {{ initiate_response.status }} — see daemon logs.
       {% endif %}
-  no_log: true
   when:
     - initiate_response is defined
     - initiate_response.status is defined

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/tasks/pair.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/tasks/pair.yaml
@@ -1,23 +1,34 @@
 ---
-# Reusable pair-handshake task file (issue #437).
+# Reusable pair-handshake task file (issue #437, locked-pair fix #445).
 #
 # Every lifecycle op that brings the zeroclaw daemon up MUST include this
-# file. There is no skip path. The daemon does not persist bearer state across
-# restarts, so the operator-visible invariant is "hosts.json.gateway.auth
-# equals the bearer the daemon will enforce on the next request" — and that
-# can only be guaranteed by always re-minting.
+# file. There is no skip path.
+#
+# Two-branch state machine, picked off the /pair/code response shape:
+#
+#   1. Fresh daemon (no row in devices.db) -> GET /pair/code returns a
+#      non-null pairing_code. Use it directly.
+#   2. Locked daemon (devices.db has prior rows, survives systemctl
+#      restart) -> GET /pair/code returns {"pairing_code": null}. POST
+#      to /api/pairing/initiate with the existing bearer to mint a fresh
+#      code, then continue down the same POST /pair path.
+#
+# Both branches converge on the existing X-Pairing-Code exchange.
 #
 # Inputs:
 #   - gateway_local_base: http://127.0.0.1:<port> (set by including playbook)
 #   - ansible_host, gateway_port (used to emit zeroclaw_gateway_url fact)
 #   - agent_name, agent_type (used in failure messages)
+#   - config.gateway.auth: current Bearer from hosts.json. Required only
+#     when /pair/code returns null. May be empty/undefined on first install
+#     (when the locked branch cannot fire anyway).
 #
 # Outputs (cacheable host facts; configure_agent / restart_agent read these
 # out of artifacts/<run>/fact_cache):
 #   - zeroclaw_gateway_token: bearer token minted by /pair
 #   - zeroclaw_gateway_url:   ws://<host>:<port>/ws/chat
 
-- name: Request pairing code
+- name: Request pairing code (fresh-boot branch)
   ansible.builtin.uri:
     url: "{{ gateway_local_base }}/pair/code"
     method: GET
@@ -27,22 +38,53 @@
   register: pair_code_response
   no_log: true
 
+# Locked branch: zeroclaw v0.7.5's /pair/code returns
+# {"pairing_code": null, "pairing_required": true} once devices.db has any
+# prior row. The authenticated initiate endpoint mints a fresh code that
+# the existing POST /pair task below can consume unchanged.
+- name: Mint pairing code via /api/pairing/initiate (locked-pair branch)
+  ansible.builtin.uri:
+    url: "{{ gateway_local_base }}/api/pairing/initiate"
+    method: POST
+    status_code: 200
+    timeout: 10
+    headers:
+      Authorization: "Bearer {{ config.gateway.auth | default('') }}"
+    return_content: yes
+  register: initiate_response
+  no_log: true
+  when:
+    - pair_code_response.json is defined
+    - pair_code_response.json.pairing_code is none
+
+- name: Resolve pairing code from whichever branch produced one
+  ansible.builtin.set_fact:
+    resolved_pairing_code: >-
+      {{
+        (initiate_response.json.pairing_code
+          if (pair_code_response.json is defined
+              and pair_code_response.json.pairing_code is none
+              and initiate_response is defined
+              and initiate_response.json is defined)
+          else pair_code_response.json.pairing_code)
+        if pair_code_response.json is defined else none
+      }}
+  no_log: true
+
 # Do NOT set `no_log: true` on this fail task. The msg body is pure
-# template-literal text (`agent_name`, `agent_type` — both safe to log) and
-# contains the operator-facing rotation instructions. The original ATX B4
-# concern (registered var from a `no_log: true` task leaking into logs)
-# does not apply here because we never reference pair_code_response.json
-# fields inside the msg.
+# template-literal text (`agent_name`, `agent_type` — both safe to log).
 - name: Validate pairing code shape
   ansible.builtin.fail:
     msg: >-
-      /pair/code did not return a usable pairing_code field. Daemon logs:
-      `journalctl --unit {{ agent_type }}-{{ agent_name }}`. Re-run
-      `clm agent configure {{ agent_name }}` after fixing the daemon.
+      Neither GET /pair/code nor POST /api/pairing/initiate returned a usable
+      pairing code. Check daemon logs:
+      `journalctl --unit {{ agent_type }}-{{ agent_name }}`. If devices.db was
+      wiped externally, run `clm agent configure {{ agent_name }}` after
+      restoring it.
   when:
-    - pair_code_response.json is not defined
-      or pair_code_response.json.pairing_code is not defined
-      or pair_code_response.json.pairing_code | length < 1
+    - resolved_pairing_code is not defined
+      or resolved_pairing_code is none
+      or resolved_pairing_code | length < 1
 
 # ZeroClaw v0.7.5 expects the one-time code via the `X-Pairing-Code` HTTP
 # header (per the daemon's startup banner), not a JSON body.
@@ -53,7 +95,7 @@
     status_code: 200
     timeout: 10
     headers:
-      X-Pairing-Code: "{{ pair_code_response.json.pairing_code }}"
+      X-Pairing-Code: "{{ resolved_pairing_code }}"
     return_content: yes
   register: pair_response
   no_log: true
@@ -67,6 +109,7 @@
   when:
     - pair_response.json is not defined
       or pair_response.json.token is not defined
+      or pair_response.json.token is none
       or pair_response.json.token | length < 16
 
 # Emit gateway token + URL as cacheable host facts. The Python caller reads

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/tasks/pair.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/tasks/pair.yaml
@@ -42,11 +42,17 @@
 # {"pairing_code": null, "pairing_required": true} once devices.db has any
 # prior row. The authenticated initiate endpoint mints a fresh code that
 # the existing POST /pair task below can consume unchanged.
+#
+# ATX B2: explicitly accept 401 and 503 so the recovery path produces an
+# actionable operator message instead of a raw `Status code was 401`
+# Ansible error. The `Validate locked-branch initiate response` task below
+# then fails with explicit guidance to re-run `clm agent configure` (401)
+# or check daemon health (503).
 - name: Mint pairing code via /api/pairing/initiate (locked-pair branch)
   ansible.builtin.uri:
     url: "{{ gateway_local_base }}/api/pairing/initiate"
     method: POST
-    status_code: 200
+    status_code: [200, 401, 503]
     timeout: 10
     headers:
       Authorization: "Bearer {{ config.gateway.auth | default('') }}"
@@ -56,6 +62,28 @@
   when:
     - pair_code_response.json is defined
     - pair_code_response.json.pairing_code is none
+
+# ATX B2: surface 401/503 as actionable operator messages BEFORE the
+# resolved_pairing_code set_fact runs, so the operator sees the right
+# remediation instead of a generic "pairing code" failure downstream.
+- name: Validate locked-branch initiate response
+  ansible.builtin.fail:
+    msg: >-
+      {% if initiate_response.status == 401 %}POST /api/pairing/initiate
+      returned 401: the bearer in hosts.json is stale (likely because
+      devices.db was wiped or rebuilt on the host). Run
+      `clm agent configure {{ agent_name }}` to re-pair from scratch.
+      {% elif initiate_response.status == 503 %}POST /api/pairing/initiate
+      returned 503: zeroclaw daemon reports pairing disabled or unavailable.
+      Check `journalctl --unit {{ agent_type }}-{{ agent_name }}` and restart
+      the daemon, then re-run `clm agent configure {{ agent_name }}`.
+      {% else %}POST /api/pairing/initiate returned an unexpected status
+      {{ initiate_response.status }} — see daemon logs.
+      {% endif %}
+  when:
+    - initiate_response is defined
+    - initiate_response.status is defined
+    - initiate_response.status != 200
 
 - name: Resolve pairing code from whichever branch produced one
   ansible.builtin.set_fact:
@@ -85,6 +113,20 @@
     - resolved_pairing_code is not defined
       or resolved_pairing_code is none
       or resolved_pairing_code | length < 1
+
+# ATX W2: declared format guard for the pairing code before it enters the
+# X-Pairing-Code HTTP header. Python's http.client already rejects CRLF in
+# header values since 3.4, so this is preventative rather than load-bearing;
+# the regex also documents the contract (alphanumeric/_/- max 128 chars) so
+# a future caller can't silently reuse the value in a shell command or URL
+# path without re-validating.
+- name: Validate pairing code format
+  ansible.builtin.fail:
+    msg: >-
+      Pairing code returned by the daemon has an unexpected format. Daemon
+      logs: `journalctl --unit {{ agent_type }}-{{ agent_name }}`.
+  when:
+    - resolved_pairing_code is not match('^[A-Za-z0-9_-]{1,128}$')
 
 # ZeroClaw v0.7.5 expects the one-time code via the `X-Pairing-Code` HTTP
 # header (per the daemon's startup banner), not a JSON body.

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -559,20 +559,32 @@ class TestZeroclawRepairAfterStart:
         rotation = [m for s, m in events if s == "gateway_token_rotated"]
         assert not rotation, f"rotation event leaked despite write failure: {rotation!r}"
 
-    def test_repair_passes_existing_bearer_in_inventory(self, tmp_path: Path):
-        """Issue #445: tasks/pair.yaml's locked-pair branch authenticates
-        against /api/pairing/initiate using the current bearer from
-        hosts.json. The Python helper must forward that bearer as
-        config.gateway.auth in the Ansible inventory so the playbook can
-        reach it. Without this, the locked branch fires with an empty
-        Authorization header and the daemon rejects it."""
-        host = self._host(auth="zc_existing_bearer_aaaaaaaaaaaaaaa")
-        runner, _ = self._setup_repair_runner(tmp_path, "new-rotated-token")
+    def _capture_repair(
+        self, host: dict, tmp_path: Path, *, new_token: str,
+    ) -> tuple[dict, dict, list[tuple[str, str]], bool, str | None]:
+        """Run _zeroclaw_repair_after_start with full instrumentation:
+        capture the inventory passed to ansible-runner, the dict produced
+        by update_host's updater closure, and the on_event sequence.
+
+        Returns (inventory, hosts_json_after, events, success, error).
+        """
+        runner, _ = self._setup_repair_runner(tmp_path, new_token)
         captured_inventory: dict = {}
+        captured_hosts: dict = {}
 
         def capture_run(**kwargs):
             captured_inventory.update(kwargs.get("inventory") or {})
             return runner
+
+        def capture_update_host(_hostname: str, updater) -> bool:
+            h = {"hostname": "192.168.1.100", "agents": dict(host["agents"])}
+            captured_hosts.update(updater(h))
+            return True
+
+        events: list[tuple[str, str]] = []
+
+        def on_event(stage: str, message: str) -> None:
+            events.append((stage, message))
 
         key_path = tmp_path / "test_key"
         key_path.write_text("key")
@@ -594,7 +606,7 @@ class TestZeroclawRepairAfterStart:
              ), \
              patch(
                 "clawrium.core.lifecycle.update_host",
-                return_value=True,
+                side_effect=capture_update_host,
              ), \
              patch(
                 "clawrium.core.lifecycle.get_config_dir",
@@ -604,16 +616,51 @@ class TestZeroclawRepairAfterStart:
             success, error = _zeroclaw_repair_after_start(
                 "192.168.1.100",
                 agent_name="zer-test",
-                on_event=None,
+                on_event=on_event,
                 reason="restart",
             )
+        return captured_inventory, captured_hosts, events, success, error
+
+    def test_repair_passes_existing_bearer_and_rotates_atomically(
+        self, tmp_path: Path
+    ):
+        """Issue #445: tasks/pair.yaml's locked-pair branch authenticates
+        against /api/pairing/initiate using the current bearer from
+        hosts.json. The Python helper must (a) forward that bearer as
+        config.gateway.auth in the Ansible inventory, AND (b) atomically
+        replace it in hosts.json with the new rotated bearer from the
+        fact_cache. ATX B4: pin the full read-existing → inject → run →
+        write-new pipeline so a refactor can't silently break either half.
+        """
+        host = self._host(auth="zc_existing_bearer_aaaaaaaaaaaaaaa")
+        inv, hosts_after, events, success, error = self._capture_repair(
+            host, tmp_path, new_token="zc_new_rotated_bearer_xxxxxxxxxxx",
+        )
         assert success is True, error
-        gateway_vars = captured_inventory["all"]["vars"]["config"]["gateway"]
-        assert gateway_vars["auth"] == "zc_existing_bearer_aaaaaaaaaaaaaaa", (
+
+        gateway_in = inv["all"]["vars"]["config"]["gateway"]
+        assert gateway_in["auth"] == "zc_existing_bearer_aaaaaaaaaaaaaaa", (
             "existing bearer must flow into the playbook so the locked-pair "
             "branch can authenticate against /api/pairing/initiate"
         )
-        assert gateway_vars["port"] == 40000
+        assert gateway_in["port"] == 40000
+
+        # B4: hosts.json must reflect the rotated bearer, not the input one.
+        gateway_out = hosts_after["agents"]["zer-test"]["config"]["gateway"]
+        assert gateway_out["auth"] == "zc_new_rotated_bearer_xxxxxxxxxxx", (
+            "hosts.json must be rewritten with the new bearer minted by "
+            "the playbook, not silently keep the stale input bearer (B4)"
+        )
+
+        # B4: exactly one rotation event fires (not zero, not multiple).
+        rotations = [m for s, m in events if s == "gateway_token_rotated"]
+        assert len(rotations) == 1, (
+            f"exactly one gateway_token_rotated event must fire per repair; "
+            f"got {len(rotations)}: {rotations!r}"
+        )
+        payload = json.loads(rotations[0])
+        assert payload["agent_key"] == "zer-test"
+        assert payload["reason"] == "restart"
 
     def test_repair_passes_empty_bearer_when_hosts_json_lacks_auth(
         self, tmp_path: Path
@@ -621,20 +668,70 @@ class TestZeroclawRepairAfterStart:
         """First-install path: hosts.json has no `auth` field yet. The
         helper must pass an empty string (not raise, not omit the key) so
         the playbook's `default('')` filter keeps the locked branch dormant
-        on a fresh daemon."""
+        on a fresh daemon. The write-back path still rotates atomically
+        once /pair returns a fresh bearer."""
         host = self._host()
         host["agents"]["zer-test"]["config"]["gateway"] = {"port": 40000}
-        runner, _ = self._setup_repair_runner(tmp_path, "fresh-token")
-        captured_inventory: dict = {}
+        inv, hosts_after, _events, success, _err = self._capture_repair(
+            host, tmp_path, new_token="zc_first_install_bearer_yyyyyyy",
+        )
+        assert success is True
+        assert inv["all"]["vars"]["config"]["gateway"]["auth"] == ""
+        # Even from an empty starting auth, the rotation closure must write
+        # the freshly minted bearer back.
+        assert (
+            hosts_after["agents"]["zer-test"]["config"]["gateway"]["auth"]
+            == "zc_first_install_bearer_yyyyyyy"
+        )
+
+
+class TestConfigureAgentZeroclawBearerForwarding:
+    """ATX #445 B1/W3: configure_agent must inject the prior bearer from
+    `agent_record.config.gateway.auth` into the Ansible inventory when the
+    caller's `config_data` lacks one, so the locked-pair branch in
+    `tasks/pair.yaml` has something to POST to `/api/pairing/initiate`."""
+
+    def _zc_host(self, *, auth_in_record: str | None) -> dict:
+        gateway: dict = {"port": 40000}
+        if auth_in_record is not None:
+            gateway["auth"] = auth_in_record
+        return {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "zer-test": {
+                    "type": "zeroclaw",
+                    "agent_name": "zerot",
+                    "onboarding": {"state": "ready"},
+                    "config": {"gateway": gateway},
+                }
+            },
+        }
+
+    def _capture_configure(
+        self, host: dict, config_data: dict, tmp_path: Path,
+    ) -> tuple[dict, bool, str | None]:
+        runner = MagicMock()
+        runner.status = "successful"
+        runner.events = []
+        artifacts_dir = tmp_path / "artifacts"
+        (artifacts_dir / "fact_cache").mkdir(parents=True)
+        runner.config.artifact_dir = str(artifacts_dir)
+
+        captured: dict = {}
 
         def capture_run(**kwargs):
-            captured_inventory.update(kwargs.get("inventory") or {})
+            captured.update(kwargs.get("inventory") or {})
             return runner
 
-        key_path = tmp_path / "test_key"
-        key_path.write_text("key")
-        playbook_path = tmp_path / "restart.yaml"
+        key_path = tmp_path / "k"
+        key_path.write_text("k")
+        playbook_path = tmp_path / "configure.yaml"
         playbook_path.write_text("---\n- hosts: all\n")
+        template_dir = tmp_path / "templates"
+        template_dir.mkdir()
 
         with patch("clawrium.core.lifecycle.get_host", return_value=host), \
              patch(
@@ -656,18 +753,89 @@ class TestZeroclawRepairAfterStart:
              patch(
                 "clawrium.core.lifecycle.get_config_dir",
                 return_value=tmp_path,
+             ), \
+             patch(
+                "clawrium.core.providers.get_provider_api_key",
+                return_value="",
+             ), \
+             patch(
+                "clawrium.core.providers.get_provider_aws_credentials",
+                return_value=("", ""),
+             ), \
+             patch(
+                "clawrium.core.secrets.get_instance_secrets",
+                return_value={},
+             ), \
+             patch(
+                "clawrium.core.integrations.get_agent_integrations",
+                return_value=[],
+             ), \
+             patch.object(
+                Path, "exists", return_value=True,
              ):
-            from clawrium.core.lifecycle import _zeroclaw_repair_after_start
-            success, _ = _zeroclaw_repair_after_start(
+            from clawrium.core.lifecycle import configure_agent
+            success, error = configure_agent(
                 "192.168.1.100",
+                "zeroclaw",
+                config_data,
                 agent_name="zer-test",
-                on_event=None,
-                reason="restart",
             )
-        assert success is True
-        assert (
-            captured_inventory["all"]["vars"]["config"]["gateway"]["auth"]
-            == ""
+        return captured, success, error
+
+    def test_configure_injects_record_bearer_when_config_data_lacks_one(
+        self, tmp_path: Path
+    ):
+        """B1 head-on: a caller that builds config_data from scratch (e.g.
+        `_run_identity_stage` at cli/agent.py:639) does not carry forward
+        `gateway.auth`. configure_agent must defensively pull it from the
+        agent record so the playbook's locked-pair branch can authenticate
+        /api/pairing/initiate."""
+        host = self._zc_host(
+            auth_in_record="zc_record_bearer_aaaaaaaaaaaaaaaaaaaa",
+        )
+        bare_config = {
+            "gateway": {"port": 40000},
+            "provider": {
+                "name": "p", "type": "ollama", "endpoint": "http://x",
+                "default_model": "m",
+            },
+        }
+        inv, success, error = self._capture_configure(
+            host, bare_config, tmp_path,
+        )
+        # Configure may bail later (no provider creds, etc.) but the
+        # inventory builder runs first; assert what was passed regardless.
+        gw = inv["all"]["vars"]["config"]["gateway"]
+        assert gw["auth"] == "zc_record_bearer_aaaaaaaaaaaaaaaaaaaa", (
+            "configure_agent must defensively pull the bearer from the "
+            "agent record so the locked-pair branch authenticates correctly "
+            "(ATX #445 B1)"
+        )
+
+    def test_configure_does_not_override_explicit_bearer(self, tmp_path: Path):
+        """If the caller already populated `gateway.auth` (e.g. via
+        cli/agent.py:357), configure_agent must NOT clobber it with the
+        record's older value. The caller's intent wins."""
+        host = self._zc_host(
+            auth_in_record="zc_record_OLD_aaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        config_with_fresh = {
+            "gateway": {
+                "port": 40000,
+                "auth": "zc_caller_FRESH_xxxxxxxxxxxxxxxxxxx",
+            },
+            "provider": {
+                "name": "p", "type": "ollama", "endpoint": "http://x",
+                "default_model": "m",
+            },
+        }
+        inv, _success, _error = self._capture_configure(
+            host, config_with_fresh, tmp_path,
+        )
+        gw = inv["all"]["vars"]["config"]["gateway"]
+        assert gw["auth"] == "zc_caller_FRESH_xxxxxxxxxxxxxxxxxxx", (
+            "configure_agent must not overwrite a caller-supplied bearer "
+            "with a stale value from hosts.json"
         )
 
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -292,21 +292,21 @@ class TestRunLifecyclePlaybook:
                 "zeroclaw", "zer-test", "192.168.1.100", "start", host
             )
 
-        # ATX iter-6: both calls MUST be intercepted. `get_instance_key`
-        # is a pure formatter and would still be invoked by any refactor
-        # that bypassed `get_instance_secrets` (e.g. inlining a json.load
-        # or introducing a new helper). With `or`, that bypass would pass
-        # silently and the real `get_instance_secrets` would read disk.
-        # `and` matches the actual call sequence at lifecycle.py:312-313
-        # — both helpers always fire on the success path.
-        assert mock_get_key.called, (
-            "get_instance_key not called — patch target or call path drifted "
-            "(ATX iter-5 NW-A / iter-6)"
-        )
+        # ATX iter-6/iter-7: both calls MUST be intercepted. `get_instance_
+        # secrets` is the security-critical gate (real disk reads); assert
+        # it first so a regression fails fast on the more important call.
+        # `get_instance_key` is a pure formatter and would still be invoked
+        # by any refactor that bypassed `get_instance_secrets` (e.g.
+        # inlining a json.load or introducing a new helper) — the second
+        # assert is the refactor-drift canary.
         assert mock_get_secrets.called, (
             "get_instance_secrets not called — this is the call that gates "
             "real secret values; if a refactor bypasses it, real "
             "~/.config/clawrium/secrets.json reads happen unintercepted "
+            "(ATX iter-5 NW-A / iter-6)"
+        )
+        assert mock_get_key.called, (
+            "get_instance_key not called — patch target or call path drifted "
             "(ATX iter-5 NW-A / iter-6)"
         )
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -559,6 +559,117 @@ class TestZeroclawRepairAfterStart:
         rotation = [m for s, m in events if s == "gateway_token_rotated"]
         assert not rotation, f"rotation event leaked despite write failure: {rotation!r}"
 
+    def test_repair_passes_existing_bearer_in_inventory(self, tmp_path: Path):
+        """Issue #445: tasks/pair.yaml's locked-pair branch authenticates
+        against /api/pairing/initiate using the current bearer from
+        hosts.json. The Python helper must forward that bearer as
+        config.gateway.auth in the Ansible inventory so the playbook can
+        reach it. Without this, the locked branch fires with an empty
+        Authorization header and the daemon rejects it."""
+        host = self._host(auth="zc_existing_bearer_aaaaaaaaaaaaaaa")
+        runner, _ = self._setup_repair_runner(tmp_path, "new-rotated-token")
+        captured_inventory: dict = {}
+
+        def capture_run(**kwargs):
+            captured_inventory.update(kwargs.get("inventory") or {})
+            return runner
+
+        key_path = tmp_path / "test_key"
+        key_path.write_text("key")
+        playbook_path = tmp_path / "restart.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host), \
+             patch(
+                "clawrium.core.lifecycle.get_host_private_key",
+                return_value=key_path,
+             ), \
+             patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook_path,
+             ), \
+             patch(
+                "clawrium.core.lifecycle.ansible_runner.run",
+                side_effect=capture_run,
+             ), \
+             patch(
+                "clawrium.core.lifecycle.update_host",
+                return_value=True,
+             ), \
+             patch(
+                "clawrium.core.lifecycle.get_config_dir",
+                return_value=tmp_path,
+             ):
+            from clawrium.core.lifecycle import _zeroclaw_repair_after_start
+            success, error = _zeroclaw_repair_after_start(
+                "192.168.1.100",
+                agent_name="zer-test",
+                on_event=None,
+                reason="restart",
+            )
+        assert success is True, error
+        gateway_vars = captured_inventory["all"]["vars"]["config"]["gateway"]
+        assert gateway_vars["auth"] == "zc_existing_bearer_aaaaaaaaaaaaaaa", (
+            "existing bearer must flow into the playbook so the locked-pair "
+            "branch can authenticate against /api/pairing/initiate"
+        )
+        assert gateway_vars["port"] == 40000
+
+    def test_repair_passes_empty_bearer_when_hosts_json_lacks_auth(
+        self, tmp_path: Path
+    ):
+        """First-install path: hosts.json has no `auth` field yet. The
+        helper must pass an empty string (not raise, not omit the key) so
+        the playbook's `default('')` filter keeps the locked branch dormant
+        on a fresh daemon."""
+        host = self._host()
+        host["agents"]["zer-test"]["config"]["gateway"] = {"port": 40000}
+        runner, _ = self._setup_repair_runner(tmp_path, "fresh-token")
+        captured_inventory: dict = {}
+
+        def capture_run(**kwargs):
+            captured_inventory.update(kwargs.get("inventory") or {})
+            return runner
+
+        key_path = tmp_path / "test_key"
+        key_path.write_text("key")
+        playbook_path = tmp_path / "restart.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host), \
+             patch(
+                "clawrium.core.lifecycle.get_host_private_key",
+                return_value=key_path,
+             ), \
+             patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook_path,
+             ), \
+             patch(
+                "clawrium.core.lifecycle.ansible_runner.run",
+                side_effect=capture_run,
+             ), \
+             patch(
+                "clawrium.core.lifecycle.update_host",
+                return_value=True,
+             ), \
+             patch(
+                "clawrium.core.lifecycle.get_config_dir",
+                return_value=tmp_path,
+             ):
+            from clawrium.core.lifecycle import _zeroclaw_repair_after_start
+            success, _ = _zeroclaw_repair_after_start(
+                "192.168.1.100",
+                agent_name="zer-test",
+                on_event=None,
+                reason="restart",
+            )
+        assert success is True
+        assert (
+            captured_inventory["all"]["vars"]["config"]["gateway"]["auth"]
+            == ""
+        )
+
 
 class TestSafeHostDisplay:
     """ATX W-R3-1: `_safe_host_display` is a path-traversal guard used at

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,4 +1,16 @@
-"""Tests for claw lifecycle management module."""
+"""Tests for claw lifecycle management module.
+
+Secrets isolation in this file relies on a load-bearing autouse fixture in
+`tests/conftest.py::_isolate_config_dir` — it redirects `XDG_CONFIG_HOME`
+to a tmp directory, so `clawrium.core.secrets.load_secrets()` returns `{}`
+for any test that doesn't explicitly mock `get_instance_secrets`. Removing
+or narrowing that fixture silently regresses ~all tests in this file that
+exercise the configure/start/restart paths — they would call the real
+secrets loader against the developer's `~/.config/clawrium/secrets.json`.
+The patches inside `_run_with_events`/`_capture_configure` are defence in
+depth (with a meta-test pinning correct interception); the fixture is the
+primary guarantee. ATX iter-6 W1.
+"""
 
 import json
 from pathlib import Path
@@ -280,15 +292,22 @@ class TestRunLifecyclePlaybook:
                 "zeroclaw", "zer-test", "192.168.1.100", "start", host
             )
 
-        # If either of these fires, the patch target is correct AND
-        # `_run_lifecycle_playbook` actually reads through the consumer
-        # binding. If both stay un-called on a future refactor that
-        # bypasses these helpers, this test alerts before the secrets-
-        # isolation guarantee silently regresses.
-        assert mock_get_secrets.called or mock_get_key.called, (
-            "Neither get_instance_secrets nor get_instance_key was called — "
-            "either the consumer no longer reads through these helpers, or "
-            "the patch target is wrong (ATX iter-5 NW-A)"
+        # ATX iter-6: both calls MUST be intercepted. `get_instance_key`
+        # is a pure formatter and would still be invoked by any refactor
+        # that bypassed `get_instance_secrets` (e.g. inlining a json.load
+        # or introducing a new helper). With `or`, that bypass would pass
+        # silently and the real `get_instance_secrets` would read disk.
+        # `and` matches the actual call sequence at lifecycle.py:312-313
+        # — both helpers always fire on the success path.
+        assert mock_get_key.called, (
+            "get_instance_key not called — patch target or call path drifted "
+            "(ATX iter-5 NW-A / iter-6)"
+        )
+        assert mock_get_secrets.called, (
+            "get_instance_secrets not called — this is the call that gates "
+            "real secret values; if a refactor bypasses it, real "
+            "~/.config/clawrium/secrets.json reads happen unintercepted "
+            "(ATX iter-5 NW-A / iter-6)"
         )
 
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -80,18 +80,9 @@ class TestRunLifecyclePlaybook:
         assert success is False
         assert "SSH key not found" in error
 
-    def test_censored_event_does_not_leak_bearer(self, tmp_path: Path):
-        """ATX iter-2 NB1: censored-guard at lifecycle.py:~360 covers the
-        generic start/stop/restart lifecycle path. Same security invariant
-        as the repair path, separate code site — pin it independently."""
-        host = {
-            "hostname": "192.168.1.100",
-            "key_id": "test",
-            "agent_name": "xclm",
-            "port": 22,
-            "agents": {"zer-test": {"type": "zeroclaw"}},
-        }
-
+    def _run_with_events(self, host, tmp_path: Path, events: list):
+        """Helper that runs _run_lifecycle_playbook with a stubbed runner
+        emitting the supplied events. Returns (success, error)."""
         playbook_path = tmp_path / "start.yaml"
         playbook_path.write_text("---\n- hosts: all\n")
         key_path = tmp_path / "key"
@@ -99,17 +90,7 @@ class TestRunLifecyclePlaybook:
 
         runner = MagicMock()
         runner.status = "failed"
-        runner.events = [
-            {
-                "event": "runner_on_failed",
-                "event_data": {
-                    "res": {
-                        "censored": "no_log: true was specified",
-                        "msg": "Bearer zc_LEAKED_FROM_START_xxxxxxxxxxx",
-                    }
-                },
-            },
-        ]
+        runner.events = events
 
         with patch(
             "clawrium.core.lifecycle._get_lifecycle_playbook_path",
@@ -124,16 +105,100 @@ class TestRunLifecyclePlaybook:
             "clawrium.core.lifecycle.get_config_dir",
             return_value=tmp_path,
         ):
-            success, error = _run_lifecycle_playbook(
+            return _run_lifecycle_playbook(
                 "zeroclaw", "zer-test", "192.168.1.100", "start", host
             )
+
+    def test_censored_event_does_not_leak_bearer(self, tmp_path: Path):
+        """ATX iter-2 NB1: censored-guard at lifecycle.py:~360 covers the
+        generic start/stop/restart lifecycle path. Same security invariant
+        as the repair path, separate code site — pin it independently."""
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {"zer-test": {"type": "zeroclaw"}},
+        }
+
+        success, error = self._run_with_events(host, tmp_path, [
+            {
+                "event": "runner_on_failed",
+                "event_data": {
+                    "res": {
+                        "censored": "no_log: true was specified",
+                        "msg": "Bearer zc_LEAKED_FROM_START_xxxxxxxxxxx",
+                    }
+                },
+            },
+        ])
 
         assert success is False
         assert "zc_LEAKED_FROM_START" not in error, (
             f"_run_lifecycle_playbook censored-guard regressed: {error!r}"
         )
         # All events censored → falls through to generic prefix.
-        assert "Start playbook failed" in error
+        assert error == "Start playbook failed: failed"
+
+    def test_all_censored_events_falls_back_to_generic_error(
+        self, tmp_path: Path
+    ):
+        """ATX iter-3 NW6: parity with TestZeroclawRepairAfterStart's
+        all-censored fallback. Two censored events with bearers in both
+        msg AND stderr — guard skips them both, generic prefix surfaces.
+        Pins exact format (S3)."""
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {"zer-test": {"type": "zeroclaw"}},
+        }
+        success, error = self._run_with_events(host, tmp_path, [
+            {
+                "event": "runner_on_failed",
+                "event_data": {
+                    "res": {
+                        "censored": "hidden",
+                        "msg": "Bearer zc_RL_LEAK_AAAAAAAAAAAAAAAAAAAAA",
+                    }
+                },
+            },
+            {
+                "event": "runner_on_failed",
+                "event_data": {
+                    "res": {
+                        "censored": "hidden",
+                        "stderr": "Bearer zc_RL_LEAK_BBBBBBBBBBBBBBBBBB",
+                    }
+                },
+            },
+        ])
+        assert success is False
+        assert "zc_" not in error
+        assert error == "Start playbook failed: failed"
+
+    def test_msg_none_event_does_not_return_none_error(
+        self, tmp_path: Path
+    ):
+        """ATX iter-3 NW4: in the generic lifecycle path too, a
+        non-censored event with msg=None must not short-circuit to None."""
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {"zer-test": {"type": "zeroclaw"}},
+        }
+        success, error = self._run_with_events(host, tmp_path, [
+            {
+                "event": "runner_on_failed",
+                "event_data": {"res": {"msg": None, "stderr": None}},
+            },
+        ])
+        assert success is False
+        assert error is not None
+        assert error == "Start playbook failed: failed"
 
 
 class TestStartClaw:
@@ -589,6 +654,10 @@ class TestZeroclawRepairAfterStart:
         """ATX iter-2 NB1 companion: when every runner_on_failed event is
         censored, the loop must fall through to the generic 'Re-pair
         playbook failed: <status>' message rather than the last seen msg.
+
+        ATX iter-3 S3: assert the EXACT generic message format so a
+        regression that drops the status suffix is caught (substring match
+        would tolerate it).
         """
         host = self._host()
         runner = MagicMock()
@@ -619,9 +688,37 @@ class TestZeroclawRepairAfterStart:
         assert "zc_" not in error, (
             f"all-censored fallback leaked a bearer fragment: {error!r}"
         )
-        # The generic prefix is what the helper produces when no usable
-        # `msg`/`stderr` is found across all events.
-        assert "Re-pair playbook failed" in error
+        # Exact format pinned (S3): drop the status suffix and this fails.
+        assert error == "Re-pair playbook failed: failed"
+
+    def test_msg_none_event_does_not_return_none_error(
+        self, tmp_path: Path
+    ):
+        """ATX iter-3 NW4: a non-censored event with `res = {'msg': None}`
+        must NOT short-circuit and return (False, None). The guard
+        `if res.get('msg') is not None` keeps the loop searching for a
+        usable msg/stderr instead of leaking a None up the stack."""
+        host = self._host()
+        runner = MagicMock()
+        runner.status = "failed"
+        runner.events = [
+            {
+                "event": "runner_on_failed",
+                "event_data": {
+                    # No censored key — this is the case the `if "msg" in res`
+                    # guard would have mishandled before the iter-3 fix.
+                    "res": {"msg": None, "stderr": None}
+                },
+            },
+        ]
+        success, error = self._run_repair(host, tmp_path, runner=runner)
+        assert success is False
+        assert error is not None, (
+            "msg=None on a non-censored event must not surface as a None "
+            "error string (iter-3 NW4)"
+        )
+        # Falls through to the generic prefix because msg and stderr are None.
+        assert error == "Re-pair playbook failed: failed"
 
     def test_returns_failure_when_update_host_returns_false(self, tmp_path: Path):
         """ATX W8: the exact divergence #437 fixes — playbook succeeds but
@@ -997,7 +1094,177 @@ class TestConfigureAgentZeroclawBearerForwarding:
         assert "zc_LEAK_FROM_CONFIGURE" not in (error or ""), (
             f"configure_agent censored-guard regressed: {error!r}"
         )
-        assert "Configure playbook failed" in (error or "")
+        # ATX iter-3 S3 / NW4: exact equality so the format itself is
+        # locked (not just a substring), and a silent None return would
+        # fail loudly.
+        assert error == "Configure playbook failed: failed"
+
+    def test_configure_all_censored_events_falls_back_to_generic_error(
+        self, tmp_path: Path
+    ):
+        """ATX iter-3 NW6: parity with the repair and lifecycle paths.
+        Multiple censored events; nothing usable surfaces; generic prefix
+        appears with the runner status."""
+        host = self._zc_host(
+            auth_in_record="zc_record_for_configure_bbbbbbbbbbbbb",
+        )
+        config_data = {
+            "gateway": {"port": 40000},
+            "provider": {
+                "name": "p", "type": "ollama", "endpoint": "http://x",
+                "default_model": "m",
+            },
+        }
+        _inv, success, error = self._capture_configure(
+            host, config_data, tmp_path,
+            runner_status="failed",
+            runner_events=[
+                {
+                    "event": "runner_on_failed",
+                    "event_data": {
+                        "res": {
+                            "censored": "hidden",
+                            "msg": "Bearer zc_CFG_LEAK_AAAAAAAAAAAAAAAAA",
+                        }
+                    },
+                },
+                {
+                    "event": "runner_on_failed",
+                    "event_data": {
+                        "res": {
+                            "censored": "hidden",
+                            "stderr": "Bearer zc_CFG_LEAK_BBBBBBBBBBBBBBB",
+                        }
+                    },
+                },
+            ],
+        )
+        assert success is False
+        assert "zc_" not in (error or "")
+        assert error == "Configure playbook failed: failed"
+
+    def test_configure_msg_none_event_does_not_return_none_error(
+        self, tmp_path: Path
+    ):
+        """ATX iter-3 NW4: configure path must also not return (False, None)
+        when a runner_on_failed event has msg=None."""
+        host = self._zc_host(
+            auth_in_record="zc_record_for_configure_ccccccccccccc",
+        )
+        config_data = {
+            "gateway": {"port": 40000},
+            "provider": {
+                "name": "p", "type": "ollama", "endpoint": "http://x",
+                "default_model": "m",
+            },
+        }
+        _inv, success, error = self._capture_configure(
+            host, config_data, tmp_path,
+            runner_status="failed",
+            runner_events=[
+                {
+                    "event": "runner_on_failed",
+                    "event_data": {"res": {"msg": None, "stderr": None}},
+                },
+            ],
+        )
+        assert success is False
+        assert error is not None
+        assert error == "Configure playbook failed: failed"
+
+    def test_configure_zeroclaw_missing_gateway_fails_port_validation(
+        self, tmp_path: Path
+    ):
+        """ATX iter-3 NW5: pin the NS1 invariant. A caller that passes
+        config_data with no `gateway` key (e.g. _run_identity_stage at
+        cli/agent.py:639 before any prior gateway state existed) must hit
+        the port validation early, BEFORE ansible_runner.run is ever
+        called. If NS1 is silently reverted (B1 injection moves back below
+        the validation block), this test fails because the validation
+        would skip when gateway is absent."""
+        host = self._zc_host(
+            auth_in_record="zc_record_for_no_gateway_dddddddddddd",
+        )
+        config_data: dict = {
+            # No "gateway" key at all — mimics a fresh-install caller path.
+            "provider": {
+                "name": "p", "type": "ollama", "endpoint": "http://x",
+                "default_model": "m",
+            },
+        }
+        runner_called = {"count": 0}
+
+        runner = MagicMock()
+        runner.status = "successful"
+        runner.events = []
+        artifacts_dir = tmp_path / "artifacts"
+        (artifacts_dir / "fact_cache").mkdir(parents=True)
+        runner.config.artifact_dir = str(artifacts_dir)
+
+        def count_runs(**_kwargs):
+            runner_called["count"] += 1
+            return runner
+
+        key_path = tmp_path / "k"
+        key_path.write_text("k")
+        playbook_path = tmp_path / "configure.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+
+        with patch("clawrium.core.lifecycle.get_host", return_value=host), \
+             patch(
+                "clawrium.core.lifecycle.get_host_private_key",
+                return_value=key_path,
+             ), \
+             patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook_path,
+             ), \
+             patch(
+                "clawrium.core.lifecycle.ansible_runner.run",
+                side_effect=count_runs,
+             ), \
+             patch(
+                "clawrium.core.lifecycle.update_host",
+                return_value=True,
+             ), \
+             patch(
+                "clawrium.core.lifecycle.get_config_dir",
+                return_value=tmp_path,
+             ), \
+             patch(
+                "clawrium.core.providers.get_provider_api_key",
+                return_value="",
+             ), \
+             patch(
+                "clawrium.core.providers.get_provider_aws_credentials",
+                return_value=("", ""),
+             ), \
+             patch(
+                "clawrium.core.secrets.get_instance_secrets",
+                return_value={},
+             ), \
+             patch(
+                "clawrium.core.integrations.get_agent_integrations",
+                return_value=[],
+             ), \
+             patch.object(Path, "exists", return_value=True):
+            from clawrium.core.lifecycle import configure_agent
+            success, error = configure_agent(
+                "192.168.1.100",
+                "zeroclaw",
+                config_data,
+                agent_name="zer-test",
+            )
+        assert success is False
+        assert error == "Incomplete gateway config - missing: port", (
+            f"NS1 regressed — port validation didn't fire: {error!r}"
+        )
+        # Critical: validation MUST run before ansible — no SSH/playbook
+        # side effects on a config that's missing required fields.
+        assert runner_called["count"] == 0, (
+            "ansible_runner.run was called despite missing gateway port; "
+            "NS1 ordering is broken"
+        )
 
     def test_configure_does_not_override_explicit_bearer(self, tmp_path: Path):
         """If the caller already populated `gateway.auth` (e.g. via

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -112,10 +112,14 @@ class TestRunLifecyclePlaybook:
             "clawrium.core.lifecycle.get_config_dir",
             return_value=tmp_path,
         ), patch(
-            "clawrium.core.secrets.get_instance_secrets",
+            # ATX iter-5: patch at the consumer namespace, not the source
+            # module. `lifecycle.py` does `from clawrium.core.secrets import
+            # get_instance_secrets` at module-load — patching the source
+            # module is a no-op against the already-bound name in lifecycle.
+            "clawrium.core.lifecycle.get_instance_secrets",
             return_value={},
         ), patch(
-            "clawrium.core.secrets.get_instance_key",
+            "clawrium.core.lifecycle.get_instance_key",
             return_value="test-key",
         ):
             return _run_lifecycle_playbook(
@@ -229,6 +233,63 @@ class TestRunLifecyclePlaybook:
         )
         assert success is False
         assert error == "Start operation timed out"
+
+    def test_secrets_patches_are_actually_called(self, tmp_path: Path):
+        """ATX iter-5 NW-A meta-test: the patch targets in `_run_with_events`
+        must hit the names actually consumed by `_run_lifecycle_playbook`.
+        A wrong patch target (e.g. `clawrium.core.secrets.*` against a
+        `from x import y` consumer) silently no-ops and the secrets-
+        isolation defence becomes illusory. Assert the mocks are called."""
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {"zer-test": {"type": "zeroclaw"}},
+        }
+
+        playbook_path = tmp_path / "start.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+
+        runner = MagicMock()
+        runner.status = "successful"
+        runner.events = []
+
+        with patch(
+            "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+            return_value=playbook_path,
+        ), patch(
+            "clawrium.core.lifecycle.get_host_private_key",
+            return_value=key_path,
+        ), patch(
+            "clawrium.core.lifecycle.ansible_runner.run",
+            return_value=runner,
+        ), patch(
+            "clawrium.core.lifecycle.get_config_dir",
+            return_value=tmp_path,
+        ), patch(
+            "clawrium.core.lifecycle.get_instance_secrets",
+            return_value={},
+        ) as mock_get_secrets, patch(
+            "clawrium.core.lifecycle.get_instance_key",
+            return_value="test-key",
+        ) as mock_get_key:
+            _run_lifecycle_playbook(
+                "zeroclaw", "zer-test", "192.168.1.100", "start", host
+            )
+
+        # If either of these fires, the patch target is correct AND
+        # `_run_lifecycle_playbook` actually reads through the consumer
+        # binding. If both stay un-called on a future refactor that
+        # bypasses these helpers, this test alerts before the secrets-
+        # isolation guarantee silently regresses.
+        assert mock_get_secrets.called or mock_get_key.called, (
+            "Neither get_instance_secrets nor get_instance_key was called — "
+            "either the consumer no longer reads through these helpers, or "
+            "the patch target is wrong (ATX iter-5 NW-A)"
+        )
 
 
 class TestStartClaw:
@@ -1037,8 +1098,14 @@ class TestConfigureAgentZeroclawBearerForwarding:
                 return_value=("", ""),
              ), \
              patch(
-                "clawrium.core.secrets.get_instance_secrets",
+                # ATX iter-5: lifecycle namespace, not source module —
+                # see _run_with_events for the same fix.
+                "clawrium.core.lifecycle.get_instance_secrets",
                 return_value={},
+             ), \
+             patch(
+                "clawrium.core.lifecycle.get_instance_key",
+                return_value="test-key",
              ), \
              patch(
                 "clawrium.core.integrations.get_agent_integrations",
@@ -1294,8 +1361,13 @@ class TestConfigureAgentZeroclawBearerForwarding:
                 return_value=("", ""),
              ), \
              patch(
-                "clawrium.core.secrets.get_instance_secrets",
+                # ATX iter-5: lifecycle namespace, not source module.
+                "clawrium.core.lifecycle.get_instance_secrets",
                 return_value={},
+             ), \
+             patch(
+                "clawrium.core.lifecycle.get_instance_key",
+                return_value="test-key",
              ), \
              patch(
                 "clawrium.core.integrations.get_agent_integrations",

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -80,16 +80,23 @@ class TestRunLifecyclePlaybook:
         assert success is False
         assert "SSH key not found" in error
 
-    def _run_with_events(self, host, tmp_path: Path, events: list):
+    def _run_with_events(
+        self, host, tmp_path: Path, events: list, *,
+        runner_status: str = "failed",
+    ):
         """Helper that runs _run_lifecycle_playbook with a stubbed runner
-        emitting the supplied events. Returns (success, error)."""
+        emitting the supplied events. Returns (success, error).
+
+        ATX iter-4 NW-A: mocks `get_instance_secrets` and `get_instance_key`
+        so a dev machine with a matching real entry in `~/.config/clawrium/
+        secrets.json` doesn't silently populate the Ansible inventory."""
         playbook_path = tmp_path / "start.yaml"
         playbook_path.write_text("---\n- hosts: all\n")
         key_path = tmp_path / "key"
         key_path.write_text("k")
 
         runner = MagicMock()
-        runner.status = "failed"
+        runner.status = runner_status
         runner.events = events
 
         with patch(
@@ -104,6 +111,12 @@ class TestRunLifecyclePlaybook:
         ), patch(
             "clawrium.core.lifecycle.get_config_dir",
             return_value=tmp_path,
+        ), patch(
+            "clawrium.core.secrets.get_instance_secrets",
+            return_value={},
+        ), patch(
+            "clawrium.core.secrets.get_instance_key",
+            return_value="test-key",
         ):
             return _run_lifecycle_playbook(
                 "zeroclaw", "zer-test", "192.168.1.100", "start", host
@@ -199,6 +212,23 @@ class TestRunLifecyclePlaybook:
         assert success is False
         assert error is not None
         assert error == "Start playbook failed: failed"
+
+    def test_timeout_returns_friendly_error(self, tmp_path: Path):
+        """ATX iter-4 NW-B: pin the timeout branch of _run_lifecycle_playbook
+        — `result.status == 'timeout'` returns a fixed string before any
+        event extraction runs."""
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {"zer-test": {"type": "zeroclaw"}},
+        }
+        success, error = self._run_with_events(
+            host, tmp_path, [], runner_status="timeout",
+        )
+        assert success is False
+        assert error == "Start operation timed out"
 
 
 class TestStartClaw:
@@ -1143,6 +1173,30 @@ class TestConfigureAgentZeroclawBearerForwarding:
         assert "zc_" not in (error or "")
         assert error == "Configure playbook failed: failed"
 
+    def test_configure_timeout_returns_friendly_error(
+        self, tmp_path: Path
+    ):
+        """ATX iter-4 NW-B: pin the configure timeout branch. The
+        configure path has its own timeout return distinct from the
+        repair path and was untested through iter-3."""
+        host = self._zc_host(
+            auth_in_record="zc_record_for_timeout_eeeeeeeeeeeeeee",
+        )
+        config_data = {
+            "gateway": {"port": 40000},
+            "provider": {
+                "name": "p", "type": "ollama", "endpoint": "http://x",
+                "default_model": "m",
+            },
+        }
+        _inv, success, error = self._capture_configure(
+            host, config_data, tmp_path,
+            runner_status="timeout",
+            runner_events=[],
+        )
+        assert success is False
+        assert error == "Configure operation timed out"
+
     def test_configure_msg_none_event_does_not_return_none_error(
         self, tmp_path: Path
     ):
@@ -1246,8 +1300,12 @@ class TestConfigureAgentZeroclawBearerForwarding:
              patch(
                 "clawrium.core.integrations.get_agent_integrations",
                 return_value=[],
-             ), \
-             patch.object(Path, "exists", return_value=True):
+             ):
+            # ATX iter-4 S-D: no `Path.exists` mock — configure_agent
+            # returns at the port validation block (~L1300) before any
+            # Path check is reached (template ~L1426, playbook ~L1431).
+            # Adding the mock would mask a future refactor that placed a
+            # Path check before port validation.
             from clawrium.core.lifecycle import configure_agent
             success, error = configure_agent(
                 "192.168.1.100",

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -80,6 +80,61 @@ class TestRunLifecyclePlaybook:
         assert success is False
         assert "SSH key not found" in error
 
+    def test_censored_event_does_not_leak_bearer(self, tmp_path: Path):
+        """ATX iter-2 NB1: censored-guard at lifecycle.py:~360 covers the
+        generic start/stop/restart lifecycle path. Same security invariant
+        as the repair path, separate code site — pin it independently."""
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {"zer-test": {"type": "zeroclaw"}},
+        }
+
+        playbook_path = tmp_path / "start.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+
+        runner = MagicMock()
+        runner.status = "failed"
+        runner.events = [
+            {
+                "event": "runner_on_failed",
+                "event_data": {
+                    "res": {
+                        "censored": "no_log: true was specified",
+                        "msg": "Bearer zc_LEAKED_FROM_START_xxxxxxxxxxx",
+                    }
+                },
+            },
+        ]
+
+        with patch(
+            "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+            return_value=playbook_path,
+        ), patch(
+            "clawrium.core.lifecycle.get_host_private_key",
+            return_value=key_path,
+        ), patch(
+            "clawrium.core.lifecycle.ansible_runner.run",
+            return_value=runner,
+        ), patch(
+            "clawrium.core.lifecycle.get_config_dir",
+            return_value=tmp_path,
+        ):
+            success, error = _run_lifecycle_playbook(
+                "zeroclaw", "zer-test", "192.168.1.100", "start", host
+            )
+
+        assert success is False
+        assert "zc_LEAKED_FROM_START" not in error, (
+            f"_run_lifecycle_playbook censored-guard regressed: {error!r}"
+        )
+        # All events censored → falls through to generic prefix.
+        assert "Start playbook failed" in error
+
 
 class TestStartClaw:
     """Tests for start_claw function."""
@@ -482,6 +537,92 @@ class TestZeroclawRepairAfterStart:
         assert success is False
         assert "pair handshake exploded" in error
 
+    def test_censored_event_does_not_leak_bearer_into_error(
+        self, tmp_path: Path
+    ):
+        """ATX iter-2 NB1: the W1 censored-guard at lifecycle.py:~808 is the
+        security invariant that keeps a `no_log: true` failure from leaking
+        a bearer into user-visible error strings. Without test coverage, a
+        one-line refactor (moving the `continue` below the `if 'msg' in res`
+        block) silently regresses it. Pin the invariant.
+
+        ansible-runner replaces the entire `res` dict with
+        `{'censored': '<reason>'}` for no_log-failed tasks — see
+        ansible_runner/display_callback/callback/awx_display.py. But a
+        misbehaving debug-mode daemon could echo the Bearer back in a 401
+        body; if that ever lands in `res.msg` alongside `censored`, we must
+        not surface it.
+        """
+        host = self._host()
+        runner = MagicMock()
+        runner.status = "failed"
+        runner.events = [
+            {
+                "event": "runner_on_failed",
+                "event_data": {
+                    "res": {
+                        "censored": "the output has been hidden due to "
+                                    "the fact that 'no_log: true' was "
+                                    "specified for this result",
+                        "msg": "Bearer zc_LEAKED_SECRET_xxxxxxxxxxxxxxxxxx",
+                    }
+                },
+            },
+            # Trailing non-censored event whose msg is safe to surface.
+            {
+                "event": "runner_on_failed",
+                "event_data": {
+                    "res": {"msg": "Re-pair playbook reported failure"}
+                },
+            },
+        ]
+        success, error = self._run_repair(host, tmp_path, runner=runner)
+        assert success is False
+        assert "zc_LEAKED_SECRET" not in error, (
+            f"censored guard regressed — bearer leaked into error: {error!r}"
+        )
+        assert "Re-pair playbook reported failure" in error
+
+    def test_all_censored_events_falls_back_to_generic_error(
+        self, tmp_path: Path
+    ):
+        """ATX iter-2 NB1 companion: when every runner_on_failed event is
+        censored, the loop must fall through to the generic 'Re-pair
+        playbook failed: <status>' message rather than the last seen msg.
+        """
+        host = self._host()
+        runner = MagicMock()
+        runner.status = "failed"
+        runner.events = [
+            {
+                "event": "runner_on_failed",
+                "event_data": {
+                    "res": {
+                        "censored": "hidden",
+                        "msg": "Bearer zc_ANOTHER_SECRET_yyyyyyyyyyyyyyy",
+                    }
+                },
+            },
+            {
+                "event": "runner_on_failed",
+                "event_data": {
+                    "res": {
+                        "censored": "hidden",
+                        "stderr": "Bearer zc_AND_ANOTHER_zzzzzzzzzzzzzzzz",
+                    }
+                },
+            },
+        ]
+        success, error = self._run_repair(host, tmp_path, runner=runner)
+        assert success is False
+        # No secret in error.
+        assert "zc_" not in error, (
+            f"all-censored fallback leaked a bearer fragment: {error!r}"
+        )
+        # The generic prefix is what the helper produces when no usable
+        # `msg`/`stderr` is found across all events.
+        assert "Re-pair playbook failed" in error
+
     def test_returns_failure_when_update_host_returns_false(self, tmp_path: Path):
         """ATX W8: the exact divergence #437 fixes — playbook succeeds but
         hosts.json never gets written. Must surface as a failure."""
@@ -711,11 +852,17 @@ class TestConfigureAgentZeroclawBearerForwarding:
         }
 
     def _capture_configure(
-        self, host: dict, config_data: dict, tmp_path: Path,
+        self,
+        host: dict,
+        config_data: dict,
+        tmp_path: Path,
+        *,
+        runner_status: str = "successful",
+        runner_events: list | None = None,
     ) -> tuple[dict, bool, str | None]:
         runner = MagicMock()
-        runner.status = "successful"
-        runner.events = []
+        runner.status = runner_status
+        runner.events = runner_events or []
         artifacts_dir = tmp_path / "artifacts"
         (artifacts_dir / "fact_cache").mkdir(parents=True)
         runner.config.artifact_dir = str(artifacts_dir)
@@ -811,6 +958,46 @@ class TestConfigureAgentZeroclawBearerForwarding:
             "agent record so the locked-pair branch authenticates correctly "
             "(ATX #445 B1)"
         )
+
+    def test_configure_censored_event_does_not_leak_bearer(
+        self, tmp_path: Path
+    ):
+        """ATX iter-2 NB1: censored-guard at lifecycle.py:~1517 covers the
+        configure path. The runner_on_failed extraction loop must skip
+        events where `res.censored` is set, even if they happen to carry a
+        `msg`/`stderr` (e.g., debug-mode daemon echoing the bearer back)."""
+        host = self._zc_host(
+            auth_in_record="zc_record_for_configure_aaaaaaaaaaaaa",
+        )
+        config_data = {
+            "gateway": {"port": 40000},
+            "provider": {
+                "name": "p", "type": "ollama", "endpoint": "http://x",
+                "default_model": "m",
+            },
+        }
+        _inv, success, error = self._capture_configure(
+            host,
+            config_data,
+            tmp_path,
+            runner_status="failed",
+            runner_events=[
+                {
+                    "event": "runner_on_failed",
+                    "event_data": {
+                        "res": {
+                            "censored": "no_log: true was specified",
+                            "msg": "Bearer zc_LEAK_FROM_CONFIGURE_xxxxxxxx",
+                        }
+                    },
+                },
+            ],
+        )
+        assert success is False
+        assert "zc_LEAK_FROM_CONFIGURE" not in (error or ""), (
+            f"configure_agent censored-guard regressed: {error!r}"
+        )
+        assert "Configure playbook failed" in (error or "")
 
     def test_configure_does_not_override_explicit_bearer(self, tmp_path: Path):
         """If the caller already populated `gateway.auth` (e.g. via

--- a/tests/test_registry_zeroclaw.py
+++ b/tests/test_registry_zeroclaw.py
@@ -437,6 +437,93 @@ def test_zeroclaw_configure_renders_workspace_with_force_no():
 # ----- ATX iter 5 W3: no_log on memory_delete across all 3 claws -----------
 
 
+def test_pair_playbook_handles_locked_daemon():
+    """Issue #445: zeroclaw v0.7.5's /pair/code returns pairing_code=null
+    after the daemon's devices.db has any prior row. The pair handshake
+    playbook must (a) not crash on the null (defensive), (b) mint a fresh
+    code via POST /api/pairing/initiate using the existing bearer
+    (correctness). This is a structural test so the bug cannot regress
+    silently.
+    """
+    from importlib.resources import files
+    import yaml
+
+    pkg = files("clawrium.platform.registry.zeroclaw")
+    pair_path = pkg / "playbooks" / "tasks" / "pair.yaml"
+    raw = pair_path.read_text()
+    tasks = yaml.safe_load(raw)
+    assert isinstance(tasks, list) and tasks, "pair.yaml must be a task list"
+
+    by_name = {t.get("name", ""): t for t in tasks if isinstance(t, dict)}
+
+    initiate_name = "Mint pairing code via /api/pairing/initiate (locked-pair branch)"
+    assert initiate_name in by_name, (
+        "pair.yaml must include a task that POSTs to /api/pairing/initiate "
+        "for the locked-pair branch"
+    )
+    initiate = by_name[initiate_name]
+    uri = initiate.get("ansible.builtin.uri") or {}
+    assert "/api/pairing/initiate" in (uri.get("url") or ""), (
+        "initiate task must hit /api/pairing/initiate"
+    )
+    assert (uri.get("method") or "").upper() == "POST"
+    auth_header = (uri.get("headers") or {}).get("Authorization", "")
+    assert auth_header.startswith("Bearer "), (
+        "initiate must authenticate with a Bearer token from hosts.json"
+    )
+    assert "config.gateway.auth" in auth_header, (
+        "Bearer value must come from config.gateway.auth so both "
+        "configure.yaml and restart.yaml can pass it through unchanged"
+    )
+    assert initiate.get("no_log") is True, (
+        "initiate task carries a bearer — must be no_log: true"
+    )
+
+    when_clause = initiate.get("when")
+    if isinstance(when_clause, list):
+        when_text = " AND ".join(str(c) for c in when_clause)
+    else:
+        when_text = str(when_clause)
+    assert "pairing_code is none" in when_text, (
+        "initiate must fire only when /pair/code returned a null code "
+        "(locked daemon); current when: {!r}".format(when_clause)
+    )
+
+    # Defensive: every `| length` check on a pair field must coexist with
+    # an `is none` guard in the same `when:` clause, so the filter never
+    # sees a null and crashes with `NoneType has no len()` (the literal
+    # error #445 fixes).
+    fields_under_check = (
+        "pair_response.json.token",
+        "resolved_pairing_code",
+    )
+    when_clauses = []
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        clause = task.get("when")
+        if clause is None:
+            continue
+        # `when:` may be a string or a list. Normalize to a single string
+        # so multi-line `or`-chains (which YAML joins with a space) are
+        # searchable as one blob.
+        if isinstance(clause, list):
+            when_clauses.append(" ".join(str(c) for c in clause))
+        else:
+            when_clauses.append(str(clause))
+
+    for field in fields_under_check:
+        guarded = any(
+            f"{field} | length" in w and f"{field} is none" in w
+            for w in when_clauses
+        )
+        assert guarded, (
+            f"`{field} | length` must coexist with `{field} is none` in "
+            f"the same when: clause; otherwise a defined-but-null daemon "
+            f"response will crash the filter (issue #445)."
+        )
+
+
 def test_memory_delete_no_log_on_delete_task_across_all_claws():
     """ATX iter 5 W3: every claw's memory_delete playbook must mark the
     file-removal task no_log: true so an Ansible run at -vvv does not

--- a/tests/test_registry_zeroclaw.py
+++ b/tests/test_registry_zeroclaw.py
@@ -525,12 +525,17 @@ def test_pair_playbook_handles_locked_daemon():
     assert "journalctl" in validate_msg, (
         "503 path must direct the operator to daemon logs (ATX B2)"
     )
-    # ATX iter-2 NW2: validate task may template `initiate_response.json` or
-    # `.content` in a future edit. Lock no_log: true so a debug-mode daemon
-    # echoing the Authorization header back in the 401 body can't leak.
-    assert validate_task.get("no_log") is True, (
-        "validate task must be no_log: true to defend against future edits "
-        "that template the daemon response body (ATX iter-2 NW2)"
+    # ATX iter-3 NB2: validate task MUST NOT be no_log: true. The
+    # lifecycle.py censored-event handler (W1) skips events where
+    # res.censored is set, which would silently swallow the operator
+    # guidance this msg encodes. The msg references only safe scalars
+    # (initiate_response.status as int, agent_name/agent_type strings).
+    # The msg's WARNING comment in pair.yaml pins this contract for
+    # future editors.
+    assert validate_task.get("no_log") is not True, (
+        "validate task must NOT be no_log: true — would defeat the W1 "
+        "censored-event handler and silently suppress the 401/503 "
+        "operator guidance this task encodes (ATX iter-3 NB2)"
     )
 
     # ATX iter-2 NW3: substring-on-raw-template is fragile — render the
@@ -550,11 +555,19 @@ def test_pair_playbook_handles_locked_daemon():
         ).split()
     )
     assert "401" in rendered_401
-    assert "stale" in rendered_401 or "devices.db" in rendered_401
-    assert "clm agent configure zer-test" in rendered_401
-    assert "journalctl" not in rendered_401, (
-        "401 branch must not also include 503's journalctl guidance"
+    # ATX iter-3 NW7: require BOTH discriminating phrases in the 401
+    # branch so a rephrasing that drops one doesn't silently lose
+    # specificity. Same constraint applies to cross-leak: BOTH must be
+    # absent from the 503 render.
+    assert "stale" in rendered_401, (
+        "401 branch must explicitly say 'stale' so the operator knows the "
+        "bearer is the problem (iter-3 NW7)"
     )
+    assert "devices.db" in rendered_401, (
+        "401 branch must name devices.db so the operator knows where to "
+        "look on the host (iter-3 NW7)"
+    )
+    assert "clm agent configure zer-test" in rendered_401
 
     rendered_503 = " ".join(
         msg_template.render(
@@ -564,10 +577,27 @@ def test_pair_playbook_handles_locked_daemon():
         ).split()
     )
     assert "503" in rendered_503
-    assert "journalctl" in rendered_503
+    # 503 branch's discriminating phrases. Both required.
+    assert "journalctl" in rendered_503, (
+        "503 branch must direct operator to daemon logs (iter-3 NW7)"
+    )
+    assert "pairing disabled" in rendered_503 or "unavailable" in rendered_503, (
+        "503 branch must explain why the daemon refused (iter-3 NW7)"
+    )
     assert "clm agent configure zer-test" in rendered_503
-    assert "stale" not in rendered_503, (
-        "503 branch must not also include 401's stale-bearer guidance"
+
+    # NW7 cross-leak: BOTH 401 phrases absent from 503, BOTH 503 phrases
+    # absent from 401. A swapped branch would fail one of these four.
+    assert "stale" not in rendered_503 and "devices.db" not in rendered_503, (
+        "401 branch's bearer-staleness guidance leaked into 503 render "
+        "(iter-3 NW7)"
+    )
+    assert "pairing disabled" not in rendered_401 and "unavailable" not in rendered_401, (
+        "503 branch's daemon-availability guidance leaked into 401 render "
+        "(iter-3 NW7)"
+    )
+    assert "journalctl" not in rendered_401, (
+        "401 branch must not also include 503's journalctl guidance"
     )
 
     # Defensive: every `| length` check on a pair field must coexist with

--- a/tests/test_registry_zeroclaw.py
+++ b/tests/test_registry_zeroclaw.py
@@ -478,6 +478,18 @@ def test_pair_playbook_handles_locked_daemon():
     assert initiate.get("no_log") is True, (
         "initiate task carries a bearer — must be no_log: true"
     )
+    # ATX B2: 401/503 from /api/pairing/initiate must be accepted so the
+    # follow-up validate task can produce an actionable operator message
+    # rather than a generic Ansible HTTP error.
+    accepted = uri.get("status_code")
+    if isinstance(accepted, int):
+        accepted = [accepted]
+    assert set(accepted or []) >= {200, 401, 503}, (
+        "initiate task must accept 200, 401, and 503 so the validate task "
+        "below can route to actionable messages (ATX B2). Got: {!r}".format(
+            uri.get("status_code")
+        )
+    )
 
     when_clause = initiate.get("when")
     if isinstance(when_clause, list):
@@ -487,6 +499,30 @@ def test_pair_playbook_handles_locked_daemon():
     assert "pairing_code is none" in when_text, (
         "initiate must fire only when /pair/code returned a null code "
         "(locked daemon); current when: {!r}".format(when_clause)
+    )
+    # ATX W4: the initiate task also needs the `is defined` guard so a
+    # network error on GET /pair/code (which leaves pair_code_response.json
+    # undefined) doesn't crash the `is none` check below.
+    assert "pair_code_response.json is defined" in when_text, (
+        "initiate task's when: clause must include "
+        "`pair_code_response.json is defined` so a /pair/code network error "
+        "fails the prior task cleanly rather than crashing this one's "
+        "is-none check (ATX W4)."
+    )
+
+    # ATX B2: validate task that routes 401/503 to operator-actionable
+    # messages must exist downstream of the initiate task.
+    validate_name = "Validate locked-branch initiate response"
+    assert validate_name in by_name, (
+        "pair.yaml must include a task that surfaces 401/503 from "
+        "/api/pairing/initiate as actionable messages (ATX B2)"
+    )
+    validate_msg = (by_name[validate_name].get("ansible.builtin.fail") or {}).get("msg", "")
+    assert "clm agent configure" in validate_msg, (
+        "401 path must direct the operator to `clm agent configure` (ATX B2)"
+    )
+    assert "journalctl" in validate_msg, (
+        "503 path must direct the operator to daemon logs (ATX B2)"
     )
 
     # Defensive: every `| length` check on a pair field must coexist with
@@ -522,6 +558,60 @@ def test_pair_playbook_handles_locked_daemon():
             f"the same when: clause; otherwise a defined-but-null daemon "
             f"response will crash the filter (issue #445)."
         )
+
+
+def test_pair_playbook_resolved_code_ternary_picks_correct_source():
+    """ATX B3: structural shape isn't enough — the `resolved_pairing_code`
+    set_fact ternary in pair.yaml is the correctness core of #445. Evaluate
+    its Jinja2 expression directly against the two production-relevant
+    states and assert the right source is picked. A reversed ternary (the
+    obvious typo) passes the existing structural test but fails this one.
+    """
+    from importlib.resources import files
+    import yaml
+    from jinja2 import Environment
+
+    pkg = files("clawrium.platform.registry.zeroclaw")
+    tasks = yaml.safe_load((pkg / "playbooks" / "tasks" / "pair.yaml").read_text())
+    by_name = {t.get("name", ""): t for t in tasks if isinstance(t, dict)}
+    set_fact_task = by_name.get(
+        "Resolve pairing code from whichever branch produced one"
+    )
+    assert set_fact_task is not None, (
+        "pair.yaml must contain the resolve-source set_fact task"
+    )
+    expr = (set_fact_task.get("ansible.builtin.set_fact") or {}).get(
+        "resolved_pairing_code"
+    )
+    assert isinstance(expr, str) and expr.strip(), (
+        "set_fact must declare a non-empty resolved_pairing_code expression"
+    )
+
+    env = Environment()
+    template = env.from_string(expr)
+
+    # Fresh-boot branch: /pair/code returned a real code, initiate never
+    # ran (undefined). Resolved must be the /pair/code value.
+    fresh = template.render(
+        pair_code_response={"json": {"pairing_code": "FRESH1"}},
+    ).strip()
+    assert fresh == "FRESH1", (
+        f"fresh-boot branch must yield /pair/code's value; got {fresh!r}. "
+        f"This catches a reversed ternary that would silently send the "
+        f"empty/undefined initiate value to /pair on first install."
+    )
+
+    # Locked branch: /pair/code returned null, initiate minted a fresh code.
+    # Resolved must be the initiate value, not the null from /pair/code.
+    locked = template.render(
+        pair_code_response={"json": {"pairing_code": None}},
+        initiate_response={"json": {"pairing_code": "LOCKD2"}},
+    ).strip()
+    assert locked == "LOCKD2", (
+        f"locked-pair branch must yield /api/pairing/initiate's value; "
+        f"got {locked!r}. A reversed ternary would pick the null from "
+        f"/pair/code and the downstream /pair POST would crash."
+    )
 
 
 def test_memory_delete_no_log_on_delete_task_across_all_claws():

--- a/tests/test_registry_zeroclaw.py
+++ b/tests/test_registry_zeroclaw.py
@@ -517,12 +517,57 @@ def test_pair_playbook_handles_locked_daemon():
         "pair.yaml must include a task that surfaces 401/503 from "
         "/api/pairing/initiate as actionable messages (ATX B2)"
     )
-    validate_msg = (by_name[validate_name].get("ansible.builtin.fail") or {}).get("msg", "")
+    validate_task = by_name[validate_name]
+    validate_msg = (validate_task.get("ansible.builtin.fail") or {}).get("msg", "")
     assert "clm agent configure" in validate_msg, (
         "401 path must direct the operator to `clm agent configure` (ATX B2)"
     )
     assert "journalctl" in validate_msg, (
         "503 path must direct the operator to daemon logs (ATX B2)"
+    )
+    # ATX iter-2 NW2: validate task may template `initiate_response.json` or
+    # `.content` in a future edit. Lock no_log: true so a debug-mode daemon
+    # echoing the Authorization header back in the 401 body can't leak.
+    assert validate_task.get("no_log") is True, (
+        "validate task must be no_log: true to defend against future edits "
+        "that template the daemon response body (ATX iter-2 NW2)"
+    )
+
+    # ATX iter-2 NW3: substring-on-raw-template is fragile — render the
+    # Jinja2 msg against fixture statuses and assert each branch produces
+    # the expected operator-actionable text. A regression that swaps the
+    # 401/503 branches or drops one would slip past the substring check
+    # above but fails here.
+    from jinja2 import Environment
+
+    env = Environment()
+    msg_template = env.from_string(validate_msg)
+    rendered_401 = " ".join(
+        msg_template.render(
+            initiate_response={"status": 401},
+            agent_name="zer-test",
+            agent_type="zeroclaw",
+        ).split()
+    )
+    assert "401" in rendered_401
+    assert "stale" in rendered_401 or "devices.db" in rendered_401
+    assert "clm agent configure zer-test" in rendered_401
+    assert "journalctl" not in rendered_401, (
+        "401 branch must not also include 503's journalctl guidance"
+    )
+
+    rendered_503 = " ".join(
+        msg_template.render(
+            initiate_response={"status": 503},
+            agent_name="zer-test",
+            agent_type="zeroclaw",
+        ).split()
+    )
+    assert "503" in rendered_503
+    assert "journalctl" in rendered_503
+    assert "clm agent configure zer-test" in rendered_503
+    assert "stale" not in rendered_503, (
+        "503 branch must not also include 401's stale-bearer guidance"
     )
 
     # Defensive: every `| length` check on a pair field must coexist with

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "clawrium"
-version = "26.5.1"
+version = "26.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },

--- a/uv.lock
+++ b/uv.lock
@@ -356,7 +356,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ansible-runner", specifier = ">=2.4.0" },
+    { name = "ansible-runner", specifier = ">=2.4.0,<3" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fuzzyfinder", specifier = ">=2.1.0,<3.0.0" },
     { name = "httpx", specifier = ">=0.27,<1.0" },


### PR DESCRIPTION
## Summary

Closes #445. Fixes a gap left by #437.

- `tasks/pair.yaml` adds a locked-pair branch using `POST /api/pairing/initiate` (authenticated zeroclaw endpoint) when `GET /pair/code` returns `{pairing_code: null}` on a previously-paired daemon. Fresh-boot path unchanged.
- All `| length` filters now guard with `is none` so defined-but-null daemon responses fail cleanly instead of crashing the Jinja2 filter with `NoneType has no len()`.
- `lifecycle.py::_zeroclaw_repair_after_start` + `configure_agent` pipe the existing bearer from `hosts.json.config.gateway.auth` into the playbook inventory so the locked branch can authenticate; configure_agent's B1 injection runs BEFORE port validation so a caller omitting the gateway block fails early with a clean error.
- `pyproject.toml` bumped to `26.5.2` and `ansible-runner` pinned `>=2.4.0,<3` (the `res.censored` key is internal callback API; 3.x rename would silently no-op the bearer-leak guard).

## Testing

### Test Results
- [x] `make lint` passes (ruff + ESLint)
- [x] `make test` passes (2377 Python + 208 UI tests)
- [x] 17 new deterministic unit tests across `tests/test_lifecycle.py` and `tests/test_registry_zeroclaw.py`. No HTTP stubs, no ansible-runner-against-localhost, no timing dependencies.

### Manual Testing

End-to-end on `wolf-i` re-validated at every iteration:
- `nemotron-alpha` + `nemotron-beta` (paired zeroclaw daemons): `clm agent restart <name>` exercises the locked-pair branch, rotates the bearer in `hosts.json`, `clm chat <name>` round-trips through Nemotron successfully.
- `e2e-test-pair` throwaway agent: full lifecycle (install → configure → start → chat → remove) — fresh-pair branch on first install, locked-pair branch on subsequent ops. Regression-clean.

### Security Checklist
- [x] Bearer is `no_log: true` on every task that touches it (uri tasks, set_fact tasks)
- [x] Validate-locked-branch fail task is NOT no_log (W1 censored-guard would suppress operator guidance); msg templates only `initiate_response.status` (int), `agent_name` (validated `^[a-z][a-z0-9_-]{0,31}$`), `agent_type` (constant)
- [x] `resolved_pairing_code` regex-validated (`^[A-Za-z0-9_-]{1,128}$`) before X-Pairing-Code header
- [x] `censored: true` guard + `msg is not None` guard in all three `runner_on_failed` loops in `lifecycle.py`
- [x] Test secrets isolation: autouse conftest fixture + meta-test asserting `get_instance_secrets`/`get_instance_key` mocks are actually called

## ATX Review Summary

**Final Review: Rating 4/5 — MERGE (unanimous, iter 7)**
**Total Cost: ~$13.50 | 7 iterations | 4-5 specialist agents per iter**

| Review | Rating | Blocking Issues | Status | Cost | Agents |
|--------|--------|-----------------|--------|------|--------|
| 1 (742ed50) | blocking | B1, B2, B3, B4 + W1, W2, W3, W4 | All fixed | $2.83 | leader, core-lifecycle, security, test-coverage, ansible |
| 2 (702f47d) | 3/5 | NB1 + NW1, NW2, NW3 + NS1 | All fixed | $3.22 | 5 |
| 3 (284e441) | 3/5 | NB2 + NW4, NW5, NW6, NW7 + S1, S2, S3 | All fixed | $2.01 | 4 (security max-turn skip) |
| 4 (9a6e88d) | 4/5 | None | Cleanups in iter 5 | $2.57 | 4 |
| 5 (d970311) | 3.5/5 | None (NW-A meta) | Fixed in iter 6 | $0.84 | 3 (test-coverage skip) |
| 6 (7b125a8) | 3.7/5 | None (or→and meta) | Fixed in iter 7 | $1.75 | 3 |
| 7 (321d1ea) | **4/5** | **None** | **MERGE** | $1.18 | 3 (unanimous) |
| 8 (aa46528) | — | (cosmetic assert-order swap; not re-reviewed) | — | — | — |

<details>
<summary>Review 1 Details (Iter-1 blockers + warnings, all fixed in iter 2)</summary>

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `lifecycle.py::configure_agent` | empty Bearer header on locked-pair branch | Defensive injection from agent_record |
| B2 | `tasks/pair.yaml` | 401/503 raw Ansible errors | New validate task with status-routed messages |
| B3 | structural test was vacuous | reversed ternary would pass | Jinja2 runtime evaluation against fixtures |
| B4 | new tests didn't pin write-back | rotation event/atomicity unasserted | `_capture_repair` helper pins full pipeline |
| W1 | `runner_on_failed` extraction | no censored-result guard | Added at all 3 sites |
| W2 | `resolved_pairing_code` | no charset guard before HTTP header | Regex validation task |
| W3 | configure-path forwarding untested | absent | `TestConfigureAgentZeroclawBearerForwarding` ×2 |
| W4 | `is defined` guard not asserted | structural | Added to test |

</details>

<details>
<summary>Review 2 Details (Iter-2 blockers + warnings, all fixed in iter 3)</summary>

| # | File | Issue | Resolution |
|---|------|-------|------------|
| NB1 | W1 censored-guard untested | one-line regression silently reopens leak | 4 unit tests (3 paths + fallback) |
| NW1 | `ansible-runner` unpinned upper | 3.x rename silently no-ops guard | `>=2.4.0,<3` |
| NW2 | NW2 fix was premature `no_log` | (became NB2 in iter 3) | Reverted in iter 4 |
| NW3 | B2 raw-substring test fragile | swapped branches would pass | Jinja2 render + assert |
| NS1 | B1 ran after port validation | empty gateway dict bypassed check | Moved before validation |

</details>

<details>
<summary>Review 3 Details (Iter-3 blocker + warnings, all fixed in iter 4)</summary>

| # | File | Issue | Resolution |
|---|------|-------|------------|
| NB2 | `no_log` on validate task | suppressed 401/503 operator guidance via W1 handler | Removed; WARNING comment for future editors |
| NW4 | `if "msg" in res` silent None | `(False, None)` on `msg=None` events | `if res.get("msg") is not None:` ×3 |
| NW5 | NS1 invariant untested | silent revert undetectable | `test_configure_zeroclaw_missing_gateway_fails_port_validation` |
| NW6 | configure fallback tests missing | partial coverage | Mirrored across 3 paths |
| NW7 | NW3 cross-leak single sentinel | rephrase would slip | Both discriminating phrases per branch |
| S1 | NS1 comment causally inverted | misleading future maintainer | Rewritten |
| S2 | ansible-runner pin comment thin | rationale unclear | Extended with call sites + gate |
| S3 | generic-msg assertion substring | format drift uncaught | Exact equality |

</details>

<details>
<summary>Review 4 Details (Iter-4 follow-ups, addressed in iter 5)</summary>

| # | File | Issue | Resolution |
|---|------|-------|------------|
| NW-A | `_run_with_events` secrets isolation gap | missing get_instance_secrets/key mocks | Added (but wrong targets — caught iter 5) |
| NW-B | configure timeout branch untested | gap | Added on both lifecycle + configure paths |
| S-D | dead `Path.exists` mock | misleading | Removed |
| S-F | `is not None` then `res["msg"]` asymmetric | cosmetic | `msg = res.get("msg")` then `is not None` |

</details>

<details>
<summary>Review 5/6 Details (Iter-5/6 meta-test corrections, addressed in iter 6/7)</summary>

| # | File | Issue | Resolution |
|---|------|-------|------------|
| NW-A redux | wrong patch target | `clawrium.core.secrets.*` is no-op for module-level `from x import y` bindings | Targets fixed to `clawrium.core.lifecycle.*` + meta-test added |
| or→and | meta-test `or` trivially satisfied | bypass of `get_instance_secrets` would pass green | Two independent `and`-style asserts |
| W1 (iter-6) | autouse conftest dependency undocumented | silent removal breaks ~30 tests | Module docstring |

</details>

<details>
<summary>Final tally — issues flagged across all reviews</summary>

**Closed**: B1, B2, B3, B4, W1, W2, W3, W4 (iter-1) — NB1, NW1, NW2, NW3, NS1 (iter-2) — NB2, NW4, NW5, NW6, NW7, S1, S2, S3 (iter-3) — NW-A, NW-B, S-D, S-F (iter-4) — NW-A patch-target (iter-5) — or→and, W1-iter6 (iter-6) — assertion order (iter-7)

**Deferred (tracked as follow-ups, non-blocking per ATX)**: W2 (configure-path meta-test parity), W3 (success-path comment).

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>