### PR TITLE
fix(zeroclaw): auto-approve sessions_current + sessions_list for chat

### DIFF
--- a/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
+++ b/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
@@ -312,6 +312,25 @@ auto_approve = [
   # Channel interaction
   "ask_user",
   "escalate_to_human",
+  # Inter-session enumeration (zeroclaw v0.7.5 crates/zeroclaw-tools/
+  # src/sessions.rs). Six sessions_* tools exist upstream. Only the two
+  # below are auto-approved because they take no `session_id` target
+  # parameter and surface only metadata:
+  #   sessions_current() — returns the active session's key/name
+  #   sessions_list(limit?) — returns {key, channel, msgs, last_activity}
+  # Gated (NOT in auto_approve) — operator must approve each call:
+  #   sessions_history(session_id, limit?) — reads ANY session's full
+  #       transcript; cross-session read is a new exposure tier
+  #       (credentials/secrets pasted into other chats).
+  #   sessions_send(session_id, message) — writes to ANY session;
+  #       enumerate→exfiltrate vector when chained with sessions_list.
+  #   sessions_reset(session_id), sessions_delete(session_id) —
+  #       destructive Act ops.
+  # Pre-approving sessions_list alone unblocks `clm chat` from dying
+  # immediately on enumeration; sessions_send-class flows still fail
+  # until clm chat learns to render approval_request frames inline.
+  "sessions_current",
+  "sessions_list",
   # Tool catalog (read-only)
   "tool_search",
 ]

--- a/tests/test_configure_zeroclaw.py
+++ b/tests/test_configure_zeroclaw.py
@@ -717,6 +717,23 @@ class TestAutonomyBlock:
         assert '"/proc"' in rendered
         assert '"~/.ssh"' in rendered
         assert '"~/.config/clawrium"' in rendered
+        # Inter-session tool gating boundary. Authoritative source is
+        # zeroclaw v0.7.5 crates/zeroclaw-tools/src/sessions.rs — six
+        # sessions_* tools exist upstream. Two take no `session_id` and
+        # are safe to auto-approve (enumeration only). The other four
+        # take a target `session_id` (cross-session read/write/destroy)
+        # and MUST stay gated; together with sessions_list they form an
+        # enumerate→exfiltrate chain. Update assertions if upstream adds
+        # or renames a sessions_* tool.
+        expected_sessions_auto_approve = {"sessions_current", "sessions_list"}
+        sessions_in_auto_approve = set(
+            _re422.findall(r'"(sessions_[^"]+)"', rendered)
+        )
+        assert sessions_in_auto_approve == expected_sessions_auto_approve, (
+            f"sessions_* mismatch — "
+            f"surplus: {sessions_in_auto_approve - expected_sessions_auto_approve} | "
+            f"missing: {expected_sessions_auto_approve - sessions_in_auto_approve}"
+        )
 
     def test_shell_env_passthrough_defaults_to_upstream_four(self):
         rendered = _render_with_channels_and_integrations(


### PR DESCRIPTION
## Summary

- `clm chat` cannot render inline tool-approval prompts; the session dies with `Protocol error: ZeroClaw requested tool approval (tool='sessions_list')` whenever the agent enumerates sessions during a chat turn (e.g. a Discord-send workflow).
- Auto-approve only the two `sessions_*` tools that take **no target `session_id`** — `sessions_current` and `sessions_list`. The other four (`sessions_history`, `sessions_send`, `sessions_reset`, `sessions_delete`) all accept a target `session_id` and remain gated, breaking the enumerate→exfiltrate chain.
- Inventory verified against zeroclaw v0.7.5 `crates/zeroclaw-tools/src/sessions.rs` (six tools total). Test enforces the allowlist via exhaustive regex set-equality so any future addition fails CI rather than silently rolling out.

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $4.58 | Total Time: ~3m 30s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1, B2 | All fixed | $1.44 | ~60s | leader, ansible-registry, security, core-lifecycle |
| 2 | 1/5 | B1, B2, B3 (staging coherence) | All fixed | $1.19 | ~50s | leader, security, test-coverage, core-lifecycle |
| 3 | 4/5 (avg) | None | W1 fixed | $1.20 | ~70s | leader, ansible-registry, security, test-coverage |
| 4 | 4/5 | None | Clean to commit | $0.75 | ~30s | leader, test-coverage, core-lifecycle |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `config.toml.j2` | `sessions_send` auto-approved + `sessions_list` auto-approved = enumerate→exfiltrate chain. Reviewer's bar: if `sessions_send` takes a target parameter, it MUST be gated. | Confirmed upstream signature: `sessions_send(session_id, message)` requires target. Removed from auto_approve. |
| B2 | `config.toml.j2` | Inventory not audited — speculated tools (`sessions_export`, `broadcast`, `fork`, `terminate`) not addressed. | Exhaustive grep of `crates/zeroclaw-tools/src/sessions.rs`: exactly six `sessions_*` tools exist in v0.7.5. Documented full inventory + dispositions in template comment. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `tests/test_configure_zeroclaw.py` | No coverage for new auto_approve category. | Added regex set-equality pin assertion (catches any sessions_* tool slipping into auto_approve). |
| W2 | `config.toml.j2` | `sessions_history` cross-session scope unconfirmed. | Confirmed at line 226-247: takes target `session_id`. Gated. |
| W3 | (PR scope) | Shared template — every zeroclaw on next sync silently picks up the change. | See "Fleet-wide rollout" section below. |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Comment risk-tier clarity. | Rewrote with full six-tool inventory grouped by `session_id`-param presence. |
| S2 | `sessions_list` channel metadata leak comment. | Acknowledged; low-risk, doc-only follow-up if needed. |

</details>

<details>
<summary>Review 2 Details (Rating 1/5 — staging coherence failure)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `config.toml.j2` | Working tree had the fix but `git add` was never re-run after the iter-1 edit. Staged content still had `sessions_send`. | Re-staged. |
| B2 | `config.toml.j2` | Same root cause for `sessions_history`. | Re-staged. |
| B3 | `tests/test_configure_zeroclaw.py` | Test changes never staged. | Staged alongside template. |

This was the highest-leverage iteration — `make test` reads the working tree (filesystem), not the git index, so the pre-commit gate passed silently while the staged commit would have shipped the iter-1 vulnerability. Worth remembering as a class.

</details>

<details>
<summary>Review 3 Details (avg 4/5)</summary>

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `tests/test_configure_zeroclaw.py:732` | Failure message only reported surplus (`computed - expected`). Missing-tool failure would print `unexpected: set()` — false-pass appearance. | Rewrote to report both directions: `surplus: {...} | missing: {...}`. |
| W2 | `tests/test_configure_zeroclaw.py:729` | Regex scans full rendered output, not the auto_approve substring. Safe today (TOML comments use unquoted mentions) but fragile. | Acknowledged; deferred to follow-up. |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Pin upstream SHA in template comment. | Deferred (cosmetic). |
| S2 | `sessions_list` channel-field metadata leak doc note. | Deferred (low-risk, doc-only). |

</details>

<details>
<summary>Review 4 Details (Rating 4/5 — clean)</summary>

No blockers, no warnings. Both specialists confirmed:
- W1 fix is correct (set `==` is bidirectional; both directions surface in the message).
- Expected set verified 1:1 against template lines.

Deferred items unchanged from iteration 3.

</details>

## Fleet-wide rollout (W3 acknowledgment)

This change ships in a shared Jinja2 template. **Every** zeroclaw agent across the fleet picks up the new `auto_approve` entries on the **next** `clm agent sync` / `configure` / `restart` — for any reason, not just an explicit intent to enable session tooling. The change is intentionally narrow (`sessions_current` + `sessions_list` only — no write side), so the worst-case behavior change is: an agent that previously crashed the chat session on `sessions_list` now succeeds at enumerating sessions.

No code change required for correctness; called out so operators know it lands silently on routine syncs.

## Testing

### Test Results
- [x] All existing tests pass (`make test`: 2,382 passed, 8 skipped)
- [x] Linter passes (`make lint`: ruff + eslint clean)
- [x] New test assertion added: `tests/test_configure_zeroclaw.py::TestAutonomyBlock::test_autonomy_block_always_renders` now contains an exhaustive set-equality pin against the rendered `sessions_*` set.

### Test Coverage
- Files changed: `src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2`, `tests/test_configure_zeroclaw.py`
- New tests: regex-based set-equality pin (catches both surplus and missing — verified to fail against iter-2 staged content and pass against the final content).
- Coverage impact: maintained.

### Manual Testing
- `clm agent sync clawrium-d01` against `wolf-i` (`wolf.tailf7742d.ts.net`) succeeded with the wider iter-1 auto_approve list (initial verification of the workflow); the deployed config there will narrow on its next sync after this PR merges.
- Discord-send chat workflow on `clawrium-d01` got past the original `sessions_list` failure point. End-to-end send still requires `sessions_send` approval — addressed by follow-up #449.

### Security Checklist
- [x] No hardcoded secrets or credentials.
- [x] Input validation N/A (static TOML list entries).
- [x] No new SQL injection, XSS, or command injection risks.
- [x] Cross-session privilege boundary preserved: all session_id-taking tools remain gated.

## Reviewer Notes

- Inventory anchor: zeroclaw v0.7.5 `crates/zeroclaw-tools/src/sessions.rs` — six tools total, verified via `grep -E '^\s*"sessions_'`.
- Follow-up issue #449: `clm chat` should learn `approval_request` frames so Act-tier tools can stay gated AND remain usable from chat.
- Unrelated context: hostname-keyed-secrets failure encountered during the live sync test is filed separately as #448 and **not** part of this PR.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>