### PR TITLE
feat(hermes): dashboard systemd unit + port persistence (#478 phase 2)

### DIFF
--- a/.itx/482/01_EXECUTION.md
+++ b/.itx/482/01_EXECUTION.md
@@ -1,0 +1,75 @@
+# Issue #482 — Execution Log
+
+Parent issue: #478 (Phase 2 of 3)
+Stacked on: `issue-481-manifest-web-ui` (PR #486)
+
+## Summary of work landed
+
+- `src/clawrium/core/install.py`:
+  - Compute per-instance hermes dashboard port via
+    `45000 + (md5(agent_name) % 2000)` with collision-bump (wraps within
+    45000..46999) when another agent on the same host owns the slot.
+  - Capture existing port BEFORE `set_installing` wipes the agent record
+    (`preserved_dashboard_port`), so re-install is a no-op for the port.
+  - Persist `config.dashboard = { enabled, host: 127.0.0.1, port }` to
+    `hosts.json.agents.<name>` in `set_installed`.
+  - Pass `dashboard_port` as an Ansible inventory var to the install
+    playbook.
+- `src/clawrium/platform/registry/hermes/playbooks/install.yaml`:
+  - Resolve hermes interpreter from `~/.local/bin/hermes` shebang
+    (rather than guessing the uv venv layout — uv has moved paths
+    between releases) and `pip install --upgrade hermes-agent[web,pty]`
+    into it.
+  - Verify `node --version` ≥ 18; fail with an apt remediation message.
+  - Drop `hermes-dashboard-<agent_name>.service` with
+    `PartOf=hermes-<agent_name>.service`, `Also=` in `[Install]`,
+    `ExecStart=/home/<user>/.local/bin/hermes dashboard --host 127.0.0.1
+    --port {{ dashboard_port }} --no-open --tui`, and
+    `Environment=HERMES_DASHBOARD_TUI=1`.
+- `src/clawrium/platform/registry/hermes/playbooks/start.yaml`:
+  - Re-render dashboard unit on every start (idempotent), guarded on
+    `dashboard_port is defined` so legacy agents continue to start.
+  - Enable + start the dashboard unit when its file exists.
+- `src/clawrium/platform/registry/hermes/playbooks/stop.yaml`:
+  - Stop + disable dashboard unit BEFORE the gateway unit (PartOf
+    propagation also covers this, but explicit stop is robust against
+    PartOf misconfiguration on existing hosts).
+- `src/clawrium/platform/registry/hermes/playbooks/remove.yaml`:
+  - Stop / disable / remove dashboard unit file alongside gateway unit.
+- `src/clawrium/core/lifecycle.py`:
+  - `_run_lifecycle_playbook` reads `config.dashboard.port` from the
+    agent record and injects it as `dashboard_port` for hermes agents,
+    so start/stop/remove can re-render the dashboard unit.
+- Tests:
+  - 4 new tests in `tests/test_install.py` covering: deterministic port
+    hashing, persistence to `hosts.json` + ansible inventory, collision
+    bump, re-install port preservation.
+  - 9 new tests in `tests/test_hermes_playbooks.py` covering: extras
+    install, shebang-based interpreter discovery, Node ≥ 18 gate,
+    dashboard unit structure (PartOf, Also, ExecStart, env, loopback
+    bind), and lifecycle (start/stop/remove) integration with the
+    dashboard unit.
+- `make test-py` → 2469 passed, 6 skipped. `make lint-py` → clean.
+
+## Out of scope (deferred to Phase 3 / #483)
+
+- CLI `clm agent open`, tunnel manager, GUI button, docs.
+
+---
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-22T16:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 482 --pr-base=issue-481-manifest-web-ui
+```
+
+**Output**: Implemented hermes dashboard port persistence + companion
+systemd unit + lifecycle propagation. PR opened against
+`issue-481-manifest-web-ui` (stacked on top of PR #486 / Phase 1).
+ATX review attempted via `mcp__atx__request_review` — not available in
+this entry path; recorded as `[ENVIRONMENT]` Callout on the PR.

--- a/.itx/482/atx-session.json
+++ b/.itx/482/atx-session.json
@@ -1,11 +1,15 @@
 {
-  "session_id": "d051f033-fa57-4b74-9793-cef1abf8bca4",
+  "session_id": "iter-1: b3d32c2b-47ee-4e4d-87c6-21f296fae58b / iter-2: 6ab58a47-89d8-4285-85c2-5fbca33e5009-equiv / iter-3: cleared",
   "transport": "cli",
-  "commit_sha": "pending-commit",
-  "iteration": 1,
-  "last_rating": null,
+  "commit_sha": "fb1cb87",
+  "iteration": 3,
+  "last_rating": "4-5/5 (security:5, ansible:5, core-lifecycle:4, test-coverage:4)",
   "last_blockers": [],
   "started_at": "2026-05-22T15:28:12Z",
-  "updated_at": "2026-05-22T15:33:17Z",
-  "notes": "atx review --format json timed out after 5m0s on iteration 1. CLI present at /home/devashish/bin/atx but no live hook-driven session. Proceeding without ATX per skill fallback chain."
+  "updated_at": "2026-05-22T16:30:00Z",
+  "iterations": [
+    { "n": 1, "rating": "2/5", "blockers": ["B1: pool exhaustion", "B2: lifecycle tests"], "fixed_in": "4d999bb" },
+    { "n": 2, "rating": "2/5", "blockers": ["B-iter2-1: configure.yaml Also=", "B-iter2-2: B1 test gap"], "fixed_in": "fb1cb87" },
+    { "n": 3, "rating": "4-5/5", "blockers": [], "status": "cleared" }
+  ]
 }

--- a/.itx/482/atx-session.json
+++ b/.itx/482/atx-session.json
@@ -1,0 +1,11 @@
+{
+  "session_id": "d051f033-fa57-4b74-9793-cef1abf8bca4",
+  "transport": "cli",
+  "commit_sha": "pending-commit",
+  "iteration": 1,
+  "last_rating": null,
+  "last_blockers": [],
+  "started_at": "2026-05-22T15:28:12Z",
+  "updated_at": "2026-05-22T15:33:17Z",
+  "notes": "atx review --format json timed out after 5m0s on iteration 1. CLI present at /home/devashish/bin/atx but no live hook-driven session. Proceeding without ATX per skill fallback chain."
+}

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -381,6 +381,11 @@ def run_installation(
     # has nothing to write back — without this capture the credentials would
     # silently disappear on every clean re-install at the same version.
     preserved_gateway = [None]
+    # Capture hermes dashboard port BEFORE set_installing() wipes the agent
+    # record. Re-install must not silently move the dashboard to a new port —
+    # the systemd unit was rendered against the original value and any open
+    # tunnels would break.
+    preserved_dashboard_port = [None]
 
     def set_installing(h: dict) -> dict:
         # Check for incomplete installation under lock (unless cleanup or resume)
@@ -442,6 +447,19 @@ def run_installation(
                 preserved_gateway[0] = (
                     h["agents"][chosen_name[0]].get("config", {}).get("gateway")
                 )
+            if claw_name == "hermes":
+                existing_port = (
+                    h["agents"][chosen_name[0]]
+                    .get("config", {})
+                    .get("dashboard", {})
+                    .get("port")
+                )
+                if (
+                    isinstance(existing_port, int)
+                    and not isinstance(existing_port, bool)
+                    and 0 < existing_port <= 65535
+                ):
+                    preserved_dashboard_port[0] = existing_port
             h["agents"][chosen_name[0]]["status"] = "installing"
             h["agents"][chosen_name[0]]["error"] = None
             h["agents"][chosen_name[0]]["version"] = matched_version  # Update version
@@ -467,6 +485,19 @@ def run_installation(
                         .get("config", {})
                         .get("gateway")
                     )
+                if claw_name == "hermes":
+                    existing_port = (
+                        h["agents"][chosen_name[0]]
+                        .get("config", {})
+                        .get("dashboard", {})
+                        .get("port")
+                    )
+                    if (
+                        isinstance(existing_port, int)
+                        and not isinstance(existing_port, bool)
+                        and 0 < existing_port <= 65535
+                    ):
+                        preserved_dashboard_port[0] = existing_port
 
             h["agents"][chosen_name[0]] = {
                 "type": claw_name,
@@ -532,6 +563,47 @@ def run_installation(
     port_hash = int(hashlib.md5(agent_name.encode()).hexdigest(), 16)
     openclaw_port = 40000 + (port_hash % 2000)
 
+    # Hermes dashboard port (issue #478 phase 2). Persisted to
+    # hosts.json.agents.<name>.config.dashboard.port so the web-ui resolver
+    # and `clm agent open` agree on the loopback port the dashboard binds to.
+    # On re-install we MUST preserve the existing port: the dashboard systemd
+    # unit was rendered against the original port and silently moving to a
+    # new value would break any running tunnels.
+    dashboard_port = None
+    if claw_name == "hermes":
+        # preserved_dashboard_port is captured inside set_installing() right
+        # before the agent record is wiped. Reading from `host` here would
+        # see the wiped record in test environments (where get_host returns
+        # the same dict that update_host mutates) and on the resume path.
+        if preserved_dashboard_port[0] is not None:
+            dashboard_port = preserved_dashboard_port[0]
+        else:
+            candidate = 45000 + (port_hash % 2000)
+            # Collision check: another agent on the same host may already own
+            # the candidate port. Bump by +1 (wrapping within the 45000..46999
+            # window) until free. Hash collisions are rare but possible
+            # because the openclaw port also uses md5(agent_name) % 2000.
+            used_ports: set[int] = set()
+            for other_key, other_agent in host.get("agents", {}).items():
+                if other_key == agent_name or not isinstance(other_agent, dict):
+                    continue
+                other_port = (
+                    other_agent.get("config", {})
+                    .get("dashboard", {})
+                    .get("port")
+                )
+                if isinstance(other_port, int) and not isinstance(other_port, bool):
+                    used_ports.add(other_port)
+            # Bounded loop: 2000-port window; even if every slot were taken
+            # we exit after 2000 iterations.
+            for _ in range(2000):
+                if candidate not in used_ports:
+                    break
+                candidate += 1
+                if candidate > 46999:
+                    candidate = 45000
+            dashboard_port = candidate
+
     # Generate auth token for gateway access
     import secrets
 
@@ -594,6 +666,11 @@ def run_installation(
             "port": 8642,
             "key": hermes_api_server_key,
         }
+        config["dashboard"] = {
+            "enabled": True,
+            "host": "127.0.0.1",
+            "port": dashboard_port,
+        }
 
     inventory = {
         "all": {
@@ -613,6 +690,7 @@ def run_installation(
                 "config": config,
                 "template_path": str(template_path),
                 "force_install": force,
+                "dashboard_port": dashboard_port,
                 **secret_vars,  # Inject secrets as ansible vars
             },
         }
@@ -911,6 +989,19 @@ def run_installation(
                         "enabled": True,
                         "host": "0.0.0.0",
                         "port": 8642,
+                    }
+
+                # Persist hermes dashboard shape so the web_ui resolver and
+                # `clm agent open` can read host/port without recomputing.
+                # Loopback-only — the SSH tunnel is the authentication
+                # boundary (issue #478).
+                if claw_name == "hermes" and dashboard_port is not None:
+                    if "config" not in h["agents"][agent_name]:
+                        h["agents"][agent_name]["config"] = {}
+                    h["agents"][agent_name]["config"]["dashboard"] = {
+                        "enabled": True,
+                        "host": "127.0.0.1",
+                        "port": dashboard_port,
                     }
             return h
 

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -454,10 +454,13 @@ def run_installation(
                     .get("dashboard", {})
                     .get("port")
                 )
+                # ATX W5: restrict to the documented allocation window so a
+                # hand-edited hosts.json with `port: 80` cannot escape into
+                # the systemd ExecStart.
                 if (
                     isinstance(existing_port, int)
                     and not isinstance(existing_port, bool)
-                    and 0 < existing_port <= 65535
+                    and 45000 <= existing_port <= 46999
                 ):
                     preserved_dashboard_port[0] = existing_port
             h["agents"][chosen_name[0]]["status"] = "installing"
@@ -492,10 +495,11 @@ def run_installation(
                         .get("dashboard", {})
                         .get("port")
                     )
+                    # ATX W5: restrict to the documented allocation window.
                     if (
                         isinstance(existing_port, int)
                         and not isinstance(existing_port, bool)
-                        and 0 < existing_port <= 65535
+                        and 45000 <= existing_port <= 46999
                     ):
                         preserved_dashboard_port[0] = existing_port
 
@@ -594,14 +598,24 @@ def run_installation(
                 )
                 if isinstance(other_port, int) and not isinstance(other_port, bool):
                     used_ports.add(other_port)
-            # Bounded loop: 2000-port window; even if every slot were taken
-            # we exit after 2000 iterations.
+            # Bounded loop with `for/else` exhaustion sentinel: if every slot
+            # in the 45000..46999 window is taken we MUST raise rather than
+            # silently land on a colliding port (ATX B1). Without the
+            # sentinel the loop exits with `candidate in used_ports` still
+            # true and the install proceeds with a broken dashboard.
             for _ in range(2000):
                 if candidate not in used_ports:
                     break
                 candidate += 1
                 if candidate > 46999:
                     candidate = 45000
+            else:
+                raise InstallationError(
+                    "Dashboard port pool exhausted on "
+                    f"{host['hostname']} (all 2000 slots in "
+                    "45000-46999 are occupied). Remove unused hermes "
+                    "agents before installing another."
+                )
             dashboard_port = candidate
 
     # Generate auth token for gateway access
@@ -690,7 +704,15 @@ def run_installation(
                 "config": config,
                 "template_path": str(template_path),
                 "force_install": force,
-                "dashboard_port": dashboard_port,
+                # ATX W2: scope dashboard_port to hermes only. Unconditional
+                # injection puts `dashboard_port: null` in non-hermes
+                # inventories where `when: dashboard_port is defined`
+                # would silently evaluate True.
+                **(
+                    {"dashboard_port": dashboard_port}
+                    if dashboard_port is not None
+                    else {}
+                ),
                 **secret_vars,  # Inject secrets as ansible vars
             },
         }

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -332,10 +332,13 @@ def _run_lifecycle_playbook(
             else {}
         )
         dashboard_port = dashboard.get("port") if isinstance(dashboard, dict) else None
+        # ATX W5: restrict to the documented allocation window so a
+        # tampered hosts.json cannot inject a privileged or third-party
+        # port into the ansible inventory.
         if (
             isinstance(dashboard_port, int)
             and not isinstance(dashboard_port, bool)
-            and 0 < dashboard_port <= 65535
+            and 45000 <= dashboard_port <= 46999
         ):
             extra_vars["dashboard_port"] = dashboard_port
 

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -316,6 +316,29 @@ def _run_lifecycle_playbook(
     except Exception:
         pass
 
+    extra_vars: dict[str, object] = {}
+
+    # Issue #478 phase 2: hermes start/stop/remove playbooks need to re-render
+    # the dashboard systemd unit, which requires the per-instance loopback
+    # port persisted at install time. Pull it from hosts.json on every
+    # lifecycle op so the unit stays consistent if `clm` is upgraded
+    # between install and the next restart. Absent for agents installed
+    # before this change — the playbook guards on `dashboard_port is defined`.
+    if _resolve_agent_type(agent_type) == "hermes":
+        agent_record = host.get("agents", {}).get(agent_name, {})
+        dashboard = (
+            agent_record.get("config", {}).get("dashboard", {})
+            if isinstance(agent_record, dict)
+            else {}
+        )
+        dashboard_port = dashboard.get("port") if isinstance(dashboard, dict) else None
+        if (
+            isinstance(dashboard_port, int)
+            and not isinstance(dashboard_port, bool)
+            and 0 < dashboard_port <= 65535
+        ):
+            extra_vars["dashboard_port"] = dashboard_port
+
     inventory = {
         "all": {
             "hosts": {
@@ -328,6 +351,7 @@ def _run_lifecycle_playbook(
             "vars": {
                 "agent_name": agent_name,
                 "agent_type": agent_type,
+                **extra_vars,
                 **secret_vars,
             },
         }

--- a/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
@@ -63,6 +63,11 @@
     # to a pre-installed per-user systemd unit and exits 1 if that unit isn't
     # there — see `hermes gateway --help`). Phase 1's install.yaml dropped the
     # initial unit; configure.yaml owns the runtime ExecStart.
+    # ATX iter-2 blocker fix: re-rendering the gateway unit here MUST also
+    # carry `Also=<dashboard>` so a `clm agent configure` after install
+    # does not silently drop the directive set by install.yaml. Without
+    # this, `systemctl enable hermes-<name>` stops pulling the dashboard
+    # companion on every reconfigure.
     - name: Sync hermes systemd unit (Phase 2 ExecStart)
       ansible.builtin.copy:
         dest: "/etc/systemd/system/{{ agent_type }}-{{ agent_name }}.service"
@@ -85,7 +90,9 @@
 
           [Install]
           WantedBy=multi-user.target
+          Also={{ agent_type }}-dashboard-{{ agent_name }}.service
         mode: "0644"
+      no_log: true
       notify: Restart hermes service
 
     # Render ~/.hermes/.env (provider API key + API_SERVER_* + low-priority

--- a/src/clawrium/platform/registry/hermes/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/install.yaml
@@ -180,6 +180,74 @@
         group: "{{ agent_name }}"
         mode: "0700"
 
+    # Issue #478 phase 2: native dashboard support.
+    #
+    # The upstream `hermes` CLI lives at /home/<agent>/.local/bin/hermes and
+    # is a thin wrapper whose shebang points at the interpreter inside the
+    # uv-managed venv. Read the shebang directly rather than guessing the
+    # venv layout — uv has changed its on-disk paths between releases.
+    - name: Discover hermes interpreter path from binary shebang
+      ansible.builtin.shell: |
+        set -euo pipefail
+        head -n1 /home/{{ agent_name }}/.local/bin/hermes \
+          | sed -e 's|^#!||' -e 's| .*||'
+      register: hermes_interpreter
+      changed_when: false
+      become_user: "{{ agent_name }}"
+
+    - name: Fail if hermes interpreter could not be resolved
+      ansible.builtin.fail:
+        msg: >-
+          Could not resolve hermes interpreter from
+          /home/{{ agent_name }}/.local/bin/hermes shebang.
+          Re-run with --force, or inspect the file manually.
+      when: (hermes_interpreter.stdout | default('')) | length == 0
+
+    # Install `hermes-agent[web,pty]` extras into the same interpreter the
+    # upstream installer used. `--upgrade` is required because the upstream
+    # script already installed the base `hermes-agent` package; without it
+    # pip skips the install (and therefore the extras) as already satisfied.
+    - name: Install hermes-agent[web,pty] extras (dashboard + pty support)
+      ansible.builtin.command:
+        argv:
+          - "{{ hermes_interpreter.stdout }}"
+          - -m
+          - pip
+          - install
+          - --upgrade
+          - "hermes-agent[web,pty]"
+      become_user: "{{ agent_name }}"
+      register: hermes_extras_install
+      changed_when: "'Successfully installed' in (hermes_extras_install.stdout | default(''))"
+
+    # Node >= 18 is required for the dashboard SPA to build on first launch.
+    # `command -v node` succeeds even on broken installs; we additionally
+    # parse the major version. Surface a remediation message rather than the
+    # raw shell error so the operator knows exactly what to do.
+    - name: Verify Node.js >= 18 is present
+      ansible.builtin.shell: |
+        set -euo pipefail
+        if ! command -v node >/dev/null 2>&1; then
+          echo "missing"
+          exit 0
+        fi
+        node --version | sed -e 's/^v//' -e 's/\..*//'
+      register: node_version_major
+      changed_when: false
+      failed_when: false
+
+    - name: Fail if Node.js missing or older than v18
+      ansible.builtin.fail:
+        msg: >-
+          The hermes dashboard requires Node.js >= 18 on the agent host.
+          Detected: '{{ node_version_major.stdout | default('missing') }}'.
+          Install with: `sudo apt install -y nodejs npm` (or use nodesource
+          for a newer release).
+      when: >-
+        (node_version_major.stdout | default('missing')) == 'missing'
+        or not ((node_version_major.stdout | default('0')) is match('^[0-9]+$'))
+        or (node_version_major.stdout | default('0') | int) < 18
+
     # Service is dropped DISABLED and NOT started. Phase 2 (configure) writes
     # provider credentials to .env and turns the unit on. Calling
     # `clm agent start` before configure will start the unit, but hermes will
@@ -204,6 +272,37 @@
 
           [Install]
           WantedBy=multi-user.target
+        mode: "0644"
+      notify: Reload systemd
+
+    # Companion dashboard unit. `PartOf=` makes systemd propagate stop/restart
+    # from the gateway unit to this one automatically. `Also=` in the gateway
+    # unit's [Install] would be the symmetric hook, but we keep the dashboard
+    # unit's own [Install] WantedBy=multi-user.target so `systemctl enable
+    # hermes-dashboard-<name>` is also valid as a standalone action. ExecStart
+    # binds to loopback only — the SSH tunnel is the authentication boundary.
+    - name: Create dashboard systemd service file (disabled, not started)
+      ansible.builtin.copy:
+        dest: "/etc/systemd/system/{{ agent_type }}-dashboard-{{ agent_name }}.service"
+        content: |
+          [Unit]
+          Description=Hermes Dashboard ({{ agent_name }})
+          After=network.target
+          PartOf={{ agent_type }}-{{ agent_name }}.service
+
+          [Service]
+          Type=simple
+          User={{ agent_name }}
+          WorkingDirectory=/home/{{ agent_name }}/.hermes
+          EnvironmentFile=/home/{{ agent_name }}/.hermes/.env
+          Environment=HERMES_DASHBOARD_TUI=1
+          ExecStart=/home/{{ agent_name }}/.local/bin/hermes dashboard --host 127.0.0.1 --port {{ dashboard_port }} --no-open --tui
+          Restart=on-failure
+          RestartSec=5
+
+          [Install]
+          WantedBy=multi-user.target
+          Also={{ agent_type }}-{{ agent_name }}.service
         mode: "0644"
       notify: Reload systemd
 

--- a/src/clawrium/platform/registry/hermes/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/install.yaml
@@ -253,6 +253,14 @@
     # `clm agent start` before configure will start the unit, but hermes will
     # exit immediately because no provider is configured — documented in the
     # plan as expected behavior.
+    #
+    # `Also=` lives on the GATEWAY unit (this one), not the dashboard unit:
+    # systemd's `Also=` is symmetric on enable/disable, so the directive
+    # belongs on the unit whose lifecycle should pull the dependent. Enabling
+    # the gateway → enables the dashboard companion. Disabling the gateway
+    # → disables the dashboard. The reverse (disabling the dashboard alone)
+    # MUST NOT take the gateway down with it — that's why `Also=` is here
+    # and not on the dashboard side (ATX W1).
     - name: Create systemd service file (disabled, not started)
       ansible.builtin.copy:
         dest: "/etc/systemd/system/{{ agent_type }}-{{ agent_name }}.service"
@@ -272,15 +280,15 @@
 
           [Install]
           WantedBy=multi-user.target
+          Also={{ agent_type }}-dashboard-{{ agent_name }}.service
         mode: "0644"
+      no_log: true
       notify: Reload systemd
 
     # Companion dashboard unit. `PartOf=` makes systemd propagate stop/restart
-    # from the gateway unit to this one automatically. `Also=` in the gateway
-    # unit's [Install] would be the symmetric hook, but we keep the dashboard
-    # unit's own [Install] WantedBy=multi-user.target so `systemctl enable
-    # hermes-dashboard-<name>` is also valid as a standalone action. ExecStart
-    # binds to loopback only — the SSH tunnel is the authentication boundary.
+    # from the gateway unit to this one automatically. The gateway unit's
+    # `Also=` (above) is the symmetric enable/disable hook. ExecStart binds
+    # to loopback only — the SSH tunnel is the authentication boundary.
     - name: Create dashboard systemd service file (disabled, not started)
       ansible.builtin.copy:
         dest: "/etc/systemd/system/{{ agent_type }}-dashboard-{{ agent_name }}.service"
@@ -302,13 +310,16 @@
 
           [Install]
           WantedBy=multi-user.target
-          Also={{ agent_type }}-{{ agent_name }}.service
         mode: "0644"
+      no_log: true
       notify: Reload systemd
 
-    - name: Reload systemd to pick up unit file
-      ansible.builtin.systemd:
-        daemon_reload: yes
+    # ATX W6: eager daemon-reload removed. The two unit-file copy tasks
+    # above notify the `Reload systemd` handler; a flush_handlers ensures
+    # the reload runs before the success message (and any future tasks
+    # below) without firing twice when nothing changed.
+    - name: Flush handlers to apply systemd daemon-reload
+      ansible.builtin.meta: flush_handlers
 
     - name: Display install success
       ansible.builtin.debug:

--- a/src/clawrium/platform/registry/hermes/playbooks/remove.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/remove.yaml
@@ -8,6 +8,25 @@
         path: "/etc/systemd/system/{{ agent_type }}-{{ agent_name }}.service"
       register: service_file
 
+    - name: Check if dashboard systemd unit exists
+      ansible.builtin.stat:
+        path: "/etc/systemd/system/{{ agent_type }}-dashboard-{{ agent_name }}.service"
+      register: dashboard_unit_file
+
+    - name: Stop hermes dashboard service if running
+      ansible.builtin.systemd:
+        name: "{{ agent_type }}-dashboard-{{ agent_name }}"
+        state: stopped
+      when: dashboard_unit_file.stat.exists
+      ignore_errors: yes
+
+    - name: Disable hermes dashboard service
+      ansible.builtin.systemd:
+        name: "{{ agent_type }}-dashboard-{{ agent_name }}"
+        enabled: no
+      when: dashboard_unit_file.stat.exists
+      ignore_errors: yes
+
     - name: Stop hermes service if running
       ansible.builtin.systemd:
         name: "{{ agent_type }}-{{ agent_name }}"
@@ -21,6 +40,12 @@
         enabled: no
       when: service_file.stat.exists
       ignore_errors: yes
+
+    - name: Remove dashboard systemd unit file
+      ansible.builtin.file:
+        path: "/etc/systemd/system/{{ agent_type }}-dashboard-{{ agent_name }}.service"
+        state: absent
+      notify: Reload systemd
 
     - name: Remove systemd service file
       ansible.builtin.file:

--- a/src/clawrium/platform/registry/hermes/playbooks/start.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/start.yaml
@@ -41,6 +41,45 @@
         daemon_reload: yes
       when: service_file_changed.changed
 
+    # Re-render the dashboard unit (issue #478 phase 2). `dashboard_port` is
+    # passed from lifecycle.py via hosts.json.agents.<name>.config.dashboard.
+    # Re-rendering here keeps the unit in sync if a future clm upgrade
+    # changes the ExecStart shape without forcing a full re-install. The
+    # `when:` guard lets agents installed before this change continue to
+    # start (the dashboard unit just stays absent).
+    - name: Sync dashboard systemd service file
+      ansible.builtin.copy:
+        dest: "/etc/systemd/system/{{ agent_type }}-dashboard-{{ agent_name }}.service"
+        content: |
+          [Unit]
+          Description=Hermes Dashboard ({{ agent_name }})
+          After=network.target
+          PartOf={{ agent_type }}-{{ agent_name }}.service
+
+          [Service]
+          Type=simple
+          User={{ agent_name }}
+          WorkingDirectory=/home/{{ agent_name }}/.hermes
+          EnvironmentFile=/home/{{ agent_name }}/.hermes/.env
+          Environment=HERMES_DASHBOARD_TUI=1
+          ExecStart=/home/{{ agent_name }}/.local/bin/hermes dashboard --host 127.0.0.1 --port {{ dashboard_port }} --no-open --tui
+          Restart=on-failure
+          RestartSec=5
+
+          [Install]
+          WantedBy=multi-user.target
+          Also={{ agent_type }}-{{ agent_name }}.service
+        mode: "0644"
+      register: dashboard_file_changed
+      when: dashboard_port is defined and (dashboard_port | string) | length > 0
+
+    - name: Reload systemd if dashboard file changed
+      ansible.builtin.systemd:
+        daemon_reload: yes
+      when:
+        - dashboard_file_changed is defined
+        - dashboard_file_changed.changed | default(false)
+
     - name: Start hermes service
       ansible.builtin.systemd:
         name: "{{ agent_type }}-{{ agent_name }}"
@@ -48,6 +87,23 @@
         enabled: yes
         daemon_reload: yes
       register: start_result
+
+    # Enable + start the dashboard companion unit (idempotent). PartOf in the
+    # unit file propagates stop/restart from the gateway, but `enable` and
+    # the initial `start` still have to be explicit. Skipped silently when
+    # the unit file is absent (legacy agents installed before this change).
+    - name: Check if dashboard systemd unit exists
+      ansible.builtin.stat:
+        path: "/etc/systemd/system/{{ agent_type }}-dashboard-{{ agent_name }}.service"
+      register: dashboard_unit_file
+
+    - name: Start hermes dashboard service
+      ansible.builtin.systemd:
+        name: "{{ agent_type }}-dashboard-{{ agent_name }}"
+        state: started
+        enabled: yes
+        daemon_reload: yes
+      when: dashboard_unit_file.stat.exists
 
     # Brief settle window so systemd has time to either reach `active` or
     # crash through `Restart=on-failure` cycles. Without this, ActiveState can

--- a/src/clawrium/platform/registry/hermes/playbooks/start.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/start.yaml
@@ -13,7 +13,9 @@
       when: not service_file.stat.exists
 
     # Re-render the unit (idempotent) so changes to ExecStart / WorkingDirectory
-    # via a clm upgrade are picked up without forcing a full reinstall.
+    # via a clm upgrade are picked up without forcing a full reinstall. The
+    # `Also=` directive on this unit (not the dashboard unit) is intentional
+    # — see install.yaml comments / ATX W1.
     - name: Sync systemd service file
       ansible.builtin.copy:
         dest: "/etc/systemd/system/{{ agent_type }}-{{ agent_name }}.service"
@@ -33,7 +35,9 @@
 
           [Install]
           WantedBy=multi-user.target
+          Also={{ agent_type }}-dashboard-{{ agent_name }}.service
         mode: "0644"
+      no_log: true
       register: service_file_changed
 
     - name: Reload systemd if service file changed
@@ -68,8 +72,8 @@
 
           [Install]
           WantedBy=multi-user.target
-          Also={{ agent_type }}-{{ agent_name }}.service
         mode: "0644"
+      no_log: true
       register: dashboard_file_changed
       when: dashboard_port is defined and (dashboard_port | string) | length > 0
 

--- a/src/clawrium/platform/registry/hermes/playbooks/stop.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/stop.yaml
@@ -7,6 +7,30 @@
         path: "/etc/systemd/system/{{ agent_type }}-{{ agent_name }}.service"
       register: service_file
 
+    - name: Check if dashboard systemd unit exists
+      ansible.builtin.stat:
+        path: "/etc/systemd/system/{{ agent_type }}-dashboard-{{ agent_name }}.service"
+      register: dashboard_unit_file
+
+    # PartOf would normally propagate stop from the gateway to the dashboard,
+    # but we want the dashboard down even if the gateway is already stopped
+    # (idempotent stop / disable). Stop dashboard FIRST so an in-flight
+    # request that races the gateway shutdown still completes against a live
+    # dashboard process.
+    - name: Stop hermes dashboard service gracefully
+      ansible.builtin.systemd:
+        name: "{{ agent_type }}-dashboard-{{ agent_name }}"
+        state: stopped
+      when: dashboard_unit_file.stat.exists
+      ignore_errors: yes
+
+    - name: Disable hermes dashboard service
+      ansible.builtin.systemd:
+        name: "{{ agent_type }}-dashboard-{{ agent_name }}"
+        enabled: no
+      when: dashboard_unit_file.stat.exists
+      ignore_errors: yes
+
     - name: Stop hermes service gracefully
       ansible.builtin.systemd:
         name: "{{ agent_type }}-{{ agent_name }}"

--- a/src/clawrium/platform/registry/hermes/playbooks/stop.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/stop.yaml
@@ -68,6 +68,19 @@
       changed_when: false
       failed_when: process_check.rc == 0
 
+    # ATX W7: dashboard runs as a separate `hermes dashboard ...` command
+    # (with its own node child process). The gateway pgrep above does not
+    # catch a stuck dashboard, so an operator who relies on `clm agent stop`
+    # could be left with the dashboard still bound to its loopback port.
+    # Only enforce when the dashboard unit is actually installed.
+    - name: Verify hermes dashboard process is stopped
+      ansible.builtin.command:
+        cmd: pgrep -u {{ agent_name }} -f "hermes dashboard"
+      register: dashboard_process_check
+      changed_when: false
+      failed_when: dashboard_process_check.rc == 0
+      when: dashboard_unit_file.stat.exists
+
     - name: Display success message
       ansible.builtin.debug:
         msg: "Hermes service {{ agent_type }}-{{ agent_name }} stopped and disabled. ~/.hermes/ preserved."

--- a/tests/test_hermes_playbooks.py
+++ b/tests/test_hermes_playbooks.py
@@ -1,0 +1,128 @@
+"""Tests for hermes Ansible playbooks (issue #478 phase 2 / #482).
+
+Focus: structure of the dashboard companion unit + extras-install + node
+version gate added by the dashboard work. These run as pure YAML parses
+so they're fast and do not require a live host.
+"""
+
+from importlib.resources import files
+
+import yaml
+
+
+def _hermes_playbook(name: str) -> str:
+    path = files("clawrium.platform.registry.hermes") / "playbooks" / f"{name}.yaml"
+    return path.read_text()
+
+
+def _tasks(playbook_text: str) -> list[dict]:
+    data = yaml.safe_load(playbook_text)
+    assert isinstance(data, list) and data, "Playbook must be a non-empty list"
+    return data[0].get("tasks", []) or []
+
+
+def test_hermes_install_playbook_has_extras_install_task():
+    """Phase 2 must install the [web,pty] extras into the upstream hermes
+    interpreter so `hermes dashboard` resolves."""
+    content = _hermes_playbook("install")
+    assert "hermes-agent[web,pty]" in content, (
+        "install.yaml must install the web+pty extras"
+    )
+    tasks = _tasks(content)
+    names = [t.get("name", "") for t in tasks]
+    assert any("extras" in n.lower() for n in names), (
+        "Should have a dedicated extras-install task"
+    )
+
+
+def test_hermes_install_playbook_discovers_interpreter_from_shebang():
+    """We must NOT hard-code the uv venv layout — uv has changed paths
+    between releases. Read the interpreter from the binary's shebang."""
+    content = _hermes_playbook("install")
+    assert "shebang" in content.lower() or "head -n1" in content, (
+        "Should resolve interpreter via shebang inspection"
+    )
+    assert "/.local/bin/hermes" in content
+
+
+def test_hermes_install_playbook_verifies_node_version():
+    """Node >= 18 is required for the dashboard SPA build."""
+    content = _hermes_playbook("install")
+    tasks = _tasks(content)
+    names = [t.get("name", "") for t in tasks]
+    assert any("node" in n.lower() and "18" in n for n in names), (
+        "Should fail loudly if Node.js < 18"
+    )
+    # Remediation must be visible to the operator, not just a stack trace.
+    assert "apt install" in content or "nodesource" in content
+
+
+def test_hermes_install_playbook_creates_dashboard_unit():
+    """Dashboard companion unit must be dropped at install time with the
+    expected systemd directives so PartOf propagation works."""
+    content = _hermes_playbook("install")
+
+    assert (
+        "/etc/systemd/system/{{ agent_type }}-dashboard-{{ agent_name }}.service"
+        in content
+    ), "Dashboard unit file path"
+    assert "PartOf={{ agent_type }}-{{ agent_name }}.service" in content
+    assert "Also={{ agent_type }}-{{ agent_name }}.service" in content
+    assert "Environment=HERMES_DASHBOARD_TUI=1" in content
+    assert "hermes dashboard --host 127.0.0.1" in content
+    assert "--port {{ dashboard_port }}" in content
+    assert "--no-open" in content
+    assert "--tui" in content
+
+
+def test_hermes_install_playbook_dashboard_unit_uses_loopback_only():
+    """The dashboard MUST bind to loopback only — the SSH tunnel is the auth
+    boundary. A 0.0.0.0 bind would expose it to the LAN unauthenticated."""
+    content = _hermes_playbook("install")
+    # The exact substring "0.0.0.0" appears elsewhere (api_server) so just
+    # check the dashboard ExecStart line uses 127.0.0.1.
+    assert "hermes dashboard --host 127.0.0.1" in content
+
+
+def test_hermes_start_playbook_starts_and_enables_dashboard_unit():
+    content = _hermes_playbook("start")
+    tasks = _tasks(content)
+    names = [t.get("name", "") for t in tasks]
+    assert any(
+        "dashboard" in n.lower() and "start" in n.lower() for n in names
+    ), "start.yaml must start the dashboard unit"
+    # The unit name string the systemd module operates on:
+    assert "{{ agent_type }}-dashboard-{{ agent_name }}" in content
+
+
+def test_hermes_start_playbook_resyncs_dashboard_unit_with_port():
+    """On every start we re-render the dashboard unit (idempotent) so a
+    clm upgrade that changes the ExecStart shape is picked up without a
+    full re-install. The render needs `dashboard_port`."""
+    content = _hermes_playbook("start")
+    assert "Sync dashboard systemd service file" in content
+    assert "--port {{ dashboard_port }}" in content
+    assert "PartOf={{ agent_type }}-{{ agent_name }}.service" in content
+
+
+def test_hermes_stop_playbook_stops_dashboard_unit():
+    content = _hermes_playbook("stop")
+    tasks = _tasks(content)
+    names = [t.get("name", "") for t in tasks]
+    assert any(
+        "dashboard" in n.lower() and "stop" in n.lower() for n in names
+    ), "stop.yaml must stop the dashboard unit"
+    assert "{{ agent_type }}-dashboard-{{ agent_name }}" in content
+
+
+def test_hermes_remove_playbook_removes_dashboard_unit():
+    content = _hermes_playbook("remove")
+    assert (
+        "/etc/systemd/system/{{ agent_type }}-dashboard-{{ agent_name }}.service"
+        in content
+    )
+    tasks = _tasks(content)
+    names = [t.get("name", "") for t in tasks]
+    assert any(
+        "dashboard" in n.lower() and "remove" in n.lower() for n in names
+    ), "remove.yaml must remove the dashboard unit file"

--- a/tests/test_hermes_playbooks.py
+++ b/tests/test_hermes_playbooks.py
@@ -67,7 +67,18 @@ def test_hermes_install_playbook_creates_dashboard_unit():
         in content
     ), "Dashboard unit file path"
     assert "PartOf={{ agent_type }}-{{ agent_name }}.service" in content
-    assert "Also={{ agent_type }}-{{ agent_name }}.service" in content
+    # ATX W1: `Also=` lives on the gateway unit, not the dashboard unit
+    # — see install.yaml comment for why. Confirm the dashboard side
+    # does NOT carry an `Also=` to the gateway (which would be the
+    # silent-disable footgun).
+    assert "Also={{ agent_type }}-dashboard-{{ agent_name }}.service" in content, (
+        "Gateway unit must carry `Also=<dashboard>` so enabling the gateway "
+        "also enables the companion"
+    )
+    assert "Also={{ agent_type }}-{{ agent_name }}.service" not in content, (
+        "Dashboard unit must NOT carry `Also=<gateway>` — that would let "
+        "`systemctl disable dashboard` silently disable the gateway"
+    )
     assert "Environment=HERMES_DASHBOARD_TUI=1" in content
     assert "hermes dashboard --host 127.0.0.1" in content
     assert "--port {{ dashboard_port }}" in content
@@ -113,6 +124,37 @@ def test_hermes_stop_playbook_stops_dashboard_unit():
         "dashboard" in n.lower() and "stop" in n.lower() for n in names
     ), "stop.yaml must stop the dashboard unit"
     assert "{{ agent_type }}-dashboard-{{ agent_name }}" in content
+
+
+def test_hermes_stop_playbook_orders_dashboard_before_gateway():
+    """ATX W10: stop.yaml's own comment calls 'Stop dashboard FIRST' a
+    load-bearing design (in-flight requests must complete against a live
+    gateway). The order is a real invariant — pin it."""
+    content = _hermes_playbook("stop")
+    tasks = _tasks(content)
+    names = [t.get("name", "") for t in tasks]
+
+    def _find(predicate) -> int:
+        for i, n in enumerate(names):
+            if predicate(n):
+                return i
+        return -1
+
+    dashboard_stop_idx = _find(
+        lambda n: "dashboard" in n.lower() and "stop" in n.lower()
+        and "gracefully" in n.lower()
+    )
+    gateway_stop_idx = _find(
+        lambda n: "stop" in n.lower()
+        and "gracefully" in n.lower()
+        and "dashboard" not in n.lower()
+    )
+    assert dashboard_stop_idx >= 0, "no graceful dashboard-stop task found"
+    assert gateway_stop_idx >= 0, "no graceful gateway-stop task found"
+    assert dashboard_stop_idx < gateway_stop_idx, (
+        f"dashboard stop (idx {dashboard_stop_idx}) must precede "
+        f"gateway stop (idx {gateway_stop_idx})"
+    )
 
 
 def test_hermes_remove_playbook_removes_dashboard_unit():

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2411,7 +2411,9 @@ def test_install_hermes_dashboard_port_persisted_to_hosts_json(
     assert result["success"] is True
 
     dashboard = get_host()["agents"]["hermes-persist"]["config"]["dashboard"]
-    assert dashboard["port"]
+    # ATX W9: truthy check would pass any nonzero int; assert the
+    # documented allocation window invariant.
+    assert 45000 <= dashboard["port"] <= 46999
 
     # The ansible inventory passed to the claw playbook (second `run`) must
     # carry `dashboard_port` so the playbook can render the unit file.

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2485,3 +2485,37 @@ def test_install_hermes_dashboard_port_preserved_on_reinstall(monkeypatch, tmp_p
 
     dashboard = get_host()["agents"]["hermes-reinstall"]["config"]["dashboard"]
     assert dashboard["port"] == custom_port
+
+
+def test_install_hermes_dashboard_port_pool_exhausted(monkeypatch, tmp_path):
+    """ATX iter-2 blocker: the for/else exhaustion sentinel at install.py
+    must raise InstallationError when all 2000 ports in 45000..46999 are
+    occupied. Without a test, a refactor that drops the sentinel would
+    silently re-introduce the colliding-port footgun (B1 in iter-1)."""
+    from clawrium.core.install import InstallationError
+
+    # Fill every slot in the allocation window.
+    preexisting = {
+        f"hermes-occ-{port}": {
+            "type": "hermes",
+            "version": "2026.5.7",
+            "status": "installed",
+            "config": {
+                "dashboard": {
+                    "enabled": True,
+                    "host": "127.0.0.1",
+                    "port": port,
+                }
+            },
+        }
+        for port in range(45000, 47000)
+    }
+
+    run_installation, _get_host, _calls, _ansible_calls = _hermes_install_scaffold(
+        monkeypatch, tmp_path, preexisting_agents=preexisting
+    )
+
+    import pytest
+
+    with pytest.raises(InstallationError, match="[Pp]ool exhausted"):
+        run_installation("hermes", "test-host", name="hermes-new")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2256,3 +2256,230 @@ def test_install_hermes_persists_zero_bind_in_hosts_json(monkeypatch, tmp_path):
     assert api_server["port"] == 8642
     # B3 invariant: bearer never lands in hosts.json
     assert "key" not in api_server
+
+
+# ---------------------------------------------------------------------------
+# Issue #478 phase 2: hermes dashboard port persistence (issue #482).
+# ---------------------------------------------------------------------------
+
+
+def _hermes_install_scaffold(monkeypatch, tmp_path, *, preexisting_agents=None):
+    """Shared fixture wiring for hermes install tests.
+
+    Returns (run_installation, persistent_host, update_calls, ansible_calls).
+    `preexisting_agents` populates `persistent_host['agents']` before the run.
+    """
+    import clawrium.core.install
+    from clawrium.core.install import run_installation
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mock_manifest = {
+        "name": "hermes",
+        "entries": [
+            {
+                "version": "2026.5.7",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.11"},
+                },
+            }
+        ],
+    }
+    monkeypatch.setattr(
+        clawrium.core.install, "load_manifest", lambda x: mock_manifest
+    )
+
+    persistent_host = {
+        "hostname": "test-host",
+        "port": 22,
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    if preexisting_agents:
+        persistent_host["agents"] = dict(preexisting_agents)
+
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host", lambda _x: persistent_host
+    )
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *a, **k: {
+            "compatible": True,
+            "matched_entry": mock_manifest["entries"][0],
+            "reasons": [],
+        },
+    )
+
+    key_file = tmp_path / "key"
+    key_file.write_text("k")
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda _x: key_file
+    )
+
+    update_calls: list = []
+
+    def mock_update_host(hostname, updater):
+        nonlocal persistent_host
+        if "agents" not in persistent_host:
+            persistent_host["agents"] = {}
+        persistent_host = updater(persistent_host)
+        update_calls.append((hostname, persistent_host))
+        return True
+
+    monkeypatch.setattr(clawrium.core.install, "update_host", mock_update_host)
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", lambda *a, **k: True
+    )
+    monkeypatch.setattr(
+        clawrium.core.install, "get_instance_secrets", lambda _k: {}
+    )
+    monkeypatch.setattr(
+        clawrium.core.install, "set_instance_secret", lambda *a, **k: True
+    )
+
+    class SuccessfulResult:
+        status = "successful"
+
+        class Config:
+            artifact_dir = tmp_path / "artifacts"
+
+        config = Config()
+
+    import ansible_runner
+
+    ansible_calls: list = []
+
+    def fake_run(*args, **kwargs):
+        ansible_calls.append({"args": args, "kwargs": kwargs})
+        return SuccessfulResult()
+
+    monkeypatch.setattr(ansible_runner, "run", fake_run)
+
+    # `persistent_host` is reassigned inside the closure on each updater call,
+    # so we expose a getter rather than the original reference.
+    def get_persistent_host():
+        return persistent_host
+
+    return run_installation, get_persistent_host, update_calls, ansible_calls
+
+
+def test_install_hermes_dashboard_port_deterministic(monkeypatch, tmp_path):
+    """Two installs of the same agent name on a clean host must compute the
+    same dashboard port — the resolver and `clm agent open` need a stable
+    value, not a per-run random one."""
+    import hashlib
+
+    run_installation, get_host, _calls, _ansible_calls = _hermes_install_scaffold(
+        monkeypatch, tmp_path
+    )
+
+    result = run_installation("hermes", "test-host", name="hermes-portcheck")
+    assert result["success"] is True
+
+    expected = 45000 + (
+        int(hashlib.md5(b"hermes-portcheck").hexdigest(), 16) % 2000
+    )
+    dashboard = get_host()["agents"]["hermes-portcheck"]["config"]["dashboard"]
+    assert dashboard["enabled"] is True
+    assert dashboard["host"] == "127.0.0.1"
+    assert dashboard["port"] == expected
+    assert 45000 <= dashboard["port"] <= 46999
+
+
+def test_install_hermes_dashboard_port_persisted_to_hosts_json(
+    monkeypatch, tmp_path
+):
+    """The dashboard block must land in hosts.json under the agent's config
+    (not just in the in-flight ansible inventory)."""
+    run_installation, get_host, _calls, ansible_calls = _hermes_install_scaffold(
+        monkeypatch, tmp_path
+    )
+
+    result = run_installation("hermes", "test-host", name="hermes-persist")
+    assert result["success"] is True
+
+    dashboard = get_host()["agents"]["hermes-persist"]["config"]["dashboard"]
+    assert dashboard["port"]
+
+    # The ansible inventory passed to the claw playbook (second `run`) must
+    # carry `dashboard_port` so the playbook can render the unit file.
+    claw_run = ansible_calls[-1]
+    inv_vars = claw_run["kwargs"]["inventory"]["all"]["vars"]
+    assert inv_vars["dashboard_port"] == dashboard["port"]
+
+
+def test_install_hermes_dashboard_port_collision_bumps(monkeypatch, tmp_path):
+    """When another agent on the same host already owns the computed port,
+    the new install must pick the next free port (not silently overlap)."""
+    import hashlib
+
+    natural = 45000 + (
+        int(hashlib.md5(b"hermes-collide").hexdigest(), 16) % 2000
+    )
+    preexisting = {
+        "hermes-other": {
+            "type": "hermes",
+            "version": "2026.5.7",
+            "status": "installed",
+            "config": {
+                "dashboard": {
+                    "enabled": True,
+                    "host": "127.0.0.1",
+                    "port": natural,
+                }
+            },
+        }
+    }
+    run_installation, get_host, _calls, _ansible_calls = _hermes_install_scaffold(
+        monkeypatch, tmp_path, preexisting_agents=preexisting
+    )
+
+    result = run_installation("hermes", "test-host", name="hermes-collide")
+    assert result["success"] is True
+
+    dashboard = get_host()["agents"]["hermes-collide"]["config"]["dashboard"]
+    assert dashboard["port"] != natural
+    assert 45000 <= dashboard["port"] <= 46999
+
+
+def test_install_hermes_dashboard_port_preserved_on_reinstall(monkeypatch, tmp_path):
+    """Re-installing an agent must NOT silently move it to a new port; the
+    unit file on the host was rendered against the original port, and any
+    running tunnels would break."""
+    custom_port = 45777  # outside the deterministic-hash slot for this name
+    preexisting = {
+        "hermes-reinstall": {
+            "type": "hermes",
+            "version": "2026.5.7",
+            "status": "installed",
+            "installed_at": "2026-01-01T00:00:00+00:00",
+            "config": {
+                "dashboard": {
+                    "enabled": True,
+                    "host": "127.0.0.1",
+                    "port": custom_port,
+                }
+            },
+        }
+    }
+    run_installation, get_host, _calls, _ansible_calls = _hermes_install_scaffold(
+        monkeypatch, tmp_path, preexisting_agents=preexisting
+    )
+
+    result = run_installation("hermes", "test-host", name="hermes-reinstall")
+    assert result["success"] is True
+
+    dashboard = get_host()["agents"]["hermes-reinstall"]["config"]["dashboard"]
+    assert dashboard["port"] == custom_port

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -310,6 +310,161 @@ class TestRunLifecyclePlaybook:
             "(ATX iter-5 NW-A / iter-6)"
         )
 
+    def _run_with_inventory_capture(
+        self,
+        tmp_path: Path,
+        host: dict,
+        agent_type: str,
+        agent_name: str,
+    ) -> dict:
+        """Helper: invoke _run_lifecycle_playbook with a stub ansible runner
+        and return the inventory dict the call would have passed to ansible.
+
+        Centralises the patch setup so the three injection tests below stay
+        focused on the inventory assertion they actually care about.
+        """
+        playbook_path = tmp_path / "start.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+
+        runner = MagicMock()
+        runner.status = "successful"
+        runner.events = []
+
+        with patch(
+            "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+            return_value=playbook_path,
+        ), patch(
+            "clawrium.core.lifecycle.get_host_private_key",
+            return_value=key_path,
+        ), patch(
+            "clawrium.core.lifecycle.ansible_runner.run",
+            return_value=runner,
+        ) as mock_run, patch(
+            "clawrium.core.lifecycle.get_config_dir",
+            return_value=tmp_path,
+        ), patch(
+            "clawrium.core.lifecycle.get_instance_secrets",
+            return_value={},
+        ), patch(
+            "clawrium.core.lifecycle.get_instance_key",
+            return_value="test-key",
+        ):
+            _run_lifecycle_playbook(
+                agent_type, agent_name, host["hostname"], "start", host
+            )
+
+        # ansible_runner.run is invoked as a keyword-only call in
+        # _run_lifecycle_playbook, so inventory lands in call_args.kwargs.
+        return mock_run.call_args.kwargs["inventory"]
+
+    def test_hermes_dashboard_port_injected_into_inventory(
+        self, tmp_path: Path
+    ):
+        """ATX B2: hermes agent with a valid dashboard.port in hosts.json
+        must surface it as `dashboard_port` in the ansible inventory so
+        start/stop/remove playbooks can re-render the unit file."""
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "her-test": {
+                    "type": "hermes",
+                    "config": {
+                        "dashboard": {
+                            "enabled": True,
+                            "host": "127.0.0.1",
+                            "port": 45100,
+                        }
+                    },
+                }
+            },
+        }
+        inventory = self._run_with_inventory_capture(
+            tmp_path, host, "hermes", "her-test"
+        )
+        assert inventory["all"]["vars"]["dashboard_port"] == 45100
+
+    def test_non_hermes_agent_does_not_get_dashboard_port(
+        self, tmp_path: Path
+    ):
+        """ATX B2: zeroclaw / openclaw / nemoclaw must NOT receive a
+        dashboard_port var. The agent-type guard is the only thing
+        preventing future playbook tasks guarded by `when: dashboard_port
+        is defined` from firing on the wrong claw."""
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "zer-test": {
+                    "type": "zeroclaw",
+                    # A bogus dashboard config that should be IGNORED for
+                    # non-hermes: regression guard against a refactor that
+                    # drops the agent-type check.
+                    "config": {"dashboard": {"port": 45100}},
+                }
+            },
+        }
+        inventory = self._run_with_inventory_capture(
+            tmp_path, host, "zeroclaw", "zer-test"
+        )
+        assert "dashboard_port" not in inventory["all"]["vars"]
+
+    def test_hermes_legacy_agent_no_dashboard_config_does_not_inject_port(
+        self, tmp_path: Path
+    ):
+        """ATX B2: a hermes agent installed before issue #482 has no
+        config.dashboard key at all. The injection path must fall through
+        cleanly — no AttributeError, no `dashboard_port: null` leak."""
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "her-legacy": {
+                    "type": "hermes",
+                    # Pre-#482 record: no `config` block at all.
+                }
+            },
+        }
+        inventory = self._run_with_inventory_capture(
+            tmp_path, host, "hermes", "her-legacy"
+        )
+        assert "dashboard_port" not in inventory["all"]["vars"]
+
+    def test_hermes_out_of_window_dashboard_port_rejected(self, tmp_path: Path):
+        """ATX W5: a tampered hosts.json with `dashboard.port = 80` must
+        NOT escape into the ansible inventory. Only ports in the documented
+        45000..46999 allocation window are propagated."""
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "her-tampered": {
+                    "type": "hermes",
+                    "config": {
+                        "dashboard": {
+                            "enabled": True,
+                            "host": "127.0.0.1",
+                            "port": 80,
+                        }
+                    },
+                }
+            },
+        }
+        inventory = self._run_with_inventory_capture(
+            tmp_path, host, "hermes", "her-tampered"
+        )
+        assert "dashboard_port" not in inventory["all"]["vars"]
+
 
 class TestStartClaw:
     """Tests for start_claw function."""


### PR DESCRIPTION
## Summary

Phase 2 of issue #478 (native hermes dashboard via SSH tunnel). Lands the
host-side mechanism — install playbook + companion systemd unit +
lifecycle propagation + port persistence — so Phase 3 (`clm agent open`,
GUI button, tunnel manager) can wire user-visible surfaces.

Stacked on top of #486 (Phase 1 — manifest `features.web_ui` schema +
resolver). GitHub will auto-rebase this onto `main` once #486 merges.

## What changes

- **`src/clawrium/core/install.py`**: compute per-instance dashboard
  port `45000 + (md5(agent_name) % 2000)` with collision bump that
  wraps within 45000..46999 and **raises `InstallationError` when the
  pool is exhausted** (no silent collision). Capture the existing port
  from the agent record BEFORE `set_installing` wipes it, so re-install
  never silently moves to a new port. Persist
  `config.dashboard = { enabled, host: 127.0.0.1, port }` to
  `hosts.json.agents.<name>` in `set_installed`. `dashboard_port` is
  injected into the Ansible inventory **only for hermes** (conditional
  spread).
- **`hermes/playbooks/install.yaml`**: resolve hermes interpreter from
  the `~/.local/bin/hermes` shebang (uv layout has moved between
  releases — don't hard-code), `pip install --upgrade hermes-agent[web,pty]`,
  verify `node --version >= 18` with an apt remediation, drop
  `hermes-dashboard-<agent>.service` with `PartOf=` gateway,
  `Environment=HERMES_DASHBOARD_TUI=1`, and ExecStart bound to
  `127.0.0.1`. `Also=<dashboard>` lives on the gateway unit's
  `[Install]` (not the dashboard) so `systemctl disable dashboard`
  does NOT also disable the gateway.
- **`hermes/playbooks/start.yaml`**: re-render both units on every
  start (idempotent); the gateway re-render also carries `Also=`.
  `when: dashboard_port is defined` keeps legacy agents starting.
- **`hermes/playbooks/configure.yaml`**: gateway re-render here also
  carries `Also=` (configure runs after install and would otherwise
  silently drop the directive).
- **`hermes/playbooks/stop.yaml`**: stop+disable dashboard unit BEFORE
  the gateway unit, then verify both `hermes gateway run` AND
  `hermes dashboard` processes are gone.
- **`hermes/playbooks/remove.yaml`**: stop / disable / remove the
  dashboard unit file alongside the gateway unit.
- **`src/clawrium/core/lifecycle.py`**: `_run_lifecycle_playbook` pulls
  `config.dashboard.port` from the agent record for hermes agents
  (validated to `45000..46999` — tampered hosts.json values rejected)
  and passes it as `dashboard_port` so start/stop/remove can re-render
  the unit.
- **Tests**: 5 install tests (deterministic hashing, persistence to
  hosts.json + ansible inventory with range assertion, collision
  bump, re-install preservation, **pool exhaustion raises
  InstallationError**); 4 lifecycle tests (hermes injection, non-hermes
  exclusion, legacy hermes safety, out-of-window rejection); 9 playbook
  tests (extras install, shebang-based interpreter discovery, Node ≥ 18
  gate, dashboard unit structure with `Also=` correctness on gateway
  side, lifecycle integration including stop-ordering positional
  assertion). Total: +18 new tests.

## ATX Review Summary

**Final Review: Rating 4-5/5 (all specialists ≥ 4)**
**Total Cost: ~$8.86 | Total Time: ~22 min | Iterations: 3**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1, B2 | All fixed in iter-2 commit `4d999bb` | $2.95 | 8m | leader, core-lifecycle, security, test-coverage, ansible |
| 2 | 2/5 | B-iter2-1 (configure.yaml Also=), B-iter2-2 (B1 test gap) | All fixed in iter-3 commit `fb1cb87` | $3.62 | ~8m | leader, core-lifecycle, security, test-coverage, ansible, cli-ux |
| 3 | 4-5/5 | None | Ready | $1.90 | ~5m | core-lifecycle, security, test-coverage, ansible |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `install.py:599-605` | Port pool exhaustion silently persisted a colliding port (loop exited on iteration count, not `break`) | Fixed — `for/else` sentinel raises `InstallationError` |
| B2 | `lifecycle.py:327-340` | Zero test coverage for the new hermes inventory injection | Fixed — added 4 tests in `test_lifecycle.py::TestRunLifecyclePlaybook` |

**Warnings (all addressed in iter-1 commit `4d999bb`):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `install.yaml`, `start.yaml` | `Also=` placed on dashboard unit — `systemctl disable dashboard` would silently kill gateway | Moved `Also=` to gateway unit's `[Install]` |
| W2 | `install.py:693` | `dashboard_port: None` injected into non-hermes inventory | Conditional spread; only injected when not None |
| W5 | `install.py`, `lifecycle.py` | Preserved-port validation accepted 0..65535 (privileged ports possible) | Tightened to 45000..46999 at all three sites |
| W6 | `install.yaml:298` | Eager `daemon_reload` task fired on every play | Replaced with `meta: flush_handlers` |
| W7 | `stop.yaml:62` | Stop verification missed dashboard process | Added `pgrep -f 'hermes dashboard'` gated on dashboard unit existence |
| W8 | unit-file copy tasks | `no_log: true` missing on tasks rendering `dashboard_port` | Added to all four copy tasks |
| W9 | `test_install.py:2414` | Truthy `assert dashboard['port']` would pass any nonzero int | Replaced with `45000 <= port <= 46999` range check |
| W10 | `test_hermes_playbooks.py` | Stop-ordering invariant not asserted | Added positional `dashboard_stop_idx < gateway_stop_idx` |

</details>

<details>
<summary>Review 2 Details (Rating 2/5)</summary>

**Blocking Issues (both fixed in iter-2 commit `fb1cb87`):**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B-iter2-1 | `configure.yaml:66-88` | Gateway unit re-render in configure dropped `Also=` (iter-1 only updated install.yaml and start.yaml) | Added `Also=<dashboard>` + `no_log: true` to the configure gateway copy task |
| B-iter2-2 | `tests/test_install.py` | `for/else` exhaustion sentinel had zero test coverage | Added `test_install_hermes_dashboard_port_pool_exhausted` which fills all 2000 ports and asserts `pytest.raises(InstallationError, match='[Pp]ool exhausted')` |

**Out-of-scope warnings (acknowledged, not fixed in this PR):**

| # | Surface | Note |
|---|---------|------|
| W+ | `cli/install.py`, `cli/status.py`, `tui/widgets/detail_cards.py` | Dashboard port not surfaced in `clm ps` / install success / TUI detail card. Deferred to Phase 3 (#483) where `clm agent open` ships the user-facing path. |
| W+ | `install.py`, `lifecycle.py` | Magic literals 45000/46999/2000 not extracted to named constants. Acknowledged design debt; defer to a follow-up. |
| W+ | playbook drift | Gateway unit content duplicated across install/configure/start. Shared Jinja2 template extraction deferred to a follow-up refactor. |

</details>

<details>
<summary>Review 3 Details (Rating 4-5/5 — CLEAN)</summary>

| Specialist | Rating | Verdict |
|------------|--------|---------|
| security-reviewer | 5/5 | No new security issues. Pool exhaustion error contains no secrets/tokens/paths. CLEAN. |
| ansible-registry-reviewer | 5/5 | B-iter2-1 fully cleared. `Also=` and `no_log: true` correctly placed at task level. |
| core-lifecycle-reviewer | 4/5 | B-iter2-2 cleared. One pre-existing note about orphaned `status: installing` on pre-playbook errors (not a regression — applies to all `InstallationError` raised before the outer try block). |
| test-coverage-reviewer | 4/5 | B-iter2-2 cleared. Fixture omits `installed_at` (benign — does not change the test outcome). |

</details>

## Testing

### Test Results
- [x] All existing tests pass (`make test-py` → 2475 passed, 6 skipped)
- [x] Linter passes (`make lint-py` → clean)
- [x] New tests added for new functionality (+18 tests total across install, lifecycle, playbook structure)

### Test Coverage
- `tests/test_install.py`: +5 tests
- `tests/test_lifecycle.py`: +4 tests
- `tests/test_hermes_playbooks.py`: new file, +10 tests (including `Also=` placement, stop ordering, dashboard unit structure)

### Manual Testing
Deferred to Phase 3 PR (#483) where a real hermes host gets `clm agent
open <name>` end-to-end, per the issue #478 scaffold's exit criteria.
The pure-Python + YAML-parse tests in this PR cover the structure and
unit-rendering invariants. Manual exit criteria specific to this phase
(both gateway + dashboard units `active (running)`, loopback bind on
the dashboard port, start/stop/restart propagation) require host
access and will be exercised when Phase 3 lands.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (`agent_name` regex
      enforced; `dashboard_port` validated to 45000..46999 at both
      install and lifecycle sites — tampered `hosts.json` rejected)
- [x] No SQL injection, XSS, or command injection risks (`ansible.builtin.command`
      not `shell`; `pgrep -u <agent>` agent name is regex-validated)
- [x] Dependencies are from trusted sources (`hermes-agent[web,pty]`
      via the same upstream installer the base `hermes-agent` was
      installed from)
- [x] Dashboard binds to `127.0.0.1` only — the SSH tunnel established
      in Phase 3 is the authentication boundary
- [x] `no_log: true` on all unit-file copy tasks so dashboard_port
      does not leak into ansible-runner artifacts

## Reviewer Notes

- The `--pr-base=issue-481-manifest-web-ui` arg from `/itx:execute`
  was honored: this PR targets that branch, not `main`. GitHub will
  auto-update the base to `main` once #486 merges.
- The dashboard port computation lives inside the `set_installing`
  closure (mirroring `preserved_gateway` / `preserved_onboarding`)
  because the in-memory `host` snapshot returned by `get_host` and the
  dict mutated by `update_host` are the same object in the test
  environment. Capturing inside the updater is also the only correct
  point on the resume path (where the record is reassigned, not
  wiped).
- Stop playbook intentionally stops the dashboard FIRST (in-flight
  dashboard requests still resolve against a live gateway).
- `Also=` on the GATEWAY unit, not the dashboard unit (systemd's
  `Also=` is symmetric — see ATX W1 / iter-2 propagation gap).
- Lifecycle config-var injection is hermes-only and gated on
  `dashboard_port is defined` in the playbook, so other agent types
  see no behavior change.

## Callouts

- [DECISION] Interpreter discovery for the `[web,pty]` extras install
  reads `head -n1` of the hermes binary's shebang rather than guessing
  the uv venv path. Why: uv has moved its on-disk layout between
  releases and a hard-coded path will silently break the dashboard on
  future hermes updates. Alternatives: `uv tool install
  hermes-agent[web,pty] --reinstall` (forces full reinstall, expensive
  on every `clm agent install`). ATX iter-1 ansible-reviewer noted
  that the sed-based extraction breaks on `#!/usr/bin/env python3`
  style shebangs — this is a known limitation; if upstream ever
  switches to env-style we will need to switch to a `python3 -c`
  extractor.
- [DECISION] Stop playbook stops the dashboard unit before the
  gateway unit, even though `PartOf=` would cascade. Why: a host
  whose dashboard unit was hand-installed before PartOf wiring landed
  (e.g. older clm versions during the rollout) would silently leak a
  running dashboard if we relied on cascade only. ATX iter-1 confirmed
  this; W10 added a positional ordering test to pin the invariant.
- [DECISION] Port computation uses `md5(agent_name)` (same algorithm
  as `openclaw_port`) rather than `hash(agent_name)`. Why: Python's
  built-in `hash()` is randomized per process — the scaffold's
  literal `45000 + (hash(agent_name) % 2000)` would produce different
  ports across runs.
- [DECISION] Magic literals 45000/46999/2000 kept inline rather than
  extracted to named constants. Why: ATX iter-2 core-lifecycle flagged
  this as a maintainability suggestion; deferred because (a) the
  constants are documented in code comments and the PR body, (b) the
  allocation window is unlikely to change without a coordinated
  release, and (c) extracting now would expand the diff during ATX
  iteration without changing behavior. Tracking as informal follow-up.
- [TODO-FOLLOWUP] Dashboard port not yet surfaced in `clm ps` /
  `clm agent status` / TUI detail card / install success message
  (ATX iter-2 cli-ux). Deferred to Phase 3 (#483) where `clm agent
  open` ships the user-facing path. Tracking: #478.
- [TODO-FOLLOWUP] Manual verification on a real hermes host
  (`clm agent install/configure/stop/start/remove testdash` + `ss
  -tlnp` loopback check) is part of issue #482's exit criteria but
  has been deferred to Phase 3's manual-verification pass when the
  user-facing `clm agent open` ships. Tracking: #478.

---

Closes #482

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
