### PR TITLE
fix(hermes): pre-build TUI bundle + ink-bundle.js alias at install time

### DIFF
--- a/.itx/478/00_PLAN.md
+++ b/.itx/478/00_PLAN.md
@@ -329,3 +329,61 @@ If the second line is `True`, the chat WebSocket will work — reload the dashbo
 
 - `tests/test_hermes_playbooks.py` — assert install.yaml uses `uv pip install … --editable …code[web,pty]`, not `pip install --upgrade hermes-agent[web,pty]`. Prevents accidental revert.
 - Optional integration assertion (if a hermes test host is available): after install, `python -c "import hermes_cli; ..."` resolves to `/home/<agent>/.hermes/code/`.
+
+---
+
+## Second follow-up — chat WS still broken (filename drift + blocking subprocess)
+
+GitHub: #490
+
+### Outcome after PR #489
+
+After PR #489 lands the editable-install fix, `hermes_cli.__file__` correctly resolves to `/home/<agent>/.hermes/code/hermes_cli/__init__.py` and `PROJECT_ROOT/ui-tui` exists. The `/api/pty` handler reaches `_make_tui_argv` without crashing — but the chat WS still fails.
+
+### Why
+
+Two distinct upstream `NousResearch/hermes-agent` v2026.5.7 defects layered on top of each other:
+
+1. **Filename drift** — `packages/hermes-ink/package.json`'s build script writes `dist/entry-exports.js`, but `hermes_cli/main.py:_hermes_ink_bundle_stale` looks for `dist/ink-bundle.js`. The check is permanently True; `_tui_build_needed` is therefore permanently True; `_make_tui_argv` runs `npm run build` on every chat WS request.
+2. **Blocking subprocess in async handler** — `web_server.py:pty_ws` calls `_resolve_chat_argv` (and through it `subprocess.run([npm, "run", "build"], …)`) synchronously between `await ws.accept()` and the PTY spawn. While npm runs (~11s on `maurice@wolf-i`), the asyncio event loop is blocked and uvicorn can't flush the queued HTTP 101 to the client. The browser's WS handshake times out.
+
+Empirical verification on `maurice@wolf-i`:
+
+| WS endpoint | Result |
+|---|---|
+| `/api/events` | open <1s |
+| `/api/ws` | open + first JSON-RPC event |
+| `/api/pub` | open <1s |
+| `/api/pty` | timeout 4s → `InvalidMessage` at 11.6s |
+
+`_make_tui_argv(...)` cold-run: 11.4s every call, because `_hermes_ink_bundle_stale` never goes False.
+
+### Mitigation (PR #491)
+
+Five new tasks in `install.yaml`, ordered between the Node ≥ 18 check and the systemd unit creation:
+
+1. **`npm install`** in `/home/<agent>/.hermes/code/ui-tui` (idempotent).
+2. **`npm run build`** in the same dir — produces `dist/entry.js` + `packages/hermes-ink/dist/entry-exports.js`. Pre-builds at install time so the runtime never reaches the blocking subprocess path.
+3. **Copy `entry-exports.js` → `ink-bundle.js`** with `remote_src: true`. Works around defect 1 (the staleness check now finds the file it's looking for).
+4. **`file: state: touch` on `ink-bundle.js`** — fresh mtime, defeats `_hermes_ink_bundle_stale`'s ts-source-mtime comparison.
+5. **`file: state: touch` on `ui-tui/dist/entry.js`** — fresh mtime, defeats `_tui_build_needed`'s walk across `.ts/.tsx` + meta files.
+
+With this in place: `_make_tui_argv` skips the build branch on every call (returns in ~20ms instead of 11s), the PTY spawns immediately, the WS handshake completes in <100ms.
+
+### Caveats
+
+- This is a workaround. The latent design flaw (sync subprocess in async handler) remains; if anything ever future-triggers `_tui_build_needed = True` (e.g., a future hermes version touches a `.ts` file mtime past `dist/entry.js`), the hang recurs.
+- Out-of-band `git pull` or `npm install` inside `/home/<agent>/.hermes/code/ui-tui` refreshes source mtimes past `dist/entry.js` and requires a `clm agent install --force` to re-apply the mtime bumps.
+- Two upstream bugs need to be filed against `NousResearch/hermes-agent` before this workaround can be retired (see #490 for the details).
+
+### Rollout
+
+PR #491 ships the install.yaml change. To apply to existing agents:
+
+```bash
+cd /home/devashish/workspace/ric03uec/clawrium
+uv run clm agent install --type hermes --host <host> --name <agent> --force
+uv run clm agent restart <agent>
+```
+
+For brand-new agents, no manual steps — the install playbook does the right thing out of the box.

--- a/src/clawrium/platform/registry/hermes/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/install.yaml
@@ -277,6 +277,84 @@
         or not ((node_version_major.stdout | default('0')) is match('^[0-9]+$'))
         or (node_version_major.stdout | default('0') | int) < 18
 
+    # Issue #490 — Pre-build the TUI bundle + work around two upstream
+    # NousResearch/hermes-agent v2026.5.7 defects.
+    #
+    # Defect A (filename drift): `ui-tui/packages/hermes-ink/package.json`'s
+    # `build` script writes `dist/entry-exports.js`, but
+    # `hermes_cli/main.py:_hermes_ink_bundle_stale` checks for
+    # `dist/ink-bundle.js`. The expected file is never produced, so the
+    # staleness check is permanently True, which propagates through
+    # `_tui_build_needed` and forces a rebuild on every dashboard chat
+    # request.
+    #
+    # Defect B (blocking subprocess in async handler):
+    # `web_server.py:pty_ws` calls `_resolve_chat_argv` (→ `_make_tui_argv`,
+    # → `subprocess.run([npm, "run", "build"], ...)`) synchronously between
+    # `await ws.accept()` and the PTY spawn. With defect A active, every
+    # chat WS upgrade triggers a multi-second blocking build that prevents
+    # uvicorn from flushing the queued HTTP 101 to the client — browsers
+    # see the handshake fail.
+    #
+    # Mitigation here:
+    #   (1) Run `npm install + npm run build` at install time so the
+    #       runtime never needs to.
+    #   (2) Copy `entry-exports.js` → `ink-bundle.js` so the staleness
+    #       check finds the file it's looking for.
+    #   (3) Touch `ink-bundle.js` (fresh mtime, defeats
+    #       `_hermes_ink_bundle_stale`) and `dist/entry.js` (fresh mtime
+    #       newer than all `.ts/.tsx` + meta files, defeats
+    #       `_tui_build_needed`).
+    #
+    # Retire this block once upstream lands fixes for both defects (track
+    # via issue #490).
+    - name: Install ui-tui Node dependencies (idempotent)
+      ansible.builtin.command:
+        cmd: npm install --silent --no-fund --no-audit --no-progress
+        chdir: "/home/{{ agent_name }}/.hermes/code/ui-tui"
+      become_user: "{{ agent_name }}"
+      environment:
+        CI: "1"
+      register: hermes_ui_tui_npm_install
+      changed_when: false
+      failed_when: hermes_ui_tui_npm_install.rc != 0
+
+    - name: Pre-build ui-tui bundle (avoid lazy build in /api/pty handler)
+      ansible.builtin.command:
+        cmd: npm run build
+        chdir: "/home/{{ agent_name }}/.hermes/code/ui-tui"
+      become_user: "{{ agent_name }}"
+      register: hermes_ui_tui_build
+      changed_when: "'esbuild' in (hermes_ui_tui_build.stdout | default(''))"
+      failed_when: hermes_ui_tui_build.rc != 0
+
+    - name: Alias entry-exports.js to ink-bundle.js (upstream filename drift workaround)
+      ansible.builtin.copy:
+        src: "/home/{{ agent_name }}/.hermes/code/ui-tui/packages/hermes-ink/dist/entry-exports.js"
+        dest: "/home/{{ agent_name }}/.hermes/code/ui-tui/packages/hermes-ink/dist/ink-bundle.js"
+        remote_src: true
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0644"
+
+    - name: Touch ink-bundle.js so _hermes_ink_bundle_stale sees a fresh mtime
+      ansible.builtin.file:
+        path: "/home/{{ agent_name }}/.hermes/code/ui-tui/packages/hermes-ink/dist/ink-bundle.js"
+        state: touch
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0644"
+      changed_when: false
+
+    - name: Touch ui-tui/dist/entry.js so _tui_build_needed sees a fresh mtime
+      ansible.builtin.file:
+        path: "/home/{{ agent_name }}/.hermes/code/ui-tui/dist/entry.js"
+        state: touch
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0755"
+      changed_when: false
+
     # Service is dropped DISABLED and NOT started. Phase 2 (configure) writes
     # provider credentials to .env and turns the unit on. Calling
     # `clm agent start` before configure will start the unit, but hermes will

--- a/tests/test_hermes_playbooks.py
+++ b/tests/test_hermes_playbooks.py
@@ -339,3 +339,156 @@ def test_hermes_remove_playbook_removes_dashboard_unit():
     assert any(
         "dashboard" in n.lower() and "remove" in n.lower() for n in names
     ), "remove.yaml must remove the dashboard unit file"
+
+
+# ---------------------------------------------------------------------------
+# Issue #490 — chat-WS pre-build workaround
+#
+# Regression anchors for the install-time mitigation against two upstream
+# NousResearch/hermes-agent v2026.5.7 defects:
+#   A. `_hermes_ink_bundle_stale` looks for `ink-bundle.js`, but the build
+#      script only produces `entry-exports.js` — staleness check is
+#      permanently True.
+#   B. `_make_tui_argv` runs synchronous `subprocess.run([npm, "run",
+#      "build"])` after `await ws.accept()`, blocking the asyncio loop and
+#      preventing the WS handshake response from reaching the client.
+#
+# Until upstream lands fixes, the install playbook pre-builds the TUI
+# bundle, creates the missing `ink-bundle.js` alias, and bumps mtimes so
+# both staleness checks resolve to False.
+# ---------------------------------------------------------------------------
+
+
+_UI_TUI_DIR = "/home/{{ agent_name }}/.hermes/code/ui-tui"
+_INK_DIST = f"{_UI_TUI_DIR}/packages/hermes-ink/dist"
+
+
+def _find_task_by_chdir(tasks: list[dict], chdir: str, cmd_contains: str):
+    """Return the first command-module task whose `cmd` contains
+    `cmd_contains` and whose `chdir` matches."""
+    for t in tasks:
+        cmd_value = _task_module_value(
+            t, "ansible.builtin.command", "command"
+        )
+        if not isinstance(cmd_value, dict):
+            continue
+        if cmd_value.get("chdir") != chdir:
+            continue
+        if cmd_contains in str(cmd_value.get("cmd", "")):
+            return t
+    return None
+
+
+def test_install_playbook_pre_builds_ui_tui_node_deps():
+    """`npm install` must run at install time in `ui-tui/`.
+
+    Pre-installing is half of the workaround for upstream defect B
+    (sync subprocess in async handler) — the runtime path in
+    `_make_tui_argv` would otherwise lazy-install on first WS request
+    and block the asyncio event loop.
+    """
+    tasks = _tasks(_hermes_playbook("install"))
+    task = _find_task_by_chdir(tasks, _UI_TUI_DIR, "npm install")
+    assert task is not None, (
+        "Missing `npm install` task with chdir = "
+        f"{_UI_TUI_DIR!r}. Required so `_make_tui_argv` doesn't lazy-"
+        "install at WS handshake time."
+    )
+    assert task.get("become_user") == "{{ agent_name }}", (
+        "npm install must run as the agent user so node_modules is "
+        "owned correctly."
+    )
+    env = task.get("environment") or {}
+    assert env.get("CI") == "1", (
+        "Set CI=1 so npm doesn't drop into interactive prompts on a "
+        "headless host."
+    )
+
+
+def test_install_playbook_pre_builds_ui_tui_bundle():
+    """`npm run build` must run at install time in `ui-tui/`.
+
+    This produces `dist/entry.js` + `packages/hermes-ink/dist/
+    entry-exports.js` so the dashboard's `_make_tui_argv` finds them
+    fresh on first chat WS request and skips the build branch
+    entirely (workaround for upstream defect B).
+    """
+    tasks = _tasks(_hermes_playbook("install"))
+    task = _find_task_by_chdir(tasks, _UI_TUI_DIR, "npm run build")
+    assert task is not None, (
+        "Missing `npm run build` task with chdir = "
+        f"{_UI_TUI_DIR!r}."
+    )
+    assert task.get("become_user") == "{{ agent_name }}", (
+        "npm run build must run as the agent user."
+    )
+
+
+def test_install_playbook_aliases_entry_exports_to_ink_bundle():
+    """Workaround for upstream defect A (filename drift): the
+    hermes-ink build script writes `entry-exports.js`, but
+    `_hermes_ink_bundle_stale` checks for `ink-bundle.js`. Copy the
+    one to the other so the check finds what it's looking for.
+    """
+    tasks = _tasks(_hermes_playbook("install"))
+    src_path = f"{_INK_DIST}/entry-exports.js"
+    dest_path = f"{_INK_DIST}/ink-bundle.js"
+    task = next(
+        (
+            t for t in tasks
+            if isinstance(
+                _task_module_value(t, "ansible.builtin.copy", "copy"), dict,
+            )
+            and _task_module_value(t, "ansible.builtin.copy", "copy").get(
+                "src"
+            ) == src_path
+            and _task_module_value(t, "ansible.builtin.copy", "copy").get(
+                "dest"
+            ) == dest_path
+        ),
+        None,
+    )
+    assert task is not None, (
+        f"Missing copy task aliasing {src_path!r} -> {dest_path!r}. "
+        "This is the upstream-filename-drift workaround for defect A "
+        "(hermes_cli/main.py:_hermes_ink_bundle_stale checks for "
+        "ink-bundle.js but the build script emits entry-exports.js)."
+    )
+    copy_args = _task_module_value(task, "ansible.builtin.copy", "copy")
+    assert copy_args.get("remote_src") is True, (
+        "Must set remote_src: true — both files live on the agent host, "
+        "not on the controller."
+    )
+
+
+def test_install_playbook_touches_ink_bundle_and_entry_js():
+    """Both `ink-bundle.js` and `dist/entry.js` must be touched at the
+    end of install so:
+      - `_hermes_ink_bundle_stale` sees a non-stale bundle (its mtime
+        is newer than any source file in packages/hermes-ink/).
+      - `_tui_build_needed` sees `dist/entry.js` newer than every
+        `.ts/.tsx` source + package.json/-lock.json/tsconfig*.json
+        meta file in ui-tui/.
+    """
+    tasks = _tasks(_hermes_playbook("install"))
+    targets = {
+        f"{_INK_DIST}/ink-bundle.js",
+        f"{_UI_TUI_DIR}/dist/entry.js",
+    }
+    touched: set[str] = set()
+    for t in tasks:
+        file_args = _task_module_value(t, "ansible.builtin.file", "file")
+        if not isinstance(file_args, dict):
+            continue
+        if file_args.get("state") != "touch":
+            continue
+        path = file_args.get("path")
+        if path in targets:
+            touched.add(path)
+    missing = targets - touched
+    assert not missing, (
+        f"Missing touch (state: touch) tasks for: {sorted(missing)}. "
+        "Without these mtime bumps, _tui_build_needed and "
+        "_hermes_ink_bundle_stale return True on first chat WS request "
+        "and the asyncio loop blocks on `npm run build`."
+    )

--- a/tests/test_hermes_playbooks.py
+++ b/tests/test_hermes_playbooks.py
@@ -492,3 +492,57 @@ def test_install_playbook_touches_ink_bundle_and_entry_js():
         "_hermes_ink_bundle_stale return True on first chat WS request "
         "and the asyncio loop blocks on `npm run build`."
     )
+
+
+def test_install_playbook_prebuild_tasks_are_ordered():
+    """ATX B1: the five pre-build tasks have a hard runtime dependency
+    chain — reordering keeps existence-only assertions green while the
+    playbook fails at runtime (`copy: src entry-exports.js not found`;
+    esbuild: missing node_modules). Pin the order.
+
+        npm install
+          → npm run build
+            → copy entry-exports.js -> ink-bundle.js
+              → touch ink-bundle.js
+              → touch dist/entry.js
+    """
+    tasks = _tasks(_hermes_playbook("install"))
+    names = [t.get("name", "") for t in tasks]
+
+    def _find(predicate) -> int:
+        for i, n in enumerate(names):
+            if predicate(n):
+                return i
+        return -1
+
+    npm_install_idx = _find(lambda n: "Install ui-tui Node dependencies" in n)
+    npm_build_idx = _find(lambda n: "Pre-build ui-tui bundle" in n)
+    copy_alias_idx = _find(lambda n: "Alias entry-exports.js to ink-bundle.js" in n)
+    touch_ink_idx = _find(lambda n: "Touch ink-bundle.js" in n)
+    touch_entry_idx = _find(lambda n: "Touch ui-tui/dist/entry.js" in n)
+
+    assert npm_install_idx >= 0, "missing `npm install` task"
+    assert npm_build_idx >= 0, "missing `npm run build` task"
+    assert copy_alias_idx >= 0, "missing entry-exports.js -> ink-bundle.js alias"
+    assert touch_ink_idx >= 0, "missing touch ink-bundle.js task"
+    assert touch_entry_idx >= 0, "missing touch dist/entry.js task"
+
+    assert npm_install_idx < npm_build_idx, (
+        f"`npm install` (idx {npm_install_idx}) must precede `npm run build` "
+        f"(idx {npm_build_idx}) — esbuild needs node_modules."
+    )
+    assert npm_build_idx < copy_alias_idx, (
+        f"`npm run build` (idx {npm_build_idx}) must precede the alias copy "
+        f"(idx {copy_alias_idx}) — entry-exports.js doesn't exist until "
+        f"build completes."
+    )
+    assert copy_alias_idx < touch_ink_idx, (
+        f"alias copy (idx {copy_alias_idx}) must precede touch of ink-bundle.js "
+        f"(idx {touch_ink_idx}) — touching a non-existent file would create "
+        f"an empty placeholder."
+    )
+    assert copy_alias_idx < touch_entry_idx, (
+        f"alias copy (idx {copy_alias_idx}) must precede touch of dist/entry.js "
+        f"(idx {touch_entry_idx}) — touches close the pre-build block and "
+        f"must come last."
+    )


### PR DESCRIPTION
## Summary

Work around two upstream `NousResearch/hermes-agent` v2026.5.7 defects that together break the dashboard chat WebSocket on every fresh install (chat tab shows bare `WebSocket connection … failed:` in the browser console). Pre-build the TUI bundle at install time and create the missing `ink-bundle.js` alias so the runtime path in `_make_tui_argv` short-circuits instead of running a blocking `npm run build` on every WS upgrade.

- Stacked on #489 (editable install fix). Once #489 merges, this PR's diff against `main` shrinks to just the 5 new install.yaml tasks + their regression anchors + plan-doc follow-up.

## Testing

### Test Results
- [x] All existing tests pass (`make test` — 2550 Python + 213 JS, green)
- [x] Linter passes (`make lint` — ruff + ESLint clean)
- [x] New regression tests added in `tests/test_hermes_playbooks.py`:
  - `test_install_playbook_pre_builds_ui_tui_node_deps` — lock-in for the `npm install` task (chdir + `CI=1` + agent become_user)
  - `test_install_playbook_pre_builds_ui_tui_bundle` — lock-in for the `npm run build` task
  - `test_install_playbook_aliases_entry_exports_to_ink_bundle` — lock-in for the `entry-exports.js → ink-bundle.js` copy with `remote_src: true`
  - `test_install_playbook_touches_ink_bundle_and_entry_js` — lock-in for both mtime bumps

### Test Coverage
- Files changed: `src/clawrium/platform/registry/hermes/playbooks/install.yaml`, `tests/test_hermes_playbooks.py`, `.itx/478/00_PLAN.md`
- New tests: 4 regression anchors covering the 5 new install tasks
- Coverage impact: increased

### Manual Testing

Reproduced the failure on `maurice@wolf-i` with #489 applied but without this PR:

| WS endpoint | Result |
|---|---|
| `/api/events` | open <1s |
| `/api/ws` | open + first JSON-RPC event |
| `/api/pub` | open <1s |
| `/api/pty` | timeout 4s → `InvalidMessage` at 11.6s |

`_make_tui_argv(ui-tui)` cold-runs in 11.4s every call because `_hermes_ink_bundle_stale` permanently returns True.

After applying the host-side workaround manually (`cp entry-exports.js ink-bundle.js && touch ui-tui/dist/entry.js`):

| Check | Before | After |
|---|---|---|
| `_hermes_ink_bundle_stale` | True | **False** |
| `_tui_build_needed` | True | **False** |
| `_make_tui_argv` | 11.4s | **0.02s** |
| `/api/pty` WS handshake | timeout / InvalidMessage | **opened in 61ms** |

E2E verification with a throwaway hermes agent (new install → chat-tab click → first WS upgrade) lands in the same PR cycle.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — `agent_name` is validated by `_validate_name_component` before reaching the playbook
- [x] No SQL injection, XSS, or command injection risks — npm subprocesses use fixed argv with no agent-controlled fields
- [x] Dependencies are from trusted sources — relies on the pinned upstream `NousResearch/hermes-agent` v2026.5.7 source tree

## Reviewer Notes

- Skipping ATX review per request.
- This is a workaround, not a real fix. The latent design flaw (sync subprocess in async handler) lives upstream and remains. If anything ever future-triggers `_tui_build_needed = True` (a `.ts` file mtime drifting newer than `dist/entry.js`, a future hermes version change), the chat WS hang recurs and a `clm agent install --force` is needed to re-apply the mtime bumps.
- Two upstream bugs need to be filed against `NousResearch/hermes-agent` — see #490 for the writeup. When upstream lands fixes, retire this block (it's clearly fenced with comments referencing #490).

Closes #490
Refs #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)
