### PR TITLE
chore(skill): add uv.lock to itx-release known set

### DIFF
--- a/.claude/skills/itx-release/SKILL.md
+++ b/.claude/skills/itx-release/SKILL.md
@@ -20,6 +20,7 @@ Hard-coded list. The skill will edit exactly these and warn if it finds version-
 | File | What to update |
 |------|----------------|
 | `pyproject.toml` | `version = "<NEW>"` (line near top) |
+| `uv.lock` | Re-run `uv sync` after editing `pyproject.toml`; the clawrium entry's `version` updates as a derived artifact. Stage and commit alongside `pyproject.toml`. |
 | `AGENTS.md` | `- Version: <NEW>` line |
 | `website/docs/installation.md` | `clawrium==<NEW>` and `clm, version <NEW>` |
 | `website/docs/guides/quickstart.md` | `clawrium==<NEW>` |
@@ -78,7 +79,7 @@ Do NOT touch:
 
 8. **Diff-scope guard** (this is the safety net for the "no ATX on release PRs" carve-out — release PRs skip automated review, so the skill must hard-fail if non-mechanical files crept in):
    ```bash
-   KNOWN_SET='^(pyproject\.toml|AGENTS\.md|website/docs/installation\.md|website/docs/guides/quickstart\.md|website/docs/scenarios/101\.md|CONTRIBUTING\.md|\.claude/skills/itx-release/SKILL\.md|tests/test_demo_assets\.py)$'
+   KNOWN_SET='^(pyproject\.toml|uv\.lock|AGENTS\.md|website/docs/installation\.md|website/docs/guides/quickstart\.md|website/docs/scenarios/101\.md|CONTRIBUTING\.md|\.claude/skills/itx-release/SKILL\.md|tests/test_demo_assets\.py)$'
    UNEXPECTED=$(git diff --name-only main...HEAD | grep -vE "$KNOWN_SET" || true)
    if [ -n "$UNEXPECTED" ]; then
      echo "BLOCKED: release branch touches files outside the known set:"
@@ -96,7 +97,7 @@ Do NOT touch:
 
 10. **Commit + push**:
     ```bash
-    git add pyproject.toml AGENTS.md website/docs/
+    git add pyproject.toml uv.lock AGENTS.md website/docs/
     git commit -m "chore(release): bump to v<NEW> + sync doc versions"
     git push -u origin release/v<NEW>
     ```


### PR DESCRIPTION
## Summary
- Add `uv.lock` to the `itx-release` skill's "known set" so the diff-scope guard doesn't block on it during a release.

## Context
`uv sync` (run as part of any lint/test cycle after a `pyproject.toml` version bump) updates the `clawrium` project entry in `uv.lock`. That edit is a mechanical derived artifact and belongs in the release commit — but the skill's diff-scope guard at step 8 only allowed the original known set, so it would flag `uv.lock` as "unexpected" and abort.

Surfaced during the v26.5.4 release (#473), where `uv.lock` had to be added by hand and noted in the commit message as a follow-up.

## Changes (all in `.claude/skills/itx-release/SKILL.md`)
1. `KNOWN_SET` regex now includes `uv\.lock`
2. "Files this skill updates" table has a `uv.lock` row explaining it's a derived artifact
3. The `git add` line in step 10 includes `uv.lock`

## Testing
- [x] Skill is documentation/instructions only — no executable changes to test
- [x] Markdown renders cleanly (verified locally)

## Out of scope
- `.github/workflows/publish.yml` not added to the known set. CI fixes in a release branch *should* trigger the diff-scope ack — that's the correct safety behavior. Only purely mechanical derived files (lockfiles, version bumps) belong in the allowlist.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)