### PR TITLE
feat(gui): add Request a feature button to every page header (#456)

### DIFF
--- a/gui/src/components/layout/external-links.tsx
+++ b/gui/src/components/layout/external-links.tsx
@@ -20,6 +20,9 @@ export const EXTERNAL_LINKS = [
   },
 ] as const;
 
+const FEATURE_REQUEST_URL =
+  "https://github.com/ric03uec/clawrium/issues/new?template=feature_request.yml";
+
 interface ExternalLinkRowsProps {
   className?: string;
 }
@@ -67,5 +70,19 @@ export function ExternalLinkIcons({ className = "" }: ExternalLinkIconsProps) {
         </a>
       ))}
     </div>
+  );
+}
+
+export function RequestFeatureButton() {
+  return (
+    <a
+      href={FEATURE_REQUEST_URL}
+      target="_blank"
+      rel="noreferrer noopener"
+      className="flex items-center gap-1.5 px-3 h-9 rounded-lg text-sm text-primary-text hover:text-primary hover:bg-panel transition-colors whitespace-nowrap"
+    >
+      <GithubIcon className="h-[18px] w-[18px]" />
+      <span>Request a feature</span>
+    </a>
   );
 }

--- a/gui/src/components/layout/page-header.test.tsx
+++ b/gui/src/components/layout/page-header.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { PageHeader } from "./page-header";
+
+describe("PageHeader", () => {
+  it("renders the title", () => {
+    render(<PageHeader title="Agents" />);
+    expect(screen.getByText("Agents")).toBeInTheDocument();
+  });
+
+  it("renders the description when provided", () => {
+    render(<PageHeader title="Agents" description="Manage your agents" />);
+    expect(screen.getByText("Manage your agents")).toBeInTheDocument();
+  });
+
+  it("renders the Request a feature button with correct href and target", () => {
+    render(<PageHeader title="Agents" />);
+    const link = screen.getByRole("link", { name: /request a feature/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/ric03uec/clawrium/issues/new?template=feature_request.yml",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel") ?? "").toContain("noreferrer");
+  });
+
+  it("renders external link icons (GitHub, Docs, Discord)", () => {
+    render(<PageHeader title="Agents" />);
+    expect(screen.getByRole("link", { name: "GitHub" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Docs" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Discord" })).toBeInTheDocument();
+  });
+
+  it("renders actions when provided", () => {
+    render(
+      <PageHeader
+        title="Agents"
+        actions={<button type="button">Add agent</button>}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Add agent" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/gui/src/components/layout/page-header.tsx
+++ b/gui/src/components/layout/page-header.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcons } from "./external-links";
+import { ExternalLinkIcons, RequestFeatureButton } from "./external-links";
 
 interface PageHeaderProps {
   title: string;
@@ -20,6 +20,8 @@ export function PageHeader({ title, description, actions }: PageHeaderProps) {
         {actions && (
           <span aria-hidden="true" className="h-6 w-px bg-default" />
         )}
+        <RequestFeatureButton />
+        <span aria-hidden="true" className="h-6 w-px bg-default" />
         <ExternalLinkIcons />
       </div>
     </div>


### PR DESCRIPTION
Added RequestFeatureButton component to external-links.tsx and wired it into page-header.tsx with vertical divider. Opens feature_request.yml in new tab. 5 new tests in page-header.test.tsx. All tests and lint pass. Closes #456 Co-Authored-By: clawrium-d01 <clawrium-d01@users.noreply.github.com>