### PR TITLE
chore(release): v26.5.4 + fix pypi-publish SHA pin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,9 +53,14 @@ jobs:
         run: make test
 
       - name: Publish to PyPI
-        # v1.14.0 — SHA-pinned. `@release/v1` is a mutable branch ref; with
-        # `id-token: write` in scope, a force-push or compromise of that
-        # branch could publish a malicious wheel to PyPI under our identity.
-        # Bumped from v1.12.4 (SHA 7f25271a) because upstream GC'd that
-        # container tag from ghcr.io, breaking the v26.5.2 publish run.
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d
+        # v1.14.0 — SHA-pinned to the COMMIT SHA the tag points to, NOT
+        # the annotated-tag object SHA. GitHub Actions resolves `uses:
+        # ...@<sha>` literally to a ghcr.io image tag, and the action's
+        # release process publishes images under the commit SHA, not the
+        # tag-object SHA. Pinning to a tag-object SHA fails at runtime
+        # with `docker: manifest unknown` (see v26.5.2/v26.5.3 publish
+        # runs that used `6733eb7d…` and `7f25271a…`, both tag-object SHAs).
+        # `@release/v1` is a mutable branch ref; with `id-token: write`
+        # in scope, a force-push or compromise of that branch could
+        # publish a malicious wheel to PyPI under our identity.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ clm ps
 
 - Repository: https://github.com/ric03uec/clawrium
 - Project Board: https://github.com/users/ric03uec/projects/1
-- Version: 26.5.3
+- Version: 26.5.4
 
 ## Gateway Token Lifecycle (zeroclaw)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawrium"
-version = "26.5.3"
+version = "26.5.4"
 description = "CLI tool for managing AI assistant fleets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "clawrium"
-version = "26.5.3"
+version = "26.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -33,7 +33,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.5.3
+ + clawrium==26.5.4
 ```
 
 Verify installation:

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -64,7 +64,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.5.3
+ + clawrium==26.5.4
 ```
 
 ### Run Without Installing
@@ -116,7 +116,7 @@ Check the version:
 clm --version
 ```
 ```
-clm, version 26.5.3
+clm, version 26.5.4
 ```
 
 ## Initialize Clawrium

--- a/website/docs/scenarios/101.md
+++ b/website/docs/scenarios/101.md
@@ -43,7 +43,7 @@ Verify the installation:
 
 ```bash
 $ clm --version
-clm 26.5.3
+clm 26.5.4
 ```
 
 ## Step 2: Initialize the Target Host


### PR DESCRIPTION
## Summary

Two-part PR because both are needed to actually ship a release:

1. **publish.yml SHA fix** — root-cause fix for the v26.5.2 and v26.5.3 publish failures. `pypa/gh-action-pypi-publish` was pinned to the **annotated-tag object SHA**, not the **commit SHA**. GitHub Actions resolves `uses: …@<sha>` literally to a ghcr.io image tag, and the action publishes images under the commit SHA. Pinning to the tag-object SHA fails with `docker: manifest unknown` at runtime.
2. **Version bump** — v26.5.3 → v26.5.4. Both v26.5.2 and v26.5.3 names are permanently reserved by GitHub (each had a release published, then deleted).

## SHA forensics

| What | Tag-object SHA | Commit SHA |
|---|---|---|
| v1.12.4 (original pin) | `7f25271a…` ❌ | `76f52bc8…` ✅ |
| v1.14.0 (previous fix) | `6733eb7d…` ❌ | `cef221092…` ✅ |

ghcr.io image presence for `cef221092…` verified with HTTP 200 before committing. v26.5.1's April publish succeeded because the tag-object-SHA image tag happened to still be cached on ghcr.io at the time; it has since been GC'd.

## Files
| File | Change |
|------|--------|
| `.github/workflows/publish.yml` | SHA pin → commit SHA + comment explaining the trap |
| `pyproject.toml` | 26.5.3 → 26.5.4 |
| `uv.lock` | Derived metadata bump |
| `AGENTS.md` | Version line |
| `website/docs/installation.md` | `clawrium==…`, `clm --version` output |
| `website/docs/guides/quickstart.md` | `clawrium==…` |
| `website/docs/scenarios/101.md` | `clm 26.5.4` |

## Testing
- [x] Lint passes (`make lint`)
- [x] Tests pass (`make test`) — 2404 Python + 213 UI
- [x] Workflow YAML structurally unchanged aside from the one-line SHA + comment update
- [x] ghcr.io image manifest verified present at the new commit SHA

## Related
- CI-hardening follow-up: #471 (covers floating-tag pins on checkout/setup-node, frozen sync, prerelease guard, version-tag parity, Python matrix)
- Pre-existing doc/test bugs: #465

## Post-merge
1. Pull main → tag `v26.5.4` → push tag
2. `gh release create v26.5.4 --generate-notes` — publish.yml now uses the correct commit-SHA pin

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)