### PR TITLE
fix(ci): #518 unblock docs/test/validate CI failures on integration PR

### DIFF
--- a/.github/workflows/skills-validate.yml
+++ b/.github/workflows/skills-validate.yml
@@ -62,6 +62,21 @@ jobs:
         # cover the newer interpreter separately.
         run: uv python install 3.10
 
+      # Hatchling force-includes `src/clawrium/gui/frontend/` in the wheel
+      # target, so `uv sync` (editable install) requires the Next.js export
+      # to be staged first. Without this step the install fails with
+      # `FileNotFoundError: Forced include not found`. Mirrors the
+      # equivalent step in test.yml.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: gui/package-lock.json
+
+      - name: Build GUI frontend
+        run: make build-ui
+
       - name: Install dependencies
         # --frozen rejects any lock-file drift in the PR — same locked
         # dependency set the contributor saw locally must be what CI

--- a/tests/cli/agent/test_configure_no_channel_prompts.py
+++ b/tests/cli/agent/test_configure_no_channel_prompts.py
@@ -195,12 +195,13 @@ def test_stage_help_text_omits_channels_from_valid_values(
     result = runner.invoke(app, ["agent", "configure", "--help"])
     assert result.exit_code == 0
     # Typer wraps help across lines with box-drawing chars at the
-    # column gutters; strip them and collapse whitespace so the
-    # phrase survives line-wrapping. The Stage enum still includes
-    # `channels` (Typer auto-generates the choices list from the
-    # enum), but the prose hint must point users at the supported
-    # set and explicitly mark `channels` as deprecated.
-    flat = re.sub(r"[│╭╰─╮╯]", " ", result.output)
+    # column gutters and (under CI's color-enabled rendering) inserts
+    # ANSI escape sequences mid-text. Strip both, plus collapse
+    # whitespace, so the phrase survives line-wrapping AND coloring.
+    # Without ANSI stripping this assertion passes locally on a wide
+    # terminal but fails on CI's 80-col color-enabled output (#518 CI run).
+    flat = re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", result.output)
+    flat = re.sub(r"[│╭╰─╮╯]", " ", flat)
     flat = re.sub(r"\s+", " ", flat)
     assert "providers, identity, validate" in flat
     assert "deprecated" in flat.lower()

--- a/website/blog/tags.yml
+++ b/website/blog/tags.yml
@@ -2,3 +2,8 @@ announcements:
   label: Announcements
   permalink: /announcements
   description: Project news and releases
+
+breaking-changes:
+  label: Breaking Changes
+  permalink: /breaking-changes
+  description: Releases with backward-incompatible CLI or API changes


### PR DESCRIPTION
## Summary

Unblocks CI on **#518** (the `feat/435-clawctl-ux → main` integration PR for #435). Three independent defects, all caught by #518's CI run because none of the bundle PRs ever triggered `test.yml` / `docs.yml` / `skills-validate.yml` — those workflows trigger only on `pull_request: branches: [main]`, and bundle PRs targeted the integration branch instead.

Targets `feat/435-clawctl-ux`. Merging this then re-running CI on #518 is what unblocks the final ship.

## What changed

### 1. `docs/build` — `website/blog/tags.yml`

Bundle 5's blog post `website/blog/2026-05-24-clawctl-kubectl-ux.md` is tagged `[announcements, breaking-changes]`, but `tags.yml` only declared `announcements`. Docusaurus' tag validator rejects undefined tags and fails the whole build:

```
Error: Tags [breaking-changes] used in 2026-05-24-clawctl-kubectl-ux.md are not defined in tags.yml
```

Added a `breaking-changes` entry pointing to `/breaking-changes` permalink.

### 2. `test` — `tests/cli/agent/test_configure_no_channel_prompts.py`

`test_stage_help_text_omits_channels_from_valid_values` flattens the Typer help block to substring-match `"providers, identity, validate"`. The pre-existing regex strips box-drawing chars (`│╭╰─╮╯`) and collapses whitespace — but does **not** strip ANSI escape sequences. Locally on a wide terminal the phrase falls on a single line and survives intact. On CI's 80-col color-enabled rendering the phrase is interleaved with `\x1b[1;33m`-style codes:

```
\x1b[1m \x1b[0m\x1b[1;33mproviders, identity\x1b[0m, \x1b[1mvalidate\x1b[0m...
```

…and the substring assertion fails. Pre-strip ANSI escapes via `re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", result.output)` BEFORE the box-drawing strip. Verified locally reproducing CI conditions (`FORCE_COLOR=1 COLUMNS=80`) — fails without the fix, passes with it. Full test suite still 3064 Python + 213 GUI.

### 3. `validate` — `.github/workflows/skills-validate.yml`

The workflow runs `uv sync --frozen` without first staging the Next.js export at `src/clawrium/gui/frontend/`. Hatchling force-includes that path in the wheel target (see `pyproject.toml`), so the editable install fails:

```
FileNotFoundError: Forced include not found:
  /home/runner/work/clawrium/clawrium/src/clawrium/gui/frontend
```

`test.yml` already handles this with `actions/setup-node@v4` + `make build-ui` before `uv sync`. Mirrored the same two steps into `skills-validate.yml`.

This is a **pre-existing latent CI bug** that only manifests when the path filter triggers — most PRs don't touch `skills/**` and skip the job entirely. The integration PR's wide diff brings it into scope.

## Testing

### Test Results
- [x] All existing tests pass (`make test`): 3064 Python + 213 GUI
- [x] Linter passes (`make lint`): ruff + next-lint clean (no source-code changes)
- [x] CI-failure reproduction: `FORCE_COLOR=1 COLUMNS=80 uv run pytest tests/cli/agent/test_configure_no_channel_prompts.py::test_stage_help_text_omits_channels_from_valid_values` — fails on pre-fix, passes on post-fix
- [x] Workflow YAML lints (visual review only — no GHA local runner available)

### Manual Testing
- Reproduced #518's `test` failure locally by mimicking CI's terminal env. Confirmed fix.
- `docs/build` and `validate` fixes are workflow-level; they'll be exercised when this PR's own CI runs (and when #518 re-runs).

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation: N/A (CI plumbing + test regex)
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies unchanged
- [x] New tag definition adds a public permalink; reviewed for path-injection safety (literal string, no interpolation)

## Reviewer Notes

- The `breaking-changes` tag description is a one-liner ("Releases with backward-incompatible CLI or API changes") — feel free to rewrite if you want it more specific.
- The ANSI strip regex `\x1b\[[0-9;]*[A-Za-z]` covers SGR (`\x1b[<n>m`) and the broader CSI family; sufficient for Click/Typer output. Could be tightened to just `m`-terminated but the broader form is safer if Typer's renderer ever emits cursor moves in help.
- `skills-validate.yml` now mirrors `test.yml`'s frontend setup verbatim — keeps maintenance simple. If a future PR consolidates these into a composite action, this is the duplication target to dedupe.

## Callouts

- [DECISION] **Three fixes batched into one PR**, not three separate PRs. They're all "CI-only, unblock #518" and the surface is tiny (3 files, +27/-6 lines). Splitting would triple review overhead for no isolation benefit.
- [DECISION] **Targeting `feat/435-clawctl-ux`, not `main`.** This needs to land before #518 can merge cleanly; sequencing it as a hotfix branch off integration mirrors the #517 pattern.
- [DECISION] **Test fix preserves the existing assertion shape** rather than rewriting the test to pin against the literal Stage enum members. The intent of the test is to catch a contributor silently re-adding `channels` to the prose hint; substring matching the rendered help is the right shape, only the rendering normalization was incomplete.
- [TODO-FOLLOWUP] **CI path-filter audit.** None of the bundle PRs running against `feat/435-clawctl-ux` exercised any of these three workflows. That meant the bug from (3) had been latent for however long, and the test from (2) had been masked. Consider either: (a) running test/docs/validate on PRs to any branch starting with `feat/`, or (b) requiring an "integration dry-run" CI workflow that mirrors the main-branch suite. Out of scope here.
- [TODO-FOLLOWUP] **Pre-commit hook for `tags.yml` validation.** A static check that every blog post's frontmatter tags are declared in `tags.yml` would have caught (1) at Bundle 5 commit time instead of #518 CI time. Tracked separately if pursued.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
