### PR TITLE
fix: skip Ollama connectivity check + add zeroclaw Discord stream_mode

### DIFF
--- a/docs/agent-support/channels/discord.md
+++ b/docs/agent-support/channels/discord.md
@@ -257,6 +257,8 @@ The clm-managed `[channels.discord]` block uses **only** the keys documented in 
 | `allowed_guilds = [...]` | `allowed_guilds` | empty array if unset; zeroclaw-specific (no hermes equivalent) |
 | `reply_to_mentions_only` | `require_mention` | renamed to match the upstream key |
 | `draft_update_interval_ms` | `draft_update_interval_ms` | optional — defaults handled by the daemon when omitted |
+| `stream_mode` | `stream_mode` | `"off"` / `"partial"` / `"multi_message"`. Wizard default is `"partial"` so long turns surface mid-turn progress to Discord instead of going silent until done. Upstream default is `"off"`. |
+| `multi_message_delay_ms` | `multi_message_delay_ms` | optional — only consulted when `stream_mode = "multi_message"`. Wizard prompts in the 10000–60000 ms range (10–60 s) so multi-paragraph responses stay under Discord's ~5 messages / 5 s per-channel rate limit; the daemon's compiled-in default applies when omitted. |
 
 ### Hermes-side fields with no ZeroClaw equivalent
 
@@ -284,8 +286,20 @@ Prompts:
 | `Allowed Discord user IDs` | `allowed_users` list |
 | `Allowed guild IDs` (optional) | `allowed_guilds` list |
 | `Reply to mentions only?` | `require_mention` → rendered as `reply_to_mentions_only` |
+| `Discord stream mode (off/partial/multi_message)` | `stream_mode` (default `partial`) |
+| `Delay between Discord messages in ms` (only when `stream_mode = multi_message`) | `multi_message_delay_ms` (10000–60000) |
 
 `clm` then runs the configure playbook, which re-renders `~/.zeroclaw/config.toml` with the `[channels.discord]` block, restarts `zeroclaw-<name>.service`, and verifies the block landed by grepping for `^bot_token =` in the file.
+
+### Streaming progress on long-running turns
+
+Without `stream_mode`, zeroclaw buffers the whole turn before posting — agents working through long tool sequences (e.g. building a PR) appear silent in Discord until they finish. `stream_mode` controls this:
+
+| Value | Behaviour |
+|---|---|
+| `off` | Upstream default. Single message posted when the turn completes. |
+| `partial` (wizard default) | Edits a single draft message in place as the agent runs tools, then finalizes with the full response. Companion knob: `draft_update_interval_ms` (default 500 ms; bump to 750–1000 if you hit Discord rate limits). |
+| `multi_message` | Splits the final reply into multiple messages at paragraph boundaries with `multi_message_delay_ms` between bubbles. Doesn't surface tool progress — only paces the final. |
 
 ### Resulting on-disk shape (ZeroClaw)
 
@@ -297,6 +311,7 @@ allowed_guilds = ["987654321098765432"]
 allowed_users = ["740723459344302120"]
 reply_to_mentions_only = true
 draft_update_interval_ms = 750
+stream_mode = "partial"
 ```
 
 In `hosts.json` (agents.`<name>`.config.channels.discord):

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -1513,7 +1513,12 @@ def _run_validate_stage(
         provider_id = provider_result.details.get("provider_id")
         conn_result = verify_provider_connectivity(provider_id)
         if conn_result.passed:
-            console.print("  [green]✓[/green] Provider connectivity OK")
+            if conn_result.details.get("skipped"):
+                console.print(
+                    "  [yellow]⚠[/yellow] Provider connectivity check skipped"
+                )
+            else:
+                console.print("  [green]✓[/green] Provider connectivity OK")
             for warning in conn_result.warnings:
                 console.print(f"    [yellow]Warning:[/yellow] {rich_escape(warning)}")
                 all_warnings.append(warning)

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -1045,13 +1045,61 @@ def _run_channels_stage(
                 "Require @mention to respond?", default=True
             )
 
+            # stream_mode (#468): upstream default is "off" which buffers
+            # the entire turn before posting — long-running tool sequences
+            # (PR-building agents) appear stuck. Default the wizard to
+            # "partial" so new agents stream progress out of the box.
+            stream_mode_raw = typer.prompt(
+                "Discord stream mode (off/partial/multi_message)",
+                default="partial",
+            )
+            stream_mode = (stream_mode_raw or "").strip().lower()
+            if stream_mode not in ("off", "partial", "multi_message"):
+                console.print(
+                    "[red]Error:[/red] Invalid stream_mode "
+                    f"'{rich_escape(stream_mode)}'. Use one of: "
+                    "off, partial, multi_message."
+                )
+                return False
+
+            multi_message_delay_ms: int | None = None
+            if stream_mode == "multi_message":
+                delay_raw = typer.prompt(
+                    "Delay between Discord messages in ms (10000-60000)",
+                    default="10000",
+                )
+                delay_str = (delay_raw or "").strip()
+                try:
+                    delay_val = int(delay_str)
+                except ValueError:
+                    console.print(
+                        "[red]Error:[/red] multi_message_delay_ms must be "
+                        f"an integer, got '{rich_escape(delay_str)}'."
+                    )
+                    return False
+                # Discord enforces ~5 messages / 5s per channel; even 1s is
+                # only safe for short bursts. 10s floor leaves headroom for
+                # the daemon's own keep-alive traffic in the same channel
+                # and keeps multi-message responses comfortably under the
+                # rate ceiling for arbitrarily long replies.
+                if not (10000 <= delay_val <= 60000):
+                    console.print(
+                        "[red]Error:[/red] multi_message_delay_ms must be "
+                        "between 10000 and 60000 ms."
+                    )
+                    return False
+                multi_message_delay_ms = delay_val
+
             zc_discord_cfg: dict = {
                 "enabled": True,
                 "allowed_users": allowed_users,
                 "require_mention": require_mention,
+                "stream_mode": stream_mode,
             }
             if allowed_guilds:
                 zc_discord_cfg["allowed_guilds"] = allowed_guilds
+            if multi_message_delay_ms is not None:
+                zc_discord_cfg["multi_message_delay_ms"] = multi_message_delay_ms
 
             channels_config = {"discord": zc_discord_cfg}
         else:

--- a/src/clawrium/core/validation.py
+++ b/src/clawrium/core/validation.py
@@ -81,12 +81,6 @@ ERROR_MESSAGES = {
         "Insufficient quota for {provider}. "
         "Check your account balance or upgrade your plan."
     ),
-    "ollama_not_running": (
-        "Ollama server is not running at {endpoint}. Start it with: ollama serve"
-    ),
-    "ollama_no_models": (
-        "No models found on Ollama server. Pull a model with: ollama pull <model>"
-    ),
     "bedrock_credentials": (
         "AWS credentials not configured for Bedrock provider '{provider}'. "
         "Run: clm provider add --type bedrock --name <name>"
@@ -137,7 +131,6 @@ ERROR_MESSAGES = {
 WARNING_MESSAGES = {
     "soul_md_empty": "SOUL.md file is empty. Agent will use default personality.",
     "soul_md_large": "SOUL.md is larger than 10KB. Consider shortening for better performance.",
-    "ollama_no_models": "No models found on Ollama server. Pull a model with: ollama pull <model>",
 }
 
 
@@ -343,8 +336,30 @@ def verify_provider_connectivity(
 
     provider_type = provider.get("type", "")
 
+    # Ollama connectivity is skipped: this check runs on the control
+    # machine (where `clm` is invoked), but Ollama will be reached from
+    # the agent host at runtime. A control-machine probe can fail purely
+    # because the operator's laptop is on a different network than the
+    # agent host, even when the agent → Ollama path works fine. The
+    # correct fix is to move the probe into the configure playbook so
+    # ansible runs it on the agent host. Tracked as a follow-up; the
+    # implementation must use Ansible's `uri:` module (not shell/curl)
+    # and re-run validate_ollama_url() at read time to block SSRF from
+    # a hand-edited providers.json.
     if provider_type == "ollama":
-        return _test_ollama_connectivity(provider, timeout)
+        endpoint = provider.get("endpoint", "")
+        endpoint_display = endpoint or "<endpoint not configured>"
+        return ValidationResult(
+            passed=True,
+            warnings=[
+                f"Ollama endpoint {endpoint_display}: this probe runs on the "
+                "control machine, but the agent will reach Ollama from the "
+                "agent host. Verify reachability manually from the agent "
+                f"host, e.g.: ssh <agent-host> curl -fsS "
+                f"{endpoint_display}/api/tags"
+            ],
+            details={"type": "ollama", "skipped": True, "endpoint": endpoint},
+        )
 
     if provider_type == "bedrock":
         return _test_bedrock_connectivity(provider, timeout)
@@ -599,55 +614,6 @@ def _test_zai_connectivity(api_key: str, timeout: int) -> ValidationResult:
         return ValidationResult(passed=True, details={"endpoint": url})
 
     return ValidationResult(passed=True)
-
-
-def _test_ollama_connectivity(provider: dict, timeout: int) -> ValidationResult:
-    """Test Ollama server connectivity."""
-    endpoint = provider.get("endpoint", "http://localhost:11434")
-
-    if endpoint.endswith("/"):
-        endpoint = endpoint.rstrip("/")
-
-    url = f"{endpoint}/api/tags"
-
-    try:
-        req = urllib.request.Request(url)
-        with urllib.request.urlopen(req, timeout=timeout) as response:
-            body = response.read().decode("utf-8")
-            data = json.loads(body) if body else {}
-            models = data.get("models", [])
-            model_names = [m.get("name", "") for m in models if isinstance(m, dict)]
-
-            warnings = []
-            if not model_names:
-                warnings.append(WARNING_MESSAGES["ollama_no_models"])
-
-            return ValidationResult(
-                passed=True,
-                warnings=warnings,
-                details={"endpoint": endpoint, "models": model_names},
-            )
-    except urllib.error.URLError as e:
-        return ValidationResult(
-            passed=False,
-            errors=[ERROR_MESSAGES["ollama_not_running"].format(endpoint=endpoint)],
-            details={"endpoint": endpoint, "error": str(e.reason)},
-        )
-    except socket.timeout:
-        return ValidationResult(
-            passed=False,
-            errors=[
-                ERROR_MESSAGES["connection_timeout"].format(
-                    provider="Ollama", timeout=timeout
-                )
-            ],
-        )
-    except Exception as e:
-        return ValidationResult(
-            passed=False,
-            errors=[ERROR_MESSAGES["ollama_not_running"].format(endpoint=endpoint)],
-            details={"error": str(e)},
-        )
 
 
 def _test_bedrock_connectivity(provider: dict, timeout: int) -> ValidationResult:

--- a/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
+++ b/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
@@ -114,16 +114,23 @@ max_tool_result_chars = 200000
 max_history_messages = 200
 keep_tool_context_turns = 8
 
-{# --- Discord channel (#422) -----------------------------------------------
-   ZeroClaw v0.7.5 schema per docs/book/src/channels/chat-others.md:
+{# --- Discord channel (#422, stream_mode added in #468) --------------------
+   ZeroClaw v0.7.5 schema per docs/book/src/channels/chat-others.md +
+   providers/streaming.md + upstream issue zeroclaw-labs/zeroclaw#4452:
      [channels.discord]
      enabled, bot_token, allowed_guilds, allowed_users,
-     reply_to_mentions_only, draft_update_interval_ms
+     reply_to_mentions_only, draft_update_interval_ms,
+     stream_mode, multi_message_delay_ms
    bot_token is inline TOML (NOT an env var) — distinct from hermes which
    reads DISCORD_BOT_TOKEN from .env. The token is hydrated into
    config.channels.discord.bot_token by lifecycle.configure_agent before this
    template runs (mirrors the hermes hydration path; same secrets.json key
    DISCORD_BOT_TOKEN).
+
+   stream_mode governs whether long turns surface mid-turn progress to
+   Discord. Upstream default is "off" (silent until the final reply lands),
+   which is the symptom #468 tracked. Valid values: "off", "partial",
+   "multi_message". The wizard defaults new agents to "partial".
 
    Hermes-wizard fields with no upstream zeroclaw equivalent are dropped
    silently here: home_channel, home_channel_name, home_channel_thread_id,
@@ -161,6 +168,20 @@ allowed_users = []
 reply_to_mentions_only = {{ _discord.get('require_mention', true) | bool | lower }}
 {% if _discord.get('draft_update_interval_ms') %}
 draft_update_interval_ms = {{ _discord.get('draft_update_interval_ms') | int }}
+{% endif %}
+{# stream_mode (#468): emitted only when set. The daemon defaults to
+   "off" when the key is absent, which is the "chat stuck until done"
+   symptom. Wizard prompts default new agents to "partial". Valid values
+   are constrained by the wizard but toml_escape is still applied so a
+   hand-edited hosts.json can't inject TOML structure via this field. #}
+{% if _discord.get('stream_mode') %}
+stream_mode = "{{ toml_escape(_discord.get('stream_mode')) }}"
+{% endif %}
+{# multi_message_delay_ms is only consulted when stream_mode = "multi_message".
+   Same falsy-zero behaviour as draft_update_interval_ms — value 0 is
+   dropped so the daemon's compiled-in default applies. #}
+{% if _discord.get('multi_message_delay_ms') %}
+multi_message_delay_ms = {{ _discord.get('multi_message_delay_ms') | int }}
 {% endif %}
 {% endif %}
 

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -3643,6 +3643,7 @@ class TestRunChannelsStageZeroclaw:
                 self._VALID_TOKEN,             # Bot token
                 "740723459344302120",          # Allowed user IDs
                 "987654321098765432",          # Allowed guild IDs
+                "partial",                     # Discord stream mode
             ]
             result = _run_channels_stage(
                 "192.168.1.100", "zeroclaw", False, "assistant"
@@ -3657,6 +3658,7 @@ class TestRunChannelsStageZeroclaw:
         assert cfg["allowed_users"] == ["740723459344302120"]
         assert cfg["allowed_guilds"] == ["987654321098765432"]
         assert cfg["require_mention"] is True
+        assert cfg["stream_mode"] == "partial"
 
         # OpenClaw nested keys MUST NOT appear (would silently disable the
         # template's [channels.discord] block because bot_token gate fails
@@ -3706,6 +3708,7 @@ class TestRunChannelsStageZeroclaw:
                 self._VALID_TOKEN,             # bot token
                 "",                            # empty allowed users
                 "",                            # empty allowed guilds
+                "partial",                     # stream mode
             ]
             result = _run_channels_stage(
                 "192.168.1.100", "zeroclaw", False, "assistant"
@@ -3941,6 +3944,7 @@ class TestRunChannelsStageZeroclaw:
                 self._VALID_TOKEN,
                 "740723459344302120",
                 "",
+                "partial",                     # stream mode
             ]
             result = _run_channels_stage(
                 "192.168.1.100", "zeroclaw", False, "assistant"
@@ -3953,4 +3957,210 @@ class TestRunChannelsStageZeroclaw:
             "Token must be stored BEFORE sync so lifecycle.configure_agent's "
             "hydration block can find it (ATX Round 3 B2 deadlock)."
         )
+
+    def test_zeroclaw_discord_stream_mode_invalid_rejected(
+        self, isolated_config: Path
+    ):
+        """#468: stream_mode is constrained to off/partial/multi_message.
+        Any other string (case-insensitive match after strip+lower) must
+        fail loudly so a typo doesn't silently fall back to upstream's
+        "off" default and bring back the "chat stuck until done" symptom."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.cli.agent._sync_channel_config"),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,
+                self._VALID_TOKEN,
+                "740723459344302120",
+                "",
+                "streamy",  # invalid
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "zeroclaw", False, "assistant"
+            )
+
+        assert result is False
+
+    def test_zeroclaw_discord_stream_mode_multi_message_persists_delay(
+        self, isolated_config: Path
+    ):
+        """When stream_mode = multi_message, the wizard prompts for the
+        per-message delay and persists it. Verifies the conditional prompt
+        branch fires + the field lands in synced channels_config."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        synced: list[dict] = []
+
+        def capture_sync(_host, _claw, channels_config, _name):
+            synced.append(channels_config)
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.cli.agent._sync_channel_config", side_effect=capture_sync),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,
+                self._VALID_TOKEN,
+                "740723459344302120",
+                "",
+                "multi_message",
+                "15000",
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "zeroclaw", False, "assistant"
+            )
+
+        assert result is True
+        assert synced[0]["discord"]["stream_mode"] == "multi_message"
+        assert synced[0]["discord"]["multi_message_delay_ms"] == 15000
+
+    def test_zeroclaw_discord_stream_mode_off_skips_delay_prompt(
+        self, isolated_config: Path
+    ):
+        """stream_mode = "off" or "partial" must NOT prompt for
+        multi_message_delay_ms — that field is only meaningful in
+        multi_message mode. A regression that prompts unconditionally would
+        consume an extra mock value and raise StopIteration here."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        synced: list[dict] = []
+
+        def capture_sync(_host, _claw, channels_config, _name):
+            synced.append(channels_config)
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.cli.agent._sync_channel_config", side_effect=capture_sync),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,
+                self._VALID_TOKEN,
+                "740723459344302120",
+                "",
+                "off",
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "zeroclaw", False, "assistant"
+            )
+
+        assert result is True
+        assert synced[0]["discord"]["stream_mode"] == "off"
+        assert "multi_message_delay_ms" not in synced[0]["discord"]
+
+    def test_zeroclaw_discord_multi_message_delay_out_of_bounds_rejected(
+        self, isolated_config: Path
+    ):
+        """Wizard bounds the delay to 10000–60000 ms. Values below the
+        floor (e.g. 5000 ms) must fail — Discord enforces ~5 messages / 5s
+        per channel, so anything tighter than ~1s/msg risks 429s on long
+        multi-paragraph responses; the 10s floor leaves a comfortable
+        headroom."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.cli.agent._sync_channel_config"),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,
+                self._VALID_TOKEN,
+                "740723459344302120",
+                "",
+                "multi_message",
+                "5000",  # below 10000 ms floor
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "zeroclaw", False, "assistant"
+            )
+
+        assert result is False
+
+    def test_zeroclaw_discord_stream_mode_case_insensitive(
+        self, isolated_config: Path
+    ):
+        """The wizard lower-cases the stream_mode input before validating.
+        "PARTIAL" must succeed and persist as "partial". Catches a
+        regression where the .lower() is dropped."""
+        from clawrium.cli.agent import _run_channels_stage
+
+        create_test_keypair(isolated_config, "work")
+        create_host_with_claw(
+            isolated_config,
+            claw_type="zeroclaw",
+            onboarding_state="channels",
+            config={"provider": {"name": "test-provider", "type": "anthropic"}},
+        )
+
+        synced: list[dict] = []
+
+        def capture_sync(_host, _claw, channels_config, _name):
+            synced.append(channels_config)
+
+        with (
+            patch("clawrium.cli.agent.typer.prompt") as mock_p,
+            patch("clawrium.cli.agent.typer.confirm", return_value=True),
+            patch("clawrium.cli.agent._sync_channel_config", side_effect=capture_sync),
+            patch("clawrium.core.secrets.set_instance_secret"),
+            patch("clawrium.cli.agent.complete_stage"),
+        ):
+            mock_p.side_effect = [
+                2,
+                self._VALID_TOKEN,
+                "740723459344302120",
+                "",
+                "PARTIAL",
+            ]
+            result = _run_channels_stage(
+                "192.168.1.100", "zeroclaw", False, "assistant"
+            )
+
+        assert result is True
+        assert synced[0]["discord"]["stream_mode"] == "partial"
 

--- a/tests/test_configure_zeroclaw.py
+++ b/tests/test_configure_zeroclaw.py
@@ -652,6 +652,103 @@ class TestChannelsDiscordBlock:
         )
         assert 'bot_token = "tok\\"with\\"quote\\\\and\\\\bs"' in rendered
 
+    def test_discord_stream_mode_omitted_when_unset(self):
+        """#468: stream_mode is only rendered when explicitly set so the
+        daemon's compiled-in default ("off") applies for legacy hosts.json
+        records that predate the field."""
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": "DUMMY",
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert "stream_mode" not in rendered
+
+    def test_discord_stream_mode_partial_rendered(self):
+        """#468 happy path: stream_mode = "partial" surfaces mid-turn
+        progress on long tool sequences."""
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": "DUMMY",
+                    "stream_mode": "partial",
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert 'stream_mode = "partial"' in rendered
+
+    def test_discord_stream_mode_multi_message_rendered(self):
+        """The third valid value alongside off/partial. Pinning the exact
+        emitted form so the daemon parses it as a string literal, not a
+        bare identifier."""
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": "DUMMY",
+                    "stream_mode": "multi_message",
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert 'stream_mode = "multi_message"' in rendered
+
+    def test_discord_stream_mode_toml_escaped(self):
+        """The wizard constrains stream_mode to off/partial/multi_message,
+        but a hand-edited hosts.json could ship anything. toml_escape on
+        the value prevents a `"; injected = "evil` payload from breaking
+        out of the basic string into a top-level TOML statement."""
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": "DUMMY",
+                    "stream_mode": 'partial"\ninjected = "evil',
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        for line in rendered.splitlines():
+            assert not line.strip().startswith("injected"), (
+                f"stream_mode value broke out of TOML basic string: {line!r}"
+            )
+
+    def test_discord_multi_message_delay_ms_rendered(self):
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": "DUMMY",
+                    "stream_mode": "multi_message",
+                    "multi_message_delay_ms": 1200,
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert "multi_message_delay_ms = 1200" in rendered
+
+    def test_discord_multi_message_delay_ms_zero_omitted(self):
+        """Symmetric to draft_update_interval_ms — the falsy-guard drops
+        zero so the daemon's default applies. Pinning so any future change
+        is intentional."""
+        rendered = _render_with_channels_and_integrations(
+            channels={
+                "discord": {
+                    "enabled": True,
+                    "bot_token": "DUMMY",
+                    "stream_mode": "multi_message",
+                    "multi_message_delay_ms": 0,
+                }
+            },
+            provider={"type": "anthropic", "default_model": "m"},
+        )
+        assert "multi_message_delay_ms" not in rendered
+
 
 class TestAgentBlock:
     """[agent] pins the daemon's tool-loop + context budgets above their

--- a/tests/test_core_validation.py
+++ b/tests/test_core_validation.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from clawrium.core.validation import (
     ValidationResult,
@@ -412,64 +412,68 @@ class TestTestProviderConnectivity:
 
 
 class TestTestOllamaConnectivity:
-    """Tests for Ollama connectivity."""
+    """Tests for Ollama connectivity skip behaviour.
 
-    def test_ollama_running(self, isolated_config: Path):
-        """Returns success when Ollama is running."""
+    `clm` runs on the control machine but the agent (which will actually
+    talk to Ollama) runs on a remote host. A control-machine HTTP probe
+    can fail purely because the operator's laptop is on a different
+    network than the agent host. The check is deliberately skipped with
+    a warning so the operator knows to verify reachability themselves.
+    """
+
+    def _write_ollama_provider(
+        self, isolated_config: Path, endpoint: str = "http://192.168.1.17:11434"
+    ) -> None:
         isolated_config.mkdir(parents=True, exist_ok=True)
-        providers_file = isolated_config / "providers.json"
-        providers_file.write_text(
+        (isolated_config / "providers.json").write_text(
             json.dumps(
-                [
-                    {
-                        "name": "test-ollama",
-                        "type": "ollama",
-                        "endpoint": "http://localhost:11434",
-                    }
-                ]
+                [{"name": "test-ollama", "type": "ollama", "endpoint": endpoint}]
             )
         )
 
+    def test_ollama_connectivity_check_is_skipped_with_warning(
+        self, isolated_config: Path
+    ):
+        """verify_provider_connectivity must NOT probe Ollama from the
+        control machine. It returns passed=True with a warning that names
+        the endpoint and points the operator at the agent host."""
+        self._write_ollama_provider(isolated_config)
+
         with patch("clawrium.core.validation.urllib.request.urlopen") as mock_urlopen:
-            mock_response = MagicMock()
-            mock_response.read.return_value = json.dumps(
-                {"models": [{"name": "llama3:latest"}]}
-            ).encode()
-            mock_response.__enter__ = MagicMock(return_value=mock_response)
-            mock_response.__exit__ = MagicMock(return_value=False)
-            mock_urlopen.return_value = mock_response
-
             result = verify_provider_connectivity("test-ollama")
-            assert result.passed is True
-            assert "llama3:latest" in result.details.get("models", [])
+            mock_urlopen.assert_not_called()
 
-    def test_ollama_no_models(self, isolated_config: Path):
-        """Returns warning when Ollama has no models."""
-        isolated_config.mkdir(parents=True, exist_ok=True)
-        providers_file = isolated_config / "providers.json"
-        providers_file.write_text(
-            json.dumps(
-                [
-                    {
-                        "name": "test-ollama",
-                        "type": "ollama",
-                        "endpoint": "http://localhost:11434",
-                    }
-                ]
-            )
+        assert result.passed is True
+        assert result.errors == []
+        assert len(result.warnings) == 1
+        warning = result.warnings[0]
+        assert "192.168.1.17:11434" in warning
+        assert "agent host" in warning.lower()
+        assert "curl" in warning
+        assert result.details.get("skipped") is True
+        assert result.details.get("type") == "ollama"
+        assert result.details.get("endpoint") == "http://192.168.1.17:11434"
+
+    def test_ollama_skip_warning_uses_fallback_when_endpoint_missing(
+        self, isolated_config: Path
+    ):
+        """When the provider entry has no endpoint, the warning still
+        renders cleanly (no empty-string artifact) and the empty-endpoint
+        path must not probe the network either."""
+        self._write_ollama_provider(isolated_config, endpoint="")
+
+        with patch("clawrium.core.validation.urllib.request.urlopen") as mock_urlopen:
+            result = verify_provider_connectivity("test-ollama")
+            mock_urlopen.assert_not_called()
+
+        assert result.passed is True
+        assert result.errors == []
+        assert result.details.get("skipped") is True
+        assert result.details.get("type") == "ollama"
+        assert result.details.get("endpoint") == ""
+        assert any("<endpoint not configured>" in w for w in result.warnings), (
+            result.warnings
         )
-
-        with patch("clawrium.core.validation.urllib.request.urlopen") as mock_urlopen:
-            mock_response = MagicMock()
-            mock_response.read.return_value = json.dumps({"models": []}).encode()
-            mock_response.__enter__ = MagicMock(return_value=mock_response)
-            mock_response.__exit__ = MagicMock(return_value=False)
-            mock_urlopen.return_value = mock_response
-
-            result = verify_provider_connectivity("test-ollama")
-            assert result.passed is True
-            assert len(result.warnings) == 1
-            assert "no models" in result.warnings[0].lower()
 
 
 class TestValidateOpenClawGateway:

--- a/website/docs/agent-support/channels/discord.md
+++ b/website/docs/agent-support/channels/discord.md
@@ -257,6 +257,8 @@ The clm-managed `[channels.discord]` block uses **only** the keys documented in 
 | `allowed_guilds = [...]` | `allowed_guilds` | empty array if unset; zeroclaw-specific (no hermes equivalent) |
 | `reply_to_mentions_only` | `require_mention` | renamed to match the upstream key |
 | `draft_update_interval_ms` | `draft_update_interval_ms` | optional — defaults handled by the daemon when omitted |
+| `stream_mode` | `stream_mode` | `"off"` / `"partial"` / `"multi_message"`. Wizard default is `"partial"` so long turns surface mid-turn progress to Discord instead of going silent until done. Upstream default is `"off"`. |
+| `multi_message_delay_ms` | `multi_message_delay_ms` | optional — only consulted when `stream_mode = "multi_message"`. Wizard prompts in the 10000–60000 ms range (10–60 s) so multi-paragraph responses stay under Discord's ~5 messages / 5 s per-channel rate limit; the daemon's compiled-in default applies when omitted. |
 
 ### Hermes-side fields with no ZeroClaw equivalent
 
@@ -284,8 +286,20 @@ Prompts:
 | `Allowed Discord user IDs` | `allowed_users` list |
 | `Allowed guild IDs` (optional) | `allowed_guilds` list |
 | `Reply to mentions only?` | `require_mention` → rendered as `reply_to_mentions_only` |
+| `Discord stream mode (off/partial/multi_message)` | `stream_mode` (default `partial`) |
+| `Delay between Discord messages in ms` (only when `stream_mode = multi_message`) | `multi_message_delay_ms` (10000–60000) |
 
 `clm` then runs the configure playbook, which re-renders `~/.zeroclaw/config.toml` with the `[channels.discord]` block, restarts `zeroclaw-<name>.service`, and verifies the block landed by grepping for `^bot_token =` in the file.
+
+### Streaming progress on long-running turns
+
+Without `stream_mode`, zeroclaw buffers the whole turn before posting — agents working through long tool sequences (e.g. building a PR) appear silent in Discord until they finish. `stream_mode` controls this:
+
+| Value | Behaviour |
+|---|---|
+| `off` | Upstream default. Single message posted when the turn completes. |
+| `partial` (wizard default) | Edits a single draft message in place as the agent runs tools, then finalizes with the full response. Companion knob: `draft_update_interval_ms` (default 500 ms; bump to 750–1000 if you hit Discord rate limits). |
+| `multi_message` | Splits the final reply into multiple messages at paragraph boundaries with `multi_message_delay_ms` between bubbles. Doesn't surface tool progress — only paces the final. |
 
 ### Resulting on-disk shape (ZeroClaw)
 
@@ -297,6 +311,7 @@ allowed_guilds = ["987654321098765432"]
 allowed_users = ["740723459344302120"]
 reply_to_mentions_only = true
 draft_update_interval_ms = 750
+stream_mode = "partial"
 ```
 
 In `hosts.json` (agents.`<name>`.config.channels.discord):


### PR DESCRIPTION
> **Note:** This PR stacks two independent fixes on the same branch — `fix(validation): skip Ollama connectivity check` (original scope) and `feat(zeroclaw): add Discord stream_mode + multi_message_delay_ms` (#468).

---

# feat(zeroclaw): add Discord `stream_mode` + `multi_message_delay_ms` (Closes #468)

## Summary
- Adds `stream_mode` (one of `off` / `partial` / `multi_message`) and `multi_message_delay_ms` under `[channels.discord]` in the zeroclaw `config.toml` renderer. Wizard prompts default new agents to `stream_mode = partial` so long tool sequences (e.g. an agent building a PR) surface mid-turn progress to Discord instead of going silent until the final reply lands. Companion delay field is bounded to 10000–60000 ms.
- Template `{% if _discord.get('stream_mode') %}` guard means legacy `hosts.json` records without the key render no value and the daemon falls back to its compiled-in `off` default — backwards-compat preserved.
- `toml_escape()` applied to the `stream_mode` value even though the wizard constrains it, so a hand-edited `hosts.json` can't inject TOML structure via this field.

## Why
Upstream zeroclaw v0.7.5 defaults `stream_mode = "off"` for Discord — chat shows nothing until the agent finishes its turn. clm's existing renderer didn't expose the field, so operators couldn't reach `partial` (in-place draft edits during tool runs) or `multi_message` (paragraph-boundary message splitting) without hand-editing `~/.zeroclaw/config.toml`, which gets clobbered on the next `clm agent configure/sync`.

Sources: zeroclaw `docs/book/src/channels/chat-others.md`, `docs/book/src/providers/streaming.md`, upstream issue `zeroclaw-labs/zeroclaw#4452`.

## Behavior change
- **New agents** configured via the wizard now ship with `stream_mode = "partial"` and stream progress to Discord automatically.
- **Existing agents** without `stream_mode` in `hosts.json` are unaffected until re-configured (template falsy-guard).
- **Re-configure** does **not** read back the existing value yet — re-running `clm agent configure --stage channels` on an agent with `stream_mode = "off"` will silently default-flip to `partial` if the operator hits Enter on the prompt. Tracked as ATX W2 below (deferred per operator).

## Files changed
- `src/clawrium/cli/agent.py` — zeroclaw branch: `stream_mode` prompt (default `partial`); conditional `multi_message_delay_ms` prompt (10000–60000 ms) when mode is `multi_message`.
- `src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2` — emits both fields under `[channels.discord]`; updated schema doc comment.
- `tests/test_configure_zeroclaw.py` — 6 new template tests (set/unset/escape/zero-omit for both fields + TOML-injection guard).
- `tests/test_cli_agent_configure.py` — 5 new wizard tests; 3 existing happy-path tests updated to feed the new prompt.
- `docs/agent-support/channels/discord.md` + `website/docs/agent-support/channels/discord.md` mirror — documented `stream_mode` / `multi_message_delay_ms` in the ZeroClaw schema table, wizard prompt list, on-disk shape, and added a "Streaming progress on long-running turns" subsection.

## Testing
- [x] `make test` — 2,427 Python tests pass; 213 GUI tests pass
- [x] `make lint` — clean
- [x] Backfilled `clawrium-d01` (live zeroclaw agent on `wolf-i`) with `stream_mode: partial` via `hosts.json` edit + `clm agent sync` — playbook re-rendered `~/.zeroclaw/config.toml` and restarted the daemon.

## ATX Review Summary (stream_mode work)

**Review 1: Rating 3/5 — no blockers**
**Cost: $1.38 | Duration: ~9 min | Agents: leader, core-lifecycle (security-reviewer + cli-ux-reviewer crashed with turn-limit errors)**

| # | Status | Issue |
|---|---|---|
| W1 | Fixed | 100 ms `multi_message_delay_ms` floor was unsafe (10 msg/s vs Discord ~5/5s limit). Raised floor to **10000 ms (10 s)** per operator decision — stricter than reviewer-suggested 500 ms. Misleading rate-limit comment corrected. |
| W2 | Acknowledged | Re-configure silently overwrites existing `stream_mode` with hard-coded `partial` default. Deferred per operator — same pattern affects existing `require_mention` prompt; fix belongs in a separate refactor that reads back all wizard defaults from `hosts.json`. |
| S1 | Acknowledged | Missing template test for explicit `stream_mode = "off"`. Deferred per operator — Jinja truthy guard handles `"off"` correctly today; regression risk is low. |

**Unreviewed surfaces (reviewer crashes — manually verified):**
- TOML injection via `stream_mode` value: template emits `stream_mode = "{{ toml_escape(...) }}"` (double-quoted, escaped). Pinned by `test_discord_stream_mode_toml_escaped`.
- Wizard prompt UX: matches `draft_update_interval_ms` pattern.

---

# fix(validation): skip Ollama connectivity check on control machine (original PR scope)

## Summary
- `verify_provider_connectivity` no longer probes Ollama from the control machine. It returns `passed=True` with a warning naming the endpoint and a concrete `ssh <agent-host> curl -fsS <endpoint>/api/tags` verification command.
- CLI render path (`_run_validate_stage`) prints a yellow `⚠ Provider connectivity check skipped` instead of green `✓ Provider connectivity OK` whenever `result.details["skipped"]` is True, so the operator isn't misled by a green checkmark over a subordinate warning.
- Dead `_test_ollama_connectivity` helper (~47 lines) and three orphan message-dict entries (`ERROR_MESSAGES["ollama_not_running"]`, both `ollama_no_models` keys) are removed.

## Why

`clm agent configure` runs on the operator's control machine, but the agent will reach Ollama from a remote agent host at runtime. A control-machine HTTP probe produced false-negative failures and blocked configure in split-network setups where Ollama was fine from the agent host but unreachable from the operator's laptop.

## Behavior change (Ollama operators)

`clm agent configure` no longer probes Ollama connectivity from the control machine. It emits a warning and proceeds. Operators should manually verify reachability from the agent host:

```
ssh <agent-host> curl -fsS <ollama-endpoint>/api/tags
```

## Follow-up (not in this PR)

Move the probe into the configure playbook so ansible runs it on the agent host using the `uri:` module and re-runs `validate_ollama_url()` to block SSRF from a hand-edited `providers.json`. Called out in the inline TODO comment.

## ATX Review Summary (Ollama-skip work)

**Final Review: Rating 4/5**
**Total Cost: $7.21 | Rounds: 3**

| Review | Rating | Blocking Issues | Status | Agents |
|--------|--------|-----------------|--------|--------|
| 1 | 2/5 | B1 | Fixed in R2 | leader, cli-ux, test-coverage, security, core-lifecycle, ansible |
| 2 | 2/5 | B2, B3 | Confirmed out-of-scope in R3 | leader, cli-ux, test-coverage, security, core-lifecycle |
| 3 | 4/5 | None | Ready to merge | leader, cli-ux, test-coverage, security, core-lifecycle |

<details>
<summary>Round 1 (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_core_validation.py:457-469` | Vacuous assertion in fallback test — missing `passed`/`errors`/`details.skipped`/`urlopen.assert_not_called` | Fixed — added all four assertions + tightened warning content check |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `src/clawrium/core/validation.py:621-667` | `_test_ollama_connectivity` is unreachable dead code | Fixed — deleted |
| W2 | `src/clawrium/cli/agent.py:1515-1516` | Green `✓ Provider connectivity OK` printed for a skipped check | Fixed — branches on `details["skipped"]`, prints yellow `⚠` |
| W3 | `src/clawrium/core/validation.py:358-363` | Warning text vague; nonsensical `'configured endpoint'` fallback | Fixed — added concrete `ssh ... curl` command; `<endpoint not configured>` placeholder |
| W4 | `src/clawrium/core/validation.py:352` | TODO has no issue reference | Acknowledged — comment expanded to name root cause + Ansible `uri:` module + SSRF guard |
| W5 | `src/clawrium/core/validation.py:84-89,140` | Dead message-dict entries | Fixed — deleted all three |

</details>

<details>
<summary>Round 2 (Rating 2/5)</summary>

**Blocking Issues (out-of-scope):**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B2 | `.github/workflows/publish.yml:15` | `actions/checkout@v4` is a mutable tag in an `id-token:write` job | Out-of-scope — `publish.yml` is unmodified by this PR; the SHA-pinning work belongs in a dedicated supply-chain PR (verified by ATX security reviewer in R3 via `git show-ref`) |
| B3 | `.github/workflows/publish.yml:30` | `actions/setup-node@v4` mutable tag in same job | Out-of-scope — same justification as B2 |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W6 | `src/clawrium/core/validation.py:355-359` | No bidi-strip on `endpoint` before rendering into warning | Deferred — pre-existing pattern (same gap at `validation.py:744,1002,1034,1060`); endpoint is local config not server-supplied; track as dedicated bidi-hardening issue |
| W7 | `src/clawrium/cli/agent.py:1516-1524` | Double-print of "skipped" state (header + warning prefix) | Fixed in R3 — dropped "Skipped" prefix from warning text; header carries the semantic |
| W8 | `src/clawrium/core/validation.py:351,359` | `<endpoint not configured>` vs `<endpoint>` placeholder mismatch | Fixed in R3 — unified to `endpoint_display` used at both sites |
| W9 | `src/clawrium/core/validation.py:359` | `<agent-host>` is a permanent literal placeholder | Deferred — requires threading `host_alias` into `verify_provider_connectivity` signature, invasive change beyond this fix |
| W10 | `src/clawrium/cli/agent.py:1516-1519` | No CLI-layer test for the new skip rendering branch | Deferred — unit-level coverage exists on `verify_provider_connectivity`; CLI-level test is a follow-up |

</details>

<details>
<summary>Round 3 (Rating 4/5)</summary>

All blocking issues resolved or confirmed out-of-scope. W7/W8 fixed; S1 (test-style polish) applied. Four new suggestion-level items (S2–S5) filed as follow-ups; none block merge.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
