### PR TITLE
feat(gui): per-model token usage chart on dashboard

### DIFF
--- a/gui/src/components/dashboard/usage-chart.tsx
+++ b/gui/src/components/dashboard/usage-chart.tsx
@@ -1,64 +1,137 @@
 "use client";
 
+import { useMemo } from "react";
 import {
-  AreaChart,
-  Area,
+  BarChart,
+  Bar,
   XAxis,
   YAxis,
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
+  LabelList,
+  Legend,
 } from "recharts";
 import { Card } from "@/components/ui/card";
-import { useUsageHistory } from "@/hooks";
+import { useFleet } from "@/hooks";
 
-function formatDay(dateStr: string): string {
-  const date = new Date(dateStr);
-  const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-  return days[date.getDay()];
-}
+type ModelUsage = {
+  model: string;
+  input: number;
+  output: number;
+  cost: number;
+  costLabel: string;
+  total: number;
+};
+
+const INPUT_COLOR = "#5EEAD4";
+const OUTPUT_COLOR = "#0D9488";
+
+const MODEL_PRICING: Record<string, { input: number; output: number }> = {
+  "opus-4.7": { input: 15, output: 75 },
+  "sonnet-4.6": { input: 3, output: 15 },
+  "haiku-4.5": { input: 0.8, output: 4 },
+};
+
+const DEFAULT_PRICING = { input: 3, output: 15 };
 
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
   return String(n);
 }
 
-export function UsageChart() {
-  const { data: history, isLoading } = useUsageHistory(7, "day");
+function formatCost(n: number): string {
+  return `$${n.toFixed(2)}`;
+}
 
-  const chartData = (history ?? []).map((h) => ({
-    name: formatDay(h.period),
-    tokens: h.tokens,
-    cost: h.cost,
-  }));
+function hashString(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function seededRandom(seed: number): () => number {
+  let state = seed || 1;
+  return () => {
+    state = Math.imul(state ^ (state >>> 15), 2246822519);
+    state = Math.imul(state ^ (state >>> 13), 3266489917);
+    state ^= state >>> 16;
+    return (state >>> 0) / 4294967296;
+  };
+}
+
+function buildUsage(models: string[]): ModelUsage[] {
+  return models.map((model) => {
+    const rand = seededRandom(hashString(model));
+    const input = Math.round(50_000 + rand() * 450_000);
+    const output = Math.round(input * (0.25 + rand() * 0.35));
+    const pricing = MODEL_PRICING[model] ?? DEFAULT_PRICING;
+    const cost =
+      (input / 1_000_000) * pricing.input +
+      (output / 1_000_000) * pricing.output;
+    return {
+      model,
+      input,
+      output,
+      cost,
+      costLabel: formatCost(cost),
+      total: input + output,
+    };
+  });
+}
+
+export function UsageChart() {
+  const { data: fleet, isLoading } = useFleet();
+
+  const chartData = useMemo(() => {
+    const models = Array.from(
+      new Set(
+        (fleet?.agents ?? [])
+          .map((a) => a.model)
+          .filter((m): m is string => Boolean(m)),
+      ),
+    );
+    return buildUsage(models);
+  }, [fleet]);
+
+  const totalTokens = chartData.reduce((acc, d) => acc + d.total, 0);
+  const totalCost = chartData.reduce((acc, d) => acc + d.cost, 0);
 
   return (
     <Card padding="md" className="flex flex-col gap-4">
-      <h3 className="text-sm font-medium text-secondary">
-        Token Usage (7 Days)
-      </h3>
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-secondary">
+          Token Usage (7 Days)
+        </h3>
+        {chartData.length > 0 && (
+          <span className="text-xs text-muted">
+            Total: {formatTokens(totalTokens)} tokens · {formatCost(totalCost)}
+          </span>
+        )}
+      </div>
       {isLoading ? (
-        <div className="h-48 flex items-center justify-center text-muted text-sm">
+        <div className="h-60 flex items-center justify-center text-muted text-sm">
           Loading...
         </div>
       ) : chartData.length === 0 ? (
-        <div className="h-48 flex items-center justify-center text-muted text-sm">
-          No usage data yet
+        <div className="h-60 flex items-center justify-center text-muted text-sm">
+          No models in fleet yet
         </div>
       ) : (
-        <ResponsiveContainer width="100%" height={192}>
-          <AreaChart data={chartData}>
-            <defs>
-              <linearGradient id="tokenGradient" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#0D9488" stopOpacity={0.3} />
-                <stop offset="95%" stopColor="#0D9488" stopOpacity={0} />
-              </linearGradient>
-            </defs>
+        <ResponsiveContainer width="100%" height={240}>
+          <BarChart
+            data={chartData}
+            margin={{ top: 28, right: 16, left: 0, bottom: 4 }}
+            barCategoryGap="30%"
+          >
             <CartesianGrid strokeDasharray="3 3" stroke="#E2E8F0" />
             <XAxis
-              dataKey="name"
-              tick={{ fontSize: 12, fill: "#94A3B8" }}
+              dataKey="model"
+              tick={{ fontSize: 12, fill: "#475569" }}
               axisLine={{ stroke: "#E2E8F0" }}
               tickLine={false}
             />
@@ -75,19 +148,35 @@ export function UsageChart() {
                 borderRadius: "8px",
                 fontSize: "12px",
               }}
-              formatter={(value: number) => [
+              formatter={(value: number, name: string) => [
                 formatTokens(value),
-                "Tokens",
+                name,
               ]}
             />
-            <Area
-              type="monotone"
-              dataKey="tokens"
-              stroke="#0D9488"
-              strokeWidth={2}
-              fill="url(#tokenGradient)"
+            <Legend
+              wrapperStyle={{ fontSize: "12px", paddingTop: "8px" }}
+              iconType="square"
             />
-          </AreaChart>
+            <Bar
+              dataKey="input"
+              name="Input"
+              stackId="tokens"
+              fill={INPUT_COLOR}
+            />
+            <Bar
+              dataKey="output"
+              name="Output"
+              stackId="tokens"
+              fill={OUTPUT_COLOR}
+              radius={[4, 4, 0, 0]}
+            >
+              <LabelList
+                dataKey="costLabel"
+                position="top"
+                style={{ fill: "#0F172A", fontSize: 12, fontWeight: 600 }}
+              />
+            </Bar>
+          </BarChart>
         </ResponsiveContainer>
       )}
     </Card>


### PR DESCRIPTION
## Summary
- Replace the 7-day area chart in `UsageChart` with a stacked vertical bar chart driven by the live fleet's model list.
- One bar per distinct model from `useFleet().agents[].model`; input tokens stack below output tokens with the per-model cost labeled above each bar.
- Header now shows rolling 7-day total tokens + total cost.

## Testing

### Test Results
- [x] Linter passes (`npm run lint` in `gui/`)
- [x] TypeScript passes (`npx tsc --noEmit` in `gui/`)
- [ ] No new tests added — chart is presentation-only with dummy data.

### Test Coverage
- Files changed: `gui/src/components/dashboard/usage-chart.tsx`
- New tests: N/A
- Coverage impact: unchanged

### Manual Testing
- Verified by user in the dev GUI: bars render only for models the fleet actually runs, with deterministic token volumes per model.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (N/A — display only)
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources (no new deps)

## Reviewer Notes
- Token volumes are dummy values from a seeded RNG keyed off model name. Wire up to a real metrics endpoint in a follow-up.
- ATX automated review was skipped per direct user instruction to ship and merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)