### PR TITLE
fix(docs): correct output examples and CLI command accuracy (#465)

### DIFF
--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -277,5 +277,5 @@ clm agent logs my-assistant
 ```
 
 Common issues:
-- Invalid API key (re-run `clm agent configure my-assistant --stage provider`)
+- Invalid API key (re-run `clm agent configure my-assistant --stage providers`)
 - Port already in use (check with `clm agent status my-assistant`)

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -131,9 +131,9 @@ Verify with:
 clm host list
 ```
 ```
-ALIAS      HOSTNAME         STATUS    CPU    MEMORY  GPU
-────────────────────────────────────────────────────────────
-homelab    192.168.1.100    online    4      16 GB   -
+Alias      Host            Architecture   Cores   Memory (GB)   Tags
+──────────────────────────────────────────────────────────────────────
+homelab    192.168.1.100   x86_64         4       16.0          -
 ```
 
 ## Step 5: Install the Agent
@@ -196,9 +196,7 @@ Stage 4/4: Validation
 ✓ Channels: CLI
 ✓ Configuration valid
 
-Save and start agent? [Y/n]: y
-✓ Configuration saved
-✓ Agent started
+Configuration complete. Run 'clm agent start my-assistant' to start your agent.
 ```
 
 ## Step 7: Check Fleet Status

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -104,7 +104,7 @@ Check the version:
 clm --version
 ```
 ```
-clm, version 26.5.4
+clm 26.5.4
 ```
 
 ## Initialize Clawrium

--- a/website/docs/scenarios/101.md
+++ b/website/docs/scenarios/101.md
@@ -86,7 +86,7 @@ Host 'mybox' added successfully!
 Configure Anthropic as your AI provider:
 
 ```bash
-$ clm provider add anthropic
+$ clm provider add anthropic --type anthropic
 Enter your Anthropic API key: sk-ant-api03-...
 Provider 'anthropic' added successfully!
 ```
@@ -180,13 +180,13 @@ If `clm agent start` fails:
 
 1. Check agent logs: `clm agent logs oc-default-mybox`
 2. Verify provider is configured: `clm provider list`
-3. Test host connectivity: `clm host status mybox`
+3. Test host connectivity: `clm host ps mybox`
 
 ### Chat Disconnects Immediately
 
 If the chat session closes:
 
-1. Ensure the agent is running: `clm agent status oc-default-mybox`
+1. Ensure the agent is running: `clm agent ps`
 2. Check for API key issues in logs: `clm agent logs oc-default-mybox --tail 20`
 
 ## Next Steps

--- a/website/docs/scenarios/101.md
+++ b/website/docs/scenarios/101.md
@@ -187,7 +187,7 @@ If `clm agent start` fails:
 If the chat session closes:
 
 1. Ensure the agent is running: `clm agent ps`
-2. Check for API key issues in logs: `clm agent logs oc-default-mybox --tail 20`
+2. Check for API key issues in logs: `clm agent logs oc-default-mybox` (note: logs command is not yet implemented)
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
Fixes doc accuracy issues where output examples don't match actual CLI behavior.

## Customer outcome
Users can trust documentation examples to match actual CLI output, reducing confusion during onboarding.

## Testing
- [x] `make lint` passed locally
- [x] Verified each output example against actual CLI source code

## Decisions made
- W4: Updated `clm --version` output format to match actual CLI ("clm 26.5.4" not "clm, version 26.5.4")
- W5: Updated `clm host list` columns to match actual output (Alias, Host, Architecture, Cores, Memory (GB), Tags)
- W6: `clm ps` columns update deferred due to unicode table border encoding in markdown
- W7: Removed `--tail 20` flag from `clm agent logs` and added note that command is not yet implemented
- S3: Removed misleading "Agent started" output from `clm agent configure` (configure does not start the agent)

## Docs
- website/docs/installation.md (W4)
- website/docs/guides/quickstart.md (W5, S3)
- website/docs/scenarios/101.md (W7)

## Out of scope
- W6: `clm ps` column update (unicode encoding issue)
- W8: Provisioning demo GIF placement (no GIF found in installation.md)
- S4: AGENTS.md quickstart configure step (already correct)
- Remaining items in #465 (W1, W9, S6, B1, W2, W3, S2)

Refs #465 — Phase 2/4

Co-Authored-By: clawrium-d01 <clawrium-d01@users.noreply.github.com>
