### PR TITLE
docs(itx): seed .itx/499 with issue-creation prompt log

### DIFF
--- a/.itx/499/00_PLAN.md
+++ b/.itx/499/00_PLAN.md
@@ -1,0 +1,22 @@
+# Issue #499 — User can configure MCP servers once and attach them to any agent
+
+GitHub: https://github.com/ric03uec/clawrium/issues/499
+
+## Issue Creation
+
+**Stage**: issue-creation
+**Skill**: /itx:issue-new
+**Timestamp**: 2026-05-23T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+add support for MCP servers. user should be able to configure mcp servers in clawrium. once configured, they can be used by one or more agents as rquired. this wwll be like providers. investivage whether tools like toolhive can be used for this.
+```
+
+**Decisions captured during issue creation**:
+
+- Customer outcome: configure MCP servers once + attach to any agent (provider/integration shape, not per-agent-only and not a curated catalog).
+- v1 scope: hermes only. openclaw and zeroclaw follow as dedicated subtasks.
+- Runtime hosting question: deferred to `/itx:plan-create`. Spike must compare at minimum toolhive (containers), plain stdio spawn by the daemon, and dedicated systemd units (mirrors the #478 dashboard pattern), with a written rationale for whichever is picked.
+
+**Output**: Created GitHub issue #499 with customer-outcome title and an open-question section calling out the runtime-hosting decision for the planning stage.


### PR DESCRIPTION
## Summary

Seed `.itx/499/00_PLAN.md` with the issue-creation prompt log for #499 ("User can configure MCP servers once and attach them to any agent"). Documentation only — no code changes.

The log captures the three decisions locked in during `/itx:issue-new`:

1. **Outcome shape**: central registry + per-agent attach (mirrors providers / integrations) — not per-agent-only and not a curated catalog.
2. **v1 scope**: hermes only. openclaw and zeroclaw follow as dedicated subtasks.
3. **Runtime hosting**: explicitly **deferred** to `/itx:plan-create`. The spike must compare at least toolhive (containers), plain stdio spawn by the agent daemon, and dedicated systemd units (mirrors the #478 dashboard pattern), with a written rationale for whichever wins.

## Testing

### Test Results
- [x] No code changed — `make test` / `make lint` not exercised
- [x] Documentation file only (`.itx/499/00_PLAN.md`)

### Test Coverage
- Files changed: `.itx/499/00_PLAN.md` (new)
- New tests: N/A
- Coverage impact: N/A

### Manual Testing
- [x] Confirmed file lives at the canonical `.itx/<issue-number>/00_PLAN.md` path per AGENTS.md "Prompt Logging Standard"
- [x] Format matches the standard (Stage / Skill / Timestamp / Model / verbatim prompt / Output)

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] No code changes — N/A
- [x] No SQL/XSS/command-injection risk — N/A
- [x] Dependencies are from trusted sources — N/A

## Reviewer Notes

- Skipping ATX review per workflow convention for `.itx/` plan-doc seeds.
- Next step after this lands is `/itx:plan-create 499` to settle the runtime-hosting question and break the issue into subtasks.

Refs #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
