### PR TITLE
chore(release): v26.5.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ clm ps
 
 - Repository: https://github.com/ric03uec/clawrium
 - Project Board: https://github.com/users/ric03uec/projects/1
-- Version: 26.5.2
+- Version: 26.5.3
 
 ## Gateway Token Lifecycle (zeroclaw)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawrium"
-version = "26.5.2"
+version = "26.5.3"
 description = "CLI tool for managing AI assistant fleets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "clawrium"
-version = "26.5.2"
+version = "26.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -33,7 +33,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.5.2
+ + clawrium==26.5.3
 ```
 
 Verify installation:

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -64,7 +64,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.5.2
+ + clawrium==26.5.3
 ```
 
 ### Run Without Installing
@@ -116,7 +116,7 @@ Check the version:
 clm --version
 ```
 ```
-clm, version 26.5.2
+clm, version 26.5.3
 ```
 
 ## Initialize Clawrium

--- a/website/docs/scenarios/101.md
+++ b/website/docs/scenarios/101.md
@@ -43,7 +43,7 @@ Verify the installation:
 
 ```bash
 $ clm --version
-clm 26.5.2
+clm 26.5.3
 ```
 
 ## Step 2: Initialize the Target Host


### PR DESCRIPTION
## Summary
- Bump `clawrium` to **v26.5.3**.
- Pivot from v26.5.2 because GitHub treats published-then-deleted tag names as immutable (supply-chain safeguard against release-tag rewrites). The v26.5.2 publish attempt failed only because the prior `pypa/gh-action-pypi-publish` SHA pin (`7f25271a...`) had been GC'd from ghcr.io — already fixed on `main` in #466 (now using v1.14.0).

## Files changed (same known set as #464)
| File | Change |
|------|--------|
| `pyproject.toml` | `26.5.2` → `26.5.3` |
| `uv.lock` | Derived metadata bump (clawrium project entry) |
| `AGENTS.md` | Version line |
| `website/docs/installation.md` | `clawrium==…`, `clm --version` output |
| `website/docs/guides/quickstart.md` | `clawrium==…` |
| `website/docs/scenarios/101.md` | `clm 26.5.3` |

## Testing
- [x] All existing tests pass (`make test`) — 2404 Python + 213 UI
- [x] Linter passes (`make lint`)
- [x] Diff-scope guard from `itx-release` skill passes (only known-set files touched, plus `uv.lock` as a derived pyproject.toml artifact)

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] No SQL injection, XSS, or command injection risks
- [x] No dep changes (only project metadata bump in `uv.lock`)

## Related
- Follow-up issue for CI hardening (pin floating action tags, `--frozen`, prerelease guard, version-tag parity, Python matrix): #471
- Follow-up issue for pre-existing doc/test bugs: #465

## Post-merge
1. Pull main → tag `v26.5.3` → push tag
2. `gh release create v26.5.3 --generate-notes` (workflow now uses v1.14.0 of pypi-publish)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)