### PR TITLE
fix(cli/clawctl): #516 lifecycle verbs resolve canonical agent key

### DIFF
--- a/.itx/435/e2e-validation.md
+++ b/.itx/435/e2e-validation.md
@@ -1,0 +1,193 @@
+# `clawctl` Gate 3 — E2E Validation
+
+End-to-end validation of the new `clawctl` write surface against the live wolf-i fleet, per [`.itx/435/01_SCAFFOLD.md`](https://github.com/ric03uec/clawrium/blob/feat/435/bundle-5-templates-docs-audit-after/.itx/435/01_SCAFFOLD.md) lines 460–478 ("Gate 3 — wolf-i full-fleet end-to-end"). Final acceptance bar before opening the `feat/435-clawctl-ux → main` integration PR.
+
+## Header
+
+| Field | Value |
+|---|---|
+| Date (UTC) | 2026-05-24 → 2026-05-25 |
+| Integration branch (pre-fix) | `feat/435-clawctl-ux` @ `3acce64` (merge of #511, #512, #513, #514, #515) |
+| Hotfix branch | `fix/516-lifecycle-verb-key-resolution` (resolves regression caught by this gate) |
+| `clawctl --version` | 26.5.4 |
+| `clawctl` binary | `/home/devashish/.local/bin/clawctl` (installed via `uv tool install -e .` from each branch in turn) |
+| Target host | `wolf-i` (ubuntu, LAN) |
+| Operator | orchestrator (`/itx:execute orchestrate 435`) |
+
+## Pre-existing fleet snapshot (untouched throughout)
+
+```
+NAME             TYPE       HOST     PROVIDER  STATUS   AGE
+wolf-i           openclaw   wolf-i   -         ready    43d
+espresso         hermes     wolf-i   -         ready    13d
+maurice          hermes     wolf-i   -         ready    2d
+clawrium-d01     zeroclaw   wolf-i   -         ready    5d
+nemotron-beta    zeroclaw   wolf-i   -         ready    4d
+nemotron-alpha   zeroclaw   wolf-i   -         ready    2d
+```
+
+The host carries **multiple instances of the same type** (3 zeroclaws, 2 hermes) — the exact shape that exposed the regression below.
+
+## Deviations from scaffold §460–478
+
+| Spec item | Action | Reason |
+|---|---|---|
+| `clawctl service init` | **SKIP** | `~/.config/clawrium/` already provisioned with 6 production agents; re-init would clobber `hosts.json`. |
+| `clawctl host create wolf-i --user <u> --bootstrap` | **SKIP** | wolf-i already registered; bootstrap would re-run `ssh-copy-id`. |
+| `clawctl provider registry create anthropic --type anthropic --api-key-stdin` | **SKIP** | No Anthropic API key in env / `pass`. Existing agents use direct in-config credentials (provider column shows `-`). |
+| `clawctl channel registry create my-discord …` | **SKIP** | No Discord token available. Scaffold explicitly accepts: "channels-not-applicable agents may skip with documented error." |
+| `clawctl agent channel attach …` | **SKIP** | Depends on the skipped channel above. |
+| `clawctl agent create … --provider anthropic --yes` | **ADAPT** | `--provider` omitted; matches existing fleet's install pattern. Side-effect: subsequent `--stage providers` step is unrunnable without a registered provider (see Phase 2 Retest analysis below). |
+
+---
+
+## Phase 1 — Initial Gate 3 attempt (pre-fix, RED)
+
+Ran [`/tmp/gate3-runner.sh`](https://github.com/ric03uec/clawrium/blob/fix/516-lifecycle-verb-key-resolution/.itx/435/e2e-validation.md) for all three agent types: `audit-zeroclaw`, `audit-hermes`, `audit-openclaw`. Each cycle: `create → configure → channel-attach (skip) → skill attach → secret create → start → get|grep → sync → describe → restart → logs → stop → delete`.
+
+### Result
+
+| Agent | Pass | Fail | Skip |
+|---|---|---|---|
+| audit-zeroclaw | 6 | 6 | 1 |
+| audit-hermes | 6 | 6 | 1 |
+| audit-openclaw | 6 | 6 | 1 |
+| **Total** | **18** | **18** | **3** |
+
+Identical failure shape across all three types — systematic, not flaky. Every write-path verb failed at the very first SSH-touching step.
+
+### Failure signature
+
+`clawctl agent delete audit-zeroclaw --yes`:
+
+```
+agent/audit-zeroclaw: [validate] Checking zeroclaw on wolf.tailf7742d.ts.net...
+Error: remote cleanup failed: Multiple zeroclaw agents found.
+       Specify instance name: clawrium-d01, nemotron-beta, nemotron-alpha, audit-zeroclaw
+```
+
+`clawctl agent configure audit-zeroclaw --stage validate`:
+
+```
+agent/audit-zeroclaw: configure stage=validate on wolf.tailf7742d.ts.net
+…
+AgentNotFoundError: Agent 'zeroclaw' not found on host 'wolf.tailf7742d.ts.net'
+```
+
+Both errors look up the **agent type** (`zeroclaw`) where the **instance name** (`audit-zeroclaw`) is required.
+
+### Root cause
+
+`src/clawrium/cli/clawctl/agent/_shared.py:safe_resolve_agent()` returns the agent's type string as its second tuple element (its own docstring says so). 6 of the 8 lifecycle verbs (`configure`, `start`, `stop`, `sync`, `restart`, `delete`) consumed that value as if it were the instance name — so on any host with >1 agent of the same type, every write-path lifecycle op was broken.
+
+A helper `resolve_agent_key(host, agent_name)` was added in Bundle 3 ATX iter-2 W3 to do the second-pass lookup, but it was only wired into the 3 Pattern A attachable verbs (`provider`, `channel`, `integration`) — the lifecycle verbs were missed. The Bundle 3 unit tests fixtured a single-agent-per-type host where the bug is invisible (dict key happens to equal the type string), so the regression slipped through every gate before Gate 3.
+
+### Tracking
+
+Filed as bug [**#516**](https://github.com/ric03uec/clawrium/issues/516) immediately on detection. Stranded 3 audit agents in `onboarding` state on wolf-i (couldn't be deleted by the same broken `delete` verb).
+
+---
+
+## Hotfix — `fix/516-lifecycle-verb-key-resolution`
+
+| Aspect | Detail |
+|---|---|
+| Branch | `fix/516-lifecycle-verb-key-resolution` (off `feat/435-clawctl-ux`) |
+| Files changed | 6 verb modules + 1 new test file (no production code outside these 6 verbs) |
+| Pattern | Each broken verb now: (a) imports `resolve_agent_key`, (b) renames the second return of `safe_resolve_agent` to `_agent_type` (its real semantics), (c) calls `agent_key = resolve_agent_key(host, name)` to get the canonical instance-name key, (d) sources `agent_type` from `claw_record["type"]` with `_agent_type` as fallback. |
+| Regression test | `tests/cli/clawctl/agent/test_multi_instance_resolution.py` — fixtures a host with 3 same-type zeroclaws keyed by instance name, asserts each of `start/stop/restart/sync/delete/configure` passes the correct instance name as `agent_name` (not the type) to its core call. 18 parametrized cases. |
+| Test suite (full) | **3064 Python + 213 GUI passing** (was 3046 pre-fix; +18 from the new file). |
+| Lint | ruff + next-lint clean. |
+| Format | `make format` idempotent (zero diff). |
+
+### Live cleanup proof (Phase 1 wreckage cleared with the fixed binary)
+
+After installing `clawctl` from the hotfix branch (`uv tool install -e <hotfix-worktree> --reinstall`), all three stranded audit agents deleted cleanly:
+
+```
+$ clawctl agent delete audit-zeroclaw --yes
+agent/audit-zeroclaw: [validate] Checking audit-zeroclaw on wolf.tailf7742d.ts.net...
+agent/audit-zeroclaw: [remove] Removing audit-zeroclaw from wolf.tailf7742d.ts.net...
+agent/audit-zeroclaw: [remove] Removing from local configuration...
+agent/audit-zeroclaw: [remove] Cleaned up instance secrets
+agent/audit-zeroclaw: [remove] Cleaned up agent state directory
+agent/audit-zeroclaw: [remove] Removed audit-zeroclaw successfully
+agent/audit-zeroclaw: deleted
+
+$ clawctl agent delete audit-hermes --yes        # same shape — deleted
+$ clawctl agent delete audit-openclaw --yes      # same shape — deleted
+```
+
+Same `delete` command that emitted `Multiple zeroclaw agents found. Specify instance name…` against the broken code now correctly targets the named instance. **The regression is reproducibly fixed against the live multi-instance fleet.**
+
+---
+
+## Phase 2 — Gate 3 retest on hotfix branch (audit-zeroclaw)
+
+Re-ran the same `gate3-runner.sh zeroclaw` script against the fixed binary, freshly creating a new `audit-zeroclaw` on wolf-i (which still has 3 sibling zeroclaws — multi-instance reproducer).
+
+### Result
+
+| Agent | Pass | Fail | Skip | Δ vs Phase 1 |
+|---|---|---|---|---|
+| audit-zeroclaw | **8** | **4** | 1 | +2 pass / −2 fail |
+
+| Step | Phase 1 (pre-fix) | Phase 2 (post-fix) |
+|---|---|---|
+| create | ✅ | ✅ |
+| configure --stage validate | ❌ (bug #516) | ❌ (state machine — see analysis) |
+| channel attach | ⏭ skip | ⏭ skip |
+| skill attach `clawrium/tdd` | ✅ | ✅ |
+| secret create FOO=bar | ✅ | ✅ |
+| start | ❌ (bug #516) | ❌ (state machine — see analysis) |
+| get \| grep | ✅ | ✅ |
+| sync | ❌ (bug #516) | ❌ (state machine — see analysis) |
+| describe | ✅ | ✅ |
+| restart | ❌ (bug #516) | ❌ (state machine — see analysis) |
+| logs --tail 10 | ✅ | ✅ |
+| stop | ❌ (bug #516) | ✅ |
+| delete | ❌ (bug #516) | ✅ |
+
+### Analysis of remaining 4 failures (NOT bug #516)
+
+The 4 still-failing verbs — `configure --stage validate`, `start`, `sync`, `restart` — fail for a **different, valid reason** that bug #516's symptom was previously masking:
+
+```
+$ clawctl agent configure audit-zeroclaw --stage validate
+agent/audit-zeroclaw: configure stage=validate on wolf.tailf7742d.ts.net
+Error: configure stage rejected: Cannot complete stage 'validate' while in state 'pending'.
+       Allowed stages in this state: ['providers']
+Hint:  clawctl agent describe audit-zeroclaw
+```
+
+```
+$ clawctl agent start audit-zeroclaw
+agent/audit-zeroclaw: [validate] Checking audit-zeroclaw on wolf.tailf7742d.ts.net...
+Error: start failed: Cannot start audit-zeroclaw: onboarding incomplete (state=pending).
+```
+
+The state machine correctly rejects skipping the `providers` configure stage. Phase 1's script jumped straight from `agent create` to `agent configure --stage validate`, skipping `--stage providers --provider <name>` — because the deviations table above struck the provider-create step (no Anthropic API key on this control machine).
+
+Pre-fix, bug #516 made `configure --stage validate` fail at its very first SSH call (instance-name lookup) before the state-machine code ever ran — hiding the prerequisite-stage rejection. With #516 fixed, the verb now reaches the state machine, which correctly enforces the `providers → identity → validate` order. The remaining failures are **expected behaviour given the deviations table** and would resolve by either:
+
+1. registering a provider (`clawctl provider registry create <name> --type <t> --api-key-stdin`) and running `--stage providers --provider <name>` before `--stage validate`, or
+2. dropping the deviation for `provider registry create` and supplying an API key.
+
+Neither is in scope for Gate 3's purpose (validate the new write surface against a multi-instance host). The `delete` and `stop` rescues from Phase 1 to Phase 2 are sufficient to demonstrate bug #516 is fixed against live data.
+
+### Cleanup
+
+The audit-zeroclaw left over from Phase 2 was removed at end of cycle by the fixed `delete` verb (the final ✅ in the retest table). Fleet is back to the original 6 pre-existing agents.
+
+---
+
+## Summary
+
+| Gate | Result | Detail |
+|---|---|---|
+| 1 — clean rebuild | ✅ PASS | `clm` removed, `clawctl` installed, all 12 top-level groups exit 0 on `--help`. |
+| 2 — test/lint/format/coverage | ✅ PASS | 3046 Python + 213 GUI tests, ruff + next-lint clean, format idempotent, coverage 82%. |
+| 3 — wolf-i multi-instance lifecycle (Phase 1) | ❌ RED | Surfaced regression bug [#516](https://github.com/ric03uec/clawrium/issues/516). |
+| 3 — wolf-i multi-instance lifecycle (Phase 2, post-#516 hotfix) | ⚠️ AMBER | Regression resolved; remaining 4 failures are state-machine prerequisite gaps caused by the documented `provider registry create` deviation, not by clawctl bugs. `delete` and `stop` improvements directly prove the fix on live data. |
+
+**Recommendation:** merge the `fix/516-lifecycle-verb-key-resolution` PR into `feat/435-clawctl-ux`, then open the `feat/435-clawctl-ux → main` integration PR. The state-machine prerequisite gaps in Phase 2 are operator-supplied prerequisites (provider registration), not code defects, and need not gate the merge.

--- a/src/clawrium/cli/clawctl/agent/configure.py
+++ b/src/clawrium/cli/clawctl/agent/configure.py
@@ -21,7 +21,7 @@ from typing import Optional
 import typer
 
 from clawrium.cli.clawctl._common import require_flag, stdin_is_tty
-from clawrium.cli.clawctl.agent._shared import safe_resolve_agent
+from clawrium.cli.clawctl.agent._shared import resolve_agent_key, safe_resolve_agent
 from clawrium.cli.output import emit_error, stream_action
 from clawrium.core.lifecycle import LifecycleError
 from clawrium.core.onboarding import (
@@ -91,9 +91,15 @@ def configure(
             ),
         )
 
-    host, agent_key, claw_record = safe_resolve_agent(name)
+    # Bug #516: `safe_resolve_agent` returns the *type string* as its
+    # second tuple element (per its own docstring). The dict key used
+    # to identify the agent on its host (and as `agent_name` in core
+    # lifecycle calls) requires a second-pass lookup. Without this,
+    # any host with >1 agent of the same type breaks lifecycle ops.
+    host, _agent_type, claw_record = safe_resolve_agent(name)
+    agent_key = resolve_agent_key(host, name)
     hostname = host["hostname"]
-    agent_type = claw_record.get("type", agent_key)
+    agent_type = claw_record.get("type", _agent_type)
 
     if stage is None:
         # Non-interactive contract: stdin closed + no stage = clean failure.

--- a/src/clawrium/cli/clawctl/agent/delete.py
+++ b/src/clawrium/cli/clawctl/agent/delete.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import typer
 
 from clawrium.cli.clawctl._common import confirm_destructive
-from clawrium.cli.clawctl.agent._shared import safe_resolve_agent
+from clawrium.cli.clawctl.agent._shared import resolve_agent_key, safe_resolve_agent
 from clawrium.cli.output import emit_error, stream_action
 from clawrium.core.lifecycle import LifecycleError, remove_agent
 
@@ -19,14 +19,16 @@ def delete(
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirm prompt."),
 ) -> None:
     """Delete an agent (remote cleanup + local record removal)."""
-    host, agent_key, claw_record = safe_resolve_agent(name)
+    # Bug #516: see configure.py for full rationale.
+    host, _agent_type, claw_record = safe_resolve_agent(name)
+    agent_key = resolve_agent_key(host, name)
     confirm_destructive(
         prompt=f"Delete agent '{name}'? Removes remote state and local record.",
         yes=yes,
     )
 
     hostname = host["hostname"]
-    agent_type = claw_record.get("type", agent_key)
+    agent_type = claw_record.get("type", _agent_type)
 
     def on_event(stage: str, message: str) -> None:
         stream_action(resource=f"agent/{name}", message=f"[{stage}] {message}")

--- a/src/clawrium/cli/clawctl/agent/restart.py
+++ b/src/clawrium/cli/clawctl/agent/restart.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import typer
 
-from clawrium.cli.clawctl.agent._shared import safe_resolve_agent
+from clawrium.cli.clawctl.agent._shared import resolve_agent_key, safe_resolve_agent
 from clawrium.cli.output import emit_error, stream_action
 from clawrium.core.lifecycle import LifecycleError, restart_agent
 
@@ -13,9 +13,11 @@ def restart(
     name: str = typer.Argument(..., help="Agent name."),
 ) -> None:
     """Restart an agent unit on its host."""
-    host, agent_key, claw_record = safe_resolve_agent(name)
+    # Bug #516: see configure.py for full rationale.
+    host, _agent_type, claw_record = safe_resolve_agent(name)
+    agent_key = resolve_agent_key(host, name)
     hostname = host["hostname"]
-    agent_type = claw_record.get("type", agent_key)
+    agent_type = claw_record.get("type", _agent_type)
 
     def on_event(stage: str, message: str) -> None:
         stream_action(resource=f"agent/{name}", message=f"[{stage}] {message}")

--- a/src/clawrium/cli/clawctl/agent/start.py
+++ b/src/clawrium/cli/clawctl/agent/start.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import typer
 
-from clawrium.cli.clawctl.agent._shared import safe_resolve_agent
+from clawrium.cli.clawctl.agent._shared import resolve_agent_key, safe_resolve_agent
 from clawrium.cli.output import emit_error, stream_action
 from clawrium.core.lifecycle import LifecycleError, start_agent
 
@@ -16,9 +16,11 @@ def start(
     ),
 ) -> None:
     """Start an agent unit on its host."""
-    host, agent_key, claw_record = safe_resolve_agent(name)
+    # Bug #516: see configure.py for full rationale.
+    host, _agent_type, claw_record = safe_resolve_agent(name)
+    agent_key = resolve_agent_key(host, name)
     hostname = host["hostname"]
-    agent_type = claw_record.get("type", agent_key)
+    agent_type = claw_record.get("type", _agent_type)
 
     def on_event(stage: str, message: str) -> None:
         stream_action(resource=f"agent/{name}", message=f"[{stage}] {message}")

--- a/src/clawrium/cli/clawctl/agent/stop.py
+++ b/src/clawrium/cli/clawctl/agent/stop.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import typer
 
-from clawrium.cli.clawctl.agent._shared import safe_resolve_agent
+from clawrium.cli.clawctl.agent._shared import resolve_agent_key, safe_resolve_agent
 from clawrium.cli.output import emit_error, stream_action
 from clawrium.core.lifecycle import LifecycleError, stop_agent
 
@@ -13,9 +13,11 @@ def stop(
     name: str = typer.Argument(..., help="Agent name."),
 ) -> None:
     """Stop an agent unit on its host."""
-    host, agent_key, claw_record = safe_resolve_agent(name)
+    # Bug #516: see configure.py for full rationale.
+    host, _agent_type, claw_record = safe_resolve_agent(name)
+    agent_key = resolve_agent_key(host, name)
     hostname = host["hostname"]
-    agent_type = claw_record.get("type", agent_key)
+    agent_type = claw_record.get("type", _agent_type)
 
     def on_event(stage: str, message: str) -> None:
         stream_action(resource=f"agent/{name}", message=f"[{stage}] {message}")

--- a/src/clawrium/cli/clawctl/agent/sync.py
+++ b/src/clawrium/cli/clawctl/agent/sync.py
@@ -34,7 +34,7 @@ import time
 import typer
 
 from clawrium.cli.clawctl._common import OutputFormat
-from clawrium.cli.clawctl.agent._shared import safe_resolve_agent
+from clawrium.cli.clawctl.agent._shared import resolve_agent_key, safe_resolve_agent
 from clawrium.cli.output import (
     NDJSONStreamer,
     emit_error,
@@ -71,9 +71,11 @@ def sync(
     ),
 ) -> None:
     """Flush local control-plane state to the agent (drift-to-zero)."""
-    host, agent_key, claw_record = safe_resolve_agent(name)
+    # Bug #516: see configure.py for full rationale.
+    host, _agent_type, claw_record = safe_resolve_agent(name)
+    agent_key = resolve_agent_key(host, name)
     hostname = host["hostname"]
-    agent_type = claw_record.get("type", agent_key)
+    agent_type = claw_record.get("type", _agent_type)
 
     resource = f"agent/{name}"
     use_json = output is OutputFormat.json

--- a/tests/cli/clawctl/agent/test_multi_instance_resolution.py
+++ b/tests/cli/clawctl/agent/test_multi_instance_resolution.py
@@ -1,0 +1,247 @@
+"""Regression tests for bug #516 — lifecycle verb key resolution.
+
+Pre-fix behaviour: `safe_resolve_agent(name)` returns the agent's *type*
+string as its second tuple element (per its own docstring — see
+`cli/clawctl/agent/_shared.py`). The lifecycle verbs (configure, start,
+stop, sync, restart, delete) used that value as `agent_name=...` in
+their core-lifecycle calls. On any host with >1 agent of the same type,
+this fails:
+
+- `start audit-2` would call `start_agent(claw_name='zeroclaw',
+  agent_name='zeroclaw')` — both kwargs collapse to the type. Core
+  side then can't disambiguate, either targets the wrong agent or
+  errors out.
+
+These tests fixture a multi-instance host (three zeroclaws keyed by
+instance name) and assert each verb passes the *correct* instance name
+to its core call. Without the fix, every parametrize case fails with
+`agent_name == "zeroclaw"` instead of the expected `"audit-N"`.
+
+The single-instance happy path is already covered by
+`test_lifecycle.py`; this file deliberately limits scope to the
+multi-instance dimension.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+
+runner = CliRunner()
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@pytest.fixture
+def multi_instance_fleet(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Fleet with 3 zeroclaws keyed by instance name on a single host.
+
+    Mirrors the wolf-i shape that surfaced bug #516 during issue #435
+    Gate 3: same type, distinct instance names, modern key-by-name.
+    """
+    config_dir = tmp_path / "clawrium"
+    config_dir.mkdir()
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    def _agent(name: str) -> dict:
+        return {
+            "type": "zeroclaw",
+            "agent_name": name,
+            "version": "0.4.2",
+            "installed_at": _utcnow(),
+            "status": "installed",
+            "onboarding": {
+                "state": "ready",
+                "stages": {
+                    "providers": {"state": "complete", "completed_at": _utcnow()},
+                    "identity": {"state": "complete", "completed_at": _utcnow()},
+                    "channels": {"state": "skipped"},
+                    "validate": {"state": "complete", "completed_at": _utcnow()},
+                },
+            },
+            "config": {"skills": []},
+        }
+
+    hosts = [
+        {
+            "hostname": "10.0.0.1",
+            "key_id": "10.0.0.1",
+            "port": 22,
+            "user": "alice",
+            "auth_method": "key",
+            "alias": "wolf-i",
+            "aliases": ["wolf-i"],
+            "addresses": [
+                {
+                    "address": "10.0.0.1",
+                    "is_primary": True,
+                    "label": None,
+                    "added_at": _utcnow(),
+                }
+            ],
+            "metadata": {
+                "added_at": _utcnow(),
+                "last_seen": _utcnow(),
+                "labels": {},
+            },
+            "hardware": {
+                "architecture": "x86_64",
+                "processor_cores": 8,
+                "memtotal_mb": 16000,
+            },
+            "agents": {
+                "audit-1": _agent("audit-1"),
+                "audit-2": _agent("audit-2"),
+                "audit-3": _agent("audit-3"),
+            },
+        }
+    ]
+    (config_dir / "hosts.json").write_text(json.dumps(hosts, indent=2))
+    return config_dir
+
+
+@pytest.mark.parametrize(
+    "verb,mock_target,past_tense",
+    [
+        ("start", "clawrium.cli.clawctl.agent.start.start_agent", "started"),
+        ("stop", "clawrium.cli.clawctl.agent.stop.stop_agent", "stopped"),
+        ("restart", "clawrium.cli.clawctl.agent.restart.restart_agent", "restarted"),
+    ],
+)
+@pytest.mark.parametrize("instance", ["audit-1", "audit-2", "audit-3"])
+def test_lifecycle_verb_passes_instance_name_not_type(
+    multi_instance_fleet,
+    monkeypatch: pytest.MonkeyPatch,
+    verb: str,
+    mock_target: str,
+    past_tense: str,
+    instance: str,
+) -> None:
+    """Each lifecycle verb must pass the *instance name* as `agent_name`,
+    not the type string. Pre-fix this passed `agent_name='zeroclaw'` for
+    every instance, so the second/third audit-* agent would either be
+    targeted incorrectly or error out at the core level.
+    """
+    captured: dict = {}
+
+    def capturing_call(**kwargs):
+        captured.update(kwargs)
+        return {"success": True}
+
+    monkeypatch.setattr(mock_target, capturing_call)
+    result = runner.invoke(app, ["agent", verb, instance])
+
+    assert result.exit_code == 0, f"{verb} {instance} failed: {result.output}"
+    assert captured.get("agent_name") == instance, (
+        f"{verb} {instance}: expected agent_name={instance!r}, got "
+        f"{captured.get('agent_name')!r} (type was {captured.get('claw_name')!r})"
+    )
+    assert captured.get("claw_name") == "zeroclaw", (
+        f"{verb} {instance}: expected claw_name='zeroclaw', got "
+        f"{captured.get('claw_name')!r}"
+    )
+
+
+@pytest.mark.parametrize("instance", ["audit-1", "audit-2", "audit-3"])
+def test_sync_passes_instance_name_not_type(
+    multi_instance_fleet,
+    monkeypatch: pytest.MonkeyPatch,
+    instance: str,
+) -> None:
+    """sync has a different mock signature (returns dict with success).
+    Verify the same instance/type contract.
+    """
+    captured: dict = {}
+
+    def capturing_sync(**kwargs):
+        captured.update(kwargs)
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.sync.sync_agent", capturing_sync
+    )
+    result = runner.invoke(app, ["agent", "sync", instance])
+
+    assert result.exit_code == 0, f"sync {instance} failed: {result.output}"
+    assert captured.get("agent_name") == instance
+    assert captured.get("claw_name") == "zeroclaw"
+
+
+@pytest.mark.parametrize("instance", ["audit-1", "audit-2", "audit-3"])
+def test_delete_passes_instance_name_not_type(
+    multi_instance_fleet,
+    monkeypatch: pytest.MonkeyPatch,
+    instance: str,
+) -> None:
+    """delete is the verb where the bug bit hardest at Gate 3 — the
+    remote cleanup script rejected the type-as-name with 'Multiple
+    zeroclaw agents found. Specify instance name: …'.
+    """
+    captured: dict = {}
+
+    def capturing_remove(**kwargs):
+        captured.update(kwargs)
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.delete.remove_agent", capturing_remove
+    )
+    result = runner.invoke(app, ["agent", "delete", instance, "--yes"])
+
+    assert result.exit_code == 0, f"delete {instance} failed: {result.output}"
+    assert captured.get("agent_name") == instance
+    assert captured.get("claw_name") == "zeroclaw"
+
+
+@pytest.mark.parametrize("instance", ["audit-1", "audit-2", "audit-3"])
+def test_configure_passes_instance_name_to_onboarding(
+    multi_instance_fleet,
+    monkeypatch: pytest.MonkeyPatch,
+    instance: str,
+) -> None:
+    """configure --stage validate must call `get_onboarding_state` with
+    the instance name as `claw_name`. Pre-fix it called with the type
+    string, surfacing `AgentNotFoundError: Agent 'zeroclaw' not found
+    on host 'wolf-i'`.
+    """
+    from clawrium.core.onboarding import OnboardingState
+
+    captured_get: dict = {}
+    captured_run: dict = {}
+
+    def capturing_get(host, claw_name, **_):
+        captured_get["host"] = host
+        captured_get["claw_name"] = claw_name
+        return OnboardingState.READY
+
+    def capturing_run(agent_type, host, claw_name, stage, **_):
+        captured_run["agent_type"] = agent_type
+        captured_run["host"] = host
+        captured_run["claw_name"] = claw_name
+        captured_run["stage"] = stage
+        return True
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.get_onboarding_state",
+        capturing_get,
+    )
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.run_stage",
+        capturing_run,
+    )
+
+    result = runner.invoke(
+        app, ["agent", "configure", instance, "--stage", "validate"]
+    )
+    assert result.exit_code == 0, f"configure {instance} failed: {result.output}"
+    assert captured_get["claw_name"] == instance
+    assert captured_run["claw_name"] == instance
+    assert captured_run["agent_type"] == "zeroclaw"


### PR DESCRIPTION
## Summary

- Fixes [#516](https://github.com/ric03uec/clawrium/issues/516) — the 6 `clawctl agent` write-path lifecycle verbs (`configure`, `start`, `stop`, `sync`, `restart`, `delete`) regressed on hosts with >1 agent of the same type. They passed `safe_resolve_agent`'s return as the instance name, but per its own docstring that value is the agent's **type string**.
- Each verb now second-pass resolves the canonical dict key via `resolve_agent_key(host, name)`, mirroring the ATX iter-2 W3 pattern already in place on the Pattern A attachable verbs (`provider`, `channel`, `integration`). That earlier fix missed the lifecycle verb cohort.
- Blocks the `feat/435-clawctl-ux → main` integration PR for #435 — must merge first.

Stacked on top of `feat/435-clawctl-ux`.

## How the bug surfaced

Caught by Gate 3 of issue #435 against the live wolf-i fleet on 2026-05-24. wolf-i carries 3 zeroclaws + 2 hermes — first real exposure to a multi-instance shape. Every write-path verb failed with one of:

```
AgentNotFoundError: Agent 'zeroclaw' not found on host 'wolf.tailf7742d.ts.net'
```
```
Error: remote cleanup failed: Multiple zeroclaw agents found.
       Specify instance name: clawrium-d01, nemotron-beta, nemotron-alpha, audit-zeroclaw
```

Bundle 3 unit tests fixtured a single-agent-per-type host where the bug is invisible (dict key happens to equal the type string), so it slipped through every gate before Gate 3.

## What changed

| File | Change |
|---|---|
| `src/clawrium/cli/clawctl/agent/configure.py` | second-pass `resolve_agent_key` after `safe_resolve_agent`; fallback `agent_type` source uses `_agent_type` |
| `src/clawrium/cli/clawctl/agent/start.py` | same |
| `src/clawrium/cli/clawctl/agent/stop.py` | same |
| `src/clawrium/cli/clawctl/agent/sync.py` | same |
| `src/clawrium/cli/clawctl/agent/restart.py` | same |
| `src/clawrium/cli/clawctl/agent/delete.py` | same |
| `tests/cli/clawctl/agent/test_multi_instance_resolution.py` | **new** — 18 parametrized regression cases |
| `.itx/435/e2e-validation.md` | **new** — full Gate 3 narrative (RED → fix → AMBER retest with analysis) |

No production code outside the 6 verbs touched. No dependency changes.

## Testing

### Test Results
- [x] All existing tests pass (`make test`): **3046 → 3064 Python (+18 from new file)**, **213 GUI**
- [x] Linter passes (`make lint`): ruff + next-lint clean
- [x] Format produces zero diff (`make format`)
- [x] New regression tests added: 18 cases — every parametrize cell fails pre-fix and passes post-fix

### Test Coverage
- Files changed: 6 source + 1 new test + 1 markdown
- New tests: `tests/cli/clawctl/agent/test_multi_instance_resolution.py` — full coverage of all 6 fixed verbs against a 3-same-type-agent fixture
- Coverage impact: maintained (82%)

### Manual Testing — live wolf-i fleet

The strongest evidence is live-data: the same `clawctl agent delete audit-<type> --yes` command that produced `Multiple <type> agents found. Specify instance name…` against the broken integration branch now completes cleanly against the hotfix, for all three stranded agents (`audit-zeroclaw`, `audit-hermes`, `audit-openclaw`).

Phase 2 Gate 3 retest (`audit-zeroclaw` cycle on the fixed binary): **8 pass / 4 fail / 1 skip** (was 6/6/1 pre-fix). `delete` and `stop` flipped from fail→pass; the remaining 4 failures are state-machine prerequisite gaps (`--stage providers` requires a registered provider, which the Gate 3 deviations table struck because no Anthropic API key is in env) and are **NOT regressions** — pre-fix bug #516 was hiding them by failing the verb at the earlier SSH-lookup step. Full analysis in `.itx/435/e2e-validation.md`.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation unchanged (fix is purely a key-resolution second-pass)
- [x] No SQL injection, XSS, or command injection risks (mechanical refactor)
- [x] Dependencies unchanged

## Reviewer Notes

- The pattern applied here is **already in production** in `cli/clawctl/agent/provider.py`, `channel.py`, `integration.py` (ATX iter-2 W3 fix from Bundle 3). This PR finishes the same refactor across the lifecycle verb cohort.
- A larger refactor — make `safe_resolve_agent` return the canonical key directly so callers don't have to remember the second pass — is sketched as "Out of scope" in #516. Not done here to keep the hotfix surface minimal.
- ATX review on this hotfix was **not yet run by the orchestrator**. The fix is small, well-tested, and proven against live data; I'd recommend a single ATX pass before merge unless you're comfortable shipping it on the manual review + regression tests alone.

## Callouts

- [DECISION] **Hotfix scope limited to the 6 write-path lifecycle verbs.** `logs.py` and `describe.py` also call `safe_resolve_agent` but don't actively misuse the return (logs is a placeholder, describe reads through `claw_record` fields). Leaving them alone keeps the surface minimal; tracked as latent risk for the proposed `safe_resolve_agent` contract refactor.
- [DECISION] **Inline comment on each verb references #516** so a future reader sees the rationale without grep-jumping to `_shared.py`. Slightly noisy but the alternative (silent fix) would invite re-regression.
- [DECISION] **`_agent_type` naming for the discarded second tuple element** — matches what `safe_resolve_agent`'s docstring says it actually is. Surfaces the true semantics at every call site so future maintainers don't repeat the bug.
- [ENVIRONMENT] **ATX review not yet executed on this hotfix.** Recommend running before merge; see Reviewer Notes.
- [TODO-FOLLOWUP] **Contract refactor of `safe_resolve_agent`** to return the canonical key directly — would eliminate the second-pass requirement for all 11 verbs and prevent this class of bug. Out of scope here per #516; file separately if pursued.
- [TODO-FOLLOWUP] **Full 3-type Gate 3 cycle with a registered provider** — would close the AMBER → GREEN gap in `.itx/435/e2e-validation.md` Phase 2. Not required to merge this hotfix or the integration PR (bug fix is independently proven by regression tests + live cleanup + the delete/stop improvements on retest).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
