### PR TITLE
fix(cli): hermes Discord allowed_channels comma-only guard + empty warning

### DIFF
--- a/.itx/424/01_EXECUTION.md
+++ b/.itx/424/01_EXECUTION.md
@@ -1,0 +1,23 @@
+# Issue #424: Hermes Discord `allowed_channels` lacks comma-only guard + empty-channel warning
+
+URL: https://github.com/ric03uec/clawrium/issues/424
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-20
+**Model**: claude-opus-4-7
+
+```prompt
+fix issue 424
+```
+
+**Output**: Added comma-only guard + empty-channel `[yellow]Note:[/yellow]` to the hermes Discord `allowed_channels` branch in `src/clawrium/cli/agent.py`, mirroring the zeroclaw `allowed_users` / `allowed_guilds` guards from #422. Added four regression tests under `TestRunChannelsStageHermesDiscord`: comma-only rejection with full no-side-effects contract, parametrized empty-channel warning across both `require_mention` values, valid happy-path with companion-field structural guards, and duplicate-preservation pin.
+
+Plan source: the issue body contained the full fix sketch with file/line pointers and proposed test names, so no separate `00_PLAN.md` was authored. The fix was executed against that sketch.
+
+ATX review iterations:
+- Round 1 (3/5, BLOCKED on B1): test missing no-mutation assertion. Fixed B1 + W1–W6 (bulk-assign parity, severity prefix, confirm patch, len/require_mention guards, happy-path test, defensive `(raw or "").strip()` form).
+- Round 2 (3/5, no blockers but below merge threshold): five new warnings (incomplete no-mutation contract, missing severity prefix, tautological assertion, dedup behavior, structural completeness). All addressed via secret-store assert_not_called, severity-prefix assert, parametrize over `require_mention_value`, dedup pin test, companion-field assertions.
+- Round 3 (4/5, no blockers, merge threshold met): three small warnings (Note severity prefix, complete_stage call assertions, confirm assert_not_called on rejection). Closed post-review as test-only tightening with no production-code change.

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -891,18 +891,43 @@ def _run_channels_stage(
                 "Allowed Discord channel IDs (comma-separated, Enter for any channel)",
                 default="",
                 show_default=False,
-            ).strip()
+            )
+            allowed_channels_raw = (allowed_channels_raw or "").strip()
             allowed_channels: list[str] = []
             if allowed_channels_raw:
-                for cid in (
-                    s.strip() for s in allowed_channels_raw.split(",") if s.strip()
-                ):
+                cids = [
+                    s.strip()
+                    for s in allowed_channels_raw.split(",")
+                    if s.strip()
+                ]
+                # Comma-only input (`,` or `, ,`) is truthy after strip but
+                # parses to an empty list — without this guard the bot would
+                # silently respond in every channel of every allowlisted guild
+                # with no operator feedback. Mirrors the zeroclaw
+                # allowed_users / allowed_guilds guards.
+                if not cids:
+                    console.print(
+                        "[red]Error:[/red] No valid channel IDs parsed from "
+                        "input. Enter 17-19 digit IDs separated by commas, "
+                        "or leave the field empty for any channel."
+                    )
+                    return False
+                for cid in cids:
                     if not re.match(r"^\d{17,19}$", cid):
                         console.print(
                             f"[red]Error:[/red] Invalid channel ID '{rich_escape(cid)}' (17-19 digits required)"
                         )
                         return False
-                    allowed_channels.append(cid)
+                allowed_channels = cids
+            else:
+                # Symmetric note to zeroclaw allowed_users/allowed_guilds
+                # empty-case warning — empty allowed_channels means the bot
+                # responds in every channel of every allowlisted guild.
+                console.print(
+                    "[yellow]Note:[/yellow] empty allowed_channels means the "
+                    "bot will respond in every channel of every allowlisted "
+                    "guild."
+                )
 
             require_mention = typer.confirm(
                 "Require @mention to respond?", default=True

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -2945,6 +2945,311 @@ class TestRunChannelsStageHermesDiscord:
             )
         assert result is False
 
+    def test_hermes_discord_rejects_comma_only_allowed_channels(
+        self, isolated_config: Path
+    ):
+        """Issue #424: comma-only input (`,` or `, ,`) is truthy after strip
+        but parses to an empty list. Without this guard the hermes bot
+        silently responds in every channel of every allowlisted guild with
+        no operator feedback. Mirrors the zeroclaw allowed_users /
+        allowed_guilds comma-only guards added in #422.
+
+        Test contract:
+          - result is False (guard fired)
+          - [red]Error:[/red] message about parsed IDs is printed
+          - _sync_channel_config is NEVER called (no config mutation —
+            this is the security-relevant guarantee the guard enforces)
+          - complete_stage is NEVER called (onboarding remains incomplete)
+        """
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            onboarding_state="channels",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch(
+                "clawrium.cli.agent.typer.confirm", return_value=True
+            ) as mock_confirm,
+            patch("clawrium.cli.agent._sync_channel_config") as mock_sync,
+            patch("clawrium.core.secrets.set_instance_secret") as mock_secret,
+            patch("clawrium.cli.agent.complete_stage") as mock_stage,
+            patch("clawrium.cli.agent.console") as mock_console,
+        ):
+            mock_p.side_effect = [
+                2,                             # discord
+                self._valid_token(),           # bot token
+                "740723459344302120",          # valid user
+                "1503238729962356777",         # home channel
+                "Home",                        # home channel name
+                ", , ,",                       # comma-only allowed channels
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "hermes", False, "assistant"
+            )
+
+        assert result is False, (
+            "Comma-only allowed_channels input silently passed — would have "
+            "produced an any-channel bot with no operator feedback."
+        )
+        # No config mutation must have occurred — the open-channel posture
+        # must NOT be persisted to disk on a rejected input. Asserting all
+        # mutation/effect sites (sync, secret store, complete_stage,
+        # require_mention confirm) makes the no-side-effects contract
+        # robust to future reorderings that might move any of these above
+        # the allowed_channels validation.
+        mock_sync.assert_not_called()
+        mock_secret.assert_not_called()
+        mock_stage.assert_not_called()
+        mock_confirm.assert_not_called()
+        # The [red]Error:[/red] message must be emitted so the operator
+        # knows why the input was rejected. Asserting the severity marker
+        # catches a regression that demotes the error to a warning.
+        error_calls = [
+            call
+            for call in mock_console.print.call_args_list
+            if call.args
+            and isinstance(call.args[0], str)
+            and "No valid channel IDs parsed" in call.args[0]
+        ]
+        assert error_calls, (
+            "Expected [red]Error:[/red] about parsed channel IDs to be "
+            "printed, but no such console.print call was made."
+        )
+        assert "[red]Error:[/red]" in error_calls[0].args[0], (
+            "Error message must carry the [red]Error:[/red] severity prefix "
+            "so the operator sees it as a hard rejection."
+        )
+
+    @pytest.mark.parametrize("require_mention_value", [True, False])
+    def test_hermes_discord_empty_allowed_channels_warns(
+        self, isolated_config: Path, require_mention_value: bool
+    ):
+        """Issue #424: when the operator presses Enter at the
+        allowed_channels prompt the configure succeeds but a yellow Note
+        must be emitted so the open-channel posture is not silent.
+        Symmetric to the zeroclaw allowed_users / allowed_guilds empty-case
+        warnings.
+
+        Parametrized across both `require_mention` values so the
+        propagation of typer.confirm into synced[\"discord\"] is actually
+        tested (asserting `is True` while confirm is patched to True is
+        tautological — the False branch closes that gap)."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            onboarding_state="channels",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        synced: list[dict] = []
+
+        def capture_sync(_host, _claw, channels_config, _name):
+            synced.append(channels_config)
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch(
+                "clawrium.cli.agent.typer.confirm",
+                return_value=require_mention_value,
+            ),
+            patch("clawrium.cli.agent._sync_channel_config", side_effect=capture_sync),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage") as mock_stage,
+            patch("clawrium.cli.agent.console") as mock_console,
+        ):
+            mock_p.side_effect = [
+                2,                             # discord
+                self._valid_token(),           # bot token
+                "740723459344302120",          # valid user
+                "1503238729962356777",         # home channel
+                "Home",                        # home channel name
+                "",                            # empty allowed channels
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "hermes", False, "assistant"
+            )
+
+        assert result is True
+        assert len(synced) == 1, (
+            "_sync_channel_config must have been called exactly once; "
+            "missing call masks unrelated infrastructure failures as "
+            "the assertion below."
+        )
+        # No allowed_channels key in the synced config — open-channel posture.
+        assert "allowed_channels" not in synced[0]["discord"]
+        # require_mention propagation guard — parametrize ensures both
+        # branches of typer.confirm reach synced[\"discord\"], catching a
+        # regression that hardcodes the value. Symmetric to ATX Round 3
+        # W6 on the zeroclaw allowed_users empty-case test.
+        assert synced[0]["discord"]["require_mention"] is require_mention_value
+        # The channels state-machine transition must have happened — a
+        # refactor that drops complete_stage would leave onboarding stuck
+        # at channels/pending with result still True.
+        mock_stage.assert_called_once()
+        # The yellow Note must have been emitted at least once, with the
+        # [yellow]Note:[/yellow] severity prefix intact. Symmetric to the
+        # error-path severity assertion on the comma-only test.
+        warning_calls = [
+            call
+            for call in mock_console.print.call_args_list
+            if call.args
+            and isinstance(call.args[0], str)
+            and "empty allowed_channels" in call.args[0]
+        ]
+        assert warning_calls, (
+            "Expected a [yellow]Note:[/yellow] about empty allowed_channels "
+            "to be printed, but no such console.print call was made."
+        )
+        assert "[yellow]Note:[/yellow]" in warning_calls[0].args[0], (
+            "Note must carry the [yellow]Note:[/yellow] severity prefix so "
+            "the operator sees it as an advisory rather than a hard error."
+        )
+
+    def test_hermes_discord_valid_allowed_channels_stored(
+        self, isolated_config: Path
+    ):
+        """Issue #424 happy-path coverage: valid IDs entered at the
+        allowed_channels prompt must round-trip through to the synced
+        config. Guards against a regression where IDs parse correctly but
+        get dropped from the discord_cfg dict.
+
+        Also asserts companion-field presence (home_channel,
+        require_mention) so the test catches a regression that drops
+        unrelated keys from the same dict in a refactor."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            onboarding_state="channels",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        synced: list[dict] = []
+
+        def capture_sync(_host, _claw, channels_config, _name):
+            synced.append(channels_config)
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.cli.agent._sync_channel_config", side_effect=capture_sync),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage") as mock_stage,
+        ):
+            mock_p.side_effect = [
+                2,                                            # discord
+                self._valid_token(),                          # bot token
+                "740723459344302120",                         # valid user
+                "1503238729962356777",                        # home channel
+                "Home",                                       # home channel name
+                "1503238729962356777,1503238729962356778",    # valid channels
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "hermes", False, "assistant"
+            )
+
+        assert result is True
+        assert len(synced) == 1
+        assert synced[0]["discord"]["allowed_channels"] == [
+            "1503238729962356777",
+            "1503238729962356778",
+        ]
+        # Companion-field structural guards — a refactor that drops these
+        # alongside an allowed_channels change should be caught here.
+        assert synced[0]["discord"]["require_mention"] is True
+        assert synced[0]["discord"]["home_channel"] == "1503238729962356777"
+        # State-machine transition must have happened.
+        mock_stage.assert_called_once()
+
+    def test_hermes_discord_allowed_channels_preserves_duplicates(
+        self, isolated_config: Path
+    ):
+        """Issue #424: pin the current dedup contract — duplicate IDs are
+        preserved in `allowed_channels`. The source assigns
+        `allowed_channels = cids` from a plain list comprehension so
+        duplicates pass through. Pinning this behavior makes a future
+        dedup change (e.g. `dict.fromkeys(cids)` or `set(cids)`) visible
+        in test diffs rather than silent."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="hermes",
+            onboarding_state="channels",
+            config={
+                "provider": {
+                    "name": "p",
+                    "type": "ollama",
+                    "default_model": "x",
+                    "endpoint": "http://h/v1",
+                }
+            },
+        )
+
+        synced: list[dict] = []
+
+        def capture_sync(_host, _claw, channels_config, _name):
+            synced.append(channels_config)
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.cli.agent._sync_channel_config", side_effect=capture_sync),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage") as mock_stage,
+        ):
+            mock_p.side_effect = [
+                2,                                            # discord
+                self._valid_token(),                          # bot token
+                "740723459344302120",                         # valid user
+                "1503238729962356777",                        # home channel
+                "Home",                                       # home channel name
+                "1503238729962356777,1503238729962356777",    # dup channels
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "hermes", False, "assistant"
+            )
+
+        assert result is True
+        assert synced[0]["discord"]["allowed_channels"] == [
+            "1503238729962356777",
+            "1503238729962356777",
+        ]
+        mock_stage.assert_called_once()
+
     def test_openclaw_discord_still_uses_guilds_shape(
         self, isolated_config: Path
     ):


### PR DESCRIPTION
## Summary

- Adds a comma-only guard to the hermes Discord `allowed_channels` prompt that rejects input like `, , ,` (truthy after strip but parses to an empty list), preventing the bot from silently going open-channel on every allowlisted guild.
- Emits a `[yellow]Note:[/yellow]` when the operator presses Enter at the prompt, so the open-channel posture is no longer silent — symmetric to zeroclaw allowed_users / allowed_guilds Notes added in #422.
- Closes #424.

The fix mirrors the zeroclaw `allowed_users` / `allowed_guilds` guards from #422 verbatim in shape: pre-split into `cids`, reject empty post-filter, bulk-assign `allowed_channels = cids` after per-ID validation. Also adopts the defensive `(raw or "").strip()` form for consistency.

## Testing

### Test Results
- [x] All existing tests pass (`make test`): 2363 pytest + 208 vitest pass, 8 skipped
- [x] Linter passes (`make lint`): ruff + ESLint clean
- [x] New tests added for new functionality (4 under `TestRunChannelsStageHermesDiscord`)

### Test Coverage
- Files changed: `src/clawrium/cli/agent.py`, `tests/test_cli_agent_configure.py`, `.itx/424/01_EXECUTION.md`
- New tests:
  - `test_hermes_discord_rejects_comma_only_allowed_channels` — comma-only rejection with full no-side-effects contract (`_sync_channel_config`, `set_instance_secret`, `complete_stage`, `typer.confirm` all asserted not_called) plus `[red]Error:[/red]` severity prefix assertion.
  - `test_hermes_discord_empty_allowed_channels_warns` — parametrized over `require_mention ∈ {True, False}` to close the tautology gap on confirm propagation; asserts `len(synced) == 1`, `allowed_channels` key absence, `require_mention` propagation, `complete_stage.assert_called_once()`, and `[yellow]Note:[/yellow]` severity prefix.
  - `test_hermes_discord_valid_allowed_channels_stored` — happy-path round-trip for two valid IDs into `synced[0]["discord"]["allowed_channels"]` with companion-field structural guards (`require_mention`, `home_channel`).
  - `test_hermes_discord_allowed_channels_preserves_duplicates` — pins the current dedup contract (duplicates preserved) so a future dedup change is visible in test diffs.
- Coverage impact: increased (4 new tests, ~190 new test lines targeting a previously-uncovered class of bug).

### Manual Testing
Targeted pytest sweep:
```
uv run pytest tests/test_cli_agent_configure.py -k hermes_discord -x
# 16 passed, 102 deselected
```
Plus the full `make test` (2363 passed).

### Security Checklist
- [x] No hardcoded secrets or credentials (test token is a fixture: `MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMw`)
- [x] Input validation for user-provided data (digit-only regex `^\d{17,19}$` per channel ID; comma-only post-filter empty guard)
- [x] No SQL injection, XSS, or command injection risks (IDs constrained before downstream use; .env.j2 shell_quote() wraps them; ansible_runner uses argv list form, no shell=True)
- [x] Dependencies are from trusted sources (no new dependencies)

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $6.83 | Total Time: ~9m | Rounds: 3**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2-3/5 | B1 | Fixed | $2.38 | ~3m | leader, cli-ux, security, test-coverage, core-lifecycle |
| 2 | 3/5 | None | Below threshold — fixed all warnings | $2.07 | ~3m | leader, cli-ux, security, test-coverage |
| 3 | 4/5 | None | Merge threshold met | $2.38 | ~3m | leader, cli-ux, security, core-lifecycle (test-coverage exceeded max turns) |

> **Note**: ATX does not expose model information per agent. Round 3 closed all Round 2 warnings; the three new Round 3 warnings (W-R3-1/2/3) were closed post-review as test-only assertion tightening with no production-code impact.

<details>
<summary>Review 1 Details (Rating 2-3/5 — BLOCKED)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_cli_agent_configure.py` | `test_hermes_discord_rejects_comma_only_allowed_channels` did not assert `_sync_channel_config.assert_not_called()` — the no-mutation guarantee (the exact regression the guard prevents) was untested | Fixed — patched `_sync_channel_config` and `complete_stage` and asserted both `assert_not_called()` |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `src/clawrium/cli/agent.py` | `allowed_channels.append(cid)` inside loop vs zeroclaw bulk-assign — 95% structural parity | Fixed — replaced with `allowed_channels = cids` post-loop |
| W2 | `tests/test_cli_agent_configure.py` | Comma-only test did not assert `[red]Error:[/red]` printed | Fixed — added console mock + assertion |
| W3 | `tests/test_cli_agent_configure.py` | `typer.confirm` not mocked in comma-only test → pre-fix failure surfaces as EOFError | Fixed — added `typer.confirm` patch |
| W4 | `tests/test_cli_agent_configure.py` | Empty-warns test missing `len(synced) == 1` and `require_mention` propagation assertions | Fixed — added both |
| W5 | `tests/test_cli_agent_configure.py` | No happy-path test for valid IDs round-tripping into synced config | Fixed — added `test_hermes_discord_valid_allowed_channels_stored` |
| W6 | `src/clawrium/cli/agent.py` | Chained `.strip()` vs defensive `(raw or "").strip()` — copy-paste trap | Fixed — adopted defensive form |

</details>

<details>
<summary>Review 2 Details (Rating 3/5 — below merge threshold, no blockers)</summary>

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W-R2-1 | `tests/test_cli_agent_configure.py` | No-mutation contract still incomplete — `set_instance_secret` patched but never asserted not_called | Fixed — captured patch as `mock_secret` and asserted `assert_not_called()` |
| W-R2-2 | `tests/test_cli_agent_configure.py` | Error severity prefix `[red]Error:[/red]` not asserted | Fixed — added `assert "[red]Error:[/red]" in error_calls[0].args[0]` |
| W-R2-3 | `tests/test_cli_agent_configure.py` | `require_mention is True` tautological because `typer.confirm` is patched True | Fixed — parametrized across `require_mention ∈ {True, False}` |
| W-R2-4 | `tests/test_cli_agent_configure.py` | Deduplication behavior unspecified — no test pins it | Fixed — added `test_hermes_discord_allowed_channels_preserves_duplicates` |
| W-R2-5 | `tests/test_cli_agent_configure.py` | Happy-path missing `require_mention` / `home_channel` structural assertions | Fixed — added both |
| W-R2-6 | `src/clawrium/cli/agent.py:918` | Pre-existing bidi gap in rejected-cid error path | Out-of-scope — confirmed not introduced by this diff (digit-only regex gates entry); track as separate issue |

</details>

<details>
<summary>Review 3 Details (Rating 4/5 — APPROVED)</summary>

**Warnings (all closed post-review as test-only tightening):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W-R3-1 | `tests/test_cli_agent_configure.py` | Empty-warns test does not assert `[yellow]Note:[/yellow]` severity prefix (asymmetric to W-R2-2 on the error path) | Fixed — added `assert "[yellow]Note:[/yellow]" in warning_calls[0].args[0]` |
| W-R3-2 | `tests/test_cli_agent_configure.py` | `complete_stage` patched but not captured/asserted in three success tests — state-machine transition invisible | Fixed — captured `complete_stage` as `mock_stage` in all three success tests and added `mock_stage.assert_called_once()` |
| W-R3-3 | `tests/test_cli_agent_configure.py` | Comma-only test missing `mock_confirm.assert_not_called()` | Fixed — captured `typer.confirm` patch as `mock_confirm` and asserted not_called |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S-R3-1 | Pre-existing inconsistency: `home_channel_raw` / `home_channel_name_raw` still use chained `.strip()` | Deferred — out of scope; `default=""` makes the chained form safe in those sites |
| S-R3-2 | `patch.object` vs string target for `set_instance_secret` would be import-hoist-resilient | Deferred — low priority; current target is correct |
| S-R3-3 | Consider `list(dict.fromkeys(cids))` for dedup | Deferred — behavior change is a separate conversation; pinned by W-R2-4 test |

</details>

## Reviewer Notes

- The fix is intentionally a narrow mirror of the #422 zeroclaw guards. Structural parity was explicitly required by the issue scope and is now verified at line-for-line shape with the zeroclaw reference (`(raw or "").strip()` form, pre-split `cids`, comma-only guard, per-ID loop, bulk-assign post-loop).
- The Round 2 → Round 3 progression iterated test-quality only — production code stabilized at Round 1's W1/W6 fixes.
- No behavior-change is in scope here; the dedup contract is pinned by test but not changed.
- The pre-existing bidi gap at `src/clawrium/cli/agent.py:918` was confirmed by all three Round 3 specialists as unrelated to this diff (new paths added in this PR use only static strings with zero user-data interpolation). Worth a separate follow-up issue.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>