### PR TITLE
feat(registry): add features.web_ui schema + resolver (#481)

### DIFF
--- a/.itx/481/01_EXECUTION.md
+++ b/.itx/481/01_EXECUTION.md
@@ -1,0 +1,33 @@
+# Issue #481 — Execution Log
+
+PR: https://github.com/ric03uec/clawrium/pull/486
+Branch: `issue-481-manifest-web-ui`
+Parent issue: #478 (Phase 1 of 3)
+
+## Summary of work landed
+
+- Extended `src/clawrium/core/registry.py` with `WebUIFeatureConfig` TypedDict and a `_validate_web_ui` validator (closed `bind` enum, required `enabled`/`default_port`/`port_field`; port constrained to `1..65535`).
+- Added `features.web_ui` block to `src/clawrium/platform/registry/hermes/manifest.yaml`.
+- New `src/clawrium/core/web_ui.py` resolver — `resolve(agent_key) -> ResolvedUI | None` reading manifest + `hosts.json` agent record.
+- 9 new tests in `tests/test_registry.py`; 11 new tests in `tests/test_web_ui_resolver.py`.
+- `make test-py` → 2456 passed. `make lint-py` → clean.
+
+## Out of scope (deferred to Phase 2 / Phase 3)
+
+- Install playbook (`hermes-dashboard` systemd unit) — Phase 2 / #482.
+- CLI `clm agent open`, tunnel manager, GUI button, docs — Phase 3 / #483.
+
+---
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-22T15:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx:execute 481
+```
+
+**Output**: Implemented Phase 1 mechanism — manifest schema + resolver. Opened PR #486 against `main`. ATX review skipped (`atx review` returned `no_changes / "No active session"` — hook-driven state not visible from this entry path); recorded as `[ENVIRONMENT]` Callout on the PR.

--- a/.itx/481/atx-session.json
+++ b/.itx/481/atx-session.json
@@ -1,0 +1,11 @@
+{
+  "session_id": null,
+  "transport": "cli",
+  "commit_sha": "d6c7de7",
+  "iteration": 0,
+  "last_rating": null,
+  "last_blockers": [],
+  "started_at": "2026-05-22T15:15:00Z",
+  "updated_at": "2026-05-22T15:15:00Z",
+  "skipped_reason": "atx CLI reported 'No active session' — hook-driven state not visible from this entry path. Documented in PR Callouts."
+}

--- a/.itx/481/atx-session.json
+++ b/.itx/481/atx-session.json
@@ -1,11 +1,39 @@
 {
-  "session_id": null,
+  "session_id": "a11a750e-7118-4b67-94c1-79bd63292954",
   "transport": "cli",
-  "commit_sha": "d6c7de7",
-  "iteration": 0,
-  "last_rating": null,
-  "last_blockers": [],
-  "started_at": "2026-05-22T15:15:00Z",
-  "updated_at": "2026-05-22T15:15:00Z",
-  "skipped_reason": "atx CLI reported 'No active session' — hook-driven state not visible from this entry path. Documented in PR Callouts."
+  "commit_sha": "8674785",
+  "iterations": [
+    {
+      "iter": 1,
+      "rating": 3,
+      "blocking": 0,
+      "warnings": 7,
+      "test_gaps": 6,
+      "suggestions": 5,
+      "cost_usd": 1.82,
+      "task_id": "a11a750e-7118-4b67-94c1-79bd63292954",
+      "agents": ["leader", "core-lifecycle", "test-coverage", "security", "ansible-registry"]
+    },
+    {
+      "iter": 2,
+      "rating": 3,
+      "blocking": 0,
+      "warnings_in_scope_fixed": 3,
+      "warnings_deferred_phase3": 2,
+      "cost_usd": 3.59,
+      "agents": ["leader", "cli-ux", "test-coverage", "security", "ansible-registry", "core-lifecycle"]
+    },
+    {
+      "iter": 3,
+      "rating_core_lifecycle": 4,
+      "blocking": 0,
+      "warnings": 2,
+      "suggestions": 2,
+      "cost_usd": 2.23,
+      "agents": ["core-lifecycle"]
+    }
+  ],
+  "total_cost_usd": 7.64,
+  "iteration_ceiling_reached": true,
+  "final_state": "no-blockers; all in-scope warnings resolved; out-of-scope items deferred to Phase 3 with TODO-FOLLOWUP callouts"
 }

--- a/src/clawrium/core/registry.py
+++ b/src/clawrium/core/registry.py
@@ -521,13 +521,23 @@ def _validate_workspace(workspace_value: object, agent_type: str) -> WorkspaceCo
 _ALLOWED_CHAT_TYPES = ("openai", "websocket", "zeroclaw")
 _ALLOWED_WEB_UI_BINDS = ("loopback",)
 
+# `port_field` is a dotted path that downstream code uses both as a config
+# lookup (`agent_record.config.<port_field>`) and — in Phase 2 — as an
+# Ansible extra-var. Constrain to dotted identifier segments so a tampered
+# or third-party manifest cannot smuggle path-traversal, prototype-pollution,
+# or shell-metachar payloads through this field.
+_PORT_FIELD_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$")
+
 
 def _validate_web_ui(web_ui_value: object, agent_type: str) -> WebUIFeatureConfig:
     """Validate `features.web_ui` block.
 
     `bind` is a closed enum (currently `loopback` only). All four fields
     (`enabled`, `bind`, `default_port`, `port_field`) are required when the
-    block is present.
+    block is present. `default_port` is constrained to 1..65535 (ports
+    <1024 are privileged and emit a warning — they are accepted because
+    a manifest *could* legitimately declare one, but the warning surfaces
+    the risk at manifest-load time rather than at agent-bind time).
     """
     web_ui = _as_dict(web_ui_value, "features.web_ui", agent_type)
 
@@ -557,12 +567,24 @@ def _validate_web_ui(web_ui_value: object, agent_type: str) -> WebUIFeatureConfi
             "has invalid `features.web_ui.default_port` "
             "(expected integer in 1..65535)",
         )
+    if default_port < 1024:
+        logger.warning(
+            "Manifest for '%s' declares privileged web_ui.default_port=%d "
+            "(<1024). Non-root agent processes will fail to bind.",
+            agent_type,
+            default_port,
+        )
 
     port_field = web_ui.get("port_field")
-    if not isinstance(port_field, str) or not port_field:
+    if (
+        not isinstance(port_field, str)
+        or not port_field.strip()
+        or not _PORT_FIELD_RE.fullmatch(port_field)
+    ):
         _raise_parse_error(
             agent_type,
-            "has invalid `features.web_ui.port_field` (expected non-empty string)",
+            "has invalid `features.web_ui.port_field` "
+            "(expected dotted identifier path, e.g. 'dashboard.port')",
         )
 
     return {

--- a/src/clawrium/core/registry.py
+++ b/src/clawrium/core/registry.py
@@ -534,10 +534,10 @@ def _validate_web_ui(web_ui_value: object, agent_type: str) -> WebUIFeatureConfi
 
     `bind` is a closed enum (currently `loopback` only). All four fields
     (`enabled`, `bind`, `default_port`, `port_field`) are required when the
-    block is present. `default_port` is constrained to 1..65535 (ports
-    <1024 are privileged and emit a warning — they are accepted because
-    a manifest *could* legitimately declare one, but the warning surfaces
-    the risk at manifest-load time rather than at agent-bind time).
+    block is present. `default_port` is constrained to 1024..65535 —
+    privileged ports (<1024) are rejected outright because non-root agent
+    processes cannot bind them. `port_field` must be a dotted identifier
+    path (e.g. `dashboard.port`).
     """
     web_ui = _as_dict(web_ui_value, "features.web_ui", agent_type)
 

--- a/src/clawrium/core/registry.py
+++ b/src/clawrium/core/registry.py
@@ -559,20 +559,17 @@ def _validate_web_ui(web_ui_value: object, agent_type: str) -> WebUIFeatureConfi
     if (
         not isinstance(default_port, int)
         or isinstance(default_port, bool)
-        or default_port <= 0
+        or default_port < 1024
         or default_port > 65535
     ):
+        # Privileged ports (1..1023) are rejected outright — non-root agent
+        # processes cannot bind them, and `logger.warning` is invisible in
+        # the default uv-tool deployment, so a silent accept would be a
+        # latent footgun. Fail loudly at manifest-load time instead.
         _raise_parse_error(
             agent_type,
             "has invalid `features.web_ui.default_port` "
-            "(expected integer in 1..65535)",
-        )
-    if default_port < 1024:
-        logger.warning(
-            "Manifest for '%s' declares privileged web_ui.default_port=%d "
-            "(<1024). Non-root agent processes will fail to bind.",
-            agent_type,
-            default_port,
+            "(expected integer in 1024..65535)",
         )
 
     port_field = web_ui.get("port_field")

--- a/src/clawrium/core/registry.py
+++ b/src/clawrium/core/registry.py
@@ -133,11 +133,27 @@ class ChatFeatureConfig(TypedDict):
     type: Literal["openai", "websocket", "zeroclaw"]
 
 
+class WebUIFeatureConfig(TypedDict):
+    """Native web UI capability descriptor.
+
+    `bind` is a closed enum; only `loopback` is accepted in this iteration —
+    LAN-bound dashboards are deliberately out of scope. `port_field` is a
+    dotted path into the agent's `hosts.json` config record (for example,
+    `dashboard.port`) so callers can locate the persisted per-instance port.
+    """
+
+    enabled: bool
+    bind: Literal["loopback"]
+    default_port: int
+    port_field: str
+
+
 class FeaturesConfig(TypedDict):
     """Capability flags advertised by an agent manifest."""
 
     memory: NotRequired[bool]
     chat: NotRequired[ChatFeatureConfig]
+    web_ui: NotRequired[WebUIFeatureConfig]
 
 
 class AgentManifest(TypedDict):
@@ -503,6 +519,58 @@ def _validate_workspace(workspace_value: object, agent_type: str) -> WorkspaceCo
 
 
 _ALLOWED_CHAT_TYPES = ("openai", "websocket", "zeroclaw")
+_ALLOWED_WEB_UI_BINDS = ("loopback",)
+
+
+def _validate_web_ui(web_ui_value: object, agent_type: str) -> WebUIFeatureConfig:
+    """Validate `features.web_ui` block.
+
+    `bind` is a closed enum (currently `loopback` only). All four fields
+    (`enabled`, `bind`, `default_port`, `port_field`) are required when the
+    block is present.
+    """
+    web_ui = _as_dict(web_ui_value, "features.web_ui", agent_type)
+
+    enabled = web_ui.get("enabled")
+    if not isinstance(enabled, bool):
+        _raise_parse_error(
+            agent_type, "has invalid `features.web_ui.enabled` (expected boolean)"
+        )
+
+    bind = web_ui.get("bind")
+    if bind not in _ALLOWED_WEB_UI_BINDS:
+        allowed = ", ".join(repr(b) for b in _ALLOWED_WEB_UI_BINDS)
+        _raise_parse_error(
+            agent_type,
+            f"has invalid `features.web_ui.bind` (expected one of {allowed})",
+        )
+
+    default_port = web_ui.get("default_port")
+    if (
+        not isinstance(default_port, int)
+        or isinstance(default_port, bool)
+        or default_port <= 0
+        or default_port > 65535
+    ):
+        _raise_parse_error(
+            agent_type,
+            "has invalid `features.web_ui.default_port` "
+            "(expected integer in 1..65535)",
+        )
+
+    port_field = web_ui.get("port_field")
+    if not isinstance(port_field, str) or not port_field:
+        _raise_parse_error(
+            agent_type,
+            "has invalid `features.web_ui.port_field` (expected non-empty string)",
+        )
+
+    return {
+        "enabled": enabled,
+        "bind": bind,
+        "default_port": default_port,
+        "port_field": port_field,
+    }
 
 
 def _validate_features(features_value: object, agent_type: str) -> FeaturesConfig:
@@ -529,6 +597,9 @@ def _validate_features(features_value: object, agent_type: str) -> FeaturesConfi
                 f"has invalid `features.chat.type` (expected one of {allowed})",
             )
         validated["chat"] = {"type": chat_type}
+
+    if "web_ui" in features:
+        validated["web_ui"] = _validate_web_ui(features["web_ui"], agent_type)
 
     return validated
 

--- a/src/clawrium/core/web_ui.py
+++ b/src/clawrium/core/web_ui.py
@@ -148,11 +148,15 @@ def resolve(agent_key: str) -> ResolvedUI | None:
         match = get_agent_by_name(agent_key)
     except ValueError as exc:
         # `get_agent_by_name` raises `ValueError` on ambiguous matches across
-        # hosts. We deliberately treat that as "no native UI available" rather
-        # than crashing — callers (CLI / GUI) render "not available" instead
-        # of a stack trace. A debug-level log preserves diagnosability without
-        # spamming production logs.
-        logger.debug("resolve(%s): suppressed ValueError: %s", agent_key, exc)
+        # hosts. We treat that as "no native UI available" rather than
+        # crashing — callers (CLI / GUI) render "not available" instead of
+        # a stack trace. Logged at WARNING so operators can act on it.
+        logger.warning(
+            "resolve(%s): agent name is ambiguous across multiple hosts — "
+            "use '<name>@<host>' to disambiguate (%s)",
+            agent_key,
+            exc,
+        )
         return None
 
     if match is None:
@@ -162,9 +166,18 @@ def resolve(agent_key: str) -> ResolvedUI | None:
 
     try:
         manifest = load_manifest(agent_type)
-    except (ManifestNotFoundError, ManifestParseError) as exc:
+    except ManifestNotFoundError as exc:
+        # Agent type with no bundled manifest — legitimate "no feature" path.
+        # Debug-level keeps production logs quiet.
         logger.debug(
-            "resolve(%s): manifest load failed for type %r: %s",
+            "resolve(%s): no manifest for type %r: %s", agent_key, agent_type, exc
+        )
+        return None
+    except ManifestParseError as exc:
+        # Corrupt manifest is operator-actionable — surface it.
+        logger.warning(
+            "resolve(%s): manifest for type %r is corrupted: %s — "
+            "run 'clm registry list' to verify",
             agent_key,
             agent_type,
             exc,

--- a/src/clawrium/core/web_ui.py
+++ b/src/clawrium/core/web_ui.py
@@ -23,6 +23,7 @@ from typing import Any, Literal
 
 from clawrium.core.hosts import get_agent_by_name
 from clawrium.core.registry import (
+    InvalidAgentTypeError,
     ManifestNotFoundError,
     ManifestParseError,
     load_manifest,
@@ -166,9 +167,11 @@ def resolve(agent_key: str) -> ResolvedUI | None:
 
     try:
         manifest = load_manifest(agent_type)
-    except ManifestNotFoundError as exc:
-        # Agent type with no bundled manifest — legitimate "no feature" path.
-        # Debug-level keeps production logs quiet.
+    except (ManifestNotFoundError, InvalidAgentTypeError) as exc:
+        # No manifest for this type, or the type itself was rejected by
+        # `validate_agent_type` (path traversal, invalid chars from a
+        # tampered hosts.json). Both are "no feature" from the resolver's
+        # perspective; keep at DEBUG to honour the None-return contract.
         logger.debug(
             "resolve(%s): no manifest for type %r: %s", agent_key, agent_type, exc
         )
@@ -194,6 +197,11 @@ def resolve(agent_key: str) -> ResolvedUI | None:
 
     config = agent_record.get("config") or {}
     persisted_port = _dotted_lookup(config, web_ui["port_field"])
+    # Persisted ports accepted down to 1 — the manifest validator forbids
+    # privileged default_port values, but a per-instance override that an
+    # operator manually wrote into hosts.json is resolved faithfully here;
+    # the bind attempt at agent-start time will surface any privilege
+    # problem with a clear OS error.
     if (
         isinstance(persisted_port, int)
         and not isinstance(persisted_port, bool)

--- a/src/clawrium/core/web_ui.py
+++ b/src/clawrium/core/web_ui.py
@@ -8,13 +8,18 @@ to act on. URL construction is intentionally *not* performed here.
 Returns `None` whenever an agent is not installed or its manifest does
 not declare `features.web_ui` — callers should treat `None` as "no native
 UI available for this agent".
+
+Bind contract: `bind: "loopback"` in this iteration MUST be interpreted
+by downstream callers as the IPv4 address `127.0.0.1`. The `BIND_ADDRESS_MAP`
+constant is the single source of truth — Phase 2's tunnel manager and any
+future consumer must import it rather than re-deriving the mapping.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 from clawrium.core.hosts import get_agent_by_name
 from clawrium.core.registry import (
@@ -25,6 +30,17 @@ from clawrium.core.registry import (
 
 logger = logging.getLogger(__name__)
 
+# Single source of truth for the `bind` enum → concrete network address.
+# Downstream callers MUST consult this map rather than hard-coding 127.0.0.1,
+# so that adding new bind modes later remains a single-file change.
+BIND_ADDRESS_MAP: dict[str, str] = {"loopback": "127.0.0.1"}
+
+# Characters that must never appear in a host-supplied identity-file path.
+# Phase 2's tunnel manager will pass this value to `ssh -i <path>`; rejecting
+# null bytes, newlines, and shell metachars at resolve-time means the
+# subprocess invocation downstream can trust its inputs.
+_FORBIDDEN_IDENTITY_FILE_CHARS = ("\x00", "\n", "\r", ";", "&", "|", "`", "$")
+
 
 @dataclass(frozen=True)
 class ResolvedUI:
@@ -33,18 +49,22 @@ class ResolvedUI:
     Attributes:
         host: Primary address (IP or DNS name) of the agent host. Caller
             decides whether this is local (skip SSH) or remote (tunnel).
+            Guaranteed non-empty — `resolve()` returns `None` rather than
+            constructing a `ResolvedUI` with an empty host.
         remote_port: TCP port the dashboard listens on inside the agent
             host. Sourced from `agent_record.config.<port_field>` when
             persisted, else the manifest's `default_port`.
-        bind: Bind scope advertised by the manifest. Always `loopback`
-            in this iteration.
+        bind: Bind scope advertised by the manifest. Closed enum — only
+            `"loopback"` is accepted in this iteration. Downstream callers
+            should look up the concrete address via `BIND_ADDRESS_MAP[bind]`.
         ssh_config: SSH-tunnel parameters: `user`, optional `port`,
-            optional `identity_file`. Empty dict for a local-only host.
+            optional `identity_file`. Empty dict when the host record
+            provides no SSH details.
     """
 
     host: str
     remote_port: int
-    bind: str
+    bind: Literal["loopback"]
     ssh_config: dict[str, Any] = field(default_factory=dict)
 
 
@@ -59,7 +79,11 @@ def _dotted_lookup(data: dict[str, Any], path: str) -> Any:
 
 
 def _primary_address(host: dict[str, Any]) -> str:
-    """Return the primary address for a host, falling back to `hostname`."""
+    """Return the primary address for a host, falling back to `hostname`.
+
+    Empty string indicates "no usable address" — `resolve()` treats that
+    as `None` rather than producing a `ResolvedUI` with an empty host.
+    """
     addresses = host.get("addresses") or []
     for addr in addresses:
         if isinstance(addr, dict) and addr.get("is_primary"):
@@ -70,6 +94,19 @@ def _primary_address(host: dict[str, Any]) -> str:
     return hostname if isinstance(hostname, str) else ""
 
 
+def _safe_identity_file(value: object) -> str | None:
+    """Return a sanitized identity-file path or `None` if it fails the safety check."""
+    if not isinstance(value, str) or not value:
+        return None
+    if any(ch in value for ch in _FORBIDDEN_IDENTITY_FILE_CHARS):
+        logger.warning(
+            "Dropping identity_file containing forbidden character "
+            "(null/newline/shell metachar)"
+        )
+        return None
+    return value
+
+
 def _build_ssh_config(host: dict[str, Any]) -> dict[str, Any]:
     """Extract SSH connection params from a host record."""
     ssh: dict[str, Any] = {}
@@ -77,10 +114,10 @@ def _build_ssh_config(host: dict[str, Any]) -> dict[str, Any]:
     if isinstance(user, str) and user:
         ssh["user"] = user
     port = host.get("ssh_port")
-    if isinstance(port, int) and port > 0:
+    if isinstance(port, int) and not isinstance(port, bool) and port > 0:
         ssh["port"] = port
-    identity = host.get("ssh_key") or host.get("identity_file")
-    if isinstance(identity, str) and identity:
+    identity = _safe_identity_file(host.get("ssh_key") or host.get("identity_file"))
+    if identity is not None:
         ssh["identity_file"] = identity
     return ssh
 
@@ -96,8 +133,10 @@ def resolve(agent_key: str) -> ResolvedUI | None:
         `features.web_ui` with `enabled: true`. Otherwise `None`.
 
         Specifically returns `None` when:
+          - the agent name is empty / whitespace,
           - the agent name is not found in `hosts.json`,
           - the agent name is ambiguous across hosts,
+          - the host record has no usable primary address,
           - the agent's manifest cannot be loaded,
           - the manifest does not declare `features.web_ui`,
           - `features.web_ui.enabled` is `False`.
@@ -107,7 +146,13 @@ def resolve(agent_key: str) -> ResolvedUI | None:
 
     try:
         match = get_agent_by_name(agent_key)
-    except ValueError:
+    except ValueError as exc:
+        # `get_agent_by_name` raises `ValueError` on ambiguous matches across
+        # hosts. We deliberately treat that as "no native UI available" rather
+        # than crashing — callers (CLI / GUI) render "not available" instead
+        # of a stack trace. A debug-level log preserves diagnosability without
+        # spamming production logs.
+        logger.debug("resolve(%s): suppressed ValueError: %s", agent_key, exc)
         return None
 
     if match is None:
@@ -117,11 +162,21 @@ def resolve(agent_key: str) -> ResolvedUI | None:
 
     try:
         manifest = load_manifest(agent_type)
-    except (ManifestNotFoundError, ManifestParseError):
+    except (ManifestNotFoundError, ManifestParseError) as exc:
+        logger.debug(
+            "resolve(%s): manifest load failed for type %r: %s",
+            agent_key,
+            agent_type,
+            exc,
+        )
         return None
 
     web_ui = manifest.get("features", {}).get("web_ui")
     if not web_ui or not web_ui.get("enabled"):
+        return None
+
+    host = _primary_address(host_record)
+    if not host:
         return None
 
     config = agent_record.get("config") or {}
@@ -136,7 +191,7 @@ def resolve(agent_key: str) -> ResolvedUI | None:
         remote_port = web_ui["default_port"]
 
     return ResolvedUI(
-        host=_primary_address(host_record),
+        host=host,
         remote_port=remote_port,
         bind=web_ui["bind"],
         ssh_config=_build_ssh_config(host_record),

--- a/src/clawrium/core/web_ui.py
+++ b/src/clawrium/core/web_ui.py
@@ -1,0 +1,143 @@
+"""Web UI resolver for native agent dashboards.
+
+Phase 1 mechanism for issue #478. Reads `features.web_ui` from an agent's
+manifest and `hosts.json` agent record, returning enough structured data
+for downstream callers (tunnel manager, CLI `clm agent open`, GUI button)
+to act on. URL construction is intentionally *not* performed here.
+
+Returns `None` whenever an agent is not installed or its manifest does
+not declare `features.web_ui` — callers should treat `None` as "no native
+UI available for this agent".
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from clawrium.core.hosts import get_agent_by_name
+from clawrium.core.registry import (
+    ManifestNotFoundError,
+    ManifestParseError,
+    load_manifest,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedUI:
+    """Resolved native-UI endpoint for an installed agent.
+
+    Attributes:
+        host: Primary address (IP or DNS name) of the agent host. Caller
+            decides whether this is local (skip SSH) or remote (tunnel).
+        remote_port: TCP port the dashboard listens on inside the agent
+            host. Sourced from `agent_record.config.<port_field>` when
+            persisted, else the manifest's `default_port`.
+        bind: Bind scope advertised by the manifest. Always `loopback`
+            in this iteration.
+        ssh_config: SSH-tunnel parameters: `user`, optional `port`,
+            optional `identity_file`. Empty dict for a local-only host.
+    """
+
+    host: str
+    remote_port: int
+    bind: str
+    ssh_config: dict[str, Any] = field(default_factory=dict)
+
+
+def _dotted_lookup(data: dict[str, Any], path: str) -> Any:
+    """Walk a dotted path into a nested dict. Returns None if any step misses."""
+    current: Any = data
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _primary_address(host: dict[str, Any]) -> str:
+    """Return the primary address for a host, falling back to `hostname`."""
+    addresses = host.get("addresses") or []
+    for addr in addresses:
+        if isinstance(addr, dict) and addr.get("is_primary"):
+            address = addr.get("address")
+            if isinstance(address, str) and address:
+                return address
+    hostname = host.get("hostname")
+    return hostname if isinstance(hostname, str) else ""
+
+
+def _build_ssh_config(host: dict[str, Any]) -> dict[str, Any]:
+    """Extract SSH connection params from a host record."""
+    ssh: dict[str, Any] = {}
+    user = host.get("user")
+    if isinstance(user, str) and user:
+        ssh["user"] = user
+    port = host.get("ssh_port")
+    if isinstance(port, int) and port > 0:
+        ssh["port"] = port
+    identity = host.get("ssh_key") or host.get("identity_file")
+    if isinstance(identity, str) and identity:
+        ssh["identity_file"] = identity
+    return ssh
+
+
+def resolve(agent_key: str) -> ResolvedUI | None:
+    """Resolve native-UI parameters for an installed agent.
+
+    Args:
+        agent_key: User-facing agent name (the key in `hosts.json.agents`).
+
+    Returns:
+        `ResolvedUI` if the agent is installed and its manifest declares
+        `features.web_ui` with `enabled: true`. Otherwise `None`.
+
+        Specifically returns `None` when:
+          - the agent name is not found in `hosts.json`,
+          - the agent name is ambiguous across hosts,
+          - the agent's manifest cannot be loaded,
+          - the manifest does not declare `features.web_ui`,
+          - `features.web_ui.enabled` is `False`.
+    """
+    if not isinstance(agent_key, str) or not agent_key.strip():
+        return None
+
+    try:
+        match = get_agent_by_name(agent_key)
+    except ValueError:
+        return None
+
+    if match is None:
+        return None
+
+    host_record, agent_type, agent_record = match
+
+    try:
+        manifest = load_manifest(agent_type)
+    except (ManifestNotFoundError, ManifestParseError):
+        return None
+
+    web_ui = manifest.get("features", {}).get("web_ui")
+    if not web_ui or not web_ui.get("enabled"):
+        return None
+
+    config = agent_record.get("config") or {}
+    persisted_port = _dotted_lookup(config, web_ui["port_field"])
+    if (
+        isinstance(persisted_port, int)
+        and not isinstance(persisted_port, bool)
+        and 0 < persisted_port <= 65535
+    ):
+        remote_port = persisted_port
+    else:
+        remote_port = web_ui["default_port"]
+
+    return ResolvedUI(
+        host=_primary_address(host_record),
+        remote_port=remote_port,
+        bind=web_ui["bind"],
+        ssh_config=_build_ssh_config(host_record),
+    )

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -13,6 +13,15 @@ features:
   # Chat dispatch resolves to the OpenAI-compatible HTTP backend for hermes.
   chat:
     type: openai
+  # Native browser dashboard shipped by hermes upstream. Bound to loopback
+  # on the agent host; clm tunnels through SSH (see issue #478). `port_field`
+  # is the dotted path inside `hosts.json.agents.<name>.config` where the
+  # per-instance dashboard port is persisted at install time.
+  web_ui:
+    enabled: true
+    bind: loopback
+    default_port: 9119
+    port_field: dashboard.port
 
 # Secrets configuration.
 # All provider keys are optional: Phase 1 installs the binary in an inert state.

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -17,6 +17,11 @@ features:
   # on the agent host; clm tunnels through SSH (see issue #478). `port_field`
   # is the dotted path inside `hosts.json.agents.<name>.config` where the
   # per-instance dashboard port is persisted at install time.
+  #
+  # default_port 9119 mirrors the upstream `hermes dashboard` default in
+  # `hermes_cli/web_server.py` (see .itx/478/00_PLAN.md for the upstream
+  # reference). Phase 2's install playbook MUST assert the deployed port
+  # matches this manifest value, or override it explicitly per-instance.
   web_ui:
     enabled: true
     bind: loopback

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1072,6 +1072,124 @@ def test_manifest_rejects_invalid_features_memory(monkeypatch):
         load_manifest("openclaw")
 
 
+def _valid_web_ui_block() -> dict:
+    """Return a minimal valid `features.web_ui` block for tests."""
+    return {
+        "enabled": True,
+        "bind": "loopback",
+        "default_port": 9119,
+        "port_field": "dashboard.port",
+    }
+
+
+def test_load_manifest_accepts_valid_web_ui(monkeypatch):
+    """A complete `features.web_ui` block round-trips through validation."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    manifest["features"] = {"web_ui": _valid_web_ui_block()}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    loaded = load_manifest("openclaw")
+    web_ui = loaded.get("features", {}).get("web_ui", {})
+    assert web_ui.get("enabled") is True
+    assert web_ui.get("bind") == "loopback"
+    assert web_ui.get("default_port") == 9119
+    assert web_ui.get("port_field") == "dashboard.port"
+
+
+def test_load_manifest_rejects_invalid_web_ui_bind(monkeypatch):
+    """`bind` is a closed enum — only `loopback` accepted in this iteration."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    block = _valid_web_ui_block()
+    block["bind"] = "0.0.0.0"
+    manifest["features"] = {"web_ui": block}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    with pytest.raises(ManifestParseError, match="features.web_ui.bind"):
+        load_manifest("openclaw")
+
+
+def test_load_manifest_rejects_web_ui_missing_default_port(monkeypatch):
+    """`default_port` is required and must be a positive integer."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    block = _valid_web_ui_block()
+    block.pop("default_port")
+    manifest["features"] = {"web_ui": block}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    with pytest.raises(ManifestParseError, match="features.web_ui.default_port"):
+        load_manifest("openclaw")
+
+
+def test_load_manifest_rejects_web_ui_non_positive_port(monkeypatch):
+    """`default_port` must be > 0 (zero/negative ports are nonsense for TCP)."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    block = _valid_web_ui_block()
+    block["default_port"] = 0
+    manifest["features"] = {"web_ui": block}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    with pytest.raises(ManifestParseError, match="features.web_ui.default_port"):
+        load_manifest("openclaw")
+
+
+def test_load_manifest_rejects_web_ui_non_bool_enabled(monkeypatch):
+    """`enabled` must be a boolean, not a truthy string."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    block = _valid_web_ui_block()
+    block["enabled"] = "yes"
+    manifest["features"] = {"web_ui": block}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    with pytest.raises(ManifestParseError, match="features.web_ui.enabled"):
+        load_manifest("openclaw")
+
+
+def test_load_manifest_rejects_web_ui_empty_port_field(monkeypatch):
+    """`port_field` must be a non-empty string (it's a config path)."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    block = _valid_web_ui_block()
+    block["port_field"] = ""
+    manifest["features"] = {"web_ui": block}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    with pytest.raises(ManifestParseError, match="features.web_ui.port_field"):
+        load_manifest("openclaw")
+
+
+def test_hermes_manifest_declares_web_ui():
+    """The bundled hermes manifest advertises native dashboard support."""
+    manifest = load_manifest("hermes")
+    web_ui = manifest.get("features", {}).get("web_ui", {})
+    assert web_ui.get("enabled") is True
+    assert web_ui.get("bind") == "loopback"
+    assert web_ui.get("default_port") == 9119
+    assert web_ui.get("port_field") == "dashboard.port"
+
+
+def test_openclaw_manifest_does_not_declare_web_ui():
+    """openclaw does not opt into the native-UI mechanism."""
+    manifest = load_manifest("openclaw")
+    assert "web_ui" not in manifest.get("features", {})
+
+
+def test_zeroclaw_manifest_does_not_declare_web_ui():
+    """zeroclaw does not opt into the native-UI mechanism."""
+    manifest = load_manifest("zeroclaw")
+    assert "web_ui" not in manifest.get("features", {})
+
+
 def test_openclaw_manifest_now_declares_memory_workspace():
     """Phase 1 backfill: openclaw manifest carries the memory metadata for Phase 3."""
     manifest = load_manifest("openclaw")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1252,31 +1252,19 @@ def test_load_manifest_rejects_web_ui_missing_field(monkeypatch, missing_field):
     "bad_port_field",
     [
         "   ",  # whitespace-only
-        "secrets.api_key",  # would be valid identifier path but flagged downstream — see below
-        "..port",  # leading dot
-        "port..nested",  # double dot
+        "..port",  # leading double dot
+        "port..nested",  # double dot in middle
         ".port",  # leading dot
         "port.",  # trailing dot
         "port name",  # space in segment
-        "__proto__.x",  # double underscore prefix is fine; this one passes the regex actually
         "9port.x",  # leading digit in first segment
+        "port-name",  # hyphen not allowed
+        "port/x",  # slash (path traversal)
     ],
 )
 def test_load_manifest_rejects_web_ui_invalid_port_field_shape(monkeypatch, bad_port_field):
-    """`port_field` must be a dotted-identifier path (rejects shell metachars, leading digits, empty segments).
-
-    Note: `secrets.api_key` and `__proto__.x` are *valid* dotted-identifier
-    paths and therefore pass the shape check — defense-in-depth happens at
-    the consumer layer in Phase 2/3 (Ansible extra-vars use parameterized
-    var substitution, not string concatenation). This test fixes the
-    *shape* contract; semantic safety is a higher-layer concern.
-    """
+    """`port_field` must be a dotted-identifier path; everything else rejected."""
     from clawrium.core import registry
-
-    # Skip the two cases that are actually valid identifier paths — they exist
-    # in the parametrize list to document the contract boundary.
-    if bad_port_field in ("secrets.api_key", "__proto__.x"):
-        return
 
     manifest = deepcopy(_valid_manifest())
     block = _valid_web_ui_block()
@@ -1286,6 +1274,39 @@ def test_load_manifest_rejects_web_ui_invalid_port_field_shape(monkeypatch, bad_
 
     with pytest.raises(ManifestParseError, match="features.web_ui.port_field"):
         load_manifest("openclaw")
+
+
+@pytest.mark.parametrize(
+    "good_port_field",
+    [
+        "port",
+        "dashboard.port",
+        "deep.nested.path.port",
+        "_underscore",
+        "with_underscore.x",
+        "__proto__.x",  # valid identifier even if semantically odd
+        "secrets.api_key",  # valid identifier — semantic safety is a higher-layer concern
+    ],
+)
+def test_load_manifest_accepts_web_ui_valid_port_field_shape(monkeypatch, good_port_field):
+    """Dotted-identifier shapes pass validation regardless of segment names.
+
+    `secrets.api_key` and `__proto__.x` are deliberately on the accept list
+    to document the contract: this validator enforces *shape* only.
+    Semantic safety (don't smuggle secrets through this field) is the
+    consumer layer's job in Phase 2 — Ansible extra-vars use parameterized
+    var substitution, not string concatenation.
+    """
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    block = _valid_web_ui_block()
+    block["port_field"] = good_port_field
+    manifest["features"] = {"web_ui": block}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    loaded = load_manifest("openclaw")
+    assert loaded["features"]["web_ui"]["port_field"] == good_port_field
 
 
 def test_allowed_web_ui_binds_matches_literal():

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1168,6 +1168,145 @@ def test_load_manifest_rejects_web_ui_empty_port_field(monkeypatch):
         load_manifest("openclaw")
 
 
+def test_load_manifest_rejects_web_ui_bool_default_port(monkeypatch):
+    """YAML `true`/`false` satisfy `isinstance(x, int)` — must be rejected."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    block = _valid_web_ui_block()
+    block["default_port"] = True
+    manifest["features"] = {"web_ui": block}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    with pytest.raises(ManifestParseError, match="features.web_ui.default_port"):
+        load_manifest("openclaw")
+
+
+@pytest.mark.parametrize(
+    "port,is_valid",
+    [
+        (-1, False),
+        (0, False),
+        (1, True),
+        (1024, True),
+        (9119, True),
+        (65535, True),
+        (65536, False),
+        (100000, False),
+    ],
+)
+def test_load_manifest_web_ui_default_port_boundaries(monkeypatch, port, is_valid):
+    """`default_port` accepts 1..65535 inclusive; everything else rejected."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    block = _valid_web_ui_block()
+    block["default_port"] = port
+    manifest["features"] = {"web_ui": block}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    if is_valid:
+        loaded = load_manifest("openclaw")
+        assert loaded["features"]["web_ui"]["default_port"] == port
+    else:
+        with pytest.raises(ManifestParseError, match="features.web_ui.default_port"):
+            load_manifest("openclaw")
+
+
+def test_load_manifest_warns_on_privileged_web_ui_port(monkeypatch, caplog):
+    """`default_port` in the privileged range emits a warning (but loads)."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    block = _valid_web_ui_block()
+    block["default_port"] = 80
+    manifest["features"] = {"web_ui": block}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    with caplog.at_level("WARNING", logger="clawrium.core.registry"):
+        loaded = load_manifest("openclaw")
+
+    assert loaded["features"]["web_ui"]["default_port"] == 80
+    assert any("privileged web_ui.default_port" in rec.message for rec in caplog.records)
+
+
+def test_load_manifest_rejects_web_ui_non_dict(monkeypatch):
+    """A scalar `features.web_ui` value must be rejected with a clear error."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    manifest["features"] = {"web_ui": "not-a-dict"}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    with pytest.raises(ManifestParseError, match="features.web_ui"):
+        load_manifest("openclaw")
+
+
+@pytest.mark.parametrize("missing_field", ["enabled", "bind", "default_port", "port_field"])
+def test_load_manifest_rejects_web_ui_missing_field(monkeypatch, missing_field):
+    """Each required `web_ui` field must be present."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    block = _valid_web_ui_block()
+    block.pop(missing_field)
+    manifest["features"] = {"web_ui": block}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    with pytest.raises(ManifestParseError, match=f"features.web_ui.{missing_field}"):
+        load_manifest("openclaw")
+
+
+@pytest.mark.parametrize(
+    "bad_port_field",
+    [
+        "   ",  # whitespace-only
+        "secrets.api_key",  # would be valid identifier path but flagged downstream — see below
+        "..port",  # leading dot
+        "port..nested",  # double dot
+        ".port",  # leading dot
+        "port.",  # trailing dot
+        "port name",  # space in segment
+        "__proto__.x",  # double underscore prefix is fine; this one passes the regex actually
+        "9port.x",  # leading digit in first segment
+    ],
+)
+def test_load_manifest_rejects_web_ui_invalid_port_field_shape(monkeypatch, bad_port_field):
+    """`port_field` must be a dotted-identifier path (rejects shell metachars, leading digits, empty segments).
+
+    Note: `secrets.api_key` and `__proto__.x` are *valid* dotted-identifier
+    paths and therefore pass the shape check — defense-in-depth happens at
+    the consumer layer in Phase 2/3 (Ansible extra-vars use parameterized
+    var substitution, not string concatenation). This test fixes the
+    *shape* contract; semantic safety is a higher-layer concern.
+    """
+    from clawrium.core import registry
+
+    # Skip the two cases that are actually valid identifier paths — they exist
+    # in the parametrize list to document the contract boundary.
+    if bad_port_field in ("secrets.api_key", "__proto__.x"):
+        return
+
+    manifest = deepcopy(_valid_manifest())
+    block = _valid_web_ui_block()
+    block["port_field"] = bad_port_field
+    manifest["features"] = {"web_ui": block}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    with pytest.raises(ManifestParseError, match="features.web_ui.port_field"):
+        load_manifest("openclaw")
+
+
+def test_allowed_web_ui_binds_matches_literal():
+    """The runtime enum and the Literal type annotation must stay in sync."""
+    import typing
+
+    from clawrium.core.registry import WebUIFeatureConfig, _ALLOWED_WEB_UI_BINDS
+
+    literal_args = typing.get_args(WebUIFeatureConfig.__annotations__["bind"])
+    assert set(literal_args) == set(_ALLOWED_WEB_UI_BINDS)
+
+
 def test_hermes_manifest_declares_web_ui():
     """The bundled hermes manifest advertises native dashboard support."""
     manifest = load_manifest("hermes")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1187,7 +1187,9 @@ def test_load_manifest_rejects_web_ui_bool_default_port(monkeypatch):
     [
         (-1, False),
         (0, False),
-        (1, True),
+        (1, False),  # privileged port rejected outright
+        (80, False),  # privileged port rejected outright
+        (1023, False),  # privileged port rejected outright
         (1024, True),
         (9119, True),
         (65535, True),
@@ -1196,7 +1198,13 @@ def test_load_manifest_rejects_web_ui_bool_default_port(monkeypatch):
     ],
 )
 def test_load_manifest_web_ui_default_port_boundaries(monkeypatch, port, is_valid):
-    """`default_port` accepts 1..65535 inclusive; everything else rejected."""
+    """`default_port` accepts 1024..65535 inclusive; everything else rejected.
+
+    Privileged ports (<1024) are rejected at manifest-load time because
+    non-root agent processes cannot bind them — `logger.warning` would be
+    invisible in the default uv-tool deployment, so a silent accept would
+    be a latent footgun.
+    """
     from clawrium.core import registry
 
     manifest = deepcopy(_valid_manifest())
@@ -1211,23 +1219,6 @@ def test_load_manifest_web_ui_default_port_boundaries(monkeypatch, port, is_vali
     else:
         with pytest.raises(ManifestParseError, match="features.web_ui.default_port"):
             load_manifest("openclaw")
-
-
-def test_load_manifest_warns_on_privileged_web_ui_port(monkeypatch, caplog):
-    """`default_port` in the privileged range emits a warning (but loads)."""
-    from clawrium.core import registry
-
-    manifest = deepcopy(_valid_manifest())
-    block = _valid_web_ui_block()
-    block["default_port"] = 80
-    manifest["features"] = {"web_ui": block}
-    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
-
-    with caplog.at_level("WARNING", logger="clawrium.core.registry"):
-        loaded = load_manifest("openclaw")
-
-    assert loaded["features"]["web_ui"]["default_port"] == 80
-    assert any("privileged web_ui.default_port" in rec.message for rec in caplog.records)
 
 
 def test_load_manifest_rejects_web_ui_non_dict(monkeypatch):

--- a/tests/test_web_ui_resolver.py
+++ b/tests/test_web_ui_resolver.py
@@ -156,6 +156,107 @@ def test_resolve_handles_unknown_agent_type(monkeypatch):
     assert resolve("x") is None
 
 
+def test_resolve_returns_none_for_host_without_address(monkeypatch):
+    """A host with no primary address and no `hostname` must yield `None`.
+
+    Otherwise the resolver would silently produce `ResolvedUI(host="")`,
+    a truthy non-None object that would feed an empty positional arg to
+    `ssh` in Phase 2.
+    """
+    host_record = {"user": "ops", "addresses": []}
+    _patch_agent(
+        monkeypatch,
+        host=host_record,
+        agent_type="hermes",
+        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+    )
+    assert resolve("demo") is None
+
+
+def test_resolve_ssh_config_includes_port_and_identity(monkeypatch):
+    """`ssh_port` and `ssh_key` from the host record flow into `ssh_config`."""
+    host_record = {
+        "hostname": "homelab",
+        "user": "ops",
+        "ssh_port": 2222,
+        "ssh_key": "/home/ops/.ssh/id_ed25519",
+        "addresses": [{"address": "homelab", "is_primary": True, "label": None}],
+    }
+    _patch_agent(
+        monkeypatch,
+        host=host_record,
+        agent_type="hermes",
+        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+    )
+
+    resolved = resolve("demo")
+    assert resolved is not None
+    assert resolved.ssh_config.get("user") == "ops"
+    assert resolved.ssh_config.get("port") == 2222
+    assert resolved.ssh_config.get("identity_file") == "/home/ops/.ssh/id_ed25519"
+
+
+def test_resolve_drops_identity_file_with_shell_metachars(monkeypatch):
+    """A malformed identity_file path (shell metachars / null bytes) is dropped."""
+    host_record = {
+        "hostname": "homelab",
+        "user": "ops",
+        "ssh_key": "/home/ops/.ssh/id_rsa; rm -rf /",
+        "addresses": [{"address": "homelab", "is_primary": True, "label": None}],
+    }
+    _patch_agent(
+        monkeypatch,
+        host=host_record,
+        agent_type="hermes",
+        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+    )
+
+    resolved = resolve("demo")
+    assert resolved is not None
+    assert "identity_file" not in resolved.ssh_config
+
+
+def test_resolve_returns_none_on_manifest_parse_error(monkeypatch):
+    """A `ManifestParseError` from `load_manifest` is treated as 'no UI available'."""
+    from clawrium.core.registry import ManifestParseError
+
+    def boom(_t):
+        raise ManifestParseError("corrupt manifest")
+
+    monkeypatch.setattr(web_ui_module, "load_manifest", boom)
+    _patch_agent(
+        monkeypatch,
+        host=_host(),
+        agent_type="hermes",
+        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+    )
+    assert resolve("demo") is None
+
+
+def test_resolve_returns_none_when_manifest_lacks_web_ui_key(monkeypatch):
+    """A manifest with `features` but no `web_ui` returns `None` (mock-based regression anchor)."""
+    manifest = {
+        "agent": {"type": "hermes", "description": "test"},
+        "platforms": [],
+        "features": {"memory": True, "chat": {"type": "openai"}},
+    }
+    monkeypatch.setattr(web_ui_module, "load_manifest", lambda _t: manifest)
+    _patch_agent(
+        monkeypatch,
+        host=_host(),
+        agent_type="hermes",
+        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+    )
+    assert resolve("demo") is None
+
+
+def test_bind_address_map_covers_loopback():
+    """`BIND_ADDRESS_MAP` is the canonical loopback → 127.0.0.1 mapping."""
+    from clawrium.core.web_ui import BIND_ADDRESS_MAP
+
+    assert BIND_ADDRESS_MAP["loopback"] == "127.0.0.1"
+
+
 def test_resolve_returns_none_when_enabled_false(monkeypatch):
     """`features.web_ui.enabled: false` should be treated as "no UI"."""
     # Sanity check that the resolver depends on enabled=True. Mock the manifest

--- a/tests/test_web_ui_resolver.py
+++ b/tests/test_web_ui_resolver.py
@@ -1,0 +1,182 @@
+"""Tests for the `clawrium.core.web_ui` resolver (issue #481).
+
+These tests cover Phase 1 mechanism only: the resolver returns
+`ResolvedUI` when the manifest declares `features.web_ui` and `None`
+otherwise. URL construction, tunnel spawning, and live health checks
+live in later phases.
+"""
+
+from clawrium.core import web_ui as web_ui_module
+from clawrium.core.web_ui import ResolvedUI, resolve
+
+
+def _host(hostname: str = "hermes-box", user: str = "xclm") -> dict:
+    return {
+        "hostname": hostname,
+        "user": user,
+        "addresses": [
+            {"address": hostname, "is_primary": True, "label": None},
+        ],
+    }
+
+
+def _patch_agent(monkeypatch, host: dict, agent_type: str, agent_record: dict) -> None:
+    monkeypatch.setattr(
+        web_ui_module,
+        "get_agent_by_name",
+        lambda _key: (host, agent_type, agent_record),
+    )
+
+
+def test_resolve_hermes_returns_default_port(monkeypatch):
+    """A hermes agent with no persisted dashboard port resolves to the manifest default."""
+    _patch_agent(
+        monkeypatch,
+        host=_host("hermes.local"),
+        agent_type="hermes",
+        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+    )
+
+    resolved = resolve("demo")
+
+    assert isinstance(resolved, ResolvedUI)
+    assert resolved.host == "hermes.local"
+    assert resolved.remote_port == 9119
+    assert resolved.bind == "loopback"
+    assert resolved.ssh_config.get("user") == "xclm"
+
+
+def test_resolve_hermes_uses_persisted_port(monkeypatch):
+    """When `config.dashboard.port` is persisted, the resolver returns it."""
+    agent_record = {
+        "agent_name": "demo",
+        "type": "hermes",
+        "config": {"dashboard": {"port": 45123, "host": "127.0.0.1"}},
+    }
+    _patch_agent(monkeypatch, host=_host(), agent_type="hermes", agent_record=agent_record)
+
+    resolved = resolve("demo")
+    assert resolved is not None
+    assert resolved.remote_port == 45123
+
+
+def test_resolve_openclaw_returns_none(monkeypatch):
+    """openclaw's manifest does not declare `features.web_ui`."""
+    _patch_agent(
+        monkeypatch,
+        host=_host(),
+        agent_type="openclaw",
+        agent_record={"agent_name": "oc", "type": "openclaw", "config": {}},
+    )
+    assert resolve("oc") is None
+
+
+def test_resolve_zeroclaw_returns_none(monkeypatch):
+    """zeroclaw's manifest does not declare `features.web_ui`."""
+    _patch_agent(
+        monkeypatch,
+        host=_host(),
+        agent_type="zeroclaw",
+        agent_record={"agent_name": "zc", "type": "zeroclaw", "config": {}},
+    )
+    assert resolve("zc") is None
+
+
+def test_resolve_missing_agent_returns_none(monkeypatch):
+    """Unknown agent name → `None` (caller decides how to surface)."""
+    monkeypatch.setattr(web_ui_module, "get_agent_by_name", lambda _key: None)
+    assert resolve("ghost") is None
+
+
+def test_resolve_ambiguous_agent_returns_none(monkeypatch):
+    """Ambiguous name (matches multiple hosts) → swallowed to `None`.
+
+    `clm chat` and similar surfaces raise an interactive prompt for this
+    case; the resolver returns `None` so the caller can render a static
+    "Native UI not available" rather than a stack trace.
+    """
+
+    def raise_ambiguous(_key):
+        raise ValueError("ambiguous across hosts")
+
+    monkeypatch.setattr(web_ui_module, "get_agent_by_name", raise_ambiguous)
+    assert resolve("dupe") is None
+
+
+def test_resolve_empty_agent_key_returns_none():
+    assert resolve("") is None
+    assert resolve("   ") is None
+
+
+def test_resolve_uses_primary_address_when_distinct_from_hostname(monkeypatch):
+    """When the host has a distinct primary address, the resolver returns it."""
+    host = {
+        "hostname": "alias",
+        "user": "ops",
+        "addresses": [
+            {"address": "10.0.0.5", "is_primary": True, "label": None},
+            {"address": "alias", "is_primary": False, "label": None},
+        ],
+    }
+    _patch_agent(
+        monkeypatch,
+        host=host,
+        agent_type="hermes",
+        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+    )
+
+    resolved = resolve("demo")
+    assert resolved is not None
+    assert resolved.host == "10.0.0.5"
+    assert resolved.ssh_config.get("user") == "ops"
+
+
+def test_resolve_falls_back_to_default_port_for_invalid_persisted(monkeypatch):
+    """A non-int (or out-of-range) persisted port is ignored; default wins."""
+    agent_record = {
+        "agent_name": "demo",
+        "type": "hermes",
+        "config": {"dashboard": {"port": "not-a-port"}},
+    }
+    _patch_agent(monkeypatch, host=_host(), agent_type="hermes", agent_record=agent_record)
+
+    resolved = resolve("demo")
+    assert resolved is not None
+    assert resolved.remote_port == 9119
+
+
+def test_resolve_handles_unknown_agent_type(monkeypatch):
+    """If the agent record references an unknown type, return `None` instead of crashing."""
+    _patch_agent(
+        monkeypatch,
+        host=_host(),
+        agent_type="nosuch",
+        agent_record={"agent_name": "x", "type": "nosuch", "config": {}},
+    )
+    assert resolve("x") is None
+
+
+def test_resolve_returns_none_when_enabled_false(monkeypatch):
+    """`features.web_ui.enabled: false` should be treated as "no UI"."""
+    # Sanity check that the resolver depends on enabled=True. Mock the manifest
+    # to flip `enabled` off.
+    manifest = {
+        "agent": {"type": "hermes", "description": "test"},
+        "platforms": [],
+        "features": {
+            "web_ui": {
+                "enabled": False,
+                "bind": "loopback",
+                "default_port": 9119,
+                "port_field": "dashboard.port",
+            }
+        },
+    }
+    monkeypatch.setattr(web_ui_module, "load_manifest", lambda _t: manifest)
+    _patch_agent(
+        monkeypatch,
+        host=_host(),
+        agent_type="hermes",
+        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+    )
+    assert resolve("demo") is None

--- a/tests/test_web_ui_resolver.py
+++ b/tests/test_web_ui_resolver.py
@@ -88,19 +88,41 @@ def test_resolve_missing_agent_returns_none(monkeypatch):
     assert resolve("ghost") is None
 
 
-def test_resolve_ambiguous_agent_returns_none(monkeypatch):
-    """Ambiguous name (matches multiple hosts) → swallowed to `None`.
+def test_resolve_ambiguous_agent_returns_none(monkeypatch, caplog):
+    """Ambiguous name (matches multiple hosts) → `None` and a WARNING log.
 
     `clm chat` and similar surfaces raise an interactive prompt for this
     case; the resolver returns `None` so the caller can render a static
-    "Native UI not available" rather than a stack trace.
+    "Native UI not available" rather than a stack trace. The log surfaces
+    the disambiguation hint to operators.
     """
 
     def raise_ambiguous(_key):
-        raise ValueError("ambiguous across hosts")
+        raise ValueError("ambiguous across hosts: demo@hostA, demo@hostB")
 
     monkeypatch.setattr(web_ui_module, "get_agent_by_name", raise_ambiguous)
-    assert resolve("dupe") is None
+    with caplog.at_level("WARNING", logger="clawrium.core.web_ui"):
+        assert resolve("dupe") is None
+    assert any("ambiguous" in rec.message for rec in caplog.records)
+
+
+def test_resolve_logs_warning_on_manifest_parse_error(monkeypatch, caplog):
+    """A corrupt manifest is operator-actionable → logged at WARNING."""
+    from clawrium.core.registry import ManifestParseError
+
+    def boom(_t):
+        raise ManifestParseError("corrupt manifest bytes")
+
+    monkeypatch.setattr(web_ui_module, "load_manifest", boom)
+    _patch_agent(
+        monkeypatch,
+        host=_host(),
+        agent_type="hermes",
+        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+    )
+    with caplog.at_level("WARNING", logger="clawrium.core.web_ui"):
+        assert resolve("demo") is None
+    assert any("corrupted" in rec.message for rec in caplog.records)
 
 
 def test_resolve_empty_agent_key_returns_none():

--- a/tests/test_web_ui_resolver.py
+++ b/tests/test_web_ui_resolver.py
@@ -106,6 +106,23 @@ def test_resolve_ambiguous_agent_returns_none(monkeypatch, caplog):
     assert any("ambiguous" in rec.message for rec in caplog.records)
 
 
+def test_resolve_returns_none_on_invalid_agent_type(monkeypatch):
+    """A tampered hosts.json with a path-traversal `type` value yields `None`."""
+    from clawrium.core.registry import InvalidAgentTypeError
+
+    def boom(_t):
+        raise InvalidAgentTypeError("path traversal in agent type")
+
+    monkeypatch.setattr(web_ui_module, "load_manifest", boom)
+    _patch_agent(
+        monkeypatch,
+        host=_host(),
+        agent_type="../evil",
+        agent_record={"agent_name": "demo", "type": "../evil", "config": {}},
+    )
+    assert resolve("demo") is None
+
+
 def test_resolve_logs_warning_on_manifest_parse_error(monkeypatch, caplog):
     """A corrupt manifest is operator-actionable → logged at WARNING."""
     from clawrium.core.registry import ManifestParseError

--- a/uv.lock
+++ b/uv.lock
@@ -349,6 +349,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "anyio" },
     { name = "jinja2" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -377,6 +378,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "anyio", specifier = ">=4.0" },
     { name = "jinja2", specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },


### PR DESCRIPTION
## Summary

- Phase 1 of issue #478: introduce `features.web_ui` manifest schema and `core/web_ui.resolve()` resolver — pure mechanism, no UI / playbook / lifecycle changes.
- Bundled hermes manifest now declares `features.web_ui` (loopback bind, default port 9119, `port_field: dashboard.port`).
- New resolver returns `ResolvedUI{ host, remote_port, bind, ssh_config }` for hermes and `None` for openclaw / zeroclaw / missing / ambiguous / corrupt-manifest / invalid-type / no-primary-address agents.

## ATX Review Summary

**Final Review: Rating 4/5 (core-lifecycle-reviewer; iter 3 single-specialist) — no blockers**
**Total Cost: ~$7.64 | Total Time: ~50m | 3 iterations**

| Review | Rating | Blocking | Status | Cost | Agents |
|--------|--------|----------|--------|------|--------|
| 1 | 3/5 | 0 | 7 warnings + 6 test gaps + 5 suggestions — all in-scope addressed | $1.82 | leader, core-lifecycle, test-coverage, security, ansible-registry |
| 2 | 3/5 | 0 | 5 new warnings (3 in-scope fixed; 2 out-of-scope deferred to Phase 3) | $3.59 | leader, cli-ux, test-coverage, security, ansible-registry, core-lifecycle |
| 3 | 4/5 (core-lifecycle) | 0 | 2 warnings + 2 suggestions — all fixed | $2.23 | core-lifecycle |

> Note: ATX does not expose per-agent model info or overall leader rating in this transport; iter 3's leader summary was not present in the captured output. Per-specialist verdicts were `WARNINGS-ONLY` across all three iterations.

<details>
<summary>Review 1 Details (Rating 3/5, 0 blockers)</summary>

**Warnings (all fixed):**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| W1 ★ | `core/web_ui.py:_primary_address` | Silent `""` → non-None `ResolvedUI(host="")` | `resolve()` returns `None` when host empty |
| W2 ★ | `core/web_ui.py:resolve` | `except ValueError: return None` swallowed silently | Added log; later promoted to WARNING (iter 2) |
| W3 | `core/registry.py:_validate_web_ui` | `port_field` accepted any non-empty string | Constrained by dotted-identifier regex |
| W4 | `core/web_ui.py:_build_ssh_config` | `identity_file` unsanitized | Added `_safe_identity_file` rejecting null/newline/shell metachars |
| W5 | `core/registry.py:_validate_web_ui` | Privileged ports (<1024) silently accepted | Initially `logger.warning`; promoted to hard rejection in iter 2 |
| W6 | `core/web_ui.py` | `loopback` → 127.0.0.1 mapping undocumented | Added `BIND_ADDRESS_MAP` constant |
| W7 | `hermes/manifest.yaml` | `default_port: 9119` not cross-referenced | Comment added citing upstream `hermes dashboard` default |

★ = cross-specialist consensus.

**Test gaps (all closed):**

| # | Gap | Resolution |
|---|-----|------------|
| G1 | `default_port` boundaries (1/65535/65536/-1) | Parametrized boundary suite |
| G2 | `default_port=True` YAML bool path | Explicit rejection test |
| G3 | Non-dict `features.web_ui` | Explicit rejection test |
| G4 | `ManifestParseError` catch arm | Mock-based resolver test |
| G5 | `ssh_config['port']` / `['identity_file']` | New resolver test asserts both |
| G6 | Empty-address host → `ResolvedUI(host="")` | Negative-path test drives the W1 fix |

**Suggestions:**

| # | Status | Item |
|---|--------|------|
| S1 ★ | Fixed | `ResolvedUI.bind` typed as `Literal["loopback"]` |
| S2 | Fixed | Test asserts `_ALLOWED_WEB_UI_BINDS` ↔ `WebUIFeatureConfig.bind` Literal sync |
| S3 | Fixed | `port_field.strip()` guard |
| S4 | Deferred | `anyio<5` upper bound — outside #481 scope |
| S5 | Fixed | Mock-based regression anchor for missing-`web_ui` branch |

</details>

<details>
<summary>Review 2 Details (Rating 3/5, 0 blockers)</summary>

**Warnings:**

| # | Status | Issue | Resolution |
|---|--------|-------|------------|
| 1 | Fixed | `ValueError` swallowed at DEBUG (invisible in `uv tool` deployments) | Promoted to WARNING with disambiguation hint |
| 2 | Fixed | `ManifestParseError` at DEBUG (operator-actionable) | Split `except`: `ManifestNotFoundError` stays DEBUG, `ManifestParseError` → WARNING |
| 3 | Fixed | Privileged-port `logger.warning` invisible in CLI | Converted to hard rejection at manifest-load time (range 1024..65535) |
| 4 | Out-of-scope | TUI drift: `AgentViewModel` has no `dashboard_port` | Deferred to Phase 3 / #483 — Phase 1 is pure mechanism |
| 5 | Out-of-scope | `resolve()` returns `None` for both "no UI" and "no host" — caller-level distinction needed | Deferred to Phase 3 / #483 when `clm agent open` is implemented |

</details>

<details>
<summary>Review 3 Details (Rating 4/5 from core-lifecycle, 0 blockers)</summary>

**Warnings (all fixed):**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| 1 | `core/registry.py:_validate_web_ui` | Stale docstring claimed privileged ports were accepted-with-warning | Docstring rewritten to reflect rejection |
| 2 | `core/web_ui.py:resolve` | `InvalidAgentTypeError` from `load_manifest` was uncaught | Added to the `ManifestNotFoundError` except arm |

**Suggestions (all fixed):**

| # | Item | Resolution |
|---|------|------------|
| 1 | Skip-via-return inside `@parametrize` hid 2 borderline valid cases | Split into rejection + acceptance parametrized tests |
| 2 | Persisted-port lower-bound asymmetry vs validator undocumented | Inline comment added on the deliberate asymmetry |

</details>

## Testing

- **Python tests:** `make test-py` → 2497 passed (was 2456; +41 new tests across iterations).
- **JS tests:** `make test-ui` → 213 passed.
- **Lint:** `make lint-py` → clean.
- **Manifest sanity:**
  - `load_manifest("hermes")["features"]["web_ui"]` returns the expected block (enabled, loopback, 9119, dashboard.port).
  - `load_manifest("openclaw")["features"]` has no `web_ui` key (no behavior change).

### Security Checklist

- [x] No hardcoded secrets or credentials.
- [x] Manifest input validated: closed `bind` enum, port range 1024..65535, `port_field` dotted-identifier regex, all required fields enforced.
- [x] Host-record input sanitized: `identity_file` rejected if it contains null bytes, newlines, or shell metachars (`;`, `&`, `|`, backtick, `$`).
- [x] No new runtime dependencies. Lockfile drift (`anyio` dev-dep already declared in `pyproject.toml`) is harmless.

## Reviewer Notes

- Phase 1 scope only. Install playbook changes (Phase 2 / #482) and CLI/GUI surfaces (Phase 3 / #483) intentionally land in follow-up PRs.
- `_validate_web_ui` rejects `bool` masquerading as `int` (`isinstance(True, int)` is `True` in Python; the validator checks `not isinstance(x, bool)` explicitly).
- Resolver intentionally swallows `ValueError` (ambiguous match), `ManifestNotFoundError` / `InvalidAgentTypeError` (type unresolvable), and `ManifestParseError` (corrupt manifest) to `None`. `KeyError` and other unexpected exceptions are deliberately *not* caught.

## Callouts

- [ENVIRONMENT] Project-board "Executing" status flip skipped.
  - Local `gh` token lacks the `project` scope. Documented here so reviewer / orchestrator can move the card manually if needed.

- [DECISION] Privileged ports (<1024) rejected outright at manifest-load time (changed in iter 2).
  - Why: `logger.warning` is invisible in the default `uv tool install` deployment where no Python logging handler is configured. A silent accept is a footgun; failing loudly at manifest-load time forces the manifest author to declare intent explicitly. ATX iter 2 cli-ux reviewer confirmed this trade-off.
  - Alternatives considered: surface a console-visible notice in `clm registry show` (rejected — requires CLI-layer changes that don't belong in Phase 1).

- [DECISION] Persisted ports accepted down to 1, but manifest `default_port` requires ≥1024.
  - Why: A manifest is a contract authored once; a per-instance override in `hosts.json` is an operator-time decision. The validator forbids the contract from declaring a privileged default; the resolver trusts an operator override and lets the bind attempt at agent-start time surface any privilege error.
  - Reviewer: confirm or push back.

- [DECISION] `port_field` shape validator allows `secrets.api_key` and `__proto__.x`.
  - Why: this validator enforces *shape* only (dotted identifier). Semantic safety (don't smuggle secret-name lookups through this field) is the consumer layer's job in Phase 2 — Ansible extra-vars use parameterized var substitution, not string concatenation.
  - Reviewer: confirm or push back.

- [DECISION] Included `uv.lock` update (adds `anyio` dev-dep entry).
  - Why: `pyproject.toml` already declares `anyio>=4.0` as a dev-dependency but the lockfile didn't have the corresponding entry. `uv sync` (triggered by `make test`) wrote the new lockfile rows. Committing keeps `main` in sync with `pyproject.toml`.

- [TODO-FOLLOWUP] TUI drift surfaced by ATX iter 2: `AgentViewModel` and `DetailCards` have no `dashboard_port` / `dashboard_url` fields.
  - Tracking: Phase 3 / issue #483. The hermes manifest now declares `features.web_ui`, but the TUI surface for it is part of "clm agent open + GUI button" work.

- [TODO-FOLLOWUP] Caller-level distinction between `None` reasons (no `web_ui` feature vs. no primary address vs. ambiguous name) deferred.
  - Tracking: Phase 3 / issue #483. The `clm agent open` command (Phase 3) will surface a specific remediation hint per reason; the resolver itself stays a simple `Optional[ResolvedUI]` to keep the contract minimal.

- [TODO-FOLLOWUP] `anyio<5` upper bound on the dev-dep (ATX iter 1 S4) not applied.
  - Tracking: out of scope for #481. File a separate dep-hygiene ticket if desired.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
