### PR TITLE
fix(lifecycle): bridge agent.providers → config.provider during sync (#426)

### DIFF
--- a/.itx/426/00_PLAN.md
+++ b/.itx/426/00_PLAN.md
@@ -1,0 +1,255 @@
+# Issue #426 — Implementation Plan
+
+## Overview
+
+Close the functional gap left by #435/Bundle 4 (#509): the new `clawctl agent
+provider attach … --agent …` records desired state in `hosts.json.agents.<n>.providers`,
+but no code path materializes that attachment into `hosts.json.agents.<n>.config.provider`,
+which is what `sync_agent` actually re-pushes to the remote via Ansible.
+
+Wire `core/lifecycle.sync_agent` to be the reconciliation point: when an
+agent has a non-empty `providers` attachment list, look up the provider record
+from `~/.config/clawrium/providers.json`, assemble the legacy provider config
+shape (the dict `_sync_provider_config` used to write), merge it into the
+in-memory `existing_config` before the Ansible push, and — if onboarding state
+is still `pending` — advance the state machine through the `providers` stage.
+
+This delivers the customer outcome of #426 ("non-interactive provider config")
+through the declarative `attach → sync` flow that #509 set up, without
+resurrecting the legacy interactive `_run_providers_stage` code path.
+
+Single-provider invariant per user decision: `attach` hard-fails on a second
+attachment. Persistence per user decision: once `config.provider` is written,
+it survives subsequent `sync` calls; `detach` does NOT strip it (last-known-good).
+
+## Files to Modify
+
+- `src/clawrium/core/lifecycle.py` — extend `sync_agent` with the
+  materialization + state-advance bridge. Single concentrated change between
+  the `_resolve_agent_record` block (line ~940) and the existing PENDING-state
+  rejection (line ~953).
+- `src/clawrium/cli/clawctl/agent/provider.py` — add single-provider guard in
+  `attach`. Reject second attachment with a clear error pointing at `detach`.
+
+## Files to Create
+
+- `tests/cli/clawctl/agent/test_sync_materializes_provider.py` — unit coverage
+  for the bridge (mocked Ansible). Three cases:
+  1. Fresh agent (`providers: ["local-inx"]`, no `config.provider`, state
+     `pending`) → `configure_agent` receives `config_data["provider"]["name"]
+     == "local-inx"`, state advances past `pending`.
+  2. Legacy agent (`config.provider` already set, no `agent.providers` list)
+     → bridge is a no-op; `configure_agent` receives the original
+     `config_data` unchanged.
+  3. Attached provider missing from `providers.json` → sync errors cleanly,
+     no partial state advance.
+- `tests/cli/clawctl/agent/test_provider_attach_single.py` — assert second
+  `attach` to the same agent fails with the documented error.
+
+## Steps
+
+1. **Provider lookup helper** (`lifecycle.py`): import
+   `from clawrium.core.providers.storage import get_provider,
+   ProvidersFileCorruptedError` near the top, alongside the existing
+   `from clawrium.core.providers import …` block at line 1029. Lazy import is
+   fine if circulars surface.
+
+2. **Bridge inside `sync_agent`** (`lifecycle.py:901`): immediately after
+   `agent_key, agent_type, claw_record = resolved` (line 943) and before the
+   state check at line 948, insert:
+   - Read `attached = claw_record.get("providers", [])`. If non-empty, take
+     `attached[0]` as `provider_name`. (Single-provider invariant is enforced
+     at `attach` time; a defensive `len > 1` check here can `LifecycleError`
+     with a "data integrity" message in case of manual edits.)
+   - Call `provider_record = get_provider(provider_name)`. If `None`, raise
+     `LifecycleError(f"attached provider '{provider_name}' not registered;
+     clawctl provider registry get")`.
+   - Assemble `provider_config` matching the legacy shape from
+     `cli/agent.py:360-374`:
+     ```python
+     provider_config = {
+         "name": provider_record.get("name", ""),
+         "type": provider_record.get("type", "ollama"),
+         "endpoint": provider_record.get("endpoint", ""),
+         "default_model": provider_record.get("default_model", ""),
+     }
+     if provider_record.get("context_window"):
+         provider_config["context_window"] = provider_record["context_window"]
+     if provider_record.get("max_tokens"):
+         provider_config["max_tokens"] = provider_record["max_tokens"]
+     ```
+   - Read the in-progress `existing_config` (the same dict the existing code
+     pulls at line 959) and overlay: `existing_config["provider"] =
+     provider_config`. Persistence requirement is met because the
+     `updater(h)` closure in `configure_agent` (`lifecycle.py:1709`)
+     writes `config_data` back into `hosts.json.agents.<key>.config` after
+     Ansible succeeds.
+
+3. **State advancement** (`lifecycle.py`, same block): if `state ==
+   OnboardingState.PENDING` and `attached` is non-empty, call
+   `complete_stage(hostname, agent_key, "providers", StageStatus.COMPLETE,
+   {"provider_id": provider_name})` before the PENDING-rejection check at
+   line 953. Re-read state value after the call so the existing check passes.
+   - Wrap in `try/except InvalidTransitionError` and downgrade to
+     `update_stage_metadata(...)` for the re-sync case (matches legacy
+     `_run_providers_stage:498-509`).
+
+4. **PENDING-message refresh** (`lifecycle.py:953-957`): the existing error
+   message references `clm agent configure`. With the bridge in place, the
+   message should point users at `clawctl agent provider attach <name>
+   --agent <agent>` instead. Update the two `LifecycleError` strings at
+   lines 954-956 and 962-964.
+
+5. **Single-provider guard** (`cli/clawctl/agent/provider.py:99`): before
+   `current.append(name)`, add:
+   ```python
+   if current and current != [name]:
+       emit_error(
+           f"agent '{agent}' already has provider {current[0]!r} attached",
+           hint=(
+               f"detach the current provider first: "
+               f"clawctl agent provider detach {current[0]} --agent {agent}"
+           ),
+       )
+   ```
+   The `current != [name]` clause preserves the existing idempotent re-attach
+   of the same name.
+
+6. **Detach semantics — no-op on `config.provider`**: confirm that
+   `cli/clawctl/agent/provider.py:detach` only mutates `agent.providers` and
+   leaves `agent.config.provider` alone. Already true by inspection (line
+   121-123); add a comment explaining the persistence decision.
+
+7. **Tests** (see Test Strategy).
+
+8. **Update CLAUDE.md / AGENTS.md** — add a one-paragraph note in the
+   `Pattern A attachables` section (or wherever Bundle 4 is documented) that
+   describes the `attach → sync` reconciliation contract for providers.
+   Optional; skip if no such section exists, and instead add a docstring to
+   `sync_agent` referencing this issue.
+
+## Test Strategy
+
+### Unit (in CI via `make test`)
+
+Mock Ansible at the `configure_agent` boundary; assert on the `config_data`
+dict it receives.
+
+- `test_sync_materializes_attached_provider_into_config` — happy path.
+- `test_sync_advances_state_through_providers_when_pending` — state
+  transition.
+- `test_sync_legacy_agent_without_attachment_unchanged` — regression guard.
+- `test_sync_unknown_attached_provider_errors_cleanly` — error path.
+- `test_provider_attach_rejects_second_attachment` — single-provider guard.
+- `test_provider_attach_same_name_twice_is_idempotent` — preserves existing
+  re-attach UX.
+
+### End-to-end (manual, on real host `wolf-i`)
+
+Provider: `local-inx` (ollama, no API key). Agent: fresh hermes named
+`test-426-hermes`. Steps and pass criteria documented in the issue body for
+reproducibility:
+
+```bash
+# clean slate
+clawctl agent get | grep test-426 && exit 1
+
+# create — no provider yet
+clawctl agent create test-426-hermes --type hermes --host wolf-i --yes
+jq '.[] | .agents."test-426-hermes" | {state: .onboarding.state, cfg_provider: .config.provider, providers}' \
+  ~/.config/clawrium/hosts.json
+# expect: state="pending", cfg_provider=null, providers=null
+
+# attach
+clawctl agent provider attach local-inx --agent test-426-hermes
+jq '.[] | .agents."test-426-hermes" | {state: .onboarding.state, cfg_provider: .config.provider, providers}' \
+  ~/.config/clawrium/hosts.json
+# expect: state="pending" (still), cfg_provider=null (still), providers=["local-inx"]
+
+# sync — the bridge fires
+clawctl agent sync test-426-hermes
+jq '.[] | .agents."test-426-hermes" | {state: .onboarding.state, cfg_provider: .config.provider, providers}' \
+  ~/.config/clawrium/hosts.json
+# expect: state advanced past "pending", cfg_provider.name == "local-inx",
+#         cfg_provider.type == "ollama", endpoint populated
+
+# remote: provider hydrated into the agent's .env
+ssh xclm@wolf.tailf7742d.ts.net 'grep -iE "^(provider|ollama|llm_)" ~/.hermes/test-426-hermes/.env'
+
+# remote: hermes unit healthy
+ssh xclm@wolf.tailf7742d.ts.net 'systemctl --user is-active hermes-test-426-hermes'
+
+# idempotency: second sync — provider must still be there
+clawctl agent sync test-426-hermes
+jq '.[] | .agents."test-426-hermes".config.provider.name' ~/.config/clawrium/hosts.json
+# expect: "local-inx"
+
+# detach: persistence check — config.provider must NOT vanish
+clawctl agent provider detach local-inx --agent test-426-hermes
+jq '.[] | .agents."test-426-hermes" | {cfg_provider: .config.provider, providers}' \
+  ~/.config/clawrium/hosts.json
+# expect: cfg_provider.name still "local-inx", providers=[]
+
+# cleanup
+clawctl agent delete test-426-hermes --yes
+```
+
+## Risks
+
+- **R1 — Provider record drift between `attach` and `sync`**: user attaches
+  `foo`, then mutates `providers.json` to point `foo` at a different
+  endpoint, then `sync`. Bridge materializes the *current* `providers.json`
+  state at sync time. **Decision: this is correct behaviour** (declarative
+  reconcile = current desired state). Document in the `sync_agent` docstring.
+- **R2 — Manual hosts.json edit creating `len(agent.providers) > 1`**: the
+  defensive check in step 2 catches it. Without that check, sync would pick
+  index 0 silently. Keep the explicit `LifecycleError`.
+- **R3 — Hermes ollama config shape**: legacy `_sync_provider_config` lived in
+  `cli/agent.py` and predates the hermes api_server changes (#346, #476).
+  Verify during E2E that the rendered `.env`/`config.toml` on the remote
+  contains the expected ollama wiring. If hermes templates expect additional
+  keys beyond `{name, type, endpoint, default_model}`, extend the assembled
+  dict accordingly.
+- **R4 — State machine: `PENDING → providers` transition**: confirmed via
+  `core/onboarding.py:279` (`"pending": ["providers"]` in allowed transitions
+  table). `complete_stage` will accept the call. The re-sync path
+  (state already past `providers`) routes through `update_stage_metadata`
+  per legacy precedent.
+- **R5 — Multi-provider future**: the design is single-provider by user
+  decision. The `agent.providers` field stays a list (don't rename to
+  scalar) so a future multi-provider extension doesn't require a hosts.json
+  migration — only relaxing the `attach` guard and a fan-out in `sync_agent`.
+
+## Subtasks
+
+None — single task execution. Scope is ~80 LOC across two files plus tests;
+all changes share one mental model and one round of E2E.
+
+---
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: planning
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-05-25T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+That seems like a bug. In the workflow. So give me a plan to resolve this and test it on a real agent. I need the same workflow where create, attach, and sync works for any provider. This needs to be tested for one provider end to end.
+
+[follow-up resolving open decisions]
+For now, single provider is fine. Don't, or fail when multi provider is added.
+Provider once added to the agent, is persistent. So however times it syncs, provider should still be there.
+Test the provider with local INX. Which is fine.
+Use Hermes agent to test. That is also fine.
+plan this
+```
+
+**Output**: `.itx/426/00_PLAN.md` — single-task plan to bridge
+`agent.providers` (attach) → `agent.config.provider` (sync) inside
+`core/lifecycle.sync_agent`, with single-provider guard at `attach` time,
+detach-preserves-config semantics, and an E2E flow against `wolf-i` using
+`local-inx` (ollama) + a fresh hermes agent.
+
+</details>

--- a/src/clawrium/cli/clawctl/agent/provider.py
+++ b/src/clawrium/cli/clawctl/agent/provider.py
@@ -86,7 +86,13 @@ def attach(
     name: str = typer.Argument(..., help="Provider name to attach."),
     agent: str = typer.Option(..., "--agent", help="Agent instance name."),
 ) -> None:
-    """Attach a registered provider to an agent."""
+    """Attach a registered provider to an agent.
+
+    The attachment is metadata only at this point — the provider config
+    is materialized onto the remote agent on the next `clawctl agent
+    sync`. Single-provider invariant: detach the current provider
+    before attaching a different one. See #426.
+    """
     _safe_get_provider(name)
     host, _agent_type, _claw = safe_resolve_agent(agent)
     hostname = host["hostname"]
@@ -120,7 +126,14 @@ def detach(
     name: str = typer.Argument(..., help="Provider name to detach."),
     agent: str = typer.Option(..., "--agent", help="Agent instance name."),
 ) -> None:
-    """Detach a provider from an agent."""
+    """Detach a provider from an agent.
+
+    Note: the provider config previously materialized into the agent's
+    `config.provider` block is preserved as last-known-good across
+    syncs. To switch providers, attach a replacement and run
+    `clawctl agent sync`; the new provider will overwrite the old.
+    See #426.
+    """
     host, _agent_type, _claw = safe_resolve_agent(agent)
     hostname = host["hostname"]
     agent_key = resolve_agent_key(host, agent)

--- a/src/clawrium/cli/clawctl/agent/provider.py
+++ b/src/clawrium/cli/clawctl/agent/provider.py
@@ -96,6 +96,19 @@ def attach(
     if name in current:
         typer.echo(f"agent/{agent}: provider {name!r} already attached")
         return
+    # Issue #426: single-provider invariant. Once an agent has a
+    # provider attached, refuse a second attachment with a clear
+    # remediation pointer. `sync` materializes the attachment into
+    # `config.provider`; multiple attachments would silently ambiguate
+    # which one wins at reconcile time.
+    if current:
+        emit_error(
+            f"agent '{agent}' already has provider {current[0]!r} attached",
+            hint=(
+                f"detach first: clawctl agent provider detach {current[0]} "
+                f"--agent {agent}"
+            ),
+        )
     current.append(name)
     if not _set_attached_providers(hostname, agent_key, current):
         emit_error(f"failed to attach provider {name!r} to agent {agent!r}")
@@ -121,6 +134,10 @@ def detach(
     current.remove(name)
     if not _set_attached_providers(hostname, agent_key, current):
         emit_error(f"failed to detach provider {name!r} from agent {agent!r}")
+    # Issue #426 design decision: detach does NOT strip
+    # `agent.config.provider`. The provider config persists across
+    # sync runs as last-known-good so the remote keeps functioning
+    # until the user explicitly attaches a replacement.
     typer.echo(f"agent/{agent}: detached provider {name!r}")
 
 

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -1011,7 +1011,13 @@ def sync_agent(
     # complete_stage on it, transition_state to the NEXT stage. The
     # difference: we never prompt — anything that would require user
     # input either has a Pattern A attachment behind it or raises.
-    if provider_name_for_state and state == OnboardingState.PENDING:
+    #
+    # Gate is `state != READY` (not just `== PENDING`) so a re-sync
+    # after a previous failed configure_agent (which leaves state at
+    # VALIDATE or earlier) can advance the agent the rest of the way.
+    # Idempotent operations inside the walk swallow InvalidTransitionError
+    # when state is already past a given stage. ATX iter-2 B-ITER2-1.
+    if provider_name_for_state and state != OnboardingState.READY:
         from clawrium.core.onboarding import (
             InvalidTransitionError,
             OnboardingState as _OS,
@@ -1104,11 +1110,19 @@ def sync_agent(
             except InvalidTransitionError:
                 pass
 
-        # --- final transition to READY ----------------------------
-        _safe_transition(_OS.READY)
-        state = _OS.READY
+        # NOTE: READY transition is deferred until AFTER configure_agent
+        # succeeds. Writing state=READY before the Ansible push lands
+        # would leave hosts.json showing READY for an agent whose
+        # systemd unit was never written if configure_agent then fails.
+        # `clawctl agent start` only gates on state==READY, so deferring
+        # is the safety boundary. ATX iter-2 B-ITER2-1.
+        walk_completed = True
+        state = _OS.VALIDATE  # furthest the pre-configure walk advances
 
-    if state == OnboardingState.PENDING:
+    else:
+        walk_completed = False
+
+    if state == OnboardingState.PENDING and not walk_completed:
         raise LifecycleError(
             f"Cannot sync {agent_key}: onboarding not started (state={state_value}). "
             f"Attach a provider first: 'clawctl agent provider attach <name> "
@@ -1126,11 +1140,13 @@ def sync_agent(
     if not existing_config:
         # install.py always writes config.gateway, so this branch
         # implies a corrupt agent record (hand-edited hosts.json) — the
-        # only honest remediation is re-create. ATX iter-1 W1.
+        # only honest remediation is re-create. ATX iter-1 W1 +
+        # iter-2 W1 (full --type/--host placeholders).
         raise LifecycleError(
             f"No configuration found for {agent_key}. Agent record is "
             f"incomplete (missing gateway config); re-create the agent: "
-            f"'clawctl agent delete {agent_key}' then 'clawctl agent create'."
+            f"'clawctl agent delete {agent_key}' then "
+            f"'clawctl agent create {agent_key} --type <type> --host <host>'."
         )
 
     emit("sync", f"Configuring {agent_key}...")
@@ -1153,6 +1169,24 @@ def sync_agent(
             "started_at": None,
             "error": f"Configure failed: {config_error}",
         }
+
+    # ATX iter-2 B-ITER2-1: only NOW commit READY to disk. Ansible
+    # succeeded, so the remote agent is actually configured and
+    # `clawctl agent start` is safe to gate on this. Try
+    # unconditionally — TRANSITIONS allows VALIDATE→READY and
+    # READY→READY (idempotent), the other states reject (in which case
+    # the post-configure cosmetic step is skipped without failing
+    # sync; state can be repaired by a subsequent sync after manual
+    # configure of stuck stages).
+    from clawrium.core.onboarding import (
+        OnboardingState as _OS_post,
+        transition_state as _transition_post,
+    )
+
+    try:
+        _transition_post(hostname, agent_key, _OS_post.READY)
+    except Exception:
+        pass
 
     emit("sync", f"Sync complete for {agent_key}")
 

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -982,9 +982,12 @@ def sync_agent(
             "endpoint": provider_record.get("endpoint", ""),
             "default_model": provider_record.get("default_model", ""),
         }
-        if provider_record.get("context_window"):
+        # `is not None` instead of truthy: max_tokens=0 / context_window=0
+        # are meaningful (no-limit signals on some APIs); a falsy check
+        # would silently drop them. ATX iter-1 S1.
+        if provider_record.get("context_window") is not None:
             provider_overlay["context_window"] = provider_record["context_window"]
-        if provider_record.get("max_tokens"):
+        if provider_record.get("max_tokens") is not None:
             provider_overlay["max_tokens"] = provider_record["max_tokens"]
         provider_name_for_state = provider_name
 
@@ -996,21 +999,56 @@ def sync_agent(
     except ValueError:
         state = OnboardingState.PENDING
 
-    # Issue #426: when a fresh agent (state=PENDING) has an attached
-    # provider, advance the state machine through the `providers` stage
-    # so the PENDING-rejection check below passes. This is what makes
-    # `create → attach → sync` work without an intermediate manual
-    # `configure --stage providers` step. Re-sync after attach swap
-    # routes through update_stage_metadata per legacy precedent
-    # (_run_providers_stage:498-509 in cli/agent.py).
+    # Issue #426 + #523: drive the onboarding state machine forward when
+    # a provider attachment is present. Option D semantics: advance as
+    # far as the per-agent manifest's `auto_skip` flags allow, completing
+    # stages that have no remaining declarative input to gather, and
+    # refusing loudly when a required stage has no clawctl declarative
+    # surface yet (today only `identity` for openclaw — tracked in #523).
+    #
+    # This mirrors the legacy `clm agent configure` driver loop
+    # (cli/agent.py:2110-2211): transition_state INTO each stage,
+    # complete_stage on it, transition_state to the NEXT stage. The
+    # difference: we never prompt — anything that would require user
+    # input either has a Pattern A attachment behind it or raises.
     if provider_name_for_state and state == OnboardingState.PENDING:
         from clawrium.core.onboarding import (
             InvalidTransitionError,
+            OnboardingState as _OS,
             StageStatus,
+            can_skip_stage,
             complete_stage,
+            transition_state,
             update_stage_metadata,
         )
 
+        def _safe_update_metadata(stage: str, meta: dict) -> None:
+            # ATX iter-1 W2: `update_stage_metadata` itself raises
+            # InvalidTransitionError if the stage record is not in
+            # `complete` status. Wrap so any failure here surfaces as a
+            # LifecycleError (operator-actionable) rather than escaping
+            # as a raw InvalidTransitionError.
+            try:
+                update_stage_metadata(hostname, agent_key, stage, meta)
+            except Exception as exc:
+                raise LifecycleError(
+                    f"could not update {stage!r} metadata for "
+                    f"{agent_key!r}: {exc}. "
+                    f"Onboarding state may be corrupt; "
+                    f"inspect with 'clawctl agent describe {agent_key}'."
+                ) from exc
+
+        def _safe_transition(target: _OS) -> None:
+            # InvalidTransitionError on a forward transition we expect
+            # to be permissible means state is already at-or-past the
+            # target (idempotent re-sync). Swallow; that's the legacy
+            # behaviour in cli/agent.py:2165-2168.
+            try:
+                transition_state(hostname, agent_key, target)
+            except InvalidTransitionError:
+                pass
+
+        # --- providers stage --------------------------------------
         try:
             complete_stage(
                 hostname,
@@ -1020,13 +1058,55 @@ def sync_agent(
                 {"provider_id": provider_name_for_state},
             )
         except InvalidTransitionError:
-            update_stage_metadata(
-                hostname,
-                agent_key,
-                "providers",
-                {"provider_id": provider_name_for_state},
+            _safe_update_metadata(
+                "providers", {"provider_id": provider_name_for_state}
             )
-        state = OnboardingState.PROVIDERS
+        _safe_transition(_OS.PROVIDERS)
+
+        # --- remaining stages (Option D walk) ---------------------
+        # Per #523 audit: today only `identity` for openclaw lacks a
+        # clawctl declarative surface. Hermes/zeroclaw mark identity
+        # `auto_skip: true`. Channels and validate are completed as
+        # state-machine bookkeeping — channels' actual content comes
+        # from the separate `clawctl agent channel attach` surface
+        # (#509), and validate's health check is implicit in
+        # configure_agent's Ansible exit code below.
+        _NO_DECLARATIVE_SURFACE_YET = {"identity"}
+        _STAGE_NEXT_STATE = {
+            "identity": _OS.IDENTITY,
+            "channels": _OS.CHANNELS,
+            "validate": _OS.VALIDATE,
+        }
+
+        for stage_name in ("identity", "channels", "validate"):
+            _safe_transition(_STAGE_NEXT_STATE[stage_name])
+            if can_skip_stage(agent_type, stage_name):
+                try:
+                    complete_stage(
+                        hostname, agent_key, stage_name, StageStatus.SKIPPED
+                    )
+                except InvalidTransitionError:
+                    pass
+                continue
+            if stage_name in _NO_DECLARATIVE_SURFACE_YET:
+                raise LifecycleError(
+                    f"agent '{agent_key}' (type={agent_type}) requires manual "
+                    f"{stage_name} configuration: no clawctl declarative "
+                    f"surface exists for the {stage_name} stage yet "
+                    f"(tracked in #523). Workaround: complete this stage via "
+                    f"'clawctl agent configure {agent_key} --stage {stage_name}', "
+                    f"then re-run sync."
+                )
+            try:
+                complete_stage(
+                    hostname, agent_key, stage_name, StageStatus.COMPLETE
+                )
+            except InvalidTransitionError:
+                pass
+
+        # --- final transition to READY ----------------------------
+        _safe_transition(_OS.READY)
+        state = _OS.READY
 
     if state == OnboardingState.PENDING:
         raise LifecycleError(
@@ -1035,22 +1115,23 @@ def sync_agent(
             f"--agent {agent_key}'."
         )
 
+    # Apply the overlay first so a freshly attached provider can rescue
+    # an otherwise-empty config (which would normally be a pathological
+    # state — install.py writes config.gateway). ATX iter-1 W5.
     existing_config = claw_record.get("config", {})
-    if not existing_config:
-        raise LifecycleError(
-            f"No configuration found for {agent_key}. "
-            f"Attach a provider first: 'clawctl agent provider attach <name> "
-            f"--agent {agent_key}'."
-        )
-
-    # Issue #426: overlay materialized provider onto existing config.
-    # configure_agent persists the merged dict into
-    # hosts.json.agents.<key>.config via its updater closure (line ~1709)
-    # after Ansible succeeds, satisfying the persistence-across-syncs
-    # contract.
     if provider_overlay is not None:
         existing_config = dict(existing_config)
         existing_config["provider"] = provider_overlay
+
+    if not existing_config:
+        # install.py always writes config.gateway, so this branch
+        # implies a corrupt agent record (hand-edited hosts.json) — the
+        # only honest remediation is re-create. ATX iter-1 W1.
+        raise LifecycleError(
+            f"No configuration found for {agent_key}. Agent record is "
+            f"incomplete (missing gateway config); re-create the agent: "
+            f"'clawctl agent delete {agent_key}' then 'clawctl agent create'."
+        )
 
     emit("sync", f"Configuring {agent_key}...")
     config_success, config_error = configure_agent(

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -942,6 +942,52 @@ def sync_agent(
         raise LifecycleError(f"Agent '{target}' not installed on '{hostname}'")
     agent_key, agent_type, claw_record = resolved
 
+    # Issue #426: bridge `agent.providers` (the attach list written by
+    # `clawctl agent provider attach`) → `config.provider` (the dict the
+    # Ansible templates render). The Pattern A surface from #509 records
+    # attachments as metadata only; sync is the declarative reconcile
+    # point that materializes those attachments into the agent's config
+    # before pushing to the remote. `detach` intentionally does NOT strip
+    # `config.provider` — once a provider lands in config it is
+    # last-known-good across subsequent syncs (design decision on #426).
+    attached_providers = claw_record.get("providers") or []
+    provider_overlay: dict | None = None
+    provider_name_for_state: str | None = None
+    if attached_providers:
+        if len(attached_providers) > 1:
+            # `attach` enforces the single-provider invariant; reaching
+            # this branch means hosts.json was hand-edited. Fail loudly
+            # rather than silently picking index 0.
+            raise LifecycleError(
+                f"agent '{agent_key}' has {len(attached_providers)} providers "
+                f"attached; single-provider invariant requires exactly one. "
+                f"Detach extras with 'clawctl agent provider detach <name> "
+                f"--agent {agent_key}'."
+            )
+        from clawrium.core.providers.storage import get_provider
+
+        provider_name = attached_providers[0]
+        provider_record = get_provider(provider_name)
+        if provider_record is None:
+            raise LifecycleError(
+                f"attached provider '{provider_name}' not registered. "
+                f"Run 'clawctl provider registry get' to list available providers."
+            )
+        # Shape mirrors the legacy `_sync_provider_config` builder
+        # (src/clawrium/cli/agent.py:360-374) so configure_agent's
+        # validation block (~lines 1266-1296) accepts the dict unchanged.
+        provider_overlay = {
+            "name": provider_record.get("name", ""),
+            "type": provider_record.get("type", "ollama"),
+            "endpoint": provider_record.get("endpoint", ""),
+            "default_model": provider_record.get("default_model", ""),
+        }
+        if provider_record.get("context_window"):
+            provider_overlay["context_window"] = provider_record["context_window"]
+        if provider_record.get("max_tokens"):
+            provider_overlay["max_tokens"] = provider_record["max_tokens"]
+        provider_name_for_state = provider_name
+
     onboarding = claw_record.get("onboarding", {})
     state_value = onboarding.get("state", "pending")
 
@@ -950,18 +996,61 @@ def sync_agent(
     except ValueError:
         state = OnboardingState.PENDING
 
+    # Issue #426: when a fresh agent (state=PENDING) has an attached
+    # provider, advance the state machine through the `providers` stage
+    # so the PENDING-rejection check below passes. This is what makes
+    # `create → attach → sync` work without an intermediate manual
+    # `configure --stage providers` step. Re-sync after attach swap
+    # routes through update_stage_metadata per legacy precedent
+    # (_run_providers_stage:498-509 in cli/agent.py).
+    if provider_name_for_state and state == OnboardingState.PENDING:
+        from clawrium.core.onboarding import (
+            InvalidTransitionError,
+            StageStatus,
+            complete_stage,
+            update_stage_metadata,
+        )
+
+        try:
+            complete_stage(
+                hostname,
+                agent_key,
+                "providers",
+                StageStatus.COMPLETE,
+                {"provider_id": provider_name_for_state},
+            )
+        except InvalidTransitionError:
+            update_stage_metadata(
+                hostname,
+                agent_key,
+                "providers",
+                {"provider_id": provider_name_for_state},
+            )
+        state = OnboardingState.PROVIDERS
+
     if state == OnboardingState.PENDING:
         raise LifecycleError(
             f"Cannot sync {agent_key}: onboarding not started (state={state_value}). "
-            f"Run 'clm agent configure {agent_key}' first."
+            f"Attach a provider first: 'clawctl agent provider attach <name> "
+            f"--agent {agent_key}'."
         )
 
     existing_config = claw_record.get("config", {})
     if not existing_config:
         raise LifecycleError(
             f"No configuration found for {agent_key}. "
-            f"Run 'clm agent configure {agent_key}' first."
+            f"Attach a provider first: 'clawctl agent provider attach <name> "
+            f"--agent {agent_key}'."
         )
+
+    # Issue #426: overlay materialized provider onto existing config.
+    # configure_agent persists the merged dict into
+    # hosts.json.agents.<key>.config via its updater closure (line ~1709)
+    # after Ansible succeeds, satisfying the persistence-across-syncs
+    # contract.
+    if provider_overlay is not None:
+        existing_config = dict(existing_config)
+        existing_config["provider"] = provider_overlay
 
     emit("sync", f"Configuring {agent_key}...")
     config_success, config_error = configure_agent(

--- a/src/clawrium/core/providers/storage.py
+++ b/src/clawrium/core/providers/storage.py
@@ -276,6 +276,18 @@ def validate_ollama_url(url: str) -> str:
     """
     url = url.strip().rstrip("/")
 
+    # ATX iter-2 W-SEC-1: reject characters that could break out of a
+    # YAML/TOML/shell scalar in downstream template rendering. The
+    # hermes config template renders this URL into a YAML double-quoted
+    # scalar; a `"` or `\` (which urlparse accepts) would produce
+    # malformed YAML and DoS the Ansible push step on every sync.
+    # Whitespace and control characters are not valid in URLs per
+    # RFC 3986 and are rejected here for defense in depth.
+    if any(ch in url for ch in ('"', "\\", "\n", "\r", "\t")):
+        raise InvalidOllamaUrlError(
+            "URL must not contain quote, backslash, or whitespace characters"
+        )
+
     try:
         parsed = urlparse(url)
     except Exception as e:

--- a/src/clawrium/platform/registry/hermes/templates/hermes-config.yaml.j2
+++ b/src/clawrium/platform/registry/hermes/templates/hermes-config.yaml.j2
@@ -77,10 +77,13 @@ model:
 {# Hermes' custom provider expects an OpenAI-compatible /v1 root. Append /v1
    when the clm provider endpoint omits it (e.g. raw Ollama base URL). #}
 {% set endpoint_clean = endpoint.rstrip('/') %}
+{# yaml_quote on the URL so a hand-edited endpoint containing " or \
+   cannot break out of the scalar and DoS the Ansible parse step.
+   ATX iter-2 W-SEC-1. #}
 {% if endpoint_clean and endpoint_clean.endswith('/v1') %}
-  base_url: "{{ endpoint_clean }}"
+  base_url: {{ yaml_quote(endpoint_clean) }}
 {% elif endpoint_clean %}
-  base_url: "{{ endpoint_clean }}/v1"
+  base_url: {{ yaml_quote(endpoint_clean ~ '/v1') }}
 {% endif %}
 {% if model_id %}  default: "{{ model_id }}"
 {% endif %}

--- a/tests/cli/clawctl/agent/test_sync_materializes_provider.py
+++ b/tests/cli/clawctl/agent/test_sync_materializes_provider.py
@@ -69,7 +69,11 @@ def test_sync_materializes_attached_provider_into_config():
             "clawrium.core.providers.storage.get_provider",
             return_value=_ollama_provider_record(),
         ),
-        patch("clawrium.core.onboarding.complete_stage") as mock_complete,
+        patch(
+            "clawrium.core.onboarding.complete_stage", return_value=True
+        ) as mock_complete,
+        patch("clawrium.core.onboarding.transition_state", return_value=True),
+        patch("clawrium.core.onboarding.can_skip_stage", return_value=True),
         patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
     ):
         result = sync_agent("192.168.1.100", "openclaw")
@@ -80,12 +84,14 @@ def test_sync_materializes_attached_provider_into_config():
     assert provider["type"] == "ollama"
     assert provider["endpoint"] == "http://192.168.1.17:11434"
     assert provider["default_model"] == "qwen3-coder:30b-128k"
-    # State must have been advanced through providers stage so the
-    # PENDING-rejection check downstream passes.
-    mock_complete.assert_called_once()
-    call_args = mock_complete.call_args
-    assert call_args.args[2] == "providers"
-    assert call_args.args[4] == {"provider_id": "local-inx"}
+    # The providers complete_stage call carries the provider_id metadata
+    # (other stages' complete_stage calls do not — they're auto-skip
+    # bookkeeping for the Option D walk).
+    providers_calls = [
+        c for c in mock_complete.call_args_list if c.args[2] == "providers"
+    ]
+    assert len(providers_calls) == 1
+    assert providers_calls[0].args[4] == {"provider_id": "local-inx"}
 
 
 def test_sync_carries_optional_provider_fields():
@@ -196,3 +202,189 @@ def test_sync_pending_without_attachment_keeps_legacy_error():
     assert "onboarding not started" in str(exc_info.value)
     # Error message now points at the new attach surface, not legacy clm.
     assert "clawctl agent provider attach" in str(exc_info.value)
+
+
+def test_sync_after_detach_preserves_last_known_good_provider():
+    """ATX iter-1 B2: agent.providers=[] (post-detach) is distinct from
+    `providers` key absent (legacy). The bridge must skip
+    re-materialization on an empty list and leave the pre-existing
+    `config.provider` (last-known-good) untouched — that is the user
+    decision documented on #426.
+    """
+    last_good = {
+        "name": "old-provider",
+        "type": "ollama",
+        "endpoint": "http://old:11434",
+        "default_model": "qwen3",
+    }
+    host = _host_with_agent(
+        state="ready",
+        providers_attached=[],
+        config={"gateway": {"port": 40000}, "provider": last_good},
+    )
+
+    captured: dict = {}
+
+    def fake_configure(hostname, claw_name, config_data, **kwargs):
+        captured["config_data"] = config_data
+        return (True, None)
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "openclaw")
+
+    assert result["success"] is True
+    # Bridge did NOT overwrite config.provider when attach list is empty.
+    assert captured["config_data"]["provider"] == last_good
+
+
+def test_sync_invalid_transition_routes_to_update_metadata():
+    """ATX iter-1 W6: when complete_stage raises InvalidTransitionError
+    (re-sync after attach swap on an already-advanced agent),
+    sync_agent falls back to update_stage_metadata instead of crashing.
+    Verifies the re-sync code path that the original test set did not
+    cover."""
+    from clawrium.core.onboarding import InvalidTransitionError
+
+    host = _host_with_agent(state="pending", providers_attached=["local-inx"])
+
+    def fake_configure(hostname, claw_name, config_data, **kwargs):
+        return (True, None)
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch(
+            "clawrium.core.providers.storage.get_provider",
+            return_value=_ollama_provider_record(),
+        ),
+        patch(
+            "clawrium.core.onboarding.complete_stage",
+            side_effect=InvalidTransitionError("already past providers"),
+        ),
+        patch("clawrium.core.onboarding.update_stage_metadata") as mock_update,
+        patch("clawrium.core.onboarding.transition_state"),
+        patch("clawrium.core.onboarding.can_skip_stage", return_value=True),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "openclaw")
+
+    assert result["success"] is True
+    # update_stage_metadata receives the same provider_id metadata.
+    mock_update.assert_any_call(
+        "192.168.1.100",
+        "opc-work",
+        "providers",
+        {"provider_id": "local-inx"},
+    )
+
+
+def test_sync_drives_state_to_ready_for_auto_skip_agent():
+    """B1 fix: when every non-providers stage is auto_skip-able for the
+    agent type (the hermes/zeroclaw pattern after manifest evaluation),
+    sync transitions state all the way to READY so a subsequent
+    `clawctl agent start` succeeds."""
+    host = _host_with_agent(state="pending", providers_attached=["local-inx"])
+
+    def fake_configure(hostname, claw_name, config_data, **kwargs):
+        return (True, None)
+
+    transitions: list[str] = []
+
+    def capture_transition(_host, _agent, target):
+        transitions.append(target.value)
+        return True
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch(
+            "clawrium.core.providers.storage.get_provider",
+            return_value=_ollama_provider_record(),
+        ),
+        patch("clawrium.core.onboarding.complete_stage", return_value=True),
+        patch(
+            "clawrium.core.onboarding.transition_state",
+            side_effect=capture_transition,
+        ),
+        patch("clawrium.core.onboarding.can_skip_stage", return_value=True),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "openclaw")
+
+    assert result["success"] is True
+    # State machine walked all the way to READY.
+    assert transitions[-1] == "ready"
+    # The full progression hit each canonical state in order.
+    assert "providers" in transitions
+    assert "identity" in transitions
+    assert "channels" in transitions
+    assert "validate" in transitions
+    assert "ready" in transitions
+
+
+def test_sync_refuses_required_stage_without_declarative_surface():
+    """Option D (issue #523 tracking): when a non-auto_skip stage lacks
+    a clawctl declarative surface (today: identity for openclaw), sync
+    must refuse rather than silently mark COMPLETE and advance to READY
+    with no actual identity files pushed."""
+
+    def can_skip_only_validate(agent_type: str, stage: str) -> bool:
+        # Simulate openclaw: identity required, channels required,
+        # validate auto-skipped.
+        return stage == "validate"
+
+    host = _host_with_agent(state="pending", providers_attached=["local-inx"])
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch(
+            "clawrium.core.providers.storage.get_provider",
+            return_value=_ollama_provider_record(),
+        ),
+        patch("clawrium.core.onboarding.complete_stage", return_value=True),
+        patch("clawrium.core.onboarding.transition_state", return_value=True),
+        patch(
+            "clawrium.core.onboarding.can_skip_stage",
+            side_effect=can_skip_only_validate,
+        ),
+    ):
+        with pytest.raises(LifecycleError) as exc_info:
+            sync_agent("192.168.1.100", "openclaw")
+
+    msg = str(exc_info.value)
+    assert "identity" in msg
+    assert "#523" in msg  # Points at the tracking issue.
+    assert "clawctl agent configure" in msg  # Workaround named.
+
+
+def test_sync_optional_field_max_tokens_zero_preserved():
+    """ATX iter-1 S1: max_tokens=0 / context_window=0 are meaningful
+    no-limit signals on some provider APIs. The `is not None` checks
+    must preserve zero values rather than dropping them on truthy."""
+    host = _host_with_agent(state="ready", providers_attached=["unlimited"])
+    rec = {
+        "name": "unlimited",
+        "type": "ollama",
+        "endpoint": "http://localhost:11434",
+        "default_model": "qwen3",
+        "max_tokens": 0,  # Explicit no-limit signal.
+    }
+
+    captured: dict = {}
+
+    def fake_configure(hostname, claw_name, config_data, **kwargs):
+        captured["config_data"] = config_data
+        return (True, None)
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch("clawrium.core.providers.storage.get_provider", return_value=rec),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "openclaw")
+
+    assert result["success"] is True
+    provider = captured["config_data"]["provider"]
+    assert "max_tokens" in provider
+    assert provider["max_tokens"] == 0

--- a/tests/cli/clawctl/agent/test_sync_materializes_provider.py
+++ b/tests/cli/clawctl/agent/test_sync_materializes_provider.py
@@ -1,0 +1,198 @@
+"""Issue #426 — sync_agent materializes `agent.providers` (attach list)
+into `config.provider` (Ansible-rendered dict) and advances the
+onboarding state machine through the `providers` stage when needed.
+
+These tests exercise `core/lifecycle.sync_agent` directly with
+`configure_agent` mocked out — so the contract under test is exactly the
+shape of the `config_data` argument the bridge feeds into the
+remote-push call.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from clawrium.core.lifecycle import LifecycleError, sync_agent
+
+
+def _host_with_agent(
+    *,
+    state: str = "pending",
+    providers_attached: list[str] | None = None,
+    config: dict | None = None,
+) -> dict:
+    """Build a minimal host record carrying one openclaw agent."""
+    agent: dict = {
+        "type": "openclaw",
+        "onboarding": {"state": state},
+        "config": {"gateway": {"port": 40000}} if config is None else config,
+    }
+    if providers_attached is not None:
+        agent["providers"] = providers_attached
+    return {
+        "hostname": "192.168.1.100",
+        "key_id": "test",
+        "agent_name": "xclm",
+        "port": 22,
+        "agents": {"opc-work": agent},
+    }
+
+
+def _ollama_provider_record() -> dict:
+    return {
+        "name": "local-inx",
+        "type": "ollama",
+        "endpoint": "http://192.168.1.17:11434",
+        "default_model": "qwen3-coder:30b-128k",
+    }
+
+
+def test_sync_materializes_attached_provider_into_config():
+    """Happy path: agent.providers=["local-inx"] + state=pending →
+    sync overlays the provider record from providers.json onto
+    config.provider before pushing.
+    """
+    host = _host_with_agent(state="pending", providers_attached=["local-inx"])
+
+    captured: dict = {}
+
+    def fake_configure(hostname, claw_name, config_data, **kwargs):
+        captured["config_data"] = config_data
+        captured["claw_name"] = claw_name
+        return (True, None)
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch(
+            "clawrium.core.providers.storage.get_provider",
+            return_value=_ollama_provider_record(),
+        ),
+        patch("clawrium.core.onboarding.complete_stage") as mock_complete,
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "openclaw")
+
+    assert result["success"] is True
+    provider = captured["config_data"]["provider"]
+    assert provider["name"] == "local-inx"
+    assert provider["type"] == "ollama"
+    assert provider["endpoint"] == "http://192.168.1.17:11434"
+    assert provider["default_model"] == "qwen3-coder:30b-128k"
+    # State must have been advanced through providers stage so the
+    # PENDING-rejection check downstream passes.
+    mock_complete.assert_called_once()
+    call_args = mock_complete.call_args
+    assert call_args.args[2] == "providers"
+    assert call_args.args[4] == {"provider_id": "local-inx"}
+
+
+def test_sync_carries_optional_provider_fields():
+    """context_window / max_tokens flow through when present on the
+    provider record."""
+    host = _host_with_agent(state="ready", providers_attached=["maurice"])
+    rec = {
+        "name": "maurice",
+        "type": "openrouter",
+        "endpoint": "https://openrouter.ai/api/v1",
+        "default_model": "z-ai/glm-4.5-air",
+        "context_window": 128000,
+        "max_tokens": 4096,
+    }
+
+    captured: dict = {}
+
+    def fake_configure(hostname, claw_name, config_data, **kwargs):
+        captured["config_data"] = config_data
+        return (True, None)
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch("clawrium.core.providers.storage.get_provider", return_value=rec),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "openclaw")
+
+    assert result["success"] is True
+    provider = captured["config_data"]["provider"]
+    assert provider["context_window"] == 128000
+    assert provider["max_tokens"] == 4096
+
+
+def test_sync_legacy_agent_without_attachment_unchanged():
+    """Regression guard: agents installed before #426 (no
+    `agent.providers` field, `config.provider` already populated by
+    the legacy `clm` flow) must sync without the bridge interfering."""
+    legacy_config = {
+        "gateway": {"port": 40000},
+        "provider": {
+            "name": "legacy-provider",
+            "type": "ollama",
+            "endpoint": "http://localhost:11434",
+            "default_model": "llama3",
+        },
+    }
+    host = _host_with_agent(state="ready", config=legacy_config)
+    # No `providers` key at all on the agent record.
+    assert "providers" not in host["agents"]["opc-work"]
+
+    captured: dict = {}
+
+    def fake_configure(hostname, claw_name, config_data, **kwargs):
+        captured["config_data"] = config_data
+        return (True, None)
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "openclaw")
+
+    assert result["success"] is True
+    # Legacy provider block flows through untouched.
+    assert captured["config_data"]["provider"]["name"] == "legacy-provider"
+
+
+def test_sync_unknown_attached_provider_errors_cleanly():
+    """Provider name in `agent.providers` not present in providers.json
+    must surface a clear LifecycleError, not a NoneType crash."""
+    host = _host_with_agent(state="pending", providers_attached=["ghost"])
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch("clawrium.core.providers.storage.get_provider", return_value=None),
+    ):
+        with pytest.raises(LifecycleError) as exc_info:
+            sync_agent("192.168.1.100", "openclaw")
+
+    assert "ghost" in str(exc_info.value)
+    assert "not registered" in str(exc_info.value)
+
+
+def test_sync_rejects_multi_provider_hand_edit():
+    """Defense-in-depth: hosts.json hand-edited to have two attached
+    providers must fail loudly rather than silently picking index 0."""
+    host = _host_with_agent(state="ready", providers_attached=["one", "two"])
+
+    with patch("clawrium.core.lifecycle.get_host", return_value=host):
+        with pytest.raises(LifecycleError) as exc_info:
+            sync_agent("192.168.1.100", "openclaw")
+
+    assert "single-provider invariant" in str(exc_info.value)
+
+
+def test_sync_pending_without_attachment_keeps_legacy_error():
+    """Agent with no provider attached AND state=pending must keep
+    erroring at the PENDING-rejection gate so users still get a clear
+    signal that the agent needs configuration."""
+    host = _host_with_agent(state="pending")
+    assert "providers" not in host["agents"]["opc-work"]
+
+    with patch("clawrium.core.lifecycle.get_host", return_value=host):
+        with pytest.raises(LifecycleError) as exc_info:
+            sync_agent("192.168.1.100", "openclaw")
+
+    assert "onboarding not started" in str(exc_info.value)
+    # Error message now points at the new attach surface, not legacy clm.
+    assert "clawctl agent provider attach" in str(exc_info.value)

--- a/tests/cli/clawctl/agent/test_sync_materializes_provider.py
+++ b/tests/cli/clawctl/agent/test_sync_materializes_provider.py
@@ -358,6 +358,123 @@ def test_sync_refuses_required_stage_without_declarative_surface():
     assert "clawctl agent configure" in msg  # Workaround named.
 
 
+def test_sync_hermes_real_manifest_configure_fail_does_not_persist_ready():
+    """ATX iter-2 B-ITER2-1 + B-ITER2-2: with the REAL hermes manifest
+    (no can_skip_stage patch), if configure_agent fails the state
+    pointer in hosts.json must NOT advance to ready. Channels and
+    validate stages are required+non-auto_skip on the real manifest;
+    the iter-1 code would have written ready before configure ran.
+    """
+    host = {
+        "hostname": "192.168.1.100",
+        "key_id": "test",
+        "agent_name": "xclm",
+        "port": 22,
+        "agents": {
+            "test-hermes": {
+                "type": "hermes",
+                "onboarding": {"state": "pending"},
+                "config": {"gateway": {"port": 45000}},
+                "providers": ["local-inx"],
+            }
+        },
+    }
+
+    transitions: list[str] = []
+    completes: list[tuple[str, str]] = []
+
+    def fake_transition(_host, _agent, target):
+        transitions.append(target.value)
+        return True
+
+    def fake_complete(_host, _agent, stage, status, _meta=None):
+        completes.append((stage, status.value))
+        return True
+
+    def fake_configure(*_args, **_kwargs):
+        return (False, "ansible exploded")
+
+    rec = _ollama_provider_record()
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch("clawrium.core.providers.storage.get_provider", return_value=rec),
+        # NOTE: can_skip_stage is NOT patched — uses real hermes manifest.
+        patch(
+            "clawrium.core.onboarding.transition_state", side_effect=fake_transition
+        ),
+        patch("clawrium.core.onboarding.complete_stage", side_effect=fake_complete),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "hermes")
+
+    assert result["success"] is False
+    assert "ansible exploded" in result["error"]
+    # CRITICAL: state must never have been advanced to ready.
+    assert "ready" not in transitions, (
+        f"state must not advance to ready when configure_agent fails; "
+        f"observed transitions: {transitions}"
+    )
+    # The walk did proceed through earlier stages (visible cosmetic
+    # writes), but ready specifically was deferred — which is the
+    # safety boundary that gates clawctl agent start.
+    assert "providers" in transitions
+    # Hermes auto_skips identity per the real manifest.
+    assert ("identity", "skipped") in completes
+    # Channels and validate are required+non-auto_skip on the real
+    # manifest — the walk completes them as state-machine bookkeeping
+    # but the ready transition is still deferred.
+    assert ("channels", "complete") in completes
+    assert ("validate", "complete") in completes
+
+
+def test_sync_hermes_real_manifest_configure_success_writes_ready():
+    """Companion to the failure-path test: with the real hermes
+    manifest, configure_agent succeeding does advance state to ready.
+    """
+    host = {
+        "hostname": "192.168.1.100",
+        "key_id": "test",
+        "agent_name": "xclm",
+        "port": 22,
+        "agents": {
+            "test-hermes": {
+                "type": "hermes",
+                "onboarding": {"state": "pending"},
+                "config": {"gateway": {"port": 45000}},
+                "providers": ["local-inx"],
+            }
+        },
+    }
+
+    transitions: list[str] = []
+
+    def fake_transition(_host, _agent, target):
+        transitions.append(target.value)
+        return True
+
+    def fake_configure(*_args, **_kwargs):
+        return (True, None)
+
+    rec = _ollama_provider_record()
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch("clawrium.core.providers.storage.get_provider", return_value=rec),
+        # No can_skip_stage patch — real hermes manifest.
+        patch(
+            "clawrium.core.onboarding.transition_state", side_effect=fake_transition
+        ),
+        patch("clawrium.core.onboarding.complete_stage", return_value=True),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "hermes")
+
+    assert result["success"] is True
+    # Now ready IS in transitions — and it comes LAST (post-configure).
+    assert transitions[-1] == "ready"
+
+
 def test_sync_optional_field_max_tokens_zero_preserved():
     """ATX iter-1 S1: max_tokens=0 / context_window=0 are meaningful
     no-limit signals on some provider APIs. The `is not None` checks

--- a/tests/cli/clawctl/provider/test_agent_attach_single.py
+++ b/tests/cli/clawctl/provider/test_agent_attach_single.py
@@ -1,0 +1,90 @@
+"""Issue #426 — single-provider invariant on `clawctl agent provider attach`.
+
+The bridge in `core/lifecycle.sync_agent` materializes
+`agent.providers[0]` into `config.provider` at reconcile time. Allowing
+more than one attachment would silently ambiguate which one wins, so
+`attach` hard-fails the 2nd attachment with a remediation pointer at
+`detach`. Same-name re-attach stays idempotent.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+
+runner = CliRunner()
+
+
+def _create_provider(name: str) -> None:
+    runner.invoke(
+        app,
+        [
+            "provider",
+            "registry",
+            "create",
+            name,
+            "--type",
+            "anthropic",
+            "--api-key",
+            "k",
+        ],
+    )
+
+
+def test_second_distinct_attach_is_rejected(fleet_dir, stdin_not_tty) -> None:
+    _create_provider("anth")
+    _create_provider("openrt")
+    first = runner.invoke(
+        app, ["agent", "provider", "attach", "anth", "--agent", "wise-hypatia"]
+    )
+    assert first.exit_code == 0, first.output
+
+    second = runner.invoke(
+        app, ["agent", "provider", "attach", "openrt", "--agent", "wise-hypatia"]
+    )
+    assert second.exit_code != 0
+    assert "already has provider" in second.output
+    # Hint must point at the right remediation surface.
+    assert "detach" in second.output
+    assert "anth" in second.output
+
+
+def test_same_name_reattach_is_idempotent(fleet_dir, stdin_not_tty) -> None:
+    """Idempotent re-attach of the same name is preserved (existing UX).
+    The single-provider guard must not fire when the user re-runs the
+    same attach command (e.g. a retry after a flaky network)."""
+    _create_provider("anth")
+    first = runner.invoke(
+        app, ["agent", "provider", "attach", "anth", "--agent", "wise-hypatia"]
+    )
+    assert first.exit_code == 0
+
+    second = runner.invoke(
+        app, ["agent", "provider", "attach", "anth", "--agent", "wise-hypatia"]
+    )
+    assert second.exit_code == 0
+    assert "already attached" in second.output
+
+
+def test_attach_after_detach_succeeds(fleet_dir, stdin_not_tty) -> None:
+    """Detach + re-attach (potentially a different provider) is the
+    documented replacement workflow. Verify the guard doesn't leak
+    state across the detach boundary."""
+    _create_provider("anth")
+    _create_provider("openrt")
+
+    attach1 = runner.invoke(
+        app, ["agent", "provider", "attach", "anth", "--agent", "wise-hypatia"]
+    )
+    assert attach1.exit_code == 0
+
+    detach = runner.invoke(
+        app, ["agent", "provider", "detach", "anth", "--agent", "wise-hypatia"]
+    )
+    assert detach.exit_code == 0
+
+    attach2 = runner.invoke(
+        app, ["agent", "provider", "attach", "openrt", "--agent", "wise-hypatia"]
+    )
+    assert attach2.exit_code == 0, attach2.output

--- a/tests/cli/clawctl/provider/test_agent_attach_single.py
+++ b/tests/cli/clawctl/provider/test_agent_attach_single.py
@@ -70,7 +70,11 @@ def test_same_name_reattach_is_idempotent(fleet_dir, stdin_not_tty) -> None:
 def test_attach_after_detach_succeeds(fleet_dir, stdin_not_tty) -> None:
     """Detach + re-attach (potentially a different provider) is the
     documented replacement workflow. Verify the guard doesn't leak
-    state across the detach boundary."""
+    state across the detach boundary AND that the on-disk attachment
+    list reflects the replacement.
+    """
+    import json
+
     _create_provider("anth")
     _create_provider("openrt")
 
@@ -88,3 +92,17 @@ def test_attach_after_detach_succeeds(fleet_dir, stdin_not_tty) -> None:
         app, ["agent", "provider", "attach", "openrt", "--agent", "wise-hypatia"]
     )
     assert attach2.exit_code == 0, attach2.output
+
+    # ATX iter-1 B3: assert the *final* attachment list, not just exit
+    # codes. A silent persistence-layer failure (or a regressed
+    # idempotent-check after detach) would leave the list as ['anth'],
+    # ['anth', 'openrt'], or [] — all of which would pass an exit-code
+    # check alone.
+    listed = runner.invoke(
+        app,
+        ["agent", "provider", "get", "--agent", "wise-hypatia", "-o", "json"],
+    )
+    assert listed.exit_code == 0
+    data = json.loads(listed.output)
+    names = sorted(p["name"] for p in data)
+    assert names == ["openrt"], f"expected ['openrt'], got {names}"


### PR DESCRIPTION
## Summary

- Wire `core/lifecycle.sync_agent` as the reconciliation point for the Pattern A `clawctl agent provider attach` surface — declarative `create → attach → sync` now delivers a provider to the remote agent.
- **Option D state-machine walk**: sync drives state to READY when it can (auto-skipping per manifest), refuses with a clear pointer at #523 for stages without a clawctl declarative surface (today: openclaw identity). READY transition is deferred until `configure_agent` succeeds so a failed Ansible push cannot leave a falsely-READY agent on disk.
- Hard-fail a second `provider attach` with a pointer at `detach` (single-provider invariant). Same-name re-attach stays idempotent.
- **Security**: `yaml_quote()` applied to the hermes endpoint scalar; `validate_ollama_url` rejects `"`, `\`, and whitespace at provider-creation time.

## Why

The Pattern A surface from #509 records provider attachments in `agent.providers` (top-level list on the agent record), but `sync_agent` reads from `agent.config` only — so the attachment never reached the Ansible push. The declarative flow ran clean but produced no remote effect.

This change makes `sync` the reconciliation point: it materializes `agent.providers[0]` into `config.provider`, walks the onboarding state machine forward as far as the per-agent manifest's `auto_skip` flags allow, defers READY commitment until Ansible succeeds, and refuses loudly for openclaw identity rather than silently advance to a broken READY. `configure_agent` persists the merged config into `hosts.json` after the Ansible push succeeds, satisfying the persistence-across-syncs contract.

The broader state-machine standardization work (uniform behavior across hermes/zeroclaw/openclaw, decision on identity attach surface, audit of `run_stage()` placeholders) is tracked separately in #523.

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — **3080 Python + 213 GUI**
- [x] Linter passes (`make lint`) — ruff + ESLint clean
- [x] **15 new test cases** across 2 files exercise the bridge end-to-end

### Test Coverage

Files changed:
- `src/clawrium/core/lifecycle.py` — `sync_agent` walk + deferred READY
- `src/clawrium/cli/clawctl/agent/provider.py` — single-provider guard, docstrings
- `src/clawrium/core/providers/storage.py` — URL validator hardening
- `src/clawrium/platform/registry/hermes/templates/hermes-config.yaml.j2` — `yaml_quote()` on endpoint

New tests in `tests/cli/clawctl/agent/test_sync_materializes_provider.py`:
- Happy path: provider materialized + state walks
- Optional fields (`context_window` / `max_tokens` with `is not None`, including 0)
- Legacy agent without attach list syncs unchanged (regression guard)
- Unknown attached provider → clean `LifecycleError`
- Multi-provider hand-edit → rejected
- PENDING + no attachment → keeps legacy error
- Detach-then-sync preserves last-known-good `config.provider`
- `InvalidTransitionError` fallback routes to `update_stage_metadata`
- State walks to READY for auto-skip agent
- **Real hermes manifest** + configure_agent fails → state NEVER advances to READY
- **Real hermes manifest** + configure_agent succeeds → state advances to READY
- Refusal path for required stage without declarative surface (openclaw identity → #523)

New tests in `tests/cli/clawctl/provider/test_agent_attach_single.py`:
- Second distinct attach rejected with detach hint
- Same-name re-attach idempotent
- Attach after detach — final list is exactly `['openrt']` (on-disk verification)

### Manual Testing

E2E flow against a real host is planned per `.itx/426/00_PLAN.md` — fresh hermes agent on `wolf-i` with `local-inx` (ollama) provider walking through create → attach → sync → start, idempotency, and detach-persistence checks. Will run after PR approval.

### Security Checklist
- [x] No hardcoded secrets — provider API keys still flow through existing `get_provider_api_key` plumbing
- [x] Input validation — `validate_ollama_url` now rejects characters that could break out of YAML/TOML/shell scalars in downstream templates
- [x] No SQL injection / XSS / command injection risks — hermes endpoint now `yaml_quote()`-wrapped (matches zeroclaw `toml_escape` and openclaw `shell_quote` hardening)
- [x] No new dependencies

## ATX Review Summary

**Final Review (iter-3): pending** — see iter-1 / iter-2 history below.
**Total cost so far: $2.68 USD | Total time: 13min 13s**

| Review | Rating | Blocking Issues | Status | Specialists |
|--------|--------|-----------------|--------|-------------|
| 1 (iter-1, `ecaee83`) | 2/5 | B1, B2, B3 | All fixed in iter-2 | core-lifecycle, cli-ux, test-coverage |
| 2 (iter-2, `2e8baf6`) | 2/5 | B-ITER2-1, B-ITER2-2, W-SEC-1 | All fixed in iter-3 | core-lifecycle, cli-ux, test-coverage, security |
| 3 (iter-3, `e092b93`) | pending | — | re-review requested | — |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 (iter-1) — Rating 2/5</summary>

**Blocking issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `lifecycle.py:1014-1029` | `transition_state` never called — `onboarding.state` stays PENDING on disk | Fixed (iter-2): Option D state walk via `_safe_transition` |
| B2 | `test_sync_materializes_provider.py` (missing) | No regression guard for detach-then-sync | Fixed (iter-2): `test_sync_after_detach_preserves_last_known_good_provider` |
| B3 | `test_agent_attach_single.py:70-90` | `test_attach_after_detach_succeeds` only asserts exit_code | Fixed (iter-2): on-disk attachment list assertion via `agent provider get -o json` |

**Warnings:**

| # | Action |
|---|--------|
| W1 | Fixed (iter-2): empty-config remediation points at re-create |
| W2 | Fixed (iter-2): `_safe_update_metadata` wraps + re-raises as `LifecycleError` |
| W3/W4 | Fixed (iter-2): docstrings document sync-materialization + persistence |
| W5 | Fixed (iter-2): overlay applied before empty-config guard |
| W6 | Fixed (iter-2): `test_sync_invalid_transition_routes_to_update_metadata` |
| W7 | Deferred to #523: re-sync recovery hint for mid-walk crash |

**Suggestions S1–S5**: S1 fixed (`is not None` checks for numeric fields). S2–S5 deferred to #523.

</details>

<details>
<summary>Review 2 (iter-2) — Rating 2/5</summary>

Iter-1 B1/B2/B3 + W1–W6/S1 all confirmed resolved. New issues surfaced from the Option D walk:

**Blocking issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B-ITER2-1 | `lifecycle.py:1081-1109` | Premature READY before `configure_agent` — failed Ansible would leave hosts.json showing READY for a never-configured agent | Fixed (iter-3): READY deferred until after configure_agent success |
| B-ITER2-2 | `test_sync_materializes_provider.py` (all walk tests) | Every walk test patches `can_skip_stage=True` — suite cannot catch B-ITER2-1 | Fixed (iter-3): two real-hermes-manifest integration tests |
| W-SEC-1 | `hermes-config.yaml.j2:81,83` | `yaml_quote()` not applied to endpoint — `"` / `\` in URL DoSes Ansible | Fixed (iter-3): `yaml_quote()` applied + `validate_ollama_url` rejects unsafe chars |

**Warnings:**

| # | Action |
|---|--------|
| W1 | Fixed (iter-3): re-create hint expanded to include `--type` and `--host` |
| W2-W7 | Deferred to #523 |

**Suggestions S1-S6**: deferred to #523.

</details>

## Callouts

- [DECISION] Bridge lives in `core/lifecycle.sync_agent` rather than `attach`. Why: matches the Pattern A "metadata only at attach, reconcile at sync" mental model. Reviewer: confirmed in iter-2.
- [DECISION] `detach` is deliberately a no-op on `config.provider`. Why: last-known-good across syncs per user decision. Reviewer: confirmed in iter-1.
- [DECISION] Single-provider invariant enforced at both `attach` (clear UX error) and `sync_agent` (catches hand-edited hosts.json). Reviewer: confirmed.
- [DECISION] Option D (refuse for openclaw identity rather than silently mark COMPLETE) chosen over Option C (drive everything to READY via `run_stage` placeholders). Why: Option C would advance openclaw to READY without identity files actually pushed. User decision.
- [DECISION] READY transition deferred until after `configure_agent` returns success. Why: avoid the iter-2 B-ITER2-1 trap where failed Ansible left hosts.json showing a falsely-READY agent.
- [TODO-FOLLOWUP] E2E test on `wolf-i` with hermes + `local-inx` provider per the plan's E2E section. Will run after iter-3 ATX clears. Tracking: this issue (#426).
- [TODO-FOLLOWUP] State-machine standardization (uniform per-agent-type behavior, identity-attach decision, `run_stage()` placeholder audit). Tracking: #523.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>