### PR TITLE
feat(zeroclaw): clm agent open + GUI button via existing gateway port (#491)

### DIFF
--- a/.itx/491/01_EXECUTION.md
+++ b/.itx/491/01_EXECUTION.md
@@ -1,0 +1,71 @@
+# Issue #491 — Execution Log
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-22T22:35:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute https://github.com/ric03uec/clawrium/issues/491 in a worktree. use atx cli for review test with existing zeroclaw agent intalled on local
+```
+
+**Output**: Branch `issue-491-zeroclaw-open` in worktree
+`~/workspace/ric03uec/clawrium-issue-491/` with the following changes:
+
+- `src/clawrium/core/registry.py`: added `wildcard` to
+  `_ALLOWED_WEB_UI_BINDS`; widened `WebUIFeatureConfig.bind` Literal.
+- `src/clawrium/core/web_ui.py`: added `wildcard → 127.0.0.1` entry to
+  `BIND_ADDRESS_MAP`; widened `ResolvedUI.bind` Literal; updated module
+  docstring to describe both bind modes.
+- `src/clawrium/platform/registry/zeroclaw/manifest.yaml`: added
+  `features.web_ui` block (`enabled: true`, `bind: wildcard`,
+  `default_port: 40000`, `port_field: gateway.port`).
+- `src/clawrium/cli/agent.py`: dropped the `claw_type != "hermes"` gate
+  in `clm agent open` and updated the docstring; resolver-None branch
+  is now the only gate.
+- `gui/src/hooks/use-agent.ts`: replaced the hermes-only `enabled`
+  gate with an allowlist `WEB_UI_AGENT_TYPES = {hermes, zeroclaw}` and
+  exported it so the render decision shares one source of truth with
+  the fetch decision.
+- `gui/src/hooks/index.ts`, `gui/src/components/agent-detail/agent-header.tsx`:
+  re-exported and consumed the allowlist so the "Open Agent UI" button
+  shows for zeroclaw too.
+- `tests/test_web_ui_resolver.py`: flipped the previous
+  `test_resolve_zeroclaw_returns_none` to assert zeroclaw resolves to
+  its persisted `gateway.port`; added a `gateway.port`-missing fallback
+  test and a `BIND_ADDRESS_MAP["wildcard"]` coverage test.
+- `tests/test_registry.py`: flipped
+  `test_zeroclaw_manifest_does_not_declare_web_ui` to assert the new
+  manifest block.
+- `tests/test_cli_agent_open.py`: renamed
+  `test_open_rejects_non_hermes_agent` →
+  `test_open_rejects_agent_without_web_ui_feature` and updated the
+  expected error string.
+
+### Verification
+
+- `make test` — 2552 passed (`pytest`), 213 passed (`vitest`).
+- `make lint` — ruff + eslint clean.
+- Manual e2e against a live `clm`-managed zeroclaw on `wolf-i`:
+  - `clm agent open clawrium-d01 --print` →
+    `http://wolf.tailf7742d.ts.net:41429/` ✓
+  - `clm agent open clawrium-d01` → tunnel established on local port
+    39211; `curl http://127.0.0.1:39211/` returned `HTTP 200` (524 B);
+    tunnel closed cleanly on Ctrl-C. ✓
+  - Negative: `clm agent open wolf-i --print` (openclaw) →
+    `Error: Agent 'wolf-i' does not declare a native web UI in its
+    manifest.` ✓
+  - Regression: `clm agent open espresso --print` (hermes) →
+    `http://wolf.tailf7742d.ts.net:9119/` ✓
+
+### ATX
+
+Run via `atx review --worktree clawrium-issue-491 --format json
+--timeout 10m`. Task `5c55522e-e8ac-4287-b0f4-18896b8bcd4e` was
+created on project `30011` but the daemon poll timed out after 10m
+without returning a rating. Session metadata persisted to
+`.itx/491/atx-session.json`. Documented in PR Callouts as an
+`[ENVIRONMENT]` note; the PR is opened anyway with the manual
+verification evidence above.

--- a/.itx/491/atx-session.json
+++ b/.itx/491/atx-session.json
@@ -1,0 +1,12 @@
+{
+  "session_id": "5c55522e-e8ac-4287-b0f4-18896b8bcd4e",
+  "transport": "cli",
+  "commit_sha": "8970916d6fac470eca168cffa47a5222ad72950f",
+  "iteration": 1,
+  "last_rating": null,
+  "last_blockers": [],
+  "started_at": "2026-05-22T22:51:54Z",
+  "updated_at": "2026-05-22T23:02:00Z",
+  "result": "timeout",
+  "note": "atx CLI review timed out after 10m without returning a rating. Work was verified manually: all 2552 python tests + 213 GUI tests pass, make lint clean, and end-to-end `clm agent open clawrium-d01` against a live local zeroclaw agent returned HTTP 200 through the SSH tunnel."
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,16 +101,24 @@ Rules (issue #437):
   whenever the bearer is overwritten. The CLI renders it as a yellow
   notice during `configure`/`sync`/`restart`.
 
-## Hermes Native Dashboard (issue #478)
+## Native Dashboards (issues #478, #491)
 
-Hermes is the only agent type that ships a native web UI today. Two systemd units run side-by-side on the agent host:
+Two agent types ship a native web UI today: **hermes** (issue #478) and **zeroclaw** (issue #491). The manifest's `features.web_ui` block is the single gate — `clm agent open <name>` and the GUI's **Open Agent UI** button both consult the resolver in `src/clawrium/core/web_ui.py`, which returns `None` for any agent whose manifest does not declare `features.web_ui`.
+
+**Hermes** (issue #478) runs the dashboard in a separate systemd unit on the agent host:
 
 - `hermes-<agent_name>.service` — the OpenAI-compatible API gateway (the existing unit).
 - `hermes-dashboard-<agent_name>.service` — the SPA dashboard, with `PartOf=hermes-<agent_name>.service` and `Also=hermes-<agent_name>.service` in `[Install]`. systemd propagates stop/restart of the gateway to the dashboard automatically; we explicitly `enable` the dashboard unit on first start.
 
-The dashboard binds `127.0.0.1:<port>` only — never `0.0.0.0`. There is no in-process auth: the **SSH key Ansible already uses for the host is the auth boundary**. Anyone with shell access to the agent host could reach loopback directly, so layering a token wall on top would not raise the security floor.
+The hermes dashboard binds `127.0.0.1:<port>` only (`features.web_ui.bind: loopback`). install.py picks the per-instance port in `45000..46999` and persists it under `hosts.json.agents.<name>.config.dashboard.port`.
 
-`clm agent open <hermes-name>` (CLI) and the GUI's **Open Agent UI** button both rely on the same loopback-bound dashboard. The tunnel manager at `src/clawrium/core/web_ui_tunnel.py` is idempotent — a second invocation for a live tunnel reuses the existing local port (state at `~/.config/clawrium/tunnels/<agent_key>.json`, PID + cmdline-guarded). The GUI auto-reaps tunnels idle > 30 minutes; CLI tunnels close on `Ctrl-C` or process exit.
+**Zeroclaw** (issue #491) does not run a separate dashboard unit — the gateway daemon itself serves the SPA on the same port as `config.gateway.port` (`features.web_ui.bind: wildcard`, port persisted under `gateway.port`). install.py picks the per-instance gateway port in `40000..41999`.
+
+**Auth boundary (both agent types).** There is no in-process auth on the dashboard: the **SSH key Ansible already uses for the host is the auth boundary**. Anyone with shell access to the agent host could reach the dashboard directly, so layering a token wall on top would not raise the security floor. Zeroclaw's `0.0.0.0` bind is an upstream property; this trust model still holds because reachability is gated at the network/SSH layer.
+
+**Tunnel reuse.** The tunnel manager at `src/clawrium/core/web_ui_tunnel.py` is idempotent — a second invocation for a live tunnel reuses the existing local port (state at `~/.config/clawrium/tunnels/<agent_key>.json`, PID + cmdline-guarded). The GUI auto-reaps tunnels idle > 30 minutes; CLI tunnels close on `Ctrl-C` or process exit. The remote target is always loopback regardless of `bind`: both `BIND_ADDRESS_MAP["loopback"]` and `BIND_ADDRESS_MAP["wildcard"]` resolve to `127.0.0.1`, because the SSH local-forward terminates on the remote loopback interface — reachable for both bind modes.
+
+**No `default_port` in bundled manifests.** Both hermes and zeroclaw manifests omit `features.web_ui.default_port`. install.py always persists a per-instance port at `port_field`; a manifest-wide default would silently collide on hosts running multiple agents of the same type. The resolver surfaces a missing persisted port as "no UI available" rather than inventing one. Third-party manifests may still opt into `default_port` — the schema accepts it.
 
 ## Tech Stack
 

--- a/gui/src/components/agent-detail/agent-header.tsx
+++ b/gui/src/components/agent-detail/agent-header.tsx
@@ -3,7 +3,7 @@
 import { AgentDetail } from "@/lib/types";
 import { StatusDot } from "@/components/ui/status-dot";
 import { Button } from "@/components/ui/button";
-import { useAgentActions, useAgentWebUI } from "@/hooks";
+import { useAgentActions, useAgentWebUI, WEB_UI_AGENT_TYPES } from "@/hooks";
 
 interface AgentHeaderProps {
   agent: AgentDetail;
@@ -14,9 +14,10 @@ export function AgentHeader({ agent }: AgentHeaderProps) {
   const isRunning = agent.status === "running";
   const isStopped = agent.status === "stopped";
 
-  // Native UI button is hermes-only today. The hook is a no-op for other
-  // agent types (enabled flag in useAgentWebUI gates the fetch).
-  const showWebUI = agent.agent_type === "hermes";
+  // Native UI button shows for any agent type whose manifest declares
+  // `features.web_ui`. Allowlist lives in the hook so the fetch and the
+  // render decision stay in sync.
+  const showWebUI = WEB_UI_AGENT_TYPES.has(agent.agent_type);
   const webUI = useAgentWebUI(agent.agent_key, agent.agent_type, agent.status);
 
   return (

--- a/gui/src/hooks/index.ts
+++ b/gui/src/hooks/index.ts
@@ -3,7 +3,12 @@ export { useFleetHealth } from "./use-fleet-health";
 export { useTopology } from "./use-topology";
 export { useProviders, useProviderTypes, useModelCatalog, useCreateProvider, useUpdateProvider, useDeleteProvider } from "./use-providers";
 export { useUsageSummary, useUsageHistory, useUsageByAgent } from "./use-usage";
-export { useAgent, useAgentActions, useAgentWebUI } from "./use-agent";
+export {
+  useAgent,
+  useAgentActions,
+  useAgentWebUI,
+  WEB_UI_AGENT_TYPES,
+} from "./use-agent";
 export { useSettings, useVersion, useClearUsage } from "./use-settings";
 export {
   useIntegrations,

--- a/gui/src/hooks/use-agent.ts
+++ b/gui/src/hooks/use-agent.ts
@@ -10,16 +10,18 @@ export function useAgent(key: string) {
   });
 }
 
+export const WEB_UI_AGENT_TYPES = new Set(["hermes", "zeroclaw"]);
+
 export function useAgentWebUI(key: string, agentType: string, status: string) {
   return useQuery({
     queryKey: ["agent-web-ui", key, status],
     queryFn: () => api.getAgentWebUI(key),
-    // Hermes is the only agent type that exposes a native UI today.
-    // Other agent types return available=false from the backend, but we
-    // skip the fetch entirely to avoid a useless request that establishes
-    // last-access state in the reaper for an agent we won't show a button
-    // for.
-    enabled: !!key && agentType === "hermes",
+    // Allowlist of agent types whose manifest declares `features.web_ui`.
+    // Other types return available=false from the backend, but we skip the
+    // fetch to avoid a useless round-trip per detail page view. Keep this
+    // in sync with the agent manifests under
+    // src/clawrium/platform/registry/<type>/manifest.yaml.
+    enabled: !!key && WEB_UI_AGENT_TYPES.has(agentType),
     // Retry an unavailable tunnel every 30s so a transient failure clears
     // itself once the host is reachable again. We stop retrying as soon as
     // the tunnel is up to keep the reaper map quiet.

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -2728,11 +2728,13 @@ def open_ui(
     """Open an agent's native web UI in your default browser.
 
     For remote agents this establishes an SSH local-port-forward tunnel to
-    the agent's loopback dashboard port and points your browser at the
-    local end of the tunnel. The tunnel runs until you Ctrl-C.
+    the agent's dashboard port (resolved to the remote loopback regardless
+    of whether the agent itself binds 127.0.0.1 or 0.0.0.0) and points your
+    browser at the local end of the tunnel. The tunnel runs until you
+    Ctrl-C.
 
-    Only hermes agents expose a native UI today; running this against an
-    openclaw / zeroclaw agent prints a hard-error.
+    Hermes and zeroclaw expose a native UI today; agents whose manifests
+    do not declare `features.web_ui` (e.g. openclaw) print a hard-error.
     """
     import signal
     import webbrowser
@@ -2756,13 +2758,6 @@ def open_ui(
         raise typer.Exit(code=1)
     except HostsFileCorruptedError as e:
         err_console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
-        raise typer.Exit(code=1)
-
-    if claw_type != "hermes":
-        err_console.print(
-            f"[red]Error:[/red] Native UI not supported for agent type "
-            f"'{rich_escape(claw_type)}'. Only hermes is supported in this release."
-        )
         raise typer.Exit(code=1)
 
     resolved = resolve_web_ui(installed_name)

--- a/src/clawrium/core/registry.py
+++ b/src/clawrium/core/registry.py
@@ -136,14 +136,19 @@ class ChatFeatureConfig(TypedDict):
 class WebUIFeatureConfig(TypedDict):
     """Native web UI capability descriptor.
 
-    `bind` is a closed enum; only `loopback` is accepted in this iteration —
-    LAN-bound dashboards are deliberately out of scope. `port_field` is a
-    dotted path into the agent's `hosts.json` config record (for example,
-    `dashboard.port`) so callers can locate the persisted per-instance port.
+    `bind` is a closed enum: `loopback` (agent listens on 127.0.0.1 only)
+    or `wildcard` (agent listens on 0.0.0.0). Either way the SSH tunnel
+    target on the remote is loopback, so `BIND_ADDRESS_MAP` resolves both
+    to `127.0.0.1`; the distinction exists so the manifest accurately
+    describes the agent's bind, not because tunneling differs.
+
+    `port_field` is a dotted path into the agent's `hosts.json` config
+    record (for example, `dashboard.port` or `gateway.port`) so callers
+    can locate the persisted per-instance port.
     """
 
     enabled: bool
-    bind: Literal["loopback"]
+    bind: Literal["loopback", "wildcard"]
     default_port: int
     port_field: str
 
@@ -519,7 +524,7 @@ def _validate_workspace(workspace_value: object, agent_type: str) -> WorkspaceCo
 
 
 _ALLOWED_CHAT_TYPES = ("openai", "websocket", "zeroclaw")
-_ALLOWED_WEB_UI_BINDS = ("loopback",)
+_ALLOWED_WEB_UI_BINDS = ("loopback", "wildcard")
 
 # `port_field` is a dotted path that downstream code uses both as a config
 # lookup (`agent_record.config.<port_field>`) and — in Phase 2 — as an
@@ -532,12 +537,12 @@ _PORT_FIELD_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*
 def _validate_web_ui(web_ui_value: object, agent_type: str) -> WebUIFeatureConfig:
     """Validate `features.web_ui` block.
 
-    `bind` is a closed enum (currently `loopback` only). All four fields
+    `bind` is a closed enum: `loopback` or `wildcard`. All four fields
     (`enabled`, `bind`, `default_port`, `port_field`) are required when the
     block is present. `default_port` is constrained to 1024..65535 —
     privileged ports (<1024) are rejected outright because non-root agent
     processes cannot bind them. `port_field` must be a dotted identifier
-    path (e.g. `dashboard.port`).
+    path (e.g. `dashboard.port`, `gateway.port`).
     """
     web_ui = _as_dict(web_ui_value, "features.web_ui", agent_type)
 

--- a/src/clawrium/core/registry.py
+++ b/src/clawrium/core/registry.py
@@ -145,11 +145,19 @@ class WebUIFeatureConfig(TypedDict):
     `port_field` is a dotted path into the agent's `hosts.json` config
     record (for example, `dashboard.port` or `gateway.port`) so callers
     can locate the persisted per-instance port.
+
+    `default_port` is optional. In practice every agent type computes a
+    per-instance port at install time and persists it under `port_field`,
+    so a single manifest-wide default would silently collide when a host
+    runs multiple agents of the same type. Manifests should omit
+    `default_port` when no static fallback exists; resolvers surface a
+    missing persisted port as "no UI available" rather than serving a
+    different instance's URL.
     """
 
     enabled: bool
     bind: Literal["loopback", "wildcard"]
-    default_port: int
+    default_port: NotRequired[int]
     port_field: str
 
 
@@ -537,12 +545,15 @@ _PORT_FIELD_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*
 def _validate_web_ui(web_ui_value: object, agent_type: str) -> WebUIFeatureConfig:
     """Validate `features.web_ui` block.
 
-    `bind` is a closed enum: `loopback` or `wildcard`. All four fields
-    (`enabled`, `bind`, `default_port`, `port_field`) are required when the
-    block is present. `default_port` is constrained to 1024..65535 —
-    privileged ports (<1024) are rejected outright because non-root agent
-    processes cannot bind them. `port_field` must be a dotted identifier
-    path (e.g. `dashboard.port`, `gateway.port`).
+    `bind` is a closed enum: `loopback` or `wildcard`. `enabled`, `bind`,
+    and `port_field` are required; `default_port` is optional (most
+    agents compute a per-instance port at install time and persist it
+    under `port_field`, so a single manifest-wide default would silently
+    collide for hosts running multiple instances of the same agent type).
+    When present, `default_port` is constrained to 1024..65535 —
+    privileged ports (<1024) are rejected outright because non-root
+    agent processes cannot bind them. `port_field` must be a dotted
+    identifier path (e.g. `dashboard.port`, `gateway.port`).
     """
     web_ui = _as_dict(web_ui_value, "features.web_ui", agent_type)
 
@@ -560,8 +571,9 @@ def _validate_web_ui(web_ui_value: object, agent_type: str) -> WebUIFeatureConfi
             f"has invalid `features.web_ui.bind` (expected one of {allowed})",
         )
 
+    has_default_port = "default_port" in web_ui
     default_port = web_ui.get("default_port")
-    if (
+    if has_default_port and (
         not isinstance(default_port, int)
         or isinstance(default_port, bool)
         or default_port < 1024
@@ -589,12 +601,14 @@ def _validate_web_ui(web_ui_value: object, agent_type: str) -> WebUIFeatureConfi
             "(expected dotted identifier path, e.g. 'dashboard.port')",
         )
 
-    return {
+    result: WebUIFeatureConfig = {
         "enabled": enabled,
         "bind": bind,
-        "default_port": default_port,
         "port_field": port_field,
     }
+    if has_default_port:
+        result["default_port"] = default_port
+    return result
 
 
 def _validate_features(features_value: object, agent_type: str) -> FeaturesConfig:

--- a/src/clawrium/core/web_ui.py
+++ b/src/clawrium/core/web_ui.py
@@ -61,7 +61,9 @@ class ResolvedUI:
             constructing a `ResolvedUI` with an empty host.
         remote_port: TCP port the dashboard listens on inside the agent
             host. Sourced from `agent_record.config.<port_field>` when
-            persisted, else the manifest's `default_port`.
+            persisted, else the manifest's `default_port` (if declared).
+            When neither is available the resolver returns `None` rather
+            than constructing a `ResolvedUI` with an invented port.
         bind: Bind scope advertised by the manifest. Closed enum:
             `"loopback"` (agent listens on 127.0.0.1 only) or `"wildcard"`
             (agent listens on 0.0.0.0). Downstream callers should look up
@@ -161,7 +163,9 @@ def resolve(agent_key: str) -> ResolvedUI | None:
           - the host record has no usable primary address,
           - the agent's manifest cannot be loaded,
           - the manifest does not declare `features.web_ui`,
-          - `features.web_ui.enabled` is `False`.
+          - `features.web_ui.enabled` is `False`,
+          - `hosts.json` carries no persisted port at `port_field` AND
+            the manifest declares no `default_port` (#491).
     """
     if not isinstance(agent_key, str) or not agent_key.strip():
         return None
@@ -229,8 +233,21 @@ def resolve(agent_key: str) -> ResolvedUI | None:
         and 0 < persisted_port <= 65535
     ):
         remote_port = persisted_port
-    else:
+    elif "default_port" in web_ui:
         remote_port = web_ui["default_port"]
+    else:
+        # Manifest has no static fallback and `hosts.json` is missing the
+        # persisted port — surface as "no UI" rather than inventing one.
+        # Inventing a default would silently serve a different instance's
+        # UI when multiple agents of the same type share a host.
+        logger.warning(
+            "resolve(%s): %r has no persisted %s in hosts.json and the "
+            "manifest declares no default_port — treating as no UI available",
+            agent_key,
+            agent_type,
+            web_ui["port_field"],
+        )
+        return None
 
     return ResolvedUI(
         host=host,

--- a/src/clawrium/core/web_ui.py
+++ b/src/clawrium/core/web_ui.py
@@ -9,10 +9,13 @@ Returns `None` whenever an agent is not installed or its manifest does
 not declare `features.web_ui` — callers should treat `None` as "no native
 UI available for this agent".
 
-Bind contract: `bind: "loopback"` in this iteration MUST be interpreted
-by downstream callers as the IPv4 address `127.0.0.1`. The `BIND_ADDRESS_MAP`
-constant is the single source of truth — Phase 2's tunnel manager and any
-future consumer must import it rather than re-deriving the mapping.
+Bind contract: `bind: "loopback"` advertises that the agent listens on
+127.0.0.1 only; `bind: "wildcard"` advertises that it listens on
+0.0.0.0 (any interface). Either way, the SSH tunnel target on the
+remote is loopback — both values resolve to `127.0.0.1` through
+`BIND_ADDRESS_MAP`. The map is the single source of truth: Phase 2's
+tunnel manager and any future consumer must import it rather than
+re-deriving the mapping.
 """
 
 from __future__ import annotations
@@ -35,7 +38,10 @@ logger = logging.getLogger(__name__)
 # Single source of truth for the `bind` enum → concrete network address.
 # Downstream callers MUST consult this map rather than hard-coding 127.0.0.1,
 # so that adding new bind modes later remains a single-file change.
-BIND_ADDRESS_MAP: dict[str, str] = {"loopback": "127.0.0.1"}
+BIND_ADDRESS_MAP: dict[str, str] = {
+    "loopback": "127.0.0.1",
+    "wildcard": "127.0.0.1",
+}
 
 # Characters that must never appear in a host-supplied identity-file path.
 # Phase 2's tunnel manager will pass this value to `ssh -i <path>`; rejecting
@@ -56,9 +62,12 @@ class ResolvedUI:
         remote_port: TCP port the dashboard listens on inside the agent
             host. Sourced from `agent_record.config.<port_field>` when
             persisted, else the manifest's `default_port`.
-        bind: Bind scope advertised by the manifest. Closed enum — only
-            `"loopback"` is accepted in this iteration. Downstream callers
-            should look up the concrete address via `BIND_ADDRESS_MAP[bind]`.
+        bind: Bind scope advertised by the manifest. Closed enum:
+            `"loopback"` (agent listens on 127.0.0.1 only) or `"wildcard"`
+            (agent listens on 0.0.0.0). Downstream callers should look up
+            the concrete tunnel target via `BIND_ADDRESS_MAP[bind]` —
+            both values map to `127.0.0.1` because the SSH tunnel always
+            forwards to the remote loopback interface regardless.
         ssh_config: SSH-tunnel parameters: `user`, optional `port`,
             optional `identity_file`. Empty dict when the host record
             provides no SSH details.
@@ -66,7 +75,7 @@ class ResolvedUI:
 
     host: str
     remote_port: int
-    bind: Literal["loopback"]
+    bind: Literal["loopback", "wildcard"]
     ssh_config: dict[str, Any] = field(default_factory=dict)
 
 

--- a/src/clawrium/core/web_ui_tunnel.py
+++ b/src/clawrium/core/web_ui_tunnel.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Any
 
 from clawrium.core.config import get_config_dir, init_config_dir
-from clawrium.core.web_ui import ResolvedUI, resolve
+from clawrium.core.web_ui import BIND_ADDRESS_MAP, ResolvedUI, resolve
 
 __all__ = [
     "TunnelError",
@@ -207,6 +207,7 @@ def _pick_free_port() -> int:
 def _ssh_command(
     local_port: int,
     remote_port: int,
+    remote_bind_addr: str,
     ssh_user: str,
     ssh_host: str,
     ssh_port: int | None,
@@ -216,7 +217,7 @@ def _ssh_command(
         "ssh",
         "-N",
         "-L",
-        f"{local_port}:127.0.0.1:{remote_port}",
+        f"{local_port}:{remote_bind_addr}:{remote_port}",
         "-o",
         "ServerAliveInterval=30",
         "-o",
@@ -376,9 +377,21 @@ def _build_ssh_for(resolved: ResolvedUI, local_port: int) -> list[str]:
         raise TunnelError(
             "SSH user not configured for host; cannot establish tunnel."
         )
+    try:
+        remote_bind_addr = BIND_ADDRESS_MAP[resolved.bind]
+    except KeyError as e:
+        # The manifest validator restricts `bind` to a closed enum, so this
+        # is unreachable in practice. Surfacing it as TunnelError keeps the
+        # BIND_ADDRESS_MAP contract enforced rather than aspirational: a
+        # future bind mode added to the manifest schema MUST also extend
+        # the map, or the tunnel builder fails loudly here.
+        raise TunnelError(
+            f"unknown bind mode {resolved.bind!r} — extend BIND_ADDRESS_MAP"
+        ) from e
     return _ssh_command(
         local_port=local_port,
         remote_port=resolved.remote_port,
+        remote_bind_addr=remote_bind_addr,
         ssh_user=user,
         ssh_host=resolved.host,
         ssh_port=ssh.get("port") if isinstance(ssh.get("port"), int) else None,

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -16,16 +16,13 @@ features:
   # Native browser dashboard shipped by hermes upstream. Bound to loopback
   # on the agent host; clm tunnels through SSH (see issue #478). `port_field`
   # is the dotted path inside `hosts.json.agents.<name>.config` where the
-  # per-instance dashboard port is persisted at install time.
-  #
-  # default_port 9119 mirrors the upstream `hermes dashboard` default in
-  # `hermes_cli/web_server.py` (see .itx/478/00_PLAN.md for the upstream
-  # reference). Phase 2's install playbook MUST assert the deployed port
-  # matches this manifest value, or override it explicitly per-instance.
+  # per-instance dashboard port is persisted at install time. No
+  # `default_port`: install.py computes a per-instance port in 45000..46999
+  # so a manifest-wide default would silently collide on a host running
+  # multiple hermes instances (issue #491).
   web_ui:
     enabled: true
     bind: loopback
-    default_port: 9119
     port_field: dashboard.port
 
 # Secrets configuration.

--- a/src/clawrium/platform/registry/zeroclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/manifest.yaml
@@ -23,14 +23,15 @@ features:
   # Native web dashboard served by the gateway daemon itself (same process,
   # same port as `config.gateway.port` — no separate systemd unit). `bind:
   # wildcard` reflects zeroclaw's actual bind on 0.0.0.0; the SSH tunnel
-  # still targets remote loopback via BIND_ADDRESS_MAP. `default_port` is a
-  # placeholder for the schema — configure.yaml always persists gateway.port
-  # (computed per-instance in 40000..41999), so this fallback rarely fires.
+  # still targets remote loopback via BIND_ADDRESS_MAP. No `default_port`
+  # because zeroclaw computes a per-instance port at install time
+  # (`40000 + hash % 2000`) and `configure.yaml` always persists it under
+  # `gateway.port` — a manifest-wide default would silently collide on a
+  # host running multiple zeroclaw instances.
   # Mirrors hermes #478 for `clm agent open`.
   web_ui:
     enabled: true
     bind: wildcard
-    default_port: 40000
     port_field: gateway.port
 
 # Secrets for this agent. Provider URL and model are now sourced from the

--- a/src/clawrium/platform/registry/zeroclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/manifest.yaml
@@ -20,6 +20,18 @@ features:
   # auth header, different stream semantics).
   chat:
     type: zeroclaw
+  # Native web dashboard served by the gateway daemon itself (same process,
+  # same port as `config.gateway.port` — no separate systemd unit). `bind:
+  # wildcard` reflects zeroclaw's actual bind on 0.0.0.0; the SSH tunnel
+  # still targets remote loopback via BIND_ADDRESS_MAP. `default_port` is a
+  # placeholder for the schema — configure.yaml always persists gateway.port
+  # (computed per-instance in 40000..41999), so this fallback rarely fires.
+  # Mirrors hermes #478 for `clm agent open`.
+  web_ui:
+    enabled: true
+    bind: wildcard
+    default_port: 40000
+    port_field: gateway.port
 
 # Secrets for this agent. Provider URL and model are now sourced from the
 # providers system (selected during the onboarding `providers` stage and

--- a/tests/test_cli_agent_open.py
+++ b/tests/test_cli_agent_open.py
@@ -139,3 +139,153 @@ def test_open_print_skips_health_probe_and_tunnel(isolated_config: Path):
         result = runner.invoke(app, ["agent", "open", "demo", "--print"])
 
     assert result.exit_code == 0
+
+
+def _running_health(agent_type: str = "hermes", host: str = "192.168.1.100") -> dict:
+    """Return a `check_claw_health` payload that satisfies the RUNNING gate."""
+    return {
+        "agent": agent_type,
+        "host": host,
+        "status": ClawStatus.RUNNING,
+        "agent_name": "demo",
+        "error": None,
+        "missing_secrets": None,
+        "onboarding_step": None,
+        "process_running": True,
+        "onboarding_stages": None,
+        "cpu_count": None,
+        "memory_total_mb": None,
+    }
+
+
+def test_open_remote_agent_spawns_tunnel_and_opens_browser(isolated_config: Path):
+    """Remote hermes agent: tunnel is established and the browser is opened
+    at the tunnel's local end. Regression anchor for ATX B5 (#491).
+    """
+    _seed_hosts(isolated_config, "hermes")
+    resolved = ResolvedUI(
+        host="hermes.local",
+        remote_port=45123,
+        bind="loopback",
+        ssh_config={"user": "xclm"},
+    )
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=resolved),
+        patch(
+            "clawrium.core.health.check_claw_health",
+            return_value=_running_health(host="hermes.local"),
+        ),
+        patch("clawrium.core.web_ui_tunnel.ensure", return_value=54321) as mock_ensure,
+        patch("clawrium.core.web_ui_tunnel.close") as mock_close,
+        patch("webbrowser.open") as mock_browser,
+        patch("threading.Event") as mock_event_cls,
+    ):
+        # threading.Event().wait() blocks until the SIGINT handler fires.
+        # Tests run in-process: wait() must return immediately.
+        mock_event_cls.return_value.wait.return_value = None
+        result = runner.invoke(app, ["agent", "open", "demo"])
+
+    assert result.exit_code == 0, result.output
+    mock_ensure.assert_called_once_with("demo")
+    mock_browser.assert_called_once_with("http://127.0.0.1:54321/")
+    mock_close.assert_called_once_with("demo")
+
+
+def test_open_remote_agent_tunnel_error_exits_nonzero(isolated_config: Path):
+    """TunnelError from ensure_tunnel surfaces as exit 1 with the message.
+    Regression anchor for ATX B6 (#491).
+    """
+    from clawrium.core.web_ui_tunnel import TunnelError
+
+    _seed_hosts(isolated_config, "hermes")
+    resolved = ResolvedUI(
+        host="hermes.local",
+        remote_port=45123,
+        bind="loopback",
+        ssh_config={"user": "xclm"},
+    )
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=resolved),
+        patch(
+            "clawrium.core.health.check_claw_health",
+            return_value=_running_health(host="hermes.local"),
+        ),
+        patch(
+            "clawrium.core.web_ui_tunnel.ensure",
+            side_effect=TunnelError("ssh refused"),
+        ),
+        patch("webbrowser.open") as mock_browser,
+    ):
+        result = runner.invoke(app, ["agent", "open", "demo"])
+
+    assert result.exit_code == 1
+    assert "ssh refused" in result.output.lower()
+    mock_browser.assert_not_called()
+
+
+def test_open_refuses_when_agent_not_running(isolated_config: Path):
+    """Health status outside {READY, RUNNING} blocks the tunnel attempt.
+    Regression anchor for ATX B7 (#491).
+    """
+    _seed_hosts(isolated_config, "hermes")
+    resolved = ResolvedUI(
+        host="hermes.local",
+        remote_port=45123,
+        bind="loopback",
+        ssh_config={"user": "xclm"},
+    )
+    health_stopped = _running_health(host="hermes.local")
+    health_stopped["status"] = ClawStatus.STOPPED
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=resolved),
+        patch(
+            "clawrium.core.health.check_claw_health",
+            return_value=health_stopped,
+        ),
+        patch(
+            "clawrium.core.web_ui_tunnel.ensure",
+            side_effect=AssertionError("tunnel must not be attempted"),
+        ),
+        patch("webbrowser.open") as mock_browser,
+    ):
+        result = runner.invoke(app, ["agent", "open", "demo"])
+
+    assert result.exit_code == 1
+    assert "not running" in result.output.lower()
+    assert "clm agent start" in result.output.lower()
+    mock_browser.assert_not_called()
+
+
+def test_open_remote_zeroclaw_spawns_tunnel_with_wildcard_bind(isolated_config: Path):
+    """zeroclaw resolves with `bind='wildcard'` and still tunnels to remote
+    loopback (BIND_ADDRESS_MAP['wildcard'] == '127.0.0.1'). Regression
+    anchor for ATX W15 (#491).
+    """
+    _seed_hosts(isolated_config, "zeroclaw")
+    resolved = ResolvedUI(
+        host="zero.local",
+        remote_port=40123,
+        bind="wildcard",
+        ssh_config={"user": "xclm"},
+    )
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=resolved),
+        patch(
+            "clawrium.core.health.check_claw_health",
+            return_value=_running_health(agent_type="zeroclaw", host="zero.local"),
+        ),
+        patch("clawrium.core.web_ui_tunnel.ensure", return_value=39211) as mock_ensure,
+        patch("clawrium.core.web_ui_tunnel.close"),
+        patch("webbrowser.open") as mock_browser,
+        patch("threading.Event") as mock_event_cls,
+    ):
+        mock_event_cls.return_value.wait.return_value = None
+        result = runner.invoke(app, ["agent", "open", "demo"])
+
+    assert result.exit_code == 0, result.output
+    mock_ensure.assert_called_once_with("demo")
+    mock_browser.assert_called_once_with("http://127.0.0.1:39211/")

--- a/tests/test_cli_agent_open.py
+++ b/tests/test_cli_agent_open.py
@@ -37,12 +37,18 @@ def _seed_hosts(config_dir: Path, agent_type: str) -> None:
     (config_dir / "hosts.json").write_text(json.dumps(hosts))
 
 
-def test_open_rejects_non_hermes_agent(isolated_config: Path):
+def test_open_rejects_agent_without_web_ui_feature(isolated_config: Path):
+    """openclaw has no `features.web_ui` in its manifest → resolver returns
+    None → CLI exits with a clear "does not declare a native web UI" error.
+
+    The hermes-only gate was dropped in #491 (zeroclaw also exposes a UI);
+    the manifest's `features.web_ui` block is now the only gate.
+    """
     _seed_hosts(isolated_config, "openclaw")
     result = runner.invoke(app, ["agent", "open", "demo"])
     assert result.exit_code == 1
-    assert "not supported" in result.output.lower()
-    assert "hermes" in result.output.lower()
+    assert "does not declare" in result.output.lower()
+    assert "native web ui" in result.output.lower()
 
 
 def test_open_unknown_agent_exits_nonzero(isolated_config: Path):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1105,7 +1105,12 @@ def test_load_manifest_accepts_valid_web_ui(monkeypatch):
 
 
 def test_load_manifest_rejects_invalid_web_ui_bind(monkeypatch):
-    """`bind` is a closed enum — only `loopback` accepted in this iteration."""
+    """`bind` is a closed enum — `loopback` and `wildcard` accepted.
+
+    Other values (e.g. `0.0.0.0`, `lan`, arbitrary strings) are rejected
+    at manifest-load so a typo can't end up as `bind: wildcrad` and
+    silently produce a broken tunnel.
+    """
     from clawrium.core import registry
 
     manifest = deepcopy(_valid_manifest())
@@ -1116,6 +1121,21 @@ def test_load_manifest_rejects_invalid_web_ui_bind(monkeypatch):
 
     with pytest.raises(ManifestParseError, match="features.web_ui.bind"):
         load_manifest("openclaw")
+
+
+@pytest.mark.parametrize("bind_value", ["loopback", "wildcard"])
+def test_load_manifest_accepts_web_ui_bind_values(monkeypatch, bind_value):
+    """Both members of the `bind` enum round-trip through validation (#491)."""
+    from clawrium.core import registry
+
+    manifest = deepcopy(_valid_manifest())
+    block = _valid_web_ui_block()
+    block["bind"] = bind_value
+    manifest["features"] = {"web_ui": block}
+    monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
+
+    loaded = load_manifest("openclaw")
+    assert loaded["features"]["web_ui"]["bind"] == bind_value
 
 
 def test_load_manifest_accepts_web_ui_without_default_port(monkeypatch):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1073,7 +1073,13 @@ def test_manifest_rejects_invalid_features_memory(monkeypatch):
 
 
 def _valid_web_ui_block() -> dict:
-    """Return a minimal valid `features.web_ui` block for tests."""
+    """Return a minimal valid `features.web_ui` block for tests.
+
+    `default_port` is included in the canonical block so the existing
+    "validator accepts a complete block" / range-boundary tests still
+    exercise that branch — but the field is optional in the schema
+    (issue #491), and the omission test below exercises that path.
+    """
     return {
         "enabled": True,
         "bind": "loopback",
@@ -1112,8 +1118,14 @@ def test_load_manifest_rejects_invalid_web_ui_bind(monkeypatch):
         load_manifest("openclaw")
 
 
-def test_load_manifest_rejects_web_ui_missing_default_port(monkeypatch):
-    """`default_port` is required and must be a positive integer."""
+def test_load_manifest_accepts_web_ui_without_default_port(monkeypatch):
+    """`default_port` is optional (issue #491).
+
+    Agents like hermes and zeroclaw compute per-instance ports at install
+    time and persist them under `port_field`; a manifest-wide default
+    would silently collide on hosts running multiple instances. The
+    resolver surfaces a missing persisted port as "no UI" instead.
+    """
     from clawrium.core import registry
 
     manifest = deepcopy(_valid_manifest())
@@ -1122,8 +1134,12 @@ def test_load_manifest_rejects_web_ui_missing_default_port(monkeypatch):
     manifest["features"] = {"web_ui": block}
     monkeypatch.setattr(registry.yaml, "safe_load", lambda _: manifest)
 
-    with pytest.raises(ManifestParseError, match="features.web_ui.default_port"):
-        load_manifest("openclaw")
+    loaded = load_manifest("openclaw")
+    web_ui = loaded["features"]["web_ui"]
+    assert "default_port" not in web_ui
+    assert web_ui["enabled"] is True
+    assert web_ui["bind"] == "loopback"
+    assert web_ui["port_field"] == "dashboard.port"
 
 
 def test_load_manifest_rejects_web_ui_non_positive_port(monkeypatch):
@@ -1233,9 +1249,13 @@ def test_load_manifest_rejects_web_ui_non_dict(monkeypatch):
         load_manifest("openclaw")
 
 
-@pytest.mark.parametrize("missing_field", ["enabled", "bind", "default_port", "port_field"])
+@pytest.mark.parametrize("missing_field", ["enabled", "bind", "port_field"])
 def test_load_manifest_rejects_web_ui_missing_field(monkeypatch, missing_field):
-    """Each required `web_ui` field must be present."""
+    """Each required `web_ui` field must be present.
+
+    `default_port` is intentionally absent from this list (issue #491) —
+    see `test_load_manifest_accepts_web_ui_without_default_port`.
+    """
     from clawrium.core import registry
 
     manifest = deepcopy(_valid_manifest())
@@ -1320,13 +1340,19 @@ def test_allowed_web_ui_binds_matches_literal():
 
 
 def test_hermes_manifest_declares_web_ui():
-    """The bundled hermes manifest advertises native dashboard support."""
+    """The bundled hermes manifest advertises native dashboard support.
+
+    No `default_port` (issue #491): install.py computes a per-instance
+    port in 45000..46999 and persists it under `dashboard.port`, so a
+    manifest-wide default would silently collide on hosts running
+    multiple hermes instances.
+    """
     manifest = load_manifest("hermes")
     web_ui = manifest.get("features", {}).get("web_ui", {})
     assert web_ui.get("enabled") is True
     assert web_ui.get("bind") == "loopback"
-    assert web_ui.get("default_port") == 9119
     assert web_ui.get("port_field") == "dashboard.port"
+    assert "default_port" not in web_ui
 
 
 def test_openclaw_manifest_does_not_declare_web_ui():
@@ -1336,16 +1362,19 @@ def test_openclaw_manifest_does_not_declare_web_ui():
 
 
 def test_zeroclaw_manifest_declares_web_ui():
-    """zeroclaw opts into the native-UI mechanism via gateway.port (#491)."""
+    """zeroclaw opts into the native-UI mechanism via gateway.port (#491).
+
+    No `default_port`: zeroclaw computes a per-instance port at install
+    time (`40000 + hash % 2000`) and persists it under `gateway.port`,
+    so a manifest-wide default would silently collide on hosts running
+    multiple zeroclaw instances.
+    """
     manifest = load_manifest("zeroclaw")
     web_ui = manifest.get("features", {}).get("web_ui", {})
     assert web_ui.get("enabled") is True
     assert web_ui.get("bind") == "wildcard"
     assert web_ui.get("port_field") == "gateway.port"
-    # default_port is a schema-required placeholder for zeroclaw: configure.yaml
-    # always persists gateway.port at install time (computed per-instance in
-    # 40000..41999), so this fallback rarely fires.
-    assert web_ui.get("default_port") == 40000
+    assert "default_port" not in web_ui
 
 
 def test_openclaw_manifest_now_declares_memory_workspace():

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1123,9 +1123,19 @@ def test_load_manifest_rejects_invalid_web_ui_bind(monkeypatch):
         load_manifest("openclaw")
 
 
-@pytest.mark.parametrize("bind_value", ["loopback", "wildcard"])
+def _allowed_web_ui_binds() -> tuple[str, ...]:
+    """Surface `_ALLOWED_WEB_UI_BINDS` for parametrize so a new enum
+    member auto-extends this test instead of silently skipping it
+    (ATX iter 3 W4).
+    """
+    from clawrium.core.registry import _ALLOWED_WEB_UI_BINDS
+
+    return _ALLOWED_WEB_UI_BINDS
+
+
+@pytest.mark.parametrize("bind_value", _allowed_web_ui_binds())
 def test_load_manifest_accepts_web_ui_bind_values(monkeypatch, bind_value):
-    """Both members of the `bind` enum round-trip through validation (#491)."""
+    """Every member of the `bind` enum round-trips through validation (#491)."""
     from clawrium.core import registry
 
     manifest = deepcopy(_valid_manifest())

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1335,10 +1335,17 @@ def test_openclaw_manifest_does_not_declare_web_ui():
     assert "web_ui" not in manifest.get("features", {})
 
 
-def test_zeroclaw_manifest_does_not_declare_web_ui():
-    """zeroclaw does not opt into the native-UI mechanism."""
+def test_zeroclaw_manifest_declares_web_ui():
+    """zeroclaw opts into the native-UI mechanism via gateway.port (#491)."""
     manifest = load_manifest("zeroclaw")
-    assert "web_ui" not in manifest.get("features", {})
+    web_ui = manifest.get("features", {}).get("web_ui", {})
+    assert web_ui.get("enabled") is True
+    assert web_ui.get("bind") == "wildcard"
+    assert web_ui.get("port_field") == "gateway.port"
+    # default_port is a schema-required placeholder for zeroclaw: configure.yaml
+    # always persists gateway.port at install time (computed per-instance in
+    # 40000..41999), so this fallback rarely fires.
+    assert web_ui.get("default_port") == 40000
 
 
 def test_openclaw_manifest_now_declares_memory_workspace():

--- a/tests/test_web_ui_resolver.py
+++ b/tests/test_web_ui_resolver.py
@@ -28,8 +28,15 @@ def _patch_agent(monkeypatch, host: dict, agent_type: str, agent_record: dict) -
     )
 
 
-def test_resolve_hermes_returns_default_port(monkeypatch):
-    """A hermes agent with no persisted dashboard port resolves to the manifest default."""
+def test_resolve_hermes_without_persisted_port_returns_none(monkeypatch, caplog):
+    """A hermes agent without persisted `dashboard.port` resolves to None.
+
+    Issue #491: the hermes manifest no longer carries a `default_port`
+    fallback (install.py computes a per-instance port in 45000..46999
+    and persists it). When the persisted value is missing the resolver
+    must surface "no UI available" rather than inventing a port that
+    would land us on whichever instance happened to bind 9119.
+    """
     _patch_agent(
         monkeypatch,
         host=_host("hermes.local"),
@@ -37,13 +44,9 @@ def test_resolve_hermes_returns_default_port(monkeypatch):
         agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
     )
 
-    resolved = resolve("demo")
-
-    assert isinstance(resolved, ResolvedUI)
-    assert resolved.host == "hermes.local"
-    assert resolved.remote_port == 9119
-    assert resolved.bind == "loopback"
-    assert resolved.ssh_config.get("user") == "xclm"
+    with caplog.at_level("WARNING", logger="clawrium.core.web_ui"):
+        assert resolve("demo") is None
+    assert any("dashboard.port" in rec.message for rec in caplog.records)
 
 
 def test_resolve_hermes_uses_persisted_port(monkeypatch):
@@ -93,18 +96,22 @@ def test_resolve_zeroclaw_returns_gateway_port(monkeypatch):
     assert resolved.bind == "wildcard"
 
 
-def test_resolve_zeroclaw_falls_back_to_default_port(monkeypatch):
-    """zeroclaw without a persisted gateway.port falls back to manifest default."""
+def test_resolve_zeroclaw_without_persisted_port_returns_none(monkeypatch, caplog):
+    """zeroclaw without persisted `gateway.port` resolves to None (#491).
+
+    Same rationale as the hermes test above: zeroclaw computes a
+    per-instance port at install time, so inventing a default would
+    silently serve a different instance's UI.
+    """
     _patch_agent(
         monkeypatch,
         host=_host(),
         agent_type="zeroclaw",
         agent_record={"agent_name": "zc", "type": "zeroclaw", "config": {}},
     )
-    resolved = resolve("zc")
-    assert resolved is not None
-    assert resolved.bind == "wildcard"
-    assert resolved.remote_port == 40000
+    with caplog.at_level("WARNING", logger="clawrium.core.web_ui"):
+        assert resolve("zc") is None
+    assert any("gateway.port" in rec.message for rec in caplog.records)
 
 
 def test_resolve_missing_agent_returns_none(monkeypatch):
@@ -186,7 +193,11 @@ def test_resolve_uses_primary_address_when_distinct_from_hostname(monkeypatch):
         monkeypatch,
         host=host,
         agent_type="hermes",
-        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+        agent_record={
+            "agent_name": "demo",
+            "type": "hermes",
+            "config": {"dashboard": {"port": 45123}},
+        },
     )
 
     resolved = resolve("demo")
@@ -195,8 +206,15 @@ def test_resolve_uses_primary_address_when_distinct_from_hostname(monkeypatch):
     assert resolved.ssh_config.get("user") == "ops"
 
 
-def test_resolve_falls_back_to_default_port_for_invalid_persisted(monkeypatch):
-    """A non-int (or out-of-range) persisted port is ignored; default wins."""
+def test_resolve_returns_none_for_invalid_persisted_when_no_default(monkeypatch, caplog):
+    """A non-int (or out-of-range) persisted port with no `default_port`
+    in the manifest → None (#491).
+
+    Previously the resolver fell back to `default_port`. Now that the
+    bundled hermes/zeroclaw manifests no longer carry a default (a
+    manifest-wide default would collide for hosts running multiple
+    instances), an invalid persisted port must surface as "no UI".
+    """
     agent_record = {
         "agent_name": "demo",
         "type": "hermes",
@@ -204,9 +222,43 @@ def test_resolve_falls_back_to_default_port_for_invalid_persisted(monkeypatch):
     }
     _patch_agent(monkeypatch, host=_host(), agent_type="hermes", agent_record=agent_record)
 
-    resolved = resolve("demo")
+    with caplog.at_level("WARNING", logger="clawrium.core.web_ui"):
+        assert resolve("demo") is None
+    assert any("dashboard.port" in rec.message for rec in caplog.records)
+
+
+def test_resolve_uses_manifest_default_when_present(monkeypatch):
+    """If a manifest *does* declare `default_port`, the resolver still
+    honors it (back-compat for third-party manifests that opt in).
+
+    The bundled hermes/zeroclaw manifests omit `default_port` post-#491
+    on purpose, but the schema still accepts it. Lock in the fallback
+    path against a mocked manifest so the behaviour doesn't regress for
+    out-of-tree consumers.
+    """
+    manifest = {
+        "agent": {"type": "third-party", "description": "t"},
+        "platforms": [],
+        "features": {
+            "web_ui": {
+                "enabled": True,
+                "bind": "loopback",
+                "default_port": 8080,
+                "port_field": "dashboard.port",
+            }
+        },
+    }
+    monkeypatch.setattr(web_ui_module, "load_manifest", lambda _t: manifest)
+    _patch_agent(
+        monkeypatch,
+        host=_host(),
+        agent_type="third-party",
+        agent_record={"agent_name": "tp", "type": "third-party", "config": {}},
+    )
+
+    resolved = resolve("tp")
     assert resolved is not None
-    assert resolved.remote_port == 9119
+    assert resolved.remote_port == 8080
 
 
 def test_resolve_handles_unknown_agent_type(monkeypatch):
@@ -273,7 +325,11 @@ def test_resolve_ssh_config_resolves_identity_via_key_id(monkeypatch, tmp_path):
         monkeypatch,
         host=host_record,
         agent_type="hermes",
-        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+        agent_record={
+            "agent_name": "demo",
+            "type": "hermes",
+            "config": {"dashboard": {"port": 45123}},
+        },
     )
 
     resolved = resolve("demo")
@@ -315,7 +371,11 @@ def test_resolve_ssh_config_falls_back_to_hostname_when_key_id_missing(
         monkeypatch,
         host=host_record,
         agent_type="hermes",
-        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+        agent_record={
+            "agent_name": "demo",
+            "type": "hermes",
+            "config": {"dashboard": {"port": 45123}},
+        },
     )
 
     resolved = resolve("demo")
@@ -346,7 +406,11 @@ def test_resolve_ssh_config_omits_identity_when_key_missing(monkeypatch):
         monkeypatch,
         host=host_record,
         agent_type="hermes",
-        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+        agent_record={
+            "agent_name": "demo",
+            "type": "hermes",
+            "config": {"dashboard": {"port": 45123}},
+        },
     )
 
     resolved = resolve("demo")
@@ -386,7 +450,11 @@ def test_resolve_ssh_config_drops_identity_with_shell_metachars_in_resolved_path
         monkeypatch,
         host=host_record,
         agent_type="hermes",
-        agent_record={"agent_name": "demo", "type": "hermes", "config": {}},
+        agent_record={
+            "agent_name": "demo",
+            "type": "hermes",
+            "config": {"dashboard": {"port": 45123}},
+        },
     )
 
     resolved = resolve("demo")

--- a/tests/test_web_ui_resolver.py
+++ b/tests/test_web_ui_resolver.py
@@ -71,15 +71,40 @@ def test_resolve_openclaw_returns_none(monkeypatch):
     assert resolve("oc") is None
 
 
-def test_resolve_zeroclaw_returns_none(monkeypatch):
-    """zeroclaw's manifest does not declare `features.web_ui`."""
+def test_resolve_zeroclaw_returns_gateway_port(monkeypatch):
+    """zeroclaw resolves to its persisted `gateway.port` (mirror of #478)."""
+    agent_record = {
+        "agent_name": "zc",
+        "type": "zeroclaw",
+        "config": {"gateway": {"port": 40123}},
+    }
+    _patch_agent(
+        monkeypatch,
+        host=_host("zero.local"),
+        agent_type="zeroclaw",
+        agent_record=agent_record,
+    )
+
+    resolved = resolve("zc")
+
+    assert isinstance(resolved, ResolvedUI)
+    assert resolved.host == "zero.local"
+    assert resolved.remote_port == 40123
+    assert resolved.bind == "wildcard"
+
+
+def test_resolve_zeroclaw_falls_back_to_default_port(monkeypatch):
+    """zeroclaw without a persisted gateway.port falls back to manifest default."""
     _patch_agent(
         monkeypatch,
         host=_host(),
         agent_type="zeroclaw",
         agent_record={"agent_name": "zc", "type": "zeroclaw", "config": {}},
     )
-    assert resolve("zc") is None
+    resolved = resolve("zc")
+    assert resolved is not None
+    assert resolved.bind == "wildcard"
+    assert resolved.remote_port == 40000
 
 
 def test_resolve_missing_agent_returns_none(monkeypatch):
@@ -408,6 +433,13 @@ def test_bind_address_map_covers_loopback():
     from clawrium.core.web_ui import BIND_ADDRESS_MAP
 
     assert BIND_ADDRESS_MAP["loopback"] == "127.0.0.1"
+
+
+def test_bind_address_map_covers_wildcard():
+    """`wildcard` agents (zeroclaw) still tunnel to remote loopback."""
+    from clawrium.core.web_ui import BIND_ADDRESS_MAP
+
+    assert BIND_ADDRESS_MAP["wildcard"] == "127.0.0.1"
 
 
 def test_resolve_returns_none_when_enabled_false(monkeypatch):

--- a/tests/test_web_ui_tunnel.py
+++ b/tests/test_web_ui_tunnel.py
@@ -87,14 +87,12 @@ def test_build_ssh_for_loopback_targets_remote_loopback():
 
 
 def test_build_ssh_for_wildcard_resolves_to_remote_loopback():
-    """A `wildcard`-bound agent (zeroclaw) still tunnels to remote loopback.
+    """Value lock-in: `bind='wildcard'` produces a `-L L:127.0.0.1:R` flag.
 
-    Locks in the BIND_ADDRESS_MAP contract: the tunnel builder consumes
-    `BIND_ADDRESS_MAP[resolved.bind]` for the `-L` remote target rather
-    than hardcoding `127.0.0.1`. The runtime output happens to be the
-    same as the loopback case today (both map to 127.0.0.1), but the
-    test asserts the *code path* — change `BIND_ADDRESS_MAP['wildcard']`
-    in `web_ui.py` and this test breaks loudly. ATX iteration 2 B-new1.
+    This is a value assertion only — both code paths (a real lookup of
+    `BIND_ADDRESS_MAP['wildcard']` and a hardcoded `'127.0.0.1'`) would
+    pass it today. `test_build_ssh_for_consults_bind_address_map_*`
+    below are the load-bearing tests for the map-lookup contract.
     """
     resolved = ResolvedUI(
         host="zero.local",
@@ -107,13 +105,12 @@ def test_build_ssh_for_wildcard_resolves_to_remote_loopback():
     assert forward == "39211:127.0.0.1:40123"
 
 
-def test_build_ssh_for_consults_bind_address_map(monkeypatch):
-    """The builder MUST go through `BIND_ADDRESS_MAP`, not a hardcoded literal.
+def test_build_ssh_for_consults_bind_address_map_wildcard(monkeypatch):
+    """The builder MUST go through `BIND_ADDRESS_MAP['wildcard']`.
 
-    Defense-in-depth regression anchor for the contract documented in
-    `web_ui.py`. We swap a sentinel into `BIND_ADDRESS_MAP['wildcard']`
-    and assert the `-L` flag reflects the swap. If a future refactor
-    re-introduces a hardcoded `127.0.0.1`, this test fails.
+    Swap a sentinel into the map and assert the `-L` flag reflects the
+    swap. If a future refactor re-introduces a hardcoded `127.0.0.1`
+    for the wildcard path this test fails. ATX iter 2 B-new1.
     """
     monkeypatch.setitem(
         web_ui_tunnel.BIND_ADDRESS_MAP, "wildcard", "10.99.99.99"
@@ -127,6 +124,50 @@ def test_build_ssh_for_consults_bind_address_map(monkeypatch):
     cmd = _build_ssh_for(resolved, local_port=39211)
     forward = next(arg for arg in cmd if arg.startswith("39211:"))
     assert forward == "39211:10.99.99.99:40123"
+
+
+def test_build_ssh_for_consults_bind_address_map_loopback(monkeypatch):
+    """Symmetric to the wildcard sentinel test, for `bind='loopback'`.
+
+    Closes a regression vector where a refactor could keep the map
+    lookup for `wildcard` while hardcoding `127.0.0.1` specifically
+    for `loopback` — the wildcard-only sentinel test would still pass.
+    ATX iter 3 W3.
+    """
+    monkeypatch.setitem(
+        web_ui_tunnel.BIND_ADDRESS_MAP, "loopback", "10.88.88.88"
+    )
+    resolved = ResolvedUI(
+        host="hermes.local",
+        remote_port=45123,
+        bind="loopback",
+        ssh_config={"user": "xclm"},
+    )
+    cmd = _build_ssh_for(resolved, local_port=39211)
+    forward = next(arg for arg in cmd if arg.startswith("39211:"))
+    assert forward == "39211:10.88.88.88:45123"
+
+
+def test_build_ssh_for_unknown_bind_raises_tunnel_error():
+    """An unknown `bind` value surfaces as `TunnelError`, not `KeyError`.
+
+    The manifest validator restricts `bind` to a closed enum at load
+    time so this path is unreachable through the bundled manifests.
+    But `Literal[...]` is unenforced at runtime — a tampered
+    `hosts.json` or a third-party manifest mocked through `load_manifest`
+    can produce a `ResolvedUI(bind='future_mode', ...)`. The builder
+    must fail loudly with a `TunnelError` referencing the bind name so
+    operators see "extend BIND_ADDRESS_MAP" rather than an opaque
+    `KeyError` traceback. ATX iter 3 W2.
+    """
+    resolved = ResolvedUI(
+        host="x.local",
+        remote_port=9000,
+        bind="future_mode",  # type: ignore[arg-type]  # intentional invalid value
+        ssh_config={"user": "u"},
+    )
+    with pytest.raises(TunnelError, match="unknown bind mode"):
+        _build_ssh_for(resolved, local_port=12345)
 
 
 def test_ensure_returns_existing_local_port_when_healthy(

--- a/tests/test_web_ui_tunnel.py
+++ b/tests/test_web_ui_tunnel.py
@@ -21,6 +21,7 @@ from clawrium.core import web_ui_tunnel
 from clawrium.core.web_ui import ResolvedUI
 from clawrium.core.web_ui_tunnel import (
     TunnelError,
+    _build_ssh_for,
     _cmdline_matches,
     _cmdline_signature,
     _pick_free_port,
@@ -70,6 +71,62 @@ def test_cmdline_signature_matches_actual_proc_format():
 def test_cmdline_signature_rejects_unrelated_cmdline():
     signature = _cmdline_signature(["ssh", "-N", "-L", "1234:127.0.0.1:9119", "xclm@host"])
     assert not _cmdline_matches("nginx: worker process", signature)
+
+
+def test_build_ssh_for_loopback_targets_remote_loopback():
+    """A `loopback`-bound agent yields a `-L L:127.0.0.1:R` forward."""
+    resolved = ResolvedUI(
+        host="hermes.local",
+        remote_port=45123,
+        bind="loopback",
+        ssh_config={"user": "xclm"},
+    )
+    cmd = _build_ssh_for(resolved, local_port=39211)
+    forward = next(arg for arg in cmd if arg.startswith("39211:"))
+    assert forward == "39211:127.0.0.1:45123"
+
+
+def test_build_ssh_for_wildcard_resolves_to_remote_loopback():
+    """A `wildcard`-bound agent (zeroclaw) still tunnels to remote loopback.
+
+    Locks in the BIND_ADDRESS_MAP contract: the tunnel builder consumes
+    `BIND_ADDRESS_MAP[resolved.bind]` for the `-L` remote target rather
+    than hardcoding `127.0.0.1`. The runtime output happens to be the
+    same as the loopback case today (both map to 127.0.0.1), but the
+    test asserts the *code path* — change `BIND_ADDRESS_MAP['wildcard']`
+    in `web_ui.py` and this test breaks loudly. ATX iteration 2 B-new1.
+    """
+    resolved = ResolvedUI(
+        host="zero.local",
+        remote_port=40123,
+        bind="wildcard",
+        ssh_config={"user": "xclm"},
+    )
+    cmd = _build_ssh_for(resolved, local_port=39211)
+    forward = next(arg for arg in cmd if arg.startswith("39211:"))
+    assert forward == "39211:127.0.0.1:40123"
+
+
+def test_build_ssh_for_consults_bind_address_map(monkeypatch):
+    """The builder MUST go through `BIND_ADDRESS_MAP`, not a hardcoded literal.
+
+    Defense-in-depth regression anchor for the contract documented in
+    `web_ui.py`. We swap a sentinel into `BIND_ADDRESS_MAP['wildcard']`
+    and assert the `-L` flag reflects the swap. If a future refactor
+    re-introduces a hardcoded `127.0.0.1`, this test fails.
+    """
+    monkeypatch.setitem(
+        web_ui_tunnel.BIND_ADDRESS_MAP, "wildcard", "10.99.99.99"
+    )
+    resolved = ResolvedUI(
+        host="zero.local",
+        remote_port=40123,
+        bind="wildcard",
+        ssh_config={"user": "xclm"},
+    )
+    cmd = _build_ssh_for(resolved, local_port=39211)
+    forward = next(arg for arg in cmd if arg.startswith("39211:"))
+    assert forward == "39211:10.99.99.99:40123"
 
 
 def test_ensure_returns_existing_local_port_when_healthy(


### PR DESCRIPTION
## Summary

- Mirror of #478 for zeroclaw: `clm agent open <zeroclaw-name>` and the GUI's **Open Agent UI** button both now open the zeroclaw SPA via SSH tunnel. No new systemd unit, no upstream change — the gateway daemon (`config.gateway.port`) already serves the dashboard from the same process/port.
- Generalised the web-UI mechanism beyond hermes:
  - `features.web_ui.bind` enum widens to `loopback | wildcard` (zeroclaw binds `0.0.0.0`; tunnel target stays loopback via `BIND_ADDRESS_MAP`).
  - `features.web_ui.default_port` becomes optional. Both hermes and zeroclaw compute per-instance ports at install time (45000..46999 / 40000..41999) — a manifest-wide default would silently collide on hosts running multiple agents of the same type. Bundled manifests no longer carry `default_port`; the resolver surfaces missing persisted ports as "no UI available" instead of inventing one.
- Dropped the hermes-only gates in `clm agent open` (CLI) and the GUI's **Open Agent UI** render path. Manifest's `features.web_ui` is now the single gate.
- Made `BIND_ADDRESS_MAP` load-bearing instead of aspirational: `_build_ssh_for` reads `BIND_ADDRESS_MAP[resolved.bind]` for the `-L` target; an unknown bind value raises `TunnelError` so future enum members must extend the map or fail loudly.

Closes #491.

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $9.45 | Total Time: 20m 36s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1, B2, B3, B4 (pre-existing), B5, B6, B7 | B5/B6/B7 Fixed, B1-B4 out-of-scope | $3.95 | 11m49s | cli-ux, core-lifecycle, ansible-registry, security, test-coverage |
| 2 | 3/5 | B-new1 (BIND_ADDRESS_MAP aspirational) | All fixed | $3.84 | 9m48s | cli-ux, core-lifecycle, ansible-registry, security, test-coverage |
| 3 | 4/5 | None | Merge-eligible | $1.66 | 5m18s | core-lifecycle, security, test-coverage |

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `cli/agent.py:1843` | Rich markup injection in `Sync failed: {error}` | Out-of-scope — pre-existing from `b8c0881c` (2026-04-15); this PR does not touch line 1843. To be filed as a follow-up security PR. |
| B2 | `cli/agent.py:2342,2425` | Rich markup injection in `[dim]{message}[/dim]` | Out-of-scope — pre-existing from `65d48186` (2026-04-08); not touched by this PR. |
| B3 | `cli/agent.py:2344,2427` | Rich markup injection in bare `{message}` | Out-of-scope — same commit as B2. |
| B4 | `cli/agent.py:427` | Rich markup injection in `ProvidersFileCorruptedError` | Out-of-scope — pre-existing from `181f0be7` (2026-04-06). |
| B5 | `tests/test_cli_agent_open.py` | Remote tunnel success path uncovered | Fixed — added `test_open_remote_agent_spawns_tunnel_and_opens_browser`. |
| B6 | `tests/test_cli_agent_open.py` | `TunnelError` exit path uncovered | Fixed — added `test_open_remote_agent_tunnel_error_exits_nonzero`. |
| B7 | `tests/test_cli_agent_open.py` | Not-running health gate uncovered | Fixed — added `test_open_refuses_when_agent_not_running`. |

**Warnings (in-scope):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W6 | `AGENTS.md` | "Hermes is the only agent type that ships a native web UI today" | Fixed — rewrote "Hermes Native Dashboard" → "Native Dashboards" with hermes/zeroclaw side-by-side, `default_port` policy, generalised auth boundary text. |
| W9 | `zeroclaw/manifest.yaml:30` | `default_port` collision risk | Fixed at a deeper level — dropped `default_port` from both bundled manifests entirely and made the field optional in the schema (iter 2). |
| W15 | `tests/test_web_ui_tunnel.py` | No test for `bind='wildcard'` SSH command | Fixed in iter 2/3 — `test_build_ssh_for_wildcard_resolves_to_remote_loopback` + the map-sentinel tests. |

**Warnings deferred as pre-existing** (not introduced by this PR; filed separately or already documented): W1 (HostsFileCorruptedError contract), W2 (SO_REUSEADDR ordering), W3 (InvalidAgentTypeError log level), W4 (`--print` loopback semantics), W5 (`0.0.0.0` in `_host_is_local`), W7 (GUI button label vs tooltip), W8 (`_ENSURE_LOCKS` no eviction), W10 (StrictHostKeyChecking=accept-new TOFU), W11 (0.0.0.0 bind no in-process auth — documented design per AGENTS.md), W12 (`_state_path` sanitisation), W13/W14/W16/W17 (test gaps in pre-existing code).

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B-new1 | `core/web_ui_tunnel.py:219` + `tests/test_cli_agent_open.py:262-291` | `BIND_ADDRESS_MAP` is "aspirational documentation, not enforced code" — `_ssh_command` hardcoded `127.0.0.1` instead of consulting the map. The iter-1 wildcard test was vacuous (patched `ensure` before any code that reads the map runs). | Fixed — `_ssh_command` now takes `remote_bind_addr`; `_build_ssh_for` looks up `BIND_ADDRESS_MAP[resolved.bind]`; a missing entry raises `TunnelError`. 3 new direct unit tests on `_build_ssh_for` (loopback + wildcard value lock-ins + a monkeypatched-sentinel test). |

**Warnings:**

| # | File | Warning | Status |
|---|------|---------|--------|
| W-new1 | `cli/agent.py:2773-2777` | `--print` emits the remote URL for loopback hermes agents (unreachable without tunnel) | Acknowledged — pre-existing from #488 (issue body's resolver was changed, this UX gap predates this PR). To be filed as a follow-up. |
| W-new2 | `install.py:567-568` | MD5-deterministic port selection, no socket availability probe — TOCTOU window for port squatting | Acknowledged — pre-existing from #478 phase 2. Threat-model note for a follow-up. |
| W-new3 | `AGENTS.md` + manifest | Reviewer flagged "SSH key is the auth boundary" wording as inaccurate for `0.0.0.0` bind | Already addressed in iter 2 (reviewer may have read the pre-rewrite AGENTS.md). The committed version distinguishes deployment boundary (SSH) from network-segment boundary (LAN reachability) and recommends VLAN segmentation for untrusted LANs. |
| W-new4 | `cli/agent.py:2779-2786` | `except Exception` health-check fallback path uncovered | Acknowledged — pre-existing from #488. Out of scope. |
| W-new5 | `tests/test_cli_agent_open.py:195-225` | B6 test doesn't lock in `'Traceback' not in output` | Acknowledged — defensive nice-to-have; not a regression vector today. |
| W-new6 | `tests/test_registry.py:1108` | Docstring says "only `loopback` accepted" + no isolated `bind: wildcard` accept test | Fixed — rewrote the rejection-test docstring and added `test_load_manifest_accepts_web_ui_bind_values` (iter 3: parametrized over `_ALLOWED_WEB_UI_BINDS`). |

</details>

<details>
<summary>Review 3 Details (Rating 4/5 — merge-eligible)</summary>

All three specialists (security, core-lifecycle, test-coverage) confirmed B-new1 cleared independently. No new blockers.

**Warnings addressed in iter 4 polish:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `tests/test_web_ui_tunnel.py` | Misleading docstring on wildcard test claimed "asserts the code path" when it only asserts the value | Fixed — rewrote docstring to be honest about scope; the sentinel-monkeypatch tests are the load-bearing anchors. |
| W2 | `tests/test_web_ui_tunnel.py` | `KeyError → TunnelError` path uncovered — the very mechanism that makes the contract enforced | Fixed — added `test_build_ssh_for_unknown_bind_raises_tunnel_error`. |
| W3 | `tests/test_web_ui_tunnel.py` | Only wildcard had a sentinel test; a refactor could re-hardcode loopback only and pass | Fixed — added `test_build_ssh_for_consults_bind_address_map_loopback`. |
| W4 | `tests/test_registry.py` | Bind parametrize hardcoded — a new enum member would silently skip | Fixed — derived parametrize from `_ALLOWED_WEB_UI_BINDS`. |

**Suggestions deferred** (low priority, pre-existing or defense-in-depth): KeyError test for IPv6 host, `--` separator before `user@host`, `Path.resolve().is_relative_to()` in `_state_path`, `isinstance(..., int) and not isinstance(..., bool)` pattern on `ssh_port`, idempotency double-call test, GUI manifest-mirror integration test for `WEB_UI_AGENT_TYPES`.

</details>

## Testing

### Test Results
- [x] All existing tests pass (`make test`): **2563** python tests, **213** GUI tests.
- [x] Linter passes (`make lint`): ruff + eslint clean.
- [x] New tests added for new functionality (10 new tests across test_cli_agent_open, test_web_ui_resolver, test_web_ui_tunnel, test_registry).

### Manual Testing

Live `clm`-managed fleet on `wolf-i`:

```
$ clm agent open clawrium-d01 --print           # zeroclaw, persisted gateway.port=41429
http://wolf.tailf7742d.ts.net:41429/

$ clm agent open clawrium-d01                    # establishes tunnel
Opening native UI for clawrium-d01
  Local port: 37993
  URL: http://127.0.0.1:37993/
$ curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:37993/
200

$ clm agent open maurice --print                 # hermes, persisted dashboard.port=45317
http://wolf.tailf7742d.ts.net:45317/

$ clm agent open espresso --print                # legacy hermes, no persisted port
Error: Agent 'espresso' does not declare a native web UI in its manifest.

$ clm agent open wolf-i --print                  # openclaw (no features.web_ui)
Error: Agent 'wolf-i' does not declare a native web UI in its manifest.
```

### Security Checklist
- [x] No hardcoded secrets or credentials.
- [x] Input validation for user-provided data — manifest validation still runs through `_validate_web_ui` (closed-enum `bind`, dotted-identifier `port_field`, port range guard when `default_port` is present).
- [x] No SQL injection, XSS, or command injection risks — no new subprocess paths; `BIND_ADDRESS_MAP` values are a hardcoded module-level dict.
- [x] Dependencies are from trusted sources — no new dependencies.

## Reviewer Notes

- **Behavior change (intentional):** Legacy hermes installs without persisted `dashboard.port` in `hosts.json` (i.e., installed before #478 phase 2) now report "does not declare a native web UI in its manifest" through `clm agent open`. The old behavior was to fall back to a hardcoded `9119`, which would silently land on the wrong instance for hosts running multiple hermes agents. To restore native UI on those installs: re-run `clm agent install --type hermes --host <host>` (install.py will persist the per-instance port), or manually write `hosts.json.agents.<name>.config.dashboard.port`.
- **`BIND_ADDRESS_MAP` contract enforcement:** iter 3 added `_build_ssh_for(resolved)` → `BIND_ADDRESS_MAP[resolved.bind]` with a `KeyError → TunnelError` wrap so the map is load-bearing. Runtime output is identical today (both modes → `127.0.0.1`) but adding a third bind mode (e.g. `lan`) requires both a manifest-schema and a map update — or the tunnel builder fails at the call site with a clear message.

## Callouts

- [DECISION] Dropped `default_port` from both bundled manifests instead of just zeroclaw.
  - Why: hermes also computes a per-instance port in 45000..46999 at install time (`install.py:585`) and persists it under `dashboard.port`. The manifest's `default_port: 9119` was a fossil that would silently route to the wrong instance on multi-hermes hosts — the same failure mode the issue body called out for zeroclaw.
  - Alternatives considered: leave hermes alone, fix only zeroclaw. Rejected because the user explicitly asked to fix both ("port should be dynamic for all agents since one instance will have multiple agents").
  - Reviewer: confirm or push back.

- [DECISION] Kept the GUI button gate as an explicit allowlist (`WEB_UI_AGENT_TYPES = {hermes, zeroclaw}`) exported from `useAgentWebUI`.
  - Why: minimal-diff fix that matches the existing pattern. Drift is bounded by the manifest itself — adding `features.web_ui` to a new manifest is a one-line GUI bump.
  - Alternatives considered: remove the gate entirely and let the backend's `available: false` decide. Cleaner long-term; deferred to keep this PR's GUI surface small.
  - Reviewer: confirm or push back.

- [DECISION] Renamed `test_open_rejects_non_hermes_agent` → `test_open_rejects_agent_without_web_ui_feature` and changed the asserted error string.
  - Why: the test was anchored to the dropped hermes-only gate's message. The replacement asserts the resolver-None branch ("does not declare a native web UI in its manifest"), which is now the only path that fires.

- [DECISION] `KeyError → TunnelError` wrap in `_build_ssh_for` (instead of letting `KeyError` propagate).
  - Why: it's the mechanism that makes `BIND_ADDRESS_MAP` the enforced single source of truth. A future bind mode added to the manifest schema without a matching map entry must fail loudly at the call site with the bind name in the error, not as an opaque `KeyError` traceback.

- [ENVIRONMENT] GitHub project board update (`Backlog` → `Executing` / `In Review`) was skipped — the local `gh` token does not carry the `project` / `read:project` scope. Please flip the card manually if the board is being watched.

- [TODO-FOLLOWUP] Pre-existing security findings flagged by ATX iter 1/2 that this PR does not introduce:
  - Rich markup injection at `cli/agent.py:427`, `1843`, `2342`, `2344`, `2425`, `2427` (B1-B4 iter 1).
  - `--print` emits a remote URL for loopback-bound agents (W4 iter 1 / W-new1 iter 2).
  - MD5-deterministic port selection with no socket availability probe in `install.py:585` (W-new2 iter 2).
  - `_ENSURE_LOCKS` dict never evicts entries (W8 iter 1).
  - `_state_path` sanitisation lacks `Path.resolve().is_relative_to()` defense-in-depth (W12 iter 1 / suggestion iter 3).
  - SSH `StrictHostKeyChecking=accept-new` TOFU window (W10 iter 1).
  - Tracking: to be filed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
