### PR TITLE
feat(gui): pairing-code button on zeroclaw agent detail page

### DIFF
--- a/gui/src/components/agent-detail/agent-header.tsx
+++ b/gui/src/components/agent-detail/agent-header.tsx
@@ -1,9 +1,16 @@
 "use client";
 
+import { useState } from "react";
 import { AgentDetail } from "@/lib/types";
 import { StatusDot } from "@/components/ui/status-dot";
 import { Button } from "@/components/ui/button";
-import { useAgentActions, useAgentWebUI, WEB_UI_AGENT_TYPES } from "@/hooks";
+import {
+  PAIRING_AGENT_TYPES,
+  WEB_UI_AGENT_TYPES,
+  useAgentActions,
+  useAgentPairingCode,
+  useAgentWebUI,
+} from "@/hooks";
 
 interface AgentHeaderProps {
   agent: AgentDetail;
@@ -19,6 +26,14 @@ export function AgentHeader({ agent }: AgentHeaderProps) {
   // render decision stay in sync.
   const showWebUI = WEB_UI_AGENT_TYPES.has(agent.agent_type);
   const webUI = useAgentWebUI(agent.agent_key, agent.agent_type, agent.status);
+
+  // Pairing code only meaningful for agent types whose SPA gates on an
+  // in-process handshake (zeroclaw). The mint is on-demand: clicking the
+  // button issues a fresh code, invalidating any previous one. We surface
+  // the most recent successful response inline.
+  const showPairing = PAIRING_AGENT_TYPES.has(agent.agent_type);
+  const pairing = useAgentPairingCode(agent.agent_key);
+  const [copied, setCopied] = useState(false);
 
   return (
     <div className="bg-white rounded-xl border border-default p-6 shadow-sm">
@@ -71,6 +86,25 @@ export function AgentHeader({ agent }: AgentHeaderProps) {
               </Button>
             );
           })()}
+          {showPairing && (
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={pairing.isPending || !isRunning}
+              onClick={() => {
+                setCopied(false);
+                pairing.mutate();
+              }}
+              title={
+                !isRunning
+                  ? "Start the agent to mint a pairing code"
+                  : "Mint a fresh pairing code (overwrites any previous code)"
+              }
+              aria-label="Generate pairing code"
+            >
+              {pairing.isPending ? "Generating..." : "Get Pairing Code"}
+            </Button>
+          )}
           {isStopped && (
             <Button
               variant="primary"
@@ -103,6 +137,56 @@ export function AgentHeader({ agent }: AgentHeaderProps) {
           )}
         </div>
       </div>
+
+      {showPairing && (pairing.data || pairing.isError) && (
+        <div className="mt-4 flex items-start gap-3 rounded-md border border-default bg-surface p-3 text-sm">
+          {pairing.data && (
+            <>
+              <div className="flex-1">
+                <div className="font-medium text-primary-text">
+                  Pairing code
+                </div>
+                <div className="mt-0.5 text-xs text-muted">
+                  Paste this into the dashboard prompt. The code is one-shot;
+                  the next mint replaces it.
+                </div>
+              </div>
+              <code className="select-all rounded bg-white px-2 py-1 font-mono text-base tracking-widest text-primary-text">
+                {pairing.data.pairing_code}
+              </code>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={async () => {
+                  try {
+                    await navigator.clipboard.writeText(
+                      pairing.data!.pairing_code,
+                    );
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 2000);
+                  } catch {
+                    // Clipboard API can fail in non-secure contexts;
+                    // the code is still readable via select-all.
+                  }
+                }}
+                aria-label="Copy pairing code to clipboard"
+              >
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </>
+          )}
+          {pairing.isError && !pairing.data && (
+            <div className="flex-1 text-red-600">
+              <div className="font-medium">Could not mint a pairing code</div>
+              <div className="mt-0.5 text-xs">
+                {pairing.error instanceof Error
+                  ? pairing.error.message
+                  : "Unknown error"}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/gui/src/hooks/index.ts
+++ b/gui/src/hooks/index.ts
@@ -7,7 +7,9 @@ export {
   useAgent,
   useAgentActions,
   useAgentWebUI,
+  useAgentPairingCode,
   WEB_UI_AGENT_TYPES,
+  PAIRING_AGENT_TYPES,
 } from "./use-agent";
 export { useSettings, useVersion, useClearUsage } from "./use-settings";
 export {

--- a/gui/src/hooks/use-agent.ts
+++ b/gui/src/hooks/use-agent.ts
@@ -12,6 +12,12 @@ export function useAgent(key: string) {
 
 export const WEB_UI_AGENT_TYPES = new Set(["hermes", "zeroclaw"]);
 
+// Agent types whose dashboard SPA requires an in-browser pairing
+// handshake. Keep in sync with `_PAIRING_AGENT_TYPES` in
+// `src/clawrium/gui/routes/fleet.py`. Today only zeroclaw — hermes
+// serves its dashboard without an in-process pairing step.
+export const PAIRING_AGENT_TYPES = new Set(["zeroclaw"]);
+
 export function useAgentWebUI(key: string, agentType: string, status: string) {
   return useQuery({
     queryKey: ["agent-web-ui", key, status],
@@ -27,6 +33,14 @@ export function useAgentWebUI(key: string, agentType: string, status: string) {
     // the tunnel is up to keep the reaper map quiet.
     refetchInterval: (query) =>
       query.state.data?.available ? false : 30_000,
+  });
+}
+
+export function useAgentPairingCode(key: string) {
+  // Mint-on-demand mutation. Each call overwrites the daemon's
+  // in-memory pairing code; the previous code becomes invalid.
+  return useMutation({
+    mutationFn: () => api.mintAgentPairingCode(key),
   });
 }
 

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -67,6 +67,10 @@ export const api = {
   getAgent: (key: string) => request<AgentDetail>(`/fleet/agents/${key}`),
   getAgentWebUI: (key: string) =>
     request<WebUIResponse>(`/fleet/agents/${key}/web-ui`),
+  mintAgentPairingCode: (key: string) =>
+    request<PairingCodeResponse>(`/fleet/agents/${key}/pairing-code`, {
+      method: "POST",
+    }),
   startAgent: (key: string) => request<ActionResponse>(`/agents/${key}/start`, { method: "POST" }),
   stopAgent: (key: string) => request<ActionResponse>(`/agents/${key}/stop`, { method: "POST" }),
   restartAgent: (key: string) => request<ActionResponse>(`/agents/${key}/restart`, { method: "POST" }),
@@ -256,6 +260,7 @@ import type {
   AgentDetail,
   ActionResponse,
   WebUIResponse,
+  PairingCodeResponse,
   TopologyResponse,
   Provider,
   ProviderTypesMap,

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -76,6 +76,14 @@ export interface WebUIResponse {
   reason: string | null;
 }
 
+// Response from POST /fleet/agents/{key}/pairing-code. Returned only by
+// agent types whose web dashboard requires an in-browser pairing
+// handshake (zeroclaw). The code is one-shot: a successful pair on the
+// daemon consumes it; another mint call overwrites it.
+export interface PairingCodeResponse {
+  pairing_code: string;
+}
+
 // Topology types
 export interface TopologyResponse {
   control: TopologyControl;

--- a/src/clawrium/gui/routes/fleet.py
+++ b/src/clawrium/gui/routes/fleet.py
@@ -357,6 +357,179 @@ async def agent_web_ui(agent_key: str) -> dict[str, Any]:
     }
 
 
+# Agent types whose web UI requires an in-browser pairing handshake. Today
+# only zeroclaw — hermes serves its dashboard without an in-process auth
+# step (the SSH key is the boundary). Keep this in sync with the frontend
+# allowlist in `gui/src/hooks/use-agent.ts`.
+_PAIRING_AGENT_TYPES = {"zeroclaw"}
+
+# Bound the upstream call to the agent daemon so a hung / unreachable
+# daemon doesn't pin a FastAPI worker. The pairing endpoint is in-process
+# on the agent and should respond in milliseconds; 10s is a generous
+# ceiling that still surfaces hangs as 504 to the browser.
+_PAIRING_UPSTREAM_TIMEOUT_S = 10.0
+
+
+@router.post("/fleet/agents/{agent_key}/pairing-code")
+async def agent_pairing_code(agent_key: str) -> dict[str, Any]:
+    """Mint a fresh pairing code for the agent's native web UI.
+
+    Only meaningful for agent types whose dashboard SPA gates browser
+    sessions with an in-process pairing handshake (zeroclaw today). The
+    endpoint:
+
+      1. Resolves the agent in ``hosts.json``.
+      2. Reuses the existing ``web_ui_tunnel`` to reach the agent's
+         dashboard daemon over SSH local-forward.
+      3. Reads the bearer token persisted at
+         ``agents.<name>.config.gateway.auth`` (the same one ansible
+         lifecycle ops mint via ``/pair`` and write to disk).
+      4. POSTs ``/api/pairing/initiate`` with that bearer; the daemon
+         overwrites its in-memory ``pairing_code`` slot and returns
+         the new code.
+
+    Each call invalidates the previous code (zeroclaw stores exactly
+    one). Callers MUST treat the response code as ephemeral and not
+    cache it. The returned bearer never leaves the gateway side; only
+    the short pairing code is sent to the browser.
+    """
+    import httpx
+
+    resolved_match = await asyncio.to_thread(resolve_agent, agent_key)
+    if resolved_match is None:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
+    _host_record, agent_type, agent_record = resolved_match
+
+    if agent_type not in _PAIRING_AGENT_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Agent type '{agent_type}' does not use an in-browser "
+                "pairing handshake."
+            ),
+        )
+
+    ui = await asyncio.to_thread(web_ui_module.resolve, agent_key)
+    if ui is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Agent '{agent_key}' does not declare a native web UI in "
+                "its manifest."
+            ),
+        )
+
+    gateway = (agent_record.get("config") or {}).get("gateway") or {}
+    bearer = gateway.get("auth")
+    if not isinstance(bearer, str) or not bearer.strip():
+        # No persisted bearer means lifecycle ops have not run successfully
+        # against this agent. Without it /api/pairing/initiate would 401 on
+        # the daemon side and the browser would see an opaque upstream
+        # error. Surface the actionable next step instead.
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Agent '{agent_key}' has no gateway bearer persisted. Run "
+                f"`clm agent configure {agent_key}` first."
+            ),
+        )
+
+    if _host_is_local(ui.host):
+        base = f"http://127.0.0.1:{ui.remote_port}"
+    else:
+        try:
+            local_port = await asyncio.to_thread(web_ui_tunnel.ensure, agent_key)
+        except web_ui_tunnel.TunnelError as e:
+            logger.warning("pairing-code tunnel failed for %s: %s", agent_key, e)
+            raise HTTPException(
+                status_code=502,
+                detail=_ABS_PATH_RE.sub("<path>", str(e)),
+            ) from e
+        except Exception as e:  # noqa: BLE001 — log full trace, generic body
+            logger.error(
+                "pairing-code tunnel unexpected error for %s",
+                agent_key,
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail="Internal error establishing tunnel; see server logs.",
+            ) from e
+
+        async with _LAST_ACCESS_LOCK:
+            WEB_UI_LAST_ACCESS[agent_key] = time.time()
+        base = f"http://127.0.0.1:{local_port}"
+
+    try:
+        async with httpx.AsyncClient(timeout=_PAIRING_UPSTREAM_TIMEOUT_S) as client:
+            resp = await client.post(
+                f"{base}/api/pairing/initiate",
+                headers={"Authorization": f"Bearer {bearer}"},
+            )
+    except httpx.TimeoutException as e:
+        logger.warning("pairing-code upstream timeout for %s", agent_key)
+        raise HTTPException(
+            status_code=504,
+            detail=(
+                f"Timed out talking to the agent daemon for '{agent_key}'. "
+                "The tunnel may be up but the daemon is unresponsive."
+            ),
+        ) from e
+    except httpx.HTTPError as e:
+        logger.warning("pairing-code upstream error for %s: %s", agent_key, e)
+        raise HTTPException(
+            status_code=502,
+            detail="Could not reach the agent daemon to mint a pairing code.",
+        ) from e
+
+    if resp.status_code == 401:
+        # Stale bearer in hosts.json (devices.db wiped or rebuilt on the
+        # agent host). Map to the same operator guidance the ansible
+        # pair.yaml validator emits.
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Agent daemon rejected the persisted bearer for "
+                f"'{agent_key}' (401). Re-run `clm agent configure "
+                f"{agent_key}` to re-pair from scratch."
+            ),
+        )
+    if resp.status_code == 503:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Agent daemon reports pairing disabled or unavailable (503). "
+                f"Check the daemon and restart with `clm agent restart "
+                f"{agent_key}`."
+            ),
+        )
+    if resp.status_code != 200:
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                f"Agent daemon returned unexpected status "
+                f"{resp.status_code} for pairing-code request."
+            ),
+        )
+
+    try:
+        body = resp.json()
+    except ValueError as e:
+        raise HTTPException(
+            status_code=502,
+            detail="Agent daemon returned a non-JSON pairing response.",
+        ) from e
+
+    code = body.get("pairing_code")
+    if not isinstance(code, str) or not code:
+        raise HTTPException(
+            status_code=502,
+            detail="Agent daemon returned an empty pairing code.",
+        )
+
+    return {"pairing_code": code}
+
+
 async def reap_idle_tunnels(threshold_seconds: float = 1800.0) -> int:
     """Close tunnels that have been idle longer than ``threshold_seconds``.
 

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -34,7 +34,15 @@ def _reset_reaper_state():
     fleet_mod.WEB_UI_LAST_ACCESS.clear()
 
 
-def _seed_hosts(config_dir: Path, agent_type: str) -> None:
+def _seed_hosts(
+    config_dir: Path,
+    agent_type: str,
+    config: dict | None = None,
+) -> None:
+    """Seed `hosts.json` with one agent. `config` overrides the agent's
+    `config` block — useful for tests that need a persisted gateway
+    bearer or dashboard port.
+    """
     hosts = [
         {
             "hostname": "192.168.1.100",
@@ -46,7 +54,7 @@ def _seed_hosts(config_dir: Path, agent_type: str) -> None:
                     "type": agent_type,
                     "agent_name": "demo",
                     "name": "demo",
-                    "config": {},
+                    "config": config or {},
                 }
             },
         }
@@ -179,3 +187,354 @@ def test_reaper_noop_when_all_fresh():
         count = asyncio.run(fleet_mod.reap_idle_tunnels(threshold_seconds=1800.0))
     assert count == 0
     mock_close.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# POST /fleet/agents/{key}/pairing-code  (zeroclaw SPA pairing handshake)
+# ---------------------------------------------------------------------------
+#
+# Contract (see `agent_pairing_code` in routes/fleet.py):
+#   - 404 when the agent is unknown.
+#   - 400 for agent types not in `_PAIRING_AGENT_TYPES` (today: anything
+#     other than zeroclaw).
+#   - 400 when the manifest does not declare features.web_ui.
+#   - 409 when `hosts.json.agents.<name>.config.gateway.auth` is missing
+#     or empty (lifecycle hasn't run yet).
+#   - 409 when the daemon returns 401 (stale bearer).
+#   - 503 when the daemon returns 503 (pairing disabled).
+#   - 502 when the tunnel fails, the upstream call errors, or the daemon
+#     returns an unexpected status / non-JSON / empty code.
+#   - 504 on upstream timeout.
+#   - 200 with {pairing_code: "..."} on success.
+
+
+def _zeroclaw_config(bearer: str = "zc_test_bearer", port: int = 40123) -> dict:
+    return {"gateway": {"auth": bearer, "port": port}}
+
+
+def _zeroclaw_resolved(host: str = "192.168.1.100") -> ResolvedUI:
+    return ResolvedUI(
+        host=host,
+        remote_port=40123,
+        bind="wildcard",
+        ssh_config={"user": "xclm"},
+    )
+
+
+def test_pairing_code_404_for_unknown_agent(isolated_config: Path):
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config())
+    with TestClient(app) as client:
+        resp = client.post("/api/fleet/agents/nope/pairing-code")
+    assert resp.status_code == 404
+
+
+def test_pairing_code_400_for_non_pairing_agent_type(isolated_config: Path):
+    """hermes uses features.web_ui but does not run the pairing handshake."""
+    _seed_hosts(isolated_config, "hermes", {"dashboard": {"port": 45123}})
+    with TestClient(app) as client:
+        resp = client.post("/api/fleet/agents/demo/pairing-code")
+    assert resp.status_code == 400
+    assert "pairing handshake" in resp.json()["detail"].lower()
+
+
+def test_pairing_code_400_when_manifest_lacks_web_ui(isolated_config: Path):
+    """openclaw has no features.web_ui — resolver returns None."""
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config())
+    with patch("clawrium.core.web_ui.resolve", return_value=None):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+    assert resp.status_code == 400
+    assert "native web ui" in resp.json()["detail"].lower()
+
+
+def test_pairing_code_409_when_bearer_missing(isolated_config: Path):
+    """No persisted gateway.auth → 409 with `clm agent configure` guidance."""
+    _seed_hosts(isolated_config, "zeroclaw", {"gateway": {"port": 40123}})
+    with patch("clawrium.core.web_ui.resolve", return_value=_zeroclaw_resolved()):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+    assert resp.status_code == 409
+    assert "clm agent configure" in resp.json()["detail"]
+
+
+def test_pairing_code_409_when_bearer_blank(isolated_config: Path):
+    _seed_hosts(isolated_config, "zeroclaw", {"gateway": {"auth": "   "}})
+    with patch("clawrium.core.web_ui.resolve", return_value=_zeroclaw_resolved()):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+    assert resp.status_code == 409
+
+
+def test_pairing_code_502_on_tunnel_failure(isolated_config: Path):
+    from clawrium.core.web_ui_tunnel import TunnelError
+
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config())
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=_zeroclaw_resolved()),
+        patch(
+            "clawrium.core.web_ui_tunnel.ensure",
+            side_effect=TunnelError("ssh refused"),
+        ),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+    assert resp.status_code == 502
+    assert "ssh refused" in resp.json()["detail"]
+
+
+def test_pairing_code_success(isolated_config: Path):
+    """Happy path: tunnel up, daemon returns 200 with a code, route relays it."""
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config("zc_bearer"))
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"pairing_code": "508333", "message": "ok"}
+
+    captured: dict = {}
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, headers=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            return _FakeResp()
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=_zeroclaw_resolved()),
+        patch("clawrium.core.web_ui_tunnel.ensure", return_value=39211),
+        patch("httpx.AsyncClient", _FakeClient),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"pairing_code": "508333"}
+    assert captured["url"] == "http://127.0.0.1:39211/api/pairing/initiate"
+    assert captured["headers"] == {"Authorization": "Bearer zc_bearer"}
+
+
+def test_pairing_code_409_on_daemon_401(isolated_config: Path):
+    """Stale bearer in hosts.json → daemon 401 → 409 with re-pair guidance."""
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config())
+
+    class _FakeResp:
+        status_code = 401
+
+        def json(self):
+            return {}
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, headers=None):
+            return _FakeResp()
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=_zeroclaw_resolved()),
+        patch("clawrium.core.web_ui_tunnel.ensure", return_value=39211),
+        patch("httpx.AsyncClient", _FakeClient),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+
+    assert resp.status_code == 409
+    assert "clm agent configure" in resp.json()["detail"]
+
+
+def test_pairing_code_503_on_daemon_503(isolated_config: Path):
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config())
+
+    class _FakeResp:
+        status_code = 503
+
+        def json(self):
+            return {}
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, headers=None):
+            return _FakeResp()
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=_zeroclaw_resolved()),
+        patch("clawrium.core.web_ui_tunnel.ensure", return_value=39211),
+        patch("httpx.AsyncClient", _FakeClient),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+
+    assert resp.status_code == 503
+    assert "clm agent restart" in resp.json()["detail"]
+
+
+def test_pairing_code_502_on_unexpected_daemon_status(isolated_config: Path):
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config())
+
+    class _FakeResp:
+        status_code = 418  # any non-200/401/503
+
+        def json(self):
+            return {}
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, headers=None):
+            return _FakeResp()
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=_zeroclaw_resolved()),
+        patch("clawrium.core.web_ui_tunnel.ensure", return_value=39211),
+        patch("httpx.AsyncClient", _FakeClient),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+
+    assert resp.status_code == 502
+    assert "418" in resp.json()["detail"]
+
+
+def test_pairing_code_502_on_empty_code(isolated_config: Path):
+    """Daemon returns 200 with a null/empty pairing_code — surface as 502."""
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config())
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"pairing_code": ""}
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, headers=None):
+            return _FakeResp()
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=_zeroclaw_resolved()),
+        patch("clawrium.core.web_ui_tunnel.ensure", return_value=39211),
+        patch("httpx.AsyncClient", _FakeClient),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+
+    assert resp.status_code == 502
+    assert "empty pairing code" in resp.json()["detail"].lower()
+
+
+def test_pairing_code_504_on_upstream_timeout(isolated_config: Path):
+    import httpx
+
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config())
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, headers=None):
+            raise httpx.ReadTimeout("timed out")
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=_zeroclaw_resolved()),
+        patch("clawrium.core.web_ui_tunnel.ensure", return_value=39211),
+        patch("httpx.AsyncClient", _FakeClient),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+
+    assert resp.status_code == 504
+
+
+def test_pairing_code_local_host_skips_tunnel(isolated_config: Path):
+    """If the agent's host is loopback, we hit the daemon directly — no SSH."""
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config("zc_local"))
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"pairing_code": "111111"}
+
+    captured: dict = {}
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, headers=None):
+            captured["url"] = url
+            return _FakeResp()
+
+    resolved = ResolvedUI(
+        host="127.0.0.1",
+        remote_port=40123,
+        bind="wildcard",
+        ssh_config={"user": "xclm"},
+    )
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=resolved),
+        patch(
+            "clawrium.core.web_ui_tunnel.ensure",
+            side_effect=AssertionError("tunnel must not be ensured for local hosts"),
+        ),
+        patch("httpx.AsyncClient", _FakeClient),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"pairing_code": "111111"}
+    # Hits the remote port directly, not the tunnel local port.
+    assert captured["url"] == "http://127.0.0.1:40123/api/pairing/initiate"


### PR DESCRIPTION
## Summary

- Adds a **"Get Pairing Code"** button on the agent detail page (next to "Open Agent UI") for zeroclaw agents.
- One click → mints a fresh pairing code on the running daemon → shows it inline with a copy action.
- Closes the manual workaround we documented during #491 testing: users no longer have to shell out and `curl /api/pairing/initiate` every time they want to bring up the zeroclaw SPA.

Follow-up to #494 (issue #491). No new agent-side change — purely a `clm` GUI / backend addition.

## Why

The upstream zeroclaw v0.7.5 dashboard SPA gates every browser session on an in-process pairing handshake. After the daemon has been paired once (its `devices.db` has rows), `GET /pair/code` returns `null` and you have to POST `/api/pairing/initiate` with the persisted bearer to mint a new code. That bearer lives in `hosts.json.agents.<name>.config.gateway.auth`. Today the user has to:

1. Read the bearer out of `hosts.json` with `jq`.
2. Find the live tunnel port from `~/.config/clawrium/tunnels/<key>.json`.
3. `curl -X POST http://127.0.0.1:<port>/api/pairing/initiate -H "Authorization: Bearer <bearer>"`.
4. Paste the code into the SPA.

That's a lot of friction for what should be a button click — and the bearer is the credential `clm` already manages, so the GUI is the right place to mint codes from.

## What changed

**Backend (`src/clawrium/gui/routes/fleet.py`)**

New `POST /api/fleet/agents/{key}/pairing-code` route. The route:

1. Resolves the agent via `resolve_agent`.
2. Gates to types in `_PAIRING_AGENT_TYPES` (today: `{"zeroclaw"}`). hermes serves its dashboard without an in-process pairing step, so the same button is hidden there.
3. Requires `features.web_ui` in the manifest (gated through `web_ui.resolve`).
4. Reads the bearer from `agent_record.config.gateway.auth`; missing/blank → 409 with `clm agent configure` guidance.
5. Reuses the existing `web_ui_tunnel.ensure` for the SSH local-forward (or skips when the host is loopback).
6. POSTs to `<base>/api/pairing/initiate` with that bearer.
7. Maps daemon responses:
   - 200 → 200 `{pairing_code}`.
   - 401 → 409 with `clm agent configure <name>` guidance (stale bearer recovery — matches the ansible `pair.yaml` validator).
   - 503 → 503 with `clm agent restart <name>` guidance.
   - Anything else / non-JSON / empty code → 502.
   - Upstream timeout (`httpx.TimeoutException`) → 504.

The bearer never leaves the GUI server — only the short pairing code is sent to the browser.

**Frontend**

- `gui/src/hooks/use-agent.ts`: new `PAIRING_AGENT_TYPES` allowlist (kept in sync with the backend's `_PAIRING_AGENT_TYPES`) and a `useAgentPairingCode(key)` mutation hook.
- `gui/src/lib/api.ts` + `lib/types.ts`: new `api.mintAgentPairingCode` client method and `PairingCodeResponse` type.
- `gui/src/components/agent-detail/agent-header.tsx`: "Get Pairing Code" button next to "Open Agent UI", zeroclaw-only. Disabled when the agent isn't running. On success the code appears in a slim panel below the header buttons with a copy-to-clipboard action and a one-line note that it's one-shot. On failure the panel shows the server's actionable detail message.

## Testing

### Test Results
- [x] All existing tests pass: **2581** python tests, **213** GUI tests.
- [x] Linter passes (`make lint`): ruff + eslint clean.
- [x] **13 new backend tests** in `tests/test_gui_routes_fleet.py`.

### Test Coverage

The new route has the following coverage (all in `test_gui_routes_fleet.py`):

| Test | Path |
|------|------|
| `test_pairing_code_404_for_unknown_agent` | Resolver miss → 404 |
| `test_pairing_code_400_for_non_pairing_agent_type` | hermes / openclaw → 400 |
| `test_pairing_code_400_when_manifest_lacks_web_ui` | `web_ui.resolve` None → 400 |
| `test_pairing_code_409_when_bearer_missing` | No `gateway.auth` → 409 + `clm agent configure` |
| `test_pairing_code_409_when_bearer_blank` | Whitespace-only bearer → 409 |
| `test_pairing_code_502_on_tunnel_failure` | `TunnelError` → 502 |
| `test_pairing_code_success` | 200 + asserts bearer header + correct URL |
| `test_pairing_code_409_on_daemon_401` | Daemon 401 → 409 with `clm agent configure` |
| `test_pairing_code_503_on_daemon_503` | Daemon 503 → 503 with `clm agent restart` |
| `test_pairing_code_502_on_unexpected_daemon_status` | Daemon 418 → 502 |
| `test_pairing_code_502_on_empty_code` | Daemon 200 with empty code → 502 |
| `test_pairing_code_504_on_upstream_timeout` | `httpx.ReadTimeout` → 504 |
| `test_pairing_code_local_host_skips_tunnel` | Loopback host: no `ensure` call, hits remote port directly |

### Manual Testing

Run live against `clawrium-d01` (zeroclaw on `wolf-i`) plus negative cases against `maurice` (hermes) and `wolf-i` (openclaw):

```
$ curl -s -X POST http://127.0.0.1:8765/api/fleet/agents/clawrium-d01/pairing-code | jq
{ "pairing_code": "095844" }

$ curl -s -X POST http://127.0.0.1:8765/api/fleet/agents/wolf-i/pairing-code -w "%{http_code}\n"
{"detail":"Agent type 'openclaw' does not use an in-browser pairing handshake."}
400

$ curl -s -X POST http://127.0.0.1:8765/api/fleet/agents/maurice/pairing-code -w "%{http_code}\n"
{"detail":"Agent type 'hermes' does not use an in-browser pairing handshake."}
400
```

End-to-end pair check (mint via the new route, then submit on the same daemon's `/api/pair`):

```
$ CODE=$(curl -s -X POST http://127.0.0.1:8765/api/fleet/agents/clawrium-d01/pairing-code | jq -r .pairing_code)
$ PORT=$(jq -r .local_port ~/.config/clawrium/tunnels/clawrium-d01.json)
$ curl -s -X POST "http://127.0.0.1:${PORT}/api/pair" \
    -H "Content-Type: application/json" \
    -d "{\"code\":\"${CODE}\",\"device_name\":\"test\",\"device_type\":\"browser\"}"
{"message":"Pairing successful","token":"zc_81c76132c4d37f06d030b6c2ffb58c01750308e43d3b5bd4f0ef5c06cd605bd0"}
HTTP 200
```

### Security Checklist
- [x] No hardcoded secrets or credentials.
- [x] The bearer never leaves the GUI server — only the short pairing code is sent to the browser.
- [x] Input validation: agent key flows through the existing `resolve_agent` path; bearer is read from already-trusted `hosts.json`; upstream URL is constructed from validated `resolve()` output.
- [x] No SQL injection, XSS, or command injection risks — no subprocess, no string templating into shell commands, no untrusted HTML.
- [x] Dependencies are from trusted sources — uses the existing `httpx` already pinned in `pyproject.toml`. No new dependencies.

## Reviewer Notes

- **One-shot semantics:** the daemon stores exactly one `pairing_code` slot. Each call to the new route overwrites it. The UI surfaces this in the inline panel ("the next mint replaces it") so the user knows clicking the button twice will invalidate the first code.
- **Bearer handling:** the bearer in `hosts.json` is the same one `clm agent configure/sync/restart` mints via `/pair`. We use it to authenticate to `/api/pairing/initiate`. If lifecycle never ran successfully against the agent, there's no bearer to use — the route surfaces 409 with explicit `clm agent configure` guidance rather than letting the browser see an opaque upstream 401.
- **No CLI surface yet:** this PR is GUI-only. A matching `clm agent pair <name>` subcommand would be a natural follow-up (file separately if desired).

## Callouts

- [DECISION] Kept the pairing logic in the GUI route rather than extracting a `core/pairing.py` module that both CLI and GUI could call.
  - Why: there's no CLI consumer yet, the logic is short, and refactoring to core is a single-file move that's easy to do later if a CLI subcommand lands.
  - Alternatives considered: introduce `core/pairing.mint_code(agent_key) -> str` and have the route be a thin wrapper. Deferred; will revisit if/when a CLI subcommand is filed.
  - Reviewer: confirm or push back.

- [DECISION] Mint-on-demand button rather than auto-fetching the code on page load.
  - Why: every call invalidates the previous code. If the page silently mints on render, a tab refresh or background re-render could invalidate a code the user is mid-way through entering elsewhere. Explicit click is safer.
  - Alternatives considered: auto-fetch + display. Rejected for the reason above.
  - Reviewer: confirm or push back.

- [DECISION] Inline disclosure panel under the header buttons (vs modal / toast).
  - Why: matches the visual weight of the existing tunnel URL the SPA already shows. Inline keeps the code visible while the user switches to the dashboard tab.
  - Alternatives considered: modal (heavyweight), toast (disappears too fast for a copy action). Rejected.
  - Reviewer: confirm or push back.

- [DECISION] `PAIRING_AGENT_TYPES = {"zeroclaw"}` is a static allowlist on both backend and frontend.
  - Why: keeps the fetch and render decisions in sync without an extra `/manifest` round trip per detail page view. Same drift posture as the existing `WEB_UI_AGENT_TYPES` allowlist.
  - Alternatives considered: drive from a `has_pairing` field on the AgentDetail response. Cleaner long-term; deferred to keep this PR focused.
  - Reviewer: confirm or push back.

- [TODO-FOLLOWUP] `clm agent pair <name>` CLI subcommand to mint a pairing code from the terminal (mirrors what this PR adds in the GUI). Tracking: to be filed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
