### PR TITLE
feat(cli): #507 Bundle 2 — clawctl foundation + service/meta + output module

### DIFF
--- a/.itx/435/audit-before.md
+++ b/.itx/435/audit-before.md
@@ -1,0 +1,1833 @@
+# `clm` Audit — Before (regression baseline)
+
+Bundle 1 of issue [#435](https://github.com/ric03uec/clawrium/issues/435).
+Companion to Bundle 5's `audit-after.md` (diff target).
+
+## Preamble — fleet shape deviation
+
+Issue [#506](https://github.com/ric03uec/clawrium/issues/506) requested a
+"clean wolf-i fleet" with exactly one of each agent type. At capture time
+wolf-i hosted **six pre-existing, in-use agent installations** that could
+not safely be removed:
+
+| Pre-existing agent | Type     | Provider     |
+|--------------------|----------|--------------|
+| `wolf-i`           | openclaw | bedrock      |
+| `espresso`         | hermes   | ollama       |
+| `maurice`          | hermes   | openrouter   |
+| `clawrium-d01`     | zeroclaw | openrouter   |
+| `nemotron-beta`    | zeroclaw | ollama       |
+| `nemotron-alpha`   | zeroclaw | ollama       |
+
+To preserve the regression-diff contract without destroying the existing
+fleet, this capture:
+
+1. Records read-only command output against the **as-found** fleet (six
+   pre-existing + three audit agents installed during capture).
+2. Adds three audit-only agents — `audit-zeroclaw`, `audit-hermes`,
+   `audit-openclaw` — installed fresh on wolf-i to produce uncontaminated
+   lifecycle transcripts.
+3. Removes only the `audit-*` agents at teardown. The pre-existing fleet
+   returns to its pre-capture state; the final `clm agent ps` is **not
+   empty**.
+
+Bundle 5's `audit-after.md` should be captured under the same conditions
+(same six pre-existing agents present, same three `audit-*` agents
+installed for its lifecycle pass, same teardown of `audit-*` only) so the
+two artifacts diff cleanly. See "Callouts" in the bundle PR for the
+documented decision.
+
+---
+
+## Header
+
+**Capture start (UTC):** 2026-05-24T03:24:13Z
+
+### `clm --version`
+
+```console
+$ clm --version
+clm 26.5.2
+```
+Exit: `0`
+
+### `uv tool list`
+
+```console
+$ uv tool list
+clawrium v26.5.2
+- clm
+```
+Exit: `0`
+
+### `clm host ps wolf-i` (target host details)
+
+```console
+$ clm host ps wolf-i
+Checking status of 'wolf-i'...
+                Host Status: wolf-i                
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Property     ┃ Value                            ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Connection   │ Connected                        │
+│ Hostname     │ wolf.tailf7742d.ts.net           │
+│ SSH Config   │ wolf-i                           │
+│ Port         │ 22                               │
+│ User         │ xclm                             │
+│ Added        │ 2026-04-11T04:46:19.295019+00:00 │
+│ Last Seen    │ 2026-04-11T04:46:19.295019+00:00 │
+│ Tags         │ -                                │
+│ Architecture │ x86_64                           │
+│ CPU Cores    │ 4                                │
+│ Memory       │ 15.5 GB                          │
+│ GPU          │ intel                            │
+└──────────────┴──────────────────────────────────┘
+
+Addresses:
+    192.168.1.36
+  * wolf.tailf7742d.ts.net (tailscale)
+```
+Exit: `0`
+
+**Summary of target:**
+- Alias: `wolf-i`
+- SSH hostname: `wolf.tailf7742d.ts.net`
+- Primary address: `wolf.tailf7742d.ts.net` (tailscale)
+- Secondary address: `192.168.1.36`
+- SSH user: `xclm`
+- SSH port: `22`
+- Architecture: x86_64
+
+---
+
+## Capture conventions
+
+All command sections in this file were captured by a helper that runs:
+
+```bash
+NO_COLOR=1 TERM=dumb COLUMNS=140 bash -c "<command>" 2>&1
+```
+
+This produces ANSI-free output at a consistent 140-column width. Bundle 5's
+`audit-after.md` MUST use the same conventions so the two files diff
+line-for-line.
+
+## Read-only command transcripts (as-found fleet)
+
+Captured against the fleet of six pre-existing agents (no `audit-*`
+agents present at this point in the capture).
+
+### `clm init`
+
+```console
+$ clm init
+Clawrium initialized!
+Config directory: /home/devashish/.config/clawrium
+
+                                                             Dependency Status                                                              
+┏━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
+┃ Dependency     ┃ Status ┃ Version/Path                                                                                 ┃ Action Required ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
+│ python         │ OK     │ 3.13.13                                                                                      │ -               │
+│ ansible        │ OK     │ ansible                                                                                      │ -               │
+│ ansible-runner │ OK     │ /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/ansible_runner/… │ -               │
+└────────────────┴────────┴──────────────────────────────────────────────────────────────────────────────────────────────┴─────────────────┘
+```
+Exit: `0`
+
+### `clm ps`
+
+```console
+$ clm ps
+
+
+                                                   Agent Fleet Status                                                   
+┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Name           ┃ Agent Type ┃ Provider   ┃ Host   ┃ Address                ┃ Port  ┃ Version  ┃ Status  ┃ Installed  ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━┩
+│ clawrium-d01   │ zeroclaw   │ openrouter │ wolf-i │ wolf.tailf7742d.ts.net │ 41429 │ 0.7.5    │ running │ 2026-05-19 │
+│ espresso       │ hermes     │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 41583 │ 2026.5.7 │ running │ 2026-05-11 │
+│ maurice        │ hermes     │ openrouter │ wolf-i │ wolf.tailf7742d.ts.net │ 40317 │ 2026.5.7 │ running │ 2026-05-22 │
+│ nemotron-alpha │ zeroclaw   │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 40919 │ 0.7.5    │ running │ 2026-05-22 │
+│ nemotron-beta  │ zeroclaw   │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 40971 │ 0.7.5    │ running │ 2026-05-20 │
+│ wolf-i         │ openclaw   │ bedrock    │ wolf-i │ wolf.tailf7742d.ts.net │ 40198 │ 2026.4.2 │ running │ 2026-04-11 │
+└────────────────┴────────────┴────────────┴────────┴────────────────────────┴───────┴──────────┴─────────┴────────────┘
+
+```
+Exit: `0`
+
+### `clm host list`
+
+```console
+$ clm host list
+                                  Registered Hosts                                  
+┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━┓
+┃ Alias  ┃ Host                        ┃ Architecture ┃ Cores ┃ Memory (GB) ┃ Tags ┃
+┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━┩
+│ wolf-i │ wolf.tailf7742d.ts.net [+1] │ x86_64       │     4 │        15.5 │ -    │
+│ kevin  │ 192.168.1.35                │ armv7l       │     1 │         0.9 │ -    │
+└────────┴─────────────────────────────┴──────────────┴───────┴─────────────┴──────┘
+```
+Exit: `0`
+
+### `clm agent ps`
+
+```console
+$ clm agent ps
+
+
+                                                   Agent Fleet Status                                                   
+┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Name           ┃ Agent Type ┃ Provider   ┃ Host   ┃ Address                ┃ Port  ┃ Version  ┃ Status  ┃ Installed  ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━┩
+│ clawrium-d01   │ zeroclaw   │ openrouter │ wolf-i │ wolf.tailf7742d.ts.net │ 41429 │ 0.7.5    │ running │ 2026-05-19 │
+│ espresso       │ hermes     │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 41583 │ 2026.5.7 │ running │ 2026-05-11 │
+│ maurice        │ hermes     │ openrouter │ wolf-i │ wolf.tailf7742d.ts.net │ 40317 │ 2026.5.7 │ running │ 2026-05-22 │
+│ nemotron-alpha │ zeroclaw   │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 40919 │ 0.7.5    │ running │ 2026-05-22 │
+│ nemotron-beta  │ zeroclaw   │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 40971 │ 0.7.5    │ running │ 2026-05-20 │
+│ wolf-i         │ openclaw   │ bedrock    │ wolf-i │ wolf.tailf7742d.ts.net │ 40198 │ 2026.4.2 │ running │ 2026-04-11 │
+└────────────────┴────────────┴────────────┴────────┴────────────────────────┴───────┴──────────┴─────────┴────────────┘
+
+```
+Exit: `0`
+
+### `clm agent registry list`
+
+```console
+$ clm agent registry list
+                                  Available Agent Types                                   
+┏━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Name     ┃ Latest Version ┃ Description                                                ┃
+┡━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ hermes   │ 2026.5.7       │ Nous Research self-improving AI agent (Python)             │
+│ openclaw │ 2026.4.2       │ Open-source AI assistant framework                         │
+│ zeroclaw │ 0.7.5          │ Lightweight AI assistant for edge devices and Raspberry Pi │
+└──────────┴────────────────┴────────────────────────────────────────────────────────────┘
+```
+Exit: `0`
+
+### `clm agent registry show zeroclaw`
+
+```console
+$ clm agent registry show zeroclaw
+
+zeroclaw
+Lightweight AI assistant for edge devices and Raspberry Pi
+
+                         Supported Platforms                         
+┏━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Version ┃ OS           ┃ Architecture ┃ Min Memory ┃ GPU Required ┃
+┡━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
+│ 0.7.5   │ debian 13    │ armv7l       │ 512MB      │ No           │
+│ 0.7.5   │ ubuntu 22.04 │ aarch64      │ 1024MB     │ No           │
+│ 0.7.5   │ ubuntu 24.04 │ aarch64      │ 1024MB     │ No           │
+│ 0.7.5   │ ubuntu 22.04 │ x86_64       │ 1024MB     │ No           │
+│ 0.7.5   │ ubuntu 24.04 │ x86_64       │ 1024MB     │ No           │
+└─────────┴──────────────┴──────────────┴────────────┴──────────────┘
+                                 Optional Secrets                                  
+┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Key               ┃ Description                                                 ┃
+┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ LLM_API_KEY       │ API key for LLM provider (optional for local)               │
+│ DISCORD_BOT_TOKEN │ Discord bot token (only when [channels.discord] is enabled) │
+└───────────────────┴─────────────────────────────────────────────────────────────┘
+
+Dependencies:
+  - python >=3.9
+```
+Exit: `0`
+
+### `clm agent registry show hermes`
+
+```console
+$ clm agent registry show hermes
+
+hermes
+Nous Research self-improving AI agent (Python)
+
+                         Supported Platforms                          
+┏━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Version  ┃ OS           ┃ Architecture ┃ Min Memory ┃ GPU Required ┃
+┡━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
+│ 2026.5.7 │ ubuntu 24.04 │ x86_64       │ 2048MB     │ No           │
+│ 2026.5.7 │ ubuntu 22.04 │ x86_64       │ 2048MB     │ No           │
+└──────────┴──────────────┴──────────────┴────────────┴──────────────┘
+                    Optional Secrets                     
+┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Key                ┃ Description                      ┃
+┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ OPENROUTER_API_KEY │ OpenRouter API key (200+ models) │
+│ ANTHROPIC_API_KEY  │ Anthropic API key                │
+│ OPENAI_API_KEY     │ OpenAI API key                   │
+└────────────────────┴──────────────────────────────────┘
+
+Dependencies:
+  - ffmpeg *
+  - python >=3.11
+  - ripgrep *
+  - uv *
+```
+Exit: `0`
+
+### `clm agent registry show openclaw`
+
+```console
+$ clm agent registry show openclaw
+
+openclaw
+Open-source AI assistant framework
+
+                         Supported Platforms                          
+┏━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Version  ┃ OS           ┃ Architecture ┃ Min Memory ┃ GPU Required ┃
+┡━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
+│ 0.1.0    │ ubuntu 24.04 │ x86_64       │ 2048MB     │ No           │
+│ 0.1.0    │ ubuntu 22.04 │ x86_64       │ 2048MB     │ No           │
+│ 2026.4.2 │ ubuntu 24.04 │ x86_64       │ 2048MB     │ No           │
+│ 2026.4.2 │ ubuntu 22.04 │ x86_64       │ 2048MB     │ No           │
+└──────────┴──────────────┴──────────────┴────────────┴──────────────┘
+                      Optional Secrets                       
+┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Key               ┃ Description                           ┃
+┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ DISCORD_BOT_TOKEN │ Discord bot token for Discord channel │
+│ SLACK_BOT_TOKEN   │ Slack bot token for Slack channel     │
+│ SLACK_APP_TOKEN   │ Slack app-level token for Socket Mode │
+└───────────────────┴───────────────────────────────────────┘
+
+Dependencies:
+  - nodejs >=18.0.0
+  - nodejs >=20.0.0
+```
+Exit: `0`
+
+### `clm provider list`
+
+```console
+$ clm provider list
+                                              Configured Providers                                              
+┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Name               ┃ Type       ┃ Model                             ┃ API Key                   ┃ Added      ┃
+┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ clm-openrouter     │ openrouter │ openai/gpt-4o                     │ sk-o...9f77               │ 2026-04-10 │
+│ local-inx          │ ollama     │ qwen3-coder:30b-128k              │ http://192.168.1.17:11434 │ 2026-04-12 │
+│ maurice-openrouter │ openrouter │ z-ai/glm-4.5-air                  │ sk-o...44cc               │ 2026-04-16 │
+│ clawrium-bedrock   │ bedrock    │ zai.glm-4.7                       │ AKIA...W5KK               │ 2026-04-17 │
+│ clawrium-coder     │ ollama     │ qwen3-coder-next:q4_K_M           │ http://192.168.1.17:11434 │ 2026-05-18 │
+│ clawrium-glm-flash │ ollama     │ glm-4.7-flash:latest              │ http://192.168.1.17:11434 │ 2026-05-19 │
+│ clawrium-nemotron  │ ollama     │ nemotron-cascade-2:30b-a3b-q4_K_M │ http://192.168.1.17:11434 │ 2026-05-19 │
+│ clawrium-deepseek  │ ollama     │ deepseek-r1:70b                   │ http://192.168.1.17:11434 │ 2026-05-19 │
+│ clawrium-glm51     │ openrouter │ z-ai/glm-5                        │ sk-o...38fc               │ 2026-05-19 │
+└────────────────────┴────────────┴───────────────────────────────────┴───────────────────────────┴────────────┘
+```
+Exit: `0`
+
+### `clm provider types`
+
+```console
+$ clm provider types
+Supported provider types:
+
+  anthropic - 7 models
+  bedrock - 8 models (SDK-based)
+  ollama - Self-hosted (dynamic model discovery)
+  openai - 8 models
+  openrouter - 14 models
+  vertex - 6 models (SDK-based)
+  zai - 8 models
+```
+Exit: `0`
+
+### `clm integration list`
+
+```console
+$ clm integration list
+                  Configured Integrations                   
+┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Name                ┃ Type   ┃ Credentials  ┃ Added      ┃
+┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ clawrium-github     │ github │ 1 configured │ 2026-04-16 │
+│ clawrium-d01        │ github │ 1 configured │ 2026-05-19 │
+│ clawrium-d01-github │ github │ 1 configured │ 2026-05-19 │
+└─────────────────────┴────────┴──────────────┴────────────┘
+```
+Exit: `0`
+
+### `clm integration types`
+
+```console
+$ clm integration types
+Supported integration types:
+
+  atlassian - Atlassian Cloud (Jira + Confluence) via API token
+    Required credentials: 3
+  github - GitHub for code hosting, PRs, and issues
+    Required credentials: 1
+  gitlab - GitLab for code hosting, MRs, and issues
+    Required credentials: 1
+  linear - Linear for issue tracking and project management
+    Required credentials: 1
+  notion - Notion for documentation and workspace management
+    Required credentials: 1
+```
+Exit: `0`
+
+### `clm skill list`
+
+```console
+$ clm skill list
+                                                     Skills catalog                                                     
+┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Ref                    ┃ Registry ┃ Description                                                                      ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ clawrium/tdd           │ clawrium │ Test-Driven Development discipline. Drives a red → green → refactor cycle for... │
+│ hermes/blog-author     │ hermes   │ Watch ric03uec/clawrium release tags; draft a short blog post per user-visibl... │
+│ hermes/daily-digest    │ hermes   │ Post a daily engineer-tone summary of the last 24h of activity on ric03uec/cl... │
+│ hermes/docs-sync       │ hermes   │ Detect user-visible changes from the last 24h of commits on main and propose ... │
+│ hermes/issue-triage    │ hermes   │ Triage new and updated GitHub issues on ric03uec/clawrium — apply type/comple... │
+│ hermes/release-watcher │ hermes   │ Watch upstream *Claw releases and clawrium discussions; surface top 3 feature... │
+└────────────────────────┴──────────┴──────────────────────────────────────────────────────────────────────────────────┘
+```
+Exit: `0`
+
+### `clm skill show clawrium/tdd`
+
+```console
+$ clm skill show clawrium/tdd
+
+clawrium/tdd
+Test-Driven Development discipline. Drives a red → green → refactor cycle for the active task: write a failing test, make it pass with the 
+minimum change, then refactor while green.
+
+                         Metadata                         
+┌───────────────┬────────────────────────────────────────┐
+│ registry      │ clawrium                               │
+│ name          │ tdd                                    │
+│ version       │ 0.1.0                                  │
+│ license       │ MIT                                    │
+│ author        │ clawrium                               │
+│ platforms     │ linux, macos                           │
+│ compatibility │ openclaw=yes, hermes=yes, zeroclaw=yes │
+└───────────────┴────────────────────────────────────────┘
+╭──────────────────────────────────────────────────────────────── SKILL.md ────────────────────────────────────────────────────────────────╮
+│                                                      TDD — Test-Driven Development                                                       │
+│                                                                                                                                          │
+│ When the user asks you to implement, change, or fix behavior, work in the red → green → refactor loop. The loop is the discipline; do    │
+│ not skip a step.                                                                                                                         │
+│                                                                                                                                          │
+│ The loop                                                                                                                                 │
+│                                                                                                                                          │
+│  1 Red. Write a single failing test that names the next behavior in the smallest reasonable scope. Run the test suite (or just the new   │
+│    test) and confirm the failure is for the right reason (asserts on behavior, not on a missing import or typo).                         │
+│  2 Green. Make the test pass with the minimum change. Resist the urge to refactor neighboring code, generalize, or anticipate the next   │
+│    test. "Minimum" means: if a literal return makes the test pass, return the literal — then write the next failing test that forces the │
+│    generalization.                                                                                                                       │
+│  3 Refactor. With the suite green, improve names, remove duplication, tighten interfaces. Run the suite after every refactor step. If a  │
+│    refactor turns the suite red, revert immediately and split it smaller.                                                                │
+│                                                                                                                                          │
+│ When to break the loop                                                                                                                   │
+│                                                                                                                                          │
+│  • Spike — explore an unknown API in a throwaway branch with no tests, then delete the spike and re-implement TDD-style.                 │
+│  • Bug report — write the failing test first that reproduces the bug, even if the production fix is one line. Without the test, the bug  │
+│    returns.                                                                                                                              │
+│  • Refactor-only — the suite must be green at start and end; no behavior changes in this mode.                                           │
+│                                                                                                                                          │
+│ Anti-patterns                                                                                                                            │
+│                                                                                                                                          │
+│  • Writing the implementation first then back-filling tests.                                                                             │
+│  • Writing many failing tests at once (you can't tell which one is driving).                                                             │
+│  • Skipping the "right reason" check in step 1.                                                                                          │
+│  • Refactoring while red.                                                                                                                │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+Exit: `0`
+
+
+---
+
+## Install transcripts (audit-* agents)
+
+Three fresh audit-only agents are installed on wolf-i below. They will be
+removed at the end of capture; the pre-existing fleet is untouched.
+
+### `clm agent install --type zeroclaw --host wolf-i --name audit-zeroclaw --yes`
+
+```console
+$ clm agent install --type zeroclaw --host wolf-i --name audit-zeroclaw --yes
+╭────────────────────────────────────────────────────────── Installation Summary ──────────────────────────────────────────────────────────╮
+│ Agent Type: zeroclaw                                                                                                                     │
+│ Version: 0.7.5                                                                                                                           │
+│ Host: wolf-i                                                                                                                             │
+│ Architecture: x86_64                                                                                                                     │
+│ Memory: 15.5GB                                                                                                                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+No config file found; using defaults
+
+PLAY [all] *********************************************************************
+
+TASK [Gathering Facts] *********************************************************
+[WARNING]: Host 'wolf.tailf7742d.ts.net' is using the discovered Python interpreter at '/usr/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.20/reference_appendices/interpreter_discovery.html for more information.
+ok: [wolf.tailf7742d.ts.net]
+
+TASK [Kill stale apt lock holders] *********************************************
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/apt/lists/lock) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/apt/lists/lock"], "delta": "0:00:00.069803", "end": "2026-05-23 20:27:44.957292", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/apt/lists/lock", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 20:27:44.887489", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/dpkg/lock) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/dpkg/lock"], "delta": "0:00:00.066395", "end": "2026-05-23 20:27:45.439068", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/dpkg/lock", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 20:27:45.372673", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/dpkg/lock-frontend) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/dpkg/lock-frontend"], "delta": "0:00:00.067464", "end": "2026-05-23 20:27:45.916375", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/dpkg/lock-frontend", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 20:27:45.848911", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+
+TASK [Update apt cache] ********************************************************
+changed: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": true, "changed": true}
+
+TASK [Check if node is installed] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "cmd": ["node", "--version"], "delta": "0:00:00.006262", "end": "2026-05-23 20:27:51.824336", "failed_when_result": false, "msg": "", "rc": 0, "start": "2026-05-23 20:27:51.818074", "stderr": "", "stderr_lines": [], "stdout": "v22.22.1", "stdout_lines": ["v22.22.1"]}
+
+TASK [Install required packages for NodeSource repository] *********************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Create keyrings directory] ***********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Download NodeSource GPG key] *********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Add NodeSource repository for Node.js 20] ********************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Install Node.js] *********************************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Install build-essential] *************************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+TASK [Install git and GitHub CLI] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+PLAY RECAP *********************************************************************
+wolf.tailf7742d.ts.net     : ok=6    changed=1    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
+No config file found; using defaults
+
+PLAY [all] *********************************************************************
+
+TASK [Gathering Facts] *********************************************************
+[WARNING]: Host 'wolf.tailf7742d.ts.net' is using the discovered Python interpreter at '/usr/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.20/reference_appendices/interpreter_discovery.html for more information.
+ok: [wolf.tailf7742d.ts.net]
+
+TASK [Validate architecture is supported] **************************************
+[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "ansible_architecture not in supported_architectures", "skip_reason": "Conditional result was False"}
+
+TASK [Normalize target ZeroClaw version (strip leading 'v')] *******************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"zeroclaw_target_version": "0.7.5"}, "changed": false}
+
+TASK [Resolve ZeroClaw release tag (always 'v'-prefixed)] **********************
+[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
+Origin: /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/platform/registry/zeroclaw/playbooks/install.yaml:14:19
+
+12       - aarch64
+13       - x86_64
+14     release_arch: "{{ arch_map[ansible_architecture] }}"
+                     ^ column 19
+
+Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
+
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"release_url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.7.5/zeroclaw-x86_64-unknown-linux-gnu.tar.gz", "zeroclaw_target_tag": "v0.7.5"}, "changed": false}
+
+TASK [Create agent user] *******************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "comment": "", "create_home": true, "group": 1012, "home": "/home/audit-zeroclaw", "name": "audit-zeroclaw", "shell": "/usr/sbin/nologin", "state": "present", "system": false, "uid": 1012}
+
+TASK [Create bin directory] ****************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1012, "group": "audit-zeroclaw", "mode": "0755", "owner": "audit-zeroclaw", "path": "/home/audit-zeroclaw/bin", "size": 4096, "state": "directory", "uid": 1012}
+
+TASK [Discover zeroclaw binary at agent's install path] ************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "stat": {"exists": false}}
+
+TASK [Get installed zeroclaw version] ******************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "zeroclaw_binary_stat.stat.exists", "skip_reason": "Conditional result was False"}
+
+TASK [Parse installed zeroclaw version] ****************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "(zeroclaw_version_check.rc | default(1)) == 0", "skip_reason": "Conditional result was False"}
+
+TASK [Set install skip condition] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"zeroclaw_already_installed": false}, "changed": false}
+
+TASK [Mark install as skipped when already installed] **************************
+skipping: [wolf.tailf7742d.ts.net] => {"false_condition": "zeroclaw_already_installed"}
+
+TASK [Note that --force was supplied (overriding skip)] ************************
+skipping: [wolf.tailf7742d.ts.net] => {"false_condition": "zeroclaw_binary_stat.stat.exists"}
+
+TASK [Download zeroclaw binary] ************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum_dest": null, "checksum_src": "bb688658508de72a086304d9213bca6d5ffd9a2b", "dest": "/tmp/zeroclaw-x86_64-unknown-linux-gnu.tar.gz", "elapsed": 1, "gid": 0, "group": "root", "md5sum": "c3a14c3247973dd891f7bce18d1aca73", "mode": "0644", "msg": "OK (15812349 bytes)", "owner": "root", "size": 15812349, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779593278.751683-1450225-102285456266319/tmp4sdjb7mn", "state": "file", "status_code": 200, "uid": 0, "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.7.5/zeroclaw-x86_64-unknown-linux-gnu.tar.gz"}
+
+TASK [Extract zeroclaw binary] *************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "dest": "/home/audit-zeroclaw/bin", "extract_results": {"cmd": ["/usr/bin/tar", "--extract", "-C", "/home/audit-zeroclaw/bin", "-z", "--owner=audit-zeroclaw", "--group=audit-zeroclaw", "-f", "/tmp/zeroclaw-x86_64-unknown-linux-gnu.tar.gz"], "err": "", "out": "", "rc": 0}, "gid": 1012, "group": "audit-zeroclaw", "handler": "TgzArchive", "mode": "0755", "owner": "audit-zeroclaw", "size": 4096, "src": "/tmp/zeroclaw-x86_64-unknown-linux-gnu.tar.gz", "state": "directory", "uid": 1012}
+
+TASK [Cleanup tarball] *********************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "path": "/tmp/zeroclaw-x86_64-unknown-linux-gnu.tar.gz", "state": "absent"}
+
+TASK [Create zeroclaw config directory] ****************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1012, "group": "audit-zeroclaw", "mode": "0700", "owner": "audit-zeroclaw", "path": "/home/audit-zeroclaw/.zeroclaw", "size": 4096, "state": "directory", "uid": 1012}
+
+TASK [Scaffold workspace directory] ********************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1012, "group": "audit-zeroclaw", "mode": "0700", "owner": "audit-zeroclaw", "path": "/home/audit-zeroclaw/.zeroclaw/workspace", "size": 4096, "state": "directory", "uid": 1012}
+
+TASK [Scaffold state directory] ************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1012, "group": "audit-zeroclaw", "mode": "0700", "owner": "audit-zeroclaw", "path": "/home/audit-zeroclaw/.zeroclaw/state", "size": 4096, "state": "directory", "uid": 1012}
+
+TASK [Create systemd service file (disabled, not started)] *********************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum": "8cdb4415394832fae557239a6717258fd9e19a56", "dest": "/etc/systemd/system/zeroclaw-audit-zeroclaw.service", "gid": 0, "group": "root", "md5sum": "0eec36b92a82858fdf84dbd6ee580130", "mode": "0644", "owner": "root", "size": 291, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779593284.6864388-1450424-6517800773627/.source.service", "state": "file", "uid": 0}
+
+TASK [Reload systemd to pick up unit file] *************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "name": null, "status": {}}
+
+TASK [Display install success] *************************************************
+ok: [wolf.tailf7742d.ts.net] => {
+    "msg": "ZeroClaw 0.7.5 installed for agent 'audit-zeroclaw'.\nService unit zeroclaw-audit-zeroclaw.service dropped (disabled, stopped).\nRun 'clm agent configure audit-zeroclaw' to render config.toml and start the daemon.\n"
+}
+
+PLAY RECAP *********************************************************************
+wolf.tailf7742d.ts.net     : ok=16   changed=9    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
+
+Success! zeroclaw v0.7.5 installed as 'audit-zeroclaw' on wolf-i
+```
+Exit: `0`
+
+### `clm agent install --type hermes --host wolf-i --name audit-hermes --yes`
+
+```console
+$ clm agent install --type hermes --host wolf-i --name audit-hermes --yes
+╭────────────────────────────────────────────────────────── Installation Summary ──────────────────────────────────────────────────────────╮
+│ Agent Type: hermes                                                                                                                       │
+│ Version: 2026.5.7                                                                                                                        │
+│ Host: wolf-i                                                                                                                             │
+│ Architecture: x86_64                                                                                                                     │
+│ Memory: 15.5GB                                                                                                                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+No config file found; using defaults
+
+PLAY [all] *********************************************************************
+
+TASK [Gathering Facts] *********************************************************
+[WARNING]: Host 'wolf.tailf7742d.ts.net' is using the discovered Python interpreter at '/usr/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.20/reference_appendices/interpreter_discovery.html for more information.
+ok: [wolf.tailf7742d.ts.net]
+
+TASK [Kill stale apt lock holders] *********************************************
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/apt/lists/lock) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/apt/lists/lock"], "delta": "0:00:00.069955", "end": "2026-05-23 20:28:20.983489", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/apt/lists/lock", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 20:28:20.913534", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/dpkg/lock) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/dpkg/lock"], "delta": "0:00:00.081451", "end": "2026-05-23 20:28:21.526158", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/dpkg/lock", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 20:28:21.444707", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/dpkg/lock-frontend) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/dpkg/lock-frontend"], "delta": "0:00:00.066138", "end": "2026-05-23 20:28:22.027585", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/dpkg/lock-frontend", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 20:28:21.961447", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+
+TASK [Update apt cache] ********************************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+TASK [Check if node is installed] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "cmd": ["node", "--version"], "delta": "0:00:00.006061", "end": "2026-05-23 20:28:23.463825", "failed_when_result": false, "msg": "", "rc": 0, "start": "2026-05-23 20:28:23.457764", "stderr": "", "stderr_lines": [], "stdout": "v22.22.1", "stdout_lines": ["v22.22.1"]}
+
+TASK [Install required packages for NodeSource repository] *********************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Create keyrings directory] ***********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Download NodeSource GPG key] *********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Add NodeSource repository for Node.js 20] ********************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Install Node.js] *********************************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Install build-essential] *************************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+TASK [Install git and GitHub CLI] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+PLAY RECAP *********************************************************************
+wolf.tailf7742d.ts.net     : ok=6    changed=0    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
+No config file found; using defaults
+
+PLAY [all] *********************************************************************
+
+TASK [Gathering Facts] *********************************************************
+[WARNING]: Host 'wolf.tailf7742d.ts.net' is using the discovered Python interpreter at '/usr/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.20/reference_appendices/interpreter_discovery.html for more information.
+ok: [wolf.tailf7742d.ts.net]
+
+TASK [Normalize target Hermes version (strip leading 'v')] *********************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"hermes_target_version": "2026.5.7"}, "changed": false}
+
+TASK [Resolve Hermes git tag for installer (always 'v'-prefixed)] **************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"hermes_target_branch": "v2026.5.7"}, "changed": false}
+
+TASK [Create agent user] *******************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "comment": "", "create_home": true, "group": 1013, "home": "/home/audit-hermes", "name": "audit-hermes", "shell": "/usr/sbin/nologin", "state": "present", "system": false, "uid": 1013}
+
+TASK [Install hermes system dependencies (ripgrep, ffmpeg)] ********************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+TASK [Discover hermes binary at agent's user-local install path] ***************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "stat": {"exists": false}}
+
+TASK [Get installed hermes version] ********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "hermes_binary_stat.stat.exists", "skip_reason": "Conditional result was False"}
+
+TASK [Parse installed hermes version] ******************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "(hermes_version_check.rc | default(1)) == 0", "skip_reason": "Conditional result was False"}
+
+TASK [Set install skip condition] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"hermes_already_installed": false}, "changed": false}
+
+TASK [Mark install as skipped when already installed] **************************
+skipping: [wolf.tailf7742d.ts.net] => {"false_condition": "hermes_already_installed"}
+
+TASK [Note that --force was supplied (overriding skip)] ************************
+skipping: [wolf.tailf7742d.ts.net] => {"false_condition": "hermes_binary_stat.stat.exists"}
+
+TASK [Remove existing Hermes binary symlink (forced reinstall)] ****************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "force_install | default(false) | bool", "skip_reason": "Conditional result was False"}
+
+TASK [Download Hermes installer script] ****************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum_dest": null, "checksum_src": "da96e86998cf4ededd3fe30be9f3b002a2f866fe", "dest": "/home/audit-hermes/hermes-install.sh", "elapsed": 0, "gid": 1013, "group": "audit-hermes", "md5sum": "857999f68cac4441a6adaebf9b5a54f2", "mode": "0700", "msg": "OK (62237 bytes)", "owner": "audit-hermes", "size": 62237, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779593310.9353557-1451408-239494034464156/tmpjcwv8rtp", "state": "file", "status_code": 200, "uid": 1013, "url": "https://raw.githubusercontent.com/NousResearch/hermes-agent/v2026.5.7/scripts/install.sh"}
+
+TASK [Install Hermes runtime (non-interactive)] ********************************
+ASYNC POLL on wolf.tailf7742d.ts.net: jid=j903788584236.480558 started=True finished=False
+ASYNC POLL on wolf.tailf7742d.ts.net: jid=j903788584236.480558 started=True finished=False
+ASYNC OK on wolf.tailf7742d.ts.net: jid=j903788584236.480558
+[WARNING]: Module remote_tmp /home/audit-hermes/.ansible/tmp did not exist and was created with a mode of 0700, this may cause issues when running as another user. To avoid this, create the remote_tmp dir with the correct permissions manually
+changed: [wolf.tailf7742d.ts.net] => {"ansible_job_id": "j903788584236.480558", "changed": true, "cmd": ["/bin/bash", "/home/audit-hermes/hermes-install.sh", "--skip-setup", "--branch", "v2026.5.7", "--hermes-home", "/home/audit-hermes/.hermes", "--dir", "/home/audit-hermes/.hermes/code"], "delta": "0:01:31.170811", "end": "2026-05-23 20:30:04.043079", "finished": true, "msg": "", "rc": 0, "results_file": "/home/audit-hermes/.ansible_async/j903788584236.480558", "start": "2026-05-23 20:28:32.872268", "started": true, "stderr": "Downloading cpython-3.11.15-linux-x86_64-gnu (download) (29.8MiB)\n Downloaded cpython-3.11.15-linux-x86_64-gnu (download)\nInstalled Python 3.11.15 in 1.76s\n + cpython-3.11.15-linux-x86_64-gnu (python3.11)\nwarning: `/home/audit-hermes/.local/bin` is not on your PATH. To use installed Python executables, add the directory to your PATH.\nCloning into '/home/audit-hermes/.hermes/code'...\nNote: switching to '498bfc7bc12a937621b4215312049b1000726df3'.\n\nYou are in 'detached HEAD' state. You can look around, make experimental\nchanges and commit them, and you can discard any commits you make in this\nstate without impacting any branches by switching back to a branch.\n\nIf you want to create a new branch to retain commits you create, you may\ndo so (now or later) by using -c with the switch command. Example:\n\n  git switch -c <new-branch-name>\n\nOr undo this operation with:\n\n  git switch -\n\nTurn off this advice by setting config variable advice.detachedHead to false\n\nUsing CPython 3.11.15\nCreating virtual environment at: venv\n/home/audit-hermes/hermes-install.sh: line 180: /dev/tty: No such device or address\n/home/audit-hermes/hermes-install.sh: line 181: /dev/tty: No such device or address\nsudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper\nsudo: a password is required", "stderr_lines": ["Downloading cpython-3.11.15-linux-x86_64-gnu (download) (29.8MiB)", " Downloaded cpython-3.11.15-linux-x86_64-gnu (download)", "Installed Python 3.11.15 in 1.76s", " + cpython-3.11.15-linux-x86_64-gnu (python3.11)", "warning: `/home/audit-hermes/.local/bin` is not on your PATH. To use installed Python executables, add the directory to your PATH.", "Cloning into '/home/audit-hermes/.hermes/code'...", "Note: switching to '498bfc7bc12a937621b4215312049b1000726df3'.", "", "You are in 'detached HEAD' state. You can look around, make experimental", "changes and commit them, and you can discard any commits you make in this", "state without impacting any branches by switching back to a branch.", "", "If you want to create a new branch to retain commits you create, you may", "do so (now or later) by using -c with the switch command. Example:", "", "  git switch -c <new-branch-name>", "", "Or undo this operation with:", "", "  git switch -", "", "Turn off this advice by setting config variable advice.detachedHead to false", "", "Using CPython 3.11.15", "Creating virtual environment at: venv", "/home/audit-hermes/hermes-install.sh: line 180: /dev/tty: No such device or address", "/home/audit-hermes/hermes-install.sh: line 181: /dev/tty: No such device or address", "sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper", "sudo: a password is required"], "stdout": "\n\u001b[0;35m\u001b[1m\n┌─────────────────────────────────────────────────────────┐\n│             ⚕ Hermes Agent Installer                    │\n├─────────────────────────────────────────────────────────┤\n│  An open source AI agent by Nous Research.              │\n└─────────────────────────────────────────────────────────┘\n\u001b[0m\n\u001b[0;32m✓\u001b[0m Detected: linux (ubuntu)\n\u001b[0;36m→\u001b[0m Install directory: /home/audit-hermes/.hermes/code (explicit)\n\u001b[0;36m→\u001b[0m Checking for uv package manager...\n\u001b[0;32m✓\u001b[0m uv found (uv 0.10.10)\n\u001b[0;36m→\u001b[0m Checking Python 3.11...\n\u001b[0;36m→\u001b[0m Python 3.11 not found, installing via uv...\n\u001b[0;32m✓\u001b[0m Python installed: Python 3.11.15\n\u001b[0;36m→\u001b[0m Checking Git...\n\u001b[0;32m✓\u001b[0m Git 2.43.0 found\n\u001b[0;36m→\u001b[0m Checking Node.js (for browser tools)...\n\u001b[0;32m✓\u001b[0m Node.js v22.22.1 found\n\u001b[0;36m→\u001b[0m Checking ripgrep (fast file search)...\n\u001b[0;32m✓\u001b[0m ripgrep 14.1.0 found\n\u001b[0;36m→\u001b[0m Checking ffmpeg (TTS voice messages)...\n\u001b[0;32m✓\u001b[0m ffmpeg 6.1.1-3ubuntu5 found\n\u001b[0;36m→\u001b[0m Installing to /home/audit-hermes/.hermes/code...\n\u001b[0;36m→\u001b[0m Trying SSH clone...\n\u001b[0;36m→\u001b[0m SSH failed, trying HTTPS...\n\u001b[0;32m✓\u001b[0m Cloned via HTTPS\n\u001b[0;32m✓\u001b[0m Repository ready\n\u001b[0;36m→\u001b[0m Creating virtual environment with Python 3.11...\n\u001b[0;32m✓\u001b[0m Virtual environment ready (Python 3.11)\n\u001b[0;36m→\u001b[0m Installing dependencies...\n\u001b[0;36m→\u001b[0m Some build tools may be needed for Python packages...\n\u001b[0;36m→\u001b[0m sudo is needed ONLY to install build tools (build-essential, python3-dev, libffi-dev) via apt.\n\u001b[0;36m→\u001b[0m Hermes Agent itself does not require or retain root access.\n\u001b[0;32m✓\u001b[0m Build tools installed\n\u001b[0;32m✓\u001b[0m Main package installed\n\u001b[0;32m✓\u001b[0m All dependencies installed\n\u001b[0;36m→\u001b[0m Installing Node.js dependencies (browser tools)...\n✅ Browser tools ready. Run: python run_agent.py --help\n\u001b[0;32m✓\u001b[0m Node.js dependencies installed\n\u001b[0;36m→\u001b[0m Installing browser engine (Playwright Chromium)...\n\u001b[0;36m→\u001b[0m Playwright may request sudo to install browser system dependencies (shared libraries).\n\u001b[0;36m→\u001b[0m This is standard Playwright setup — Hermes itself does not require root access.\nInstalling dependencies...\nSwitching to root user to install dependencies...\nFailed to install browsers\nError: Installation process exited with code: 1\n\u001b[0;33m⚠\u001b[0m Playwright browser installation failed — browser tools will not work.\n\u001b[0;33m⚠\u001b[0m Try running manually: cd /home/audit-hermes/.hermes/code && npx playwright install --with-deps chromium\n\u001b[0;32m✓\u001b[0m Browser engine setup complete\n\u001b[0;36m→\u001b[0m Installing TUI dependencies...\n\u001b[0;32m✓\u001b[0m TUI dependencies installed\n\u001b[0;36m→\u001b[0m Setting up hermes command...\n\u001b[0;32m✓\u001b[0m Installed hermes launcher → ~/.local/bin/hermes\n\u001b[0;32m✓\u001b[0m Added ~/.local/bin to PATH in /home/audit-hermes/.bashrc\n\u001b[0;32m✓\u001b[0m hermes command ready\n\u001b[0;36m→\u001b[0m Setting up configuration files...\n\u001b[0;32m✓\u001b[0m Created ~/.hermes/.env from template\n\u001b[0;32m✓\u001b[0m Created ~/.hermes/config.yaml from template\n\u001b[0;32m✓\u001b[0m Created ~/.hermes/SOUL.md (edit to customize personality)\n\u001b[0;32m✓\u001b[0m Configuration directory ready: ~/.hermes/\n\u001b[0;36m→\u001b[0m Syncing bundled skills to ~/.hermes/skills/ ...\nSyncing bundled skills into ~/.hermes/skills/ ...\n  + xurl\n  + openhue\n  + youtube-content\n  + gif-search\n  + heartmula\n  + spotify\n  + songsee\n  + notion\n  + powerpoint\n  + linear\n  + maps\n  + google-workspace\n  + nano-pdf\n  + ocr-and-documents\n  + airtable\n  + huggingface-hub\n  + dspy\n  + audiocraft-audio-generation\n  + segment-anything-model\n  + outlines\n  + serving-llms-vllm\n  + obliteratus\n  + llama-cpp\n  + unsloth\n  + axolotl\n  + fine-tuning-with-trl\n  + evaluating-llms-harness\n  + weights-and-biases\n  + apple-notes\n  + findmy\n  + imessage\n  + apple-reminders\n  + polymarket\n  + llm-wiki\n  + arxiv\n  + research-paper-writing\n  + blogwatcher\n  + godmode\n  + jupyter-live-kernel\n  + claude-code\n  + opencode\n  + hermes-agent\n  + codex\n  + himalaya\n  + native-mcp\n  + minecraft-modpack-server\n  + pokemon-player\n  + yuanbao\n  + python-debugpy\n  + writing-plans\n  + systematic-debugging\n  + hermes-agent-skill-authoring\n  + test-driven-development\n  + node-inspect-debugger\n  + requesting-code-review\n  + plan\n  + spike\n  + debugging-hermes-tui-commands\n  + subagent-driven-development\n  + kanban-worker\n  + webhook-subscriptions\n  + kanban-orchestrator\n  + dogfood\n  + github-auth\n  + github-pr-workflow\n  + github-repo-management\n  + github-code-review\n  + codebase-inspection\n  + github-issues\n  + touchdesigner-mcp\n  + popular-web-designs\n  + p5js\n  + comfyui\n  + baoyu-comic\n  + sketch\n  + ideation\n  + claude-design\n  + pixel-art\n  + baoyu-infographic\n  + manim-video\n  + pretext\n  + excalidraw\n  + ascii-video\n  + songwriting-and-ai-music\n  + architecture-diagram\n  + humanizer\n  + ascii-art\n  + design-md\n  + obsidian\n\nDone: 89 new, 0 updated, 0 unchanged. 89 total bundled.\n\u001b[0;32m✓\u001b[0m Skills synced to ~/.hermes/skills/\n\u001b[0;36m→\u001b[0m Skipping setup wizard (--skip-setup)\n\n\u001b[0;32m\u001b[1m\n┌─────────────────────────────────────────────────────────┐\n│              ✓ Installation Complete!                   │\n└─────────────────────────────────────────────────────────┘\n\u001b[0m\n\n\u001b[0;36m\u001b[1m📁 Your files:\u001b[0m\n\n   \u001b[0;33mConfig:\u001b[0m    /home/audit-hermes/.hermes/config.yaml\n   \u001b[0;33mAPI Keys:\u001b[0m  /home/audit-hermes/.hermes/.env\n   \u001b[0;33mData:\u001b[0m      /home/audit-hermes/.hermes/cron/, sessions/, logs/\n   \u001b[0;33mCode:\u001b[0m      /home/audit-hermes/.hermes/code\n\n\u001b[0;36m─────────────────────────────────────────────────────────\u001b[0m\n\n\u001b[0;36m\u001b[1m🚀 Commands:\u001b[0m\n\n   \u001b[0;32mhermes\u001b[0m              Start chatting\n   \u001b[0;32mhermes setup\u001b[0m        Configure API keys & settings\n   \u001b[0;32mhermes config\u001b[0m       View/edit configuration\n   \u001b[0;32mhermes config edit\u001b[0m  Open config in editor\n   \u001b[0;32mhermes gateway install\u001b[0m Install gateway service (messaging + cron)\n   \u001b[0;32mhermes update\u001b[0m       Update to latest version\n\n\u001b[0;36m─────────────────────────────────────────────────────────\u001b[0m\n\n\u001b[0;33m⚡ Reload your shell to use 'hermes' command:\u001b[0m\n\n   source ~/.bashrc   # or ~/.zshrc", "stdout_lines": ["", "\u001b[0;35m\u001b[1m", "┌─────────────────────────────────────────────────────────┐", "│             ⚕ Hermes Agent Installer                    │", "├─────────────────────────────────────────────────────────┤", "│  An open source AI agent by Nous Research.              │", "└─────────────────────────────────────────────────────────┘", "\u001b[0m", "\u001b[0;32m✓\u001b[0m Detected: linux (ubuntu)", "\u001b[0;36m→\u001b[0m Install directory: /home/audit-hermes/.hermes/code (explicit)", "\u001b[0;36m→\u001b[0m Checking for uv package manager...", "\u001b[0;32m✓\u001b[0m uv found (uv 0.10.10)", "\u001b[0;36m→\u001b[0m Checking Python 3.11...", "\u001b[0;36m→\u001b[0m Python 3.11 not found, installing via uv...", "\u001b[0;32m✓\u001b[0m Python installed: Python 3.11.15", "\u001b[0;36m→\u001b[0m Checking Git...", "\u001b[0;32m✓\u001b[0m Git 2.43.0 found", "\u001b[0;36m→\u001b[0m Checking Node.js (for browser tools)...", "\u001b[0;32m✓\u001b[0m Node.js v22.22.1 found", "\u001b[0;36m→\u001b[0m Checking ripgrep (fast file search)...", "\u001b[0;32m✓\u001b[0m ripgrep 14.1.0 found", "\u001b[0;36m→\u001b[0m Checking ffmpeg (TTS voice messages)...", "\u001b[0;32m✓\u001b[0m ffmpeg 6.1.1-3ubuntu5 found", "\u001b[0;36m→\u001b[0m Installing to /home/audit-hermes/.hermes/code...", "\u001b[0;36m→\u001b[0m Trying SSH clone...", "\u001b[0;36m→\u001b[0m SSH failed, trying HTTPS...", "\u001b[0;32m✓\u001b[0m Cloned via HTTPS", "\u001b[0;32m✓\u001b[0m Repository ready", "\u001b[0;36m→\u001b[0m Creating virtual environment with Python 3.11...", "\u001b[0;32m✓\u001b[0m Virtual environment ready (Python 3.11)", "\u001b[0;36m→\u001b[0m Installing dependencies...", "\u001b[0;36m→\u001b[0m Some build tools may be needed for Python packages...", "\u001b[0;36m→\u001b[0m sudo is needed ONLY to install build tools (build-essential, python3-dev, libffi-dev) via apt.", "\u001b[0;36m→\u001b[0m Hermes Agent itself does not require or retain root access.", "\u001b[0;32m✓\u001b[0m Build tools installed", "\u001b[0;32m✓\u001b[0m Main package installed", "\u001b[0;32m✓\u001b[0m All dependencies installed", "\u001b[0;36m→\u001b[0m Installing Node.js dependencies (browser tools)...", "✅ Browser tools ready. Run: python run_agent.py --help", "\u001b[0;32m✓\u001b[0m Node.js dependencies installed", "\u001b[0;36m→\u001b[0m Installing browser engine (Playwright Chromium)...", "\u001b[0;36m→\u001b[0m Playwright may request sudo to install browser system dependencies (shared libraries).", "\u001b[0;36m→\u001b[0m This is standard Playwright setup — Hermes itself does not require root access.", "Installing dependencies...", "Switching to root user to install dependencies...", "Failed to install browsers", "Error: Installation process exited with code: 1", "\u001b[0;33m⚠\u001b[0m Playwright browser installation failed — browser tools will not work.", "\u001b[0;33m⚠\u001b[0m Try running manually: cd /home/audit-hermes/.hermes/code && npx playwright install --with-deps chromium", "\u001b[0;32m✓\u001b[0m Browser engine setup complete", "\u001b[0;36m→\u001b[0m Installing TUI dependencies...", "\u001b[0;32m✓\u001b[0m TUI dependencies installed", "\u001b[0;36m→\u001b[0m Setting up hermes command...", "\u001b[0;32m✓\u001b[0m Installed hermes launcher → ~/.local/bin/hermes", "\u001b[0;32m✓\u001b[0m Added ~/.local/bin to PATH in /home/audit-hermes/.bashrc", "\u001b[0;32m✓\u001b[0m hermes command ready", "\u001b[0;36m→\u001b[0m Setting up configuration files...", "\u001b[0;32m✓\u001b[0m Created ~/.hermes/.env from template", "\u001b[0;32m✓\u001b[0m Created ~/.hermes/config.yaml from template", "\u001b[0;32m✓\u001b[0m Created ~/.hermes/SOUL.md (edit to customize personality)", "\u001b[0;32m✓\u001b[0m Configuration directory ready: ~/.hermes/", "\u001b[0;36m→\u001b[0m Syncing bundled skills to ~/.hermes/skills/ ...", "Syncing bundled skills into ~/.hermes/skills/ ...", "  + xurl", "  + openhue", "  + youtube-content", "  + gif-search", "  + heartmula", "  + spotify", "  + songsee", "  + notion", "  + powerpoint", "  + linear", "  + maps", "  + google-workspace", "  + nano-pdf", "  + ocr-and-documents", "  + airtable", "  + huggingface-hub", "  + dspy", "  + audiocraft-audio-generation", "  + segment-anything-model", "  + outlines", "  + serving-llms-vllm", "  + obliteratus", "  + llama-cpp", "  + unsloth", "  + axolotl", "  + fine-tuning-with-trl", "  + evaluating-llms-harness", "  + weights-and-biases", "  + apple-notes", "  + findmy", "  + imessage", "  + apple-reminders", "  + polymarket", "  + llm-wiki", "  + arxiv", "  + research-paper-writing", "  + blogwatcher", "  + godmode", "  + jupyter-live-kernel", "  + claude-code", "  + opencode", "  + hermes-agent", "  + codex", "  + himalaya", "  + native-mcp", "  + minecraft-modpack-server", "  + pokemon-player", "  + yuanbao", "  + python-debugpy", "  + writing-plans", "  + systematic-debugging", "  + hermes-agent-skill-authoring", "  + test-driven-development", "  + node-inspect-debugger", "  + requesting-code-review", "  + plan", "  + spike", "  + debugging-hermes-tui-commands", "  + subagent-driven-development", "  + kanban-worker", "  + webhook-subscriptions", "  + kanban-orchestrator", "  + dogfood", "  + github-auth", "  + github-pr-workflow", "  + github-repo-management", "  + github-code-review", "  + codebase-inspection", "  + github-issues", "  + touchdesigner-mcp", "  + popular-web-designs", "  + p5js", "  + comfyui", "  + baoyu-comic", "  + sketch", "  + ideation", "  + claude-design", "  + pixel-art", "  + baoyu-infographic", "  + manim-video", "  + pretext", "  + excalidraw", "  + ascii-video", "  + songwriting-and-ai-music", "  + architecture-diagram", "  + humanizer", "  + ascii-art", "  + design-md", "  + obsidian", "", "Done: 89 new, 0 updated, 0 unchanged. 89 total bundled.", "\u001b[0;32m✓\u001b[0m Skills synced to ~/.hermes/skills/", "\u001b[0;36m→\u001b[0m Skipping setup wizard (--skip-setup)", "", "\u001b[0;32m\u001b[1m", "┌─────────────────────────────────────────────────────────┐", "│              ✓ Installation Complete!                   │", "└─────────────────────────────────────────────────────────┘", "\u001b[0m", "", "\u001b[0;36m\u001b[1m📁 Your files:\u001b[0m", "", "   \u001b[0;33mConfig:\u001b[0m    /home/audit-hermes/.hermes/config.yaml", "   \u001b[0;33mAPI Keys:\u001b[0m  /home/audit-hermes/.hermes/.env", "   \u001b[0;33mData:\u001b[0m      /home/audit-hermes/.hermes/cron/, sessions/, logs/", "   \u001b[0;33mCode:\u001b[0m      /home/audit-hermes/.hermes/code", "", "\u001b[0;36m─────────────────────────────────────────────────────────\u001b[0m", "", "\u001b[0;36m\u001b[1m🚀 Commands:\u001b[0m", "", "   \u001b[0;32mhermes\u001b[0m              Start chatting", "   \u001b[0;32mhermes setup\u001b[0m        Configure API keys & settings", "   \u001b[0;32mhermes config\u001b[0m       View/edit configuration", "   \u001b[0;32mhermes config edit\u001b[0m  Open config in editor", "   \u001b[0;32mhermes gateway install\u001b[0m Install gateway service (messaging + cron)", "   \u001b[0;32mhermes update\u001b[0m       Update to latest version", "", "\u001b[0;36m─────────────────────────────────────────────────────────\u001b[0m", "", "\u001b[0;33m⚡ Reload your shell to use 'hermes' command:\u001b[0m", "", "   source ~/.bashrc   # or ~/.zshrc"]}
+
+TASK [Clean up installer script] ***********************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "path": "/home/audit-hermes/hermes-install.sh", "state": "absent"}
+
+TASK [Create Hermes config directory] ******************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1013, "group": "audit-hermes", "mode": "0700", "owner": "audit-hermes", "path": "/home/audit-hermes/.hermes", "size": 4096, "state": "directory", "uid": 1013}
+
+TASK [Create empty Hermes environment file (preserved across re-installs)] *****
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "dest": "/home/audit-hermes/.hermes/.env", "src": "/home/devashish/.ansible/tmp/ansible-local-1451238qiq9miop/.d4gtow2m"}
+
+TASK [Enforce 0600 permissions on Hermes environment file] *********************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1013, "group": "audit-hermes", "mode": "0600", "owner": "audit-hermes", "path": "/home/audit-hermes/.hermes/.env", "size": 21610, "state": "file", "uid": 1013}
+
+TASK [Create Hermes memories directory] ****************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1013, "group": "audit-hermes", "mode": "0700", "owner": "audit-hermes", "path": "/home/audit-hermes/.hermes/memories", "size": 4096, "state": "directory", "uid": 1013}
+
+TASK [Create systemd service file (disabled, not started)] *********************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum": "5e2484049c86e18e63c6656da16b88160498093b", "dest": "/etc/systemd/system/hermes-audit-hermes.service", "gid": 0, "group": "root", "md5sum": "9410301ab80f533592b9f0bbe8c83db8", "mode": "0644", "owner": "root", "size": 333, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779593407.3811157-1454408-256975507905295/.source.service", "state": "file", "uid": 0}
+
+TASK [Reload systemd to pick up unit file] *************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "name": null, "status": {}}
+
+TASK [Display install success] *************************************************
+ok: [wolf.tailf7742d.ts.net] => {
+    "msg": "Hermes 2026.5.7 installed for agent 'audit-hermes'.\nService unit hermes-audit-hermes.service dropped (disabled, stopped).\nRun `clm agent configure audit-hermes` to provision a provider and start the gateway.\n"
+}
+
+RUNNING HANDLER [Reload systemd] ***********************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "name": null, "status": {}}
+
+PLAY RECAP *********************************************************************
+wolf.tailf7742d.ts.net     : ok=18   changed=8    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
+
+Success! hermes v2026.5.7 installed as 'audit-hermes' on wolf-i
+```
+Exit: `0`
+
+### `clm agent install --type openclaw --host wolf-i --name audit-openclaw --yes`
+
+```console
+$ clm agent install --type openclaw --host wolf-i --name audit-openclaw --yes
+╭────────────────────────────────────────────────────────── Installation Summary ──────────────────────────────────────────────────────────╮
+│ Agent Type: openclaw                                                                                                                     │
+│ Version: 2026.4.2                                                                                                                        │
+│ Host: wolf-i                                                                                                                             │
+│ Architecture: x86_64                                                                                                                     │
+│ Memory: 15.5GB                                                                                                                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+No config file found; using defaults
+
+PLAY [all] *********************************************************************
+
+TASK [Gathering Facts] *********************************************************
+[WARNING]: Host 'wolf.tailf7742d.ts.net' is using the discovered Python interpreter at '/usr/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.20/reference_appendices/interpreter_discovery.html for more information.
+ok: [wolf.tailf7742d.ts.net]
+
+TASK [Kill stale apt lock holders] *********************************************
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/apt/lists/lock) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/apt/lists/lock"], "delta": "0:00:00.072885", "end": "2026-05-23 20:30:16.509716", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/apt/lists/lock", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 20:30:16.436831", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/dpkg/lock) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/dpkg/lock"], "delta": "0:00:00.073788", "end": "2026-05-23 20:30:17.096600", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/dpkg/lock", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 20:30:17.022812", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/dpkg/lock-frontend) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/dpkg/lock-frontend"], "delta": "0:00:00.072710", "end": "2026-05-23 20:30:17.748403", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/dpkg/lock-frontend", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 20:30:17.675693", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+
+TASK [Update apt cache] ********************************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+TASK [Check if node is installed] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "cmd": ["node", "--version"], "delta": "0:00:00.006134", "end": "2026-05-23 20:30:19.246381", "failed_when_result": false, "msg": "", "rc": 0, "start": "2026-05-23 20:30:19.240247", "stderr": "", "stderr_lines": [], "stdout": "v22.22.1", "stdout_lines": ["v22.22.1"]}
+
+TASK [Install required packages for NodeSource repository] *********************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Create keyrings directory] ***********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Download NodeSource GPG key] *********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Add NodeSource repository for Node.js 20] ********************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Install Node.js] *********************************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Install build-essential] *************************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+TASK [Install git and GitHub CLI] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+PLAY RECAP *********************************************************************
+wolf.tailf7742d.ts.net     : ok=6    changed=0    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
+No config file found; using defaults
+
+PLAY [all] *********************************************************************
+
+TASK [Gathering Facts] *********************************************************
+[WARNING]: Host 'wolf.tailf7742d.ts.net' is using the discovered Python interpreter at '/usr/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.20/reference_appendices/interpreter_discovery.html for more information.
+ok: [wolf.tailf7742d.ts.net]
+
+TASK [Normalize target OpenClaw version] ***************************************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"openclaw_target_version": "2026.4.2"}, "changed": false}
+
+TASK [Create agent user] *******************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "comment": "", "create_home": true, "group": 1014, "home": "/home/audit-openclaw", "name": "audit-openclaw", "shell": "/bin/bash", "state": "present", "system": false, "uid": 1014}
+
+TASK [Check per-agent openclaw binary] *****************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "stat": {"exists": false}}
+
+TASK [Discover openclaw binary in PATH] ****************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "cmd": ["which", "openclaw"], "delta": "0:00:00.003177", "end": "2026-05-23 20:30:25.790927", "failed_when_result": false, "msg": "", "rc": 0, "start": "2026-05-23 20:30:25.787750", "stderr": "", "stderr_lines": [], "stdout": "/usr/local/bin/openclaw", "stdout_lines": ["/usr/local/bin/openclaw"]}
+
+TASK [Resolve openclaw binary (per-agent preferred, PATH fallback)] ************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"openclaw_discovered_binary": "/usr/local/bin/openclaw"}, "changed": false}
+
+TASK [Validate discovered binary path] *****************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "(openclaw_discovered_binary | length) > 0 and not (openclaw_discovered_binary.startswith('/usr/local/bin/') or\n     openclaw_discovered_binary.startswith('/usr/bin/') or\n     openclaw_discovered_binary.startswith('/home/'))\n", "skip_reason": "Conditional result was False"}
+
+TASK [Get installed openclaw version] ******************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "cmd": ["/usr/local/bin/openclaw", "--version"], "delta": "0:00:00.120211", "end": "2026-05-23 20:30:26.539960", "failed_when_result": false, "msg": "", "rc": 0, "start": "2026-05-23 20:30:26.419749", "stderr": "", "stderr_lines": [], "stdout": "OpenClaw 2026.3.13 (61d171a)", "stdout_lines": ["OpenClaw 2026.3.13 (61d171a)"]}
+
+TASK [Parse installed openclaw version] ****************************************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"openclaw_installed_version": "2026.3.13"}, "changed": false}
+
+TASK [Set install skip condition] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"openclaw_already_installed": false, "openclaw_runtime_binary": "/usr/local/bin/openclaw"}, "changed": false}
+
+TASK [Mark install as skipped when already installed] **************************
+skipping: [wolf.tailf7742d.ts.net] => {"false_condition": "openclaw_already_installed"}
+
+TASK [Note that --force was supplied (overriding skip)] ************************
+skipping: [wolf.tailf7742d.ts.net] => {"false_condition": "force_install | default(false) | bool"}
+
+TASK [Download OpenClaw installer script] **************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum_dest": null, "checksum_src": "0b1b0e8e1f7af258783bc2944917e053b15c8e6d", "dest": "/home/audit-openclaw/openclaw-install.sh", "elapsed": 0, "gid": 1014, "group": "audit-openclaw", "md5sum": "9b0627a698f72a649a41b5a642f2bcd6", "mode": "0700", "msg": "OK (26204 bytes)", "owner": "audit-openclaw", "size": 26204, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779593426.808022-1455344-135150799570064/tmp1sn47h9_", "state": "file", "status_code": 200, "uid": 1014, "url": "https://openclaw.ai/install-cli.sh"}
+
+TASK [Install OpenClaw CLI runtime] ********************************************
+[WARNING]: Module remote_tmp /home/audit-openclaw/.ansible/tmp did not exist and was created with a mode of 0700, this may cause issues when running as another user. To avoid this, create the remote_tmp dir with the correct permissions manually
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "cmd": ["/bin/bash", "/home/audit-openclaw/openclaw-install.sh", "--prefix", "/home/audit-openclaw/.openclaw", "--install-method", "npm", "--version", "2026.4.2", "--no-onboard"], "delta": "0:01:13.123201", "end": "2026-05-23 20:31:41.063940", "msg": "", "rc": 0, "start": "2026-05-23 20:30:27.940739", "stderr": "npm notice\nnpm notice New major version of npm available! 10.9.4 -> 11.15.0\nnpm notice Changelog: https://github.com/npm/cli/releases/tag/v11.15.0\nnpm notice To update run: npm install -g npm@11.15.0\nnpm notice", "stderr_lines": ["npm notice", "npm notice New major version of npm available! 10.9.4 -> 11.15.0", "npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.15.0", "npm notice To update run: npm install -g npm@11.15.0", "npm notice"], "stdout": "Installing Node 22.22.0 (user-space)...\nInstalling OpenClaw (2026.4.2)...\n\nadded 472 packages in 1m\nOpenClaw installed (OpenClaw 2026.4.2 (d74a122)).", "stdout_lines": ["Installing Node 22.22.0 (user-space)...", "Installing OpenClaw (2026.4.2)...", "", "added 472 packages in 1m", "OpenClaw installed (OpenClaw 2026.4.2 (d74a122))."]}
+
+TASK [Clean up installer script] ***********************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "path": "/home/audit-openclaw/openclaw-install.sh", "state": "absent"}
+
+TASK [Create workspace directory] **********************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1014, "group": "audit-openclaw", "mode": "0700", "owner": "audit-openclaw", "path": "/home/audit-openclaw/workspace", "size": 4096, "state": "directory", "uid": 1014}
+
+TASK [Create OpenClaw config directory] ****************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1014, "group": "audit-openclaw", "mode": "0700", "owner": "audit-openclaw", "path": "/home/audit-openclaw/.openclaw", "size": 4096, "state": "directory", "uid": 1014}
+
+TASK [Calculate unique port (40000-42000 range)] *******************************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"openclaw_port": 40612}, "changed": false}
+
+TASK [Write openclaw config from template] *************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum": "052399dd085ac29822b7cd6c336a643cb75d02d3", "dest": "/home/audit-openclaw/.openclaw/openclaw.json", "gid": 1014, "group": "audit-openclaw", "md5sum": "5654d91f9664b6c543fb085dab67d18c", "mode": "0600", "owner": "audit-openclaw", "size": 1055, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779593502.6812377-1457982-239208318569034/.source.json", "state": "file", "uid": 1014}
+
+TASK [Write exec approvals policy from template] *******************************
+changed: [wolf.tailf7742d.ts.net] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": true}
+
+TASK [Verify exec approvals JSON is valid] *************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "cmd": ["python3", "-m", "json.tool", "/home/audit-openclaw/.openclaw/exec-approvals.json"], "delta": "0:00:00.042602", "end": "2026-05-23 20:31:44.878616", "msg": "", "rc": 0, "start": "2026-05-23 20:31:44.836014", "stderr": "", "stderr_lines": [], "stdout": "{\n    \"version\": 1,\n    \"defaults\": {\n        \"security\": \"full\",\n        \"ask\": \"off\",\n        \"askFallback\": \"full\",\n        \"autoAllowSkills\": false\n    }\n}", "stdout_lines": ["{", "    \"version\": 1,", "    \"defaults\": {", "        \"security\": \"full\",", "        \"ask\": \"off\",", "        \"askFallback\": \"full\",", "        \"autoAllowSkills\": false", "    }", "}"]}
+
+TASK [Create environment file for agent] ***************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709", "dest": "/home/audit-openclaw/.openclaw/env", "gid": 1014, "group": "audit-openclaw", "md5sum": "d41d8cd98f00b204e9800998ecf8427e", "mode": "0600", "owner": "audit-openclaw", "size": 0, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779593504.969828-1458101-236418003765705/.source", "state": "file", "uid": 1014}
+
+TASK [Create systemd service file] *********************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum": "03157cd39147163a5b8960f4a0ea98bdcad103b0", "dest": "/etc/systemd/system/openclaw-audit-openclaw.service", "gid": 0, "group": "root", "md5sum": "dfad988ba86b2d25c76ab4f7cc3b22ce", "mode": "0644", "owner": "root", "size": 354, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779593505.7843945-1458149-73265254501936/.source.service", "state": "file", "uid": 0}
+
+TASK [Restart openclaw service on ExecStart change] ****************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "enabled": true, "name": "openclaw-audit-openclaw", "state": "started", "status": {"ActiveEnterTimestampMonotonic": "0", "ActiveExitTimestampMonotonic": "0", "ActiveState": "inactive", "After": "-.mount home.mount systemd-journald.socket sysinit.target basic.target network.target system.slice", "AllowIsolate": "no", "AssertResult": "no", "AssertTimestampMonotonic": "0", "Before": "shutdown.target", "BlockIOAccounting": "no", "BlockIOWeight": "[not set]", "CPUAccounting": "yes", "CPUAffinityFromNUMA": "no", "CPUQuotaPerSecUSec": "infinity", "CPUQuotaPeriodUSec": "infinity", "CPUSchedulingPolicy": "0", "CPUSchedulingPriority": "0", "CPUSchedulingResetOnFork": "no", "CPUShares": "[not set]", "CPUUsageNSec": "[not set]", "CPUWeight": "[not set]", "CacheDirectoryMode": "0755", "CanFreeze": "yes", "CanIsolate": "no", "CanReload": "no", "CanStart": "yes", "CanStop": "yes", "CapabilityBoundingSet": "cap_chown cap_dac_override cap_dac_read_search cap_fowner cap_fsetid cap_kill cap_setgid cap_setuid cap_setpcap cap_linux_immutable cap_net_bind_service cap_net_broadcast cap_net_admin cap_net_raw cap_ipc_lock cap_ipc_owner cap_sys_module cap_sys_rawio cap_sys_chroot cap_sys_ptrace cap_sys_pacct cap_sys_admin cap_sys_boot cap_sys_nice cap_sys_resource cap_sys_time cap_sys_tty_config cap_mknod cap_lease cap_audit_write cap_audit_control cap_setfcap cap_mac_override cap_mac_admin cap_syslog cap_wake_alarm cap_block_suspend cap_audit_read cap_perfmon cap_bpf cap_checkpoint_restore", "CleanResult": "success", "CollectMode": "inactive", "ConditionResult": "no", "ConditionTimestampMonotonic": "0", "ConfigurationDirectoryMode": "0755", "Conflicts": "shutdown.target", "ControlGroupId": "0", "ControlPID": "0", "CoredumpFilter": "0x33", "CoredumpReceive": "no", "DefaultDependencies": "yes", "DefaultMemoryLow": "0", "DefaultMemoryMin": "0", "DefaultStartupMemoryLow": "0", "Delegate": "no", "Description": "OpenClaw AI Assistant (audit-openclaw)", "DevicePolicy": "auto", "DynamicUser": "no", "EnvironmentFiles": "/home/audit-openclaw/.openclaw/env (ignore_errors=no)", "ExecMainCode": "0", "ExecMainExitTimestampMonotonic": "0", "ExecMainPID": "0", "ExecMainStartTimestampMonotonic": "0", "ExecMainStatus": "0", "ExecStart": "{ path=/usr/local/bin/openclaw ; argv[]=/usr/local/bin/openclaw gateway run --allow-unconfigured ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }", "ExecStartEx": "{ path=/usr/local/bin/openclaw ; argv[]=/usr/local/bin/openclaw gateway run --allow-unconfigured ; flags= ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }", "ExitType": "main", "ExtensionImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent", "FailureAction": "none", "FileDescriptorStoreMax": "0", "FileDescriptorStorePreserve": "restart", "FinalKillSignal": "9", "FragmentPath": "/etc/systemd/system/openclaw-audit-openclaw.service", "FreezerState": "running", "GID": "[not set]", "GuessMainPID": "yes", "IOAccounting": "no", "IOReadBytes": "[not set]", "IOReadOperations": "[not set]", "IOSchedulingClass": "2", "IOSchedulingPriority": "4", "IOWeight": "[not set]", "IOWriteBytes": "[not set]", "IOWriteOperations": "[not set]", "IPAccounting": "no", "IPEgressBytes": "[no data]", "IPEgressPackets": "[no data]", "IPIngressBytes": "[no data]", "IPIngressPackets": "[no data]", "Id": "openclaw-audit-openclaw.service", "IgnoreOnIsolate": "no", "IgnoreSIGPIPE": "yes", "InactiveEnterTimestampMonotonic": "0", "InactiveExitTimestampMonotonic": "0", "JobRunningTimeoutUSec": "infinity", "JobTimeoutAction": "none", "JobTimeoutUSec": "infinity", "KeyringMode": "private", "KillMode": "control-group", "KillSignal": "15", "LimitAS": "infinity", "LimitASSoft": "infinity", "LimitCORE": "infinity", "LimitCORESoft": "0", "LimitCPU": "infinity", "LimitCPUSoft": "infinity", "LimitDATA": "infinity", "LimitDATASoft": "infinity", "LimitFSIZE": "infinity", "LimitFSIZESoft": "infinity", "LimitLOCKS": "infinity", "LimitLOCKSSoft": "infinity", "LimitMEMLOCK": "8388608", "LimitMEMLOCKSoft": "8388608", "LimitMSGQUEUE": "819200", "LimitMSGQUEUESoft": "819200", "LimitNICE": "0", "LimitNICESoft": "0", "LimitNOFILE": "524288", "LimitNOFILESoft": "1024", "LimitNPROC": "62947", "LimitNPROCSoft": "62947", "LimitRSS": "infinity", "LimitRSSSoft": "infinity", "LimitRTPRIO": "0", "LimitRTPRIOSoft": "0", "LimitRTTIME": "infinity", "LimitRTTIMESoft": "infinity", "LimitSIGPENDING": "62947", "LimitSIGPENDINGSoft": "62947", "LimitSTACK": "infinity", "LimitSTACKSoft": "8388608", "LoadState": "loaded", "LockPersonality": "no", "LogLevelMax": "-1", "LogRateLimitBurst": "0", "LogRateLimitIntervalUSec": "0", "LogsDirectoryMode": "0755", "MainPID": "0", "ManagedOOMMemoryPressure": "auto", "ManagedOOMMemoryPressureLimit": "0", "ManagedOOMPreference": "none", "ManagedOOMSwap": "auto", "MemoryAccounting": "yes", "MemoryAvailable": "11460218880", "MemoryCurrent": "[not set]", "MemoryDenyWriteExecute": "no", "MemoryHigh": "infinity", "MemoryKSM": "no", "MemoryLimit": "infinity", "MemoryLow": "0", "MemoryMax": "infinity", "MemoryMin": "0", "MemoryPeak": "[not set]", "MemoryPressureThresholdUSec": "200ms", "MemoryPressureWatch": "auto", "MemorySwapCurrent": "[not set]", "MemorySwapMax": "infinity", "MemorySwapPeak": "[not set]", "MemoryZSwapCurrent": "[not set]", "MemoryZSwapMax": "infinity", "MountAPIVFS": "no", "MountImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent", "NFileDescriptorStore": "0", "NRestarts": "0", "NUMAPolicy": "n/a", "Names": "openclaw-audit-openclaw.service", "NeedDaemonReload": "no", "Nice": "0", "NoNewPrivileges": "no", "NonBlocking": "no", "NotifyAccess": "none", "OOMPolicy": "stop", "OOMScoreAdjust": "0", "OnFailureJobMode": "replace", "OnSuccessJobMode": "fail", "Perpetual": "no", "PrivateDevices": "no", "PrivateIPC": "no", "PrivateMounts": "no", "PrivateNetwork": "no", "PrivateTmp": "no", "PrivateUsers": "no", "ProcSubset": "all", "ProtectClock": "no", "ProtectControlGroups": "no", "ProtectHome": "no", "ProtectHostname": "no", "ProtectKernelLogs": "no", "ProtectKernelModules": "no", "ProtectKernelTunables": "no", "ProtectProc": "default", "ProtectSystem": "no", "RefuseManualStart": "no", "RefuseManualStop": "no", "ReloadResult": "success", "ReloadSignal": "1", "RemainAfterExit": "no", "RemoveIPC": "no", "Requires": "system.slice -.mount home.mount sysinit.target", "RequiresMountsFor": "/home/audit-openclaw/workspace", "Restart": "always", "RestartKillSignal": "15", "RestartMaxDelayUSec": "infinity", "RestartMode": "normal", "RestartSteps": "0", "RestartUSec": "5s", "RestartUSecNext": "5s", "RestrictNamespaces": "no", "RestrictRealtime": "no", "RestrictSUIDSGID": "no", "Result": "success", "RootDirectoryStartOnly": "no", "RootEphemeral": "no", "RootImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent", "RuntimeDirectoryMode": "0755", "RuntimeDirectoryPreserve": "no", "RuntimeMaxUSec": "infinity", "RuntimeRandomizedExtraUSec": "0", "SameProcessGroup": "no", "SecureBits": "0", "SendSIGHUP": "no", "SendSIGKILL": "yes", "SetLoginEnvironment": "no", "Slice": "system.slice", "StandardError": "inherit", "StandardInput": "null", "StandardOutput": "journal", "StartLimitAction": "none", "StartLimitBurst": "5", "StartLimitIntervalUSec": "10s", "StartupBlockIOWeight": "[not set]", "StartupCPUShares": "[not set]", "StartupCPUWeight": "[not set]", "StartupIOWeight": "[not set]", "StartupMemoryHigh": "infinity", "StartupMemoryLow": "0", "StartupMemoryMax": "infinity", "StartupMemorySwapMax": "infinity", "StartupMemoryZSwapMax": "infinity", "StateChangeTimestampMonotonic": "0", "StateDirectoryMode": "0755", "StatusErrno": "0", "StopWhenUnneeded": "no", "SubState": "dead", "SuccessAction": "none", "SurviveFinalKillSignal": "no", "SyslogFacility": "3", "SyslogLevel": "6", "SyslogLevelPrefix": "yes", "SyslogPriority": "30", "SystemCallErrorNumber": "2147483646", "TTYReset": "no", "TTYVHangup": "no", "TTYVTDisallocate": "no", "TasksAccounting": "yes", "TasksCurrent": "[not set]", "TasksMax": "18884", "TimeoutAbortUSec": "1min 30s", "TimeoutCleanUSec": "infinity", "TimeoutStartFailureMode": "terminate", "TimeoutStartUSec": "1min 30s", "TimeoutStopFailureMode": "terminate", "TimeoutStopUSec": "1min 30s", "TimerSlackNSec": "50000", "Transient": "no", "Type": "simple", "UID": "[not set]", "UMask": "0022", "UnitFilePreset": "enabled", "UnitFileState": "disabled", "User": "audit-openclaw", "UtmpMode": "init", "WatchdogSignal": "6", "WatchdogTimestampMonotonic": "0", "WatchdogUSec": "infinity", "WorkingDirectory": "/home/audit-openclaw/workspace"}}
+
+TASK [Enable and start openclaw service] ***************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "enabled": true, "name": "openclaw-audit-openclaw", "state": "started", "status": {"ActiveEnterTimestamp": "Sat 2026-05-23 20:31:48 PDT", "ActiveEnterTimestampMonotonic": "6597732633876", "ActiveExitTimestampMonotonic": "0", "ActiveState": "active", "After": "system.slice sysinit.target home.mount network.target systemd-journald.socket basic.target -.mount", "AllowIsolate": "no", "AssertResult": "yes", "AssertTimestamp": "Sat 2026-05-23 20:31:48 PDT", "AssertTimestampMonotonic": "6597732632336", "Before": "shutdown.target multi-user.target", "BlockIOAccounting": "no", "BlockIOWeight": "[not set]", "CPUAccounting": "yes", "CPUAffinityFromNUMA": "no", "CPUQuotaPerSecUSec": "infinity", "CPUQuotaPeriodUSec": "infinity", "CPUSchedulingPolicy": "0", "CPUSchedulingPriority": "0", "CPUSchedulingResetOnFork": "no", "CPUShares": "[not set]", "CPUUsageNSec": "1743925000", "CPUWeight": "[not set]", "CacheDirectoryMode": "0755", "CanFreeze": "yes", "CanIsolate": "no", "CanReload": "no", "CanStart": "yes", "CanStop": "yes", "CapabilityBoundingSet": "cap_chown cap_dac_override cap_dac_read_search cap_fowner cap_fsetid cap_kill cap_setgid cap_setuid cap_setpcap cap_linux_immutable cap_net_bind_service cap_net_broadcast cap_net_admin cap_net_raw cap_ipc_lock cap_ipc_owner cap_sys_module cap_sys_rawio cap_sys_chroot cap_sys_ptrace cap_sys_pacct cap_sys_admin cap_sys_boot cap_sys_nice cap_sys_resource cap_sys_time cap_sys_tty_config cap_mknod cap_lease cap_audit_write cap_audit_control cap_setfcap cap_mac_override cap_mac_admin cap_syslog cap_wake_alarm cap_block_suspend cap_audit_read cap_perfmon cap_bpf cap_checkpoint_restore", "CleanResult": "success", "CollectMode": "inactive", "ConditionResult": "yes", "ConditionTimestamp": "Sat 2026-05-23 20:31:48 PDT", "ConditionTimestampMonotonic": "6597732632332", "ConfigurationDirectoryMode": "0755", "Conflicts": "shutdown.target", "ControlGroup": "/system.slice/openclaw-audit-openclaw.service", "ControlGroupId": "25593535", "ControlPID": "0", "CoredumpFilter": "0x33", "CoredumpReceive": "no", "DefaultDependencies": "yes", "DefaultMemoryLow": "0", "DefaultMemoryMin": "0", "DefaultStartupMemoryLow": "0", "Delegate": "no", "Description": "OpenClaw AI Assistant (audit-openclaw)", "DevicePolicy": "auto", "DynamicUser": "no", "EnvironmentFiles": "/home/audit-openclaw/.openclaw/env (ignore_errors=no)", "ExecMainCode": "0", "ExecMainExitTimestampMonotonic": "0", "ExecMainPID": "485482", "ExecMainStartTimestamp": "Sat 2026-05-23 20:31:48 PDT", "ExecMainStartTimestampMonotonic": "6597732633656", "ExecMainStatus": "0", "ExecStart": "{ path=/usr/local/bin/openclaw ; argv[]=/usr/local/bin/openclaw gateway run --allow-unconfigured ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }", "ExecStartEx": "{ path=/usr/local/bin/openclaw ; argv[]=/usr/local/bin/openclaw gateway run --allow-unconfigured ; flags= ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }", "ExitType": "main", "ExtensionImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent", "FailureAction": "none", "FileDescriptorStoreMax": "0", "FileDescriptorStorePreserve": "restart", "FinalKillSignal": "9", "FragmentPath": "/etc/systemd/system/openclaw-audit-openclaw.service", "FreezerState": "running", "GID": "1014", "GuessMainPID": "yes", "IOAccounting": "no", "IOReadBytes": "[not set]", "IOReadOperations": "[not set]", "IOSchedulingClass": "2", "IOSchedulingPriority": "4", "IOWeight": "[not set]", "IOWriteBytes": "[not set]", "IOWriteOperations": "[not set]", "IPAccounting": "no", "IPEgressBytes": "[no data]", "IPEgressPackets": "[no data]", "IPIngressBytes": "[no data]", "IPIngressPackets": "[no data]", "Id": "openclaw-audit-openclaw.service", "IgnoreOnIsolate": "no", "IgnoreSIGPIPE": "yes", "InactiveEnterTimestampMonotonic": "0", "InactiveExitTimestamp": "Sat 2026-05-23 20:31:48 PDT", "InactiveExitTimestampMonotonic": "6597732633876", "InvocationID": "41ef9b9328b1441795bdeb96f1ba7571", "JobRunningTimeoutUSec": "infinity", "JobTimeoutAction": "none", "JobTimeoutUSec": "infinity", "KeyringMode": "private", "KillMode": "control-group", "KillSignal": "15", "LimitAS": "infinity", "LimitASSoft": "infinity", "LimitCORE": "infinity", "LimitCORESoft": "0", "LimitCPU": "infinity", "LimitCPUSoft": "infinity", "LimitDATA": "infinity", "LimitDATASoft": "infinity", "LimitFSIZE": "infinity", "LimitFSIZESoft": "infinity", "LimitLOCKS": "infinity", "LimitLOCKSSoft": "infinity", "LimitMEMLOCK": "8388608", "LimitMEMLOCKSoft": "8388608", "LimitMSGQUEUE": "819200", "LimitMSGQUEUESoft": "819200", "LimitNICE": "0", "LimitNICESoft": "0", "LimitNOFILE": "524288", "LimitNOFILESoft": "1024", "LimitNPROC": "62947", "LimitNPROCSoft": "62947", "LimitRSS": "infinity", "LimitRSSSoft": "infinity", "LimitRTPRIO": "0", "LimitRTPRIOSoft": "0", "LimitRTTIME": "infinity", "LimitRTTIMESoft": "infinity", "LimitSIGPENDING": "62947", "LimitSIGPENDINGSoft": "62947", "LimitSTACK": "infinity", "LimitSTACKSoft": "8388608", "LoadState": "loaded", "LockPersonality": "no", "LogLevelMax": "-1", "LogRateLimitBurst": "0", "LogRateLimitIntervalUSec": "0", "LogsDirectoryMode": "0755", "MainPID": "485482", "ManagedOOMMemoryPressure": "auto", "ManagedOOMMemoryPressureLimit": "0", "ManagedOOMPreference": "none", "ManagedOOMSwap": "auto", "MemoryAccounting": "yes", "MemoryAvailable": "11346976768", "MemoryCurrent": "142753792", "MemoryDenyWriteExecute": "no", "MemoryHigh": "infinity", "MemoryKSM": "no", "MemoryLimit": "infinity", "MemoryLow": "0", "MemoryMax": "infinity", "MemoryMin": "0", "MemoryPeak": "142770176", "MemoryPressureThresholdUSec": "200ms", "MemoryPressureWatch": "auto", "MemorySwapCurrent": "0", "MemorySwapMax": "infinity", "MemorySwapPeak": "0", "MemoryZSwapCurrent": "0", "MemoryZSwapMax": "infinity", "MountAPIVFS": "no", "MountImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent", "NFileDescriptorStore": "0", "NRestarts": "0", "NUMAPolicy": "n/a", "Names": "openclaw-audit-openclaw.service", "NeedDaemonReload": "no", "Nice": "0", "NoNewPrivileges": "no", "NonBlocking": "no", "NotifyAccess": "none", "OOMPolicy": "stop", "OOMScoreAdjust": "0", "OnFailureJobMode": "replace", "OnSuccessJobMode": "fail", "Perpetual": "no", "PrivateDevices": "no", "PrivateIPC": "no", "PrivateMounts": "no", "PrivateNetwork": "no", "PrivateTmp": "no", "PrivateUsers": "no", "ProcSubset": "all", "ProtectClock": "no", "ProtectControlGroups": "no", "ProtectHome": "no", "ProtectHostname": "no", "ProtectKernelLogs": "no", "ProtectKernelModules": "no", "ProtectKernelTunables": "no", "ProtectProc": "default", "ProtectSystem": "no", "RefuseManualStart": "no", "RefuseManualStop": "no", "ReloadResult": "success", "ReloadSignal": "1", "RemainAfterExit": "no", "RemoveIPC": "no", "Requires": "-.mount sysinit.target home.mount system.slice", "RequiresMountsFor": "/home/audit-openclaw/workspace", "Restart": "always", "RestartKillSignal": "15", "RestartMaxDelayUSec": "infinity", "RestartMode": "normal", "RestartSteps": "0", "RestartUSec": "5s", "RestartUSecNext": "5s", "RestrictNamespaces": "no", "RestrictRealtime": "no", "RestrictSUIDSGID": "no", "Result": "success", "RootDirectoryStartOnly": "no", "RootEphemeral": "no", "RootImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent", "RuntimeDirectoryMode": "0755", "RuntimeDirectoryPreserve": "no", "RuntimeMaxUSec": "infinity", "RuntimeRandomizedExtraUSec": "0", "SameProcessGroup": "no", "SecureBits": "0", "SendSIGHUP": "no", "SendSIGKILL": "yes", "SetLoginEnvironment": "no", "Slice": "system.slice", "StandardError": "inherit", "StandardInput": "null", "StandardOutput": "journal", "StartLimitAction": "none", "StartLimitBurst": "5", "StartLimitIntervalUSec": "10s", "StartupBlockIOWeight": "[not set]", "StartupCPUShares": "[not set]", "StartupCPUWeight": "[not set]", "StartupIOWeight": "[not set]", "StartupMemoryHigh": "infinity", "StartupMemoryLow": "0", "StartupMemoryMax": "infinity", "StartupMemorySwapMax": "infinity", "StartupMemoryZSwapMax": "infinity", "StateChangeTimestamp": "Sat 2026-05-23 20:31:48 PDT", "StateChangeTimestampMonotonic": "6597732633876", "StateDirectoryMode": "0755", "StatusErrno": "0", "StopWhenUnneeded": "no", "SubState": "running", "SuccessAction": "none", "SurviveFinalKillSignal": "no", "SyslogFacility": "3", "SyslogLevel": "6", "SyslogLevelPrefix": "yes", "SyslogPriority": "30", "SystemCallErrorNumber": "2147483646", "TTYReset": "no", "TTYVHangup": "no", "TTYVTDisallocate": "no", "TasksAccounting": "yes", "TasksCurrent": "14", "TasksMax": "18884", "TimeoutAbortUSec": "1min 30s", "TimeoutCleanUSec": "infinity", "TimeoutStartFailureMode": "terminate", "TimeoutStartUSec": "1min 30s", "TimeoutStopFailureMode": "terminate", "TimeoutStopUSec": "1min 30s", "TimerSlackNSec": "50000", "Transient": "no", "Type": "simple", "UID": "1014", "UMask": "0022", "UnitFilePreset": "enabled", "UnitFileState": "enabled", "User": "audit-openclaw", "UtmpMode": "init", "WantedBy": "multi-user.target", "WatchdogSignal": "6", "WatchdogTimestampMonotonic": "0", "WatchdogUSec": "0", "WorkingDirectory": "/home/audit-openclaw/workspace"}}
+
+TASK [Wait for gateway port to be listening] ***********************************
+ok: [wolf.tailf7742d.ts.net -> localhost] => {"changed": false, "elapsed": 29, "match_groupdict": {}, "match_groups": [], "path": null, "port": 40612, "search_regex": null, "state": "started"}
+
+TASK [Read gateway authentication token from config file] **********************
+ok: [wolf.tailf7742d.ts.net] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
+
+TASK [Parse gateway token from config] *****************************************
+ok: [wolf.tailf7742d.ts.net] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
+
+TASK [Validate gateway token format] *******************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "gateway_token_result_stdout is not defined or gateway_token_result_stdout | length < 32 or not (gateway_token_result_stdout is regex('^[a-zA-Z0-9_-]+$'))", "skip_reason": "Conditional result was False"}
+
+TASK [Copy device pairing script] **********************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum": "de98a7e90a1640675b8454bf6b538aa34650626e", "dest": "/home/audit-openclaw/pair_device.mjs", "gid": 1014, "group": "audit-openclaw", "md5sum": "dad2220cdb88526b9d9855e07fcceaaa", "mode": "0700", "owner": "audit-openclaw", "size": 5993, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779593539.7906888-1459356-67064077187122/.source.mjs", "state": "file", "uid": 1014}
+
+TASK [Install ws package for pairing script] ***********************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "cmd": ["npm", "install", "ws"], "delta": "0:00:00.428655", "end": "2026-05-23 20:32:21.411781", "msg": "", "rc": 0, "start": "2026-05-23 20:32:20.983126", "stderr": "", "stderr_lines": [], "stdout": "\nadded 1 package in 357ms", "stdout_lines": ["", "added 1 package in 357ms"]}
+
+TASK [Run device pairing via localhost] ****************************************
+changed: [wolf.tailf7742d.ts.net] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": true}
+
+TASK [Parse device credentials] ************************************************
+ok: [wolf.tailf7742d.ts.net] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
+
+TASK [Validate device credentials] *********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "device_credentials.deviceToken is not defined or device_credentials.deviceToken | length < 10", "skip_reason": "Conditional result was False"}
+
+TASK [Clean up pairing script] *************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "path": "/home/audit-openclaw/pair_device.mjs", "state": "absent"}
+
+TASK [Clean up node_modules from pairing] **************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "path": "/home/audit-openclaw/node_modules", "state": "absent"}
+
+TASK [Save all credentials to fact for retrieval] ******************************
+ok: [wolf.tailf7742d.ts.net] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
+
+PLAY RECAP *********************************************************************
+wolf.tailf7742d.ts.net     : ok=32   changed=16   unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
+
+Success! openclaw v2026.4.2 installed as 'audit-openclaw' on wolf-i
+```
+Exit: `0`
+
+
+---
+
+## Lifecycle transcripts (audit-* agents)
+
+For each agent type, the full sequence is captured in order:
+`configure` → `start` → `sync` → `stop` → `restart`. Install was captured
+in the previous section.
+
+After all three agents are configured and started, the post-install
+`clm agent ps` capture documents the running state. Per-agent read-only
+commands (`secret list`, `memory show`, `integration list`, `skill list`,
+`logs --tail 20`) are captured while the agents are running.
+
+### audit-zeroclaw (configure + start)
+
+### `clm agent configure audit-zeroclaw --yes`
+
+```console
+$ clm agent configure audit-zeroclaw --yes
+╭────────────────────────────────────────────────────────── Agent Configuration ───────────────────────────────────────────────────────────╮
+│ Onboarding: audit-zeroclaw on wolf-i                                                                                                     │
+│ Current state: PENDING                                                                                                                   │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+Starting onboarding...
+
+═══════════════════════════════════════════════════
+ Stage 1/4: PROVIDERS
+ Assign inference provider to this agent
+═══════════════════════════════════════════════════
+
+Available providers:
+  1. clm-openrouter (openrouter, openai/gpt-4o) ✓
+  2. local-inx (ollama, qwen3-coder:30b-128k) ✓
+  3. maurice-openrouter (openrouter, z-ai/glm-4.5-air) ✓
+  4. clawrium-bedrock (bedrock, zai.glm-4.7) ✓
+  5. clawrium-coder (ollama, qwen3-coder-next:q4_K_M) ✓
+  6. clawrium-glm-flash (ollama, glm-4.7-flash:latest) ✓
+  7. clawrium-nemotron (ollama, nemotron-cascade-2:30b-a3b-q4_K_M) ✓
+  8. clawrium-deepseek (ollama, deepseek-r1:70b) ✓
+  9. clawrium-glm51 (openrouter, z-ai/glm-5) ✓
+
+
+Syncing config to agent... ✓
+Saving provider selection... ✓
+
+Stage PROVIDERS complete.
+Stage 2/4: IDENTITY — auto-skipped (ZeroClaw uses minimal identity)
+
+═══════════════════════════════════════════════════
+ Stage 3/4: CHANNELS
+ Configure communication channels
+═══════════════════════════════════════════════════
+
+Select default channel:
+  1. cli (recommended)
+  2. discord
+
+✓ Default channel: cli
+
+Stage CHANNELS complete.
+
+═══════════════════════════════════════════════════
+ Stage 4/4: VALIDATE
+ Verify agent is properly configured
+═══════════════════════════════════════════════════
+
+[1/3] Validating agent installation...
+  ✓ Agent installed
+[2/3] Validating provider configuration...
+  ✓ Provider: clm-openrouter (openrouter)
+  Checking API key...
+  ✓ API credentials configured
+[3/3] Testing provider connectivity...
+  ✓ Provider connectivity OK
+
+Validation passed
+
+Stage VALIDATE complete.
+
+═══════════════════════════════════════════════════
+ Onboarding Complete!
+═══════════════════════════════════════════════════
+
+State: READY
+Run 'clm agent start audit-zeroclaw' to start your agent.
+```
+Exit: `0`
+
+### `clm agent start audit-zeroclaw`
+
+```console
+$ clm agent start audit-zeroclaw
+Starting agent: audit-zeroclaw on wolf-i
+  Checking audit-zeroclaw on wolf.tailf7742d.ts.net...
+  Starting audit-zeroclaw on wolf.tailf7742d.ts.net...
+  Daemon started; pairing audit-zeroclaw...
+  Re-pairing zeroclaw after start...
+  Gateway token rotated for audit-zeroclaw. Active chat sessions on other machines will need to reconnect.
+  Pairing token refreshed
+  Started audit-zeroclaw successfully
+✓ Agent started successfully
+  Run 'clm agent ps' to check status
+```
+Exit: `0`
+
+
+### audit-hermes (configure + start)
+
+### `clm agent configure audit-hermes --yes`
+
+```console
+$ clm agent configure audit-hermes --yes
+╭────────────────────────────────────────────────────────── Agent Configuration ───────────────────────────────────────────────────────────╮
+│ Onboarding: audit-hermes on wolf-i                                                                                                       │
+│ Current state: PENDING                                                                                                                   │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+Starting onboarding...
+
+═══════════════════════════════════════════════════
+ Stage 1/4: PROVIDERS
+ Assign inference provider to this agent
+═══════════════════════════════════════════════════
+
+Available providers:
+  1. clm-openrouter (openrouter, openai/gpt-4o) ✓
+  2. local-inx (ollama, qwen3-coder:30b-128k) ✓
+  3. maurice-openrouter (openrouter, z-ai/glm-4.5-air) ✓
+  4. clawrium-bedrock (bedrock, zai.glm-4.7) ✓
+  5. clawrium-coder (ollama, qwen3-coder-next:q4_K_M) ✓
+  6. clawrium-glm-flash (ollama, glm-4.7-flash:latest) ✓
+  7. clawrium-nemotron (ollama, nemotron-cascade-2:30b-a3b-q4_K_M) ✓
+  8. clawrium-deepseek (ollama, deepseek-r1:70b) ✓
+  9. clawrium-glm51 (openrouter, z-ai/glm-5) ✓
+
+
+Syncing config to agent... ✓
+Saving provider selection... ✓
+
+Stage PROVIDERS complete.
+Stage 2/4: IDENTITY — auto-skipped (Hermes manages SOUL.md/AGENTS.md inside ~/.hermes/; clm does not push identity files in this iteration)
+
+═══════════════════════════════════════════════════
+ Stage 3/4: CHANNELS
+ Configure communication channels
+═══════════════════════════════════════════════════
+
+Select default channel:
+  1. cli (recommended)
+  2. discord
+  3. slack
+
+✓ Default channel: cli
+
+Stage CHANNELS complete.
+
+═══════════════════════════════════════════════════
+ Stage 4/4: VALIDATE
+ Verify agent is properly configured
+═══════════════════════════════════════════════════
+
+[1/4] Validating agent installation...
+  ✓ Agent installed
+[2/4] Validating provider configuration...
+  ✓ Provider: clm-openrouter (openrouter)
+  Checking API key...
+  ✓ API credentials configured
+[3/4] Testing provider connectivity...
+  ✓ Provider connectivity OK
+[4/4] Verifying hermes health on agent host...
+  ✓ hermes --version OK, ~/.hermes/.env exists, /health returned 200
+
+Validation passed
+
+Stage VALIDATE complete.
+
+═══════════════════════════════════════════════════
+ Onboarding Complete!
+═══════════════════════════════════════════════════
+
+State: READY
+Run 'clm agent start audit-hermes' to start your agent.
+```
+Exit: `0`
+
+### `clm agent start audit-hermes`
+
+```console
+$ clm agent start audit-hermes
+Starting agent: audit-hermes on wolf-i
+  Checking audit-hermes on wolf.tailf7742d.ts.net...
+  Starting audit-hermes on wolf.tailf7742d.ts.net...
+  Started audit-hermes successfully
+✓ Agent started successfully
+  Run 'clm agent ps' to check status
+```
+Exit: `0`
+
+
+### audit-openclaw (configure + start)
+
+### `clm agent configure audit-openclaw --yes`
+
+```console
+$ clm agent configure audit-openclaw --yes
+╭────────────────────────────────────────────────────────── Agent Configuration ───────────────────────────────────────────────────────────╮
+│ Onboarding: audit-openclaw on wolf-i                                                                                                     │
+│ Current state: PENDING                                                                                                                   │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+Starting onboarding...
+
+═══════════════════════════════════════════════════
+ Stage 1/4: PROVIDERS
+ Assign inference provider to this agent
+═══════════════════════════════════════════════════
+
+Available providers:
+  1. clm-openrouter (openrouter, openai/gpt-4o) ✓
+  2. local-inx (ollama, qwen3-coder:30b-128k) ✓
+  3. maurice-openrouter (openrouter, z-ai/glm-4.5-air) ✓
+  4. clawrium-bedrock (bedrock, zai.glm-4.7) ✓
+  5. clawrium-coder (ollama, qwen3-coder-next:q4_K_M) ✓
+  6. clawrium-glm-flash (ollama, glm-4.7-flash:latest) ✓
+  7. clawrium-nemotron (ollama, nemotron-cascade-2:30b-a3b-q4_K_M) ✓
+  8. clawrium-deepseek (ollama, deepseek-r1:70b) ✓
+  9. clawrium-glm51 (openrouter, z-ai/glm-5) ✓
+
+
+Syncing config to agent... ✗ Failed to configure openclaw: Configure playbook failed: failed
+Error: Failed to apply provider configuration. Run 'clm agent configure audit-openclaw --stage providers' to retry.
+Onboarding failed at stage: providers
+```
+Exit: `1`
+
+
+> **Note:** `audit-openclaw configure --yes` fails on this fleet with no
+> default provider auto-selected. The remaining lifecycle commands below
+> are still run sequentially to capture their verbatim behavior against
+> an unconfigured agent — this is intentional baseline data. See
+> Callouts on the PR for the documented decision.
+
+#### audit-openclaw: `start` (against unconfigured agent)
+
+### `clm agent start audit-openclaw`
+
+```console
+$ clm agent start audit-openclaw
+
+Error: Cannot start audit-openclaw - onboarding incomplete
+
+Current state: PROVIDERS (0/4)
+
+Incomplete stages:
+  ○ providers  - Assign inference provider to this agent
+  ○ identity   - Configure agent personality and behavior
+  ○ channels   - Configure communication channels
+  ○ validate   - Verify agent is properly configured
+
+Run 'clm agent configure audit-openclaw' to complete onboarding.
+
+To force start anyway (not recommended):
+  clm agent start audit-openclaw --force
+
+```
+Exit: `1`
+
+
+#### audit-openclaw: `sync`
+
+### `clm agent sync audit-openclaw`
+
+```console
+$ clm agent sync audit-openclaw
+Syncing agent: audit-openclaw on wolf-i
+  Syncing audit-openclaw on wolf.tailf7742d.ts.net...
+  Configuring audit-openclaw...
+  Configuring audit-openclaw on wolf.tailf7742d.ts.net...
+  Running Ansible playbook...
+  Saving configuration to hosts.json...
+  Successfully configured audit-openclaw
+  Sync complete for audit-openclaw
+✓ Configuration synced
+  Run 'clm agent ps' to check status
+```
+Exit: `0`
+
+
+#### audit-openclaw: `stop`
+
+### `clm agent stop audit-openclaw`
+
+```console
+$ clm agent stop audit-openclaw
+Stopping agent: audit-openclaw on wolf-i
+  Checking audit-openclaw on wolf.tailf7742d.ts.net...
+  Stopping audit-openclaw on wolf.tailf7742d.ts.net...
+  Stopped audit-openclaw successfully
+✓ Agent stopped successfully
+```
+Exit: `0`
+
+
+#### audit-openclaw: `restart`
+
+### `clm agent restart audit-openclaw`
+
+```console
+$ clm agent restart audit-openclaw
+Restarting agent: audit-openclaw on wolf-i
+  Restarting audit-openclaw on wolf.tailf7742d.ts.net...
+  Checking audit-openclaw on wolf.tailf7742d.ts.net...
+  Stopping audit-openclaw on wolf.tailf7742d.ts.net...
+  Stopped audit-openclaw successfully
+  Checking audit-openclaw on wolf.tailf7742d.ts.net...
+Error: Cannot start audit-openclaw: onboarding incomplete (state=providers). Run 'clm agent configure audit-openclaw' first.
+```
+Exit: `1`
+
+
+### audit-zeroclaw: sync / stop / restart
+
+
+#### audit-zeroclaw: `sync`
+
+### `clm agent sync audit-zeroclaw`
+
+```console
+$ clm agent sync audit-zeroclaw
+Syncing agent: audit-zeroclaw on wolf-i
+  Syncing audit-zeroclaw on wolf.tailf7742d.ts.net...
+  Configuring audit-zeroclaw...
+  Configuring audit-zeroclaw on wolf.tailf7742d.ts.net...
+  Loaded provider API key from secrets
+  Running Ansible playbook...
+  Pairing token captured
+  Saving configuration to hosts.json...
+  Gateway token rotated for audit-zeroclaw. Active chat sessions on other machines will need to reconnect.
+  Successfully configured audit-zeroclaw
+  Sync complete for audit-zeroclaw
+✓ Configuration synced
+  Run 'clm agent ps' to check status
+```
+Exit: `0`
+
+
+#### audit-zeroclaw: `stop`
+
+### `clm agent stop audit-zeroclaw`
+
+```console
+$ clm agent stop audit-zeroclaw
+Stopping agent: audit-zeroclaw on wolf-i
+  Checking audit-zeroclaw on wolf.tailf7742d.ts.net...
+  Stopping audit-zeroclaw on wolf.tailf7742d.ts.net...
+  Stopped audit-zeroclaw successfully
+✓ Agent stopped successfully
+```
+Exit: `0`
+
+
+#### audit-zeroclaw: `restart`
+
+### `clm agent restart audit-zeroclaw`
+
+```console
+$ clm agent restart audit-zeroclaw
+Restarting agent: audit-zeroclaw on wolf-i
+  Restarting audit-zeroclaw on wolf.tailf7742d.ts.net...
+  Checking audit-zeroclaw on wolf.tailf7742d.ts.net...
+  Stopping audit-zeroclaw on wolf.tailf7742d.ts.net...
+  Stopped audit-zeroclaw successfully
+  Checking audit-zeroclaw on wolf.tailf7742d.ts.net...
+  Starting audit-zeroclaw on wolf.tailf7742d.ts.net...
+  Daemon started; pairing audit-zeroclaw...
+  Re-pairing zeroclaw after restart...
+  Gateway token rotated for audit-zeroclaw. Active chat sessions on other machines will need to reconnect.
+  Pairing token refreshed
+  Started audit-zeroclaw successfully
+✓ Agent restarted successfully
+  Run 'clm agent ps' to check status
+```
+Exit: `0`
+
+
+### audit-hermes: sync / stop / restart
+
+
+#### audit-hermes: `sync`
+
+### `clm agent sync audit-hermes`
+
+```console
+$ clm agent sync audit-hermes
+Syncing agent: audit-hermes on wolf-i
+  Syncing audit-hermes on wolf.tailf7742d.ts.net...
+  Configuring audit-hermes...
+  Configuring audit-hermes on wolf.tailf7742d.ts.net...
+  Loaded provider API key from secrets
+  Running Ansible playbook...
+  Saving configuration to hosts.json...
+  Successfully configured audit-hermes
+  Sync complete for audit-hermes
+✓ Configuration synced
+  Run 'clm agent ps' to check status
+```
+Exit: `0`
+
+
+#### audit-hermes: `stop`
+
+### `clm agent stop audit-hermes`
+
+```console
+$ clm agent stop audit-hermes
+Stopping agent: audit-hermes on wolf-i
+  Checking audit-hermes on wolf.tailf7742d.ts.net...
+  Stopping audit-hermes on wolf.tailf7742d.ts.net...
+  Stopped audit-hermes successfully
+✓ Agent stopped successfully
+```
+Exit: `0`
+
+
+#### audit-hermes: `restart`
+
+### `clm agent restart audit-hermes`
+
+```console
+$ clm agent restart audit-hermes
+Restarting agent: audit-hermes on wolf-i
+  Restarting audit-hermes on wolf.tailf7742d.ts.net...
+  Checking audit-hermes on wolf.tailf7742d.ts.net...
+  Stopping audit-hermes on wolf.tailf7742d.ts.net...
+  Stopped audit-hermes successfully
+  Checking audit-hermes on wolf.tailf7742d.ts.net...
+  Starting audit-hermes on wolf.tailf7742d.ts.net...
+  Started audit-hermes successfully
+✓ Agent restarted successfully
+  Run 'clm agent ps' to check status
+```
+Exit: `0`
+
+
+### Post-lifecycle agent ps (audit-* agents visible)
+
+### `clm agent ps`
+
+```console
+$ clm agent ps
+
+
+                                                       Agent Fleet Status                                                        
+┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Name           ┃ Agent Type ┃ Provider   ┃ Host   ┃ Address                ┃ Port  ┃ Version  ┃ Status           ┃ Installed  ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ audit-hermes   │ hermes     │ openrouter │ wolf-i │ wolf.tailf7742d.ts.net │ 40425 │ 2026.5.7 │ ready (stopped)  │ 2026-05-24 │
+│ audit-openclaw │ openclaw   │ -          │ wolf-i │ wolf.tailf7742d.ts.net │ 40612 │ 2026.4.2 │ onboarding (0/4) │ 2026-05-24 │
+│ audit-zeroclaw │ zeroclaw   │ openrouter │ wolf-i │ wolf.tailf7742d.ts.net │ 40616 │ 0.7.5    │ running          │ 2026-05-24 │
+│ clawrium-d01   │ zeroclaw   │ openrouter │ wolf-i │ wolf.tailf7742d.ts.net │ 41429 │ 0.7.5    │ running          │ 2026-05-19 │
+│ espresso       │ hermes     │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 41583 │ 2026.5.7 │ running          │ 2026-05-11 │
+│ maurice        │ hermes     │ openrouter │ wolf-i │ wolf.tailf7742d.ts.net │ 40317 │ 2026.5.7 │ running          │ 2026-05-22 │
+│ nemotron-alpha │ zeroclaw   │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 40919 │ 0.7.5    │ running          │ 2026-05-22 │
+│ nemotron-beta  │ zeroclaw   │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 40971 │ 0.7.5    │ running          │ 2026-05-20 │
+│ wolf-i         │ openclaw   │ bedrock    │ wolf-i │ wolf.tailf7742d.ts.net │ 40198 │ 2026.4.2 │ running          │ 2026-04-11 │
+└────────────────┴────────────┴────────────┴────────┴────────────────────────┴───────┴──────────┴──────────────────┴────────────┘
+
+
+audit-hermes on wolf-i:
+  ✓ providers  - (2026-05-24)
+  ○ identity   - (skipped)
+  ✓ channels   - (2026-05-24)
+  ✓ validate   - (2026-05-24)
+
+audit-openclaw on wolf-i:
+  ○ providers  - pending
+  ○ identity   - pending
+  ○ channels   - pending
+  ○ validate   - pending
+```
+Exit: `0`
+
+
+---
+
+## Per-agent read-only command transcripts (audit-* agents)
+
+For each audit-* agent: secret list, memory show, integration list,
+skill list, logs --tail 20. Captured while the agents are in their
+post-lifecycle state.
+
+### audit-zeroclaw
+
+### `clm agent secret list audit-zeroclaw`
+
+```console
+$ clm agent secret list audit-zeroclaw
+╭─────────────────────────────────────────────────── Traceback (most recent call last) ────────────────────────────────────────────────────╮
+│ /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/cli/agent.py:2686 in secret_list                    │
+│                                                                                                                                          │
+│   2683 │   """List secrets for an agent."""                                                                                              │
+│   2684 │   from clawrium.cli.secret import list_cmd                                                                                      │
+│   2685 │                                                                                                                                 │
+│ ❱ 2686 │   list_cmd(claw_name=claw_name)                                                                                                 │
+│   2687                                                                                                                                   │
+│   2688                                                                                                                                   │
+│   2689 @secret_app.command(name="remove")                                                                                                │
+│                                                                                                                                          │
+│ /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/cli/secret.py:130 in list_cmd                       │
+│                                                                                                                                          │
+│   127 │   instance_secrets = secrets.get(instance_key, {})                                                                               │
+│   128 │                                                                                                                                  │
+│   129 │   # Build gateway config based on agent type                                                                                     │
+│ ❱ 130 │   required_secrets = get_required_secrets(claw_type)                                                                             │
+│   131 │   required_keys = {s["key"] for s in required_secrets}                                                                           │
+│   132 │   stored_keys = set(instance_secrets.keys())                                                                                     │
+│   133 │   missing_keys = required_keys - stored_keys                                                                                     │
+│                                                                                                                                          │
+│ /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/core/registry.py:744 in get_required_secrets        │
+│                                                                                                                                          │
+│   741 │   Returns:                                                                                                                       │
+│   742 │   │   List of required `SecretDefinition` objects                                                                                │
+│   743 │   """                                                                                                                            │
+│ ❱ 744 │   manifest = load_manifest(claw_name)                                                                                            │
+│   745 │   return manifest.get("secrets", {}).get("required", [])                                                                         │
+│   746                                                                                                                                    │
+│   747                                                                                                                                    │
+│                                                                                                                                          │
+│ /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/core/registry.py:638 in load_manifest               │
+│                                                                                                                                          │
+│   635 │   │   agent_dir = registry_package / claw_name                                                                                   │
+│   636 │   │                                                                                                                              │
+│   637 │   │   if not agent_dir.is_dir():                                                                                                 │
+│ ❱ 638 │   │   │   raise ManifestNotFoundError(                                                                                           │
+│   639 │   │   │   │   f"Agent type '{claw_name}' not found in registry"                                                                  │
+│   640 │   │   │   )                                                                                                                      │
+│   641                                                                                                                                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+ManifestNotFoundError: Agent type 'audit-zeroclaw' not found in registry
+```
+Exit: `1`
+
+### `clm agent memory show audit-zeroclaw`
+
+```console
+$ clm agent memory show audit-zeroclaw
+
+Agent: audit-zeroclaw (wolf.tailf7742d.ts.net)
+Workspace: /home/audit-zeroclaw/.zeroclaw/workspace
+Total size: 2.2 KB
+
+ File          Status    Size 
+ SOUL.md       present  325 B 
+ IDENTITY.md   present  376 B 
+ USER.md       present  247 B 
+ AGENTS.md     present  391 B 
+ TOOLS.md      present  387 B 
+ MEMORY.md     present  176 B 
+ HEARTBEAT.md  present  381 B 
+```
+Exit: `0`
+
+### `clm agent integration list audit-zeroclaw`
+
+```console
+$ clm agent integration list audit-zeroclaw
+
+Agent: audit-zeroclaw
+  No integrations assigned
+
+Use 'clm agent integration add <agent> <integration>' to assign integrations
+```
+Exit: `0`
+
+### `clm agent skill list audit-zeroclaw`
+
+```console
+$ clm agent skill list audit-zeroclaw
+No skills installed on audit-zeroclaw. Try clm agent skill install audit-zeroclaw clawrium/tdd.
+```
+Exit: `0`
+
+### `clm agent logs audit-zeroclaw --tail 20`
+
+```console
+$ clm agent logs audit-zeroclaw --tail 20
+Usage: clm agent logs [OPTIONS] CLAW_NAME
+Try 'clm agent logs --help' for help.
+╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ No such option '--tail'.                                                                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+Exit: `2`
+
+
+### audit-hermes
+
+### `clm agent secret list audit-hermes`
+
+```console
+$ clm agent secret list audit-hermes
+╭─────────────────────────────────────────────────── Traceback (most recent call last) ────────────────────────────────────────────────────╮
+│ /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/cli/agent.py:2686 in secret_list                    │
+│                                                                                                                                          │
+│   2683 │   """List secrets for an agent."""                                                                                              │
+│   2684 │   from clawrium.cli.secret import list_cmd                                                                                      │
+│   2685 │                                                                                                                                 │
+│ ❱ 2686 │   list_cmd(claw_name=claw_name)                                                                                                 │
+│   2687                                                                                                                                   │
+│   2688                                                                                                                                   │
+│   2689 @secret_app.command(name="remove")                                                                                                │
+│                                                                                                                                          │
+│ /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/cli/secret.py:130 in list_cmd                       │
+│                                                                                                                                          │
+│   127 │   instance_secrets = secrets.get(instance_key, {})                                                                               │
+│   128 │                                                                                                                                  │
+│   129 │   # Build gateway config based on agent type                                                                                     │
+│ ❱ 130 │   required_secrets = get_required_secrets(claw_type)                                                                             │
+│   131 │   required_keys = {s["key"] for s in required_secrets}                                                                           │
+│   132 │   stored_keys = set(instance_secrets.keys())                                                                                     │
+│   133 │   missing_keys = required_keys - stored_keys                                                                                     │
+│                                                                                                                                          │
+│ /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/core/registry.py:744 in get_required_secrets        │
+│                                                                                                                                          │
+│   741 │   Returns:                                                                                                                       │
+│   742 │   │   List of required `SecretDefinition` objects                                                                                │
+│   743 │   """                                                                                                                            │
+│ ❱ 744 │   manifest = load_manifest(claw_name)                                                                                            │
+│   745 │   return manifest.get("secrets", {}).get("required", [])                                                                         │
+│   746                                                                                                                                    │
+│   747                                                                                                                                    │
+│                                                                                                                                          │
+│ /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/core/registry.py:638 in load_manifest               │
+│                                                                                                                                          │
+│   635 │   │   agent_dir = registry_package / claw_name                                                                                   │
+│   636 │   │                                                                                                                              │
+│   637 │   │   if not agent_dir.is_dir():                                                                                                 │
+│ ❱ 638 │   │   │   raise ManifestNotFoundError(                                                                                           │
+│   639 │   │   │   │   f"Agent type '{claw_name}' not found in registry"                                                                  │
+│   640 │   │   │   )                                                                                                                      │
+│   641                                                                                                                                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+ManifestNotFoundError: Agent type 'audit-hermes' not found in registry
+```
+Exit: `1`
+
+### `clm agent memory show audit-hermes`
+
+```console
+$ clm agent memory show audit-hermes
+
+Agent: audit-hermes (wolf.tailf7742d.ts.net)
+Workspace: /home/audit-hermes/.hermes/memories
+Total size: 537 B
+
+ File       Status    Size 
+ MEMORY.md  missing      - 
+ USER.md    missing      - 
+ SOUL.md    present  537 B 
+```
+Exit: `0`
+
+### `clm agent integration list audit-hermes`
+
+```console
+$ clm agent integration list audit-hermes
+
+Agent: audit-hermes
+  No integrations assigned
+
+Use 'clm agent integration add <agent> <integration>' to assign integrations
+```
+Exit: `0`
+
+### `clm agent skill list audit-hermes`
+
+```console
+$ clm agent skill list audit-hermes
+No skills installed on audit-hermes. Try clm agent skill install audit-hermes clawrium/tdd.
+```
+Exit: `0`
+
+### `clm agent logs audit-hermes --tail 20`
+
+```console
+$ clm agent logs audit-hermes --tail 20
+Usage: clm agent logs [OPTIONS] CLAW_NAME
+Try 'clm agent logs --help' for help.
+╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ No such option '--tail'.                                                                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+Exit: `2`
+
+
+### audit-openclaw
+
+### `clm agent secret list audit-openclaw`
+
+```console
+$ clm agent secret list audit-openclaw
+╭─────────────────────────────────────────────────── Traceback (most recent call last) ────────────────────────────────────────────────────╮
+│ /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/cli/agent.py:2686 in secret_list                    │
+│                                                                                                                                          │
+│   2683 │   """List secrets for an agent."""                                                                                              │
+│   2684 │   from clawrium.cli.secret import list_cmd                                                                                      │
+│   2685 │                                                                                                                                 │
+│ ❱ 2686 │   list_cmd(claw_name=claw_name)                                                                                                 │
+│   2687                                                                                                                                   │
+│   2688                                                                                                                                   │
+│   2689 @secret_app.command(name="remove")                                                                                                │
+│                                                                                                                                          │
+│ /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/cli/secret.py:130 in list_cmd                       │
+│                                                                                                                                          │
+│   127 │   instance_secrets = secrets.get(instance_key, {})                                                                               │
+│   128 │                                                                                                                                  │
+│   129 │   # Build gateway config based on agent type                                                                                     │
+│ ❱ 130 │   required_secrets = get_required_secrets(claw_type)                                                                             │
+│   131 │   required_keys = {s["key"] for s in required_secrets}                                                                           │
+│   132 │   stored_keys = set(instance_secrets.keys())                                                                                     │
+│   133 │   missing_keys = required_keys - stored_keys                                                                                     │
+│                                                                                                                                          │
+│ /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/core/registry.py:744 in get_required_secrets        │
+│                                                                                                                                          │
+│   741 │   Returns:                                                                                                                       │
+│   742 │   │   List of required `SecretDefinition` objects                                                                                │
+│   743 │   """                                                                                                                            │
+│ ❱ 744 │   manifest = load_manifest(claw_name)                                                                                            │
+│   745 │   return manifest.get("secrets", {}).get("required", [])                                                                         │
+│   746                                                                                                                                    │
+│   747                                                                                                                                    │
+│                                                                                                                                          │
+│ /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/core/registry.py:638 in load_manifest               │
+│                                                                                                                                          │
+│   635 │   │   agent_dir = registry_package / claw_name                                                                                   │
+│   636 │   │                                                                                                                              │
+│   637 │   │   if not agent_dir.is_dir():                                                                                                 │
+│ ❱ 638 │   │   │   raise ManifestNotFoundError(                                                                                           │
+│   639 │   │   │   │   f"Agent type '{claw_name}' not found in registry"                                                                  │
+│   640 │   │   │   )                                                                                                                      │
+│   641                                                                                                                                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+ManifestNotFoundError: Agent type 'audit-openclaw' not found in registry
+```
+Exit: `1`
+
+### `clm agent memory show audit-openclaw`
+
+```console
+$ clm agent memory show audit-openclaw
+
+Agent: audit-openclaw (wolf.tailf7742d.ts.net)
+Workspace: /home/audit-openclaw/.openclaw/workspace
+Total size: 0 B
+
+ File         Status   Size 
+ SOUL.md      missing     - 
+ IDENTITY.md  missing     - 
+ USER.md      missing     - 
+ TOOLS.md     missing     - 
+```
+Exit: `0`
+
+### `clm agent integration list audit-openclaw`
+
+```console
+$ clm agent integration list audit-openclaw
+
+Agent: audit-openclaw
+  No integrations assigned
+
+Use 'clm agent integration add <agent> <integration>' to assign integrations
+```
+Exit: `0`
+
+### `clm agent skill list audit-openclaw`
+
+```console
+$ clm agent skill list audit-openclaw
+No skills installed on audit-openclaw. Try clm agent skill install audit-openclaw clawrium/tdd.
+```
+Exit: `0`
+
+### `clm agent logs audit-openclaw --tail 20`
+
+```console
+$ clm agent logs audit-openclaw --tail 20
+Usage: clm agent logs [OPTIONS] CLAW_NAME
+Try 'clm agent logs --help' for help.
+╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ No such option '--tail'.                                                                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+Exit: `2`
+
+
+---
+
+## Teardown — remove audit-* agents
+
+Only the three `audit-*` agents are removed. Pre-existing agents are
+preserved. `--force` is used to avoid the interactive confirmation
+prompt; this matches the non-interactive baseline goal.
+
+### `clm agent remove audit-zeroclaw --force`
+
+```console
+$ clm agent remove audit-zeroclaw --force
+Removing agent: audit-zeroclaw from wolf-i
+  Checking audit-zeroclaw on wolf.tailf7742d.ts.net...
+  Stopping audit-zeroclaw before removal...
+  Checking audit-zeroclaw on wolf.tailf7742d.ts.net...
+  Removing audit-zeroclaw from wolf.tailf7742d.ts.net...
+  Removing from local configuration...
+  Cleaned up instance secrets
+  Agent state directory already absent
+  Removed audit-zeroclaw successfully
+✓ Agent removed successfully
+```
+Exit: `0`
+
+### `clm agent remove audit-hermes --force`
+
+```console
+$ clm agent remove audit-hermes --force
+Removing agent: audit-hermes from wolf-i
+  Checking audit-hermes on wolf.tailf7742d.ts.net...
+  Stopping audit-hermes before removal...
+  Checking audit-hermes on wolf.tailf7742d.ts.net...
+  Removing audit-hermes from wolf.tailf7742d.ts.net...
+  Removing from local configuration...
+  Cleaned up instance secrets
+  Agent state directory already absent
+  Removed audit-hermes successfully
+✓ Agent removed successfully
+```
+Exit: `0`
+
+### `clm agent remove audit-openclaw --force`
+
+```console
+$ clm agent remove audit-openclaw --force
+Removing agent: audit-openclaw from wolf-i
+  Checking audit-openclaw on wolf.tailf7742d.ts.net...
+  Removing audit-openclaw from wolf.tailf7742d.ts.net...
+  Removing from local configuration...
+  Cleaned up instance secrets
+  Agent state directory already absent
+  Removed audit-openclaw successfully
+✓ Agent removed successfully
+```
+Exit: `0`
+
+
+---
+
+## Final state (post-teardown)
+
+Verifies that wolf-i has returned to its pre-capture state (the six
+pre-existing agents). The fleet is **not empty** — the issue contract
+called for an empty fleet but the audit preserved the pre-existing
+fleet (see Preamble and PR Callouts).
+
+### `clm agent ps`
+
+```console
+$ clm agent ps
+
+
+                                                   Agent Fleet Status                                                   
+┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Name           ┃ Agent Type ┃ Provider   ┃ Host   ┃ Address                ┃ Port  ┃ Version  ┃ Status  ┃ Installed  ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━┩
+│ clawrium-d01   │ zeroclaw   │ openrouter │ wolf-i │ wolf.tailf7742d.ts.net │ 41429 │ 0.7.5    │ running │ 2026-05-19 │
+│ espresso       │ hermes     │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 41583 │ 2026.5.7 │ running │ 2026-05-11 │
+│ maurice        │ hermes     │ openrouter │ wolf-i │ wolf.tailf7742d.ts.net │ 40317 │ 2026.5.7 │ running │ 2026-05-22 │
+│ nemotron-alpha │ zeroclaw   │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 40919 │ 0.7.5    │ running │ 2026-05-22 │
+│ nemotron-beta  │ zeroclaw   │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 40971 │ 0.7.5    │ running │ 2026-05-20 │
+│ wolf-i         │ openclaw   │ bedrock    │ wolf-i │ wolf.tailf7742d.ts.net │ 40198 │ 2026.4.2 │ running │ 2026-04-11 │
+└────────────────┴────────────┴────────────┴────────┴────────────────────────┴───────┴──────────┴─────────┴────────────┘
+
+```
+Exit: `0`
+
+### `clm host ps wolf-i`
+
+```console
+$ clm host ps wolf-i
+Checking status of 'wolf-i'...
+                Host Status: wolf-i                
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Property     ┃ Value                            ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Connection   │ Connected                        │
+│ Hostname     │ wolf.tailf7742d.ts.net           │
+│ SSH Config   │ wolf-i                           │
+│ Port         │ 22                               │
+│ User         │ xclm                             │
+│ Added        │ 2026-04-11T04:46:19.295019+00:00 │
+│ Last Seen    │ 2026-04-11T04:46:19.295019+00:00 │
+│ Tags         │ -                                │
+│ Architecture │ x86_64                           │
+│ CPU Cores    │ 4                                │
+│ Memory       │ 15.5 GB                          │
+│ GPU          │ intel                            │
+└──────────────┴──────────────────────────────────┘
+
+Addresses:
+    192.168.1.36
+  * wolf.tailf7742d.ts.net (tailscale)
+```
+Exit: `0`
+
+
+---
+
+**Capture end (UTC):** 2026-05-24T03:42:22Z
+

--- a/.itx/435/audit-before.md
+++ b/.itx/435/audit-before.md
@@ -1442,7 +1442,7 @@ Exit: `0`
 
 ### Post-lifecycle agent ps (audit-* agents visible)
 
-### `clm agent ps`
+#### `clm agent ps`
 
 ```console
 $ clm agent ps
@@ -1946,7 +1946,7 @@ already reflects the cleanup).
 The pre-#435 `clm` top-level and `clm agent` surface, frozen so the
 post-#435 `clawctl` surface diffs against a structural baseline.
 
-### `clm --help`
+#### `clm --help`
 
 ```console
 $ clm --help
@@ -1976,7 +1976,7 @@ $ clm --help
 ```
 Exit: `0`
 
-### `clm agent --help`
+#### `clm agent --help`
 
 ```console
 $ clm agent --help
@@ -2008,7 +2008,7 @@ $ clm agent --help
 ```
 Exit: `0`
 
-### `clm agent logs --help`
+#### `clm agent logs --help`
 
 ```console
 $ clm agent logs --help
@@ -2029,7 +2029,7 @@ $ clm agent logs --help
 ```
 Exit: `0`
 
-### `clm integration --help`
+#### `clm integration --help`
 
 ```console
 $ clm integration --help
@@ -2053,7 +2053,7 @@ $ clm integration --help
 ```
 Exit: `0`
 
-### `clm integration show --help`
+#### `clm integration show --help`
 
 ```console
 $ clm integration show --help
@@ -2075,7 +2075,7 @@ $ clm integration show --help
 ```
 Exit: `0`
 
-### `clm integration credentials --help`
+#### `clm integration credentials --help`
 
 ```console
 $ clm integration credentials --help
@@ -2102,7 +2102,7 @@ $ clm integration credentials --help
 ```
 Exit: `0`
 
-### `clm agent secret list --help`
+#### `clm agent secret list --help`
 
 ```console
 $ clm agent secret list --help
@@ -2127,7 +2127,7 @@ Exit: `0`
 Iter2 reinstall — same install path as iter1, captured for completeness
 and to anchor the W8 intermediate-state ps below.
 
-### `clm agent install --type zeroclaw --host wolf-i --name audit-zeroclaw --yes`
+#### `clm agent install --type zeroclaw --host wolf-i --name audit-zeroclaw --yes`
 
 ```console
 $ clm agent install --type zeroclaw --host wolf-i --name audit-zeroclaw --yes
@@ -2269,7 +2269,7 @@ Success! zeroclaw v0.7.5 installed as 'audit-zeroclaw' on wolf-i
 ```
 Exit: `0`
 
-### `clm agent install --type hermes --host wolf-i --name audit-hermes --yes`
+#### `clm agent install --type hermes --host wolf-i --name audit-hermes --yes`
 
 ```console
 $ clm agent install --type hermes --host wolf-i --name audit-hermes --yes
@@ -2411,7 +2411,7 @@ Success! hermes v2026.5.7 installed as 'audit-hermes' on wolf-i
 ```
 Exit: `0`
 
-### `clm agent install --type openclaw --host wolf-i --name audit-openclaw --yes`
+#### `clm agent install --type openclaw --host wolf-i --name audit-openclaw --yes`
 
 ```console
 $ clm agent install --type openclaw --host wolf-i --name audit-openclaw --yes
@@ -2597,7 +2597,7 @@ or start yet applied to any audit-* agent. Surfaces the post-install
 status of each agent type so Bundle 5 can diff state transitions
 directly.
 
-### `clm agent ps`
+#### `clm agent ps`
 
 ```console
 $ clm agent ps
@@ -2631,14 +2631,32 @@ Exit: `0`
 ### `clm agent open <a>` baseline (B4)
 
 `clm agent open` does **not** exist in v26.5.2 — the AGENTS.md
-reference is forward-looking (likely part of issue #435's surface).
-Captured below as the baseline so Bundle 5's `clawctl agent open`
-introductions diff cleanly against three explicit `No such command`
-errors. Captured against `audit-zeroclaw` (zeroclaw, running),
-`audit-hermes` (hermes, configured/`ready (stopped)`), and
-`audit-openclaw` (openclaw, install-started, no onboarding).
+reference is forward-looking (part of issue #435's surface as
+`clawctl agent open`). Captured below as the baseline so Bundle 5's
+`clawctl agent open` introductions diff cleanly against three
+explicit `No such command` errors.
 
-### `clm agent open audit-zeroclaw`
+**State at capture time (post-iter2 configure+start, before iter2
+teardown — not captured as separate transcripts because iter1
+already covered configure/start, but state differs from the W8
+snapshot above):**
+
+- `audit-zeroclaw`: zeroclaw, `running` (configured + started in
+  iter2)
+- `audit-hermes`: hermes, `ready (stopped)` (iter2 configure
+  succeeded; iter2 start reported success but daemon ended stopped —
+  same behaviour as iter1; surfaced as an additional baseline
+  finding worth flagging in Bundle 5)
+- `audit-openclaw`: openclaw, `onboarding (0/4)` (iter2 configure
+  was not re-attempted; the agent remained in its post-install,
+  pre-onboarding state matching iter1 behaviour)
+
+Functionally the `No such command 'open'` error fires at CLI
+dispatch before any agent-state lookup, so the state above does not
+affect the captured output — it is documented purely for reviewer
+orientation.
+
+#### `clm agent open audit-zeroclaw`
 
 ```console
 $ clm agent open audit-zeroclaw
@@ -2650,7 +2668,7 @@ Try 'clm agent --help' for help.
 ```
 Exit: `2`
 
-### `clm agent open audit-hermes`
+#### `clm agent open audit-hermes`
 
 ```console
 $ clm agent open audit-hermes
@@ -2662,7 +2680,7 @@ Try 'clm agent --help' for help.
 ```
 Exit: `2`
 
-### `clm agent open audit-openclaw`
+#### `clm agent open audit-openclaw`
 
 ```console
 $ clm agent open audit-openclaw

--- a/.itx/435/audit-before.md
+++ b/.itx/435/audit-before.md
@@ -37,6 +37,54 @@ installed for its lifecycle pass, same teardown of `audit-*` only) so the
 two artifacts diff cleanly. See "Callouts" in the bundle PR for the
 documented decision.
 
+### Spec items 3, 7, 8 — intentionally unmet (regression baseline preserved instead)
+
+The issue's Definition of Done lists three items this capture does
+**not** satisfy literally; each is unmet on purpose:
+
+- **Item 3 (`clm agent ps` shows one of each agent type, all running).**
+  The post-lifecycle `agent ps` shows nine agents (six pre-existing +
+  three audit-*). All three audit types are present, but `audit-hermes`
+  was captured as `ready (stopped)` and `audit-openclaw` never
+  successfully onboarded (see "Known defects" below). All three agent
+  types ARE represented in `running` state via the pre-existing fleet
+  (`espresso`/hermes, `wolf-i`/openclaw, `clawrium-d01`/zeroclaw etc.).
+  Bundle 5 must reproduce these conditions for a clean diff.
+- **Item 7 (teardown verified, empty `agent ps`).** Only the three
+  audit-* agents are removed. The pre-existing six are preserved by
+  design.
+- **Item 8 (`clm host ps wolf-i` shows no agents at end of capture).**
+  Same reason as item 7. Post-teardown `clm host ps wolf-i` shows
+  the six pre-existing agents intact.
+
+### Known v26.5.2 defects surfaced by this capture (frozen as baseline)
+
+These behaviors are real bugs in `clm 26.5.2`. They are captured
+verbatim in the relevant sections below and called out inline. The
+diff against `audit-after.md` will validate whether Bundle 5 fixes or
+preserves each:
+
+- **`clm agent secret list <a>` crashes** with `ManifestNotFoundError`
+  for every agent — root cause traced to `secret.py:130` passing the
+  instance name where a manifest type is expected.
+- **`clm agent logs <a> --tail N` rejects `--tail`** (exit 2) — the
+  `logs` subcommand is `[Not yet implemented]`; `--tail` is the
+  documented target form for post-#435.
+- **`clm agent configure audit-openclaw --yes` fails at the provider
+  assignment step** — the providers list IS presented, but the
+  subsequent sync-to-agent call returns the bare string
+  `Configure playbook failed: failed` with no further diagnosis. The
+  `--yes` path therefore never persists a `provider_id` and onboarding
+  remains in `state=providers`.
+- **`clm agent sync <a>` exits 0 even on an unconfigured agent**
+  (audit-openclaw), while `start` and `restart` correctly exit 1 with
+  "onboarding incomplete" — state-machine asymmetry.
+- **`clm agent open <a>` does not exist** in v26.5.2 (exits with
+  `No such command 'open'`). The web-UI resolver in
+  `src/clawrium/core/web_ui.py` is reachable only through the GUI in
+  this baseline. Bundle 5 should diff against this baseline to confirm
+  the new `clawctl agent open` entrypoint.
+
 ---
 
 ## Header
@@ -109,8 +157,45 @@ NO_COLOR=1 TERM=dumb COLUMNS=140 bash -c "<command>" 2>&1
 ```
 
 This produces ANSI-free output at a consistent 140-column width. Bundle 5's
-`audit-after.md` MUST use the same conventions so the two files diff
-line-for-line.
+`audit-after.md` MUST use the same conventions.
+
+### Diff scope — what is line-for-line vs what is not
+
+The two files diff line-for-line **only** for content that does not embed
+volatile system state. The following classes of output are intentionally
+expected to differ between runs and must NOT be flagged as regressions:
+
+- **Ansible task JSON output** (every `clm agent install`, and any
+  lifecycle command whose transcript surfaces raw Ansible task results).
+  These blocks contain dozens of inherently volatile fields:
+  `delta`/`start`/`end` wall-clock timestamps, `cache_update_time`
+  epochs, SHA1/MD5 checksums, dynamically generated `/home/xclm/.ansible/tmp/...`
+  paths, async job IDs, UIDs/GIDs, and (for openclaw install) a ~200-field
+  systemd unit property dump (`ActiveEnterTimestamp`, `ExecMainPID`,
+  `InvocationID`, `MemoryPeak`, etc.). Diff at the task-name level, not
+  the raw-JSON level.
+- **Dynamic ports** in `clm agent ps` / `clm host ps` tables. clm
+  allocates per-instance ports in `40000..46999` for zeroclaw/openclaw
+  and `45000..46999` for hermes dashboards. Expect distinct values
+  every run.
+- **`Last Seen` timestamp** in `clm host ps wolf-i` — moves forward
+  every time clm touches the host.
+- **`Added`/`Installed` timestamps and onboarding `completed_at`**
+  fields embedded in CLI output — they reflect this capture's wall
+  clock, not v26.5.2 behavior.
+- **Device IDs, gateway tokens, private keys, pairing codes** — these
+  are regenerated on every fresh install and rotated on
+  configure/sync/restart.
+- **ANSI escape codes inside hermes installer subprocess output.**
+  Even though the capture helper sets `NO_COLOR=1`, the hermes
+  installer (uv/pip subprocess on the remote) re-introduces colour
+  codes that pass through Ansible's `stdout` field unmodified. Expect
+  identical-looking residual ANSI in `audit-after.md`.
+
+Tooling guidance: when diffing the two audits, exclude or normalize the
+above fields (a `sed` strip of the obvious volatile patterns is
+sufficient — there is no need for a custom diff tool). The diff that
+remains IS the regression contract.
 
 ## Read-only command transcripts (as-found fleet)
 
@@ -927,7 +1012,7 @@ commands (`secret list`, `memory show`, `integration list`, `skill list`,
 
 ### audit-zeroclaw (configure + start)
 
-### `clm agent configure audit-zeroclaw --yes`
+#### `clm agent configure audit-zeroclaw --yes`
 
 ```console
 $ clm agent configure audit-zeroclaw --yes
@@ -1001,7 +1086,7 @@ Run 'clm agent start audit-zeroclaw' to start your agent.
 ```
 Exit: `0`
 
-### `clm agent start audit-zeroclaw`
+#### `clm agent start audit-zeroclaw`
 
 ```console
 $ clm agent start audit-zeroclaw
@@ -1021,7 +1106,7 @@ Exit: `0`
 
 ### audit-hermes (configure + start)
 
-### `clm agent configure audit-hermes --yes`
+#### `clm agent configure audit-hermes --yes`
 
 ```console
 $ clm agent configure audit-hermes --yes
@@ -1098,7 +1183,7 @@ Run 'clm agent start audit-hermes' to start your agent.
 ```
 Exit: `0`
 
-### `clm agent start audit-hermes`
+#### `clm agent start audit-hermes`
 
 ```console
 $ clm agent start audit-hermes
@@ -1114,7 +1199,7 @@ Exit: `0`
 
 ### audit-openclaw (configure + start)
 
-### `clm agent configure audit-openclaw --yes`
+#### `clm agent configure audit-openclaw --yes`
 
 ```console
 $ clm agent configure audit-openclaw --yes
@@ -1149,15 +1234,22 @@ Onboarding failed at stage: providers
 Exit: `1`
 
 
-> **Note:** `audit-openclaw configure --yes` fails on this fleet with no
-> default provider auto-selected. The remaining lifecycle commands below
-> are still run sequentially to capture their verbatim behavior against
-> an unconfigured agent — this is intentional baseline data. See
-> Callouts on the PR for the documented decision.
+> **Known bug (preserved as baseline):** `audit-openclaw configure --yes`
+> fails at the provider assignment step. The providers list IS
+> presented in the transcript, but the subsequent "Syncing config to
+> agent..." call returns the bare string
+> `Configure playbook failed: failed` with no further diagnosis. The
+> `--yes` path therefore never persists a `provider_id`, leaving
+> `onboarding.state == providers`. As a side effect, the remaining
+> lifecycle commands below operate against an unconfigured agent —
+> `start` and `restart` correctly exit 1 with "onboarding incomplete",
+> but `sync` exits 0 (state-machine asymmetry, surfaced as a separate
+> baseline finding). The transcripts are still captured sequentially
+> as intentional baseline data — see Callouts on the PR for the
+> documented decision.
 
-#### audit-openclaw: `start` (against unconfigured agent)
 
-### `clm agent start audit-openclaw`
+#### `clm agent start audit-openclaw`
 
 ```console
 $ clm agent start audit-openclaw
@@ -1181,9 +1273,8 @@ To force start anyway (not recommended):
 Exit: `1`
 
 
-#### audit-openclaw: `sync`
 
-### `clm agent sync audit-openclaw`
+#### `clm agent sync audit-openclaw`
 
 ```console
 $ clm agent sync audit-openclaw
@@ -1201,9 +1292,8 @@ Syncing agent: audit-openclaw on wolf-i
 Exit: `0`
 
 
-#### audit-openclaw: `stop`
 
-### `clm agent stop audit-openclaw`
+#### `clm agent stop audit-openclaw`
 
 ```console
 $ clm agent stop audit-openclaw
@@ -1216,9 +1306,8 @@ Stopping agent: audit-openclaw on wolf-i
 Exit: `0`
 
 
-#### audit-openclaw: `restart`
 
-### `clm agent restart audit-openclaw`
+#### `clm agent restart audit-openclaw`
 
 ```console
 $ clm agent restart audit-openclaw
@@ -1236,9 +1325,8 @@ Exit: `1`
 ### audit-zeroclaw: sync / stop / restart
 
 
-#### audit-zeroclaw: `sync`
 
-### `clm agent sync audit-zeroclaw`
+#### `clm agent sync audit-zeroclaw`
 
 ```console
 $ clm agent sync audit-zeroclaw
@@ -1259,9 +1347,8 @@ Syncing agent: audit-zeroclaw on wolf-i
 Exit: `0`
 
 
-#### audit-zeroclaw: `stop`
 
-### `clm agent stop audit-zeroclaw`
+#### `clm agent stop audit-zeroclaw`
 
 ```console
 $ clm agent stop audit-zeroclaw
@@ -1274,9 +1361,8 @@ Stopping agent: audit-zeroclaw on wolf-i
 Exit: `0`
 
 
-#### audit-zeroclaw: `restart`
 
-### `clm agent restart audit-zeroclaw`
+#### `clm agent restart audit-zeroclaw`
 
 ```console
 $ clm agent restart audit-zeroclaw
@@ -1301,9 +1387,8 @@ Exit: `0`
 ### audit-hermes: sync / stop / restart
 
 
-#### audit-hermes: `sync`
 
-### `clm agent sync audit-hermes`
+#### `clm agent sync audit-hermes`
 
 ```console
 $ clm agent sync audit-hermes
@@ -1322,9 +1407,8 @@ Syncing agent: audit-hermes on wolf-i
 Exit: `0`
 
 
-#### audit-hermes: `stop`
 
-### `clm agent stop audit-hermes`
+#### `clm agent stop audit-hermes`
 
 ```console
 $ clm agent stop audit-hermes
@@ -1337,9 +1421,8 @@ Stopping agent: audit-hermes on wolf-i
 Exit: `0`
 
 
-#### audit-hermes: `restart`
 
-### `clm agent restart audit-hermes`
+#### `clm agent restart audit-hermes`
 
 ```console
 $ clm agent restart audit-hermes
@@ -1404,9 +1487,24 @@ For each audit-* agent: secret list, memory show, integration list,
 skill list, logs --tail 20. Captured while the agents are in their
 post-lifecycle state.
 
+> **Known bug (preserved as baseline):** `clm agent secret list <a>`
+> crashes with `ManifestNotFoundError: Agent type '<instance-name>'
+> not found in registry` for every agent below. The traceback points
+> at `secret.py:130` where `get_required_secrets(claw_type)` is called
+> with the instance name (`audit-zeroclaw`) instead of the manifest
+> type (`zeroclaw`). Bundle 5 must either show a successful table for
+> the same command (fix landed) or the same crash (carry-forward).
+>
+> **Known bug (preserved as baseline):** `clm agent logs <a> --tail N`
+> rejects `--tail` with `Error: No such option '--tail'` (exit 2) for
+> every agent below. `clm agent logs` itself is `[Not yet implemented]`
+> in v26.5.2 (see `clm agent logs --help` capture in the Iteration 2
+> addendum). Bundle 5 should show either a streaming/tail-N output or
+> a documented-and-implemented usage error.
+
 ### audit-zeroclaw
 
-### `clm agent secret list audit-zeroclaw`
+#### `clm agent secret list audit-zeroclaw`
 
 ```console
 $ clm agent secret list audit-zeroclaw
@@ -1455,7 +1553,7 @@ ManifestNotFoundError: Agent type 'audit-zeroclaw' not found in registry
 ```
 Exit: `1`
 
-### `clm agent memory show audit-zeroclaw`
+#### `clm agent memory show audit-zeroclaw`
 
 ```console
 $ clm agent memory show audit-zeroclaw
@@ -1475,7 +1573,7 @@ Total size: 2.2 KB
 ```
 Exit: `0`
 
-### `clm agent integration list audit-zeroclaw`
+#### `clm agent integration list audit-zeroclaw`
 
 ```console
 $ clm agent integration list audit-zeroclaw
@@ -1487,7 +1585,7 @@ Use 'clm agent integration add <agent> <integration>' to assign integrations
 ```
 Exit: `0`
 
-### `clm agent skill list audit-zeroclaw`
+#### `clm agent skill list audit-zeroclaw`
 
 ```console
 $ clm agent skill list audit-zeroclaw
@@ -1495,7 +1593,7 @@ No skills installed on audit-zeroclaw. Try clm agent skill install audit-zerocla
 ```
 Exit: `0`
 
-### `clm agent logs audit-zeroclaw --tail 20`
+#### `clm agent logs audit-zeroclaw --tail 20`
 
 ```console
 $ clm agent logs audit-zeroclaw --tail 20
@@ -1510,7 +1608,7 @@ Exit: `2`
 
 ### audit-hermes
 
-### `clm agent secret list audit-hermes`
+#### `clm agent secret list audit-hermes`
 
 ```console
 $ clm agent secret list audit-hermes
@@ -1559,7 +1657,7 @@ ManifestNotFoundError: Agent type 'audit-hermes' not found in registry
 ```
 Exit: `1`
 
-### `clm agent memory show audit-hermes`
+#### `clm agent memory show audit-hermes`
 
 ```console
 $ clm agent memory show audit-hermes
@@ -1575,7 +1673,7 @@ Total size: 537 B
 ```
 Exit: `0`
 
-### `clm agent integration list audit-hermes`
+#### `clm agent integration list audit-hermes`
 
 ```console
 $ clm agent integration list audit-hermes
@@ -1587,7 +1685,7 @@ Use 'clm agent integration add <agent> <integration>' to assign integrations
 ```
 Exit: `0`
 
-### `clm agent skill list audit-hermes`
+#### `clm agent skill list audit-hermes`
 
 ```console
 $ clm agent skill list audit-hermes
@@ -1595,7 +1693,7 @@ No skills installed on audit-hermes. Try clm agent skill install audit-hermes cl
 ```
 Exit: `0`
 
-### `clm agent logs audit-hermes --tail 20`
+#### `clm agent logs audit-hermes --tail 20`
 
 ```console
 $ clm agent logs audit-hermes --tail 20
@@ -1610,7 +1708,7 @@ Exit: `2`
 
 ### audit-openclaw
 
-### `clm agent secret list audit-openclaw`
+#### `clm agent secret list audit-openclaw`
 
 ```console
 $ clm agent secret list audit-openclaw
@@ -1659,7 +1757,7 @@ ManifestNotFoundError: Agent type 'audit-openclaw' not found in registry
 ```
 Exit: `1`
 
-### `clm agent memory show audit-openclaw`
+#### `clm agent memory show audit-openclaw`
 
 ```console
 $ clm agent memory show audit-openclaw
@@ -1676,7 +1774,7 @@ Total size: 0 B
 ```
 Exit: `0`
 
-### `clm agent integration list audit-openclaw`
+#### `clm agent integration list audit-openclaw`
 
 ```console
 $ clm agent integration list audit-openclaw
@@ -1688,7 +1786,7 @@ Use 'clm agent integration add <agent> <integration>' to assign integrations
 ```
 Exit: `0`
 
-### `clm agent skill list audit-openclaw`
+#### `clm agent skill list audit-openclaw`
 
 ```console
 $ clm agent skill list audit-openclaw
@@ -1696,7 +1794,7 @@ No skills installed on audit-openclaw. Try clm agent skill install audit-opencla
 ```
 Exit: `0`
 
-### `clm agent logs audit-openclaw --tail 20`
+#### `clm agent logs audit-openclaw --tail 20`
 
 ```console
 $ clm agent logs audit-openclaw --tail 20
@@ -1830,4 +1928,752 @@ Exit: `0`
 ---
 
 **Capture end (UTC):** 2026-05-24T03:42:22Z
+
+
+---
+
+## Iteration 2 addendum (post-ATX-review captures)
+
+Captured during a second pass triggered by ATX review iteration 1
+(rating 2/5). Adds command captures that were missing from the
+original pass and intermediate state snapshots required for diff
+clarity. Audit-* agents were re-installed for this section and
+removed at the end (the post-teardown fleet state shown above
+already reflects the cleanup).
+
+### Help-text captures (S1, S2, W5)
+
+The pre-#435 `clm` top-level and `clm agent` surface, frozen so the
+post-#435 `clawctl` surface diffs against a structural baseline.
+
+### `clm --help`
+
+```console
+$ clm --help
+                                                                                                                                            
+ Usage: clm [OPTIONS] COMMAND [ARGS]...                                                                                                     
+                                                                                                                                            
+ Clawrium - Manage your AI assistant fleet. Use 'clm agent' for agent management.                                                           
+                                                                                                                                            
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --version          Show version and exit                                                                                                 │
+│ --help             Show this message and exit.                                                                                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ init         Initialize Clawrium and check dependencies.                                                                                 │
+│ ps           Quick fleet overview - show agents and hosts status.                                                                        │
+│ chat         Start interactive chat with an installed agent (use `clm ps` to find names).                                                │
+│ snapshot     Backup full system state.                                                                                                   │
+│ tui          Launch the interactive TUI dashboard.                                                                                       │
+│ gui          Launch the local web GUI dashboard.                                                                                         │
+│ agent        Manage AI agents in your fleet                                                                                              │
+│ host         Manage hosts in your fleet (infrastructure management)                                                                      │
+│ provider     Manage inference providers (LLM APIs)                                                                                       │
+│ integration  Manage external service integrations (GitHub, Atlassian, etc.)                                                              │
+│ skill        Browse the clawrium-managed skills catalog.                                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+```
+Exit: `0`
+
+### `clm agent --help`
+
+```console
+$ clm agent --help
+                                                                                                                                            
+ Usage: clm agent [OPTIONS] COMMAND [ARGS]...                                                                                               
+                                                                                                                                            
+ Manage AI agents in your fleet                                                                                                             
+                                                                                                                                            
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ install      Install an agent on a host.                                                                                                 │
+│ ps           Show status of agents across hosts.                                                                                         │
+│ configure    Configure agent settings through an interactive wizard.                                                                     │
+│ remove       Remove an agent from a host.                                                                                                │
+│ start        Start an agent.                                                                                                             │
+│ stop         Stop an agent.                                                                                                              │
+│ restart      Restart an agent.                                                                                                           │
+│ sync         Sync configuration and optionally restart an agent.                                                                         │
+│ logs         View agent logs.                                                                                                            │
+│ secret       Manage secrets for agents                                                                                                   │
+│ memory       Inspect and manage memory for memory-capable agents                                                                         │
+│ integration  Manage integrations assigned to agents                                                                                      │
+│ registry     Browse available agent types                                                                                                │
+│ skill        Manage skills installed on an agent.                                                                                        │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+```
+Exit: `0`
+
+### `clm agent logs --help`
+
+```console
+$ clm agent logs --help
+                                                                                                                                            
+ Usage: clm agent logs [OPTIONS] CLAW_NAME                                                                                                  
+                                                                                                                                            
+ View agent logs.                                                                                                                           
+                                                                                                                                            
+ [Not yet implemented]                                                                                                                      
+                                                                                                                                            
+╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ *    claw_name      TEXT  Agent name to view logs for [required]                                                                         │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+```
+Exit: `0`
+
+### `clm integration --help`
+
+```console
+$ clm integration --help
+                                                                                                                                            
+ Usage: clm integration [OPTIONS] COMMAND [ARGS]...                                                                                         
+                                                                                                                                            
+ Manage external service integrations (GitHub, Atlassian, etc.)                                                                             
+                                                                                                                                            
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ types        List supported integration types.                                                                                           │
+│ list         List all configured integrations.                                                                                           │
+│ add          Add a new external service integration.                                                                                     │
+│ show         Show details of a configured integration.                                                                                   │
+│ remove       Remove an integration configuration.                                                                                        │
+│ credentials  View or update credentials for an integration.                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+```
+Exit: `0`
+
+### `clm integration show --help`
+
+```console
+$ clm integration show --help
+                                                                                                                                            
+ Usage: clm integration show [OPTIONS] NAME                                                                                                 
+                                                                                                                                            
+ Show details of a configured integration.                                                                                                  
+                                                                                                                                            
+ Examples:                                                                                                                                  
+ clm integration show my-github                                                                                                             
+                                                                                                                                            
+╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ *    name      TEXT  Integration name to show [required]                                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+```
+Exit: `0`
+
+### `clm integration credentials --help`
+
+```console
+$ clm integration credentials --help
+                                                                                                                                            
+ Usage: clm integration credentials [OPTIONS] NAME                                                                                          
+                                                                                                                                            
+ View or update credentials for an integration.                                                                                             
+                                                                                                                                            
+ Without --update, shows current credential status (masked).                                                                                
+ With --update, prompts for new values for all credentials.                                                                                 
+                                                                                                                                            
+ Examples:                                                                                                                                  
+     clm integration credentials my-github                                                                                                  
+     clm integration credentials my-github --update                                                                                         
+                                                                                                                                            
+╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ *    name      TEXT  Integration name [required]                                                                                         │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --update  -u        Update credentials (will prompt for all values)                                                                      │
+│ --help              Show this message and exit.                                                                                          │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+```
+Exit: `0`
+
+### `clm agent secret list --help`
+
+```console
+$ clm agent secret list --help
+                                                                                                                                            
+ Usage: clm agent secret list [OPTIONS] CLAW_NAME                                                                                           
+                                                                                                                                            
+ List secrets for an agent.                                                                                                                 
+                                                                                                                                            
+╭─ Arguments ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ *    claw_name      TEXT  Agent instance name [required]                                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+```
+Exit: `0`
+
+
+### Re-install transcripts (iter2)
+
+Iter2 reinstall — same install path as iter1, captured for completeness
+and to anchor the W8 intermediate-state ps below.
+
+### `clm agent install --type zeroclaw --host wolf-i --name audit-zeroclaw --yes`
+
+```console
+$ clm agent install --type zeroclaw --host wolf-i --name audit-zeroclaw --yes
+╭────────────────────────────────────────────────────────── Installation Summary ──────────────────────────────────────────────────────────╮
+│ Agent Type: zeroclaw                                                                                                                     │
+│ Version: 0.7.5                                                                                                                           │
+│ Host: wolf-i                                                                                                                             │
+│ Architecture: x86_64                                                                                                                     │
+│ Memory: 15.5GB                                                                                                                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+No config file found; using defaults
+
+PLAY [all] *********************************************************************
+
+TASK [Gathering Facts] *********************************************************
+[WARNING]: Host 'wolf.tailf7742d.ts.net' is using the discovered Python interpreter at '/usr/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.20/reference_appendices/interpreter_discovery.html for more information.
+ok: [wolf.tailf7742d.ts.net]
+
+TASK [Kill stale apt lock holders] *********************************************
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/apt/lists/lock) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/apt/lists/lock"], "delta": "0:00:00.069836", "end": "2026-05-23 21:00:50.399477", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/apt/lists/lock", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 21:00:50.329641", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/dpkg/lock) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/dpkg/lock"], "delta": "0:00:00.066847", "end": "2026-05-23 21:00:50.882029", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/dpkg/lock", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 21:00:50.815182", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/dpkg/lock-frontend) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/dpkg/lock-frontend"], "delta": "0:00:00.066087", "end": "2026-05-23 21:00:51.392070", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/dpkg/lock-frontend", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 21:00:51.325983", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+
+TASK [Update apt cache] ********************************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+TASK [Check if node is installed] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "cmd": ["node", "--version"], "delta": "0:00:00.007244", "end": "2026-05-23 21:00:52.870434", "failed_when_result": false, "msg": "", "rc": 0, "start": "2026-05-23 21:00:52.863190", "stderr": "", "stderr_lines": [], "stdout": "v22.22.1", "stdout_lines": ["v22.22.1"]}
+
+TASK [Install required packages for NodeSource repository] *********************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Create keyrings directory] ***********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Download NodeSource GPG key] *********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Add NodeSource repository for Node.js 20] ********************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Install Node.js] *********************************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Install build-essential] *************************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+TASK [Install git and GitHub CLI] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+PLAY RECAP *********************************************************************
+wolf.tailf7742d.ts.net     : ok=6    changed=0    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
+No config file found; using defaults
+
+PLAY [all] *********************************************************************
+
+TASK [Gathering Facts] *********************************************************
+[WARNING]: Host 'wolf.tailf7742d.ts.net' is using the discovered Python interpreter at '/usr/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.20/reference_appendices/interpreter_discovery.html for more information.
+ok: [wolf.tailf7742d.ts.net]
+
+TASK [Validate architecture is supported] **************************************
+[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "ansible_architecture not in supported_architectures", "skip_reason": "Conditional result was False"}
+
+TASK [Normalize target ZeroClaw version (strip leading 'v')] *******************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"zeroclaw_target_version": "0.7.5"}, "changed": false}
+
+TASK [Resolve ZeroClaw release tag (always 'v'-prefixed)] **********************
+[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
+Origin: /home/devashish/.local/share/uv/tools/clawrium/lib/python3.13/site-packages/clawrium/platform/registry/zeroclaw/playbooks/install.yaml:14:19
+
+12       - aarch64
+13       - x86_64
+14     release_arch: "{{ arch_map[ansible_architecture] }}"
+                     ^ column 19
+
+Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
+
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"release_url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.7.5/zeroclaw-x86_64-unknown-linux-gnu.tar.gz", "zeroclaw_target_tag": "v0.7.5"}, "changed": false}
+
+TASK [Create agent user] *******************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "comment": "", "create_home": true, "group": 1012, "home": "/home/audit-zeroclaw", "name": "audit-zeroclaw", "shell": "/usr/sbin/nologin", "state": "present", "system": false, "uid": 1012}
+
+TASK [Create bin directory] ****************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1012, "group": "audit-zeroclaw", "mode": "0755", "owner": "audit-zeroclaw", "path": "/home/audit-zeroclaw/bin", "size": 4096, "state": "directory", "uid": 1012}
+
+TASK [Discover zeroclaw binary at agent's install path] ************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "stat": {"exists": false}}
+
+TASK [Get installed zeroclaw version] ******************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "zeroclaw_binary_stat.stat.exists", "skip_reason": "Conditional result was False"}
+
+TASK [Parse installed zeroclaw version] ****************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "(zeroclaw_version_check.rc | default(1)) == 0", "skip_reason": "Conditional result was False"}
+
+TASK [Set install skip condition] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"zeroclaw_already_installed": false}, "changed": false}
+
+TASK [Mark install as skipped when already installed] **************************
+skipping: [wolf.tailf7742d.ts.net] => {"false_condition": "zeroclaw_already_installed"}
+
+TASK [Note that --force was supplied (overriding skip)] ************************
+skipping: [wolf.tailf7742d.ts.net] => {"false_condition": "zeroclaw_binary_stat.stat.exists"}
+
+TASK [Download zeroclaw binary] ************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum_dest": null, "checksum_src": "bb688658508de72a086304d9213bca6d5ffd9a2b", "dest": "/tmp/zeroclaw-x86_64-unknown-linux-gnu.tar.gz", "elapsed": 1, "gid": 0, "group": "root", "md5sum": "c3a14c3247973dd891f7bce18d1aca73", "mode": "0644", "msg": "OK (15812349 bytes)", "owner": "root", "size": 15812349, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779595260.067752-1519474-115372506749734/tmpvzw77__d", "state": "file", "status_code": 200, "uid": 0, "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.7.5/zeroclaw-x86_64-unknown-linux-gnu.tar.gz"}
+
+TASK [Extract zeroclaw binary] *************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "dest": "/home/audit-zeroclaw/bin", "extract_results": {"cmd": ["/usr/bin/tar", "--extract", "-C", "/home/audit-zeroclaw/bin", "-z", "--owner=audit-zeroclaw", "--group=audit-zeroclaw", "-f", "/tmp/zeroclaw-x86_64-unknown-linux-gnu.tar.gz"], "err": "", "out": "", "rc": 0}, "gid": 1012, "group": "audit-zeroclaw", "handler": "TgzArchive", "mode": "0755", "owner": "audit-zeroclaw", "size": 4096, "src": "/tmp/zeroclaw-x86_64-unknown-linux-gnu.tar.gz", "state": "directory", "uid": 1012}
+
+TASK [Cleanup tarball] *********************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "path": "/tmp/zeroclaw-x86_64-unknown-linux-gnu.tar.gz", "state": "absent"}
+
+TASK [Create zeroclaw config directory] ****************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1012, "group": "audit-zeroclaw", "mode": "0700", "owner": "audit-zeroclaw", "path": "/home/audit-zeroclaw/.zeroclaw", "size": 4096, "state": "directory", "uid": 1012}
+
+TASK [Scaffold workspace directory] ********************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1012, "group": "audit-zeroclaw", "mode": "0700", "owner": "audit-zeroclaw", "path": "/home/audit-zeroclaw/.zeroclaw/workspace", "size": 4096, "state": "directory", "uid": 1012}
+
+TASK [Scaffold state directory] ************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1012, "group": "audit-zeroclaw", "mode": "0700", "owner": "audit-zeroclaw", "path": "/home/audit-zeroclaw/.zeroclaw/state", "size": 4096, "state": "directory", "uid": 1012}
+
+TASK [Create systemd service file (disabled, not started)] *********************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum": "8cdb4415394832fae557239a6717258fd9e19a56", "dest": "/etc/systemd/system/zeroclaw-audit-zeroclaw.service", "gid": 0, "group": "root", "md5sum": "0eec36b92a82858fdf84dbd6ee580130", "mode": "0644", "owner": "root", "size": 291, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779595266.354721-1519683-222476361120786/.source.service", "state": "file", "uid": 0}
+
+TASK [Reload systemd to pick up unit file] *************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "name": null, "status": {}}
+
+TASK [Display install success] *************************************************
+ok: [wolf.tailf7742d.ts.net] => {
+    "msg": "ZeroClaw 0.7.5 installed for agent 'audit-zeroclaw'.\nService unit zeroclaw-audit-zeroclaw.service dropped (disabled, stopped).\nRun 'clm agent configure audit-zeroclaw' to render config.toml and start the daemon.\n"
+}
+
+PLAY RECAP *********************************************************************
+wolf.tailf7742d.ts.net     : ok=16   changed=9    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
+
+Success! zeroclaw v0.7.5 installed as 'audit-zeroclaw' on wolf-i
+```
+Exit: `0`
+
+### `clm agent install --type hermes --host wolf-i --name audit-hermes --yes`
+
+```console
+$ clm agent install --type hermes --host wolf-i --name audit-hermes --yes
+╭────────────────────────────────────────────────────────── Installation Summary ──────────────────────────────────────────────────────────╮
+│ Agent Type: hermes                                                                                                                       │
+│ Version: 2026.5.7                                                                                                                        │
+│ Host: wolf-i                                                                                                                             │
+│ Architecture: x86_64                                                                                                                     │
+│ Memory: 15.5GB                                                                                                                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+No config file found; using defaults
+
+PLAY [all] *********************************************************************
+
+TASK [Gathering Facts] *********************************************************
+[WARNING]: Host 'wolf.tailf7742d.ts.net' is using the discovered Python interpreter at '/usr/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.20/reference_appendices/interpreter_discovery.html for more information.
+ok: [wolf.tailf7742d.ts.net]
+
+TASK [Kill stale apt lock holders] *********************************************
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/apt/lists/lock) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/apt/lists/lock"], "delta": "0:00:00.069266", "end": "2026-05-23 21:01:11.995970", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/apt/lists/lock", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 21:01:11.926704", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/dpkg/lock) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/dpkg/lock"], "delta": "0:00:00.070830", "end": "2026-05-23 21:01:12.503934", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/dpkg/lock", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 21:01:12.433104", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/dpkg/lock-frontend) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/dpkg/lock-frontend"], "delta": "0:00:00.067509", "end": "2026-05-23 21:01:13.044843", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/dpkg/lock-frontend", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 21:01:12.977334", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+
+TASK [Update apt cache] ********************************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+TASK [Check if node is installed] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "cmd": ["node", "--version"], "delta": "0:00:00.006575", "end": "2026-05-23 21:01:14.482159", "failed_when_result": false, "msg": "", "rc": 0, "start": "2026-05-23 21:01:14.475584", "stderr": "", "stderr_lines": [], "stdout": "v22.22.1", "stdout_lines": ["v22.22.1"]}
+
+TASK [Install required packages for NodeSource repository] *********************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Create keyrings directory] ***********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Download NodeSource GPG key] *********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Add NodeSource repository for Node.js 20] ********************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Install Node.js] *********************************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Install build-essential] *************************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+TASK [Install git and GitHub CLI] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+PLAY RECAP *********************************************************************
+wolf.tailf7742d.ts.net     : ok=6    changed=0    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
+No config file found; using defaults
+
+PLAY [all] *********************************************************************
+
+TASK [Gathering Facts] *********************************************************
+[WARNING]: Host 'wolf.tailf7742d.ts.net' is using the discovered Python interpreter at '/usr/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.20/reference_appendices/interpreter_discovery.html for more information.
+ok: [wolf.tailf7742d.ts.net]
+
+TASK [Normalize target Hermes version (strip leading 'v')] *********************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"hermes_target_version": "2026.5.7"}, "changed": false}
+
+TASK [Resolve Hermes git tag for installer (always 'v'-prefixed)] **************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"hermes_target_branch": "v2026.5.7"}, "changed": false}
+
+TASK [Create agent user] *******************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "comment": "", "create_home": true, "group": 1013, "home": "/home/audit-hermes", "name": "audit-hermes", "shell": "/usr/sbin/nologin", "state": "present", "system": false, "uid": 1013}
+
+TASK [Install hermes system dependencies (ripgrep, ffmpeg)] ********************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+TASK [Discover hermes binary at agent's user-local install path] ***************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "stat": {"exists": false}}
+
+TASK [Get installed hermes version] ********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "hermes_binary_stat.stat.exists", "skip_reason": "Conditional result was False"}
+
+TASK [Parse installed hermes version] ******************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "(hermes_version_check.rc | default(1)) == 0", "skip_reason": "Conditional result was False"}
+
+TASK [Set install skip condition] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"hermes_already_installed": false}, "changed": false}
+
+TASK [Mark install as skipped when already installed] **************************
+skipping: [wolf.tailf7742d.ts.net] => {"false_condition": "hermes_already_installed"}
+
+TASK [Note that --force was supplied (overriding skip)] ************************
+skipping: [wolf.tailf7742d.ts.net] => {"false_condition": "hermes_binary_stat.stat.exists"}
+
+TASK [Remove existing Hermes binary symlink (forced reinstall)] ****************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "force_install | default(false) | bool", "skip_reason": "Conditional result was False"}
+
+TASK [Download Hermes installer script] ****************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum_dest": null, "checksum_src": "da96e86998cf4ededd3fe30be9f3b002a2f866fe", "dest": "/home/audit-hermes/hermes-install.sh", "elapsed": 0, "gid": 1013, "group": "audit-hermes", "md5sum": "857999f68cac4441a6adaebf9b5a54f2", "mode": "0700", "msg": "OK (62237 bytes)", "owner": "audit-hermes", "size": 62237, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779595282.136234-1520276-239495228897294/tmp0w8ppntq", "state": "file", "status_code": 200, "uid": 1013, "url": "https://raw.githubusercontent.com/NousResearch/hermes-agent/v2026.5.7/scripts/install.sh"}
+
+TASK [Install Hermes runtime (non-interactive)] ********************************
+ASYNC POLL on wolf.tailf7742d.ts.net: jid=j37785903598.513601 started=True finished=False
+ASYNC POLL on wolf.tailf7742d.ts.net: jid=j37785903598.513601 started=True finished=False
+ASYNC POLL on wolf.tailf7742d.ts.net: jid=j37785903598.513601 started=True finished=False
+ASYNC OK on wolf.tailf7742d.ts.net: jid=j37785903598.513601
+[WARNING]: Module remote_tmp /home/audit-hermes/.ansible/tmp did not exist and was created with a mode of 0700, this may cause issues when running as another user. To avoid this, create the remote_tmp dir with the correct permissions manually
+changed: [wolf.tailf7742d.ts.net] => {"ansible_job_id": "j37785903598.513601", "changed": true, "cmd": ["/bin/bash", "/home/audit-hermes/hermes-install.sh", "--skip-setup", "--branch", "v2026.5.7", "--hermes-home", "/home/audit-hermes/.hermes", "--dir", "/home/audit-hermes/.hermes/code"], "delta": "0:01:36.867077", "end": "2026-05-23 21:03:00.762972", "finished": true, "msg": "", "rc": 0, "results_file": "/home/audit-hermes/.ansible_async/j37785903598.513601", "start": "2026-05-23 21:01:23.895895", "started": true, "stderr": "Downloading cpython-3.11.15-linux-x86_64-gnu (download) (29.8MiB)\n Downloaded cpython-3.11.15-linux-x86_64-gnu (download)\nInstalled Python 3.11.15 in 2.02s\n + cpython-3.11.15-linux-x86_64-gnu (python3.11)\nwarning: `/home/audit-hermes/.local/bin` is not on your PATH. To use installed Python executables, add the directory to your PATH.\nCloning into '/home/audit-hermes/.hermes/code'...\nNote: switching to '498bfc7bc12a937621b4215312049b1000726df3'.\n\nYou are in 'detached HEAD' state. You can look around, make experimental\nchanges and commit them, and you can discard any commits you make in this\nstate without impacting any branches by switching back to a branch.\n\nIf you want to create a new branch to retain commits you create, you may\ndo so (now or later) by using -c with the switch command. Example:\n\n  git switch -c <new-branch-name>\n\nOr undo this operation with:\n\n  git switch -\n\nTurn off this advice by setting config variable advice.detachedHead to false\n\nUsing CPython 3.11.15\nCreating virtual environment at: venv\n/home/audit-hermes/hermes-install.sh: line 180: /dev/tty: No such device or address\n/home/audit-hermes/hermes-install.sh: line 181: /dev/tty: No such device or address\nsudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper\nsudo: a password is required", "stderr_lines": ["Downloading cpython-3.11.15-linux-x86_64-gnu (download) (29.8MiB)", " Downloaded cpython-3.11.15-linux-x86_64-gnu (download)", "Installed Python 3.11.15 in 2.02s", " + cpython-3.11.15-linux-x86_64-gnu (python3.11)", "warning: `/home/audit-hermes/.local/bin` is not on your PATH. To use installed Python executables, add the directory to your PATH.", "Cloning into '/home/audit-hermes/.hermes/code'...", "Note: switching to '498bfc7bc12a937621b4215312049b1000726df3'.", "", "You are in 'detached HEAD' state. You can look around, make experimental", "changes and commit them, and you can discard any commits you make in this", "state without impacting any branches by switching back to a branch.", "", "If you want to create a new branch to retain commits you create, you may", "do so (now or later) by using -c with the switch command. Example:", "", "  git switch -c <new-branch-name>", "", "Or undo this operation with:", "", "  git switch -", "", "Turn off this advice by setting config variable advice.detachedHead to false", "", "Using CPython 3.11.15", "Creating virtual environment at: venv", "/home/audit-hermes/hermes-install.sh: line 180: /dev/tty: No such device or address", "/home/audit-hermes/hermes-install.sh: line 181: /dev/tty: No such device or address", "sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper", "sudo: a password is required"], "stdout": "\n\u001b[0;35m\u001b[1m\n┌─────────────────────────────────────────────────────────┐\n│             ⚕ Hermes Agent Installer                    │\n├─────────────────────────────────────────────────────────┤\n│  An open source AI agent by Nous Research.              │\n└─────────────────────────────────────────────────────────┘\n\u001b[0m\n\u001b[0;32m✓\u001b[0m Detected: linux (ubuntu)\n\u001b[0;36m→\u001b[0m Install directory: /home/audit-hermes/.hermes/code (explicit)\n\u001b[0;36m→\u001b[0m Checking for uv package manager...\n\u001b[0;32m✓\u001b[0m uv found (uv 0.10.10)\n\u001b[0;36m→\u001b[0m Checking Python 3.11...\n\u001b[0;36m→\u001b[0m Python 3.11 not found, installing via uv...\n\u001b[0;32m✓\u001b[0m Python installed: Python 3.11.15\n\u001b[0;36m→\u001b[0m Checking Git...\n\u001b[0;32m✓\u001b[0m Git 2.43.0 found\n\u001b[0;36m→\u001b[0m Checking Node.js (for browser tools)...\n\u001b[0;32m✓\u001b[0m Node.js v22.22.1 found\n\u001b[0;36m→\u001b[0m Checking ripgrep (fast file search)...\n\u001b[0;32m✓\u001b[0m ripgrep 14.1.0 found\n\u001b[0;36m→\u001b[0m Checking ffmpeg (TTS voice messages)...\n\u001b[0;32m✓\u001b[0m ffmpeg 6.1.1-3ubuntu5 found\n\u001b[0;36m→\u001b[0m Installing to /home/audit-hermes/.hermes/code...\n\u001b[0;36m→\u001b[0m Trying SSH clone...\n\u001b[0;36m→\u001b[0m SSH failed, trying HTTPS...\n\u001b[0;32m✓\u001b[0m Cloned via HTTPS\n\u001b[0;32m✓\u001b[0m Repository ready\n\u001b[0;36m→\u001b[0m Creating virtual environment with Python 3.11...\n\u001b[0;32m✓\u001b[0m Virtual environment ready (Python 3.11)\n\u001b[0;36m→\u001b[0m Installing dependencies...\n\u001b[0;36m→\u001b[0m Some build tools may be needed for Python packages...\n\u001b[0;36m→\u001b[0m sudo is needed ONLY to install build tools (build-essential, python3-dev, libffi-dev) via apt.\n\u001b[0;36m→\u001b[0m Hermes Agent itself does not require or retain root access.\n\u001b[0;32m✓\u001b[0m Build tools installed\n\u001b[0;32m✓\u001b[0m Main package installed\n\u001b[0;32m✓\u001b[0m All dependencies installed\n\u001b[0;36m→\u001b[0m Installing Node.js dependencies (browser tools)...\n✅ Browser tools ready. Run: python run_agent.py --help\n\u001b[0;32m✓\u001b[0m Node.js dependencies installed\n\u001b[0;36m→\u001b[0m Installing browser engine (Playwright Chromium)...\n\u001b[0;36m→\u001b[0m Playwright may request sudo to install browser system dependencies (shared libraries).\n\u001b[0;36m→\u001b[0m This is standard Playwright setup — Hermes itself does not require root access.\nInstalling dependencies...\nSwitching to root user to install dependencies...\nFailed to install browsers\nError: Installation process exited with code: 1\n\u001b[0;33m⚠\u001b[0m Playwright browser installation failed — browser tools will not work.\n\u001b[0;33m⚠\u001b[0m Try running manually: cd /home/audit-hermes/.hermes/code && npx playwright install --with-deps chromium\n\u001b[0;32m✓\u001b[0m Browser engine setup complete\n\u001b[0;36m→\u001b[0m Installing TUI dependencies...\n\u001b[0;32m✓\u001b[0m TUI dependencies installed\n\u001b[0;36m→\u001b[0m Setting up hermes command...\n\u001b[0;32m✓\u001b[0m Installed hermes launcher → ~/.local/bin/hermes\n\u001b[0;32m✓\u001b[0m Added ~/.local/bin to PATH in /home/audit-hermes/.bashrc\n\u001b[0;32m✓\u001b[0m hermes command ready\n\u001b[0;36m→\u001b[0m Setting up configuration files...\n\u001b[0;32m✓\u001b[0m Created ~/.hermes/.env from template\n\u001b[0;32m✓\u001b[0m Created ~/.hermes/config.yaml from template\n\u001b[0;32m✓\u001b[0m Created ~/.hermes/SOUL.md (edit to customize personality)\n\u001b[0;32m✓\u001b[0m Configuration directory ready: ~/.hermes/\n\u001b[0;36m→\u001b[0m Syncing bundled skills to ~/.hermes/skills/ ...\nSyncing bundled skills into ~/.hermes/skills/ ...\n  + xurl\n  + openhue\n  + youtube-content\n  + gif-search\n  + heartmula\n  + spotify\n  + songsee\n  + notion\n  + powerpoint\n  + linear\n  + maps\n  + google-workspace\n  + nano-pdf\n  + ocr-and-documents\n  + airtable\n  + huggingface-hub\n  + dspy\n  + audiocraft-audio-generation\n  + segment-anything-model\n  + outlines\n  + serving-llms-vllm\n  + obliteratus\n  + llama-cpp\n  + unsloth\n  + axolotl\n  + fine-tuning-with-trl\n  + evaluating-llms-harness\n  + weights-and-biases\n  + apple-notes\n  + findmy\n  + imessage\n  + apple-reminders\n  + polymarket\n  + llm-wiki\n  + arxiv\n  + research-paper-writing\n  + blogwatcher\n  + godmode\n  + jupyter-live-kernel\n  + claude-code\n  + opencode\n  + hermes-agent\n  + codex\n  + himalaya\n  + native-mcp\n  + minecraft-modpack-server\n  + pokemon-player\n  + yuanbao\n  + python-debugpy\n  + writing-plans\n  + systematic-debugging\n  + hermes-agent-skill-authoring\n  + test-driven-development\n  + node-inspect-debugger\n  + requesting-code-review\n  + plan\n  + spike\n  + debugging-hermes-tui-commands\n  + subagent-driven-development\n  + kanban-worker\n  + webhook-subscriptions\n  + kanban-orchestrator\n  + dogfood\n  + github-auth\n  + github-pr-workflow\n  + github-repo-management\n  + github-code-review\n  + codebase-inspection\n  + github-issues\n  + touchdesigner-mcp\n  + popular-web-designs\n  + p5js\n  + comfyui\n  + baoyu-comic\n  + sketch\n  + ideation\n  + claude-design\n  + pixel-art\n  + baoyu-infographic\n  + manim-video\n  + pretext\n  + excalidraw\n  + ascii-video\n  + songwriting-and-ai-music\n  + architecture-diagram\n  + humanizer\n  + ascii-art\n  + design-md\n  + obsidian\n\nDone: 89 new, 0 updated, 0 unchanged. 89 total bundled.\n\u001b[0;32m✓\u001b[0m Skills synced to ~/.hermes/skills/\n\u001b[0;36m→\u001b[0m Skipping setup wizard (--skip-setup)\n\n\u001b[0;32m\u001b[1m\n┌─────────────────────────────────────────────────────────┐\n│              ✓ Installation Complete!                   │\n└─────────────────────────────────────────────────────────┘\n\u001b[0m\n\n\u001b[0;36m\u001b[1m📁 Your files:\u001b[0m\n\n   \u001b[0;33mConfig:\u001b[0m    /home/audit-hermes/.hermes/config.yaml\n   \u001b[0;33mAPI Keys:\u001b[0m  /home/audit-hermes/.hermes/.env\n   \u001b[0;33mData:\u001b[0m      /home/audit-hermes/.hermes/cron/, sessions/, logs/\n   \u001b[0;33mCode:\u001b[0m      /home/audit-hermes/.hermes/code\n\n\u001b[0;36m─────────────────────────────────────────────────────────\u001b[0m\n\n\u001b[0;36m\u001b[1m🚀 Commands:\u001b[0m\n\n   \u001b[0;32mhermes\u001b[0m              Start chatting\n   \u001b[0;32mhermes setup\u001b[0m        Configure API keys & settings\n   \u001b[0;32mhermes config\u001b[0m       View/edit configuration\n   \u001b[0;32mhermes config edit\u001b[0m  Open config in editor\n   \u001b[0;32mhermes gateway install\u001b[0m Install gateway service (messaging + cron)\n   \u001b[0;32mhermes update\u001b[0m       Update to latest version\n\n\u001b[0;36m─────────────────────────────────────────────────────────\u001b[0m\n\n\u001b[0;33m⚡ Reload your shell to use 'hermes' command:\u001b[0m\n\n   source ~/.bashrc   # or ~/.zshrc", "stdout_lines": ["", "\u001b[0;35m\u001b[1m", "┌─────────────────────────────────────────────────────────┐", "│             ⚕ Hermes Agent Installer                    │", "├─────────────────────────────────────────────────────────┤", "│  An open source AI agent by Nous Research.              │", "└─────────────────────────────────────────────────────────┘", "\u001b[0m", "\u001b[0;32m✓\u001b[0m Detected: linux (ubuntu)", "\u001b[0;36m→\u001b[0m Install directory: /home/audit-hermes/.hermes/code (explicit)", "\u001b[0;36m→\u001b[0m Checking for uv package manager...", "\u001b[0;32m✓\u001b[0m uv found (uv 0.10.10)", "\u001b[0;36m→\u001b[0m Checking Python 3.11...", "\u001b[0;36m→\u001b[0m Python 3.11 not found, installing via uv...", "\u001b[0;32m✓\u001b[0m Python installed: Python 3.11.15", "\u001b[0;36m→\u001b[0m Checking Git...", "\u001b[0;32m✓\u001b[0m Git 2.43.0 found", "\u001b[0;36m→\u001b[0m Checking Node.js (for browser tools)...", "\u001b[0;32m✓\u001b[0m Node.js v22.22.1 found", "\u001b[0;36m→\u001b[0m Checking ripgrep (fast file search)...", "\u001b[0;32m✓\u001b[0m ripgrep 14.1.0 found", "\u001b[0;36m→\u001b[0m Checking ffmpeg (TTS voice messages)...", "\u001b[0;32m✓\u001b[0m ffmpeg 6.1.1-3ubuntu5 found", "\u001b[0;36m→\u001b[0m Installing to /home/audit-hermes/.hermes/code...", "\u001b[0;36m→\u001b[0m Trying SSH clone...", "\u001b[0;36m→\u001b[0m SSH failed, trying HTTPS...", "\u001b[0;32m✓\u001b[0m Cloned via HTTPS", "\u001b[0;32m✓\u001b[0m Repository ready", "\u001b[0;36m→\u001b[0m Creating virtual environment with Python 3.11...", "\u001b[0;32m✓\u001b[0m Virtual environment ready (Python 3.11)", "\u001b[0;36m→\u001b[0m Installing dependencies...", "\u001b[0;36m→\u001b[0m Some build tools may be needed for Python packages...", "\u001b[0;36m→\u001b[0m sudo is needed ONLY to install build tools (build-essential, python3-dev, libffi-dev) via apt.", "\u001b[0;36m→\u001b[0m Hermes Agent itself does not require or retain root access.", "\u001b[0;32m✓\u001b[0m Build tools installed", "\u001b[0;32m✓\u001b[0m Main package installed", "\u001b[0;32m✓\u001b[0m All dependencies installed", "\u001b[0;36m→\u001b[0m Installing Node.js dependencies (browser tools)...", "✅ Browser tools ready. Run: python run_agent.py --help", "\u001b[0;32m✓\u001b[0m Node.js dependencies installed", "\u001b[0;36m→\u001b[0m Installing browser engine (Playwright Chromium)...", "\u001b[0;36m→\u001b[0m Playwright may request sudo to install browser system dependencies (shared libraries).", "\u001b[0;36m→\u001b[0m This is standard Playwright setup — Hermes itself does not require root access.", "Installing dependencies...", "Switching to root user to install dependencies...", "Failed to install browsers", "Error: Installation process exited with code: 1", "\u001b[0;33m⚠\u001b[0m Playwright browser installation failed — browser tools will not work.", "\u001b[0;33m⚠\u001b[0m Try running manually: cd /home/audit-hermes/.hermes/code && npx playwright install --with-deps chromium", "\u001b[0;32m✓\u001b[0m Browser engine setup complete", "\u001b[0;36m→\u001b[0m Installing TUI dependencies...", "\u001b[0;32m✓\u001b[0m TUI dependencies installed", "\u001b[0;36m→\u001b[0m Setting up hermes command...", "\u001b[0;32m✓\u001b[0m Installed hermes launcher → ~/.local/bin/hermes", "\u001b[0;32m✓\u001b[0m Added ~/.local/bin to PATH in /home/audit-hermes/.bashrc", "\u001b[0;32m✓\u001b[0m hermes command ready", "\u001b[0;36m→\u001b[0m Setting up configuration files...", "\u001b[0;32m✓\u001b[0m Created ~/.hermes/.env from template", "\u001b[0;32m✓\u001b[0m Created ~/.hermes/config.yaml from template", "\u001b[0;32m✓\u001b[0m Created ~/.hermes/SOUL.md (edit to customize personality)", "\u001b[0;32m✓\u001b[0m Configuration directory ready: ~/.hermes/", "\u001b[0;36m→\u001b[0m Syncing bundled skills to ~/.hermes/skills/ ...", "Syncing bundled skills into ~/.hermes/skills/ ...", "  + xurl", "  + openhue", "  + youtube-content", "  + gif-search", "  + heartmula", "  + spotify", "  + songsee", "  + notion", "  + powerpoint", "  + linear", "  + maps", "  + google-workspace", "  + nano-pdf", "  + ocr-and-documents", "  + airtable", "  + huggingface-hub", "  + dspy", "  + audiocraft-audio-generation", "  + segment-anything-model", "  + outlines", "  + serving-llms-vllm", "  + obliteratus", "  + llama-cpp", "  + unsloth", "  + axolotl", "  + fine-tuning-with-trl", "  + evaluating-llms-harness", "  + weights-and-biases", "  + apple-notes", "  + findmy", "  + imessage", "  + apple-reminders", "  + polymarket", "  + llm-wiki", "  + arxiv", "  + research-paper-writing", "  + blogwatcher", "  + godmode", "  + jupyter-live-kernel", "  + claude-code", "  + opencode", "  + hermes-agent", "  + codex", "  + himalaya", "  + native-mcp", "  + minecraft-modpack-server", "  + pokemon-player", "  + yuanbao", "  + python-debugpy", "  + writing-plans", "  + systematic-debugging", "  + hermes-agent-skill-authoring", "  + test-driven-development", "  + node-inspect-debugger", "  + requesting-code-review", "  + plan", "  + spike", "  + debugging-hermes-tui-commands", "  + subagent-driven-development", "  + kanban-worker", "  + webhook-subscriptions", "  + kanban-orchestrator", "  + dogfood", "  + github-auth", "  + github-pr-workflow", "  + github-repo-management", "  + github-code-review", "  + codebase-inspection", "  + github-issues", "  + touchdesigner-mcp", "  + popular-web-designs", "  + p5js", "  + comfyui", "  + baoyu-comic", "  + sketch", "  + ideation", "  + claude-design", "  + pixel-art", "  + baoyu-infographic", "  + manim-video", "  + pretext", "  + excalidraw", "  + ascii-video", "  + songwriting-and-ai-music", "  + architecture-diagram", "  + humanizer", "  + ascii-art", "  + design-md", "  + obsidian", "", "Done: 89 new, 0 updated, 0 unchanged. 89 total bundled.", "\u001b[0;32m✓\u001b[0m Skills synced to ~/.hermes/skills/", "\u001b[0;36m→\u001b[0m Skipping setup wizard (--skip-setup)", "", "\u001b[0;32m\u001b[1m", "┌─────────────────────────────────────────────────────────┐", "│              ✓ Installation Complete!                   │", "└─────────────────────────────────────────────────────────┘", "\u001b[0m", "", "\u001b[0;36m\u001b[1m📁 Your files:\u001b[0m", "", "   \u001b[0;33mConfig:\u001b[0m    /home/audit-hermes/.hermes/config.yaml", "   \u001b[0;33mAPI Keys:\u001b[0m  /home/audit-hermes/.hermes/.env", "   \u001b[0;33mData:\u001b[0m      /home/audit-hermes/.hermes/cron/, sessions/, logs/", "   \u001b[0;33mCode:\u001b[0m      /home/audit-hermes/.hermes/code", "", "\u001b[0;36m─────────────────────────────────────────────────────────\u001b[0m", "", "\u001b[0;36m\u001b[1m🚀 Commands:\u001b[0m", "", "   \u001b[0;32mhermes\u001b[0m              Start chatting", "   \u001b[0;32mhermes setup\u001b[0m        Configure API keys & settings", "   \u001b[0;32mhermes config\u001b[0m       View/edit configuration", "   \u001b[0;32mhermes config edit\u001b[0m  Open config in editor", "   \u001b[0;32mhermes gateway install\u001b[0m Install gateway service (messaging + cron)", "   \u001b[0;32mhermes update\u001b[0m       Update to latest version", "", "\u001b[0;36m─────────────────────────────────────────────────────────\u001b[0m", "", "\u001b[0;33m⚡ Reload your shell to use 'hermes' command:\u001b[0m", "", "   source ~/.bashrc   # or ~/.zshrc"]}
+
+TASK [Clean up installer script] ***********************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "path": "/home/audit-hermes/hermes-install.sh", "state": "absent"}
+
+TASK [Create Hermes config directory] ******************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1013, "group": "audit-hermes", "mode": "0700", "owner": "audit-hermes", "path": "/home/audit-hermes/.hermes", "size": 4096, "state": "directory", "uid": 1013}
+
+TASK [Create empty Hermes environment file (preserved across re-installs)] *****
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "dest": "/home/audit-hermes/.hermes/.env", "src": "/home/devashish/.ansible/tmp/ansible-local-1520107xcerhf9c/.jc_52p9m"}
+
+TASK [Enforce 0600 permissions on Hermes environment file] *********************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1013, "group": "audit-hermes", "mode": "0600", "owner": "audit-hermes", "path": "/home/audit-hermes/.hermes/.env", "size": 21610, "state": "file", "uid": 1013}
+
+TASK [Create Hermes memories directory] ****************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1013, "group": "audit-hermes", "mode": "0700", "owner": "audit-hermes", "path": "/home/audit-hermes/.hermes/memories", "size": 4096, "state": "directory", "uid": 1013}
+
+TASK [Create systemd service file (disabled, not started)] *********************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum": "5e2484049c86e18e63c6656da16b88160498093b", "dest": "/etc/systemd/system/hermes-audit-hermes.service", "gid": 0, "group": "root", "md5sum": "9410301ab80f533592b9f0bbe8c83db8", "mode": "0644", "owner": "root", "size": 333, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779595409.7583148-1524183-102445187271966/.source.service", "state": "file", "uid": 0}
+
+TASK [Reload systemd to pick up unit file] *************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "name": null, "status": {}}
+
+TASK [Display install success] *************************************************
+ok: [wolf.tailf7742d.ts.net] => {
+    "msg": "Hermes 2026.5.7 installed for agent 'audit-hermes'.\nService unit hermes-audit-hermes.service dropped (disabled, stopped).\nRun `clm agent configure audit-hermes` to provision a provider and start the gateway.\n"
+}
+
+RUNNING HANDLER [Reload systemd] ***********************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "name": null, "status": {}}
+
+PLAY RECAP *********************************************************************
+wolf.tailf7742d.ts.net     : ok=18   changed=8    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
+
+Success! hermes v2026.5.7 installed as 'audit-hermes' on wolf-i
+```
+Exit: `0`
+
+### `clm agent install --type openclaw --host wolf-i --name audit-openclaw --yes`
+
+```console
+$ clm agent install --type openclaw --host wolf-i --name audit-openclaw --yes
+╭────────────────────────────────────────────────────────── Installation Summary ──────────────────────────────────────────────────────────╮
+│ Agent Type: openclaw                                                                                                                     │
+│ Version: 2026.4.2                                                                                                                        │
+│ Host: wolf-i                                                                                                                             │
+│ Architecture: x86_64                                                                                                                     │
+│ Memory: 15.5GB                                                                                                                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+No config file found; using defaults
+
+PLAY [all] *********************************************************************
+
+TASK [Gathering Facts] *********************************************************
+[WARNING]: Host 'wolf.tailf7742d.ts.net' is using the discovered Python interpreter at '/usr/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.20/reference_appendices/interpreter_discovery.html for more information.
+ok: [wolf.tailf7742d.ts.net]
+
+TASK [Kill stale apt lock holders] *********************************************
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/apt/lists/lock) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/apt/lists/lock"], "delta": "0:00:00.071189", "end": "2026-05-23 21:03:36.689179", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/apt/lists/lock", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 21:03:36.617990", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/dpkg/lock) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/dpkg/lock"], "delta": "0:00:00.068940", "end": "2026-05-23 21:03:37.297638", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/dpkg/lock", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 21:03:37.228698", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+ok: [wolf.tailf7742d.ts.net] => (item=/var/lib/dpkg/lock-frontend) => {"ansible_loop_var": "item", "changed": false, "cmd": ["fuser", "-k", "/var/lib/dpkg/lock-frontend"], "delta": "0:00:00.068869", "end": "2026-05-23 21:03:37.839854", "failed_when_result": false, "failed_when_suppressed_exception": "(traceback unavailable)", "item": "/var/lib/dpkg/lock-frontend", "msg": "non-zero return code", "rc": 1, "start": "2026-05-23 21:03:37.770985", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+
+TASK [Update apt cache] ********************************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+TASK [Check if node is installed] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "cmd": ["node", "--version"], "delta": "0:00:00.006311", "end": "2026-05-23 21:03:39.578792", "failed_when_result": false, "msg": "", "rc": 0, "start": "2026-05-23 21:03:39.572481", "stderr": "", "stderr_lines": [], "stdout": "v22.22.1", "stdout_lines": ["v22.22.1"]}
+
+TASK [Install required packages for NodeSource repository] *********************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Create keyrings directory] ***********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Download NodeSource GPG key] *********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Add NodeSource repository for Node.js 20] ********************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Install Node.js] *********************************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "node_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Install build-essential] *************************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+TASK [Install git and GitHub CLI] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"cache_update_time": 1779593268, "cache_updated": false, "changed": false}
+
+PLAY RECAP *********************************************************************
+wolf.tailf7742d.ts.net     : ok=6    changed=0    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
+No config file found; using defaults
+
+PLAY [all] *********************************************************************
+
+TASK [Gathering Facts] *********************************************************
+[WARNING]: Host 'wolf.tailf7742d.ts.net' is using the discovered Python interpreter at '/usr/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.20/reference_appendices/interpreter_discovery.html for more information.
+ok: [wolf.tailf7742d.ts.net]
+
+TASK [Normalize target OpenClaw version] ***************************************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"openclaw_target_version": "2026.4.2"}, "changed": false}
+
+TASK [Create agent user] *******************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "comment": "", "create_home": true, "group": 1014, "home": "/home/audit-openclaw", "name": "audit-openclaw", "shell": "/bin/bash", "state": "present", "system": false, "uid": 1014}
+
+TASK [Check per-agent openclaw binary] *****************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "stat": {"exists": false}}
+
+TASK [Discover openclaw binary in PATH] ****************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "cmd": ["which", "openclaw"], "delta": "0:00:00.003034", "end": "2026-05-23 21:03:46.543501", "failed_when_result": false, "msg": "", "rc": 0, "start": "2026-05-23 21:03:46.540467", "stderr": "", "stderr_lines": [], "stdout": "/usr/local/bin/openclaw", "stdout_lines": ["/usr/local/bin/openclaw"]}
+
+TASK [Resolve openclaw binary (per-agent preferred, PATH fallback)] ************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"openclaw_discovered_binary": "/usr/local/bin/openclaw"}, "changed": false}
+
+TASK [Validate discovered binary path] *****************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "(openclaw_discovered_binary | length) > 0 and not (openclaw_discovered_binary.startswith('/usr/local/bin/') or\n     openclaw_discovered_binary.startswith('/usr/bin/') or\n     openclaw_discovered_binary.startswith('/home/'))\n", "skip_reason": "Conditional result was False"}
+
+TASK [Get installed openclaw version] ******************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "cmd": ["/usr/local/bin/openclaw", "--version"], "delta": "0:00:00.121171", "end": "2026-05-23 21:03:47.203200", "failed_when_result": false, "msg": "", "rc": 0, "start": "2026-05-23 21:03:47.082029", "stderr": "", "stderr_lines": [], "stdout": "OpenClaw 2026.3.13 (61d171a)", "stdout_lines": ["OpenClaw 2026.3.13 (61d171a)"]}
+
+TASK [Parse installed openclaw version] ****************************************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"openclaw_installed_version": "2026.3.13"}, "changed": false}
+
+TASK [Set install skip condition] **********************************************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"openclaw_already_installed": false, "openclaw_runtime_binary": "/usr/local/bin/openclaw"}, "changed": false}
+
+TASK [Mark install as skipped when already installed] **************************
+skipping: [wolf.tailf7742d.ts.net] => {"false_condition": "openclaw_already_installed"}
+
+TASK [Note that --force was supplied (overriding skip)] ************************
+skipping: [wolf.tailf7742d.ts.net] => {"false_condition": "force_install | default(false) | bool"}
+
+TASK [Download OpenClaw installer script] **************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum_dest": null, "checksum_src": "dd70e5e4401b6d631c50e6bdcdfbbca23464fdf1", "dest": "/home/audit-openclaw/openclaw-install.sh", "elapsed": 0, "gid": 1014, "group": "audit-openclaw", "md5sum": "399298ea827b715409201bb59307f133", "mode": "0700", "msg": "OK (26738 bytes)", "owner": "audit-openclaw", "size": 26738, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779595427.4608543-1524781-203175596156224/tmpmi1l8wam", "state": "file", "status_code": 200, "uid": 1014, "url": "https://openclaw.ai/install-cli.sh"}
+
+TASK [Install OpenClaw CLI runtime] ********************************************
+[WARNING]: Module remote_tmp /home/audit-openclaw/.ansible/tmp did not exist and was created with a mode of 0700, this may cause issues when running as another user. To avoid this, create the remote_tmp dir with the correct permissions manually
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "cmd": ["/bin/bash", "/home/audit-openclaw/openclaw-install.sh", "--prefix", "/home/audit-openclaw/.openclaw", "--install-method", "npm", "--version", "2026.4.2", "--no-onboard"], "delta": "0:01:08.737580", "end": "2026-05-23 21:04:57.341605", "msg": "", "rc": 0, "start": "2026-05-23 21:03:48.604025", "stderr": "npm notice\nnpm notice New major version of npm available! 10.9.4 -> 11.15.0\nnpm notice Changelog: https://github.com/npm/cli/releases/tag/v11.15.0\nnpm notice To update run: npm install -g npm@11.15.0\nnpm notice", "stderr_lines": ["npm notice", "npm notice New major version of npm available! 10.9.4 -> 11.15.0", "npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.15.0", "npm notice To update run: npm install -g npm@11.15.0", "npm notice"], "stdout": "Installing Node 22.22.0 (user-space)...\nInstalling OpenClaw (2026.4.2)...\n\nadded 472 packages in 1m\nOpenClaw installed (OpenClaw 2026.4.2 (d74a122)).", "stdout_lines": ["Installing Node 22.22.0 (user-space)...", "Installing OpenClaw (2026.4.2)...", "", "added 472 packages in 1m", "OpenClaw installed (OpenClaw 2026.4.2 (d74a122))."]}
+
+TASK [Clean up installer script] ***********************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "path": "/home/audit-openclaw/openclaw-install.sh", "state": "absent"}
+
+TASK [Create workspace directory] **********************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1014, "group": "audit-openclaw", "mode": "0700", "owner": "audit-openclaw", "path": "/home/audit-openclaw/workspace", "size": 4096, "state": "directory", "uid": 1014}
+
+TASK [Create OpenClaw config directory] ****************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "gid": 1014, "group": "audit-openclaw", "mode": "0700", "owner": "audit-openclaw", "path": "/home/audit-openclaw/.openclaw", "size": 4096, "state": "directory", "uid": 1014}
+
+TASK [Calculate unique port (40000-42000 range)] *******************************
+ok: [wolf.tailf7742d.ts.net] => {"ansible_facts": {"openclaw_port": 40612}, "changed": false}
+
+TASK [Write openclaw config from template] *************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum": "3ab0781d599943bd856a987d44d145d41b249579", "dest": "/home/audit-openclaw/.openclaw/openclaw.json", "gid": 1014, "group": "audit-openclaw", "md5sum": "54da959f914a8086caf7a8e4d33bda5a", "mode": "0600", "owner": "audit-openclaw", "size": 1055, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779595499.1994913-1526708-98425113375815/.source.json", "state": "file", "uid": 1014}
+
+TASK [Write exec approvals policy from template] *******************************
+changed: [wolf.tailf7742d.ts.net] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": true}
+
+TASK [Verify exec approvals JSON is valid] *************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "cmd": ["python3", "-m", "json.tool", "/home/audit-openclaw/.openclaw/exec-approvals.json"], "delta": "0:00:00.043777", "end": "2026-05-23 21:05:01.638552", "msg": "", "rc": 0, "start": "2026-05-23 21:05:01.594775", "stderr": "", "stderr_lines": [], "stdout": "{\n    \"version\": 1,\n    \"defaults\": {\n        \"security\": \"full\",\n        \"ask\": \"off\",\n        \"askFallback\": \"full\",\n        \"autoAllowSkills\": false\n    }\n}", "stdout_lines": ["{", "    \"version\": 1,", "    \"defaults\": {", "        \"security\": \"full\",", "        \"ask\": \"off\",", "        \"askFallback\": \"full\",", "        \"autoAllowSkills\": false", "    }", "}"]}
+
+TASK [Create environment file for agent] ***************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709", "dest": "/home/audit-openclaw/.openclaw/env", "gid": 1014, "group": "audit-openclaw", "md5sum": "d41d8cd98f00b204e9800998ecf8427e", "mode": "0600", "owner": "audit-openclaw", "size": 0, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779595501.7441127-1526797-155741217062752/.source", "state": "file", "uid": 1014}
+
+TASK [Create systemd service file] *********************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum": "03157cd39147163a5b8960f4a0ea98bdcad103b0", "dest": "/etc/systemd/system/openclaw-audit-openclaw.service", "gid": 0, "group": "root", "md5sum": "dfad988ba86b2d25c76ab4f7cc3b22ce", "mode": "0644", "owner": "root", "size": 354, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779595502.7917416-1526838-144101235155345/.source.service", "state": "file", "uid": 0}
+
+TASK [Restart openclaw service on ExecStart change] ****************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "enabled": true, "name": "openclaw-audit-openclaw", "state": "started", "status": {"ActiveEnterTimestamp": "Sat 2026-05-23 20:38:13 PDT", "ActiveEnterTimestampMonotonic": "6598118115363", "ActiveExitTimestamp": "Sat 2026-05-23 20:38:19 PDT", "ActiveExitTimestampMonotonic": "6598123708146", "ActiveState": "failed", "After": "basic.target system.slice sysinit.target -.mount network.target home.mount systemd-journald.socket", "AllowIsolate": "no", "AssertResult": "yes", "AssertTimestamp": "Sat 2026-05-23 20:38:13 PDT", "AssertTimestampMonotonic": "6598118097530", "Before": "shutdown.target", "BlockIOAccounting": "no", "BlockIOWeight": "[not set]", "CPUAccounting": "yes", "CPUAffinityFromNUMA": "no", "CPUQuotaPerSecUSec": "infinity", "CPUQuotaPeriodUSec": "infinity", "CPUSchedulingPolicy": "0", "CPUSchedulingPriority": "0", "CPUSchedulingResetOnFork": "no", "CPUShares": "[not set]", "CPUUsageNSec": "7514173000", "CPUWeight": "[not set]", "CacheDirectoryMode": "0755", "CanFreeze": "yes", "CanIsolate": "no", "CanReload": "no", "CanStart": "yes", "CanStop": "yes", "CapabilityBoundingSet": "cap_chown cap_dac_override cap_dac_read_search cap_fowner cap_fsetid cap_kill cap_setgid cap_setuid cap_setpcap cap_linux_immutable cap_net_bind_service cap_net_broadcast cap_net_admin cap_net_raw cap_ipc_lock cap_ipc_owner cap_sys_module cap_sys_rawio cap_sys_chroot cap_sys_ptrace cap_sys_pacct cap_sys_admin cap_sys_boot cap_sys_nice cap_sys_resource cap_sys_time cap_sys_tty_config cap_mknod cap_lease cap_audit_write cap_audit_control cap_setfcap cap_mac_override cap_mac_admin cap_syslog cap_wake_alarm cap_block_suspend cap_audit_read cap_perfmon cap_bpf cap_checkpoint_restore", "CleanResult": "success", "CollectMode": "inactive", "ConditionResult": "yes", "ConditionTimestamp": "Sat 2026-05-23 20:38:13 PDT", "ConditionTimestampMonotonic": "6598118097528", "ConfigurationDirectoryMode": "0755", "Conflicts": "shutdown.target", "ControlGroupId": "0", "ControlPID": "0", "CoredumpFilter": "0x33", "CoredumpReceive": "no", "DefaultDependencies": "yes", "DefaultMemoryLow": "0", "DefaultMemoryMin": "0", "DefaultStartupMemoryLow": "0", "Delegate": "no", "Description": "OpenClaw AI Assistant (audit-openclaw)", "DevicePolicy": "auto", "DynamicUser": "no", "EnvironmentFiles": "/home/audit-openclaw/.openclaw/env (ignore_errors=no)", "ExecMainCode": "1", "ExecMainExitTimestamp": "Sat 2026-05-23 20:38:19 PDT", "ExecMainExitTimestampMonotonic": "6598123856252", "ExecMainPID": "498041", "ExecMainStartTimestamp": "Sat 2026-05-23 20:38:13 PDT", "ExecMainStartTimestampMonotonic": "6598118115134", "ExecMainStatus": "1", "ExecStart": "{ path=/usr/local/bin/openclaw ; argv[]=/usr/local/bin/openclaw gateway run --allow-unconfigured ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }", "ExecStartEx": "{ path=/usr/local/bin/openclaw ; argv[]=/usr/local/bin/openclaw gateway run --allow-unconfigured ; flags= ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }", "ExitType": "main", "ExtensionImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent", "FailureAction": "none", "FileDescriptorStoreMax": "0", "FileDescriptorStorePreserve": "restart", "FinalKillSignal": "9", "FragmentPath": "/etc/systemd/system/openclaw-audit-openclaw.service", "FreezerState": "running", "GID": "[not set]", "GuessMainPID": "yes", "IOAccounting": "no", "IOReadBytes": "[not set]", "IOReadOperations": "[not set]", "IOSchedulingClass": "2", "IOSchedulingPriority": "4", "IOWeight": "[not set]", "IOWriteBytes": "[not set]", "IOWriteOperations": "[not set]", "IPAccounting": "no", "IPEgressBytes": "[no data]", "IPEgressPackets": "[no data]", "IPIngressBytes": "[no data]", "IPIngressPackets": "[no data]", "Id": "openclaw-audit-openclaw.service", "IgnoreOnIsolate": "no", "IgnoreSIGPIPE": "yes", "InactiveEnterTimestamp": "Sat 2026-05-23 20:38:19 PDT", "InactiveEnterTimestampMonotonic": "6598123856404", "InactiveExitTimestamp": "Sat 2026-05-23 20:38:13 PDT", "InactiveExitTimestampMonotonic": "6598118115363", "InvocationID": "8218c8973fa54c1db4dd3828d140e18d", "JobRunningTimeoutUSec": "infinity", "JobTimeoutAction": "none", "JobTimeoutUSec": "infinity", "KeyringMode": "private", "KillMode": "control-group", "KillSignal": "15", "LimitAS": "infinity", "LimitASSoft": "infinity", "LimitCORE": "infinity", "LimitCORESoft": "0", "LimitCPU": "infinity", "LimitCPUSoft": "infinity", "LimitDATA": "infinity", "LimitDATASoft": "infinity", "LimitFSIZE": "infinity", "LimitFSIZESoft": "infinity", "LimitLOCKS": "infinity", "LimitLOCKSSoft": "infinity", "LimitMEMLOCK": "8388608", "LimitMEMLOCKSoft": "8388608", "LimitMSGQUEUE": "819200", "LimitMSGQUEUESoft": "819200", "LimitNICE": "0", "LimitNICESoft": "0", "LimitNOFILE": "524288", "LimitNOFILESoft": "1024", "LimitNPROC": "62947", "LimitNPROCSoft": "62947", "LimitRSS": "infinity", "LimitRSSSoft": "infinity", "LimitRTPRIO": "0", "LimitRTPRIOSoft": "0", "LimitRTTIME": "infinity", "LimitRTTIMESoft": "infinity", "LimitSIGPENDING": "62947", "LimitSIGPENDINGSoft": "62947", "LimitSTACK": "infinity", "LimitSTACKSoft": "8388608", "LoadState": "loaded", "LockPersonality": "no", "LogLevelMax": "-1", "LogRateLimitBurst": "0", "LogRateLimitIntervalUSec": "0", "LogsDirectoryMode": "0755", "MainPID": "0", "ManagedOOMMemoryPressure": "auto", "ManagedOOMMemoryPressureLimit": "0", "ManagedOOMPreference": "none", "ManagedOOMSwap": "auto", "MemoryAccounting": "yes", "MemoryAvailable": "11604840448", "MemoryCurrent": "[not set]", "MemoryDenyWriteExecute": "no", "MemoryHigh": "infinity", "MemoryKSM": "no", "MemoryLimit": "infinity", "MemoryLow": "0", "MemoryMax": "infinity", "MemoryMin": "0", "MemoryPeak": "280276992", "MemoryPressureThresholdUSec": "200ms", "MemoryPressureWatch": "auto", "MemorySwapCurrent": "[not set]", "MemorySwapMax": "infinity", "MemorySwapPeak": "0", "MemoryZSwapCurrent": "[not set]", "MemoryZSwapMax": "infinity", "MountAPIVFS": "no", "MountImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent", "NFileDescriptorStore": "0", "NRestarts": "0", "NUMAPolicy": "n/a", "Names": "openclaw-audit-openclaw.service", "NeedDaemonReload": "no", "Nice": "0", "NoNewPrivileges": "no", "NonBlocking": "no", "NotifyAccess": "none", "OOMPolicy": "stop", "OOMScoreAdjust": "0", "OnFailureJobMode": "replace", "OnSuccessJobMode": "fail", "Perpetual": "no", "PrivateDevices": "no", "PrivateIPC": "no", "PrivateMounts": "no", "PrivateNetwork": "no", "PrivateTmp": "no", "PrivateUsers": "no", "ProcSubset": "all", "ProtectClock": "no", "ProtectControlGroups": "no", "ProtectHome": "no", "ProtectHostname": "no", "ProtectKernelLogs": "no", "ProtectKernelModules": "no", "ProtectKernelTunables": "no", "ProtectProc": "default", "ProtectSystem": "no", "RefuseManualStart": "no", "RefuseManualStop": "no", "ReloadResult": "success", "ReloadSignal": "1", "RemainAfterExit": "no", "RemoveIPC": "no", "Requires": "sysinit.target home.mount -.mount system.slice", "RequiresMountsFor": "/home/audit-openclaw/workspace", "Restart": "always", "RestartKillSignal": "15", "RestartMaxDelayUSec": "infinity", "RestartMode": "normal", "RestartSteps": "0", "RestartUSec": "5s", "RestartUSecNext": "5s", "RestrictNamespaces": "no", "RestrictRealtime": "no", "RestrictSUIDSGID": "no", "Result": "exit-code", "RootDirectoryStartOnly": "no", "RootEphemeral": "no", "RootImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent", "RuntimeDirectoryMode": "0755", "RuntimeDirectoryPreserve": "no", "RuntimeMaxUSec": "infinity", "RuntimeRandomizedExtraUSec": "0", "SameProcessGroup": "no", "SecureBits": "0", "SendSIGHUP": "no", "SendSIGKILL": "yes", "SetLoginEnvironment": "no", "Slice": "system.slice", "StandardError": "inherit", "StandardInput": "null", "StandardOutput": "journal", "StartLimitAction": "none", "StartLimitBurst": "5", "StartLimitIntervalUSec": "10s", "StartupBlockIOWeight": "[not set]", "StartupCPUShares": "[not set]", "StartupCPUWeight": "[not set]", "StartupIOWeight": "[not set]", "StartupMemoryHigh": "infinity", "StartupMemoryLow": "0", "StartupMemoryMax": "infinity", "StartupMemorySwapMax": "infinity", "StartupMemoryZSwapMax": "infinity", "StateChangeTimestamp": "Sat 2026-05-23 20:38:19 PDT", "StateChangeTimestampMonotonic": "6598123856404", "StateDirectoryMode": "0755", "StatusErrno": "0", "StopWhenUnneeded": "no", "SubState": "failed", "SuccessAction": "none", "SurviveFinalKillSignal": "no", "SyslogFacility": "3", "SyslogLevel": "6", "SyslogLevelPrefix": "yes", "SyslogPriority": "30", "SystemCallErrorNumber": "2147483646", "TTYReset": "no", "TTYVHangup": "no", "TTYVTDisallocate": "no", "TasksAccounting": "yes", "TasksCurrent": "[not set]", "TasksMax": "18884", "TimeoutAbortUSec": "1min 30s", "TimeoutCleanUSec": "infinity", "TimeoutStartFailureMode": "terminate", "TimeoutStartUSec": "1min 30s", "TimeoutStopFailureMode": "terminate", "TimeoutStopUSec": "1min 30s", "TimerSlackNSec": "50000", "Transient": "no", "Type": "simple", "UID": "[not set]", "UMask": "0022", "UnitFilePreset": "enabled", "UnitFileState": "disabled", "User": "audit-openclaw", "UtmpMode": "init", "WatchdogSignal": "6", "WatchdogTimestampMonotonic": "0", "WatchdogUSec": "0", "WorkingDirectory": "/home/audit-openclaw/workspace"}}
+
+TASK [Enable and start openclaw service] ***************************************
+ok: [wolf.tailf7742d.ts.net] => {"changed": false, "enabled": true, "name": "openclaw-audit-openclaw", "state": "started", "status": {"ActiveEnterTimestamp": "Sat 2026-05-23 21:05:05 PDT", "ActiveEnterTimestampMonotonic": "6599729872414", "ActiveExitTimestamp": "Sat 2026-05-23 20:38:19 PDT", "ActiveExitTimestampMonotonic": "6598123708146", "ActiveState": "active", "After": "systemd-journald.socket sysinit.target home.mount network.target basic.target system.slice -.mount", "AllowIsolate": "no", "AssertResult": "yes", "AssertTimestamp": "Sat 2026-05-23 21:05:05 PDT", "AssertTimestampMonotonic": "6599729864140", "Before": "shutdown.target multi-user.target", "BlockIOAccounting": "no", "BlockIOWeight": "[not set]", "CPUAccounting": "yes", "CPUAffinityFromNUMA": "no", "CPUQuotaPerSecUSec": "infinity", "CPUQuotaPeriodUSec": "infinity", "CPUSchedulingPolicy": "0", "CPUSchedulingPriority": "0", "CPUSchedulingResetOnFork": "no", "CPUShares": "[not set]", "CPUUsageNSec": "1714386000", "CPUWeight": "[not set]", "CacheDirectoryMode": "0755", "CanFreeze": "yes", "CanIsolate": "no", "CanReload": "no", "CanStart": "yes", "CanStop": "yes", "CapabilityBoundingSet": "cap_chown cap_dac_override cap_dac_read_search cap_fowner cap_fsetid cap_kill cap_setgid cap_setuid cap_setpcap cap_linux_immutable cap_net_bind_service cap_net_broadcast cap_net_admin cap_net_raw cap_ipc_lock cap_ipc_owner cap_sys_module cap_sys_rawio cap_sys_chroot cap_sys_ptrace cap_sys_pacct cap_sys_admin cap_sys_boot cap_sys_nice cap_sys_resource cap_sys_time cap_sys_tty_config cap_mknod cap_lease cap_audit_write cap_audit_control cap_setfcap cap_mac_override cap_mac_admin cap_syslog cap_wake_alarm cap_block_suspend cap_audit_read cap_perfmon cap_bpf cap_checkpoint_restore", "CleanResult": "success", "CollectMode": "inactive", "ConditionResult": "yes", "ConditionTimestamp": "Sat 2026-05-23 21:05:05 PDT", "ConditionTimestampMonotonic": "6599729864138", "ConfigurationDirectoryMode": "0755", "Conflicts": "shutdown.target", "ControlGroup": "/system.slice/openclaw-audit-openclaw.service", "ControlGroupId": "25607266", "ControlPID": "0", "CoredumpFilter": "0x33", "CoredumpReceive": "no", "DefaultDependencies": "yes", "DefaultMemoryLow": "0", "DefaultMemoryMin": "0", "DefaultStartupMemoryLow": "0", "Delegate": "no", "Description": "OpenClaw AI Assistant (audit-openclaw)", "DevicePolicy": "auto", "DynamicUser": "no", "EnvironmentFiles": "/home/audit-openclaw/.openclaw/env (ignore_errors=no)", "ExecMainCode": "0", "ExecMainExitTimestampMonotonic": "0", "ExecMainPID": "516384", "ExecMainStartTimestamp": "Sat 2026-05-23 21:05:05 PDT", "ExecMainStartTimestampMonotonic": "6599729872164", "ExecMainStatus": "0", "ExecStart": "{ path=/usr/local/bin/openclaw ; argv[]=/usr/local/bin/openclaw gateway run --allow-unconfigured ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }", "ExecStartEx": "{ path=/usr/local/bin/openclaw ; argv[]=/usr/local/bin/openclaw gateway run --allow-unconfigured ; flags= ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }", "ExitType": "main", "ExtensionImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent", "FailureAction": "none", "FileDescriptorStoreMax": "0", "FileDescriptorStorePreserve": "restart", "FinalKillSignal": "9", "FragmentPath": "/etc/systemd/system/openclaw-audit-openclaw.service", "FreezerState": "running", "GID": "1014", "GuessMainPID": "yes", "IOAccounting": "no", "IOReadBytes": "[not set]", "IOReadOperations": "[not set]", "IOSchedulingClass": "2", "IOSchedulingPriority": "4", "IOWeight": "[not set]", "IOWriteBytes": "[not set]", "IOWriteOperations": "[not set]", "IPAccounting": "no", "IPEgressBytes": "[no data]", "IPEgressPackets": "[no data]", "IPIngressBytes": "[no data]", "IPIngressPackets": "[no data]", "Id": "openclaw-audit-openclaw.service", "IgnoreOnIsolate": "no", "IgnoreSIGPIPE": "yes", "InactiveEnterTimestamp": "Sat 2026-05-23 20:38:19 PDT", "InactiveEnterTimestampMonotonic": "6598123856404", "InactiveExitTimestamp": "Sat 2026-05-23 21:05:05 PDT", "InactiveExitTimestampMonotonic": "6599729872414", "InvocationID": "f9049c1b5ad0463ca2ac2b861749d132", "JobRunningTimeoutUSec": "infinity", "JobTimeoutAction": "none", "JobTimeoutUSec": "infinity", "KeyringMode": "private", "KillMode": "control-group", "KillSignal": "15", "LimitAS": "infinity", "LimitASSoft": "infinity", "LimitCORE": "infinity", "LimitCORESoft": "0", "LimitCPU": "infinity", "LimitCPUSoft": "infinity", "LimitDATA": "infinity", "LimitDATASoft": "infinity", "LimitFSIZE": "infinity", "LimitFSIZESoft": "infinity", "LimitLOCKS": "infinity", "LimitLOCKSSoft": "infinity", "LimitMEMLOCK": "8388608", "LimitMEMLOCKSoft": "8388608", "LimitMSGQUEUE": "819200", "LimitMSGQUEUESoft": "819200", "LimitNICE": "0", "LimitNICESoft": "0", "LimitNOFILE": "524288", "LimitNOFILESoft": "1024", "LimitNPROC": "62947", "LimitNPROCSoft": "62947", "LimitRSS": "infinity", "LimitRSSSoft": "infinity", "LimitRTPRIO": "0", "LimitRTPRIOSoft": "0", "LimitRTTIME": "infinity", "LimitRTTIMESoft": "infinity", "LimitSIGPENDING": "62947", "LimitSIGPENDINGSoft": "62947", "LimitSTACK": "infinity", "LimitSTACKSoft": "8388608", "LoadState": "loaded", "LockPersonality": "no", "LogLevelMax": "-1", "LogRateLimitBurst": "0", "LogRateLimitIntervalUSec": "0", "LogsDirectoryMode": "0755", "MainPID": "516384", "ManagedOOMMemoryPressure": "auto", "ManagedOOMMemoryPressureLimit": "0", "ManagedOOMPreference": "none", "ManagedOOMSwap": "auto", "MemoryAccounting": "yes", "MemoryAvailable": "11508674560", "MemoryCurrent": "152596480", "MemoryDenyWriteExecute": "no", "MemoryHigh": "infinity", "MemoryKSM": "no", "MemoryLimit": "infinity", "MemoryLow": "0", "MemoryMax": "infinity", "MemoryMin": "0", "MemoryPeak": "152633344", "MemoryPressureThresholdUSec": "200ms", "MemoryPressureWatch": "auto", "MemorySwapCurrent": "0", "MemorySwapMax": "infinity", "MemorySwapPeak": "0", "MemoryZSwapCurrent": "0", "MemoryZSwapMax": "infinity", "MountAPIVFS": "no", "MountImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent", "NFileDescriptorStore": "0", "NRestarts": "0", "NUMAPolicy": "n/a", "Names": "openclaw-audit-openclaw.service", "NeedDaemonReload": "no", "Nice": "0", "NoNewPrivileges": "no", "NonBlocking": "no", "NotifyAccess": "none", "OOMPolicy": "stop", "OOMScoreAdjust": "0", "OnFailureJobMode": "replace", "OnSuccessJobMode": "fail", "Perpetual": "no", "PrivateDevices": "no", "PrivateIPC": "no", "PrivateMounts": "no", "PrivateNetwork": "no", "PrivateTmp": "no", "PrivateUsers": "no", "ProcSubset": "all", "ProtectClock": "no", "ProtectControlGroups": "no", "ProtectHome": "no", "ProtectHostname": "no", "ProtectKernelLogs": "no", "ProtectKernelModules": "no", "ProtectKernelTunables": "no", "ProtectProc": "default", "ProtectSystem": "no", "RefuseManualStart": "no", "RefuseManualStop": "no", "ReloadResult": "success", "ReloadSignal": "1", "RemainAfterExit": "no", "RemoveIPC": "no", "Requires": "system.slice home.mount sysinit.target -.mount", "RequiresMountsFor": "/home/audit-openclaw/workspace", "Restart": "always", "RestartKillSignal": "15", "RestartMaxDelayUSec": "infinity", "RestartMode": "normal", "RestartSteps": "0", "RestartUSec": "5s", "RestartUSecNext": "5s", "RestrictNamespaces": "no", "RestrictRealtime": "no", "RestrictSUIDSGID": "no", "Result": "success", "RootDirectoryStartOnly": "no", "RootEphemeral": "no", "RootImagePolicy": "root=verity+signed+encrypted+unprotected+absent:usr=verity+signed+encrypted+unprotected+absent:home=encrypted+unprotected+absent:srv=encrypted+unprotected+absent:tmp=encrypted+unprotected+absent:var=encrypted+unprotected+absent", "RuntimeDirectoryMode": "0755", "RuntimeDirectoryPreserve": "no", "RuntimeMaxUSec": "infinity", "RuntimeRandomizedExtraUSec": "0", "SameProcessGroup": "no", "SecureBits": "0", "SendSIGHUP": "no", "SendSIGKILL": "yes", "SetLoginEnvironment": "no", "Slice": "system.slice", "StandardError": "inherit", "StandardInput": "null", "StandardOutput": "journal", "StartLimitAction": "none", "StartLimitBurst": "5", "StartLimitIntervalUSec": "10s", "StartupBlockIOWeight": "[not set]", "StartupCPUShares": "[not set]", "StartupCPUWeight": "[not set]", "StartupIOWeight": "[not set]", "StartupMemoryHigh": "infinity", "StartupMemoryLow": "0", "StartupMemoryMax": "infinity", "StartupMemorySwapMax": "infinity", "StartupMemoryZSwapMax": "infinity", "StateChangeTimestamp": "Sat 2026-05-23 21:05:05 PDT", "StateChangeTimestampMonotonic": "6599729872414", "StateDirectoryMode": "0755", "StatusErrno": "0", "StopWhenUnneeded": "no", "SubState": "running", "SuccessAction": "none", "SurviveFinalKillSignal": "no", "SyslogFacility": "3", "SyslogLevel": "6", "SyslogLevelPrefix": "yes", "SyslogPriority": "30", "SystemCallErrorNumber": "2147483646", "TTYReset": "no", "TTYVHangup": "no", "TTYVTDisallocate": "no", "TasksAccounting": "yes", "TasksCurrent": "14", "TasksMax": "18884", "TimeoutAbortUSec": "1min 30s", "TimeoutCleanUSec": "infinity", "TimeoutStartFailureMode": "terminate", "TimeoutStartUSec": "1min 30s", "TimeoutStopFailureMode": "terminate", "TimeoutStopUSec": "1min 30s", "TimerSlackNSec": "50000", "Transient": "no", "Type": "simple", "UID": "1014", "UMask": "0022", "UnitFilePreset": "enabled", "UnitFileState": "enabled", "User": "audit-openclaw", "UtmpMode": "init", "WantedBy": "multi-user.target", "WatchdogSignal": "6", "WatchdogTimestampMonotonic": "0", "WatchdogUSec": "0", "WorkingDirectory": "/home/audit-openclaw/workspace"}}
+
+TASK [Wait for gateway port to be listening] ***********************************
+ok: [wolf.tailf7742d.ts.net -> localhost] => {"changed": false, "elapsed": 24, "match_groupdict": {}, "match_groups": [], "path": null, "port": 40612, "search_regex": null, "state": "started"}
+
+TASK [Read gateway authentication token from config file] **********************
+ok: [wolf.tailf7742d.ts.net] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
+
+TASK [Parse gateway token from config] *****************************************
+ok: [wolf.tailf7742d.ts.net] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
+
+TASK [Validate gateway token format] *******************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "gateway_token_result_stdout is not defined or gateway_token_result_stdout | length < 32 or not (gateway_token_result_stdout is regex('^[a-zA-Z0-9_-]+$'))", "skip_reason": "Conditional result was False"}
+
+TASK [Copy device pairing script] **********************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "checksum": "de98a7e90a1640675b8454bf6b538aa34650626e", "dest": "/home/audit-openclaw/pair_device.mjs", "gid": 1014, "group": "audit-openclaw", "md5sum": "dad2220cdb88526b9d9855e07fcceaaa", "mode": "0700", "owner": "audit-openclaw", "size": 5993, "src": "/home/xclm/.ansible/tmp/ansible-tmp-1779595532.2782943-1527681-175401960827757/.source.mjs", "state": "file", "uid": 1014}
+
+TASK [Install ws package for pairing script] ***********************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "cmd": ["npm", "install", "ws"], "delta": "0:00:00.431689", "end": "2026-05-23 21:05:33.955469", "msg": "", "rc": 0, "start": "2026-05-23 21:05:33.523780", "stderr": "", "stderr_lines": [], "stdout": "\nadded 1 package in 354ms", "stdout_lines": ["", "added 1 package in 354ms"]}
+
+TASK [Run device pairing via localhost] ****************************************
+changed: [wolf.tailf7742d.ts.net] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": true}
+
+TASK [Parse device credentials] ************************************************
+ok: [wolf.tailf7742d.ts.net] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
+
+TASK [Validate device credentials] *********************************************
+skipping: [wolf.tailf7742d.ts.net] => {"changed": false, "false_condition": "device_credentials.deviceToken is not defined or device_credentials.deviceToken | length < 10", "skip_reason": "Conditional result was False"}
+
+TASK [Clean up pairing script] *************************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "path": "/home/audit-openclaw/pair_device.mjs", "state": "absent"}
+
+TASK [Clean up node_modules from pairing] **************************************
+changed: [wolf.tailf7742d.ts.net] => {"changed": true, "path": "/home/audit-openclaw/node_modules", "state": "absent"}
+
+TASK [Save all credentials to fact for retrieval] ******************************
+ok: [wolf.tailf7742d.ts.net] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
+
+PLAY RECAP *********************************************************************
+wolf.tailf7742d.ts.net     : ok=32   changed=16   unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
+
+Success! openclaw v2026.4.2 installed as 'audit-openclaw' on wolf-i
+```
+Exit: `0`
+
+
+### Intermediate state — `clm agent ps` after install, before configure (W8)
+
+Captured immediately after the three installs above, with no configure
+or start yet applied to any audit-* agent. Surfaces the post-install
+status of each agent type so Bundle 5 can diff state transitions
+directly.
+
+### `clm agent ps`
+
+```console
+$ clm agent ps
+
+
+                                                       Agent Fleet Status                                                       
+┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Name           ┃ Agent Type ┃ Provider   ┃ Host   ┃ Address                ┃ Port  ┃ Version  ┃ Status          ┃ Installed  ┃
+┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+│ audit-hermes   │ hermes     │ -          │ wolf-i │ wolf.tailf7742d.ts.net │ -     │ 2026.5.7 │ pending onboard │ 2026-05-24 │
+│ audit-openclaw │ openclaw   │ -          │ wolf-i │ wolf.tailf7742d.ts.net │ 40612 │ 2026.4.2 │ running         │ 2026-05-24 │
+│ audit-zeroclaw │ zeroclaw   │ -          │ wolf-i │ wolf.tailf7742d.ts.net │ -     │ 0.7.5    │ pending onboard │ 2026-05-24 │
+│ clawrium-d01   │ zeroclaw   │ openrouter │ wolf-i │ wolf.tailf7742d.ts.net │ 41429 │ 0.7.5    │ running         │ 2026-05-19 │
+│ espresso       │ hermes     │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 41583 │ 2026.5.7 │ running         │ 2026-05-11 │
+│ maurice        │ hermes     │ openrouter │ wolf-i │ wolf.tailf7742d.ts.net │ 40317 │ 2026.5.7 │ running         │ 2026-05-22 │
+│ nemotron-alpha │ zeroclaw   │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 40919 │ 0.7.5    │ running         │ 2026-05-22 │
+│ nemotron-beta  │ zeroclaw   │ ollama     │ wolf-i │ wolf.tailf7742d.ts.net │ 40971 │ 0.7.5    │ running         │ 2026-05-20 │
+│ wolf-i         │ openclaw   │ bedrock    │ wolf-i │ wolf.tailf7742d.ts.net │ 40198 │ 2026.4.2 │ running         │ 2026-04-11 │
+└────────────────┴────────────┴────────────┴────────┴────────────────────────┴───────┴──────────┴─────────────────┴────────────┘
+
+
+audit-hermes on wolf-i:
+  No onboarding data available
+
+audit-zeroclaw on wolf-i:
+  No onboarding data available
+```
+Exit: `0`
+
+
+### `clm agent open <a>` baseline (B4)
+
+`clm agent open` does **not** exist in v26.5.2 — the AGENTS.md
+reference is forward-looking (likely part of issue #435's surface).
+Captured below as the baseline so Bundle 5's `clawctl agent open`
+introductions diff cleanly against three explicit `No such command`
+errors. Captured against `audit-zeroclaw` (zeroclaw, running),
+`audit-hermes` (hermes, configured/`ready (stopped)`), and
+`audit-openclaw` (openclaw, install-started, no onboarding).
+
+### `clm agent open audit-zeroclaw`
+
+```console
+$ clm agent open audit-zeroclaw
+Usage: clm agent [OPTIONS] COMMAND [ARGS]...
+Try 'clm agent --help' for help.
+╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ No such command 'open'.                                                                                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+Exit: `2`
+
+### `clm agent open audit-hermes`
+
+```console
+$ clm agent open audit-hermes
+Usage: clm agent [OPTIONS] COMMAND [ARGS]...
+Try 'clm agent --help' for help.
+╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ No such command 'open'.                                                                                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+Exit: `2`
+
+### `clm agent open audit-openclaw`
+
+```console
+$ clm agent open audit-openclaw
+Usage: clm agent [OPTIONS] COMMAND [ARGS]...
+Try 'clm agent --help' for help.
+╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ No such command 'open'.                                                                                                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+Exit: `2`
+
+
+**Capture end (iter2, UTC):** 2026-05-24T04:14:27Z
 

--- a/.itx/506/01_EXECUTION.md
+++ b/.itx/506/01_EXECUTION.md
@@ -1,0 +1,12 @@
+## Execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-24T03:25:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 506
+```
+
+**Output**: Captures wolf-i fleet audit baseline to `.itx/435/audit-before.md`. Bundle 1 of issue #435 (clawctl kubectl-style UX). No code changes — verbatim transcript only. PR opened against integration branch `feat/435-clawctl-ux`.

--- a/.itx/506/atx-session.json
+++ b/.itx/506/atx-session.json
@@ -1,0 +1,10 @@
+{
+  "session_id": null,
+  "transport": "cli",
+  "commit_sha": "e2d2b4833616783dcc812164d69587d31e7a56f1",
+  "iteration": 0,
+  "last_rating": null,
+  "last_blockers": [],
+  "started_at": "2026-05-24T03:43:30Z",
+  "updated_at": "2026-05-24T03:43:30Z"
+}

--- a/.itx/506/atx-session.json
+++ b/.itx/506/atx-session.json
@@ -1,10 +1,11 @@
 {
-  "session_id": null,
+  "session_id": "217d1015-59e0-434b-ac89-3eb09ec8e346",
+  "task_id_iter_1": "27907d34-c29b-4e61-8082-fdb6086c83d0",
   "transport": "cli",
-  "commit_sha": "e2d2b4833616783dcc812164d69587d31e7a56f1",
-  "iteration": 0,
-  "last_rating": null,
-  "last_blockers": [],
-  "started_at": "2026-05-24T03:43:30Z",
-  "updated_at": "2026-05-24T03:43:30Z"
+  "commit_sha": "2f7b7ba82063e39788a04f8d0044207135192bc5",
+  "iteration": 1,
+  "last_rating": 2,
+  "last_blockers": ["B1", "B2", "B3", "B4", "B5", "B6"],
+  "started_at": "2026-05-24T03:24:13Z",
+  "updated_at": "2026-05-24T04:00:44Z"
 }

--- a/.itx/506/atx-session.json
+++ b/.itx/506/atx-session.json
@@ -1,11 +1,15 @@
 {
-  "session_id": "217d1015-59e0-434b-ac89-3eb09ec8e346",
+  "session_id_iter_1": "217d1015-59e0-434b-ac89-3eb09ec8e346",
   "task_id_iter_1": "27907d34-c29b-4e61-8082-fdb6086c83d0",
+  "session_id_iter_2": "6daef740-3880-4412-b715-bedfb3190251",
+  "task_id_iter_2": "a21bb380-67b9-44ba-b2c2-d6718c7ea4db",
   "transport": "cli",
-  "commit_sha": "2f7b7ba82063e39788a04f8d0044207135192bc5",
-  "iteration": 1,
-  "last_rating": 2,
-  "last_blockers": ["B1", "B2", "B3", "B4", "B5", "B6"],
+  "commit_sha": "bfc0b4dc1299fa5af8a01afa3bb24072a6cabe6f",
+  "iteration": 2,
+  "last_rating": 4,
+  "last_blockers": [],
+  "remaining_warnings": ["W4-partial-iter2-addendum (fixed in iter2-cleanup commit)", "W-new-1-B4-state-prose (fixed)", "W-new-2-bare-logs-baseline (deferred to Bundle 5 PR per ATX recommendation)"],
+  "merge_eligible": true,
   "started_at": "2026-05-24T03:24:13Z",
-  "updated_at": "2026-05-24T04:00:44Z"
+  "updated_at": "2026-05-24T04:22:01Z"
 }

--- a/.itx/507/01_EXECUTION.md
+++ b/.itx/507/01_EXECUTION.md
@@ -1,0 +1,32 @@
+# Issue #507 — Bundle 2: clawctl foundation + service/meta commands
+
+GitHub: https://github.com/ric03uec/clawrium/issues/507
+
+Parent: #435 — clawctl kubectl-style UX
+
+---
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-24T03:30:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx:execute 507 --pr-base=feat/435-clawctl-ux
+```
+
+**Output**: Bundle 2 foundation landed:
+
+1. `pyproject.toml` — `[project.scripts]` renamed from `clm = "clawrium.cli.main:app"` to `clawctl = "clawrium.cli:app"`. Clean break, no alias.
+2. `src/clawrium/cli/__init__.py` — new top-level `clawctl` Typer app. Registers `service`, `version`, `completion`, `tui`, `gui`, `host`, `agent`, `provider`, `channel`, `integration`, `skill`, `mcp` (plan §4 surface complete; closes Risk R2).
+3. `src/clawrium/cli/output/{table,json_yaml,stream,errors,age,status}.py` — shared rendering primitives implementing the plan §6 output contract.
+4. `src/clawrium/cli/service.py` — `service init` (delegates to existing init), `service start|stop|snapshot` (placeholder stubs).
+5. `src/clawrium/cli/meta.py` — `version` + `completion <bash|zsh|fish>` (uses Click's `shell_completion`).
+6. `src/clawrium/cli/clawctl/{host,agent,provider,channel,integration,skill,mcp}.py` — stub group apps. Each verb prints `Not implemented: <group> <verb>` exit 0. Living under a sub-package avoids name collisions with legacy `cli/host.py`, `cli/agent.py` etc. that still serve the `clm` test surface.
+7. `tests/cli/output/` + `tests/cli/test_service.py` + `tests/cli/test_meta.py` + `tests/cli/test_app.py` — 82 new tests covering the plan §"Specific Outcomes to Validate" assertions.
+
+Verification: `uv run pytest -q` → 2660 passed, 6 skipped (was 2578 + 6). `uv run ruff check src tests` → all checks passed. Legacy `clm` Typer app at `clawrium.cli.main:app` unchanged; legacy tests continue to pass.
+
+`make format` was NOT run repo-wide — it would reformat ~66 unrelated files (pre-existing drift), violating the `clawrium.core.*` untouched guardrail. Only the new files (already ruff-format-clean) are touched.

--- a/.itx/507/atx-session.json
+++ b/.itx/507/atx-session.json
@@ -1,57 +1,118 @@
 {
-  "task_id_iter_1": "446de768-7641-4906-947d-b9bd84cca25e",
   "transport": "cli",
-  "commit_sha_iter_1": "1f3ded4",
-  "iteration": 1,
-  "last_rating_iter_1": 2,
-  "blockers_iter_1": [
+  "iterations": [
     {
-      "id": "B1",
-      "location": "src/clawrium/cli/output/errors.py:32,36",
-      "issue": "emit_error writes message/hint to stderr without bidi-strip",
-      "status": "fixed in 23df959 — sanitize() applied to both args"
+      "iteration": 1,
+      "task_id": "446de768-7641-4906-947d-b9bd84cca25e",
+      "commit_sha": "1f3ded4",
+      "rating_overall": null,
+      "specialists_completed": ["security-reviewer"],
+      "specialists_failed": [
+        "test-coverage-reviewer",
+        "cli-ux-reviewer",
+        "core-lifecycle-reviewer"
+      ],
+      "blockers": [
+        {
+          "id": "B1",
+          "location": "src/clawrium/cli/output/errors.py:32,36",
+          "issue": "emit_error writes message/hint without bidi-strip",
+          "fix_commit": "23df959"
+        },
+        {
+          "id": "B2",
+          "location": "src/clawrium/cli/output/stream.py:68",
+          "issue": "stream_action writes resource/message without sanitization",
+          "fix_commit": "23df959"
+        }
+      ],
+      "warnings_fixed": ["W1 (table.render cell sanitization)", "W2 (dump_name sanitization)"],
+      "suggestions_deferred": [
+        "S1 (NDJSONStreamer extra-kwargs) → bundle 3 audit point"
+      ],
+      "cost_usd": 1.15932235,
+      "duration_ms": 515289
     },
     {
-      "id": "B2",
-      "location": "src/clawrium/cli/output/stream.py:68",
-      "issue": "stream_action writes resource/message to stdout without sanitization",
-      "status": "fixed in 23df959 — sanitize() applied to both args"
-    }
-  ],
-  "warnings_iter_1": [
-    {
-      "id": "W1",
-      "location": "src/clawrium/cli/output/table.py:38-39",
-      "issue": "render() does not sanitize cells; drift trap",
-      "status": "fixed in 23df959 — sanitize() applied to headers + cells; docstring updated"
+      "iteration": 2,
+      "task_id": "fdc4ce99-... (see /tmp/atx-iter2.json)",
+      "commit_sha": "23df959",
+      "rating_overall": 2,
+      "specialists_completed": [
+        "security-reviewer",
+        "test-coverage-reviewer",
+        "cli-ux-reviewer",
+        "core-lifecycle-reviewer",
+        "ansible-registry-reviewer"
+      ],
+      "specialists_failed": [],
+      "ratings": {
+        "security": 2,
+        "test-coverage": 2,
+        "cli-ux": 2,
+        "core-lifecycle": 3,
+        "ansible-registry": 4
+      },
+      "blockers": [
+        {
+          "id": "B-sec/cli-ux",
+          "location": "src/clawrium/cli/output/_sanitize.py:36-42",
+          "issue": "Literal Unicode bytes in regex char class violates own \\uXXXX-only contract",
+          "fix_commit": "4266803"
+        },
+        {
+          "id": "B-test-corpus",
+          "location": "tests/cli/output/test_sanitize.py:26-45",
+          "issue": "BIDI_AND_CONTROL corpus omits LRE/RLE/PDF/LRO/ZWNJ/ZWJ (6 codepoints)",
+          "fix_commit": "4266803"
+        },
+        {
+          "id": "B-test-emit-event",
+          "location": "tests/cli/output/test_sanitize.py + stream.py",
+          "issue": "emit_event() + dump_json() have no ensure_ascii property test",
+          "fix_commit": "4266803"
+        },
+        {
+          "id": "B-cli-ux-clm-removal",
+          "location": "pyproject.toml:41",
+          "issue": "cli-ux recommended restoring clm alias for deprecation window",
+          "fix_commit": "DECLINED",
+          "rationale": "Issue #507 explicitly requires 'No alias, no deprecation, clm is fully off PATH'. The rename is the intended behavior. Documented in PR Callouts."
+        }
+      ],
+      "warnings_fixed": [
+        "W4 hint-only emit_error test",
+        "W5 ensure_ascii=True explicit",
+        "W6 dump_json/dump_yaml bidi tests",
+        "W7 format_status unknown-token sanitization",
+        "W2 (cli-ux) service.py stubs delegate to echo_not_implemented",
+        "S2 (cli-ux) version_cmd docstring/help kwarg parity"
+      ],
+      "suggestions_deferred": [
+        "S1 (NDJSONStreamer extra-kwargs) → bundle 3 audit point",
+        "Architectural lint for sanitize() on new primitives → bundle 3",
+        "AGENTS.md clm→clawctl docs sweep → bundle 5",
+        "agent create vs apply idempotency naming → bundle 3 plan"
+      ],
+      "cost_usd": 4.0569365,
+      "duration_ms": 865689
     },
     {
-      "id": "W2",
-      "location": "src/clawrium/cli/output/json_yaml.py:53",
-      "issue": "dump_name() emits raw kind/name without sanitization",
-      "status": "fixed in 23df959 — sanitize() applied to both"
+      "iteration": 3,
+      "task_id": "caf0acdb-3b16-4ffd-b629-a8ff570e93e0",
+      "commit_sha": "4266803",
+      "status": "timeout",
+      "duration_ms": 900000,
+      "notes": "ATX upstream timed out after 15min. iter-2 blockers all addressed in 4266803. No code-side regression — proceeding to PR per skill's 3-iteration ceiling rule. Manual review during stacked-PR merge will be the final gate."
     }
   ],
-  "suggestions_iter_1": [
-    {
-      "id": "S1",
-      "location": "src/clawrium/cli/output/stream.py:42-52",
-      "issue": "NDJSONStreamer.emit() passes **extra kwargs through without validation; secret leak risk",
-      "status": "deferred to bundle 3 (#508) per ATX recommendation — docstring marks it as future audit point"
-    },
-    {
-      "id": "S2",
-      "location": "src/clawrium/cli/meta.py:67",
-      "issue": "completion_cmd Click ShellComplete call path review",
-      "status": "ATX confirmed clean (Enum constraint = correct mitigation)"
-    }
-  ],
-  "agents_failed_iter_1": [
-    "test-coverage-reviewer",
-    "cli-ux-reviewer",
-    "core-lifecycle-reviewer"
-  ],
-  "agents_failed_note_iter_1": "Three of four agents failed to complete. Only security-reviewer returned full findings. Iter-2 should re-engage the failed agents.",
+  "final_state": {
+    "all_iter1_blockers_fixed": true,
+    "all_iter2_blockers_fixed_or_declined": true,
+    "iter3_status": "infrastructure-timeout",
+    "merge_eligible": true,
+    "note": "iter-3 timeout is upstream ATX infrastructure, not a code-quality signal. Reviewer should evaluate code against iter-1/iter-2 findings and the resolutions documented in the corresponding fix commits."
+  },
   "started_at": "2026-05-24T04:44:47Z",
-  "updated_at": "2026-05-24T04:55:00Z"
+  "updated_at": "2026-05-24T05:35:00Z"
 }

--- a/.itx/507/atx-session.json
+++ b/.itx/507/atx-session.json
@@ -13,29 +13,15 @@
         "core-lifecycle-reviewer"
       ],
       "blockers": [
-        {
-          "id": "B1",
-          "location": "src/clawrium/cli/output/errors.py:32,36",
-          "issue": "emit_error writes message/hint without bidi-strip",
-          "fix_commit": "23df959"
-        },
-        {
-          "id": "B2",
-          "location": "src/clawrium/cli/output/stream.py:68",
-          "issue": "stream_action writes resource/message without sanitization",
-          "fix_commit": "23df959"
-        }
+        {"id": "B1", "issue": "emit_error bidi-strip", "fix_commit": "23df959"},
+        {"id": "B2", "issue": "stream_action bidi-strip", "fix_commit": "23df959"}
       ],
-      "warnings_fixed": ["W1 (table.render cell sanitization)", "W2 (dump_name sanitization)"],
-      "suggestions_deferred": [
-        "S1 (NDJSONStreamer extra-kwargs) → bundle 3 audit point"
-      ],
+      "warnings_fixed": ["W1 table.render", "W2 dump_name"],
       "cost_usd": 1.15932235,
       "duration_ms": 515289
     },
     {
       "iteration": 2,
-      "task_id": "fdc4ce99-... (see /tmp/atx-iter2.json)",
       "commit_sha": "23df959",
       "rating_overall": 2,
       "specialists_completed": [
@@ -45,7 +31,6 @@
         "core-lifecycle-reviewer",
         "ansible-registry-reviewer"
       ],
-      "specialists_failed": [],
       "ratings": {
         "security": 2,
         "test-coverage": 2,
@@ -54,45 +39,10 @@
         "ansible-registry": 4
       },
       "blockers": [
-        {
-          "id": "B-sec/cli-ux",
-          "location": "src/clawrium/cli/output/_sanitize.py:36-42",
-          "issue": "Literal Unicode bytes in regex char class violates own \\uXXXX-only contract",
-          "fix_commit": "4266803"
-        },
-        {
-          "id": "B-test-corpus",
-          "location": "tests/cli/output/test_sanitize.py:26-45",
-          "issue": "BIDI_AND_CONTROL corpus omits LRE/RLE/PDF/LRO/ZWNJ/ZWJ (6 codepoints)",
-          "fix_commit": "4266803"
-        },
-        {
-          "id": "B-test-emit-event",
-          "location": "tests/cli/output/test_sanitize.py + stream.py",
-          "issue": "emit_event() + dump_json() have no ensure_ascii property test",
-          "fix_commit": "4266803"
-        },
-        {
-          "id": "B-cli-ux-clm-removal",
-          "location": "pyproject.toml:41",
-          "issue": "cli-ux recommended restoring clm alias for deprecation window",
-          "fix_commit": "DECLINED",
-          "rationale": "Issue #507 explicitly requires 'No alias, no deprecation, clm is fully off PATH'. The rename is the intended behavior. Documented in PR Callouts."
-        }
-      ],
-      "warnings_fixed": [
-        "W4 hint-only emit_error test",
-        "W5 ensure_ascii=True explicit",
-        "W6 dump_json/dump_yaml bidi tests",
-        "W7 format_status unknown-token sanitization",
-        "W2 (cli-ux) service.py stubs delegate to echo_not_implemented",
-        "S2 (cli-ux) version_cmd docstring/help kwarg parity"
-      ],
-      "suggestions_deferred": [
-        "S1 (NDJSONStreamer extra-kwargs) → bundle 3 audit point",
-        "Architectural lint for sanitize() on new primitives → bundle 3",
-        "AGENTS.md clm→clawctl docs sweep → bundle 5",
-        "agent create vs apply idempotency naming → bundle 3 plan"
+        {"id": "B-sec/cli-ux", "issue": "_sanitize.py literal Unicode bytes", "fix_commit": "4266803"},
+        {"id": "B-test-corpus", "issue": "BIDI_AND_CONTROL omits 6 codepoints", "fix_commit": "4266803"},
+        {"id": "B-test-emit-event", "issue": "emit_event ensure_ascii not tested", "fix_commit": "4266803"},
+        {"id": "B-cli-ux-clm", "issue": "restore clm alias", "fix_commit": "DECLINED", "rationale": "Issue spec mandates clean break"}
       ],
       "cost_usd": 4.0569365,
       "duration_ms": 865689
@@ -101,18 +51,27 @@
       "iteration": 3,
       "task_id": "caf0acdb-3b16-4ffd-b629-a8ff570e93e0",
       "commit_sha": "4266803",
-      "status": "timeout",
-      "duration_ms": 900000,
-      "notes": "ATX upstream timed out after 15min. iter-2 blockers all addressed in 4266803. No code-side regression — proceeding to PR per skill's 3-iteration ceiling rule. Manual review during stacked-PR merge will be the final gate."
+      "status": "completed",
+      "duration_ms": 1164216,
+      "rating_overall": 4,
+      "verdict": "WARNINGS-ONLY, no blockers, all iter-2 blockers confirmed closed, B2 decline accepted",
+      "warnings": [
+        {"id": "W1", "issue": "README.md still references clm in quickstart", "fix_commit": "PENDING"},
+        {"id": "W2", "issue": "yaml.safe_dump does NOT escape LF; docstring claims it does", "fix_commit": "PENDING"},
+        {"id": "W3", "issue": "__init__.py contract table for format_status stale (says N/A)", "fix_commit": "PENDING"},
+        {"id": "W4", "issue": "NDJSONStreamer extra-kwargs no enforcement (advisory for bundle 3)", "fix_commit": "DEFERRED to bundle 3"}
+      ],
+      "suggestions_applied": ["S1 allow_unicode=False", "S2 add \\t\\n\\r to corpus", "S4 emit_event round-trip assertion", "S5 monkeypatch for env isolation"],
+      "merge_gate": "W1+W2+W3 pre-merge; W4 advisory",
+      "client_timeout_note": "atx CLI client timed out at 15min but task continued; final result retrieved via supervisor HTTP API at task_id caf0acdb-3b16-4ffd-b629-a8ff570e93e0"
     }
   ],
   "final_state": {
-    "all_iter1_blockers_fixed": true,
-    "all_iter2_blockers_fixed_or_declined": true,
-    "iter3_status": "infrastructure-timeout",
-    "merge_eligible": true,
-    "note": "iter-3 timeout is upstream ATX infrastructure, not a code-quality signal. Reviewer should evaluate code against iter-1/iter-2 findings and the resolutions documented in the corresponding fix commits."
+    "iter3_rating": 4,
+    "iter3_blockers": 0,
+    "all_warnings_addressed": true,
+    "merge_eligible": true
   },
   "started_at": "2026-05-24T04:44:47Z",
-  "updated_at": "2026-05-24T05:35:00Z"
+  "updated_at": "2026-05-24T08:30:00Z"
 }

--- a/.itx/507/atx-session.json
+++ b/.itx/507/atx-session.json
@@ -1,0 +1,57 @@
+{
+  "task_id_iter_1": "446de768-7641-4906-947d-b9bd84cca25e",
+  "transport": "cli",
+  "commit_sha_iter_1": "1f3ded4",
+  "iteration": 1,
+  "last_rating_iter_1": 2,
+  "blockers_iter_1": [
+    {
+      "id": "B1",
+      "location": "src/clawrium/cli/output/errors.py:32,36",
+      "issue": "emit_error writes message/hint to stderr without bidi-strip",
+      "status": "fixed in 23df959 — sanitize() applied to both args"
+    },
+    {
+      "id": "B2",
+      "location": "src/clawrium/cli/output/stream.py:68",
+      "issue": "stream_action writes resource/message to stdout without sanitization",
+      "status": "fixed in 23df959 — sanitize() applied to both args"
+    }
+  ],
+  "warnings_iter_1": [
+    {
+      "id": "W1",
+      "location": "src/clawrium/cli/output/table.py:38-39",
+      "issue": "render() does not sanitize cells; drift trap",
+      "status": "fixed in 23df959 — sanitize() applied to headers + cells; docstring updated"
+    },
+    {
+      "id": "W2",
+      "location": "src/clawrium/cli/output/json_yaml.py:53",
+      "issue": "dump_name() emits raw kind/name without sanitization",
+      "status": "fixed in 23df959 — sanitize() applied to both"
+    }
+  ],
+  "suggestions_iter_1": [
+    {
+      "id": "S1",
+      "location": "src/clawrium/cli/output/stream.py:42-52",
+      "issue": "NDJSONStreamer.emit() passes **extra kwargs through without validation; secret leak risk",
+      "status": "deferred to bundle 3 (#508) per ATX recommendation — docstring marks it as future audit point"
+    },
+    {
+      "id": "S2",
+      "location": "src/clawrium/cli/meta.py:67",
+      "issue": "completion_cmd Click ShellComplete call path review",
+      "status": "ATX confirmed clean (Enum constraint = correct mitigation)"
+    }
+  ],
+  "agents_failed_iter_1": [
+    "test-coverage-reviewer",
+    "cli-ux-reviewer",
+    "core-lifecycle-reviewer"
+  ],
+  "agents_failed_note_iter_1": "Three of four agents failed to complete. Only security-reviewer returned full findings. Iter-2 should re-engage the failed agents.",
+  "started_at": "2026-05-24T04:44:47Z",
+  "updated_at": "2026-05-24T04:55:00Z"
+}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <img src="docs/assets/clawrium-architecture.png" alt="Clawrium architecture - control node managing agents across hosts" width="100%" />
 </p>
 
-Clawrium uses Ansible under the hood for SSH-based orchestration. You run `clm` from your control machine, which talks to target hosts over SSH. No agents, no containers, no Kubernetes complexity - just processes running on hosts with a unified management layer.
+Clawrium uses Ansible under the hood for SSH-based orchestration. You run `clawctl` from your control machine, which talks to target hosts over SSH. No agents, no containers, no Kubernetes complexity - just processes running on hosts with a unified management layer.
 
 ## Why Clawrium
 
@@ -60,13 +60,13 @@ It is _not_ a hosted platform. There's no dashboard, no SaaS, no account signup.
 
 | Requirement | Why |
 |-------------|-----|
-| Python 3.10+ | Runtime for `clm` CLI |
+| Python 3.10+ | Runtime for `clawctl` CLI |
 | [uv](https://docs.astral.sh/uv/) | Fast Python package installer |
 | SSH access to a remote host | Clawrium manages agents over SSH |
 | API key (Anthropic, OpenAI, etc.) | Agents need inference providers |
 
 <p align="center">
-  <img src="docs/demos/agent-reprovision.gif" alt="Provisioning a new agent with clm" width="100%">
+  <img src="docs/demos/agent-reprovision.gif" alt="Provisioning a new agent with clawctl" width="100%">
 </p>
 
 ### Install & Run
@@ -76,7 +76,7 @@ It is _not_ a hosted platform. There's no dashboard, no SaaS, no account signup.
 uv tool install clawrium
 
 # Or run without installing
-uvx --from clawrium clm --help
+uvx --from clawrium clawctl --help
 ```
 
 For full installation instructions including how to install `uv`, see [docs/installation.md](docs/installation.md).
@@ -85,49 +85,45 @@ For full installation instructions including how to install `uv`, see [docs/inst
 
 ```bash
 # Initialize config
-clm init
+clawctl service init
 # → Created /home/user/.config/clawrium/config.yaml
 
-# Set up SSH to your host
-clm host init 192.168.1.100 --user myuser
+# Set up SSH to your host (one step — bootstrap key + add)
+clawctl host create 192.168.1.100 --user myuser --alias worker-1 --bootstrap
 # → Checking SSH connectivity...
 # → SSH key copied to 192.168.1.100
-
-# Add the host to your fleet
-clm host add 192.168.1.100 --alias worker-1
 # → Host 'worker-1' added
 
-# Add an inference provider
-clm provider add anthropic --type anthropic
-# → Enter API key: ********
+# Register an inference provider
+clawctl provider registry create anthropic --type anthropic --api-key-stdin
 # → Provider 'anthropic' configured
 
 # Install OpenClaw agent
-clm agent install --type openclaw --host worker-1 --name my-assistant
+clawctl agent create my-assistant --type openclaw --host worker-1 --provider anthropic
 # → Installing openclaw on worker-1...
 # → Agent 'my-assistant' installed
 
 # Configure and start
-clm agent configure my-assistant
-clm agent start my-assistant
+clawctl agent configure my-assistant
+clawctl agent start my-assistant
 # → Agent 'my-assistant' started
 
 # Check fleet status
-clm ps
-# NAME           TYPE      PROVIDER  HOST      STATUS   UPTIME
-# my-assistant   openclaw  openai    worker-1  running  2m
+clawctl agent get
+# NAME           TYPE       HOST       PROVIDER    STATUS    AGE
+# my-assistant   openclaw   worker-1   anthropic   running   2m
 
 # Chat with your agent
-clm chat my-assistant
+clawctl agent chat my-assistant
 # → Connected to my-assistant
 # → Type your message...
 
 # Or open the local web dashboard
-clm gui
+clawctl gui
 # → Clawrium GUI starting on http://127.0.0.1:36000 — press Ctrl+C to stop
 ```
 
-**You should see:** A running agent in `clm ps` output with status `running`.
+**You should see:** A running agent in `clawctl agent get` output with status `running`.
 
 **→ Full setup guide: [ric03uec.github.io/clawrium](https://ric03uec.github.io/clawrium/)**
 
@@ -153,7 +149,7 @@ Other Linux distributions may work, but they are not currently part of the test 
 
 [OpenClaw](https://github.com/openclaw/openclaw) is officially supported and tested end-to-end.
 
-[Hermes](https://github.com/NousResearch/hermes-agent) (Nous Research) is supported in `🚧 In Development` status — install, configure, and a local OpenAI-compatible HTTP API on `127.0.0.1:8642` are wired end-to-end. `clm chat` and external messaging gateways are not yet supported for hermes. See the [Hermes Support Matrix](https://ric03uec.github.io/clawrium/docs/agent-support/hermes) for details.
+[Hermes](https://github.com/NousResearch/hermes-agent) (Nous Research) is supported in `🚧 In Development` status — install, configure, and a local OpenAI-compatible HTTP API on `127.0.0.1:8642` are wired end-to-end. `clawctl agent chat` and external messaging gateways are not yet supported for hermes. See the [Hermes Support Matrix](https://ric03uec.github.io/clawrium/docs/agent-support/hermes) for details.
 
 Additional agent types are planned.
 
@@ -173,7 +169,7 @@ No. Clawrium does not require Docker or Kubernetes. It manages agent processes o
 
 ### 6. Can I manage multiple hosts with different agent types?
 
-Yes. You can register multiple hosts and run different agent types on each host from the same `clm` control node.
+Yes. You can register multiple hosts and run different agent types on each host from the same `clawctl` control node.
 
 ### 7. Why doesn't it support x-agent and y-feature?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 ]
 
 [project.scripts]
-clm = "clawrium.cli.main:app"
+clawctl = "clawrium.cli:app"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/clawrium/cli/__init__.py
+++ b/src/clawrium/cli/__init__.py
@@ -1,1 +1,111 @@
-"""CLI commands for Clawrium."""
+"""`clawctl` — the kubectl-style CLI for Clawrium.
+
+This module exports `app`, the top-level Typer entrypoint wired to the
+`clawctl` script in `pyproject.toml`. The legacy `clm` CLI continues
+to live at `clawrium.cli.main:app` and is still imported by the
+existing test suite — the two coexist while bundles 3-5 (#508, #509,
+#510) replace the underlying implementations one verb-group at a time.
+
+Plan §4 lists the complete group surface; this module registers every
+group declared there so bundles 3-4 can fill in module internals
+without touching `cli/__init__.py` (closes Risk R2 from the plan).
+"""
+
+import typer
+
+from clawrium import __version__
+from clawrium.cli.clawctl.agent import agent_app
+from clawrium.cli.clawctl.channel import channel_app
+from clawrium.cli.clawctl.host import host_app
+from clawrium.cli.clawctl.integration import integration_app
+from clawrium.cli.clawctl.mcp import mcp_app
+from clawrium.cli.clawctl.provider import provider_app
+from clawrium.cli.clawctl.skill import skill_app
+from clawrium.cli.meta import completion_cmd, version_cmd
+from clawrium.cli.service import service_app
+
+__all__ = ["app"]
+
+
+app = typer.Typer(
+    name="clawctl",
+    help=(
+        "clawctl — manage your AI assistant fleet, kubectl-style.\n\n"
+        "Run 'clawctl <group> --help' for group-specific options."
+    ),
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+@app.callback(invoke_without_command=True)
+def _root(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        False,
+        "--version",
+        help="Show clawctl version and exit.",
+        is_eager=True,
+    ),
+) -> None:
+    """clawctl root callback — handles `--version` and falls through to subcommands."""
+    if version:
+        typer.echo(f"clawctl {__version__}")
+        raise typer.Exit(code=0)
+    # Otherwise Typer dispatches to the chosen subcommand. When no
+    # subcommand is given Typer prints help (no_args_is_help=True).
+
+
+# Meta verbs: `version` and `completion`.
+app.command(name="version", help="Show clawctl version and exit.")(version_cmd)
+app.command(name="completion", help="Emit a shell-completion script.")(completion_cmd)
+
+
+# `tui` and `gui` are rebrand wrappers — they delegate to the same
+# implementations the legacy `clm` CLI used. No behavioural change.
+@app.command(name="tui", help="Launch the interactive TUI dashboard.")
+def tui_cmd() -> None:
+    """Launch the Clawrium TUI dashboard."""
+    try:
+        from clawrium.cli.tui import launch_tui
+    except ImportError:
+        typer.echo(
+            "Error: TUI requires textual. Reinstall with: "
+            "uv tool install --force clawrium",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    launch_tui()
+
+
+@app.command(name="gui", help="Launch the local web GUI dashboard.")
+def gui_cmd(
+    port: int = typer.Option(
+        36000,
+        "--port",
+        "-p",
+        min=1,
+        max=65535,
+        help="Local TCP port to bind (1-65535).",
+    ),
+    no_open: bool = typer.Option(
+        False,
+        "--no-open",
+        help="Skip auto-opening the browser. Useful for headless/SSH sessions.",
+    ),
+) -> None:
+    """Launch the local web GUI dashboard (binds to 127.0.0.1 only)."""
+    from clawrium.cli.gui import gui as _gui_impl
+
+    _gui_impl(port=port, no_open=no_open)
+
+
+# Group registrations. Order here drives `--help` listing.
+app.add_typer(service_app, name="service")
+app.add_typer(host_app, name="host")
+app.add_typer(agent_app, name="agent")
+app.add_typer(provider_app, name="provider")
+app.add_typer(channel_app, name="channel")
+app.add_typer(integration_app, name="integration")
+app.add_typer(skill_app, name="skill")
+app.add_typer(mcp_app, name="mcp")

--- a/src/clawrium/cli/clawctl/__init__.py
+++ b/src/clawrium/cli/clawctl/__init__.py
@@ -1,0 +1,18 @@
+"""Stub group apps for `clawctl` noun-groups.
+
+Each module in this package exports a Typer app for one top-level noun
+(`host`, `agent`, `provider`, `channel`, `integration`, `skill`, `mcp`).
+This bundle (#507) only registers the groups and stubs their verbs;
+real implementations land in bundles 3-4 (#508, #509) by editing the
+respective module files.
+
+The convention for stub verbs is `not_implemented(group, verb)` — a
+helper from `_stub` that prints `Not implemented: <group> <verb>` and
+exits 0. This matches today's `clm snapshot` placeholder behavior.
+
+Living under `clawrium.cli.clawctl.*` (not `clawrium.cli.*`) is
+deliberate: the legacy `clm` CLI keeps its modules at `clawrium.cli.*`
+(`cli/agent.py`, `cli/host.py`, etc.) and is still imported by the
+existing test suite. Splitting namespaces keeps bundle 2 from touching
+any legacy code path.
+"""

--- a/src/clawrium/cli/clawctl/_stub.py
+++ b/src/clawrium/cli/clawctl/_stub.py
@@ -1,0 +1,37 @@
+"""Shared helpers for the `clawctl` stub group commands.
+
+The wording `Not implemented: <group> <verb>` is the single contract
+asserted in tests (see plan §"Specific Outcomes to Validate"). Keeping
+it in one place means bundles 3/4 can replace stubs verb-by-verb
+without drifting the message.
+"""
+
+import typer
+
+__all__ = ["echo_not_implemented", "register_stub"]
+
+
+def echo_not_implemented(group: str, verb: str) -> None:
+    """Print the canonical placeholder line. Exit 0."""
+    typer.echo(f"Not implemented: {group} {verb}")
+
+
+def register_stub(
+    app: typer.Typer,
+    *,
+    group: str,
+    verb: str,
+    help_text: str = "",
+) -> None:
+    """Register a `<verb>` command on `app` that emits the placeholder.
+
+    Used by the per-group stub modules so the surface visible in
+    `clawctl <group> --help` matches the planned §4 verb list, even
+    before bundles 3-4 wire up the real logic.
+    """
+
+    def _stub() -> None:
+        echo_not_implemented(group, verb)
+
+    _stub.__doc__ = help_text or f"{verb} (not yet implemented)"
+    app.command(name=verb)(_stub)

--- a/src/clawrium/cli/clawctl/agent.py
+++ b/src/clawrium/cli/clawctl/agent.py
@@ -1,0 +1,50 @@
+"""`clawctl agent` — Pattern B target (stub surface for bundle 2).
+
+Real implementation lands in bundles 3-4 (#508, #509). This bundle
+only registers the verb surface so `clawctl agent --help` lists the
+planned commands from plan §4.
+"""
+
+import typer
+
+from clawrium.cli.clawctl._stub import register_stub
+
+__all__ = ["agent_app"]
+
+
+agent_app = typer.Typer(
+    name="agent",
+    help="Manage AI assistant instances (agents).",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+_GROUP = "agent"
+_VERBS = (
+    ("create", "Install an agent on a host."),
+    ("get", "List agents."),
+    ("describe", "Describe an agent."),
+    ("delete", "Delete an agent."),
+    ("edit", "Edit an agent record."),
+    ("configure", "Configure an agent non-interactively."),
+    ("start", "Start an agent."),
+    ("stop", "Stop an agent."),
+    ("restart", "Restart an agent."),
+    ("sync", "Flush local control-plane state to the agent."),
+    ("logs", "Stream agent logs."),
+    ("chat", "Chat with an agent."),
+    ("open", "Open the agent's web UI in a browser."),
+    ("port-forward", "Forward a local port to the agent."),
+    ("exec", "Execute a command on the agent host (placeholder)."),
+    ("secret", "Manage per-agent secrets."),
+    ("memory", "Manage per-agent memory files."),
+    ("provider", "Attach/detach providers to/from an agent."),
+    ("channel", "Attach/detach channels to/from an agent."),
+    ("integration", "Attach/detach integrations to/from an agent."),
+    ("skill", "Attach/detach skills to/from an agent."),
+    ("registry", "Read-only agent-types catalog."),
+)
+
+for _verb, _help in _VERBS:
+    register_stub(agent_app, group=_GROUP, verb=_verb, help_text=_help)

--- a/src/clawrium/cli/clawctl/channel.py
+++ b/src/clawrium/cli/clawctl/channel.py
@@ -1,0 +1,42 @@
+"""`clawctl channel` — Pattern A attachable (NEW noun; stub for bundle 2).
+
+Real implementation lands in bundle 4 (#509). Plan §8 documents the
+schema and the Discord/Slack-extraction goal driving the new top-level
+noun.
+"""
+
+import typer
+
+from clawrium.cli.clawctl._stub import register_stub
+
+__all__ = ["channel_app"]
+
+
+channel_app = typer.Typer(
+    name="channel",
+    help="Chat surfaces (Discord, Slack) (Pattern A attachable).",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+channel_registry_app = typer.Typer(
+    name="registry",
+    help="CRUD entrypoint for the channel registry.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+_GROUP = "channel registry"
+_VERBS = (
+    ("create", "Register a channel."),
+    ("get", "List registered channels."),
+    ("describe", "Describe a channel."),
+    ("delete", "Delete a channel."),
+    ("edit", "Edit a channel."),
+)
+
+for _verb, _help in _VERBS:
+    register_stub(channel_registry_app, group=_GROUP, verb=_verb, help_text=_help)
+
+channel_app.add_typer(channel_registry_app, name="registry")

--- a/src/clawrium/cli/clawctl/host.py
+++ b/src/clawrium/cli/clawctl/host.py
@@ -1,0 +1,38 @@
+"""`clawctl host` — Pattern B target (stub surface for bundle 2).
+
+Real implementation lands in bundle 3 (#508). This bundle only
+registers the verb surface so `clawctl host --help` lists the planned
+commands from plan §4 and each one prints the placeholder line.
+"""
+
+import typer
+
+from clawrium.cli.clawctl._stub import register_stub
+
+__all__ = ["host_app"]
+
+
+host_app = typer.Typer(
+    name="host",
+    help="Manage fleet machines (hosts).",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+_GROUP = "host"
+_VERBS = (
+    ("create", "Create a host record."),
+    ("get", "List hosts."),
+    ("describe", "Describe a host."),
+    ("delete", "Delete a host record."),
+    ("edit", "Edit a host record."),
+    ("reset", "Wipe remote state on a host."),
+    ("alias", "Manage host aliases (multi-value)."),
+    ("address", "Manage host addresses."),
+    ("label", "Manage host labels."),
+    ("registry", "Read-only host-types catalog."),
+)
+
+for _verb, _help in _VERBS:
+    register_stub(host_app, group=_GROUP, verb=_verb, help_text=_help)

--- a/src/clawrium/cli/clawctl/integration.py
+++ b/src/clawrium/cli/clawctl/integration.py
@@ -1,0 +1,40 @@
+"""`clawctl integration` — Pattern A attachable (stub for bundle 2).
+
+Real implementation lands in bundle 4 (#509).
+"""
+
+import typer
+
+from clawrium.cli.clawctl._stub import register_stub
+
+__all__ = ["integration_app"]
+
+
+integration_app = typer.Typer(
+    name="integration",
+    help="External service integrations (Pattern A attachable).",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+integration_registry_app = typer.Typer(
+    name="registry",
+    help="CRUD entrypoint for the integration registry.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+_GROUP = "integration registry"
+_VERBS = (
+    ("create", "Register an integration."),
+    ("get", "List registered integrations."),
+    ("describe", "Describe an integration."),
+    ("delete", "Delete an integration."),
+    ("edit", "Edit an integration."),
+)
+
+for _verb, _help in _VERBS:
+    register_stub(integration_registry_app, group=_GROUP, verb=_verb, help_text=_help)
+
+integration_app.add_typer(integration_registry_app, name="registry")

--- a/src/clawrium/cli/clawctl/mcp.py
+++ b/src/clawrium/cli/clawctl/mcp.py
@@ -1,0 +1,38 @@
+"""`clawctl mcp` — Pattern A attachable (PLACEHOLDER; bundle 2 stub).
+
+Per plan §4 the entire `mcp` group is a placeholder for now. Bundle 4
+keeps it as a placeholder pending a separate MCP design.
+"""
+
+import typer
+
+from clawrium.cli.clawctl._stub import register_stub
+
+__all__ = ["mcp_app"]
+
+
+mcp_app = typer.Typer(
+    name="mcp",
+    help="MCP servers (Pattern A attachable; placeholder).",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+mcp_registry_app = typer.Typer(
+    name="registry",
+    help="Read-only entrypoint for the MCP registry (placeholder).",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+_GROUP = "mcp registry"
+_VERBS = (
+    ("get", "List registered MCP servers."),
+    ("describe", "Describe an MCP server."),
+)
+
+for _verb, _help in _VERBS:
+    register_stub(mcp_registry_app, group=_GROUP, verb=_verb, help_text=_help)
+
+mcp_app.add_typer(mcp_registry_app, name="registry")

--- a/src/clawrium/cli/clawctl/provider.py
+++ b/src/clawrium/cli/clawctl/provider.py
@@ -1,0 +1,43 @@
+"""`clawctl provider` — Pattern A attachable (stub surface for bundle 2).
+
+Real implementation lands in bundle 4 (#509). This bundle registers
+the nested `registry` subgroup as the only CRUD entrypoint, per plan
+§3 / §4.
+"""
+
+import typer
+
+from clawrium.cli.clawctl._stub import register_stub
+
+__all__ = ["provider_app"]
+
+
+provider_app = typer.Typer(
+    name="provider",
+    help="Inference backend providers (Pattern A attachable).",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+provider_registry_app = typer.Typer(
+    name="registry",
+    help="CRUD entrypoint for the provider registry.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+_GROUP = "provider registry"
+_VERBS = (
+    ("create", "Register a provider."),
+    ("get", "List registered providers."),
+    ("describe", "Describe a provider."),
+    ("delete", "Delete a provider."),
+    ("edit", "Edit a provider."),
+    ("refresh", "Refresh provider models / metadata."),
+)
+
+for _verb, _help in _VERBS:
+    register_stub(provider_registry_app, group=_GROUP, verb=_verb, help_text=_help)
+
+provider_app.add_typer(provider_registry_app, name="registry")

--- a/src/clawrium/cli/clawctl/skill.py
+++ b/src/clawrium/cli/clawctl/skill.py
@@ -1,0 +1,38 @@
+"""`clawctl skill` — Pattern A attachable (read-only registry; stub).
+
+Real implementation lands in bundle 4 (#509). Skills are repo-bundled
+so the registry is read-only (`get` / `describe`).
+"""
+
+import typer
+
+from clawrium.cli.clawctl._stub import register_stub
+
+__all__ = ["skill_app"]
+
+
+skill_app = typer.Typer(
+    name="skill",
+    help="Skills catalog (Pattern A attachable, read-only).",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+skill_registry_app = typer.Typer(
+    name="registry",
+    help="Read-only entrypoint for the skill registry.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+_GROUP = "skill registry"
+_VERBS = (
+    ("get", "List available skills."),
+    ("describe", "Describe a skill."),
+)
+
+for _verb, _help in _VERBS:
+    register_stub(skill_registry_app, group=_GROUP, verb=_verb, help_text=_help)
+
+skill_app.add_typer(skill_registry_app, name="registry")

--- a/src/clawrium/cli/meta.py
+++ b/src/clawrium/cli/meta.py
@@ -34,7 +34,7 @@ class Shell(str, Enum):
 
 
 def version_cmd() -> None:
-    """Print the clawctl version."""
+    """Show clawctl version and exit."""
     typer.echo(f"clawctl {__version__}")
 
 

--- a/src/clawrium/cli/meta.py
+++ b/src/clawrium/cli/meta.py
@@ -1,0 +1,67 @@
+"""`clawctl version` and `clawctl completion` — meta verbs.
+
+Plan §4 / §5:
+
+- `clawctl version`           → prints `clawctl <version>` to stdout.
+- `clawctl --version`         → same, handled in the root callback.
+- `clawctl completion <shell>` → emits a Click-generated completion
+  script for bash/zsh/fish. The user pipes the output into their shell
+  rc file (`clawctl completion bash >> ~/.bashrc`).
+
+Click's `shell_completion` module owns the script generation; we just
+expose it as a Typer subcommand with a friendly enum of shells. Calling
+`get_completion_class(shell)(...).source()` is the same path Click uses
+internally for `_<APP>_COMPLETE=<shell>_source`.
+"""
+
+from enum import Enum
+
+import click
+import typer
+from click import shell_completion
+
+from clawrium import __version__
+
+__all__ = ["Shell", "completion_cmd", "version_cmd"]
+
+
+class Shell(str, Enum):
+    """Supported shells for `clawctl completion`."""
+
+    bash = "bash"
+    zsh = "zsh"
+    fish = "fish"
+
+
+def version_cmd() -> None:
+    """Print the clawctl version."""
+    typer.echo(f"clawctl {__version__}")
+
+
+def completion_cmd(
+    shell: Shell = typer.Argument(
+        ..., help="Shell to generate completion for (bash, zsh, or fish)."
+    ),
+) -> None:
+    """Emit a shell-completion script for `clawctl`.
+
+    Usage:
+      clawctl completion bash >> ~/.bashrc
+      clawctl completion zsh  >> ~/.zshrc
+      clawctl completion fish >> ~/.config/fish/completions/clawctl.fish
+    """
+    complete_class = shell_completion.get_completion_class(shell.value)
+    if complete_class is None:
+        # Shouldn't be reachable — Enum constrains the input.
+        typer.echo(f"Error: unsupported shell: {shell.value}", err=True)
+        raise typer.Exit(code=1)
+
+    ctx = click.get_current_context()
+    root = ctx.find_root().command
+    instance = complete_class(
+        cli=root,
+        ctx_args={},
+        prog_name="clawctl",
+        complete_var="_CLAWCTL_COMPLETE",
+    )
+    typer.echo(instance.source())

--- a/src/clawrium/cli/output/__init__.py
+++ b/src/clawrium/cli/output/__init__.py
@@ -15,6 +15,25 @@ this module. The contract is documented in `.itx/435/00_PLAN.md` §6
 
 This module imports nothing from `clawrium.core.*`; it deals only with
 rendering primitives.
+
+Sanitization contract (#507 ATX iter-1):
+
+| Primitive                              | Sanitizes? |
+|----------------------------------------|------------|
+| `errors.emit_error(message, hint)`     | Yes        |
+| `stream.stream_action(resource, msg)`  | Yes        |
+| `json_yaml.dump_name(kind, name)`      | Yes        |
+| `table.render()` cells + headers       | Yes        |
+| `stream.NDJSONStreamer.emit()`         | Safe via `json.dumps` (`ensure_ascii=True`) |
+| `stream.emit_event()`                  | Safe via `json.dumps` |
+| `json_yaml.dump_json()`                | Safe via `json.dumps` |
+| `json_yaml.dump_yaml()`                | Safe via `yaml.safe_dump` |
+| `age.format_age()`                     | N/A — int input |
+| `status.format_status()`               | N/A — input constrained to status vocab |
+
+The shared pattern lives in `_sanitize.py` and mirrors
+`cli/chat.py:_CONTROL_AND_BIDI_RE` so the coverage stays identical
+to the legacy parity contract from ATX #341 v3 / #455 W2.
 """
 
 from clawrium.cli.output.age import format_age

--- a/src/clawrium/cli/output/__init__.py
+++ b/src/clawrium/cli/output/__init__.py
@@ -1,0 +1,37 @@
+"""Shared output-rendering primitives for the `clawctl` CLI.
+
+Every `get`/`describe` subcommand built in later bundles renders through
+this module. The contract is documented in `.itx/435/00_PLAN.md` §6
+(output format contract). Highlights:
+
+- `table.render()`  — kubectl tabwriter-style padding, min 3-space gap.
+- `json_yaml.dump()` — `-o json` / `-o yaml` serializers (snake_case keys,
+  RFC3339 UTC timestamps, `age_seconds` ints).
+- `stream.NDJSONStreamer` — one JSON object per line for action output.
+- `errors.emit_error()` — `Error: ...\nHint: ...\n` to stderr + nonzero
+  exit.
+- `age.format_age()` — kubectl-style AGE column (s/m/h/d only).
+- `status.format_status()` — TTY-only color for the STATUS column.
+
+This module imports nothing from `clawrium.core.*`; it deals only with
+rendering primitives.
+"""
+
+from clawrium.cli.output.age import format_age
+from clawrium.cli.output.errors import emit_error
+from clawrium.cli.output.json_yaml import dump_json, dump_yaml, dump_name
+from clawrium.cli.output.status import format_status
+from clawrium.cli.output.stream import NDJSONStreamer, stream_action
+from clawrium.cli.output.table import render as render_table
+
+__all__ = [
+    "NDJSONStreamer",
+    "dump_json",
+    "dump_name",
+    "dump_yaml",
+    "emit_error",
+    "format_age",
+    "format_status",
+    "render_table",
+    "stream_action",
+]

--- a/src/clawrium/cli/output/__init__.py
+++ b/src/clawrium/cli/output/__init__.py
@@ -16,20 +16,25 @@ this module. The contract is documented in `.itx/435/00_PLAN.md` §6
 This module imports nothing from `clawrium.core.*`; it deals only with
 rendering primitives.
 
-Sanitization contract (#507 ATX iter-1):
+Sanitization contract (#507 ATX iter-1/2/3):
 
 | Primitive                              | Sanitizes? |
 |----------------------------------------|------------|
-| `errors.emit_error(message, hint)`     | Yes        |
-| `stream.stream_action(resource, msg)`  | Yes        |
-| `json_yaml.dump_name(kind, name)`      | Yes        |
-| `table.render()` cells + headers       | Yes        |
-| `stream.NDJSONStreamer.emit()`         | Safe via `json.dumps` (`ensure_ascii=True`) |
-| `stream.emit_event()`                  | Safe via `json.dumps` |
-| `json_yaml.dump_json()`                | Safe via `json.dumps` |
-| `json_yaml.dump_yaml()`                | Safe via `yaml.safe_dump` |
+| `errors.emit_error(message, hint)`     | Yes |
+| `stream.stream_action(resource, msg)`  | Yes |
+| `json_yaml.dump_name(kind, name)`      | Yes |
+| `json_yaml.dump_yaml()` string scalars | Yes (recursive, via `_sanitize_value`) |
+| `table.render()` cells + headers       | Yes |
+| `stream.NDJSONStreamer.emit()`         | Safe via `json.dumps(..., ensure_ascii=True)` |
+| `stream.emit_event()`                  | Safe via `json.dumps(..., ensure_ascii=True)` |
+| `json_yaml.dump_json()`                | Safe via `json.dumps(..., ensure_ascii=True)` |
+| `status.format_status()`               | Yes (unknown-token path; known vocab tokens are identity-returned) |
 | `age.format_age()`                     | N/A — int input |
-| `status.format_status()`               | N/A — input constrained to status vocab |
+
+`sanitize()` IS NOT a secret redactor — see `_sanitize.py` module
+docstring. Callers must never pass secret-valued strings to any
+output primitive; the safety boundary lives at the call site that
+decides what to log.
 
 The shared pattern lives in `_sanitize.py` and mirrors
 `cli/chat.py:_CONTROL_AND_BIDI_RE` so the coverage stays identical

--- a/src/clawrium/cli/output/_sanitize.py
+++ b/src/clawrium/cli/output/_sanitize.py
@@ -1,0 +1,56 @@
+"""Terminal-output sanitization for the `clawctl` output primitives.
+
+The output module writes server-supplied strings (agent names from
+hosts.json, ansible-runner event text, hermes HTTP response bodies,
+etc.) directly to stdout/stderr. A malicious upstream emitting bidi
+override codepoints (U+202E etc.) can silently reverse-print the
+user's terminal output — the exact class of bug ATX #341 v3 / #455 W2
+hardened against in `cli/chat.py`.
+
+`_CONTROL_AND_BIDI_RE` mirrors the pattern in `cli/chat.py` so the
+coverage stays identical to the legacy parity contract. We re-state
+the pattern here (rather than importing from chat.py) for two reasons:
+
+1. The output module must stay self-contained — bundles 3-5 will
+   refactor `cli/chat.py` and the import could break or shift coverage.
+2. Drift detection: `tests/cli/output/test_sanitize.py` codifies the
+   character set; any future edit to either copy must update both,
+   surfacing the drift in CI.
+
+Sanitization is applied at every primitive that writes a raw string
+to a terminal stream: `emit_error()`, `stream_action()`, `dump_name()`,
+`render_table()` cells. `NDJSONStreamer.emit()` and `dump_yaml()` are
+safe by serialization (json.dumps with ensure_ascii=True and
+yaml.safe_dump escape control characters in their output).
+"""
+
+import re
+
+_CONTROL_AND_BIDI_RE = re.compile(
+    # Mirrors `cli/chat.py:_CONTROL_AND_BIDI_RE`. Use explicit \uXXXX
+    # escapes so literal bidi/zero-width codepoints never appear in
+    # source — they are invisible to most editors and trivially
+    # corrupted by auto-formatters / BOM insertion / careless paste.
+    "["
+    "\x00-\x1f\x7f-\x9f"
+    "؜"  # ARABIC LETTER MARK
+    "​-‏"  # ZWSP, ZWNJ, ZWJ, LRM, RLM
+    " - "  # LINE / PARAGRAPH SEPARATOR
+    "‪-‮"  # LRE, RLE, PDF, LRO, RLO
+    "⁠"  # WORD JOINER
+    "⁦-⁩"  # LRI, RLI, FSI, PDI
+    "﻿"  # ZWNBSP / BOM
+    "]"
+)
+
+
+def sanitize(value: str) -> str:
+    """Strip control / bidi / zero-width chars; replace with a single space.
+
+    Idempotent and pass-through for well-formed strings — only the
+    dangerous codepoints are touched. Returns the input unchanged when
+    nothing matches (no allocation in the common case).
+    """
+    if not _CONTROL_AND_BIDI_RE.search(value):
+        return value
+    return _CONTROL_AND_BIDI_RE.sub(" ", value)

--- a/src/clawrium/cli/output/_sanitize.py
+++ b/src/clawrium/cli/output/_sanitize.py
@@ -27,10 +27,16 @@ that decides what to log, not at the writer that flushes it.
 
 Sanitization is applied at every primitive that writes a raw string
 to a terminal stream: `emit_error()`, `stream_action()`, `dump_name()`,
-`render_table()` cells, and `format_status()`. `NDJSONStreamer.emit()`,
-`emit_event()`, `dump_json()`, and `dump_yaml()` are safe by
-serialization (json.dumps with `ensure_ascii=True` and yaml.safe_dump
-escape control characters in their output).
+`render_table()` cells, and `format_status()` (unknown-token path).
+`NDJSONStreamer.emit()`, `emit_event()`, and `dump_json()` are safe
+by serialization (`json.dumps(..., ensure_ascii=True)` escapes every
+non-ASCII codepoint as `\\uXXXX`).
+
+`dump_yaml()` is the exception: `yaml.safe_dump` quotes most C0/C1
+control chars but does NOT escape LF (`U+000A`) -- it emits a block
+scalar with the literal newline. To preserve parity with the other
+primitives, `dump_yaml()` recursively sanitizes every string scalar
+before passing to PyYAML (#507 ATX iter-3 W2).
 """
 
 import re

--- a/src/clawrium/cli/output/_sanitize.py
+++ b/src/clawrium/cli/output/_sanitize.py
@@ -4,42 +4,55 @@ The output module writes server-supplied strings (agent names from
 hosts.json, ansible-runner event text, hermes HTTP response bodies,
 etc.) directly to stdout/stderr. A malicious upstream emitting bidi
 override codepoints (U+202E etc.) can silently reverse-print the
-user's terminal output — the exact class of bug ATX #341 v3 / #455 W2
+user's terminal output -- the exact class of bug ATX #341 v3 / #455 W2
 hardened against in `cli/chat.py`.
 
 `_CONTROL_AND_BIDI_RE` mirrors the pattern in `cli/chat.py` so the
 coverage stays identical to the legacy parity contract. We re-state
 the pattern here (rather than importing from chat.py) for two reasons:
 
-1. The output module must stay self-contained — bundles 3-5 will
+1. The output module must stay self-contained -- bundles 3-5 will
    refactor `cli/chat.py` and the import could break or shift coverage.
 2. Drift detection: `tests/cli/output/test_sanitize.py` codifies the
    character set; any future edit to either copy must update both,
-   surfacing the drift in CI.
+   surfacing the drift in CI. The drift-detection guard in that file
+   also asserts the source uses ASCII-only Python `\\uXXXX` escapes
+   (no literal Unicode codepoints anywhere in this module).
+
+**`sanitize()` IS NOT a secret redactor.** It only strips control and
+bidi/zero-width codepoints; alphanumeric secrets (API keys, tokens)
+pass through unmodified. Callers must never pass secret-valued strings
+to any output primitive -- the safety boundary lives at the call site
+that decides what to log, not at the writer that flushes it.
 
 Sanitization is applied at every primitive that writes a raw string
 to a terminal stream: `emit_error()`, `stream_action()`, `dump_name()`,
-`render_table()` cells. `NDJSONStreamer.emit()` and `dump_yaml()` are
-safe by serialization (json.dumps with ensure_ascii=True and
-yaml.safe_dump escape control characters in their output).
+`render_table()` cells, and `format_status()`. `NDJSONStreamer.emit()`,
+`emit_event()`, `dump_json()`, and `dump_yaml()` are safe by
+serialization (json.dumps with `ensure_ascii=True` and yaml.safe_dump
+escape control characters in their output).
 """
 
 import re
 
 _CONTROL_AND_BIDI_RE = re.compile(
-    # Mirrors `cli/chat.py:_CONTROL_AND_BIDI_RE`. Use explicit \uXXXX
-    # escapes so literal bidi/zero-width codepoints never appear in
-    # source — they are invisible to most editors and trivially
-    # corrupted by auto-formatters / BOM insertion / careless paste.
+    # Mirrors `cli/chat.py:_CONTROL_AND_BIDI_RE`. Explicit `\uXXXX`
+    # text escapes only -- literal bidi / zero-width codepoints MUST
+    # NOT appear in this source. They are invisible to most editors
+    # and trivially corrupted by auto-formatters / BOM insertion /
+    # careless paste. ATX iter-2 #507 caught a regression where the
+    # pattern below was checked in with literal bytes; the contract
+    # is now enforced by
+    # `tests/cli/output/test_sanitize.py::test_source_is_pure_ascii`.
     "["
     "\x00-\x1f\x7f-\x9f"
-    "؜"  # ARABIC LETTER MARK
-    "​-‏"  # ZWSP, ZWNJ, ZWJ, LRM, RLM
-    " - "  # LINE / PARAGRAPH SEPARATOR
-    "‪-‮"  # LRE, RLE, PDF, LRO, RLO
-    "⁠"  # WORD JOINER
-    "⁦-⁩"  # LRI, RLI, FSI, PDI
-    "﻿"  # ZWNBSP / BOM
+    "\u061c"  # ARABIC LETTER MARK (UAX#9 bidi format char)
+    "\u200b-\u200f"  # ZWSP, ZWNJ, ZWJ, LRM, RLM
+    "\u2028-\u2029"  # LINE / PARAGRAPH SEPARATOR
+    "\u202a-\u202e"  # LRE, RLE, PDF, LRO, RLO
+    "\u2060"  # WORD JOINER
+    "\u2066-\u2069"  # LRI, RLI, FSI, PDI
+    "\ufeff"  # ZWNBSP / BOM
     "]"
 )
 
@@ -47,9 +60,17 @@ _CONTROL_AND_BIDI_RE = re.compile(
 def sanitize(value: str) -> str:
     """Strip control / bidi / zero-width chars; replace with a single space.
 
-    Idempotent and pass-through for well-formed strings — only the
+    Idempotent and pass-through for well-formed strings -- only the
     dangerous codepoints are touched. Returns the input unchanged when
     nothing matches (no allocation in the common case).
+
+    NOTE: Whitespace control chars (`\\t`, `\\n`, `\\r`) ARE stripped
+    because they fall in `\\x00-\\x1f`. This matches the chat.py parity
+    contract; multi-line diagnostic structure in error messages is
+    deliberately collapsed to a single line. Callers that need
+    structured multi-line output should format BEFORE calling the
+    sanitizer (or write to stderr in pieces with separate emit_error
+    calls).
     """
     if not _CONTROL_AND_BIDI_RE.search(value):
         return value

--- a/src/clawrium/cli/output/age.py
+++ b/src/clawrium/cli/output/age.py
@@ -1,0 +1,35 @@
+"""kubectl-style AGE column formatter.
+
+Plan §6.14:
+
+- `<60s`  → `Xs`
+- `<60m`  → `Xm`
+- `<24h`  → `Xh`
+- everything else → `Xd`
+
+No weeks, no months — matches `kubectl`'s AGE column verbatim. Caller
+passes the elapsed seconds as an int (already-computed against
+`age_seconds` for JSON/YAML output).
+"""
+
+_MIN_S = 60
+_HOUR_S = 60 * 60
+_DAY_S = 24 * 60 * 60
+
+
+def format_age(seconds: int) -> str:
+    """Format `seconds` as kubectl's AGE token.
+
+    Negative inputs are clamped to `0s` — easier to spot in output than
+    raising, and matches the practical case where wall-clock skew makes
+    a freshly-created resource look like it's from the future.
+    """
+    if seconds < 0:
+        return "0s"
+    if seconds < _MIN_S:
+        return f"{seconds}s"
+    if seconds < _HOUR_S:
+        return f"{seconds // _MIN_S}m"
+    if seconds < _DAY_S:
+        return f"{seconds // _HOUR_S}h"
+    return f"{seconds // _DAY_S}d"

--- a/src/clawrium/cli/output/errors.py
+++ b/src/clawrium/cli/output/errors.py
@@ -7,12 +7,21 @@ Plan §6.1 / §6.12:
   the `Error:` prefix (`Hint:  <text>` — two trailing spaces after the
   colon so the body aligns with `Error:`'s body).
 - Process exits non-zero.
+
+Both `message` and `hint` are bidi/control-char sanitized (#507 ATX
+iter-1 B1): callers frequently forward server-supplied strings (HTTP
+error bodies, ansible event text) and the bug class this guards
+against — `U+202E` reversing terminal output — was already hardened in
+`cli/chat.py:_sanitize_exception_text`. Sanitizing at the primitive
+keeps callers from having to remember.
 """
 
 import sys
 from typing import IO, NoReturn, Optional
 
 import typer
+
+from clawrium.cli.output._sanitize import sanitize
 
 
 def emit_error(
@@ -29,10 +38,10 @@ def emit_error(
     `pytest.raises(typer.Exit)` or `CliRunner.invoke().exit_code`.
     """
     target = stream if stream is not None else sys.stderr
-    target.write(f"Error: {message}\n")
+    target.write(f"Error: {sanitize(message)}\n")
     if hint is not None:
         # Two spaces after "Hint:" so the body aligns under the body
         # of "Error:" — both have a 7-char prefix to their content.
-        target.write(f"Hint:  {hint}\n")
+        target.write(f"Hint:  {sanitize(hint)}\n")
     target.flush()
     raise typer.Exit(code=exit_code)

--- a/src/clawrium/cli/output/errors.py
+++ b/src/clawrium/cli/output/errors.py
@@ -1,0 +1,38 @@
+"""Unified error formatter.
+
+Plan §6.1 / §6.12:
+
+- Every error writes `Error: <msg>` to stderr.
+- An optional one-line `Hint: <text>` follows, vertically aligned with
+  the `Error:` prefix (`Hint:  <text>` — two trailing spaces after the
+  colon so the body aligns with `Error:`'s body).
+- Process exits non-zero.
+"""
+
+import sys
+from typing import IO, NoReturn, Optional
+
+import typer
+
+
+def emit_error(
+    message: str,
+    *,
+    hint: Optional[str] = None,
+    exit_code: int = 1,
+    stream: Optional[IO[str]] = None,
+) -> NoReturn:
+    """Write a structured error to stderr and raise `typer.Exit`.
+
+    Raises `typer.Exit(exit_code)` so Typer's runtime catches it and
+    sets the process exit code. Tests can intercept via
+    `pytest.raises(typer.Exit)` or `CliRunner.invoke().exit_code`.
+    """
+    target = stream if stream is not None else sys.stderr
+    target.write(f"Error: {message}\n")
+    if hint is not None:
+        # Two spaces after "Hint:" so the body aligns under the body
+        # of "Error:" — both have a 7-char prefix to their content.
+        target.write(f"Hint:  {hint}\n")
+    target.flush()
+    raise typer.Exit(code=exit_code)

--- a/src/clawrium/cli/output/json_yaml.py
+++ b/src/clawrium/cli/output/json_yaml.py
@@ -37,16 +37,49 @@ def dump_json(rows: Sequence[Mapping[str, Any]]) -> str:
     return json.dumps(list(rows), indent=2, sort_keys=False, ensure_ascii=True) + "\n"
 
 
+def _sanitize_value(value: Any) -> Any:
+    """Recursively `sanitize()` every string scalar in a nested structure.
+
+    Used by `dump_yaml()` because `yaml.safe_dump()` does NOT escape
+    LF (U+000A) inside block scalars — a crafted string with `\\n`
+    survives verbatim in the YAML output. `dump_json()` is safe via
+    `ensure_ascii=True`. Recursion handles nested lists/dicts so any
+    future row schema with sub-objects keeps the invariant.
+    """
+    if isinstance(value, str):
+        return sanitize(value)
+    if isinstance(value, Mapping):
+        return {k: _sanitize_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_sanitize_value(v) for v in value]
+    return value
+
+
 def dump_yaml(rows: Sequence[Mapping[str, Any]]) -> str:
     """Serialize `rows` as a YAML list.
 
     Equivalence guarantee (asserted in tests):
-    `yaml.safe_load(dump_yaml(rows)) == json.loads(dump_json(rows))`.
+    `yaml.safe_load(dump_yaml(rows)) == json.loads(dump_json(rows))`
+    (modulo sanitization side-effects — both serializers neutralize
+    bidi/control chars but via different mechanisms).
+
+    Every string scalar is sanitized recursively (#507 ATX iter-3 W2):
+    `yaml.safe_dump` escapes most C0/C1 control chars in single-quoted
+    style but NOT LF (it emits a block scalar). Sanitizing at the
+    primitive keeps parity with `dump_json` / `dump_name` and prevents
+    a crafted agent name containing `\\n` from producing multi-line
+    YAML from a field expected to be atomic.
+
+    `allow_unicode=False` is explicit so any non-ASCII codepoint in
+    a string scalar emerges as `\\uXXXX` instead of raw bytes. This
+    makes the safety boundary auditable (#507 iter-3 S1).
     """
+    safe_rows = [_sanitize_value(row) for row in rows]
     return yaml.safe_dump(
-        list(rows),
+        safe_rows,
         sort_keys=False,
         default_flow_style=False,
+        allow_unicode=False,
     )
 
 
@@ -60,7 +93,8 @@ def dump_name(rows: Sequence[Mapping[str, Any]]) -> str:
     Both `kind` and `name` are bidi/control-char sanitized at write
     time (#507 ATX iter-1 W2): names come from agent-registry-derived
     strings and a crafted manifest could embed bidi overrides.
-    `dump_json()` and `dump_yaml()` are safe by serialization.
+    `dump_json()` is safe by serialization (`ensure_ascii=True`).
+    `dump_yaml()` sanitizes recursively (see `_sanitize_value`).
     """
     lines = [
         f"{sanitize(str(row['kind']))}/{sanitize(str(row['name']))}" for row in rows

--- a/src/clawrium/cli/output/json_yaml.py
+++ b/src/clawrium/cli/output/json_yaml.py
@@ -1,0 +1,56 @@
+"""`-o json`, `-o yaml`, and `-o name` serializers.
+
+Contract (plan §6.5–6.6):
+
+- `dump_json(rows)`  — array of objects, snake_case keys, RFC3339 UTC
+  timestamps (caller pre-serializes datetimes), `age_seconds` ints.
+- `dump_yaml(rows)`  — same shape, YAML-encoded.
+- `dump_name(rows)`  — `<kind>/<name>` one per line; requires each row
+  to carry `kind` and `name` keys.
+
+All three return a single string ending in a newline; callers print
+verbatim. JSON output is pretty-printed (2-space indent) so output is
+human-readable AND machine-parseable.
+"""
+
+import json
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+
+def dump_json(rows: Sequence[Mapping[str, Any]]) -> str:
+    """Serialize `rows` as a JSON array.
+
+    Keys, values, and types pass through unchanged. Callers are
+    responsible for emitting snake_case keys and pre-formatted RFC3339
+    UTC timestamps (the rule lives in the plan; this module just
+    serializes).
+    """
+    return json.dumps(list(rows), indent=2, sort_keys=False) + "\n"
+
+
+def dump_yaml(rows: Sequence[Mapping[str, Any]]) -> str:
+    """Serialize `rows` as a YAML list.
+
+    Equivalence guarantee (asserted in tests):
+    `yaml.safe_load(dump_yaml(rows)) == json.loads(dump_json(rows))`.
+    """
+    return yaml.safe_dump(
+        list(rows),
+        sort_keys=False,
+        default_flow_style=False,
+    )
+
+
+def dump_name(rows: Sequence[Mapping[str, Any]]) -> str:
+    """Serialize `rows` as `<kind>/<name>` lines.
+
+    Each row MUST have `kind` and `name` keys. Missing keys raise
+    `KeyError` — surfacing the problem to the caller is preferable to
+    silently dropping records.
+    """
+    lines = [f"{row['kind']}/{row['name']}" for row in rows]
+    if not lines:
+        return ""
+    return "\n".join(lines) + "\n"

--- a/src/clawrium/cli/output/json_yaml.py
+++ b/src/clawrium/cli/output/json_yaml.py
@@ -28,8 +28,13 @@ def dump_json(rows: Sequence[Mapping[str, Any]]) -> str:
     responsible for emitting snake_case keys and pre-formatted RFC3339
     UTC timestamps (the rule lives in the plan; this module just
     serializes).
+
+    `ensure_ascii=True` is explicit (Python default, but stated here
+    so the safety boundary is visible -- raw bidi/control chars in
+    string values become `\\uXXXX` escapes in the output, never
+    reaching the terminal in raw form).
     """
-    return json.dumps(list(rows), indent=2, sort_keys=False) + "\n"
+    return json.dumps(list(rows), indent=2, sort_keys=False, ensure_ascii=True) + "\n"
 
 
 def dump_yaml(rows: Sequence[Mapping[str, Any]]) -> str:

--- a/src/clawrium/cli/output/json_yaml.py
+++ b/src/clawrium/cli/output/json_yaml.py
@@ -18,6 +18,8 @@ from typing import Any, Mapping, Sequence
 
 import yaml
 
+from clawrium.cli.output._sanitize import sanitize
+
 
 def dump_json(rows: Sequence[Mapping[str, Any]]) -> str:
     """Serialize `rows` as a JSON array.
@@ -49,8 +51,15 @@ def dump_name(rows: Sequence[Mapping[str, Any]]) -> str:
     Each row MUST have `kind` and `name` keys. Missing keys raise
     `KeyError` — surfacing the problem to the caller is preferable to
     silently dropping records.
+
+    Both `kind` and `name` are bidi/control-char sanitized at write
+    time (#507 ATX iter-1 W2): names come from agent-registry-derived
+    strings and a crafted manifest could embed bidi overrides.
+    `dump_json()` and `dump_yaml()` are safe by serialization.
     """
-    lines = [f"{row['kind']}/{row['name']}" for row in rows]
+    lines = [
+        f"{sanitize(str(row['kind']))}/{sanitize(str(row['name']))}" for row in rows
+    ]
     if not lines:
         return ""
     return "\n".join(lines) + "\n"

--- a/src/clawrium/cli/output/status.py
+++ b/src/clawrium/cli/output/status.py
@@ -30,6 +30,8 @@ import os
 import sys
 from typing import IO, Optional
 
+from clawrium.cli.output._sanitize import sanitize
+
 _COLORS = {
     "running": "32",  # green
     "degraded": "33",  # yellow
@@ -62,10 +64,16 @@ def format_status(
     stream: Optional[IO[str]] = None,
     force_color: bool = False,
 ) -> str:
-    """Return `token` wrapped in the matching ANSI color, or raw."""
+    """Return `token` wrapped in the matching ANSI color, or raw.
+
+    Unknown tokens pass through sanitize() before returning (#507 ATX
+    iter-2 W7): a compromised agent host writing a crafted `status`
+    field to hosts.json could otherwise smuggle bidi overrides into
+    the terminal via the "unknown token" fallthrough.
+    """
     code = _COLORS.get(token)
     if code is None:
-        return token
+        return sanitize(token)
     if not _color_enabled(stream, force_color=force_color):
         return token
     return f"\x1b[{code}m{token}\x1b[0m"

--- a/src/clawrium/cli/output/status.py
+++ b/src/clawrium/cli/output/status.py
@@ -1,0 +1,71 @@
+"""STATUS column formatter.
+
+Plan §6.13:
+
+| Token         | TTY color |
+|---------------|-----------|
+| running       | green     |
+| degraded      | yellow    |
+| stopped       | red       |
+| pending       | yellow    |
+| onboarding    | cyan      |
+| ready         | blue      |
+| installing    | yellow    |
+| failed        | red       |
+| unknown       | yellow    |
+
+Coloring rules:
+
+- On a TTY → wrap with the matching ANSI color sequence.
+- Non-TTY (pipe / file) → emit the raw token, no ANSI.
+- `NO_COLOR=1` (de-facto standard) → emit the raw token regardless.
+- `force_color=True` overrides the TTY check (used by tests).
+
+Unknown tokens are returned uncolored. This is a deliberate choice —
+the status vocabulary is the source of truth; surfacing an unrecognized
+token without color makes the gap visible in fleet output.
+"""
+
+import os
+import sys
+from typing import IO, Optional
+
+_COLORS = {
+    "running": "32",  # green
+    "degraded": "33",  # yellow
+    "stopped": "31",  # red
+    "pending": "33",  # yellow
+    "onboarding": "36",  # cyan
+    "ready": "34",  # blue
+    "installing": "33",  # yellow
+    "failed": "31",  # red
+    "unknown": "33",  # yellow
+}
+
+
+def _color_enabled(
+    stream: Optional[IO[str]],
+    *,
+    force_color: bool,
+) -> bool:
+    if os.environ.get("NO_COLOR"):
+        return False
+    if force_color:
+        return True
+    target = stream if stream is not None else sys.stdout
+    return bool(getattr(target, "isatty", lambda: False)())
+
+
+def format_status(
+    token: str,
+    *,
+    stream: Optional[IO[str]] = None,
+    force_color: bool = False,
+) -> str:
+    """Return `token` wrapped in the matching ANSI color, or raw."""
+    code = _COLORS.get(token)
+    if code is None:
+        return token
+    if not _color_enabled(stream, force_color=force_color):
+        return token
+    return f"\x1b[{code}m{token}\x1b[0m"

--- a/src/clawrium/cli/output/stream.py
+++ b/src/clawrium/cli/output/stream.py
@@ -60,7 +60,14 @@ class NDJSONStreamer:
         }
         for key, value in extra.items():
             payload[key] = value
-        self._stream.write(json.dumps(payload, sort_keys=False) + "\n")
+        # `ensure_ascii=True` is the explicit safety boundary cited in
+        # `_sanitize.py` -- every non-ASCII codepoint becomes `\\uXXXX`
+        # in the output, so raw bidi/control chars never reach the
+        # terminal even though we don't call sanitize() here. Removing
+        # this kwarg would silently regress the contract.
+        self._stream.write(
+            json.dumps(payload, sort_keys=False, ensure_ascii=True) + "\n"
+        )
         self._stream.flush()
 
 
@@ -93,5 +100,7 @@ def emit_event(event: Mapping[str, Any], stream: Optional[IO[str]] = None) -> No
         if key not in event:
             raise KeyError(f"missing required key: {key}")
     target = stream if stream is not None else sys.stdout
-    target.write(json.dumps(dict(event), sort_keys=False) + "\n")
+    # `ensure_ascii=True` is the explicit safety boundary -- see the
+    # matching comment in `NDJSONStreamer.emit()`.
+    target.write(json.dumps(dict(event), sort_keys=False, ensure_ascii=True) + "\n")
     target.flush()

--- a/src/clawrium/cli/output/stream.py
+++ b/src/clawrium/cli/output/stream.py
@@ -5,13 +5,25 @@ each with at least `resource`, `phase`, `state`, `ts` keys. Extra keys
 are passed through.
 
 `stream_action()` is a convenience for the default (non-JSON) mode —
-one human line per phase, e.g. `agent/wise-hypatia: installed`.
+one human line per phase, e.g. `agent/wise-hypatia: installed`. Both
+`resource` and `message` are bidi/control-char sanitized here (#507
+ATX iter-1 B2): they will carry server-supplied strings (agent names
+from hosts.json, ansible event text) once bundles 3-4 wire real
+lifecycle ops to this primitive.
+
+`NDJSONStreamer.emit()` and `emit_event()` are safe by serialization:
+`json.dumps(..., ensure_ascii=True)` escapes control chars as `\\uXXXX`
+in the output. Future audit point — if a caller passes a secret-valued
+extra kwarg, it would still be serialized to the stream; this is
+flagged for review when the first real caller lands in bundle 3.
 """
 
 import json
 import sys
 from datetime import datetime, timezone
 from typing import Any, IO, Mapping, Optional
+
+from clawrium.cli.output._sanitize import sanitize
 
 
 def _utc_now_rfc3339() -> str:
@@ -65,7 +77,7 @@ def stream_action(
     with whatever the underlying lifecycle code logs.
     """
     target = stream if stream is not None else sys.stdout
-    target.write(f"{resource}: {message}\n")
+    target.write(f"{sanitize(resource)}: {sanitize(message)}\n")
     target.flush()
 
 

--- a/src/clawrium/cli/output/stream.py
+++ b/src/clawrium/cli/output/stream.py
@@ -1,0 +1,85 @@
+"""NDJSON action streamer for `-o json` on lifecycle commands.
+
+Plan §6.9: actions stream events to stdout, one JSON object per line,
+each with at least `resource`, `phase`, `state`, `ts` keys. Extra keys
+are passed through.
+
+`stream_action()` is a convenience for the default (non-JSON) mode —
+one human line per phase, e.g. `agent/wise-hypatia: installed`.
+"""
+
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Any, IO, Mapping, Optional
+
+
+def _utc_now_rfc3339() -> str:
+    """Return the current UTC time as RFC3339 (`2026-05-23T10:14:00Z`)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class NDJSONStreamer:
+    """Emit one JSON object per line to a stream (default `sys.stdout`).
+
+    The streamer is intentionally minimal — no buffering beyond the
+    underlying stream's, no schema enforcement beyond the required keys.
+    """
+
+    REQUIRED_KEYS = ("resource", "phase", "state")
+
+    def __init__(self, stream: Optional[IO[str]] = None) -> None:
+        self._stream = stream if stream is not None else sys.stdout
+
+    def emit(
+        self,
+        *,
+        resource: str,
+        phase: str,
+        state: str,
+        ts: Optional[str] = None,
+        **extra: Any,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "resource": resource,
+            "phase": phase,
+            "state": state,
+            "ts": ts if ts is not None else _utc_now_rfc3339(),
+        }
+        for key, value in extra.items():
+            payload[key] = value
+        self._stream.write(json.dumps(payload, sort_keys=False) + "\n")
+        self._stream.flush()
+
+
+def stream_action(
+    *,
+    resource: str,
+    message: str,
+    stream: Optional[IO[str]] = None,
+) -> None:
+    """Emit one human-readable phase line: `<resource>: <message>`.
+
+    Counterpart to `NDJSONStreamer.emit()` for the default (non-JSON)
+    output mode. Flushes immediately so phase lines appear interleaved
+    with whatever the underlying lifecycle code logs.
+    """
+    target = stream if stream is not None else sys.stdout
+    target.write(f"{resource}: {message}\n")
+    target.flush()
+
+
+def emit_event(event: Mapping[str, Any], stream: Optional[IO[str]] = None) -> None:
+    """Emit a pre-built event mapping as a single NDJSON line.
+
+    Convenience for callers that already have the event payload in
+    dict form (e.g. forwarded from a backend). Validates the required
+    keys before writing — missing keys raise `KeyError` so the caller
+    learns immediately.
+    """
+    for key in NDJSONStreamer.REQUIRED_KEYS:
+        if key not in event:
+            raise KeyError(f"missing required key: {key}")
+    target = stream if stream is not None else sys.stdout
+    target.write(json.dumps(dict(event), sort_keys=False) + "\n")
+    target.flush()

--- a/src/clawrium/cli/output/table.py
+++ b/src/clawrium/cli/output/table.py
@@ -11,9 +11,16 @@ Padding rule (plan §6.1 / Option B):
 
 This renderer is intentionally simple — no truncation, no wrapping. The
 goal is byte-stable, grep-friendly output that mirrors `kubectl get`.
+
+Every cell is bidi/control-char sanitized before width computation and
+write (#507 ATX iter-1 W1): future callers in bundles 3-4 will pass
+agent/host names sourced from `hosts.json`. Sanitizing at the renderer
+removes the drift trap where each caller must remember.
 """
 
 from typing import Sequence
+
+from clawrium.cli.output._sanitize import sanitize
 
 GAP = "   "  # 3 spaces between columns
 
@@ -35,8 +42,8 @@ def render(
     when at least one row is present. An empty result (no headers and
     no rows) returns the empty string.
     """
-    headers = [str(h) for h in headers]
-    norm_rows: list[list[str]] = [[str(cell) for cell in row] for row in rows]
+    headers = [sanitize(str(h)) for h in headers]
+    norm_rows: list[list[str]] = [[sanitize(str(cell)) for cell in row] for row in rows]
 
     if not headers and not norm_rows:
         return ""

--- a/src/clawrium/cli/output/table.py
+++ b/src/clawrium/cli/output/table.py
@@ -1,0 +1,76 @@
+"""Plain-text aligned table rendering (kubectl tabwriter style).
+
+Padding rule (plan §6.1 / Option B):
+
+- Each column is padded to the max width of any cell in that column.
+- A fixed 3-space gap separates adjacent columns (no Rich borders).
+- No trailing whitespace on any line.
+- `--no-headers` omits the header row but width is still computed from
+  data rows.
+- Empty rows render as a single newline (no padding).
+
+This renderer is intentionally simple — no truncation, no wrapping. The
+goal is byte-stable, grep-friendly output that mirrors `kubectl get`.
+"""
+
+from typing import Sequence
+
+GAP = "   "  # 3 spaces between columns
+
+
+def render(
+    headers: Sequence[str],
+    rows: Sequence[Sequence[str]],
+    *,
+    no_headers: bool = False,
+) -> str:
+    """Render `rows` as an aligned table.
+
+    `headers` and each row in `rows` must be sequences of strings. None
+    or non-string values must be stringified by the caller — this keeps
+    rendering rules in one place (callers know how to format their own
+    domain values).
+
+    Returns the rendered table as a single string ending in a newline
+    when at least one row is present. An empty result (no headers and
+    no rows) returns the empty string.
+    """
+    headers = [str(h) for h in headers]
+    norm_rows: list[list[str]] = [[str(cell) for cell in row] for row in rows]
+
+    if not headers and not norm_rows:
+        return ""
+
+    # Width per column is the max width across header (if shown) + rows.
+    n_cols = max(
+        (len(headers) if not no_headers else 0),
+        max((len(r) for r in norm_rows), default=0),
+    )
+    widths = [0] * n_cols
+    candidate_rows: list[list[str]] = []
+    if not no_headers and headers:
+        candidate_rows.append(list(headers))
+    candidate_rows.extend(norm_rows)
+    for r in candidate_rows:
+        for i, cell in enumerate(r):
+            if i < n_cols and len(cell) > widths[i]:
+                widths[i] = len(cell)
+
+    def fmt(row: Sequence[str]) -> str:
+        parts: list[str] = []
+        last = len(row) - 1
+        for i, cell in enumerate(row):
+            if i < last:
+                parts.append(cell.ljust(widths[i]))
+            else:
+                # No padding on the last cell — keeps no trailing whitespace.
+                parts.append(cell)
+        return GAP.join(parts).rstrip()
+
+    lines: list[str] = []
+    if not no_headers and headers:
+        lines.append(fmt(headers))
+    for r in norm_rows:
+        lines.append(fmt(r))
+
+    return "\n".join(lines) + "\n"

--- a/src/clawrium/cli/service.py
+++ b/src/clawrium/cli/service.py
@@ -1,0 +1,54 @@
+"""`clawctl service` — system-level lifecycle ops.
+
+Plan §4 / §5:
+
+| Subcommand   | Status (this bundle) |
+|--------------|----------------------|
+| `init`       | Real — delegates to the same `init` implementation `clm init` used. |
+| `start`      | Stub — prints `Not implemented: service start`, exits 0. |
+| `stop`       | Stub — prints `Not implemented: service stop`, exits 0. |
+| `snapshot`   | Stub — prints `Not implemented: service snapshot`, exits 0. |
+
+`status` lands in a later issue (out of scope for #435 per the plan
+table in §1). Stubs mirror today's `clm snapshot` behavior — informative
+message, zero exit code — so scripts can probe for availability without
+crashing.
+"""
+
+import typer
+
+from clawrium.cli.init import init as _init_impl
+
+__all__ = ["service_app"]
+
+
+service_app = typer.Typer(
+    name="service",
+    help="System-level lifecycle ops (init, start, stop, snapshot).",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+@service_app.command("init")
+def init() -> None:
+    """Initialize Clawrium configuration and check dependencies."""
+    _init_impl()
+
+
+@service_app.command("start")
+def start() -> None:
+    """Start the Clawrium daemon (placeholder)."""
+    typer.echo("Not implemented: service start")
+
+
+@service_app.command("stop")
+def stop() -> None:
+    """Stop the Clawrium daemon (placeholder)."""
+    typer.echo("Not implemented: service stop")
+
+
+@service_app.command("snapshot")
+def snapshot() -> None:
+    """Snapshot fleet state (placeholder)."""
+    typer.echo("Not implemented: service snapshot")

--- a/src/clawrium/cli/service.py
+++ b/src/clawrium/cli/service.py
@@ -17,6 +17,7 @@ crashing.
 
 import typer
 
+from clawrium.cli.clawctl._stub import echo_not_implemented
 from clawrium.cli.init import init as _init_impl
 
 __all__ = ["service_app"]
@@ -39,16 +40,18 @@ def init() -> None:
 @service_app.command("start")
 def start() -> None:
     """Start the Clawrium daemon (placeholder)."""
-    typer.echo("Not implemented: service start")
+    # Delegate to the shared stub helper so the "Not implemented:"
+    # wording stays in one place (#507 ATX iter-2 W2).
+    echo_not_implemented("service", "start")
 
 
 @service_app.command("stop")
 def stop() -> None:
     """Stop the Clawrium daemon (placeholder)."""
-    typer.echo("Not implemented: service stop")
+    echo_not_implemented("service", "stop")
 
 
 @service_app.command("snapshot")
 def snapshot() -> None:
     """Snapshot fleet state (placeholder)."""
-    typer.echo("Not implemented: service snapshot")
+    echo_not_implemented("service", "snapshot")

--- a/tests/cli/output/test_age.py
+++ b/tests/cli/output/test_age.py
@@ -1,0 +1,31 @@
+"""Tests for kubectl-style AGE formatter."""
+
+import pytest
+
+from clawrium.cli.output.age import format_age
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [
+        (0, "0s"),
+        (1, "1s"),
+        (59, "59s"),
+        (60, "1m"),
+        (61, "1m"),
+        (3599, "59m"),
+        (3600, "1h"),
+        (3661, "1h"),
+        (86399, "23h"),
+        (86400, "1d"),
+        (86401, "1d"),
+        (8640000, "100d"),
+    ],
+)
+def test_boundary_table(seconds: int, expected: str) -> None:
+    assert format_age(seconds) == expected
+
+
+def test_negative_clamps_to_zero() -> None:
+    assert format_age(-1) == "0s"
+    assert format_age(-10000) == "0s"

--- a/tests/cli/output/test_errors.py
+++ b/tests/cli/output/test_errors.py
@@ -1,0 +1,40 @@
+"""Tests for the unified error formatter."""
+
+import io
+
+import pytest
+import typer
+
+from clawrium.cli.output.errors import emit_error
+
+
+class TestEmitError:
+    def test_writes_error_to_stderr_then_exits(self) -> None:
+        buf = io.StringIO()
+        with pytest.raises(typer.Exit) as exc:
+            emit_error("foo", hint="bar", stream=buf)
+        assert exc.value.exit_code == 1
+        assert buf.getvalue() == "Error: foo\nHint:  bar\n"
+
+    def test_no_hint(self) -> None:
+        buf = io.StringIO()
+        with pytest.raises(typer.Exit):
+            emit_error("no hint provided", stream=buf)
+        assert buf.getvalue() == "Error: no hint provided\n"
+
+    def test_custom_exit_code(self) -> None:
+        buf = io.StringIO()
+        with pytest.raises(typer.Exit) as exc:
+            emit_error("oh no", exit_code=2, stream=buf)
+        assert exc.value.exit_code == 2
+
+    def test_hint_indent_aligns_with_error_body(self) -> None:
+        """`Hint:` has two trailing spaces so the body aligns with `Error:`'s body."""
+        buf = io.StringIO()
+        with pytest.raises(typer.Exit):
+            emit_error("foo", hint="bar", stream=buf)
+        lines = buf.getvalue().splitlines()
+        # Both bodies start at column 7 (0-indexed): "Error: foo" and "Hint:  bar"
+        error_body_col = lines[0].index("foo")
+        hint_body_col = lines[1].index("bar")
+        assert error_body_col == hint_body_col == 7

--- a/tests/cli/output/test_json_yaml.py
+++ b/tests/cli/output/test_json_yaml.py
@@ -1,0 +1,86 @@
+"""Tests for `-o json`, `-o yaml`, `-o name` serializers."""
+
+import json
+
+import yaml
+
+from clawrium.cli.output.json_yaml import dump_json, dump_name, dump_yaml
+
+
+SAMPLE_ROWS = [
+    {
+        "kind": "agent",
+        "name": "wise-hypatia",
+        "type": "openclaw",
+        "host": "wolf-i",
+        "status": "running",
+        "age_seconds": 259200,
+        "installed_at": "2026-05-20T14:23:11Z",
+    },
+    {
+        "kind": "agent",
+        "name": "hermes-prod",
+        "type": "hermes",
+        "host": "kevin",
+        "status": "running",
+        "age_seconds": 86400,
+        "installed_at": "2026-05-22T09:00:00Z",
+    },
+]
+
+
+class TestDumpJson:
+    def test_parses_as_json_array(self) -> None:
+        out = dump_json(SAMPLE_ROWS)
+        parsed = json.loads(out)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 2
+
+    def test_snake_case_keys(self) -> None:
+        out = dump_json(SAMPLE_ROWS)
+        parsed = json.loads(out)
+        for row in parsed:
+            for key in row:
+                assert "_" in key or key.islower(), f"non-snake_case key: {key}"
+
+    def test_age_seconds_is_int(self) -> None:
+        out = dump_json(SAMPLE_ROWS)
+        parsed = json.loads(out)
+        for row in parsed:
+            assert isinstance(row["age_seconds"], int)
+
+    def test_ends_with_newline(self) -> None:
+        out = dump_json(SAMPLE_ROWS)
+        assert out.endswith("\n")
+
+
+class TestDumpYaml:
+    def test_yaml_equivalent_to_json(self) -> None:
+        out_yaml = dump_yaml(SAMPLE_ROWS)
+        out_json = dump_json(SAMPLE_ROWS)
+        assert yaml.safe_load(out_yaml) == json.loads(out_json)
+
+    def test_yaml_is_block_style(self) -> None:
+        out = dump_yaml(SAMPLE_ROWS)
+        # block style uses `- ` for list items and `key:` per line
+        assert "- kind:" in out or "- name:" in out or "- " in out
+
+
+class TestDumpName:
+    def test_one_per_line(self) -> None:
+        out = dump_name(SAMPLE_ROWS)
+        lines = out.strip().split("\n")
+        assert lines == ["agent/wise-hypatia", "agent/hermes-prod"]
+
+    def test_no_header(self) -> None:
+        out = dump_name(SAMPLE_ROWS)
+        assert "KIND" not in out
+        assert "NAME" not in out
+
+    def test_no_padding(self) -> None:
+        out = dump_name(SAMPLE_ROWS)
+        for line in out.strip().split("\n"):
+            assert line == line.strip()
+
+    def test_empty_input(self) -> None:
+        assert dump_name([]) == ""

--- a/tests/cli/output/test_sanitize.py
+++ b/tests/cli/output/test_sanitize.py
@@ -6,7 +6,19 @@ shows up here. ATX #341 v3 / #455 W2 hardened chat.py against this
 class of terminal-deception attack (U+202E RIGHT-TO-LEFT OVERRIDE
 silently reverse-prints subsequent output); #507 ATX iter-1 B1/B2/W1/W2
 extended the contract to every output primitive that writes raw
-strings.
+strings; #507 ATX iter-2 added the 6 missing codepoints below
+(LRE/RLE/PDF/LRO + ZWNJ/ZWJ) and the per-primitive ensure_ascii
+property tests for emit_event/dump_json/dump_yaml/format_status.
+
+Test design rules:
+
+- The corpus uses `chr(0xXXXX)` instead of literal Unicode characters
+  so this test file is itself ASCII-safe in source. Same hygiene rule
+  as `_sanitize.py`: literal bidi codepoints in source are invisible
+  to most editors and silently corruptible.
+- Every codepoint in `_CONTROL_AND_BIDI_RE`'s character class MUST
+  have an entry below — `test_source_is_pure_ascii` asserts the
+  hygiene rule on `_sanitize.py` itself.
 """
 
 import io
@@ -14,35 +26,48 @@ import json
 
 import pytest
 import typer
+import yaml
 
 from clawrium.cli.output._sanitize import _CONTROL_AND_BIDI_RE, sanitize
 from clawrium.cli.output.errors import emit_error
-from clawrium.cli.output.json_yaml import dump_name
-from clawrium.cli.output.stream import NDJSONStreamer, stream_action
+from clawrium.cli.output.json_yaml import dump_json, dump_name, dump_yaml
+from clawrium.cli.output.status import format_status
+from clawrium.cli.output.stream import NDJSONStreamer, emit_event, stream_action
 from clawrium.cli.output.table import render
 
 
-# Canonical adversarial codepoints — every entry here MUST be stripped.
+# Canonical adversarial codepoints -- every entry here MUST be stripped.
+# Use chr() so this file stays pure ASCII (same hygiene rule as
+# _sanitize.py). Drift on either side fails CI.
 BIDI_AND_CONTROL = [
-    "‮",  # RIGHT-TO-LEFT OVERRIDE  (the classic v3 demo)
-    "⁦",  # LEFT-TO-RIGHT ISOLATE
-    "⁧",  # RIGHT-TO-LEFT ISOLATE
-    "⁨",  # FIRST STRONG ISOLATE
-    "⁩",  # POP DIRECTIONAL ISOLATE
-    "‎",  # LRM
-    "‏",  # RLM
-    "​",  # ZERO-WIDTH SPACE
-    " ",  # LINE SEPARATOR
-    " ",  # PARAGRAPH SEPARATOR
-    "⁠",  # WORD JOINER
-    "﻿",  # ZWNBSP / BOM
-    "؜",  # ARABIC LETTER MARK
+    chr(0x202E),  # RLO -- the classic v3 demo
+    chr(0x2066),  # LRI
+    chr(0x2067),  # RLI
+    chr(0x2068),  # FSI
+    chr(0x2069),  # PDI
+    chr(0x200E),  # LRM
+    chr(0x200F),  # RLM
+    chr(0x200B),  # ZWSP
+    chr(0x200C),  # ZWNJ -- added iter-2
+    chr(0x200D),  # ZWJ  -- added iter-2
+    chr(0x2028),  # LINE SEPARATOR
+    chr(0x2029),  # PARAGRAPH SEPARATOR
+    chr(0x2060),  # WORD JOINER
+    chr(0xFEFF),  # ZWNBSP / BOM
+    chr(0x061C),  # ARABIC LETTER MARK
+    chr(0x202A),  # LRE -- added iter-2
+    chr(0x202B),  # RLE -- added iter-2
+    chr(0x202C),  # PDF -- added iter-2
+    chr(0x202D),  # LRO -- added iter-2
     "\x00",  # NUL
-    "\x07",  # BEL — terminals will beep
-    "\x1b",  # ESC — starts ANSI sequences
+    "\x07",  # BEL -- terminals will beep
+    "\x1b",  # ESC -- starts ANSI sequences
     "\x7f",  # DEL
     "\x9b",  # CSI (C1)
 ]
+
+RLO = chr(0x202E)
+LRI = chr(0x2066)
 
 
 @pytest.mark.parametrize("dangerous", BIDI_AND_CONTROL)
@@ -58,73 +83,176 @@ def test_sanitize_passes_through_safe_strings() -> None:
     assert sanitize(safe) is safe  # cheap identity short-circuit
 
 
+def test_sanitize_mixed_vector() -> None:
+    """A single string with both a C0 control char and a bidi override.
+
+    Guards against a future regex rewrite that uses `|` alternation
+    instead of a character class and accidentally drops multi-char
+    handling.
+    """
+    cleaned = sanitize(f"\x1b[31m{RLO}red text")
+    assert "\x1b" not in cleaned
+    assert RLO not in cleaned
+    assert "red text" in cleaned
+
+
+def test_source_is_pure_ascii() -> None:
+    """`_sanitize.py` must contain no literal Unicode bytes -- only
+    `\\uXXXX` text escapes. Codified after #507 ATX iter-2 caught a
+    regression where literal codepoints were checked in.
+    """
+    from pathlib import Path
+
+    import clawrium.cli.output._sanitize as mod
+
+    raw = Path(mod.__file__).read_bytes()
+    non_ascii = [(i, b) for i, b in enumerate(raw) if b > 0x7F]
+    assert not non_ascii, (
+        f"_sanitize.py has {len(non_ascii)} non-ASCII bytes; "
+        f"first at offset {non_ascii[0][0]} (0x{non_ascii[0][1]:02x}). "
+        "Use \\uXXXX escapes instead of literal Unicode chars."
+    )
+
+
 class TestEmitErrorSanitization:
     def test_strips_bidi_from_message(self) -> None:
         buf = io.StringIO()
         with pytest.raises(typer.Exit):
-            emit_error("agent‮xists", hint="check‮state", stream=buf)
-        for dangerous in ("‮",):
-            assert dangerous not in buf.getvalue(), (
-                f"emit_error leaked U+{ord(dangerous):04X}"
-            )
+            emit_error(f"agent{RLO}exists", hint=f"check{RLO}state", stream=buf)
+        assert RLO not in buf.getvalue()
+
+    def test_strips_bidi_from_hint_only(self) -> None:
+        """Isolates the hint-path sanitize() call from the message path."""
+        buf = io.StringIO()
+        with pytest.raises(typer.Exit):
+            emit_error("clean message", hint=f"check{RLO}state", stream=buf)
+        assert RLO not in buf.getvalue()
+        assert "clean message" in buf.getvalue()
 
 
 class TestStreamActionSanitization:
     def test_strips_bidi_from_resource_and_message(self) -> None:
         buf = io.StringIO()
         stream_action(
-            resource="agent/wise⁦hypatia",
-            message="install‮complete",
+            resource=f"agent/wise{LRI}hypatia",
+            message=f"install{RLO}complete",
             stream=buf,
         )
-        for dangerous in ("‮", "⁦"):
+        for dangerous in (RLO, LRI):
             assert dangerous not in buf.getvalue()
 
 
 class TestNDJSONStreamerSerialization:
-    """`json.dumps(..., ensure_ascii=True)` is the safety boundary —
-    every non-ASCII codepoint becomes `\\uXXXX` in the output, never the
-    raw control char. Verify the property at the API boundary so a
-    future switch to `ensure_ascii=False` immediately fails CI.
+    """`json.dumps(..., ensure_ascii=True)` is the safety boundary --
+    every non-ASCII codepoint becomes `\\uXXXX` in the output, never
+    the raw control char. Verify the property at the API boundary so a
+    future flip to `ensure_ascii=False` immediately fails CI.
     """
 
     def test_dangerous_codepoint_emerges_escaped_not_raw(self) -> None:
         buf = io.StringIO()
         s = NDJSONStreamer(stream=buf)
         s.emit(
-            resource="agent/x‮y",
+            resource=f"agent/x{RLO}y",
             phase="install",
             state="started",
             ts="2026-05-23T10:14:00Z",
         )
         raw = buf.getvalue()
-        # Raw control char NEVER appears verbatim.
-        assert "‮" not in raw
-        # Escaped form does (json's representation).
+        assert RLO not in raw
         assert "\\u202e" in raw
-        # And the parsed JSON still contains the codepoint as a value —
-        # that's fine; consumers of NDJSON parse the JSON and know what
-        # they're getting.
+        # Consumers parsing the NDJSON still see the codepoint as a
+        # value -- they own the decision to display it safely.
         parsed = json.loads(raw)
-        assert "‮" in parsed["resource"]
+        assert RLO in parsed["resource"]
+
+
+class TestEmitEventSerialization:
+    """Mirrors `TestNDJSONStreamerSerialization` for `emit_event()`.
+    Added iter-2 (#507): the iter-1 commit asserted ensure_ascii
+    property only for `NDJSONStreamer.emit()`; `emit_event()` had no
+    coverage even though it shares the json.dumps call path.
+    """
+
+    def test_dangerous_codepoint_emerges_escaped_not_raw(self) -> None:
+        buf = io.StringIO()
+        emit_event(
+            {
+                "resource": f"agent/x{RLO}y",
+                "phase": "install",
+                "state": "started",
+                "ts": "2026-05-23T10:14:00Z",
+            },
+            stream=buf,
+        )
+        raw = buf.getvalue()
+        assert RLO not in raw
+        assert "\\u202e" in raw
+
+
+class TestDumpJsonSanitization:
+    """Same property as the NDJSON streamer -- exercises dump_json's
+    own json.dumps call.
+    """
+
+    def test_dangerous_codepoint_emerges_escaped_not_raw(self) -> None:
+        out = dump_json([{"kind": f"agent{RLO}", "name": "x"}])
+        assert RLO not in out
+        assert "\\u202e" in out
+
+
+class TestDumpYamlSanitization:
+    """yaml.safe_dump escapes control chars in scalar values."""
+
+    def test_dangerous_codepoint_not_raw(self) -> None:
+        out = dump_yaml([{"name": f"x{RLO}y"}])
+        # The raw codepoint should not appear verbatim in the YAML
+        # serialization (safe_dump escapes it).
+        assert RLO not in out
+        # The parsed YAML still carries the codepoint -- consumers own
+        # display safety.
+        parsed = yaml.safe_load(out)
+        assert RLO in parsed[0]["name"]
 
 
 class TestDumpNameSanitization:
     def test_strips_bidi_from_kind_and_name(self) -> None:
         out = dump_name(
             [
-                {"kind": "agent‮", "name": "wise⁦hypatia"},
+                {"kind": f"agent{RLO}", "name": f"wise{LRI}hypatia"},
             ]
         )
-        for dangerous in ("‮", "⁦"):
+        for dangerous in (RLO, LRI):
             assert dangerous not in out
 
 
 class TestRenderSanitization:
     def test_strips_bidi_from_cells_and_headers(self) -> None:
         out = render(
-            headers=["NAME‮", "STATUS"],
-            rows=[["wise⁦hypatia", "run‮ning"]],
+            headers=[f"NAME{RLO}", "STATUS"],
+            rows=[[f"wise{LRI}hypatia", f"run{RLO}ning"]],
         )
-        for dangerous in ("‮", "⁦"):
+        for dangerous in (RLO, LRI):
             assert dangerous not in out
+
+
+class TestFormatStatusSanitization:
+    """`format_status()` returns unknown tokens via the sanitize() path
+    (#507 ATX iter-2 W7). Known tokens skip sanitization because they
+    are already vocabulary-constrained.
+    """
+
+    def test_unknown_token_is_sanitized(self) -> None:
+        out = format_status(f"running{RLO}foo", force_color=True)
+        assert RLO not in out
+
+    def test_known_token_is_unmodified_when_no_color(self) -> None:
+        # When color is disabled, known tokens pass through verbatim
+        # -- vocabulary constraint is the proof that no sanitization
+        # is needed.
+        import os
+
+        os.environ.pop("NO_COLOR", None)
+        buf = io.StringIO()
+        out = format_status("running", stream=buf)
+        assert out == "running"

--- a/tests/cli/output/test_sanitize.py
+++ b/tests/cli/output/test_sanitize.py
@@ -61,6 +61,9 @@ BIDI_AND_CONTROL = [
     chr(0x202D),  # LRO -- added iter-2
     "\x00",  # NUL
     "\x07",  # BEL -- terminals will beep
+    "\t",  # TAB    -- added iter-3 (S2), explicitly stripped by docstring
+    "\n",  # LF     -- added iter-3 (S2), explicitly stripped by docstring
+    "\r",  # CR     -- added iter-3 (S2), explicitly stripped by docstring
     "\x1b",  # ESC -- starts ANSI sequences
     "\x7f",  # DEL
     "\x9b",  # CSI (C1)
@@ -188,6 +191,11 @@ class TestEmitEventSerialization:
         raw = buf.getvalue()
         assert RLO not in raw
         assert "\\u202e" in raw
+        # Round-trip: NDJSON consumer parses the line and recovers the
+        # codepoint as a value -- the display-safety decision is theirs
+        # (#507 iter-3 S4 round-trip assertion).
+        parsed = json.loads(raw.strip())
+        assert RLO in parsed["resource"]
 
 
 class TestDumpJsonSanitization:
@@ -202,17 +210,58 @@ class TestDumpJsonSanitization:
 
 
 class TestDumpYamlSanitization:
-    """yaml.safe_dump escapes control chars in scalar values."""
+    """`dump_yaml` recursively sanitizes string scalars (#507 iter-3 W2):
+    `yaml.safe_dump` does NOT escape LF, so we strip it (and every other
+    dangerous codepoint) at the primitive.
+    """
 
     def test_dangerous_codepoint_not_raw(self) -> None:
         out = dump_yaml([{"name": f"x{RLO}y"}])
-        # The raw codepoint should not appear verbatim in the YAML
-        # serialization (safe_dump escapes it).
         assert RLO not in out
-        # The parsed YAML still carries the codepoint -- consumers own
-        # display safety.
+        # After iter-3 sanitization, the parsed value has the codepoint
+        # replaced with a space (sanitize() collapses dangerous chars
+        # to a single space).
         parsed = yaml.safe_load(out)
-        assert RLO in parsed[0]["name"]
+        assert RLO not in parsed[0]["name"]
+        # The non-dangerous prefix and suffix survive.
+        assert parsed[0]["name"].startswith("x") and parsed[0]["name"].endswith("y")
+
+    def test_lf_in_name_is_stripped(self) -> None:
+        """`yaml.safe_dump` leaves literal LF in block scalars. A
+        crafted agent name containing `\\n` would produce multi-line
+        YAML from a field expected to be atomic — break shell scripts
+        that parse the YAML output line-by-line. `dump_yaml()` strips
+        LF via the recursive `_sanitize_value` helper.
+        """
+        out = dump_yaml([{"name": "wise\nhypatia"}])
+        # The literal LF inside the value must NOT survive in the
+        # serialized output (other than the trailing record-separator
+        # newlines yaml emits between fields).
+        parsed = yaml.safe_load(out)
+        assert "\n" not in parsed[0]["name"]
+        # The non-LF parts survive.
+        assert "wise" in parsed[0]["name"] and "hypatia" in parsed[0]["name"]
+
+    def test_nested_string_in_list_is_sanitized(self) -> None:
+        """`_sanitize_value` recurses into nested structures."""
+        out = dump_yaml([{"skills": [f"clawrium/tdd{RLO}", "openclaw/lint"]}])
+        assert RLO not in out
+
+
+class TestDumpJsonSanitizationLF:
+    """`json.dumps(..., ensure_ascii=True)` escapes LF as `\\n` (not as
+    a literal newline). Codified here so a regression cannot land
+    silently.
+    """
+
+    def test_lf_in_value_emerges_escaped(self) -> None:
+        out = dump_json([{"name": "wise\nhypatia"}])
+        # The raw LF inside the value must appear escaped, not
+        # injected as a real line break.
+        # (`\n` in JSON = the 2-character escape sequence backslash-n.)
+        assert "wise\\nhypatia" in out
+        parsed = json.loads(out)
+        assert parsed[0]["name"] == "wise\nhypatia"
 
 
 class TestDumpNameSanitization:
@@ -246,13 +295,15 @@ class TestFormatStatusSanitization:
         out = format_status(f"running{RLO}foo", force_color=True)
         assert RLO not in out
 
-    def test_known_token_is_unmodified_when_no_color(self) -> None:
-        # When color is disabled, known tokens pass through verbatim
-        # -- vocabulary constraint is the proof that no sanitization
-        # is needed.
-        import os
-
-        os.environ.pop("NO_COLOR", None)
-        buf = io.StringIO()
+    def test_known_token_is_unmodified_on_non_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On non-TTY, known vocabulary tokens pass through verbatim;
+        the vocabulary constraint is the proof that sanitization is
+        unnecessary on this code path. Use `monkeypatch` for env
+        isolation (#507 iter-3 S5).
+        """
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        buf = io.StringIO()  # not a TTY
         out = format_status("running", stream=buf)
         assert out == "running"

--- a/tests/cli/output/test_sanitize.py
+++ b/tests/cli/output/test_sanitize.py
@@ -1,0 +1,130 @@
+"""Bidi / control-char sanitization corpus tests.
+
+Codifies the dangerous codepoint set in `cli/output/_sanitize.py` so
+any future drift between it and `cli/chat.py:_CONTROL_AND_BIDI_RE`
+shows up here. ATX #341 v3 / #455 W2 hardened chat.py against this
+class of terminal-deception attack (U+202E RIGHT-TO-LEFT OVERRIDE
+silently reverse-prints subsequent output); #507 ATX iter-1 B1/B2/W1/W2
+extended the contract to every output primitive that writes raw
+strings.
+"""
+
+import io
+import json
+
+import pytest
+import typer
+
+from clawrium.cli.output._sanitize import _CONTROL_AND_BIDI_RE, sanitize
+from clawrium.cli.output.errors import emit_error
+from clawrium.cli.output.json_yaml import dump_name
+from clawrium.cli.output.stream import NDJSONStreamer, stream_action
+from clawrium.cli.output.table import render
+
+
+# Canonical adversarial codepoints — every entry here MUST be stripped.
+BIDI_AND_CONTROL = [
+    "‮",  # RIGHT-TO-LEFT OVERRIDE  (the classic v3 demo)
+    "⁦",  # LEFT-TO-RIGHT ISOLATE
+    "⁧",  # RIGHT-TO-LEFT ISOLATE
+    "⁨",  # FIRST STRONG ISOLATE
+    "⁩",  # POP DIRECTIONAL ISOLATE
+    "‎",  # LRM
+    "‏",  # RLM
+    "​",  # ZERO-WIDTH SPACE
+    " ",  # LINE SEPARATOR
+    " ",  # PARAGRAPH SEPARATOR
+    "⁠",  # WORD JOINER
+    "﻿",  # ZWNBSP / BOM
+    "؜",  # ARABIC LETTER MARK
+    "\x00",  # NUL
+    "\x07",  # BEL — terminals will beep
+    "\x1b",  # ESC — starts ANSI sequences
+    "\x7f",  # DEL
+    "\x9b",  # CSI (C1)
+]
+
+
+@pytest.mark.parametrize("dangerous", BIDI_AND_CONTROL)
+def test_sanitize_strips_each_codepoint(dangerous: str) -> None:
+    assert _CONTROL_AND_BIDI_RE.search(dangerous) is not None
+    cleaned = sanitize(f"alpha{dangerous}omega")
+    assert dangerous not in cleaned, f"codepoint U+{ord(dangerous):04X} survived"
+    assert "alpha" in cleaned and "omega" in cleaned
+
+
+def test_sanitize_passes_through_safe_strings() -> None:
+    safe = "agent/wise-hypatia: installed at 2026-05-20T14:23:11Z"
+    assert sanitize(safe) is safe  # cheap identity short-circuit
+
+
+class TestEmitErrorSanitization:
+    def test_strips_bidi_from_message(self) -> None:
+        buf = io.StringIO()
+        with pytest.raises(typer.Exit):
+            emit_error("agent‮xists", hint="check‮state", stream=buf)
+        for dangerous in ("‮",):
+            assert dangerous not in buf.getvalue(), (
+                f"emit_error leaked U+{ord(dangerous):04X}"
+            )
+
+
+class TestStreamActionSanitization:
+    def test_strips_bidi_from_resource_and_message(self) -> None:
+        buf = io.StringIO()
+        stream_action(
+            resource="agent/wise⁦hypatia",
+            message="install‮complete",
+            stream=buf,
+        )
+        for dangerous in ("‮", "⁦"):
+            assert dangerous not in buf.getvalue()
+
+
+class TestNDJSONStreamerSerialization:
+    """`json.dumps(..., ensure_ascii=True)` is the safety boundary —
+    every non-ASCII codepoint becomes `\\uXXXX` in the output, never the
+    raw control char. Verify the property at the API boundary so a
+    future switch to `ensure_ascii=False` immediately fails CI.
+    """
+
+    def test_dangerous_codepoint_emerges_escaped_not_raw(self) -> None:
+        buf = io.StringIO()
+        s = NDJSONStreamer(stream=buf)
+        s.emit(
+            resource="agent/x‮y",
+            phase="install",
+            state="started",
+            ts="2026-05-23T10:14:00Z",
+        )
+        raw = buf.getvalue()
+        # Raw control char NEVER appears verbatim.
+        assert "‮" not in raw
+        # Escaped form does (json's representation).
+        assert "\\u202e" in raw
+        # And the parsed JSON still contains the codepoint as a value —
+        # that's fine; consumers of NDJSON parse the JSON and know what
+        # they're getting.
+        parsed = json.loads(raw)
+        assert "‮" in parsed["resource"]
+
+
+class TestDumpNameSanitization:
+    def test_strips_bidi_from_kind_and_name(self) -> None:
+        out = dump_name(
+            [
+                {"kind": "agent‮", "name": "wise⁦hypatia"},
+            ]
+        )
+        for dangerous in ("‮", "⁦"):
+            assert dangerous not in out
+
+
+class TestRenderSanitization:
+    def test_strips_bidi_from_cells_and_headers(self) -> None:
+        out = render(
+            headers=["NAME‮", "STATUS"],
+            rows=[["wise⁦hypatia", "run‮ning"]],
+        )
+        for dangerous in ("‮", "⁦"):
+            assert dangerous not in out

--- a/tests/cli/output/test_status.py
+++ b/tests/cli/output/test_status.py
@@ -1,0 +1,47 @@
+"""Tests for the STATUS column formatter."""
+
+import io
+
+import pytest
+
+from clawrium.cli.output.status import _COLORS, format_status
+
+
+@pytest.mark.parametrize("token", list(_COLORS))
+def test_force_color_emits_ansi(token: str) -> None:
+    out = format_status(token, force_color=True)
+    assert out.startswith("\x1b[")
+    assert out.endswith("\x1b[0m")
+    assert token in out
+
+
+def test_non_tty_emits_raw_token() -> None:
+    stream = io.StringIO()  # not a TTY
+    out = format_status("running", stream=stream)
+    assert out == "running"
+
+
+def test_no_color_env_blocks_ansi(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    out = format_status("running", force_color=True)
+    assert out == "running"
+
+
+def test_unknown_token_passes_through() -> None:
+    out = format_status("nonsense-token", force_color=True)
+    assert out == "nonsense-token"
+
+
+def test_known_vocabulary_complete() -> None:
+    expected = {
+        "running",
+        "degraded",
+        "stopped",
+        "pending",
+        "onboarding",
+        "ready",
+        "installing",
+        "failed",
+        "unknown",
+    }
+    assert set(_COLORS) == expected

--- a/tests/cli/output/test_stream.py
+++ b/tests/cli/output/test_stream.py
@@ -1,0 +1,77 @@
+"""Tests for the NDJSON action streamer."""
+
+import io
+import json
+
+import pytest
+
+from clawrium.cli.output.stream import NDJSONStreamer, emit_event, stream_action
+
+
+class TestNDJSONStreamer:
+    def test_emit_writes_one_object_per_line(self) -> None:
+        buf = io.StringIO()
+        s = NDJSONStreamer(stream=buf)
+        s.emit(
+            resource="agent/wise-hypatia",
+            phase="install",
+            state="started",
+            ts="2026-05-23T10:14:00Z",
+        )
+        s.emit(
+            resource="agent/wise-hypatia",
+            phase="install",
+            state="complete",
+            ts="2026-05-23T10:14:42Z",
+            version="0.4.2",
+        )
+
+        lines = buf.getvalue().strip().split("\n")
+        assert len(lines) == 2
+        first = json.loads(lines[0])
+        second = json.loads(lines[1])
+        # Required keys present
+        for ev in (first, second):
+            for k in ("resource", "phase", "state", "ts"):
+                assert k in ev
+        # Extras pass through
+        assert second["version"] == "0.4.2"
+
+    def test_ts_auto_populated_when_missing(self) -> None:
+        buf = io.StringIO()
+        s = NDJSONStreamer(stream=buf)
+        s.emit(resource="agent/x", phase="install", state="started")
+        ev = json.loads(buf.getvalue().strip())
+        # RFC3339 ends with Z
+        assert ev["ts"].endswith("Z")
+
+
+class TestEmitEvent:
+    def test_pre_built_event(self) -> None:
+        buf = io.StringIO()
+        emit_event(
+            {
+                "resource": "agent/x",
+                "phase": "start",
+                "state": "complete",
+                "ts": "2026-05-23T10:15:00Z",
+            },
+            stream=buf,
+        )
+        ev = json.loads(buf.getvalue().strip())
+        assert ev["resource"] == "agent/x"
+
+    def test_missing_key_raises(self) -> None:
+        with pytest.raises(KeyError):
+            emit_event({"resource": "x", "phase": "p"}, stream=io.StringIO())
+
+
+class TestStreamAction:
+    def test_human_line_format(self) -> None:
+        buf = io.StringIO()
+        stream_action(
+            resource="agent/wise-hypatia",
+            message="installed",
+            stream=buf,
+        )
+        assert buf.getvalue() == "agent/wise-hypatia: installed\n"

--- a/tests/cli/output/test_table.py
+++ b/tests/cli/output/test_table.py
@@ -1,0 +1,72 @@
+"""Tests for the tabwriter-style table renderer (`output.table`)."""
+
+from clawrium.cli.output.table import GAP, render
+
+
+class TestRender:
+    def test_padding_per_column(self) -> None:
+        out = render(
+            headers=["NAME", "TYPE", "AGE"],
+            rows=[
+                ["a", "x", "1d"],
+                ["bbbb", "yy", "30s"],
+                ["cc", "zzzz", "5m"],
+            ],
+        )
+        # Headers: NAME(4), TYPE(4), AGE(3). Column widths from max:
+        #   col0: max(NAME=4, a=1, bbbb=4, cc=2) = 4
+        #   col1: max(TYPE=4, x=1, yy=2, zzzz=4) = 4
+        #   col2 last column → no padding
+        expected = (
+            f"NAME{GAP}TYPE{GAP}AGE\n"
+            f"a   {GAP}x   {GAP}1d\n"
+            f"bbbb{GAP}yy  {GAP}30s\n"
+            f"cc  {GAP}zzzz{GAP}5m\n"
+        )
+        assert out == expected
+
+    def test_gap_is_exactly_three_spaces(self) -> None:
+        out = render(headers=["A", "B"], rows=[["x", "y"]])
+        # `A   B\nx   y\n` — 3 spaces between cols.
+        first_line = out.splitlines()[0]
+        assert first_line == "A   B"
+        # explicit GAP check
+        assert "   " in first_line
+        assert "    " not in first_line  # not 4 spaces
+
+    def test_no_trailing_whitespace(self) -> None:
+        out = render(
+            headers=["X", "Y"],
+            rows=[["short", "longer-value"], ["alpha", "beta"]],
+        )
+        for line in out.splitlines():
+            assert line == line.rstrip(), f"line has trailing whitespace: {line!r}"
+
+    def test_no_headers_omits_header_row(self) -> None:
+        out_with = render(
+            headers=["NAME", "AGE"],
+            rows=[["a", "1d"], ["bbbb", "5m"]],
+        )
+        out_without = render(
+            headers=["NAME", "AGE"],
+            rows=[["a", "1d"], ["bbbb", "5m"]],
+            no_headers=True,
+        )
+        assert "NAME" not in out_without
+        # widths must still be computed including header for compat with
+        # piped output (columns line up). Without header AND header is
+        # the widest cell, we want widths to be max(data) for tightness.
+        # Here, header NAME(4) == bbbb(4) so result is the same width.
+        assert "a   " in out_without
+        # The header-less output should be a strict suffix of the row
+        # data (no extra blank line)
+        assert out_without == "\n".join(out_with.splitlines()[1:]) + "\n"
+
+    def test_empty_input_returns_empty_string(self) -> None:
+        assert render(headers=[], rows=[]) == ""
+
+    def test_single_column_no_padding(self) -> None:
+        # Last column gets no padding; with only one column there's no
+        # padding at all.
+        out = render(headers=["NAME"], rows=[["a"], ["bbbb"]])
+        assert out == "NAME\na\nbbbb\n"

--- a/tests/cli/test_app.py
+++ b/tests/cli/test_app.py
@@ -1,0 +1,103 @@
+"""Tests for the top-level `clawctl` Typer app skeleton.
+
+These cover plan §"Specific Outcomes to Validate":
+
+- `clawctl --help` lists every top-level group from plan §4.
+- Every group's `--help` exits 0 (proves Risk R2 is closed).
+- Stubbed subcommands print the canonical `Not implemented: <group> <verb>`
+  line.
+"""
+
+import pytest
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+
+runner = CliRunner()
+
+
+EXPECTED_TOP_LEVEL = [
+    "service",
+    "version",
+    "completion",
+    "tui",
+    "gui",
+    "host",
+    "agent",
+    "provider",
+    "channel",
+    "integration",
+    "skill",
+    "mcp",
+]
+
+
+def test_root_help_lists_every_group() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for token in EXPECTED_TOP_LEVEL:
+        assert token in result.output, f"missing from root --help: {token}"
+
+
+@pytest.mark.parametrize(
+    "group",
+    [
+        "service",
+        "host",
+        "agent",
+        "provider",
+        "channel",
+        "integration",
+        "skill",
+        "mcp",
+    ],
+)
+def test_group_help_exits_zero(group: str) -> None:
+    result = runner.invoke(app, [group, "--help"])
+    assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    "argv,expected",
+    [
+        (["host", "create"], "Not implemented: host create"),
+        (["host", "get"], "Not implemented: host get"),
+        (["agent", "create"], "Not implemented: agent create"),
+        (["agent", "sync"], "Not implemented: agent sync"),
+        (
+            ["provider", "registry", "create"],
+            "Not implemented: provider registry create",
+        ),
+        (["channel", "registry", "create"], "Not implemented: channel registry create"),
+        (
+            ["integration", "registry", "get"],
+            "Not implemented: integration registry get",
+        ),
+        (["skill", "registry", "get"], "Not implemented: skill registry get"),
+        (["mcp", "registry", "get"], "Not implemented: mcp registry get"),
+    ],
+)
+def test_stub_verb_emits_canonical_line(argv: list[str], expected: str) -> None:
+    result = runner.invoke(app, argv)
+    assert result.exit_code == 0
+    assert result.output.strip() == expected
+
+
+def test_pattern_a_registry_subgroup_exposed() -> None:
+    """Each Pattern A noun has `registry` as its only subgroup (plan §3)."""
+    for noun in ("provider", "channel", "integration", "skill", "mcp"):
+        result = runner.invoke(app, [noun, "--help"])
+        assert result.exit_code == 0
+        assert "registry" in result.output, f"{noun}: registry subgroup missing"
+
+
+def test_core_untouched_by_imports() -> None:
+    """Importing `clawrium.cli` (the new clawctl app) must not pull in
+    any `clawrium.core` module side-effects beyond what was already
+    needed for `__version__`. This is a smoke check; the real guarantee
+    is the `git diff` rule in the Acceptance Criteria.
+    """
+    import importlib
+
+    importlib.import_module("clawrium.cli")
+    # If this import succeeded, we know clawrium.cli works in isolation.

--- a/tests/cli/test_meta.py
+++ b/tests/cli/test_meta.py
@@ -1,0 +1,39 @@
+"""Tests for `clawctl version`, `clawctl --version`, and `clawctl completion`."""
+
+from typer.testing import CliRunner
+
+from clawrium import __version__
+from clawrium.cli import app
+
+runner = CliRunner()
+
+
+class TestVersion:
+    def test_flag_and_subcommand_match(self) -> None:
+        flag = runner.invoke(app, ["--version"])
+        sub = runner.invoke(app, ["version"])
+        assert flag.exit_code == 0
+        assert sub.exit_code == 0
+        assert flag.output.strip() == sub.output.strip() == f"clawctl {__version__}"
+
+
+class TestCompletion:
+    def test_bash(self) -> None:
+        result = runner.invoke(app, ["completion", "bash"])
+        assert result.exit_code == 0
+        # Click's bash completion script defines a `_<APP>_completion` shell fn.
+        assert "_clawctl_completion" in result.output or "complete -" in result.output
+
+    def test_zsh(self) -> None:
+        result = runner.invoke(app, ["completion", "zsh"])
+        assert result.exit_code == 0
+        assert "_clawctl_completion" in result.output or "compdef" in result.output
+
+    def test_fish(self) -> None:
+        result = runner.invoke(app, ["completion", "fish"])
+        assert result.exit_code == 0
+        assert "complete --no-files" in result.output or "complete -" in result.output
+
+    def test_rejects_unknown_shell(self) -> None:
+        result = runner.invoke(app, ["completion", "powershell"])
+        assert result.exit_code != 0

--- a/tests/cli/test_service.py
+++ b/tests/cli/test_service.py
@@ -1,0 +1,50 @@
+"""Tests for the `clawctl service` group."""
+
+import os
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+
+runner = CliRunner()
+
+
+class TestServiceInit:
+    def test_creates_config_dir(self, isolated_config: Path) -> None:
+        """`clawctl service init` creates `~/.config/clawrium/` (same as `clm init`)."""
+        assert not isolated_config.exists()
+        result = runner.invoke(app, ["service", "init"], env=os.environ)
+        assert result.exit_code == 0
+        assert isolated_config.exists()
+        assert isolated_config.is_dir()
+
+    def test_emits_success_line(self, isolated_config: Path) -> None:
+        result = runner.invoke(app, ["service", "init"], env=os.environ)
+        assert result.exit_code == 0
+        assert (
+            "initialized" in result.output.lower() or "created" in result.output.lower()
+        )
+
+
+class TestServiceStubs:
+    def test_start_stub(self) -> None:
+        result = runner.invoke(app, ["service", "start"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "Not implemented: service start"
+
+    def test_stop_stub(self) -> None:
+        result = runner.invoke(app, ["service", "stop"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "Not implemented: service stop"
+
+    def test_snapshot_stub(self) -> None:
+        result = runner.invoke(app, ["service", "snapshot"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "Not implemented: service snapshot"
+
+    def test_help_exits_zero(self) -> None:
+        result = runner.invoke(app, ["service", "--help"])
+        assert result.exit_code == 0
+        for verb in ("init", "start", "stop", "snapshot"):
+            assert verb in result.output


### PR DESCRIPTION
Bundle 2 of #435 (kubectl-style CLI sweep). Lands the `clawctl` entrypoint and the foundation every later bundle builds on.

Stacked on top of `feat/435-clawctl-ux` — depends on Bundle 1 (PR #511, audit-before baseline) merging into that branch first.

Closes #507

## Summary

- `pyproject.toml` script entry replaced: `clm = "clawrium.cli.main:app"` → `clawctl = "clawrium.cli:app"`. No alias.
- `src/clawrium/cli/__init__.py` — new top-level Typer app. Registers every command/group from plan §4: `service`, `version`, `completion`, `tui`, `gui`, `host`, `agent`, `provider`, `channel`, `integration`, `skill`, `mcp`. Closes Risk R2 — bundles 3-4 only edit their group files.
- `src/clawrium/cli/output/{table,json_yaml,stream,errors,age,status,_sanitize}.py` — kubectl-style output primitives implementing plan §6 (tabwriter padding, `-o json|yaml|name`, NDJSON streamer, error/age/status formatters). Every raw-string-write primitive applies bidi/control-char sanitization (parity with `cli/chat.py`).
- `src/clawrium/cli/service.py` — `service init` (real, delegates to existing `init_command`), `service start|stop|snapshot` (stubs).
- `src/clawrium/cli/meta.py` — `version` + `completion <bash|zsh|fish>` (Click `shell_completion`).
- `src/clawrium/cli/clawctl/{host,agent,provider,channel,integration,skill,mcp}.py` — stub group apps. Each verb prints `Not implemented: <group> <verb>` exit 0. Sub-package isolates new clawctl surface from legacy `cli/host.py`/`cli/agent.py`/... which still serve the `clm` test suite.
- `README.md` quickstart rewritten to use `clawctl` verbs (iter-3 W1).
- `tests/cli/` — 126 new tests including a 27-codepoint bidi corpus + integration assertions per output primitive + source-hygiene drift guard + dump_yaml LF stripping.

## Testing

### Test Results
- [x] All existing tests pass (`uv run pytest`): 2704 passed, 6 skipped (was 2578 + 6 — +126 from this bundle)
- [x] Linter passes (`uv run ruff check src tests`)
- [x] New tests added covering plan §"Specific Outcomes to Validate" + ATX iter-1/iter-2/iter-3 regression coverage

### Test Coverage

| Path | Tests |
|---|---|
| `tests/cli/test_app.py` | top-level `clawctl --help`, `--version`, group registration, stub verb output |
| `tests/cli/test_meta.py` | `version` flag + subcommand parity, completion bash/zsh/fish |
| `tests/cli/test_service.py` | `service init` config dir creation, start/stop/snapshot stub output |
| `tests/cli/output/test_table.py` | tabwriter padding rules, `--no-headers`, 3-space gap |
| `tests/cli/output/test_json_yaml.py` | `-o json`/`-o yaml` equivalence, `-o name` format, snake_case keys |
| `tests/cli/output/test_age.py` | kubectl AGE boundary table (0s → 100d) |
| `tests/cli/output/test_status.py` | TTY color, NO_COLOR env, unknown-token passthrough |
| `tests/cli/output/test_stream.py` | NDJSON one-object-per-line, required keys, human stream_action |
| `tests/cli/output/test_errors.py` | Error/Hint to stderr, alignment, exit codes |
| `tests/cli/output/test_sanitize.py` | 27-codepoint corpus + per-primitive integration tests + source-hygiene drift guard + LF stripping in `dump_yaml` + `ensure_ascii` round-trip in `emit_event` |

### Manual Testing

- `clawctl --help` lists all 12 expected commands/groups.
- `clawctl --version` and `clawctl version` both print `clawctl 26.5.4`.
- Each group `--help` exits 0.
- `clawctl service init` creates `~/.config/clawrium/` (with XDG override).
- `clawctl service start|stop|snapshot` print the canonical placeholder line.
- `clawctl completion bash` emits a Click-generated completion script.
- All stubbed sub-verbs (e.g., `clawctl host create`, `clawctl provider registry get`) print `Not implemented: <group> <verb>` exit 0.

### Security Checklist
- [x] No hardcoded secrets or credentials.
- [x] Input validation for user-provided data (completion shell enum, port range).
- [x] Bidi / control-char sanitization at every raw-string-write primitive — mirrors the `cli/chat.py` parity contract from ATX #341 v3 / #455 W2.
- [x] No new subprocess surface, no new file paths, no new dependencies.
- [x] `clawrium.core.*` untouched (Acceptance Criterion 4) — verified with `git diff main...HEAD -- src/clawrium/core/` returning zero lines.

## ATX Review Summary

**Final review: Rating 4/5, WARNINGS-ONLY, MERGE-READY.** All iter-2 blockers closed in 4266803; all iter-3 W1/W2/W3 warnings closed in e0f951c. iter-2 cli-ux B2 decline (`restore clm` alias) accepted by iter-3 panel.

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | n/a (3 of 4 specialists failed) | B1, B2 | All fixed in 23df959 | $1.16 | 8m35s | security (others failed) |
| 2 | 2/5 overall | B-sec, B-test-corpus, B-test-emit-event, B-cli-ux-clm-removal | 3 fixed in 4266803, 1 declined | $4.06 | 14m25s | leader + 5 specialists |
| 3 | 4/5 — WARNINGS-ONLY | none | W1/W2/W3 fixed in e0f951c, W4 deferred to bundle 3 | ~$3.16 | 19m24s | leader + 4 specialists |

> Note: ATX iter-3 client timed out at 15min but the server-side task continued and completed at 19m24s. Final result was retrieved via the supervisor HTTP API (task `caf0acdb-3b16-4ffd-b629-a8ff570e93e0`). Details preserved in `.itx/507/atx-session.json`.

<details>
<summary>Review 1 details (commit 1f3ded4 — security-reviewer only; 3 others failed)</summary>

**Blocking issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `src/clawrium/cli/output/errors.py:32,36` | `emit_error()` writes message/hint to stderr without bidi/control-char filtering | Fixed in 23df959 — new `_sanitize.py` mirrors `cli/chat.py:_CONTROL_AND_BIDI_RE`; `sanitize()` applied to both args |
| B2 | `src/clawrium/cli/output/stream.py:68` | `stream_action()` writes resource/message to stdout without sanitization | Fixed in 23df959 — `sanitize()` applied to both args |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `src/clawrium/cli/output/table.py` | `render()` cells/headers not sanitized | Fixed in 23df959 — `sanitize()` applied; contract documented |
| W2 | `src/clawrium/cli/output/json_yaml.py` | `dump_name()` emits raw kind/name | Fixed in 23df959 — `sanitize()` applied |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | NDJSONStreamer `**extra` kwargs could leak secrets if a future caller forwards `api_key=…` | Deferred to bundle 3 — documented as audit point in `stream.py` |
| S2 | `completion_cmd` Click `shell_completion` call path security review | Confirmed clean by ATX (Enum constraint is the correct mitigation) |

</details>

<details>
<summary>Review 2 details (commit 23df959 — all 5 specialists completed)</summary>

**Blocking issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B-sec/cli-ux | `src/clawrium/cli/output/_sanitize.py:36-42` | Literal Unicode bytes in regex char class — violates the file's own stated `\uXXXX`-only convention | Fixed in 4266803 — rewrote with explicit `\uXXXX` text escapes; file now 0 non-ASCII bytes; new `test_source_is_pure_ascii` drift guard |
| B-test-coverage (1) | `tests/cli/output/test_sanitize.py:26-45` | `BIDI_AND_CONTROL` corpus omits 6 codepoints (LRE/RLE/PDF/LRO/ZWNJ/ZWJ) — silently allows regex drift | Fixed in 4266803 — added all 6; corpus now 24 entries |
| B-test-coverage (2) | `src/clawrium/cli/output/stream.py:63,96` + `json_yaml.py:32` | `emit_event()` + `dump_json()` rely on `json.dumps`' `ensure_ascii=True` default but have no property test | Fixed in 4266803 — `ensure_ascii=True` made explicit at all three call sites; new `TestEmitEventSerialization` + `TestDumpJsonSanitization` + `TestDumpYamlSanitization` classes |
| B-cli-ux | `pyproject.toml:41` | Restore `clm` script entry for deprecation window | **DECLINED** — Issue #507 explicitly requires "No alias, no deprecation, `clm` fully off PATH". iter-3 panel accepted the decline. |

**Warnings (fixed):** W-sec/core W7 (`format_status` unknown tokens), W2 cli-ux (service stubs → helper), W4 test-cov (hint-only test), W5 test-cov (`ensure_ascii=True` explicit), W6 test-cov (`dump_json`/`dump_yaml` tests), S2 cli-ux (`version_cmd` docstring parity).

**Deferred:** AGENTS.md docs sweep → bundle 5; `agent create` vs `apply` idempotency naming → bundle 3 plan; NDJSONStreamer extra-kwargs audit → bundle 3; architectural lint for `sanitize()` wiring on new primitives → bundle 3.

</details>

<details>
<summary>Review 3 details (commit 4266803 — leader + 4 specialists)</summary>

**Verdict: 4/5 WARNINGS-ONLY. All iter-2 blockers confirmed CLOSED. B2 decline accepted.**

**Warnings (fixed in e0f951c):**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `README.md` quickstart | Still references `clm` — would break first-install UX | Fixed — quickstart rewritten with `clawctl` verbs per parent plan §5 BEFORE→AFTER map |
| W2 | `json_yaml.py:40-50` + docstring | `yaml.safe_dump` does NOT escape LF; docstring claims parity with `dump_json` | Fixed — new `_sanitize_value()` recursively sanitizes string scalars; docstring corrected; `test_lf_in_name_is_stripped` + `test_nested_string_in_list_is_sanitized` codify; `TestDumpJsonSanitizationLF` codifies the JSON side |
| W3 | `__init__.py:32` | Contract table said `format_status` is "N/A" but it now sanitizes — drift trap for bundle 3 readers | Fixed — table entry updated to "Yes (unknown-token path)"; added "sanitize() IS NOT a secret redactor" note |

**Warning W4 (advisory, deferred to bundle 3):**

| # | File | Warning | Plan |
|---|------|---------|------|
| W4 | `stream.py:46-64` | NDJSONStreamer `**extra` kwargs not enforced against secret keys | Bundle 3 — current bundle has no caller passing extras; a temporary allowlist would be premature. Comment in `stream.py` flags it as audit point. |

**Suggestions applied (cheap wins):**

| # | Suggestion | Status |
|---|------------|--------|
| S1 | `allow_unicode=False` explicit on `yaml.safe_dump` | Done in e0f951c |
| S2 | Add TAB/LF/CR to `BIDI_AND_CONTROL` corpus | Done — corpus now 27 entries |
| S4 | `emit_event` round-trip assertion | Done — parses NDJSON line and recovers codepoint |
| S5 | `test_known_token_is_unmodified_when_no_color` → use `monkeypatch` | Done — renamed to `on_non_tty`; bare `os.environ.pop` replaced |

</details>

## Callouts

- [DECISION] `clm` script entry fully removed; **no** deprecation alias added.
  - Why: Issue #507 explicitly says "**`clm` entry is removed (no alias)**" and lists negative checks `clm --help` returning "command not found" + no `clm = ...` references in `pyproject.toml` as plan §"Specific Outcomes to Validate" items.
  - History: ATX iter-2 cli-ux flagged this as a blocker (suggested restoring an alias). iter-3 panel reviewed the decline and accepted it as consistent with the issue scope.
  - Reviewer: confirmed.

- [DECISION] New clawctl stub group apps live under `src/clawrium/cli/clawctl/` (sub-package), NOT at the top level alongside legacy `cli/agent.py` / `cli/host.py`.
  - Why: The legacy `clm` Typer app at `clawrium.cli.main:app` is still imported by ~2500 existing tests. Putting new `agent.py`/`host.py` etc. at `src/clawrium/cli/` would name-collide and force a much larger refactor inside bundle 2. The issue's "Files affected" list suggests top-level placement; I traded that against the test-impact and rephrased it as a sub-package. Bundles 3-4 will edit `cli/clawctl/agent.py` (etc.) for the real implementations — no further reshuffling.
  - Alternatives considered: rename legacy files first (rejected — out of scope, would explode the bundle's diff).
  - Reviewer: confirm.

- [DECISION] `make format` was NOT run repo-wide. The pre-existing codebase has accumulated ~66 files of ruff-format drift in legacy paths (including `src/clawrium/core/*` — Acceptance Criterion 4 guardrail). Running `make format` would touch all of them.
  - Why: AC4 says "verify with `git diff main...HEAD -- src/clawrium/core/` returns zero lines." Running `make format` would violate this guardrail and balloon the diff with reformats unrelated to this bundle's scope.
  - How to apply: I ran `ruff format` only on my new + edited files. `uv run ruff format --check` on the bundle's paths is clean.
  - Reviewer: the "make format produces zero diff" Acceptance Criterion item is partially met — clean for this bundle's files, pre-existing drift in legacy files left alone for a separate cleanup PR.

- [DECISION] Bundle's stub groups added planned verb stubs (e.g., `clawctl host create`, `clawctl agent sync`, `clawctl provider registry create`) rather than empty group apps.
  - Why: Closes Risk R2 ("complete group skeleton lands here so Bundles 3/4 only fill in module internals"). Bundles 3-4 only replace function bodies — no need to register new commands. This is the stronger reading of "complete group skeleton."
  - Reviewer: confirm reading.

- [DECISION] `dump_yaml` recursively sanitizes string scalars (collapsing LF / TAB / CR to a single space), even though those are otherwise legitimate YAML scalars.
  - Why: ATX iter-3 W2 — `yaml.safe_dump` emits a block scalar with a literal LF inside, which would break shell scripts parsing the YAML output line-by-line. The threat model is a hostile agent name. Parity with `dump_json` (which escapes LF as `\n`) and `dump_name` (which sanitizes) is the cleaner contract; one primitive in the family staying permissive creates a drift trap.
  - Alternatives considered: document the LF passthrough as intentional (rejected — breaks the parity that the contract table asserts).
  - Reviewer: confirm.

- [TODO-FOLLOWUP] NDJSONStreamer `**extra` kwargs allowlist/denylist (ATX iter-1 S1 / iter-2 carryover / iter-3 W4). No real caller in this bundle passes extras; the gate is needed before the first lifecycle caller lands in bundle 3 (#508). Tracked in the bundle 3 plan as an audit point. Comment in `stream.py` flags the call site.

- [TODO-FOLLOWUP] AGENTS.md and the rest of the docs tree still reference `clm` — bundle 5 (#510) owns the docs sweep per parent plan §12. (README.md, which is the user-visible quickstart, is updated in this PR per iter-3 W1.)

- [TODO-FOLLOWUP] Whitespace stripping in `sanitize()` collapses multi-line error structure (chat.py parity behavior). If bundle 3 wants multi-line `clawctl agent describe` errors, the lifecycle caller should pre-format multi-line output to single-line OR write to stderr via several `emit_error` calls. Documented in `_sanitize.py` docstring.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
