### PR TITLE
fix(docs): #518 repair 5 broken anchors in cli/host.md (greenify docs build)

### DIFF
--- a/website/docs/reference/cli/host.md
+++ b/website/docs/reference/cli/host.md
@@ -14,7 +14,7 @@ clawctl host <command> [options]
 | [`clawctl host create`](#clawctl-host-create) | Add a new host to the fleet |
 | [`clawctl host get`](#clawctl-host-get) | List all registered hosts |
 | [`clawctl host delete`](#clawctl-host-delete) | Remove a host from the fleet |
-| [`clawctl host status`](#clawctl-host-describe) | Check status of a host |
+| [`clawctl host status`](#clawctl-host-status) | Check status of a host |
 | [`clawctl host reset`](#clawctl-host-reset) | Reset a host, removing all claws and users |
 | [`clawctl host address`](#address-subcommands) | Manage multiple addresses for a host |
 
@@ -365,10 +365,10 @@ clawctl host address <command> [options]
 
 | Command | Description |
 |---------|-------------|
-| [`clawctl host address add`](#clawctl-host-createress-add) | Add an address to a host |
-| [`clawctl host address remove`](#clawctl-host-createress-remove) | Remove an address from a host |
-| [`clawctl host address list`](#clawctl-host-createress-list) | List all addresses for a host |
-| [`clawctl host address set-primary`](#clawctl-host-createress-set-primary) | Set a different address as primary |
+| [`clawctl host address add`](#clawctl-host-address-add) | Add an address to a host |
+| [`clawctl host address remove`](#clawctl-host-address-remove) | Remove an address from a host |
+| [`clawctl host address list`](#clawctl-host-address-list) | List all addresses for a host |
+| [`clawctl host address set-primary`](#clawctl-host-address-set-primary) | Set a different address as primary |
 
 ---
 


### PR DESCRIPTION
## Summary

Repairs 5 broken anchor refs in \`website/docs/reference/cli/host.md\` that were blocking the \`docs/build\` (Docusaurus) CI job on **#518** (the \`feat/435-clawctl-ux → main\` integration PR).

Targets \`feat/435-clawctl-ux\`. Merge this → CI re-runs on #518 → integration ships.

## Root cause

Bundle 5 (#510)'s bulk-regex docs sweep ran an \`s/add/create/\`-style substitution across the markdown tree to align with the kubectl-style verb rename. The regex was not word-boundary-anchored, so it matched \`add\` inside the word \`address\` and produced:

- \`#clawctl-host-createress-add\`
- \`#clawctl-host-createress-remove\`
- \`#clawctl-host-createress-list\`
- \`#clawctl-host-createress-set-primary\`

Plus a separate stale half-rename: \`clawctl host status\` link text pointing at \`#clawctl-host-describe\` (the actual heading on the page is \`## clawctl host status\`).

Docusaurus' broken-link checker rejects the build on any unresolved anchor; the entire docs site won't render until these 5 are fixed.

## Fix

| Line | Before | After |
|---|---|---|
| 17 | \`[clawctl host status](#clawctl-host-describe)\` | \`[...](#clawctl-host-status)\` |
| 368 | \`...(#clawctl-host-createress-add)\` | \`...(#clawctl-host-address-add)\` |
| 369 | \`...(#clawctl-host-createress-remove)\` | \`...(#clawctl-host-address-remove)\` |
| 370 | \`...(#clawctl-host-createress-list)\` | \`...(#clawctl-host-address-list)\` |
| 371 | \`...(#clawctl-host-createress-set-primary)\` | \`...(#clawctl-host-address-set-primary)\` |

5 link-target edits in one file. No heading changes, no other content changes.

## Testing

### Local Docusaurus build (the exact CI job)
Pre-fix \`cd website && npm run build\`:
\`\`\`
[ERROR] Docusaurus found broken anchors!
- Broken anchor on source page path = /clawrium/docs/reference/cli/host:
   -> linking to #clawctl-host-describe
   -> linking to #clawctl-host-createress-add  (+3 more createress-*)
\`\`\`
Post-fix:
\`\`\`
[SUCCESS] Generated static files in \"build\".
\`\`\`

The broken-link checker scans every page on the site (not just \`host.md\`), so \`[SUCCESS]\` confirms global anchor cleanliness.

### Test Results
- [x] Docusaurus build green locally (\`cd website && npm run build\`)
- [x] No other markdown files contained \"createress\" (\`grep -rln createress\` returned only the one file fixed here)
- [x] \`make test\` not re-run — no source-code or test changes

### Security Checklist
- [x] No code changes; 5 markdown link-target edits only

## Reviewer Notes

The 5th edit (line 17, \`describe\` → \`status\`) is a judgment call. The heading on the page is \`## clawctl host status\` (which matches the legacy verb). Bundle 3 renamed \`status\` → \`describe\` in the CLI, but neither the heading nor the link text in this doc was updated to reflect that. Pointing the anchor at the heading-that-exists unblocks the build today; aligning the doc's verb language to the actual CLI surface is a separate content-correctness pass — see Callouts.

## Callouts

- [DECISION] **Anchor pointed at \`#clawctl-host-status\`, not \`#clawctl-host-describe\`.** Two ways to fix the line-17 stale ref: (a) change anchor target to match the existing heading (this PR), or (b) rename the heading + link text to \`describe\` to match the actual CLI verb. Option (a) is the minimum-risk fix to unblock CI today; option (b) is a content refresh that belongs in a doc-correctness pass alongside any other Bundle 3 verb-rename stragglers. The legacy \`status\` text is internally consistent within the page right now — nothing on the page actually says \`describe\`.
- [TODO-FOLLOWUP] **Audit the docs tree for other word-boundary regex casualties from Bundle 5.** Docusaurus only flagged the cases where an anchor was broken. A bulk \`s/add/create/\` pass could just as easily have produced bad prose (\`createitionally\`, \`createendum\`, etc.) that compiles fine but reads wrong. \`grep -rE '\\b(create|delete|get)(itionally|endum|ress|ress-|ing)' website/docs/ docs/\` would be a starter sweep.
- [TODO-FOLLOWUP] **Verb-language refresh in \`host.md\`.** The doc still uses \`clawctl host status\` headings + prose; the CLI ships \`clawctl host describe\`. Out of scope for this CI unblock — file as a doc-correctness issue if the new verb is canonical.
- [TODO-FOLLOWUP] **Add \`docusaurus build\` as a pre-merge check in \`.github/workflows/docs.yml\` triggered on any \`pull_request\`** (not just to \`main\`). Bundle 5's PR (#515) didn't run the docs build because it targeted the integration branch — this is the same trigger-gap pattern that hid the issues #519 fixed earlier. Filing the pattern as a follow-up.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)