### PR TITLE
ci(publish): bump pypa/gh-action-pypi-publish to v1.14.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,9 @@ jobs:
         run: make test
 
       - name: Publish to PyPI
-        # v1.12.4 — SHA-pinned. `@release/v1` is a mutable branch ref; with
+        # v1.14.0 — SHA-pinned. `@release/v1` is a mutable branch ref; with
         # `id-token: write` in scope, a force-push or compromise of that
         # branch could publish a malicious wheel to PyPI under our identity.
-        uses: pypa/gh-action-pypi-publish@7f25271a4aa483500f742f9492b2ab5648d61011
+        # Bumped from v1.12.4 (SHA 7f25271a) because upstream GC'd that
+        # container tag from ghcr.io, breaking the v26.5.2 publish run.
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d


### PR DESCRIPTION
## Summary
- Bump `pypa/gh-action-pypi-publish` SHA pin from `7f25271a` (v1.12.4) → `6733eb7d` (v1.14.0).
- Unblocks the v26.5.2 release. The previous pin's container image (`ghcr.io/pypa/gh-action-pypi-publish:7f25271a...`) is gone from ghcr.io; the v26.5.2 publish run failed with `docker: Error response from daemon: manifest unknown`.

## Context
This was caught during the v26.5.2 release flow ([failed run](https://github.com/ric03uec/clawrium/actions/runs/26232115966)). Build/lint/test all succeeded — only the PyPI publish step failed, and only because the action's Docker image manifest was no longer resolvable. No PyPI artifact landed.

The v26.5.1 publish (Apr 18) succeeded with the same SHA pin, so the image existed then but has since been pulled from the registry. Upstream's git tag `v1.12.4` still resolves, but Docker-based actions need the container tag, not just the git tag.

## Why v1.14.0
| Version | Released | Git SHA | Available |
|---------|----------|---------|-----------|
| v1.14.0 | 2026-04-07 | `6733eb7d` | current |
| v1.13.0 | 2025-09-04 | `106e0b0b` | likely |
| v1.12.4 | 2025-01-24 | `7f25271a` | container GC'd |

## Testing
- [x] Workflow file YAML is valid (single-line change, no structural diff)
- [x] No code change — only the action SHA pin moves

### Post-merge follow-up
After this merges, the v26.5.2 tag + release need to be re-created at the new main HEAD so the corrected workflow runs.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)