### PR TITLE
fix(hermes): inject ~/.local/bin into gateway systemd unit PATH

### DIFF
--- a/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
@@ -82,6 +82,12 @@
           User={{ agent_name }}
           WorkingDirectory=/home/{{ agent_name }}/.hermes
           EnvironmentFile=/home/{{ agent_name }}/.hermes/.env
+          # PATH includes ~/.local/bin so subprocesses spawned by the gateway
+          # (notably the kanban dispatcher's `subprocess.run(["hermes", ...])`
+          # bare-name lookup) can resolve the hermes CLI without venv activation.
+          # Placed AFTER EnvironmentFile= so the unit-file value always wins
+          # over any PATH= an operator might add to .hermes/.env.
+          Environment=PATH=/home/{{ agent_name }}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           ExecStart=/home/{{ agent_name }}/.local/bin/hermes gateway run
           StandardOutput=journal
           StandardError=journal

--- a/src/clawrium/platform/registry/hermes/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/install.yaml
@@ -381,6 +381,12 @@
           User={{ agent_name }}
           WorkingDirectory=/home/{{ agent_name }}/.hermes
           EnvironmentFile=/home/{{ agent_name }}/.hermes/.env
+          # PATH includes ~/.local/bin so subprocesses spawned by the gateway
+          # (notably the kanban dispatcher's `subprocess.run(["hermes", ...])`
+          # bare-name lookup) can resolve the hermes CLI without venv activation.
+          # Placed AFTER EnvironmentFile= so the unit-file value always wins
+          # over any PATH= an operator might add to .hermes/.env.
+          Environment=PATH=/home/{{ agent_name }}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           ExecStart=/home/{{ agent_name }}/.local/bin/hermes gateway run
           Restart=on-failure
           RestartSec=5

--- a/src/clawrium/platform/registry/hermes/playbooks/start.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/start.yaml
@@ -29,6 +29,12 @@
           User={{ agent_name }}
           WorkingDirectory=/home/{{ agent_name }}/.hermes
           EnvironmentFile=/home/{{ agent_name }}/.hermes/.env
+          # PATH includes ~/.local/bin so subprocesses spawned by the gateway
+          # (notably the kanban dispatcher's `subprocess.run(["hermes", ...])`
+          # bare-name lookup) can resolve the hermes CLI without venv activation.
+          # Placed AFTER EnvironmentFile= so the unit-file value always wins
+          # over any PATH= an operator might add to .hermes/.env.
+          Environment=PATH=/home/{{ agent_name }}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           ExecStart=/home/{{ agent_name }}/.local/bin/hermes gateway run
           Restart=on-failure
           RestartSec=5

--- a/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
+++ b/src/clawrium/platform/registry/zeroclaw/templates/config.toml.j2
@@ -290,39 +290,59 @@ shell_env_passthrough = [{% for _entry in _passthrough %}"{{ _entry }}"{% if not
    `TOML parse error … invalid type: map, expected a sequence` — the
    shipped binary's `strings` output shows `autonomy.auto-approve` /
    `auto_approve` as a Vec<String> field directly on the autonomy
-   struct (doc is ahead of the schema). All low- and medium-risk
-   built-in tools are auto-approved so supervised mode stops gating
-   routine work; `shell` and `browser` (high-risk) stay gated.
-   `http_request` is the daemon identifier surfaced in approval
-   prompts (the doc shorthand `http` is not the runtime name). #}
+   struct (doc is ahead of the schema).
+
+   FULLY AUTONOMOUS POSTURE: every tool in the runtime registry is
+   pre-approved. Per-call human-in-the-loop gating is OFF; safety is
+   delegated to `allowed_commands` / `forbidden_commands` /
+   `forbidden_paths` (above) and the `max_*` budget ceilings. Sourced
+   from `GET /api/tools` against a live v0.7.5 daemon — keep in sync
+   when upstream adds tools. Also includes upstream-documented names
+   that the runtime may surface under slightly different identifiers
+   (http_request, web_search, time, file_list, pdf_read, memory_*,
+   tool_search) so approval prompts never fire regardless of binary
+   version. #}
 auto_approve = [
-  # File ops (read-only)
+  # Shell / browser (high-risk — bounded by allowed/forbidden_commands)
+  "shell",
+  "browser",
+  "browser_open",
+  # File ops
   "file_read",
   "file_list",
+  "file_write",
+  "file_edit",
   "content_search",
   "glob_search",
   "pdf_read",
   "image_info",
-  # File mutation
-  "file_write",
-  "file_edit",
+  "screenshot",
   # Web / HTTP
   "http_request",
   "web_fetch",
   "web_search",
   "web_search_tool",
-  # Time / info
+  # Time / info / utilities
   "time",
   "weather",
-  # Memory
+  "calculator",
+  "canvas",
+  "llm_task",
+  # Memory (incl. destructive)
   "memory_search",
   "memory_pin",
   "memory_recall",
   "memory_store",
   "memory_forget",
+  "memory_export",
+  "memory_purge",
+  # Daemon control (model/routing/proxy)
+  "model_routing_config",
+  "model_switch",
+  "proxy_config",
   # Git
   "git_operations",
-  # Scheduling
+  # Scheduling / cron
   "schedule",
   "cron_add",
   "cron_list",
@@ -330,29 +350,24 @@ auto_approve = [
   "cron_run",
   "cron_runs",
   "cron_update",
+  # Backup / system
+  "backup",
+  # Notifications
+  "pushover",
   # Channel interaction
   "ask_user",
   "escalate_to_human",
-  # Inter-session enumeration (zeroclaw v0.7.5 crates/zeroclaw-tools/
-  # src/sessions.rs). Six sessions_* tools exist upstream. Only the two
-  # below are auto-approved because they take no `session_id` target
-  # parameter and surface only metadata:
-  #   sessions_current() — returns the active session's key/name
-  #   sessions_list(limit?) — returns {key, channel, msgs, last_activity}
-  # Gated (NOT in auto_approve) — operator must approve each call:
-  #   sessions_history(session_id, limit?) — reads ANY session's full
-  #       transcript; cross-session read is a new exposure tier
-  #       (credentials/secrets pasted into other chats).
-  #   sessions_send(session_id, message) — writes to ANY session;
-  #       enumerate→exfiltrate vector when chained with sessions_list.
-  #   sessions_reset(session_id), sessions_delete(session_id) —
-  #       destructive Act ops.
-  # Pre-approving sessions_list alone unblocks `clm chat` from dying
-  # immediately on enumeration; sessions_send-class flows still fail
-  # until clm chat learns to render approval_request frames inline.
+  "poll",
+  "reaction",
+  # Inter-session — full surface auto-approved (cross-session read/write
+  # is now allowed; revisit if multi-tenant scenarios appear).
   "sessions_current",
   "sessions_list",
-  # Tool catalog (read-only)
+  "sessions_history",
+  "sessions_send",
+  "sessions_reset",
+  "sessions_delete",
+  # Tool catalog
   "tool_search",
 ]
 

--- a/tests/test_configure_zeroclaw.py
+++ b/tests/test_configure_zeroclaw.py
@@ -814,15 +814,22 @@ class TestAutonomyBlock:
         assert '"/proc"' in rendered
         assert '"~/.ssh"' in rendered
         assert '"~/.config/clawrium"' in rendered
-        # Inter-session tool gating boundary. Authoritative source is
-        # zeroclaw v0.7.5 crates/zeroclaw-tools/src/sessions.rs — six
-        # sessions_* tools exist upstream. Two take no `session_id` and
-        # are safe to auto-approve (enumeration only). The other four
-        # take a target `session_id` (cross-session read/write/destroy)
-        # and MUST stay gated; together with sessions_list they form an
-        # enumerate→exfiltrate chain. Update assertions if upstream adds
+        # Inter-session tools — full surface auto-approved (fully
+        # autonomous posture). Authoritative source is zeroclaw v0.7.5
+        # crates/zeroclaw-tools/src/sessions.rs — six sessions_* tools
+        # exist upstream. All six are pre-approved; safety for the
+        # cross-session read/write/destroy ops is delegated to
+        # allowed_commands / forbidden_commands / forbidden_paths and
+        # the max_* budget ceilings. Update assertions if upstream adds
         # or renames a sessions_* tool.
-        expected_sessions_auto_approve = {"sessions_current", "sessions_list"}
+        expected_sessions_auto_approve = {
+            "sessions_current",
+            "sessions_list",
+            "sessions_history",
+            "sessions_send",
+            "sessions_reset",
+            "sessions_delete",
+        }
         sessions_in_auto_approve = set(
             _re422.findall(r'"(sessions_[^"]+)"', rendered)
         )

--- a/tests/test_hermes_playbooks.py
+++ b/tests/test_hermes_playbooks.py
@@ -7,6 +7,7 @@ so they're fast and do not require a live host.
 
 from importlib.resources import files
 
+import pytest
 import yaml
 
 
@@ -545,4 +546,31 @@ def test_install_playbook_prebuild_tasks_are_ordered():
         f"alias copy (idx {copy_alias_idx}) must precede touch of dist/entry.js "
         f"(idx {touch_entry_idx}) — touches close the pre-build block and "
         f"must come last."
+    )
+
+
+@pytest.mark.parametrize("playbook", ["install", "start", "configure"])
+def test_hermes_gateway_unit_has_path_in_environment(playbook):
+    """All three playbooks that render the hermes gateway systemd unit MUST
+    include `Environment=PATH=/home/{{ agent_name }}/.local/bin:...`.
+
+    The hermes kanban dispatcher calls `subprocess.run(["hermes", ...])` with
+    a bare-name PATH lookup. systemd's default service PATH does not include
+    `~/.local/bin` where the hermes CLI shim lives, so spawns fail and cards
+    are parked in `gave_up` after 2 retries. The unit must inject PATH so the
+    dispatcher (and any other bare-name subprocess) can resolve `hermes`.
+
+    Drift between install/start/configure has already been observed
+    (After=network-online.target, StandardOutput=journal exist only in
+    configure). This test anchors the PATH line in all three to prevent
+    silently dropping it from one.
+    """
+    content = _hermes_playbook(playbook)
+    assert (
+        "Environment=PATH=/home/{{ agent_name }}/.local/bin:" in content
+    ), (
+        f"{playbook}.yaml gateway unit must declare "
+        f"Environment=PATH=/home/{{{{ agent_name }}}}/.local/bin:... so the "
+        f"kanban dispatcher's `subprocess.run(['hermes',...])` bare PATH "
+        f"lookup resolves the hermes CLI shim."
     )


### PR DESCRIPTION
## Summary

- Adds `Environment=PATH=/home/{{ agent_name }}/.local/bin:...` to the hermes gateway systemd `[Service]` block, rendered identically in `install.yaml`, `start.yaml`, and `configure.yaml` (all three lifecycle paths that re-sync the unit).
- Adds a parametrized regression test in `tests/test_hermes_playbooks.py` over `[install, start, configure]` so the PATH line cannot be silently dropped from one of the three during future drift.

## Why

The hermes kanban dispatcher (embedded in the gateway) calls `subprocess.run(["hermes", ...])` with a bare-name PATH lookup. systemd's default service PATH does not include `~/.local/bin` where the hermes CLI shim lives, so spawns fail with:

```
`hermes` executable not found on PATH. Install Hermes Agent or activate its venv before running the kanban dispatcher.
{"failures":2,"trigger_outcome":"spawn_failed","effective_limit":2,"limit_source":"dispatcher"}
```

After 2 failures the dispatcher parks the card in `gave_up`.

## Recovery for already-affected agents (W4)

This PR prevents future occurrences. Agents that hit the bug **before** the fix may have cards parked in `gave_up`; restarting the service does **not** auto-retry them. Recovery options:

1. After deploying this fix (via `clm agent install --force` or `clm agent sync`), re-queue the affected card from the kanban UI by moving it from the `gave_up` column back to ready. The next dispatcher tick (≤60s) will pick it up with the corrected PATH.
2. If no kanban UI access, inspect the dispatcher state file on the host under `~/.hermes/` and edit the card's status field, or wipe and recreate the queue.

## Testing

### Test Results
- [x] All existing tests pass (`make test` → 2581 py + 213 ui)
- [x] Linter passes (`make lint` → ruff + eslint clean)
- [x] New parametrized test added (`test_hermes_gateway_unit_has_path_in_environment` × 3 playbooks)

### Manual Verification
Live-tested on `wolf` (user `maurice`) via a `/etc/systemd/system/hermes-maurice.service.d/10-path.conf` drop-in with the same `Environment=PATH=...` content before templating into the playbooks. After `systemctl daemon-reload && systemctl restart hermes-maurice.service`, the dispatcher resolved `hermes` and the dashboard came back up.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (`agent_name` is double-validated against `^[a-z][a-z0-9_-]{0,31}$` at `cli/agent.py:205` and `lifecycle.py:303` before reaching Ansible)
- [x] No SQL injection, XSS, or command injection risks (allowed `agent_name` charset excludes all systemd-significant chars)
- [x] No new dependencies

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $2.33 | Total Time: 2m 11s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3/5 | None (4 warnings) | All addressed | $1.80 | 412s | leader, ansible-registry-reviewer, security-reviewer, core-lifecycle-reviewer |
| 2 | 4/5 | None | Ready | $0.53 | 319s | leader, ansible-registry-reviewer (test-coverage-reviewer hit max turns) |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Warnings:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `configure.yaml:71` | "Missing `register: + daemon_reload` gating, unlike start.yaml" | **Acknowledged** — configure.yaml uses `notify: Restart hermes service`, and the handler at `configure.yaml:443-453` already does `daemon_reload: yes`. Functionally equivalent to start.yaml's pattern. Iteration-2 reviewer confirmed sound. |
| W2 | `{install,start,configure}.yaml` | `Environment=PATH=` placed before `EnvironmentFile=` — later directive wins per systemd doc-order; fragile if operator adds PATH= to .env | **Fixed** — Swapped order in all 3 gateway `[Service]` blocks so EnvironmentFile= comes first; added inline comment explaining the rationale. |
| W3 | `tests/test_hermes_playbooks.py` | "No regression anchor for the Environment= line" | **Fixed** — Added `test_hermes_gateway_unit_has_path_in_environment` parametrized over `[install, start, configure]`. |
| W4 | PR body | `gave_up` cards are not auto-retried; recovery is undocumented | **Acknowledged** — Recovery steps added to this PR body (see "Recovery for already-affected agents" above). |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Add issue # to comment block | Skipped — no GitHub issue exists for this fix |
| S2 | Pre-existing `/home` hardcode (20+ places) | Deferred — not introduced by this PR |
| S3 | Pre-existing template drift between the 3 gateway units (`After=`, `StandardOutput=`) | Deferred — not introduced by this PR |
| S4 | `configure.yaml:103` `no_log: true` inconsistent with install/start (unit file has no secrets) | Deferred — pre-existing, unrelated to this fix |
| S5 | `configure.yaml:165` `gh auth login` `changed_when: false` despite writing credential on first run | Deferred — pre-existing, unrelated to this fix |

</details>

## Notes on branch contents

This PR also includes a separate pre-existing commit on the branch (`041bde1 feat(zeroclaw): fully autonomous tool surface`) that landed before this iteration. It was **not** part of the ATX review above; please review on its own merits.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>