### PR TITLE
feat(cli): styled, named, editable prompts in clm chat

### DIFF
--- a/.itx/455/02_EXECUTION.md
+++ b/.itx/455/02_EXECUTION.md
@@ -1,0 +1,28 @@
+# Issue #455 — Execution log
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-20T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx:execute 455
+```
+
+**Output**: Implemented styled, named, editable prompts in `clm chat`
+per the spec in the issue body. Added `prompt_toolkit` dependency,
+refactored `_read_user_input` to use a reusable `PromptSession`
+(with a non-TTY fallback to the original bare-`input()` path), plumbed
+`agent_label=str(display_agent)` through `_chat_loop`, and styled the
+three former `"agent> "` literal print sites with `style="bold green"`.
+Added three new tests in `tests/test_cli_chat.py`
+(`test_chat_loop_uses_agent_name_in_prefix`,
+`test_chat_loop_agent_prefix_uses_green_style`,
+`test_read_user_input_signature_preserved`). `make lint` and `make
+test` both pass. PR: #462.
+
+Note: ATX MCP review tool was not available in this execution
+environment; PR uses the manual-review format, matching recent merged
+PRs (#450, #454, #446, #447).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
     "jsonschema>=4.17.0,<5.0.0",
+    "prompt_toolkit>=3.0.43,<4.0.0",
 ]
 
 [project.scripts]

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -13,9 +13,8 @@ from __future__ import annotations
 
 import asyncio
 import re
-from typing import Any, TypedDict
-
 import sys
+from typing import Any, TypedDict
 
 import typer
 from prompt_toolkit import PromptSession
@@ -59,6 +58,37 @@ class GatewayConfig(TypedDict, total=False):
 
 
 _SESSION_PATTERN = re.compile(r"^[a-zA-Z0-9_:.-]{1,255}$")
+
+# C0/C1 control + Unicode bidi-formatting + zero-width + line/paragraph
+# separators. Kept in sync with `_sanitize_exception_text` below and
+# `chat_hermes._CONTROL_CHARS_RE`. Shared so the agent-label sanitizer
+# (issue #455 ATX W2) and the exception sanitizer use identical
+# coverage; drifting one would reintroduce the bypass.
+_CONTROL_AND_BIDI_RE = re.compile(
+    "["
+    "\x00-\x1f\x7f-\x9f"
+    "؜"             # ARABIC LETTER MARK (UAX#9 bidi format char)
+    "​-‏"      # ZWSP, ZWNJ, ZWJ, LRM, RLM
+    " - "      # LINE / PARAGRAPH SEPARATOR
+    "‪-‮"      # LRE, RLE, PDF, LRO, RLO
+    "⁠"             # WORD JOINER
+    "⁦-⁩"      # LRI, RLI, FSI, PDI
+    "﻿"             # ZWNBSP / BOM
+    "]"
+)
+
+
+def _sanitize_agent_label(label: str) -> str:
+    """Strip control / bidi / zero-width chars from `label` so it is
+    safe to render at terminal output sites.
+
+    Replaces dangerous codepoints with a single space, then collapses
+    runs of whitespace. Returns a literal `agent` fallback when the
+    input collapses to empty so the prefix is never just `> `.
+    """
+    cleaned = _CONTROL_AND_BIDI_RE.sub(" ", label)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned or "agent"
 
 
 def chat(
@@ -201,6 +231,15 @@ def chat(
 
     attempted_reconnect = False
     while True:
+        # Drop the module-level PromptSession between reconnect iterations.
+        # Each `asyncio.run(_chat_loop(...))` is a fresh event loop; reusing
+        # a PromptSession that was created during the previous loop's
+        # `prompt_async` (and whose `Application`/`AsyncOutput` may still
+        # hold fd refs / terminal state from that loop) risks anchoring the
+        # second iteration to an already-closed loop. Forcing a fresh
+        # session on each retry costs one extra object construction and
+        # eliminates that whole class of cross-loop weirdness.
+        _reset_prompt_session()
         try:
             asyncio.run(
                 _chat_loop(
@@ -342,7 +381,14 @@ async def _chat_loop(
         await backend.connect()
 
     history_capable = chat_type == "openai"
-    agent_prefix_plain = f"{agent_label}> "
+    # Parity with `_sanitize_exception_text` (issue #455 ATX W2): strip
+    # C0/C1 control bytes + bidi-formatting + zero-width + line/paragraph
+    # separators from the agent label before it reaches the terminal.
+    # Normal lifecycle validation (^[a-z][a-z0-9_-]{0,31}$) already
+    # precludes these, but a hand-edited `hosts.json` could smuggle in a
+    # bidi-spoofed label; this guarantees the styled prefix can never be
+    # the injection site.
+    agent_prefix_plain = f"{_sanitize_agent_label(agent_label)}> "
 
     try:
         while True:
@@ -392,14 +438,20 @@ async def _chat_loop(
                 nonlocal shown_prefix
                 _stop_status()
                 if not shown_prefix:
-                    # `style=` (not markup) — `agent_label` may legitimately
-                    # contain `[`/`]`, which would otherwise be parsed as
-                    # Rich markup and crash or render wrong.
+                    # `style=` (not f-string markup) AND `markup=False`:
+                    # `style=` alone does NOT disable Rich's markup parser
+                    # (it's on by default), so an `agent_label` containing
+                    # `[red]…[/red]` or `[link=…]…[/link]` would still be
+                    # consumed by the parser even though the string is
+                    # passed positionally. `markup=False` is what actually
+                    # turns parsing off; `style=` then applies the color
+                    # to the literal text.
                     console.print(
                         agent_prefix_plain,
                         end="",
                         style="bold green",
                         highlight=False,
+                        markup=False,
                     )
                     shown_prefix = True
                 console.print(delta, end="", markup=False, highlight=False)
@@ -453,6 +505,7 @@ async def _chat_loop(
                     end="",
                     style="bold green",
                     highlight=False,
+                    markup=False,
                 )
                 console.print(final_text, markup=False, highlight=False)
             else:
@@ -461,6 +514,7 @@ async def _chat_loop(
                     end="",
                     style="bold green",
                     highlight=False,
+                    markup=False,
                 )
                 console.print("[no response]", markup=False, highlight=False)
 
@@ -489,11 +543,24 @@ def _get_prompt_session() -> PromptSession[str]:
     return _PROMPT_SESSION
 
 
+def _reset_prompt_session() -> None:
+    """Drop the cached PromptSession so the next `_read_user_input` call
+    constructs a fresh one. Called at the start of each `chat()`
+    reconnect iteration; safe to call when no session has been created
+    yet."""
+    global _PROMPT_SESSION
+    _PROMPT_SESSION = None
+
+
 async def _read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
     # Non-TTY fallback: prompt_toolkit requires a real terminal and raises
     # if stdin is piped or otherwise not a TTY. Preserve the bare `input()`
     # behavior so scripted callers (`echo hi | clm chat ...`) still work.
-    if not sys.stdin.isatty():
+    # `sys.stdin is None` covers detached embedders (Windows GUI hosts,
+    # `subprocess.Popen(stdin=DEVNULL)`, sites that set `sys.stdin = None`):
+    # without the explicit None check, `.isatty()` would raise
+    # `AttributeError` before the fallback can take over.
+    if sys.stdin is None or not sys.stdin.isatty():
         task = asyncio.create_task(asyncio.to_thread(input, prompt))
         try:
             if idle_timeout_seconds > 0:
@@ -788,23 +855,12 @@ def _validate_session_key(session_key: str) -> None:
 
 def _sanitize_exception_text(exc: Exception, max_len: int = 500) -> str:
     # Strip C0/C1 control bytes AND Unicode bidi-formatting + zero-width
-    # + line/paragraph-separator codepoints. Same coverage as
-    # chat_hermes._CONTROL_CHARS_RE (keep in sync). Closes the W-A bypass
-    # where a remote-supplied error body can embed RTLO/LRM/LINE-SEP/etc.
-    cleaned = re.sub(
-        "["
-        "\x00-\x1f\x7f-\x9f"
-        "\u061c"             # ARABIC LETTER MARK (UAX#9 bidi format char)
-        "\u200b-\u200f"      # ZWSP, ZWNJ, ZWJ, LRM, RLM
-        "\u2028-\u2029"      # LINE / PARAGRAPH SEPARATOR
-        "\u202a-\u202e"      # LRE, RLE, PDF, LRO, RLO
-        "\u2060"             # WORD JOINER
-        "\u2066-\u2069"      # LRI, RLI, FSI, PDI
-        "\ufeff"             # ZWNBSP / BOM
-        "]",
-        " ",
-        str(exc),
-    )
+    # + line/paragraph-separator codepoints. Uses the shared
+    # `_CONTROL_AND_BIDI_RE` so the coverage stays identical to
+    # `_sanitize_agent_label` and `chat_hermes._CONTROL_CHARS_RE`.
+    # Closes the W-A bypass where a remote-supplied error body can
+    # embed RTLO/LRM/LINE-SEP/etc.
+    cleaned = _CONTROL_AND_BIDI_RE.sub(" ", str(exc))
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
     # First pass: redact `<scheme> <value>` header forms like
     # `Authorization: Bearer abc-123` and the shorthand `bearer abc-123`.

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -65,15 +65,20 @@ _SESSION_PATTERN = re.compile(r"^[a-zA-Z0-9_:.-]{1,255}$")
 # (issue #455 ATX W2) and the exception sanitizer use identical
 # coverage; drifting one would reintroduce the bypass.
 _CONTROL_AND_BIDI_RE = re.compile(
+    # Use explicit \uXXXX escapes (matching chat_hermes._CONTROL_CHARS_RE).
+    # Literal bidi/zero-width codepoints in source are invisible to most
+    # editors and easily corrupted by auto-formatters, BOM insertion, or
+    # careless copy-paste — \uXXXX escapes are grep-able and survive
+    # every editor.
     "["
     "\x00-\x1f\x7f-\x9f"
-    "؜"             # ARABIC LETTER MARK (UAX#9 bidi format char)
-    "​-‏"      # ZWSP, ZWNJ, ZWJ, LRM, RLM
-    " - "      # LINE / PARAGRAPH SEPARATOR
-    "‪-‮"      # LRE, RLE, PDF, LRO, RLO
-    "⁠"             # WORD JOINER
-    "⁦-⁩"      # LRI, RLI, FSI, PDI
-    "﻿"             # ZWNBSP / BOM
+    "\u061c"             # ARABIC LETTER MARK (UAX#9 bidi format char)
+    "\u200b-\u200f"      # ZWSP, ZWNJ, ZWJ, LRM, RLM
+    "\u2028-\u2029"      # LINE / PARAGRAPH SEPARATOR
+    "\u202a-\u202e"      # LRE, RLE, PDF, LRO, RLO
+    "\u2060"             # WORD JOINER
+    "\u2066-\u2069"      # LRI, RLI, FSI, PDI
+    "\ufeff"             # ZWNBSP / BOM
     "]"
 )
 

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -15,7 +15,11 @@ import asyncio
 import re
 from typing import Any, TypedDict
 
+import sys
+
 import typer
+from prompt_toolkit import PromptSession
+from prompt_toolkit.formatted_text import FormattedText
 from rich.console import Console
 from rich.markup import escape as rich_escape
 
@@ -205,6 +209,7 @@ def chat(
                     response_timeout_seconds=timeout,
                     idle_timeout_seconds=idle_timeout,
                     chat_type=chat_type,
+                    agent_label=str(display_agent),
                 )
             )
             if attempted_reconnect:
@@ -331,11 +336,13 @@ async def _chat_loop(
     response_timeout_seconds: float,
     idle_timeout_seconds: float,
     chat_type: str = "websocket",
+    agent_label: str = "agent",
 ) -> None:
     with console.status("Connecting to agent...", spinner="dots"):
         await backend.connect()
 
     history_capable = chat_type == "openai"
+    agent_prefix_plain = f"{agent_label}> "
 
     try:
         while True:
@@ -385,7 +392,15 @@ async def _chat_loop(
                 nonlocal shown_prefix
                 _stop_status()
                 if not shown_prefix:
-                    console.print("agent> ", end="", markup=False, highlight=False)
+                    # `style=` (not markup) — `agent_label` may legitimately
+                    # contain `[`/`]`, which would otherwise be parsed as
+                    # Rich markup and crash or render wrong.
+                    console.print(
+                        agent_prefix_plain,
+                        end="",
+                        style="bold green",
+                        highlight=False,
+                    )
                     shown_prefix = True
                 console.print(delta, end="", markup=False, highlight=False)
 
@@ -433,9 +448,21 @@ async def _chat_loop(
             if shown_prefix:
                 console.print("")
             elif final_text:
-                console.print(f"agent> {final_text}", markup=False, highlight=False)
+                console.print(
+                    agent_prefix_plain,
+                    end="",
+                    style="bold green",
+                    highlight=False,
+                )
+                console.print(final_text, markup=False, highlight=False)
             else:
-                console.print("agent> [no response]", markup=False, highlight=False)
+                console.print(
+                    agent_prefix_plain,
+                    end="",
+                    style="bold green",
+                    highlight=False,
+                )
+                console.print("[no response]", markup=False, highlight=False)
 
             # Surface a user-visible notice when the backend silently trimmed
             # the conversation history to stay under MAX_HISTORY_TURNS. Only
@@ -452,15 +479,36 @@ async def _chat_loop(
         await backend.close()
 
 
+_PROMPT_SESSION: PromptSession[str] | None = None
+
+
+def _get_prompt_session() -> PromptSession[str]:
+    global _PROMPT_SESSION
+    if _PROMPT_SESSION is None:
+        _PROMPT_SESSION = PromptSession()
+    return _PROMPT_SESSION
+
+
 async def _read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
-    task = asyncio.create_task(asyncio.to_thread(input, prompt))
-    try:
-        if idle_timeout_seconds > 0:
-            return await asyncio.wait_for(task, timeout=idle_timeout_seconds)
-        return await task
-    except TimeoutError:
-        task.cancel()
-        raise
+    # Non-TTY fallback: prompt_toolkit requires a real terminal and raises
+    # if stdin is piped or otherwise not a TTY. Preserve the bare `input()`
+    # behavior so scripted callers (`echo hi | clm chat ...`) still work.
+    if not sys.stdin.isatty():
+        task = asyncio.create_task(asyncio.to_thread(input, prompt))
+        try:
+            if idle_timeout_seconds > 0:
+                return await asyncio.wait_for(task, timeout=idle_timeout_seconds)
+            return await task
+        except TimeoutError:
+            task.cancel()
+            raise
+
+    styled = FormattedText([("ansiblue bold", prompt)])
+    session = _get_prompt_session()
+    coro = session.prompt_async(styled)
+    if idle_timeout_seconds > 0:
+        return await asyncio.wait_for(coro, timeout=idle_timeout_seconds)
+    return await coro
 
 
 def _resolve_chat_type(agent_type: str) -> str:

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1624,9 +1624,35 @@ class TestZeroclawChat:
 # --- Styled chat prompts (issue #455) ---------------------------------
 
 
-def test_chat_loop_uses_agent_name_in_prefix(monkeypatch, capsys):
+class _PrintRecorder:
+    """Capture every `console.print(...)` call's positional args and
+    kwargs so tests can assert on style/markup independent of Rich's
+    output stream (which may have been bound at module import time and
+    thus escape `capsys`)."""
+
+    def __init__(self, real_print):
+        self.calls: list[dict[str, object]] = []
+        self._real_print = real_print
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append({"args": args, "kwargs": kwargs})
+        return self._real_print(*args, **kwargs)
+
+
+def _install_print_recorder(monkeypatch) -> _PrintRecorder:
+    recorder = _PrintRecorder(chat_module.console.print)
+    monkeypatch.setattr(chat_module.console, "print", recorder)
+    return recorder
+
+
+def test_chat_loop_uses_agent_name_in_prefix(monkeypatch):
     """The agent prefix must surface the resolved agent name, not the
-    literal `agent>`, so multi-agent sessions are distinguishable."""
+    literal `agent>`, so multi-agent sessions are distinguishable.
+
+    Uses the `console.print` recorder rather than `capsys` because Rich's
+    `Console()` captures `sys.stdout` at import time; depending on import
+    order, `capsys` may not see Rich output (ATX issue #455 W6).
+    """
     fake_client = FakeChatClient()
     inputs = iter(["hello", "/exit"])
 
@@ -1634,6 +1660,7 @@ def test_chat_loop_uses_agent_name_in_prefix(monkeypatch, capsys):
         return next(inputs)
 
     monkeypatch.setattr(chat_module, "_read_user_input", fake_read_user_input)
+    recorder = _install_print_recorder(monkeypatch)
 
     asyncio.run(
         chat_module._chat_loop(
@@ -1646,15 +1673,19 @@ def test_chat_loop_uses_agent_name_in_prefix(monkeypatch, capsys):
         )
     )
 
-    captured = capsys.readouterr().out
-    assert "cuddly-otter> " in captured
-    assert "agent> " not in captured
+    rendered_first_args = [
+        call["args"][0] for call in recorder.calls if call["args"]
+    ]
+    assert "cuddly-otter> " in rendered_first_args
+    assert "agent> " not in rendered_first_args
 
 
 def test_chat_loop_agent_prefix_uses_green_style(monkeypatch):
     """The streaming agent-prefix print must use `style='bold green'`
-    rather than markup, so labels containing `[`/`]` render correctly
-    and the bold-green visual matches the spec."""
+    AND `markup=False` together. `style=` alone does not disable Rich's
+    markup parser — `markup=False` is what actually keeps `[red]…[/red]`
+    in `agent_label` from being consumed by the parser (ATX issue #455
+    B1 / W4)."""
     fake_client = FakeChatClient()
     inputs = iter(["hi", "/exit"])
 
@@ -1662,15 +1693,7 @@ def test_chat_loop_agent_prefix_uses_green_style(monkeypatch):
         return next(inputs)
 
     monkeypatch.setattr(chat_module, "_read_user_input", fake_read_user_input)
-
-    captured_prints: list[dict[str, object]] = []
-    real_print = chat_module.console.print
-
-    def recording_print(*args, **kwargs):
-        captured_prints.append({"args": args, "kwargs": kwargs})
-        return real_print(*args, **kwargs)
-
-    monkeypatch.setattr(chat_module.console, "print", recording_print)
+    recorder = _install_print_recorder(monkeypatch)
 
     asyncio.run(
         chat_module._chat_loop(
@@ -1685,16 +1708,151 @@ def test_chat_loop_agent_prefix_uses_green_style(monkeypatch):
 
     prefix_calls = [
         call
-        for call in captured_prints
+        for call in recorder.calls
         if call["args"] and call["args"][0] == "my-agent> "
     ]
     assert prefix_calls, "No print call emitted the agent prefix"
     for call in prefix_calls:
+        kwargs = call["kwargs"]
+        assert kwargs.get("style") == "bold green", (
+            f"prefix call lacks style='bold green': {kwargs!r}"
+        )
+        # Must be explicit `False` — absent means Rich's default
+        # (markup=True) is active, which is exactly the regression W4
+        # describes.
+        assert kwargs.get("markup") is False, (
+            f"prefix call must set markup=False explicitly: {kwargs!r}"
+        )
+
+
+class _NonStreamingFakeClient(FakeChatClient):
+    """Drives the `elif final_text` branch in `_chat_loop` — the one
+    that emits the styled prefix from the non-streaming path. Unlike
+    `FakeChatClient.send_message`, this variant does NOT call
+    `on_delta`, so `shown_prefix` stays False and the final-text print
+    site is the one that runs."""
+
+    async def send_message(self, message: str, **kwargs):
+        self.messages.append(message)
+        self.last_kwargs = kwargs
+        return "final-response-text"
+
+
+def test_chat_loop_non_streaming_final_text_uses_green_style(monkeypatch):
+    """The non-streaming final-text print site (`elif final_text`) must
+    also use `style='bold green'` + `markup=False`. The streaming-only
+    test does not cover this branch because `FakeChatClient` always
+    streams a delta (ATX issue #455 W5)."""
+    backend = _NonStreamingFakeClient()
+    inputs = iter(["hello", "/exit"])
+
+    async def fake_read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
+        return next(inputs)
+
+    monkeypatch.setattr(chat_module, "_read_user_input", fake_read_user_input)
+    recorder = _install_print_recorder(monkeypatch)
+
+    asyncio.run(
+        chat_module._chat_loop(
+            backend=backend,
+            session_key="main",
+            response_timeout_seconds=30.0,
+            idle_timeout_seconds=10.0,
+            chat_type="websocket",
+            agent_label="nemo",
+        )
+    )
+
+    prefix_calls = [
+        call
+        for call in recorder.calls
+        if call["args"] and call["args"][0] == "nemo> "
+    ]
+    assert prefix_calls, "non-streaming path did not emit the agent prefix"
+    for call in prefix_calls:
         assert call["kwargs"].get("style") == "bold green"
-        # `markup` must not be set to True for this call; the prefix is
-        # printed with `style=` precisely so the label is safe against
-        # any `[` characters it might contain.
-        assert "markup" not in call["kwargs"] or call["kwargs"]["markup"] is False
+        assert call["kwargs"].get("markup") is False
+    # final text body should also be rendered with markup off.
+    final_calls = [
+        call
+        for call in recorder.calls
+        if call["args"] and call["args"][0] == "final-response-text"
+    ]
+    assert final_calls, "final-text body print not observed"
+    for call in final_calls:
+        assert call["kwargs"].get("markup") is False
+
+
+def test_chat_loop_agent_label_with_markup_chars_renders_literally(monkeypatch):
+    """A hostile (or just unusual) `agent_label` containing Rich-markup
+    syntax must reach the recorded print call as a literal string —
+    `markup=False` is what guarantees this, and ATX B1 demonstrated
+    that `style=` alone was insufficient."""
+    backend = FakeChatClient()
+    inputs = iter(["hi", "/exit"])
+
+    async def fake_read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
+        return next(inputs)
+
+    monkeypatch.setattr(chat_module, "_read_user_input", fake_read_user_input)
+    recorder = _install_print_recorder(monkeypatch)
+
+    asyncio.run(
+        chat_module._chat_loop(
+            backend=backend,
+            session_key="main",
+            response_timeout_seconds=30.0,
+            idle_timeout_seconds=10.0,
+            chat_type="websocket",
+            agent_label="[red]hack[/red]",
+        )
+    )
+
+    prefix_calls = [
+        call
+        for call in recorder.calls
+        if call["args"] and call["args"][0] == "[red]hack[/red]> "
+    ]
+    assert prefix_calls, (
+        "markup chars must reach the print call as a literal, not get "
+        "consumed by Rich's parser"
+    )
+    for call in prefix_calls:
+        assert call["kwargs"].get("markup") is False
+
+
+def test_chat_loop_strips_bidi_chars_from_agent_label(monkeypatch):
+    """Hand-edited `hosts.json` could smuggle bidi/zero-width chars into
+    `agent_record.agent_name`. The label seen at the prefix print site
+    must be the sanitized form, matching the parity guarantee enforced
+    on exception bodies (ATX issue #455 W2)."""
+    backend = FakeChatClient()
+    inputs = iter(["hi", "/exit"])
+
+    async def fake_read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
+        return next(inputs)
+
+    monkeypatch.setattr(chat_module, "_read_user_input", fake_read_user_input)
+    recorder = _install_print_recorder(monkeypatch)
+
+    # U+202E RIGHT-TO-LEFT OVERRIDE between "neat" and "agent"
+    spoofed = "neat‮agent"
+    asyncio.run(
+        chat_module._chat_loop(
+            backend=backend,
+            session_key="main",
+            response_timeout_seconds=30.0,
+            idle_timeout_seconds=10.0,
+            chat_type="websocket",
+            agent_label=spoofed,
+        )
+    )
+
+    first_args = [c["args"][0] for c in recorder.calls if c["args"]]
+    # No prefix should still contain the bidi char.
+    assert not any("‮" in arg for arg in first_args if isinstance(arg, str)), (
+        "RLO U+202E leaked into a print call's first positional arg"
+    )
 
 
 def test_read_user_input_signature_preserved():
@@ -1713,3 +1871,134 @@ def test_read_user_input_signature_preserved():
     idle_ann = sig.parameters["idle_timeout_seconds"].annotation
     assert prompt_ann in (str, "str")
     assert idle_ann in (float, "float")
+    assert asyncio.iscoroutinefunction(chat_module._read_user_input)
+
+
+def test_read_user_input_non_tty_uses_input_fallback(monkeypatch):
+    """When stdin is not a TTY, `_read_user_input` must fall back to
+    the bare `input()` path so piped invocations
+    (`echo hi | clm chat ...`) keep working. prompt_toolkit's
+    `PromptSession` must NOT be touched in this branch (ATX issue #455
+    B2 non-TTY half).
+    """
+    import sys as _sys
+
+    # Force the non-TTY branch.
+    class _FakeStdin:
+        def isatty(self):
+            return False
+
+    monkeypatch.setattr(_sys, "stdin", _FakeStdin())
+    monkeypatch.setattr("builtins.input", lambda _prompt: "piped-line")
+
+    # Sentinel: if the TTY branch is taken, this raises.
+    def _fail_get_session():
+        raise AssertionError(
+            "_get_prompt_session must not be called when stdin is non-TTY"
+        )
+
+    monkeypatch.setattr(chat_module, "_get_prompt_session", _fail_get_session)
+
+    result = asyncio.run(chat_module._read_user_input("you> ", 0.0))
+    assert result == "piped-line"
+
+
+def test_read_user_input_non_tty_handles_stdin_none(monkeypatch):
+    """`sys.stdin` can be `None` (Windows GUI hosts, Popen with
+    stdin=DEVNULL). `_read_user_input` must not crash with
+    AttributeError before the fallback runs (ATX issue #455 W1)."""
+    import sys as _sys
+
+    monkeypatch.setattr(_sys, "stdin", None)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "fallback")
+    monkeypatch.setattr(
+        chat_module,
+        "_get_prompt_session",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("PromptSession touched while stdin is None")
+        ),
+    )
+
+    result = asyncio.run(chat_module._read_user_input("you> ", 0.0))
+    assert result == "fallback"
+
+
+def test_read_user_input_tty_uses_prompt_session_with_formatted_text(monkeypatch):
+    """When stdin is a TTY, `_read_user_input` must drive
+    `PromptSession.prompt_async` with a `FormattedText([(...)])` styled
+    in `ansiblue bold`. Covers the TTY half of ATX B2 — the feature this
+    PR exists to deliver."""
+    import sys as _sys
+
+    class _FakeStdin:
+        def isatty(self):
+            return True
+
+    monkeypatch.setattr(_sys, "stdin", _FakeStdin())
+    # Reset the cached PromptSession so the test sees a clean state.
+    monkeypatch.setattr(chat_module, "_PROMPT_SESSION", None)
+
+    captured: dict[str, object] = {}
+
+    class _FakeSession:
+        async def prompt_async(self, styled):
+            captured["styled"] = styled
+            return "typed-line"
+
+    monkeypatch.setattr(chat_module, "_get_prompt_session", lambda: _FakeSession())
+
+    result = asyncio.run(chat_module._read_user_input("you> ", 0.0))
+    assert result == "typed-line"
+    styled = captured["styled"]
+    from prompt_toolkit.formatted_text import FormattedText
+
+    assert isinstance(styled, FormattedText)
+    assert list(styled) == [("ansiblue bold", "you> ")]
+
+
+def test_read_user_input_tty_honors_idle_timeout(monkeypatch):
+    """Idle-timeout wrap (`asyncio.wait_for`) must apply to the TTY
+    branch too — otherwise the `--idle-timeout` behavior silently
+    disappears on real terminals (the same path users actually exercise).
+    """
+    import sys as _sys
+
+    class _FakeStdin:
+        def isatty(self):
+            return True
+
+    monkeypatch.setattr(_sys, "stdin", _FakeStdin())
+    monkeypatch.setattr(chat_module, "_PROMPT_SESSION", None)
+
+    class _SlowSession:
+        async def prompt_async(self, styled):
+            # Sleep longer than the timeout; wait_for must cancel us.
+            await asyncio.sleep(5)
+            return "never"
+
+    monkeypatch.setattr(chat_module, "_get_prompt_session", lambda: _SlowSession())
+
+    with pytest.raises(TimeoutError):
+        asyncio.run(chat_module._read_user_input("you> ", 0.05))
+
+
+def test_sanitize_agent_label_strips_bidi_and_control(monkeypatch):
+    """Direct coverage of the sanitizer used in `_chat_loop` so a
+    refactor that swaps the regex out is caught without going through
+    the whole loop."""
+    assert chat_module._sanitize_agent_label("cuddly-otter") == "cuddly-otter"
+    assert chat_module._sanitize_agent_label("a‮b") == "a b"
+    assert chat_module._sanitize_agent_label("a​b") == "a b"
+    assert chat_module._sanitize_agent_label("a\x07b") == "a b"
+    # Collapses to empty → returns literal fallback so the prefix is
+    # never just `> `.
+    assert chat_module._sanitize_agent_label("‮​") == "agent"
+
+
+def test_reset_prompt_session_clears_global():
+    """`_reset_prompt_session` is called on every reconnect iteration of
+    `chat()`; the contract is that the next `_get_prompt_session()`
+    constructs a fresh object."""
+    chat_module._PROMPT_SESSION = object()
+    chat_module._reset_prompt_session()
+    assert chat_module._PROMPT_SESSION is None

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1849,9 +1849,16 @@ def test_chat_loop_strips_bidi_chars_from_agent_label(monkeypatch):
     )
 
     first_args = [c["args"][0] for c in recorder.calls if c["args"]]
-    # No prefix should still contain the bidi char.
+    # No print call's first arg should still contain the bidi char.
     assert not any("‮" in arg for arg in first_args if isinstance(arg, str)), (
         "RLO U+202E leaked into a print call's first positional arg"
+    )
+    # Positive assertion (ATX round-2 gap #3): the sanitized prefix
+    # must actually be present — a sanitizer that drops the entire
+    # label would silently satisfy the negative assertion above.
+    assert "neat agent> " in first_args, (
+        "expected sanitized prefix 'neat agent> ' was not emitted; "
+        f"observed first args: {first_args!r}"
     )
 
 
@@ -2002,3 +2009,140 @@ def test_reset_prompt_session_clears_global():
     chat_module._PROMPT_SESSION = object()
     chat_module._reset_prompt_session()
     assert chat_module._PROMPT_SESSION is None
+
+
+class _NullResponseFakeClient(FakeChatClient):
+    """Drives the `else` / `[no response]` branch in `_chat_loop` — no
+    streaming delta and an empty/falsy final response. `FakeChatClient`
+    streams a delta, so this branch is dead code without a dedicated
+    variant (ATX round-2 gap #1)."""
+
+    async def send_message(self, message: str, **kwargs):
+        self.messages.append(message)
+        self.last_kwargs = kwargs
+        return ""
+
+
+def test_chat_loop_no_response_branch_uses_green_style(monkeypatch):
+    """The `else` branch that emits `[no response]` is itself a
+    Rich-markup-like string. If a future regression removed
+    `markup=False` there, Rich would attempt to parse `[no response]`
+    as a tag (`[no` → opening) and either crash or render the line
+    wrong. Pin both the prefix and body kwargs (ATX round-2 gap #1)."""
+    backend = _NullResponseFakeClient()
+    inputs = iter(["hello", "/exit"])
+
+    async def fake_read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
+        return next(inputs)
+
+    monkeypatch.setattr(chat_module, "_read_user_input", fake_read_user_input)
+    recorder = _install_print_recorder(monkeypatch)
+
+    asyncio.run(
+        chat_module._chat_loop(
+            backend=backend,
+            session_key="main",
+            response_timeout_seconds=30.0,
+            idle_timeout_seconds=10.0,
+            chat_type="websocket",
+            agent_label="silent",
+        )
+    )
+
+    prefix_calls = [
+        call
+        for call in recorder.calls
+        if call["args"] and call["args"][0] == "silent> "
+    ]
+    assert prefix_calls, "no-response path did not emit the agent prefix"
+    for call in prefix_calls:
+        assert call["kwargs"].get("style") == "bold green"
+        assert call["kwargs"].get("markup") is False
+
+    no_response_calls = [
+        call
+        for call in recorder.calls
+        if call["args"] and call["args"][0] == "[no response]"
+    ]
+    assert no_response_calls, "expected literal '[no response]' body to be printed"
+    for call in no_response_calls:
+        # markup=False is what guarantees Rich does NOT parse `[no` as
+        # an opening tag — the regression this test guards against.
+        assert call["kwargs"].get("markup") is False
+
+
+def test_read_user_input_non_tty_honors_idle_timeout(monkeypatch):
+    """`asyncio.wait_for` must wrap the non-TTY arm too, not only the
+    TTY one. Otherwise piped invocations with `--idle-timeout` would
+    silently hang waiting on `input()` forever (ATX round-2 gap #4)."""
+    import sys as _sys
+
+    class _FakeStdin:
+        def isatty(self):
+            return False
+
+    monkeypatch.setattr(_sys, "stdin", _FakeStdin())
+
+    def _slow_input(_prompt):
+        import time
+
+        time.sleep(5)
+        return "never"
+
+    monkeypatch.setattr("builtins.input", _slow_input)
+
+    with pytest.raises(TimeoutError):
+        asyncio.run(chat_module._read_user_input("you> ", 0.05))
+
+
+def test_chat_invokes_reset_prompt_session_before_chat_loop(monkeypatch):
+    """`chat()` MUST call `_reset_prompt_session` at the top of every
+    reconnect iteration so a stale `PromptSession` from a previous
+    `asyncio.run()` cannot anchor the new event loop. Pin the call-
+    site contract against future regressions, e.g. someone moving the
+    reset into the `except` block (ATX round-2 gap #5)."""
+    # Patch the get_agent_by_name resolution and backend builder so
+    # `chat()` reaches the reconnect loop without doing network I/O.
+    host = {"hostname": "host1", "alias": "h1"}
+    agent = {
+        "agent_name": "spy-agent",
+        "config": {"gateway": {"url": "ws://host1:9", "auth": "tok"}},
+    }
+    monkeypatch.setattr(
+        "clawrium.cli.chat.get_agent_by_name",
+        lambda _name: (host, "openclaw", agent),
+    )
+
+    class _StubBackend:
+        async def connect(self):
+            pass
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(
+        chat_module,
+        "_build_openclaw_backend",
+        lambda **_: _StubBackend(),
+    )
+
+    # No-op _chat_loop so we observe the reset call without driving
+    # the whole REPL.
+    async def _noop_chat_loop(**_kwargs):
+        return None
+
+    monkeypatch.setattr(chat_module, "_chat_loop", _noop_chat_loop)
+
+    counter = {"calls": 0}
+
+    def _spy_reset():
+        counter["calls"] += 1
+
+    monkeypatch.setattr(chat_module, "_reset_prompt_session", _spy_reset)
+
+    result = runner.invoke(app, ["chat", "spy-agent"])
+    assert result.exit_code == 0, result.output
+    # At least one reset before the first (and only successful) loop run.
+    assert counter["calls"] >= 1, (
+        "chat() must call _reset_prompt_session before asyncio.run(_chat_loop)"
+    )

--- a/tests/test_cli_chat.py
+++ b/tests/test_cli_chat.py
@@ -1619,3 +1619,97 @@ class TestZeroclawChat:
 
         assert result.exit_code == 0, result.output
         assert captured["backend"].gateway_url.endswith("/ws/chat")
+
+
+# --- Styled chat prompts (issue #455) ---------------------------------
+
+
+def test_chat_loop_uses_agent_name_in_prefix(monkeypatch, capsys):
+    """The agent prefix must surface the resolved agent name, not the
+    literal `agent>`, so multi-agent sessions are distinguishable."""
+    fake_client = FakeChatClient()
+    inputs = iter(["hello", "/exit"])
+
+    async def fake_read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
+        return next(inputs)
+
+    monkeypatch.setattr(chat_module, "_read_user_input", fake_read_user_input)
+
+    asyncio.run(
+        chat_module._chat_loop(
+            backend=fake_client,
+            session_key="main",
+            response_timeout_seconds=30.0,
+            idle_timeout_seconds=10.0,
+            chat_type="websocket",
+            agent_label="cuddly-otter",
+        )
+    )
+
+    captured = capsys.readouterr().out
+    assert "cuddly-otter> " in captured
+    assert "agent> " not in captured
+
+
+def test_chat_loop_agent_prefix_uses_green_style(monkeypatch):
+    """The streaming agent-prefix print must use `style='bold green'`
+    rather than markup, so labels containing `[`/`]` render correctly
+    and the bold-green visual matches the spec."""
+    fake_client = FakeChatClient()
+    inputs = iter(["hi", "/exit"])
+
+    async def fake_read_user_input(prompt: str, idle_timeout_seconds: float) -> str:
+        return next(inputs)
+
+    monkeypatch.setattr(chat_module, "_read_user_input", fake_read_user_input)
+
+    captured_prints: list[dict[str, object]] = []
+    real_print = chat_module.console.print
+
+    def recording_print(*args, **kwargs):
+        captured_prints.append({"args": args, "kwargs": kwargs})
+        return real_print(*args, **kwargs)
+
+    monkeypatch.setattr(chat_module.console, "print", recording_print)
+
+    asyncio.run(
+        chat_module._chat_loop(
+            backend=fake_client,
+            session_key="main",
+            response_timeout_seconds=30.0,
+            idle_timeout_seconds=10.0,
+            chat_type="websocket",
+            agent_label="my-agent",
+        )
+    )
+
+    prefix_calls = [
+        call
+        for call in captured_prints
+        if call["args"] and call["args"][0] == "my-agent> "
+    ]
+    assert prefix_calls, "No print call emitted the agent prefix"
+    for call in prefix_calls:
+        assert call["kwargs"].get("style") == "bold green"
+        # `markup` must not be set to True for this call; the prefix is
+        # printed with `style=` precisely so the label is safe against
+        # any `[` characters it might contain.
+        assert "markup" not in call["kwargs"] or call["kwargs"]["markup"] is False
+
+
+def test_read_user_input_signature_preserved():
+    """The `_read_user_input` signature is part of the test surface —
+    `tests/test_cli_chat.py` monkeypatches it with the exact
+    `(prompt, idle_timeout_seconds) -> str` shape. Guard against
+    accidental signature drift."""
+    import inspect
+
+    sig = inspect.signature(chat_module._read_user_input)
+    params = list(sig.parameters)
+    assert params == ["prompt", "idle_timeout_seconds"]
+    # `from __future__ import annotations` turns annotations into strings,
+    # so compare by name to stay robust to that.
+    prompt_ann = sig.parameters["prompt"].annotation
+    idle_ann = sig.parameters["idle_timeout_seconds"].annotation
+    assert prompt_ann in (str, "str")
+    assert idle_ann in (float, "float")

--- a/uv.lock
+++ b/uv.lock
@@ -337,6 +337,7 @@ dependencies = [
     { name = "msgpack" },
     { name = "packaging" },
     { name = "paramiko" },
+    { name = "prompt-toolkit" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
@@ -364,6 +365,7 @@ requires-dist = [
     { name = "msgpack", specifier = ">=1.1.2" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "paramiko", specifier = ">=3.0.0" },
+    { name = "prompt-toolkit", specifier = ">=3.0.43,<4.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "rich", specifier = ">=14.0.0" },
@@ -1023,6 +1025,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -1839,6 +1853,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
     { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace the plain `you> ` / `agent> ` prompts in `clm chat` with styled prompts: bold-blue `you>` driven by `prompt_toolkit`, bold-green agent prefix that surfaces the resolved agent name (e.g. `cuddly-otter> `).
- `prompt_toolkit` gives the user arrow-key cursor movement, in-session history (Up/Down), word-jump shortcuts (Ctrl+A/E/K/U/W, Alt+B/F), and reliable bracketed paste, all on top of the existing async REPL.
- Scoped change: only `src/clawrium/cli/chat.py`, `pyproject.toml`/`uv.lock`, and `tests/test_cli_chat.py`. Backends, gateway code, and the TUI chat panel are untouched.

## Implementation notes

- A module-level `PromptSession` is reused across turns via `prompt_async`. The `(prompt, idle_timeout_seconds) -> str` signature on `_read_user_input` is preserved so every existing `monkeypatch.setattr(chat_module, "_read_user_input", ...)` test keeps working without modification.
- `_chat_loop` gains an `agent_label` kwarg (default `"agent"` so external callers / tests that don't pass it still work). The `chat()` callsite passes `str(display_agent)`, resolved from `agent_record.get("agent_name") or .get("name") or agent_type`.
- All three former `"agent> "` literal sites use `style="bold green"` **and** `markup=False`. `style=` alone does not disable Rich's markup parser; both are required so an `agent_label` containing `[red]…[/red]`/`[link=…]…[/link]` reaches the terminal as a literal string.
- `agent_label` is also bidi-sanitized at the top of `_chat_loop` via a shared `_CONTROL_AND_BIDI_RE` regex (uses `\uXXXX` escapes, byte-identical to `chat_hermes._CONTROL_CHARS_RE`). Lifecycle validation already rejects these codepoints in `agent_name`, but a hand-edited `hosts.json` could smuggle them in.
- Idle timeout, EOF, and KeyboardInterrupt semantics are preserved: `asyncio.wait_for` wraps the prompt coroutine when `idle_timeout > 0` (both TTY and non-TTY branches), and prompt_toolkit's EOF/Ctrl+C translate cleanly into the existing exception paths.
- **Non-TTY fallback**: prompt_toolkit raises if stdin is not a TTY. `_read_user_input` checks `sys.stdin is None or not sys.stdin.isatty()` and falls back to `asyncio.to_thread(input, prompt)` when stdin is missing or piped (`echo hi | clm chat …`). The `sys.stdin is None` half guards Windows GUI hosts and `Popen(stdin=DEVNULL)` from crashing with `AttributeError` before the fallback runs.
- The module-level `PromptSession` is reset at the start of every `chat()` reconnect iteration via `_reset_prompt_session()`. Each `asyncio.run(_chat_loop(...))` is a fresh event loop; reusing a `PromptSession` whose `Application`/`AsyncOutput` was bound to the previous loop would anchor the new iteration to an already-closed loop.

## Testing

### Test Results
- [x] All existing tests pass (`make test`): **2391 passed, 14 skipped** (Python) + **213 passed** (gui suite).
- [x] Linter passes (`make lint`): ruff + next lint clean.
- [x] New tests added for new functionality (~15 new tests in `tests/test_cli_chat.py`).

### New tests
- `_read_user_input` branch coverage: `test_read_user_input_non_tty_uses_input_fallback`, `test_read_user_input_non_tty_handles_stdin_none`, `test_read_user_input_non_tty_honors_idle_timeout`, `test_read_user_input_tty_uses_prompt_session_with_formatted_text`, `test_read_user_input_tty_honors_idle_timeout`, `test_read_user_input_signature_preserved`.
- Styled-prefix coverage (streaming, non-streaming, no-response): `test_chat_loop_uses_agent_name_in_prefix`, `test_chat_loop_agent_prefix_uses_green_style`, `test_chat_loop_non_streaming_final_text_uses_green_style`, `test_chat_loop_no_response_branch_uses_green_style`.
- Injection hardening: `test_chat_loop_agent_label_with_markup_chars_renders_literally`, `test_chat_loop_strips_bidi_chars_from_agent_label`, `test_sanitize_agent_label_strips_bidi_and_control`.
- Lifecycle / reset: `test_reset_prompt_session_clears_global`, `test_chat_invokes_reset_prompt_session_before_chat_loop`.

### Manual testing
Not exercised end-to-end against a live agent in this environment. Standard manual smoke (per acceptance criteria): `clm chat <name>`, paste a multi-line string, exercise Ctrl+A/E/W and Up-arrow recall, then `/exit`.

### Security checklist
- [x] No hardcoded secrets or credentials.
- [x] Input validation for user-provided data — chat input is forwarded to the existing backend unchanged.
- [x] No SQL injection, XSS, or command injection risks — change is REPL UI only.
- [x] Markup-injection hardening — `markup=False` on every styled-prefix print site, covered by tests with `agent_label='[red]hack[/red]'`.
- [x] Bidi-injection hardening — `_sanitize_agent_label` strips the same codepoints as `_sanitize_exception_text`; parity assured by sharing `_CONTROL_AND_BIDI_RE`.
- [x] Dependencies are from trusted sources — `prompt_toolkit` is the canonical line-editing library used by IPython / pgcli; pinned to `>=3.0.43,<4.0.0`.

## ATX Review Summary

**Final Review: Rating 4/5 | Blocking Issues: 0**

| Review | Rating | Blocking | Status | Cost | Time |
|--------|--------|----------|--------|------|------|
| 1 | 2/5 | B1, B2 | All fixed | $2.07 | 29m |
| 2 | 4/5 | None | Cleared blockers + 6 warnings | $2.34 | 20m |
| 3 | 4/5 | None | All 5 round-2 gaps closed | $2.32 | 20m |

Specialists: `leader`, `cli-ux-reviewer`, `test-coverage-reviewer`, `security-reviewer`, `core-lifecycle-reviewer` (max-turns on round 1; completed rounds 2–3).

<details>
<summary>Round 1 (Rating 2/5) — fixed in <code>1b62098</code></summary>

| # | Severity | Location | Issue | Resolution |
|---|----------|----------|-------|------------|
| B1 | Blocking | `chat.py` (3 prefix print sites) | `markup=False` missing — `style=` alone doesn't disable Rich's markup parser, so `[red]…[/red]` in `agent_label` was being consumed | Added `markup=False` to all three call sites |
| B2 | Blocking | `tests/test_cli_chat.py` | Non-TTY + TTY branches of `_read_user_input` had zero coverage | Added 3 dedicated branch tests with sentinel monkeypatches |
| W1 | Warning | `chat.py` | `sys.stdin.isatty()` crashes when `sys.stdin is None` | Added `sys.stdin is None or …` guard + test |
| W2 | Warning | `chat.py` | Bidi-sanitization gap on `agent_prefix_plain` vs. existing parity requirement | Extracted shared `_CONTROL_AND_BIDI_RE`; added `_sanitize_agent_label` + tests |
| W3 | Warning | `chat.py` | `_PROMPT_SESSION` reused across `asyncio.run()` reconnect iterations | Added `_reset_prompt_session()` called at top of reconnect loop + test |
| W4 | Warning | `tests/…` | Markup assertion passed vacuously when kwarg absent | Tightened to `assert kwargs.get("markup") is False` |
| W5 | Warning | `tests/…` | Non-streaming output branches were dead code in tests | Added `_NonStreamingFakeClient` + dedicated test |
| W6 | Warning | `tests/…` | `capsys` may miss Rich output bound at import time | Replaced with shared `_PrintRecorder` helper |

</details>

<details>
<summary>Round 2 (Rating 4/5) — gaps closed in <code>b4f6b2c</code></summary>

All round-1 blockers + warnings confirmed cleared. Five non-blocking gaps reported and closed:

| # | Item | Resolution |
|---|------|------------|
| Gap #1 | `markup=False` not pinned on `[no response]` branch | Added `_NullResponseFakeClient` + `test_chat_loop_no_response_branch_uses_green_style` |
| Gap #2 | Literal Unicode chars in `_CONTROL_AND_BIDI_RE` regex source | Migrated to `\uXXXX` escapes (byte-identical pattern, matches `chat_hermes._CONTROL_CHARS_RE`) |
| Gap #3 | Bidi test had only a negative assertion | Added positive assertion that `"neat agent> "` is present |
| Gap #4 | Non-TTY idle-timeout sub-branch untested | Added `test_read_user_input_non_tty_honors_idle_timeout` |
| Gap #5 | `_reset_prompt_session` call from `chat()` not pinned | Added spy test `test_chat_invokes_reset_prompt_session_before_chat_loop` |

</details>

<details>
<summary>Round 3 (Rating 4/5) — open follow-ups</summary>

All 5 round-2 gaps confirmed closed. No blockers. Three new warnings + four suggestions reported, all non-blocking — leaving as follow-ups since the merge bar (>3/5, 0 blockers) is met:

| # | Severity | Item |
|---|----------|------|
| W1 | Warning | Thread-leak in `_slow_input` (Gap #4 test): `time.sleep(5)` outlives `asyncio.run` by ~5 s |
| W2 | Warning | Gap #5 test reads `manifest.yaml` from disk because `_resolve_chat_type` isn't patched |
| W3 | Warning | **Pre-existing**: `HostsFileCorruptedError` print site at `chat.py:137` omits `rich_escape` (out of scope) |
| S1 | Suggestion | No-response branch test doesn't assert `highlight=False` (production code sets it) |
| S2 | Suggestion | `_reset_prompt_session` spy could record call order vs. `_chat_loop` |
| S3 | Suggestion | Sanitizer spot-checks only cover U+202E/U+200B; add one char per new range (U+061C, U+2028, U+2066, U+FEFF) |
| S4 | Suggestion | Add a parity assert between `chat._CONTROL_AND_BIDI_RE.pattern` and `chat_hermes._CONTROL_CHARS_RE.pattern` |

</details>

Closes #455

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)