### PR TITLE
feat(cli): implement clawctl agent exec passthrough (#413)

### DIFF
--- a/.itx/413/00_PLAN.md
+++ b/.itx/413/00_PLAN.md
@@ -1,9 +1,201 @@
-# Issue #413: User can run agent-native commands on remote hosts without SSH using `clm agent pt`
+# Issue #413: User can run agent-native commands on remote hosts using `clawctl agent exec`
 
 URL: https://github.com/ric03uec/clawrium/issues/413
 
+> Note: The issue body uses the older command name `clm agent pt`. Implementation wires the feature into the existing `clawctl agent exec` placeholder stub (`clm` is now `clawctl`; the `exec` command name supersedes `pt`). Issue body will be updated when the PR opens.
+
+## Overview
+
+Replace the existing `clawctl agent exec` placeholder stub with a real implementation that executes commands against an installed agent's native CLI on the remote host, using ansible. stdout, stderr, and the remote exit code are propagated to the local terminal.
+
+## Approach
+
+Three per-type ansible playbooks (`exec.yaml` under each agent type's playbook directory) hardcode the binary path and workspace directory for that type. A shared core dispatcher (`core/agent_exec.py`) runs the type-appropriate playbook via `ansible_runner`, parses base64-encoded stdout/stderr/rc from debug events, and returns a `(stdout, stderr, rc)` tuple. The CLI command writes streams to the local terminal and exits with the remote rc.
+
+No live streaming in v1: ansible's `command` module returns output at task completion, not character-by-character. The original AC wording "streamed live" is revised to "returned at command completion" for v1.
+
+## Per-Type Paths
+
+Convention matches existing `install.yaml` and `memory_info.yaml` per type. Paths are baked into each playbook; not persisted in `hosts.json`.
+
+| Type | Binary | Workspace (`chdir`) |
+|---|---|---|
+| hermes | `/home/<agent_name>/.local/bin/hermes` | `/home/<agent_name>/.hermes` |
+| zeroclaw | `/home/<agent_name>/bin/zeroclaw` | `/home/<agent_name>/.zeroclaw/workspace` |
+| openclaw | `/home/<agent_name>/.openclaw/bin/openclaw` | `/home/<agent_name>/.openclaw/workspace` |
+
+## CLI Surface
+
+```
+clawctl agent exec <agent-name> -- <cmd> [args...]
+```
+
+Examples:
+```bash
+clawctl agent exec wolf-i -- openclaw --version
+clawctl agent exec my-hermes -- hermes config show
+clawctl agent exec my-zeroclaw -- zeroclaw status
+```
+
+### Behavior
+
+| Aspect | Value |
+|---|---|
+| Working directory | Per-type default workspace, hardcoded in playbook. Not user-configurable in v1. |
+| TTY | None (`ansible.builtin.command` module, non-interactive). |
+| Output | stdout → local stdout, stderr → local stderr, returned at command completion. |
+| Exit code | Remote `rc` → `clawctl` exit. SSH/setup failure → 255. Unknown agent → 2. |
+| `--` separator | Mandatory; everything after is `argv` to the remote binary. |
+
+### Help Text
+
+```
+Usage: clawctl agent exec [OPTIONS] AGENT_NAME [COMMAND]...
+
+  Execute a command against the agent's native CLI on its host.
+
+  The command runs as the agent's user in the agent's workspace directory.
+  Use `--` to separate clawctl flags from the remote command:
+
+      clawctl agent exec my-agent -- hermes --version
+
+  Non-interactive only: no TTY is allocated, so commands that prompt
+  for input or render TTY-only UI (progress bars, colors) will not work.
+  stdout and stderr are returned to the local terminal when the remote
+  command completes. The remote exit code is propagated.
+
+Arguments:
+  AGENT_NAME      Agent name (as shown by `clawctl agent ps`).  [required]
+  COMMAND...      Command and args to run on the agent host (after `--`).
+
+Options:
+  --help          Show this message and exit.
+```
+
+## Files
+
+| File | Change |
+|---|---|
+| `src/clawrium/platform/registry/hermes/playbooks/exec.yaml` | New per-type passthrough playbook (hermes constants). |
+| `src/clawrium/platform/registry/zeroclaw/playbooks/exec.yaml` | New, zeroclaw constants. |
+| `src/clawrium/platform/registry/openclaw/playbooks/exec.yaml` | New, openclaw constants. |
+| `src/clawrium/core/agent_exec.py` | New. `run_agent_exec(hostname, agent_name, claw_type, cmd_argv) -> (stdout: str, stderr: str, rc: int)`. Builds extra_vars, runs `ansible_runner.run` against `<type>/playbooks/exec.yaml`, parses events for `EXEC_STDOUT=`/`EXEC_STDERR=`/`EXEC_RC=` markers. |
+| `src/clawrium/cli/clawctl/agent/exec.py` | Replace `echo_not_implemented` body. Resolve agent → call `run_agent_exec` → write streams → `raise typer.Exit(rc)`. Help text updated. |
+| `tests/core/test_agent_exec.py` | New. Unit tests for event parsing + extra_vars construction. |
+| `tests/cli/clawctl/agent/test_exec.py` | New (or extended if exists). CLI command tests. |
+| `AGENTS.md` Quickstart | Add one example line. |
+
+**Estimated diff**: ~120 LOC core + ~15 LOC CLI + 3 × ~30 LOC playbooks + ~130 LOC tests + docs.
+
+## Playbook Shape (each `exec.yaml`)
+
+```yaml
+- hosts: all
+  gather_facts: false
+  vars:
+    binary: "/home/{{ agent_name }}/.local/bin/hermes"   # per-type constant
+    workdir: "/home/{{ agent_name }}/.hermes"            # per-type constant
+  tasks:
+    - name: Run agent exec command
+      ansible.builtin.command:
+        argv: "{{ [binary] + cmd_argv }}"
+        chdir: "{{ workdir }}"
+      become: true
+      become_user: "{{ agent_name }}"
+      register: exec_result
+      failed_when: false
+      changed_when: false
+
+    - name: Emit stdout
+      ansible.builtin.debug:
+        msg: "EXEC_STDOUT={{ exec_result.stdout | default('') | b64encode }}"
+
+    - name: Emit stderr
+      ansible.builtin.debug:
+        msg: "EXEC_STDERR={{ exec_result.stderr | default('') | b64encode }}"
+
+    - name: Emit rc
+      ansible.builtin.debug:
+        msg: "EXEC_RC={{ exec_result.rc | default(255) }}"
+```
+
+Base64-encoding stdout/stderr through the debug event avoids YAML/multiline-quoting issues when parsing `runner_on_ok` events. `agent_exec.py` decodes back before writing to the local terminal.
+
+## Argument Safety
+
+`argv:` list bypasses shell entirely. Args travel through `extra_vars` as a typed list. No shell metachar interpretation anywhere. No `shlex.quote` needed.
+
+## TTY Implications (v1: no PTY)
+
+- Interactive prompts will hang/fail — out of scope per issue.
+- Color output disabled by most CLIs that detect no TTY.
+- TTY-dependent progress bars / spinners won't render.
+- Help text documents these limits.
+
+---
+
+## Testing Process
+
+### Unit tests (must pass in `make test`)
+
+**`tests/core/test_agent_exec.py`**
+- `test_run_agent_exec_success` — mock `ansible_runner.run` with synthetic events containing base64-encoded `EXEC_STDOUT=`, `EXEC_STDERR=`, `EXEC_RC=0`; assert returned tuple matches decoded values.
+- `test_run_agent_exec_nonzero_rc` — same shape, `EXEC_RC=42`; assert tuple `[2]` == 42.
+- `test_run_agent_exec_unreachable` — `ansible_runner.run` returns `status='failed'` with no events; assert tuple = `("", <error-msg>, 255)`.
+- `test_extra_vars_construction` — assert `cmd_argv` is passed through as a typed list, not stringified.
+- `test_unknown_claw_type` — passing an unsupported claw_type raises a clear error before invoking ansible_runner.
+
+**`tests/cli/clawctl/agent/test_exec.py`** (Typer `CliRunner` + mocks)
+- `test_exec_success` — mock agent resolver + `run_agent_exec` → assert stdout written, exit code 0.
+- `test_exec_nonzero_exit_propagation` — mock `run_agent_exec` returning rc=7; assert `result.exit_code == 7`.
+- `test_exec_unknown_agent` — resolver raises `AgentNameResolutionError`; assert exit 2 + error message on stderr.
+- `test_exec_unreachable_host` — `run_agent_exec` returns rc=255 + error message; assert stderr contains it, exit 255.
+- `test_exec_requires_dash_dash` — `clawctl agent exec foo` (no command tail) → assert exit != 0 + help-style message.
+- `test_exec_stderr_separation` — both stdout and stderr in result; assert each lands on the correct local stream.
+- `test_exec_help_documents_double_dash` — `clawctl agent exec --help` output contains the `--` convention.
+
+### Lint
+- `make lint` clean.
+
+### Coverage
+- `make test-cov` shows `core/agent_exec.py` ≥ 90% lines and `cli/clawctl/agent/exec.py` ≥ 90%.
+
+### Manual integration test (executed before opening PR, recorded in PR Testing section)
+
+Against `wolf-i` (existing openclaw agent in `hosts.json`):
+
+1. `clawctl agent exec wolf-i -- openclaw --version` — expect version string, exit 0.
+2. `clawctl agent exec wolf-i -- openclaw bogus-subcommand` — expect non-zero exit, stderr from openclaw surfaced locally.
+3. `clawctl agent exec does-not-exist -- echo hi` — expect exit 2, clear "agent not found" message, no ansible invocation.
+4. Against a hermes agent if available; if not, document gap and rely on unit tests for hermes/zeroclaw playbook coverage.
+
+Each manual step's copy-pasted output goes into the PR Testing section.
+
+### Acceptance-Criteria Mapping
+
+| AC | Verified by |
+|---|---|
+| Runs `<cmd>` against agent's native CLI on correct host | Unit `test_exec_success` + manual #1 |
+| stdout/stderr returned to local terminal | Unit `test_exec_stderr_separation` + manual #1, #2 |
+| Remote exit code propagated | Unit `test_exec_nonzero_exit_propagation` + manual #2 |
+| Works for hermes, zeroclaw, openclaw | 3 per-type playbooks + manual #1 (openclaw) + #4 (hermes if available); zeroclaw covered by unit tests |
+| Clear error on unknown agent / unreachable | Unit `test_exec_unknown_agent`, `test_exec_unreachable_host` + manual #3 |
+| Help documents `--` convention | Unit `test_exec_help_documents_double_dash` |
+| Tests cover all four scenarios | All four covered in `tests/cli/clawctl/agent/test_exec.py` |
+| AGENTS.md updated | Quickstart edit included in this plan |
+
+**Note on revised AC**: "streamed live" → "returned at command completion" for v1. Original wording will be edited in the issue body when the PR opens, with a one-line note explaining the ansible constraint.
+
+## Subtasks
+
+None — single-PR execution.
+
+---
+
 <details>
 <summary>Prompt Log</summary>
+
+## Issue Creation
 
 **Stage**: issue-creation
 **Skill**: /itx:issue-new
@@ -22,10 +214,23 @@ passthrough option in CLM will allow users to do that.
 
 ### Clarifications captured
 
-- **Syntax**: `clm agent pt <name> -- <cmd>` (Unix `--` separator convention)
-- **Output**: Stream live (stdout/stderr) to local terminal
+- **Syntax**: `clm agent pt <name> -- <cmd>` (Unix `--` separator convention) — superseded: now uses existing `clawctl agent exec <name> -- <cmd>` placeholder.
+- **Output**: Stream live (stdout/stderr) to local terminal — revised: returned at command completion (ansible constraint).
 - **Interactivity**: Non-interactive only in v1 (no TTY)
 - **Agent types in v1**: hermes, zeroclaw, openclaw (nemoclaw out of scope)
-- **Exit code propagation**: Required (must propagate remote exit code as `clm` exit code)
+- **Exit code propagation**: Required (must propagate remote exit code as `clawctl` exit code)
+
+## Planning
+
+**Stage**: planning
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-05-26T01:21:17Z
+**Model**: claude-opus-4-7
+
+```prompt
+413. dont create plan files yet. (clm is now called clawctl). give me a high level plan first before macking any file chnages
+```
+
+**Output**: `.itx/413/00_PLAN.md` — implementation plan for wiring up `clawctl agent exec` via three per-type ansible playbooks and a shared core dispatcher. Single-PR execution, no subtasks.
 
 </details>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,9 @@ clawctl agent create <agent-name> --type openclaw --host mybox
 clawctl agent configure <agent-name>
 clawctl agent start <agent-name>
 
+# Run a command against the agent's native CLI on its host
+clawctl agent exec <agent-name> -- --version
+
 # Install a skill onto the agent (catalog: skills/)
 clawctl skill registry get
 clawctl skill registry describe clawrium/tdd       # Inspect a skill before installing

--- a/src/clawrium/cli/clawctl/agent/__init__.py
+++ b/src/clawrium/cli/clawctl/agent/__init__.py
@@ -72,7 +72,7 @@ agent_app.command(name="port-forward", help="Forward a local port to the agent."
     _port_forward.port_forward
 )
 agent_app.command(
-    name="exec", help="Execute a command on the agent host (placeholder)."
+    name="exec", help="Execute a command against the agent's native CLI on its host."
 )(_exec.exec_cmd)
 
 

--- a/src/clawrium/cli/clawctl/agent/__init__.py
+++ b/src/clawrium/cli/clawctl/agent/__init__.py
@@ -72,7 +72,9 @@ agent_app.command(name="port-forward", help="Forward a local port to the agent."
     _port_forward.port_forward
 )
 agent_app.command(
-    name="exec", help="Execute a command against the agent's native CLI on its host."
+    name="exec",
+    help="Execute a command against the agent's native CLI on its host.",
+    context_settings=_exec.EXEC_CONTEXT_SETTINGS,
 )(_exec.exec_cmd)
 
 

--- a/src/clawrium/cli/clawctl/agent/exec.py
+++ b/src/clawrium/cli/clawctl/agent/exec.py
@@ -1,20 +1,24 @@
-"""`clawctl agent exec <name> -- <cmd...>` — passthrough to the agent's
+"""`clawctl agent exec <name> <cmd...>` -- passthrough to the agent's
 native CLI on the remote host.
 
 The agent type's native binary path is hardcoded per claw type in the
-matching `exec.yaml` playbook; `<cmd...>` is the argv passed to that
-binary. stdout/stderr/exit-code are captured at command completion and
-forwarded to the local terminal.
+matching `exec.yaml` playbook; remaining args are forwarded as argv to
+that binary. stdout/stderr/exit-code are captured at command completion
+and forwarded to the local terminal.
+
+Unknown options pass through (Typer `ignore_unknown_options`), so
+`clawctl agent exec myagent --version` works without a `--` separator;
+`--` may still be used to disambiguate.
 """
 
 from __future__ import annotations
 
 import sys
-from typing import Optional
 
 import typer
 
 from clawrium.cli.clawctl.agent._shared import safe_resolve_agent
+from clawrium.cli.output._sanitize import sanitize_passthrough
 from clawrium.cli.output.errors import emit_error
 from clawrium.core.agent_exec import (
     SUPPORTED_CLAW_TYPES,
@@ -22,35 +26,37 @@ from clawrium.core.agent_exec import (
     run_agent_exec,
 )
 
+EXEC_CONTEXT_SETTINGS = {
+    "ignore_unknown_options": True,
+    "allow_extra_args": True,
+}
+
 
 def exec_cmd(
+    ctx: typer.Context,
     name: str = typer.Argument(
         ..., help="Agent name (as shown by `clawctl agent get`)."
-    ),
-    cmd: Optional[list[str]] = typer.Argument(
-        None,
-        help=(
-            "Command and args to pass to the agent's native CLI "
-            "(use `--` to separate from clawctl flags)."
-        ),
     ),
 ) -> None:
     """Execute a command against the agent's native CLI on its host.
 
     The command runs as the agent's user in the agent's workspace
-    directory. Use `--` to separate clawctl flags from the remote args:
+    directory. Everything after the agent name is forwarded as argv to
+    the agent's native binary:
 
-        clawctl agent exec my-agent -- --version
+        clawctl agent exec my-agent --version
+        clawctl agent exec my-agent -- --some-flag
 
     Non-interactive only: no TTY is allocated, so commands that prompt
     for input or render TTY-only UI (progress bars, colors) will not
     work. stdout and stderr are returned to the local terminal when the
     remote command completes. The remote exit code is propagated.
     """
+    cmd = list(ctx.args)
     if not cmd:
         emit_error(
             "no command provided",
-            hint="clawctl agent exec <name> -- <args...>",
+            hint="clawctl agent exec <name> <args...>",
             exit_code=2,
         )
 
@@ -70,19 +76,23 @@ def exec_cmd(
             hostname=host["hostname"],
             agent_name=unix_name,
             claw_type=claw_type,
-            cmd_argv=list(cmd),
+            cmd_argv=cmd,
         )
     except AgentExecError as exc:
-        emit_error(str(exc), exit_code=2)
+        emit_error(
+            str(exc), hint="clawctl agent exec --help", exit_code=2
+        )
 
     if stdout:
-        sys.stdout.write(stdout)
-        if not stdout.endswith("\n"):
+        clean = sanitize_passthrough(stdout)
+        sys.stdout.write(clean)
+        if not clean.endswith("\n"):
             sys.stdout.write("\n")
         sys.stdout.flush()
     if stderr:
-        sys.stderr.write(stderr)
-        if not stderr.endswith("\n"):
+        clean = sanitize_passthrough(stderr)
+        sys.stderr.write(clean)
+        if not clean.endswith("\n"):
             sys.stderr.write("\n")
         sys.stderr.flush()
 

--- a/src/clawrium/cli/clawctl/agent/exec.py
+++ b/src/clawrium/cli/clawctl/agent/exec.py
@@ -51,6 +51,11 @@ def exec_cmd(
         clawctl agent exec my-agent --version
         clawctl agent exec my-agent -- --some-flag
 
+    Exception: `--help` is intercepted by clawctl and shows this help
+    page. To forward `--help` to the remote agent's binary, use:
+
+        clawctl agent exec my-agent -- --help
+
     Non-interactive only: no TTY is allocated, so commands that prompt
     for input or render TTY-only UI (progress bars, colors) will not
     work. stdout and stderr are returned to the local terminal when the

--- a/src/clawrium/cli/clawctl/agent/exec.py
+++ b/src/clawrium/cli/clawctl/agent/exec.py
@@ -9,6 +9,10 @@ and forwarded to the local terminal.
 Unknown options pass through (Typer `ignore_unknown_options`), so
 `clawctl agent exec myagent --version` works without a `--` separator;
 `--` may still be used to disambiguate.
+
+Exception: `--help` is intercepted by Typer and shows clawctl's own
+help. Use `clawctl agent exec myagent -- --help` to forward `--help`
+to the remote binary (ATX iter-2 NW3).
 """
 
 from __future__ import annotations

--- a/src/clawrium/cli/clawctl/agent/exec.py
+++ b/src/clawrium/cli/clawctl/agent/exec.py
@@ -1,26 +1,89 @@
-"""`clawctl agent exec <name> -- <cmd>` — placeholder per plan §4.
+"""`clawctl agent exec <name> -- <cmd...>` — passthrough to the agent's
+native CLI on the remote host.
 
-Plan §"Specific Outcomes": prints `Not implemented: agent exec` and
-exits 0.
+The agent type's native binary path is hardcoded per claw type in the
+matching `exec.yaml` playbook; `<cmd...>` is the argv passed to that
+binary. stdout/stderr/exit-code are captured at command completion and
+forwarded to the local terminal.
 """
 
 from __future__ import annotations
 
+import sys
 from typing import Optional
 
 import typer
 
-from clawrium.cli.clawctl._stub import echo_not_implemented
+from clawrium.cli.clawctl.agent._shared import safe_resolve_agent
+from clawrium.cli.output.errors import emit_error
+from clawrium.core.agent_exec import (
+    SUPPORTED_CLAW_TYPES,
+    AgentExecError,
+    run_agent_exec,
+)
 
 
 def exec_cmd(
-    name: str = typer.Argument(..., help="Agent name."),
+    name: str = typer.Argument(
+        ..., help="Agent name (as shown by `clawctl agent get`)."
+    ),
     cmd: Optional[list[str]] = typer.Argument(
-        None, help="Command to execute (after `--`)."
+        None,
+        help=(
+            "Command and args to pass to the agent's native CLI "
+            "(use `--` to separate from clawctl flags)."
+        ),
     ),
 ) -> None:
-    """Execute a command on the agent host (placeholder; exits 0)."""
-    # Silence unused warnings; the surface accepts the args so help
-    # text and parsing match plan §4.
-    _ = (name, cmd)
-    echo_not_implemented("agent", "exec")
+    """Execute a command against the agent's native CLI on its host.
+
+    The command runs as the agent's user in the agent's workspace
+    directory. Use `--` to separate clawctl flags from the remote args:
+
+        clawctl agent exec my-agent -- --version
+
+    Non-interactive only: no TTY is allocated, so commands that prompt
+    for input or render TTY-only UI (progress bars, colors) will not
+    work. stdout and stderr are returned to the local terminal when the
+    remote command completes. The remote exit code is propagated.
+    """
+    if not cmd:
+        emit_error(
+            "no command provided",
+            hint="clawctl agent exec <name> -- <args...>",
+            exit_code=2,
+        )
+
+    host, agent_type, claw_record = safe_resolve_agent(name)
+    claw_type = claw_record.get("type") or agent_type
+    if claw_type not in SUPPORTED_CLAW_TYPES:
+        emit_error(
+            f"agent type '{claw_type}' does not support exec",
+            hint="supported types: " + ", ".join(sorted(SUPPORTED_CLAW_TYPES)),
+            exit_code=2,
+        )
+
+    unix_name = claw_record.get("agent_name") or name
+
+    try:
+        stdout, stderr, rc = run_agent_exec(
+            hostname=host["hostname"],
+            agent_name=unix_name,
+            claw_type=claw_type,
+            cmd_argv=list(cmd),
+        )
+    except AgentExecError as exc:
+        emit_error(str(exc), exit_code=2)
+
+    if stdout:
+        sys.stdout.write(stdout)
+        if not stdout.endswith("\n"):
+            sys.stdout.write("\n")
+        sys.stdout.flush()
+    if stderr:
+        sys.stderr.write(stderr)
+        if not stderr.endswith("\n"):
+            sys.stderr.write("\n")
+        sys.stderr.flush()
+
+    raise typer.Exit(code=rc)

--- a/src/clawrium/cli/output/_sanitize.py
+++ b/src/clawrium/cli/output/_sanitize.py
@@ -88,23 +88,20 @@ def sanitize(value: str) -> str:
 # exec`) that forward agent-controlled output verbatim and must
 # preserve whitespace including \n/\t/\r. Literal bidi codepoints
 # MUST NOT appear in this source -- same hygiene rule as above.
-def _build_bidi_only_pattern() -> str:
-    parts = [
-        (0x061C, 0x061C),
-        (0x200B, 0x200F),
-        (0x2028, 0x2029),
-        (0x202A, 0x202E),
-        (0x2060, 0x2060),
-        (0x2066, 0x2069),
-        (0xFEFF, 0xFEFF),
-    ]
-    body = "".join(
-        f"{chr(lo)}-{chr(hi)}" if lo != hi else chr(lo) for lo, hi in parts
-    )
-    return "[" + body + "]"
-
-
-_BIDI_ONLY_RE = re.compile(_build_bidi_only_pattern())
+_BIDI_ONLY_RE = re.compile(
+    # \uXXXX escapes only -- the test_source_is_pure_ascii guard
+    # mirrors the same hygiene rule applied to _CONTROL_AND_BIDI_RE
+    # above (ATX iter-2 NW4).
+    "["
+    "\u061c"
+    "\u200b-\u200f"
+    "\u2028-\u2029"
+    "\u202a-\u202e"
+    "\u2060"
+    "\u2066-\u2069"
+    "\ufeff"
+    "]"
+)
 
 
 def sanitize_passthrough(value: str) -> str:

--- a/src/clawrium/cli/output/_sanitize.py
+++ b/src/clawrium/cli/output/_sanitize.py
@@ -81,3 +81,38 @@ def sanitize(value: str) -> str:
     if not _CONTROL_AND_BIDI_RE.search(value):
         return value
     return _CONTROL_AND_BIDI_RE.sub(" ", value)
+
+
+# Same UAX#9 / zero-width set as `_CONTROL_AND_BIDI_RE` minus C0/C1
+# control bytes. For passthrough callers (issue #413 `clawctl agent
+# exec`) that forward agent-controlled output verbatim and must
+# preserve whitespace including \n/\t/\r. Literal bidi codepoints
+# MUST NOT appear in this source -- same hygiene rule as above.
+def _build_bidi_only_pattern() -> str:
+    parts = [
+        (0x061C, 0x061C),
+        (0x200B, 0x200F),
+        (0x2028, 0x2029),
+        (0x202A, 0x202E),
+        (0x2060, 0x2060),
+        (0x2066, 0x2069),
+        (0xFEFF, 0xFEFF),
+    ]
+    body = "".join(
+        f"{chr(lo)}-{chr(hi)}" if lo != hi else chr(lo) for lo, hi in parts
+    )
+    return "[" + body + "]"
+
+
+_BIDI_ONLY_RE = re.compile(_build_bidi_only_pattern())
+
+
+def sanitize_passthrough(value: str) -> str:
+    """Strip UAX#9 bidi/zero-width codepoints only; preserve all whitespace.
+
+    For use on agent-controlled output forwarded to the terminal
+    verbatim (issue #413, ATX iter-1 B1).
+    """
+    if not _BIDI_ONLY_RE.search(value):
+        return value
+    return _BIDI_ONLY_RE.sub("", value)

--- a/src/clawrium/core/agent_exec.py
+++ b/src/clawrium/core/agent_exec.py
@@ -23,7 +23,9 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import re
 import shutil
+import uuid
 from datetime import datetime
 from pathlib import Path
 
@@ -44,6 +46,17 @@ _REGISTRY_DIR = Path(__file__).parent.parent / "platform" / "registry"
 # subcommands (e.g. an openclaw config dump) but short enough that a
 # hung remote can't pin the local CLI indefinitely.
 _DEFAULT_TIMEOUT = 120
+
+# Same shape playbooks enforce server-side; the Python-side check is
+# defense-in-depth so non-CLI callers (or a future playbook edit that
+# drops the regex task) cannot smuggle an arbitrary string into Ansible
+# extravars (ATX iter-1 W3).
+_AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
+
+# `log_dir` directory-name component must contain only filename-safe
+# characters. A tampered hosts.json alias of `../tmp/evil` would otherwise
+# escape the logs root (ATX iter-1 W4).
+_LOG_DIR_SAFE_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 class AgentExecError(Exception):
@@ -68,6 +81,11 @@ def _cleanup_artifacts(log_dir: Path) -> None:
                 shutil.rmtree(target)
             except OSError as e:
                 logger.warning("Failed to clean up %s: %s", target, e)
+    # Drop the now-empty per-run directory (ATX iter-1 W8).
+    try:
+        log_dir.rmdir()
+    except OSError:
+        pass
 
 
 def _build_inventory(host: dict, ssh_key: Path, extra_vars: dict) -> dict:
@@ -91,7 +109,7 @@ def _parse_events(result) -> tuple[str, str, int | None]:
     stderr = ""
     rc: int | None = None
     for event in result.events:
-        if event.get("event") not in {"runner_on_ok", "runner_item_on_ok"}:
+        if event.get("event") != "runner_on_ok":
             continue
         msg = event.get("event_data", {}).get("res", {}).get("msg")
         if not isinstance(msg, str):
@@ -153,6 +171,8 @@ def run_agent_exec(
         )
     if not isinstance(cmd_argv, list) or not cmd_argv:
         raise AgentExecError("cmd_argv must be a non-empty list")
+    if not _AGENT_NAME_RE.match(agent_name):
+        raise AgentExecError(f"invalid agent_name: {agent_name!r}")
 
     playbook = _playbook_path(claw_type)
     if not playbook.exists():
@@ -179,8 +199,19 @@ def run_agent_exec(
     try:
         inventory = _build_inventory(host, ssh_key, extra_vars)
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        host_display = host.get("alias") or host.get("key_id") or host["hostname"]
-        log_dir = _logs_dir() / f"exec-{claw_type}-{host_display}-{timestamp}"
+        raw_display = host.get("alias") or host.get("key_id") or host["hostname"]
+        # Defense-in-depth: drop anything that's not filename-safe before
+        # interpolating into the directory name (ATX iter-1 W4).
+        host_display = (
+            raw_display if _LOG_DIR_SAFE_RE.match(raw_display or "") else "host"
+        )
+        # Collision suffix: timestamp resolution is 1s; two concurrent
+        # calls would otherwise share private_data_dir and `rmtree`
+        # nukes both (ATX iter-1 W1).
+        suffix = uuid.uuid4().hex[:8]
+        log_dir = (
+            _logs_dir() / f"exec-{claw_type}-{host_display}-{timestamp}-{suffix}"
+        )
         log_dir.mkdir(parents=True, exist_ok=True)
         os.chmod(log_dir, 0o700)
     except OSError as e:

--- a/src/clawrium/core/agent_exec.py
+++ b/src/clawrium/core/agent_exec.py
@@ -213,7 +213,16 @@ def run_agent_exec(
             _logs_dir() / f"exec-{claw_type}-{host_display}-{timestamp}-{suffix}"
         )
         log_dir.mkdir(parents=True, exist_ok=True)
-        os.chmod(log_dir, 0o700)
+        try:
+            os.chmod(log_dir, 0o700)
+        except OSError:
+            # Don't leave an orphaned dir on disk if chmod fails
+            # (ATX iter-2 NW6).
+            try:
+                log_dir.rmdir()
+            except OSError:
+                pass
+            raise
     except OSError as e:
         return "", f"Failed to set up runner workdir: {e}", 255
 

--- a/src/clawrium/core/agent_exec.py
+++ b/src/clawrium/core/agent_exec.py
@@ -1,0 +1,217 @@
+"""Dispatch native agent CLI commands to a remote host via Ansible.
+
+`run_agent_exec(hostname, agent_name, claw_type, cmd_argv)` invokes the
+per-type `exec.yaml` playbook against the host that owns the agent.
+The playbook runs the agent's native CLI binary (path baked into the
+playbook for each claw type), captures stdout/stderr/rc, and emits them
+as three base64-tagged debug events (`EXEC_STDOUT=`, `EXEC_STDERR=`,
+`EXEC_RC=`). This module parses those events and returns
+`(stdout, stderr, rc)`.
+
+Failure modes:
+    - Unknown claw type → AgentExecError (caller turns into exit 2).
+    - SSH/setup failure → ("", error_msg, 255).
+    - Remote command nonzero rc → that rc is propagated.
+
+There is no live streaming in v1: ansible's `command` module returns
+output at task completion. The CLI layer writes the captured output
+to the local terminal once the playbook finishes.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+import ansible_runner
+
+from clawrium.core import keys as core_keys
+from clawrium.core.config import get_config_dir
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["AgentExecError", "SUPPORTED_CLAW_TYPES", "run_agent_exec"]
+
+SUPPORTED_CLAW_TYPES: frozenset[str] = frozenset({"hermes", "zeroclaw", "openclaw"})
+
+_REGISTRY_DIR = Path(__file__).parent.parent / "platform" / "registry"
+
+# Cap on remote execution time. Picked to be long enough for slow agent
+# subcommands (e.g. an openclaw config dump) but short enough that a
+# hung remote can't pin the local CLI indefinitely.
+_DEFAULT_TIMEOUT = 120
+
+
+class AgentExecError(Exception):
+    """Raised for caller-recoverable errors before invoking ansible_runner."""
+
+
+def _playbook_path(claw_type: str) -> Path:
+    return _REGISTRY_DIR / claw_type / "playbooks" / "exec.yaml"
+
+
+def _logs_dir() -> Path:
+    d = get_config_dir() / "logs"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _cleanup_artifacts(log_dir: Path) -> None:
+    for sub in ("artifacts", "env", "inventory"):
+        target = log_dir / sub
+        if target.exists():
+            try:
+                shutil.rmtree(target)
+            except OSError as e:
+                logger.warning("Failed to clean up %s: %s", target, e)
+
+
+def _build_inventory(host: dict, ssh_key: Path, extra_vars: dict) -> dict:
+    return {
+        "all": {
+            "hosts": {
+                host["hostname"]: {
+                    "ansible_user": host.get("user", "xclm"),
+                    "ansible_port": host.get("port", 22),
+                    "ansible_ssh_private_key_file": str(ssh_key),
+                }
+            },
+            "vars": extra_vars,
+        }
+    }
+
+
+def _parse_events(result) -> tuple[str, str, int | None]:
+    """Walk runner events and extract EXEC_STDOUT/EXEC_STDERR/EXEC_RC."""
+    stdout = ""
+    stderr = ""
+    rc: int | None = None
+    for event in result.events:
+        if event.get("event") not in {"runner_on_ok", "runner_item_on_ok"}:
+            continue
+        msg = event.get("event_data", {}).get("res", {}).get("msg")
+        if not isinstance(msg, str):
+            continue
+        if msg.startswith("EXEC_STDOUT="):
+            try:
+                stdout = base64.b64decode(msg[len("EXEC_STDOUT=") :]).decode(
+                    "utf-8", errors="replace"
+                )
+            except (ValueError, TypeError):
+                stdout = ""
+        elif msg.startswith("EXEC_STDERR="):
+            try:
+                stderr = base64.b64decode(msg[len("EXEC_STDERR=") :]).decode(
+                    "utf-8", errors="replace"
+                )
+            except (ValueError, TypeError):
+                stderr = ""
+        elif msg.startswith("EXEC_RC="):
+            try:
+                rc = int(msg[len("EXEC_RC=") :])
+            except ValueError:
+                rc = None
+    return stdout, stderr, rc
+
+
+def _extract_failure_message(result, default: str) -> str:
+    for event in result.events:
+        if event.get("event") == "runner_on_unreachable":
+            res = event.get("event_data", {}).get("res", {})
+            msg = res.get("msg") or "host unreachable"
+            return f"Host unreachable: {msg}"
+    for event in result.events:
+        if event.get("event") == "runner_on_failed":
+            res = event.get("event_data", {}).get("res", {})
+            if "msg" in res:
+                return res["msg"]
+            if "stderr" in res:
+                return res["stderr"]
+    return default
+
+
+def run_agent_exec(
+    hostname: str,
+    agent_name: str,
+    claw_type: str,
+    cmd_argv: list[str],
+    timeout: int = _DEFAULT_TIMEOUT,
+) -> tuple[str, str, int]:
+    """Run `cmd_argv` against the agent's native CLI on its host.
+
+    Returns (stdout, stderr, rc). Setup failures return rc=255 with the
+    error message on stderr.
+    """
+    if claw_type not in SUPPORTED_CLAW_TYPES:
+        raise AgentExecError(
+            f"agent type '{claw_type}' does not support exec "
+            f"(supported: {', '.join(sorted(SUPPORTED_CLAW_TYPES))})"
+        )
+    if not isinstance(cmd_argv, list) or not cmd_argv:
+        raise AgentExecError("cmd_argv must be a non-empty list")
+
+    playbook = _playbook_path(claw_type)
+    if not playbook.exists():
+        return "", f"Playbook not found: {playbook}", 255
+
+    from clawrium.core.hosts import get_host
+
+    host = get_host(hostname)
+    if not host:
+        return "", f"host '{hostname}' not found", 255
+
+    key_id = host.get("key_id") or host["hostname"]
+    ssh_key = core_keys.get_host_private_key(key_id)
+    if not ssh_key:
+        return (
+            "",
+            f"SSH key for host '{key_id}' not found. "
+            f"Run 'clawctl host init {host['hostname']}' to provision it.",
+            255,
+        )
+
+    extra_vars = {"agent_name": agent_name, "cmd_argv": cmd_argv}
+
+    try:
+        inventory = _build_inventory(host, ssh_key, extra_vars)
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        host_display = host.get("alias") or host.get("key_id") or host["hostname"]
+        log_dir = _logs_dir() / f"exec-{claw_type}-{host_display}-{timestamp}"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        os.chmod(log_dir, 0o700)
+    except OSError as e:
+        return "", f"Failed to set up runner workdir: {e}", 255
+
+    try:
+        result = ansible_runner.run(
+            private_data_dir=str(log_dir),
+            inventory=inventory,
+            playbook=str(playbook),
+            quiet=True,
+            timeout=timeout,
+        )
+    except Exception as e:
+        _cleanup_artifacts(log_dir)
+        return "", f"ansible-runner error: {e}", 255
+
+    try:
+        if result.status == "timeout":
+            return "", f"remote command timed out after {timeout}s", 255
+        if result.status != "successful":
+            err = _extract_failure_message(result, f"playbook {result.status}")
+            return "", err, 255
+
+        stdout, stderr, rc = _parse_events(result)
+        if rc is None:
+            return (
+                stdout,
+                stderr or "remote command did not report an exit code",
+                255,
+            )
+        return stdout, stderr, rc
+    finally:
+        _cleanup_artifacts(log_dir)

--- a/src/clawrium/platform/registry/hermes/playbooks/exec.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/exec.yaml
@@ -1,0 +1,35 @@
+---
+# Passthrough: run the hermes native CLI on the agent host.
+- hosts: all
+  become: yes
+  gather_facts: false
+  vars:
+    binary: "/home/{{ agent_name }}/.local/bin/hermes"
+    workdir: "/home/{{ agent_name }}/.hermes"
+  tasks:
+    - name: Validate agent_name (defense-in-depth)
+      ansible.builtin.fail:
+        msg: "Invalid agent_name"
+      when:
+        - agent_name is not match('^[a-z][a-z0-9_-]{0,31}$')
+
+    - name: Run agent exec command
+      ansible.builtin.command:
+        argv: "{{ [binary] + cmd_argv }}"
+        chdir: "{{ workdir }}"
+      become_user: "{{ agent_name }}"
+      register: exec_result
+      failed_when: false
+      changed_when: false
+
+    - name: Emit stdout
+      ansible.builtin.debug:
+        msg: "EXEC_STDOUT={{ exec_result.stdout | default('') | b64encode }}"
+
+    - name: Emit stderr
+      ansible.builtin.debug:
+        msg: "EXEC_STDERR={{ exec_result.stderr | default('') | b64encode }}"
+
+    - name: Emit rc
+      ansible.builtin.debug:
+        msg: "EXEC_RC={{ exec_result.rc | default(255) }}"

--- a/src/clawrium/platform/registry/hermes/playbooks/exec.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/exec.yaml
@@ -1,7 +1,6 @@
 ---
 # Passthrough: run the hermes native CLI on the agent host.
 - hosts: all
-  become: yes
   gather_facts: false
   vars:
     binary: "/home/{{ agent_name }}/.local/bin/hermes"
@@ -17,10 +16,12 @@
       ansible.builtin.command:
         argv: "{{ [binary] + cmd_argv }}"
         chdir: "{{ workdir }}"
+      become: true
       become_user: "{{ agent_name }}"
       register: exec_result
       failed_when: false
       changed_when: false
+      no_log: true
 
     - name: Emit stdout
       ansible.builtin.debug:

--- a/src/clawrium/platform/registry/openclaw/playbooks/exec.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/exec.yaml
@@ -2,10 +2,12 @@
 # Passthrough: run the openclaw native CLI on the agent host.
 # Binary discovery mirrors install.yaml: prefer the per-agent install
 # under /home/<agent>/.openclaw/bin/openclaw, fall back to whatever
-# `which openclaw` resolves on PATH. The discovered binary is restricted
-# to the /usr/local/bin, /usr/bin, /home allowlist for defense-in-depth.
+# `which openclaw` resolves on PATH for that agent user. Discovery and
+# validation run as the agent user (NOT root, ATX iter-1 B3) so the
+# binary the play executes is the same one the agent user actually sees
+# on PATH. The resolved path must be either the exact per-agent file or
+# under /usr/local/bin or /usr/bin (ATX iter-1 B2).
 - hosts: all
-  become: yes
   gather_facts: false
   vars:
     per_agent_binary: "/home/{{ agent_name }}/.openclaw/bin/openclaw"
@@ -17,13 +19,17 @@
       when:
         - agent_name is not match('^[a-z][a-z0-9_-]{0,31}$')
 
-    - name: Stat per-agent openclaw binary
+    - name: Stat per-agent openclaw binary (as agent user)
       ansible.builtin.stat:
         path: "{{ per_agent_binary }}"
+      become: true
+      become_user: "{{ agent_name }}"
       register: per_agent_stat
 
-    - name: Discover openclaw in PATH (fallback)
+    - name: Discover openclaw in PATH (as agent user)
       ansible.builtin.command: which openclaw
+      become: true
+      become_user: "{{ agent_name }}"
       register: which_result
       changed_when: false
       failed_when: false
@@ -44,27 +50,30 @@
         msg: "openclaw binary not found on host (checked {{ per_agent_binary }} and PATH)"
       when: (resolved_binary | length) == 0
 
-    - name: Validate resolved binary path
+    - name: Validate resolved binary path (allowlist)
       ansible.builtin.fail:
         msg: "Resolved openclaw binary at unsafe path: {{ resolved_binary }}"
-      when: not (resolved_binary.startswith('/usr/local/bin/')
-                 or resolved_binary.startswith('/usr/bin/')
-                 or resolved_binary.startswith('/home/'))
+      when: not (resolved_binary == per_agent_binary
+                 or resolved_binary.startswith('/usr/local/bin/')
+                 or resolved_binary.startswith('/usr/bin/'))
 
     - name: Ensure workspace directory exists
       ansible.builtin.file:
         path: "{{ workdir }}"
         state: directory
+      become: true
       become_user: "{{ agent_name }}"
 
     - name: Run agent exec command
       ansible.builtin.command:
         argv: "{{ [resolved_binary] + cmd_argv }}"
         chdir: "{{ workdir }}"
+      become: true
       become_user: "{{ agent_name }}"
       register: exec_result
       failed_when: false
       changed_when: false
+      no_log: true
 
     - name: Emit stdout
       ansible.builtin.debug:

--- a/src/clawrium/platform/registry/openclaw/playbooks/exec.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/exec.yaml
@@ -50,6 +50,17 @@
         msg: "openclaw binary not found on host (checked {{ per_agent_binary }} and PATH)"
       when: (resolved_binary | length) == 0
 
+    - name: Reject `..` segments in resolved binary path
+      # `startswith('/usr/local/bin/')` can be bypassed by a path like
+      # `/usr/local/bin/../../tmp/evil` (ATX iter-2 NW1). Reject any
+      # path containing a `..` segment outright; symlinks are still
+      # honored at exec time because `command:` follows them.
+      ansible.builtin.fail:
+        msg: "Resolved openclaw binary contains '..' path segment: {{ resolved_binary }}"
+      when: ('/../' in resolved_binary)
+            or resolved_binary.endswith('/..')
+            or resolved_binary.startswith('../')
+
     - name: Validate resolved binary path (allowlist)
       ansible.builtin.fail:
         msg: "Resolved openclaw binary at unsafe path: {{ resolved_binary }}"

--- a/src/clawrium/platform/registry/openclaw/playbooks/exec.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/exec.yaml
@@ -1,0 +1,79 @@
+---
+# Passthrough: run the openclaw native CLI on the agent host.
+# Binary discovery mirrors install.yaml: prefer the per-agent install
+# under /home/<agent>/.openclaw/bin/openclaw, fall back to whatever
+# `which openclaw` resolves on PATH. The discovered binary is restricted
+# to the /usr/local/bin, /usr/bin, /home allowlist for defense-in-depth.
+- hosts: all
+  become: yes
+  gather_facts: false
+  vars:
+    per_agent_binary: "/home/{{ agent_name }}/.openclaw/bin/openclaw"
+    workdir: "/home/{{ agent_name }}/.openclaw/workspace"
+  tasks:
+    - name: Validate agent_name (defense-in-depth)
+      ansible.builtin.fail:
+        msg: "Invalid agent_name"
+      when:
+        - agent_name is not match('^[a-z][a-z0-9_-]{0,31}$')
+
+    - name: Stat per-agent openclaw binary
+      ansible.builtin.stat:
+        path: "{{ per_agent_binary }}"
+      register: per_agent_stat
+
+    - name: Discover openclaw in PATH (fallback)
+      ansible.builtin.command: which openclaw
+      register: which_result
+      changed_when: false
+      failed_when: false
+
+    - name: Resolve openclaw binary
+      ansible.builtin.set_fact:
+        resolved_binary: >-
+          {{ per_agent_binary
+             if (per_agent_stat.stat.exists
+                 and per_agent_stat.stat.executable | default(false)
+                 and (per_agent_stat.stat.size | default(0)) > 0)
+             else (which_result.stdout
+                   if (which_result.rc | default(1)) == 0
+                   else '') }}
+
+    - name: Fail if openclaw not found
+      ansible.builtin.fail:
+        msg: "openclaw binary not found on host (checked {{ per_agent_binary }} and PATH)"
+      when: (resolved_binary | length) == 0
+
+    - name: Validate resolved binary path
+      ansible.builtin.fail:
+        msg: "Resolved openclaw binary at unsafe path: {{ resolved_binary }}"
+      when: not (resolved_binary.startswith('/usr/local/bin/')
+                 or resolved_binary.startswith('/usr/bin/')
+                 or resolved_binary.startswith('/home/'))
+
+    - name: Ensure workspace directory exists
+      ansible.builtin.file:
+        path: "{{ workdir }}"
+        state: directory
+      become_user: "{{ agent_name }}"
+
+    - name: Run agent exec command
+      ansible.builtin.command:
+        argv: "{{ [resolved_binary] + cmd_argv }}"
+        chdir: "{{ workdir }}"
+      become_user: "{{ agent_name }}"
+      register: exec_result
+      failed_when: false
+      changed_when: false
+
+    - name: Emit stdout
+      ansible.builtin.debug:
+        msg: "EXEC_STDOUT={{ exec_result.stdout | default('') | b64encode }}"
+
+    - name: Emit stderr
+      ansible.builtin.debug:
+        msg: "EXEC_STDERR={{ exec_result.stderr | default('') | b64encode }}"
+
+    - name: Emit rc
+      ansible.builtin.debug:
+        msg: "EXEC_RC={{ exec_result.rc | default(255) }}"

--- a/src/clawrium/platform/registry/openclaw/playbooks/exec.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/exec.yaml
@@ -56,17 +56,19 @@
       # path containing a `..` segment outright; symlinks are still
       # honored at exec time because `command:` follows them.
       ansible.builtin.fail:
-        msg: "Resolved openclaw binary contains '..' path segment: {{ resolved_binary }}"
+        msg: "Resolved openclaw binary contains '..' path segment"
       when: ('/../' in resolved_binary)
             or resolved_binary.endswith('/..')
             or resolved_binary.startswith('../')
+      no_log: true
 
     - name: Validate resolved binary path (allowlist)
       ansible.builtin.fail:
-        msg: "Resolved openclaw binary at unsafe path: {{ resolved_binary }}"
+        msg: "Resolved openclaw binary at unsafe path"
       when: not (resolved_binary == per_agent_binary
                  or resolved_binary.startswith('/usr/local/bin/')
                  or resolved_binary.startswith('/usr/bin/'))
+      no_log: true
 
     - name: Ensure workspace directory exists
       ansible.builtin.file:

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/exec.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/exec.yaml
@@ -1,0 +1,35 @@
+---
+# Passthrough: run the zeroclaw native CLI on the agent host.
+- hosts: all
+  become: yes
+  gather_facts: false
+  vars:
+    binary: "/home/{{ agent_name }}/bin/zeroclaw"
+    workdir: "/home/{{ agent_name }}/.zeroclaw/workspace"
+  tasks:
+    - name: Validate agent_name (defense-in-depth)
+      ansible.builtin.fail:
+        msg: "Invalid agent_name"
+      when:
+        - agent_name is not match('^[a-z][a-z0-9_-]{0,31}$')
+
+    - name: Run agent exec command
+      ansible.builtin.command:
+        argv: "{{ [binary] + cmd_argv }}"
+        chdir: "{{ workdir }}"
+      become_user: "{{ agent_name }}"
+      register: exec_result
+      failed_when: false
+      changed_when: false
+
+    - name: Emit stdout
+      ansible.builtin.debug:
+        msg: "EXEC_STDOUT={{ exec_result.stdout | default('') | b64encode }}"
+
+    - name: Emit stderr
+      ansible.builtin.debug:
+        msg: "EXEC_STDERR={{ exec_result.stderr | default('') | b64encode }}"
+
+    - name: Emit rc
+      ansible.builtin.debug:
+        msg: "EXEC_RC={{ exec_result.rc | default(255) }}"

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/exec.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/exec.yaml
@@ -1,7 +1,6 @@
 ---
 # Passthrough: run the zeroclaw native CLI on the agent host.
 - hosts: all
-  become: yes
   gather_facts: false
   vars:
     binary: "/home/{{ agent_name }}/bin/zeroclaw"
@@ -17,10 +16,12 @@
       ansible.builtin.command:
         argv: "{{ [binary] + cmd_argv }}"
         chdir: "{{ workdir }}"
+      become: true
       become_user: "{{ agent_name }}"
       register: exec_result
       failed_when: false
       changed_when: false
+      no_log: true
 
     - name: Emit stdout
       ansible.builtin.debug:

--- a/tests/cli/clawctl/agent/test_exec.py
+++ b/tests/cli/clawctl/agent/test_exec.py
@@ -10,8 +10,34 @@ from typer.testing import CliRunner
 
 from clawrium.cli import app
 from clawrium.cli.clawctl.agent import exec as exec_module
+from clawrium.core.agent_exec import AgentExecError
 
 runner = CliRunner()
+
+
+@pytest.fixture
+def exec_fleet(fleet_dir):
+    """Augment the shared fleet with hermes + zeroclaw agents for B5 coverage."""
+    import json
+
+    hosts_path = fleet_dir / "hosts.json"
+    data = json.loads(hosts_path.read_text())
+    data[0]["agents"]["espresso"] = {
+        "type": "hermes",
+        "agent_name": "espresso",
+        "version": "0.14.0",
+        "installed_at": "2026-05-25T00:00:00+00:00",
+        "status": "installed",
+    }
+    data[0]["agents"]["clawrium-d01"] = {
+        "type": "zeroclaw",
+        "agent_name": "clawrium-d01",
+        "version": "0.7.5",
+        "installed_at": "2026-05-25T00:00:00+00:00",
+        "status": "installed",
+    }
+    hosts_path.write_text(json.dumps(data, indent=2))
+    return fleet_dir
 
 
 @pytest.fixture
@@ -93,3 +119,60 @@ def test_exec_stdout_and_stderr_both_emitted(fleet_dir, stdin_not_tty, stub_exec
     assert result.exit_code == 0
     assert "out line" in result.output
     assert "err line" in result.output
+
+
+def test_exec_works_without_dash_dash(fleet_dir, stdin_not_tty, stub_exec):
+    """B4: `--version` (no `--`) must pass through, not raise Typer error."""
+    result = runner.invoke(app, ["agent", "exec", "wise-hypatia", "--version"])
+    assert result.exit_code == 0, result.output
+    assert stub_exec["cmd_argv"] == ["--version"]
+
+
+@pytest.mark.parametrize(
+    "agent,expected_type",
+    [
+        ("wise-hypatia", "openclaw"),
+        ("espresso", "hermes"),
+        ("clawrium-d01", "zeroclaw"),
+    ],
+)
+def test_exec_routes_by_claw_type(
+    exec_fleet, stdin_not_tty, stub_exec, agent, expected_type
+):
+    """B5: hermes/zeroclaw must route through the dispatcher with correct type."""
+    result = runner.invoke(app, ["agent", "exec", agent, "--", "--version"])
+    assert result.exit_code == 0, result.output
+    assert stub_exec["claw_type"] == expected_type
+
+
+def test_exec_agent_exec_error_from_core(
+    fleet_dir, stdin_not_tty, monkeypatch
+):
+    """B6: AgentExecError raised by core surfaces as exit 2 with the message."""
+    def boom(**kw):
+        raise AgentExecError("unsupported binary")
+
+    monkeypatch.setattr(exec_module, "run_agent_exec", boom)
+    result = runner.invoke(app, ["agent", "exec", "wise-hypatia", "--", "x"])
+    assert result.exit_code == 2
+    assert "unsupported binary" in result.output
+
+
+def test_exec_strips_bidi_from_remote_stdout(
+    fleet_dir, stdin_not_tty, stub_exec
+):
+    """B1: U+202E injected by a remote agent must not reach the terminal."""
+    stub_exec["_stdout"] = "ok" + chr(0x202E) + "danger\n"
+    result = runner.invoke(app, ["agent", "exec", "wise-hypatia", "--", "x"])
+    assert result.exit_code == 0
+    assert chr(0x202E) not in result.output
+    # Whitespace (newline) preserved.
+    assert "okdanger" in result.output
+
+
+def test_exec_preserves_remote_newlines(fleet_dir, stdin_not_tty, stub_exec):
+    """sanitize_passthrough must not strip \\n the way sanitize() does."""
+    stub_exec["_stdout"] = "line1\nline2\nline3\n"
+    result = runner.invoke(app, ["agent", "exec", "wise-hypatia", "--", "x"])
+    assert result.exit_code == 0
+    assert "line1\nline2\nline3" in result.output

--- a/tests/cli/clawctl/agent/test_exec.py
+++ b/tests/cli/clawctl/agent/test_exec.py
@@ -170,6 +170,18 @@ def test_exec_strips_bidi_from_remote_stdout(
     assert "okdanger" in result.output
 
 
+def test_exec_strips_bidi_from_remote_stderr(
+    fleet_dir, stdin_not_tty, stub_exec
+):
+    """ATX iter-2 NW5: stderr path must also be sanitized."""
+    stub_exec["_stdout"] = ""
+    stub_exec["_stderr"] = "err" + chr(0x202E) + "line\n"
+    result = runner.invoke(app, ["agent", "exec", "wise-hypatia", "--", "x"])
+    assert result.exit_code == 0
+    assert chr(0x202E) not in result.output
+    assert "errline" in result.output
+
+
 def test_exec_preserves_remote_newlines(fleet_dir, stdin_not_tty, stub_exec):
     """sanitize_passthrough must not strip \\n the way sanitize() does."""
     stub_exec["_stdout"] = "line1\nline2\nline3\n"

--- a/tests/cli/clawctl/agent/test_exec.py
+++ b/tests/cli/clawctl/agent/test_exec.py
@@ -1,0 +1,95 @@
+"""Tests for `clawctl agent exec`.
+
+Mocks `core.agent_exec.run_agent_exec` to keep the suite hermetic.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+from clawrium.cli.clawctl.agent import exec as exec_module
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def stub_exec(monkeypatch: pytest.MonkeyPatch):
+    calls: dict = {}
+
+    def fake(hostname, agent_name, claw_type, cmd_argv, timeout=120):
+        calls.update(
+            {
+                "hostname": hostname,
+                "agent_name": agent_name,
+                "claw_type": claw_type,
+                "cmd_argv": cmd_argv,
+            }
+        )
+        return calls.get("_stdout", "ok\n"), calls.get("_stderr", ""), calls.get(
+            "_rc", 0
+        )
+
+    monkeypatch.setattr(exec_module, "run_agent_exec", fake)
+    return calls
+
+
+def test_exec_success(fleet_dir, stdin_not_tty, stub_exec):
+    result = runner.invoke(
+        app, ["agent", "exec", "wise-hypatia", "--", "--version"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "ok" in result.output
+    assert stub_exec["claw_type"] == "openclaw"
+    assert stub_exec["cmd_argv"] == ["--version"]
+
+
+def test_exec_nonzero_exit_propagation(fleet_dir, stdin_not_tty, stub_exec):
+    stub_exec["_rc"] = 7
+    stub_exec["_stderr"] = "boom\n"
+    result = runner.invoke(
+        app, ["agent", "exec", "wise-hypatia", "--", "bogus"]
+    )
+    assert result.exit_code == 7
+    assert "boom" in result.output
+
+
+def test_exec_unknown_agent(fleet_dir, stdin_not_tty, stub_exec):
+    result = runner.invoke(
+        app, ["agent", "exec", "does-not-exist", "--", "echo", "hi"]
+    )
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
+def test_exec_unreachable_host(fleet_dir, stdin_not_tty, stub_exec):
+    stub_exec["_rc"] = 255
+    stub_exec["_stderr"] = "Host unreachable: ssh failed"
+    result = runner.invoke(
+        app, ["agent", "exec", "wise-hypatia", "--", "x"]
+    )
+    assert result.exit_code == 255
+    assert "unreachable" in result.output.lower()
+
+
+def test_exec_requires_command(fleet_dir, stdin_not_tty, stub_exec):
+    result = runner.invoke(app, ["agent", "exec", "wise-hypatia"])
+    assert result.exit_code != 0
+
+
+def test_exec_help_documents_double_dash(fleet_dir):
+    result = runner.invoke(app, ["agent", "exec", "--help"])
+    assert result.exit_code == 0
+    assert "--" in result.output
+
+
+def test_exec_stdout_and_stderr_both_emitted(fleet_dir, stdin_not_tty, stub_exec):
+    stub_exec["_stdout"] = "out line\n"
+    stub_exec["_stderr"] = "err line\n"
+    result = runner.invoke(
+        app, ["agent", "exec", "wise-hypatia", "--", "x"]
+    )
+    assert result.exit_code == 0
+    assert "out line" in result.output
+    assert "err line" in result.output

--- a/tests/cli/clawctl/agent/test_non_interactive.py
+++ b/tests/cli/clawctl/agent/test_non_interactive.py
@@ -82,12 +82,6 @@ def test_delete_stdin_closed_without_yes_fails(fleet_dir, stdin_not_tty) -> None
     assert "--yes" in result.output
 
 
-def test_exec_is_placeholder(fleet_dir) -> None:
-    result = runner.invoke(app, ["agent", "exec", "wise-hypatia", "echo", "hi"])
-    assert result.exit_code == 0
-    assert "Not implemented: agent exec" in result.output
-
-
 def test_registry_get_lists_supported_types(fleet_dir) -> None:
     result = runner.invoke(app, ["agent", "registry", "get"])
     assert result.exit_code == 0

--- a/tests/cli/clawctl/conftest.py
+++ b/tests/cli/clawctl/conftest.py
@@ -88,7 +88,7 @@ def fleet_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
                         "providers": {"anthropic": {"model": "claude-opus"}},
                         "skills": ["clawrium/tdd"],
                     },
-                }
+                },
             },
         },
         {

--- a/tests/cli/output/test_sanitize.py
+++ b/tests/cli/output/test_sanitize.py
@@ -28,7 +28,11 @@ import pytest
 import typer
 import yaml
 
-from clawrium.cli.output._sanitize import _CONTROL_AND_BIDI_RE, sanitize
+from clawrium.cli.output._sanitize import (
+    _CONTROL_AND_BIDI_RE,
+    sanitize,
+    sanitize_passthrough,
+)
 from clawrium.cli.output.errors import emit_error
 from clawrium.cli.output.json_yaml import dump_json, dump_name, dump_yaml
 from clawrium.cli.output.status import format_status
@@ -97,6 +101,31 @@ def test_sanitize_mixed_vector() -> None:
     assert "\x1b" not in cleaned
     assert RLO not in cleaned
     assert "red text" in cleaned
+
+
+BIDI_ONLY = [
+    chr(0x202E), chr(0x2066), chr(0x2067), chr(0x2068), chr(0x2069),
+    chr(0x200E), chr(0x200F), chr(0x200B), chr(0x200C), chr(0x200D),
+    chr(0x2028), chr(0x2029), chr(0x2060), chr(0xFEFF), chr(0x061C),
+    chr(0x202A), chr(0x202B), chr(0x202C), chr(0x202D),
+]
+
+
+@pytest.mark.parametrize("dangerous", BIDI_ONLY)
+def test_sanitize_passthrough_strips_bidi(dangerous: str) -> None:
+    cleaned = sanitize_passthrough(f"alpha{dangerous}omega")
+    assert dangerous not in cleaned
+    assert "alpha" in cleaned and "omega" in cleaned
+
+
+def test_sanitize_passthrough_preserves_whitespace() -> None:
+    s = "line1\nline2\tcol\rend"
+    assert sanitize_passthrough(s) == s
+
+
+def test_sanitize_passthrough_passes_through_safe_strings() -> None:
+    safe = "OpenClaw 2026.3.13 (61d171a)\n"
+    assert sanitize_passthrough(safe) is safe
 
 
 def test_source_is_pure_ascii() -> None:

--- a/tests/cli/test_app.py
+++ b/tests/cli/test_app.py
@@ -61,18 +61,13 @@ def test_group_help_exits_zero(group: str) -> None:
     "argv,expected",
     [
         # `mcp registry` remains a placeholder per plan §4 (no MCP
-        # implementation yet); `agent exec` is intentionally a
-        # placeholder. The Pattern A registries (provider, channel,
-        # integration, skill) were stubs in bundle 3 (#508) and were
-        # replaced with real implementations in bundle 4 (#509) —
-        # those tests live alongside the per-noun modules under
-        # `tests/cli/clawctl/<noun>/`.
+        # implementation yet). `agent exec` was implemented in #413;
+        # its tests live in `tests/cli/clawctl/agent/test_exec.py`.
         (["mcp", "registry", "get"], "Not implemented: mcp registry get"),
         (
             ["mcp", "registry", "describe", "foo"],
             "Not implemented: mcp registry describe",
         ),
-        (["agent", "exec", "any-name", "echo", "hi"], "Not implemented: agent exec"),
     ],
 )
 def test_stub_verb_emits_canonical_line(argv: list[str], expected: str) -> None:

--- a/tests/core/test_agent_exec.py
+++ b/tests/core/test_agent_exec.py
@@ -163,6 +163,89 @@ def test_missing_host(monkeypatch, patched_env):
     assert "not found" in stderr
 
 
+def test_invalid_agent_name_raises(patched_env):
+    with pytest.raises(agent_exec.AgentExecError):
+        agent_exec.run_agent_exec("10.0.0.1", "Bad Name!", "openclaw", ["x"])
+
+
+@pytest.mark.parametrize("claw_type", ["hermes", "zeroclaw"])
+def test_run_agent_exec_per_type_success(monkeypatch, patched_env, claw_type):
+    captured = {}
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+        return _make_result(
+            [
+                _ok_event(
+                    "EXEC_STDOUT=" + base64.b64encode(b"v1.0").decode()
+                ),
+                _ok_event("EXEC_STDERR=" + base64.b64encode(b"").decode()),
+                _ok_event("EXEC_RC=0"),
+            ]
+        )
+
+    monkeypatch.setattr(agent_exec.ansible_runner, "run", fake_run)
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "10.0.0.1", "agent", claw_type, ["--version"]
+    )
+    assert (stdout, rc) == ("v1.0", 0)
+    assert claw_type in captured["playbook"]
+
+
+def test_runner_on_failed_with_msg(monkeypatch, patched_env):
+    failed = {
+        "event": "runner_on_failed",
+        "event_data": {"res": {"msg": "binary not found"}},
+    }
+    monkeypatch.setattr(
+        agent_exec.ansible_runner,
+        "run",
+        lambda **kw: _make_result([failed], status="failed"),
+    )
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "10.0.0.1", "wolf-i", "openclaw", ["x"]
+    )
+    assert rc == 255
+    assert "binary not found" in stderr
+
+
+def test_runner_on_failed_with_stderr(monkeypatch, patched_env):
+    failed = {
+        "event": "runner_on_failed",
+        "event_data": {"res": {"stderr": "permission denied"}},
+    }
+    monkeypatch.setattr(
+        agent_exec.ansible_runner,
+        "run",
+        lambda **kw: _make_result([failed], status="failed"),
+    )
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "10.0.0.1", "wolf-i", "openclaw", ["x"]
+    )
+    assert rc == 255
+    assert "permission denied" in stderr
+
+
+def test_log_dir_uses_uuid_suffix(monkeypatch, patched_env):
+    captured = {}
+
+    def fake_run(**kw):
+        captured["pd"] = kw["private_data_dir"]
+        return _make_result(
+            [
+                _ok_event("EXEC_STDOUT=" + base64.b64encode(b"").decode()),
+                _ok_event("EXEC_STDERR=" + base64.b64encode(b"").decode()),
+                _ok_event("EXEC_RC=0"),
+            ]
+        )
+
+    monkeypatch.setattr(agent_exec.ansible_runner, "run", fake_run)
+    agent_exec.run_agent_exec("10.0.0.1", "wolf-i", "openclaw", ["x"])
+    # Path ends in `-<8 hex chars>`
+    suffix = captured["pd"].rsplit("-", 1)[-1]
+    assert len(suffix) == 8 and all(c in "0123456789abcdef" for c in suffix)
+
+
 def test_missing_rc_marker(monkeypatch, patched_env):
     monkeypatch.setattr(
         agent_exec.ansible_runner,

--- a/tests/core/test_agent_exec.py
+++ b/tests/core/test_agent_exec.py
@@ -1,0 +1,183 @@
+"""Unit tests for core/agent_exec.py — Ansible passthrough dispatcher.
+
+ansible_runner is mocked so tests run offline. Event lists model what
+the real `exec.yaml` playbook emits: three debug events tagged
+EXEC_STDOUT=/EXEC_STDERR=/EXEC_RC=.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from clawrium.core import agent_exec
+
+
+def _ok_event(msg: str) -> dict:
+    return {"event": "runner_on_ok", "event_data": {"res": {"msg": msg}}}
+
+
+def _make_result(events: list[dict], status: str = "successful") -> SimpleNamespace:
+    return SimpleNamespace(events=events, status=status)
+
+
+@pytest.fixture
+def patched_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(
+        agent_exec,
+        "get_config_dir",
+        lambda: tmp_path / "config",
+    )
+    monkeypatch.setattr(
+        agent_exec.core_keys,
+        "get_host_private_key",
+        lambda key_id: tmp_path / "fake-key",
+    )
+    (tmp_path / "fake-key").write_text("KEY")
+    # Make all per-type playbook paths exist
+    for ctype in agent_exec.SUPPORTED_CLAW_TYPES:
+        p = agent_exec._playbook_path(ctype)
+        if not p.exists():  # pragma: no cover — real playbooks exist
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("dummy")
+    # Stub get_host
+    from clawrium.core import hosts as hosts_module
+
+    monkeypatch.setattr(
+        hosts_module,
+        "get_host",
+        lambda h: {"hostname": h, "user": "alice", "port": 22, "alias": "wolf-i"},
+    )
+    return tmp_path
+
+
+def test_run_agent_exec_success(monkeypatch, patched_env):
+    captured = {}
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+        return _make_result(
+            [
+                _ok_event(
+                    "EXEC_STDOUT=" + base64.b64encode(b"hello world").decode()
+                ),
+                _ok_event("EXEC_STDERR=" + base64.b64encode(b"").decode()),
+                _ok_event("EXEC_RC=0"),
+            ]
+        )
+
+    monkeypatch.setattr(agent_exec.ansible_runner, "run", fake_run)
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "10.0.0.1", "wolf-i", "openclaw", ["--version"]
+    )
+    assert (stdout, stderr, rc) == ("hello world", "", 0)
+    # extra_vars passes cmd_argv as a typed list
+    inv = captured["inventory"]
+    assert inv["all"]["vars"]["cmd_argv"] == ["--version"]
+    assert inv["all"]["vars"]["agent_name"] == "wolf-i"
+
+
+def test_run_agent_exec_nonzero_rc(monkeypatch, patched_env):
+    monkeypatch.setattr(
+        agent_exec.ansible_runner,
+        "run",
+        lambda **kw: _make_result(
+            [
+                _ok_event("EXEC_STDOUT=" + base64.b64encode(b"").decode()),
+                _ok_event(
+                    "EXEC_STDERR=" + base64.b64encode(b"oops\n").decode()
+                ),
+                _ok_event("EXEC_RC=42"),
+            ]
+        ),
+    )
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "10.0.0.1", "wolf-i", "openclaw", ["bogus"]
+    )
+    assert rc == 42
+    assert "oops" in stderr
+
+
+def test_run_agent_exec_unreachable(monkeypatch, patched_env):
+    unreach = {
+        "event": "runner_on_unreachable",
+        "event_data": {"res": {"msg": "ssh failed"}},
+    }
+    monkeypatch.setattr(
+        agent_exec.ansible_runner,
+        "run",
+        lambda **kw: _make_result([unreach], status="failed"),
+    )
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "10.0.0.1", "wolf-i", "openclaw", ["x"]
+    )
+    assert rc == 255
+    assert "unreachable" in stderr.lower()
+
+
+def test_run_agent_exec_timeout(monkeypatch, patched_env):
+    monkeypatch.setattr(
+        agent_exec.ansible_runner,
+        "run",
+        lambda **kw: _make_result([], status="timeout"),
+    )
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "10.0.0.1", "wolf-i", "openclaw", ["x"]
+    )
+    assert rc == 255
+    assert "timed out" in stderr
+
+
+def test_unknown_claw_type_raises(patched_env):
+    with pytest.raises(agent_exec.AgentExecError):
+        agent_exec.run_agent_exec("10.0.0.1", "x", "nemoclaw", ["foo"])
+
+
+def test_empty_cmd_argv_raises(patched_env):
+    with pytest.raises(agent_exec.AgentExecError):
+        agent_exec.run_agent_exec("10.0.0.1", "x", "openclaw", [])
+
+
+def test_missing_ssh_key(monkeypatch, patched_env):
+    monkeypatch.setattr(
+        agent_exec.core_keys, "get_host_private_key", lambda key_id: None
+    )
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "10.0.0.1", "wolf-i", "openclaw", ["x"]
+    )
+    assert rc == 255
+    assert "SSH key" in stderr
+
+
+def test_missing_host(monkeypatch, patched_env):
+    from clawrium.core import hosts as hosts_module
+
+    monkeypatch.setattr(hosts_module, "get_host", lambda h: None)
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "nope", "x", "openclaw", ["v"]
+    )
+    assert rc == 255
+    assert "not found" in stderr
+
+
+def test_missing_rc_marker(monkeypatch, patched_env):
+    monkeypatch.setattr(
+        agent_exec.ansible_runner,
+        "run",
+        lambda **kw: _make_result(
+            [
+                _ok_event(
+                    "EXEC_STDOUT=" + base64.b64encode(b"out").decode()
+                ),
+                _ok_event("EXEC_STDERR=" + base64.b64encode(b"").decode()),
+                # no EXEC_RC
+            ]
+        ),
+    )
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "10.0.0.1", "wolf-i", "openclaw", ["x"]
+    )
+    assert rc == 255

--- a/tests/test_exec_binary_discovery.py
+++ b/tests/test_exec_binary_discovery.py
@@ -1,0 +1,127 @@
+"""Structural tests for the openclaw `exec` playbook binary discovery.
+
+Mirrors the pattern in `test_start_binary_discovery.py`: parses the
+playbook YAML and asserts task names, ordering, and `when:` conditions
+that constitute the security gate. A future edit that deletes the
+allowlist task or weakens its conditions fails here, even without
+running ansible (ATX iter-2 NB1).
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+EXEC_PLAYBOOK = (
+    Path(__file__).parent.parent
+    / "src"
+    / "clawrium"
+    / "platform"
+    / "registry"
+    / "openclaw"
+    / "playbooks"
+    / "exec.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def exec_tasks() -> list[dict]:
+    play = yaml.safe_load(EXEC_PLAYBOOK.read_text())
+    assert isinstance(play, list) and len(play) == 1
+    tasks = play[0].get("tasks", [])
+    assert tasks
+    return tasks
+
+
+def _by_name(tasks: list[dict], name: str) -> dict | None:
+    return next((t for t in tasks if t.get("name") == name), None)
+
+
+def _idx(tasks: list[dict], name: str) -> int:
+    return next(i for i, t in enumerate(tasks) if t.get("name") == name)
+
+
+def test_allowlist_validation_task_present(exec_tasks: list[dict]) -> None:
+    """The validate task gates the exec; deleting it must fail here."""
+    validate = _by_name(exec_tasks, "Validate resolved binary path (allowlist)")
+    assert validate is not None, "allowlist validation task removed"
+    fail = validate.get("ansible.builtin.fail") or validate.get("fail")
+    assert fail is not None, "validate must use ansible.builtin.fail"
+
+
+def test_allowlist_rejects_dotdot_segments(exec_tasks: list[dict]) -> None:
+    """ATX iter-2 NW1: paths with `..` segments must be rejected before
+    the prefix allowlist runs (`/usr/local/bin/../../etc/...` would
+    otherwise pass startswith()).
+    """
+    reject = _by_name(exec_tasks, "Reject `..` segments in resolved binary path")
+    assert reject is not None
+    when = reject["when"]
+    assert "/../" in when
+
+
+def test_allowlist_allowed_paths(exec_tasks: list[dict]) -> None:
+    """The allowlist must accept: the per-agent path, /usr/local/bin/*,
+    and /usr/bin/*.
+    """
+    validate = _by_name(exec_tasks, "Validate resolved binary path (allowlist)")
+    when = validate["when"]
+    assert "per_agent_binary" in when
+    assert "/usr/local/bin/" in when
+    assert "/usr/bin/" in when
+
+
+def test_discovery_runs_as_agent_user(exec_tasks: list[dict]) -> None:
+    """ATX iter-1 B3: `which` and `stat` must run as the agent user, not root."""
+    for name in (
+        "Stat per-agent openclaw binary (as agent user)",
+        "Discover openclaw in PATH (as agent user)",
+    ):
+        task = _by_name(exec_tasks, name)
+        assert task is not None, f"task missing: {name}"
+        assert task.get("become_user") == "{{ agent_name }}"
+
+
+def test_exec_runs_as_agent_user_with_no_log(exec_tasks: list[dict]) -> None:
+    """The exec task itself must run as the agent user with no_log: true
+    (ATX iter-1 W2 / B3).
+    """
+    run = _by_name(exec_tasks, "Run agent exec command")
+    assert run is not None
+    assert run.get("become_user") == "{{ agent_name }}"
+    assert run.get("no_log") is True
+
+
+def test_task_ordering(exec_tasks: list[dict]) -> None:
+    """stat → which → resolve → normalize → validate → exec."""
+    order = [
+        "Validate agent_name (defense-in-depth)",
+        "Stat per-agent openclaw binary (as agent user)",
+        "Discover openclaw in PATH (as agent user)",
+        "Resolve openclaw binary",
+        "Fail if openclaw not found",
+        "Reject `..` segments in resolved binary path",
+        "Validate resolved binary path (allowlist)",
+        "Ensure workspace directory exists",
+        "Run agent exec command",
+    ]
+    indexes = [_idx(exec_tasks, n) for n in order]
+    assert indexes == sorted(indexes), f"task order wrong: {indexes}"
+
+
+@pytest.mark.parametrize("claw_type", ["hermes", "zeroclaw"])
+def test_per_type_playbooks_use_no_log(claw_type: str) -> None:
+    """ATX iter-1 W2 mirror: hermes + zeroclaw exec tasks also need no_log."""
+    path = (
+        EXEC_PLAYBOOK.parent.parent.parent
+        / claw_type
+        / "playbooks"
+        / "exec.yaml"
+    )
+    play = yaml.safe_load(path.read_text())
+    tasks = play[0]["tasks"]
+    run = _by_name(tasks, "Run agent exec command")
+    assert run is not None
+    assert run.get("no_log") is True
+    assert run.get("become_user") == "{{ agent_name }}"

--- a/tests/test_exec_binary_discovery.py
+++ b/tests/test_exec_binary_discovery.py
@@ -51,14 +51,17 @@ def test_allowlist_validation_task_present(exec_tasks: list[dict]) -> None:
 
 
 def test_allowlist_rejects_dotdot_segments(exec_tasks: list[dict]) -> None:
-    """ATX iter-2 NW1: paths with `..` segments must be rejected before
-    the prefix allowlist runs (`/usr/local/bin/../../etc/...` would
-    otherwise pass startswith()).
+    """ATX iter-2 NW1 / iter-3 NB2: paths with `..` segments must be
+    rejected before the prefix allowlist runs. Each sub-pattern is
+    asserted independently so a refactor that drops one branch fails
+    here.
     """
     reject = _by_name(exec_tasks, "Reject `..` segments in resolved binary path")
     assert reject is not None
     when = reject["when"]
-    assert "/../" in when
+    assert "'/../' in resolved_binary" in when
+    assert "endswith('/..')" in when
+    assert "startswith('../')" in when
 
 
 def test_allowlist_allowed_paths(exec_tasks: list[dict]) -> None:
@@ -125,3 +128,34 @@ def test_per_type_playbooks_use_no_log(claw_type: str) -> None:
     assert run is not None
     assert run.get("no_log") is True
     assert run.get("become_user") == "{{ agent_name }}"
+
+
+@pytest.mark.parametrize("claw_type", ["openclaw", "hermes", "zeroclaw"])
+def test_per_type_playbooks_validate_agent_name(claw_type: str) -> None:
+    """ATX iter-3 NB3: every exec playbook must guard agent_name
+    against shell-special / path-traversal characters, since
+    `agent_name` is interpolated into paths and become_user. For
+    hermes/zeroclaw this is the only injection guard (no realpath/
+    discovery layer).
+    """
+    path = (
+        EXEC_PLAYBOOK.parent.parent.parent
+        / claw_type
+        / "playbooks"
+        / "exec.yaml"
+    )
+    play = yaml.safe_load(path.read_text())
+    tasks = play[0]["tasks"]
+    validate = _by_name(tasks, "Validate agent_name (defense-in-depth)")
+    assert validate is not None, f"{claw_type}: agent_name validate task missing"
+    fail = validate.get("ansible.builtin.fail") or validate.get("fail")
+    assert fail is not None, f"{claw_type}: validate must use ansible.builtin.fail"
+    when = validate["when"]
+    when_str = " ".join(when) if isinstance(when, list) else str(when)
+    assert "^[a-z][a-z0-9_-]{0,31}$" in when_str, (
+        f"{claw_type}: agent_name regex missing or weakened"
+    )
+    # The validate task must run first (before any task that touches paths).
+    assert tasks.index(validate) == 0, (
+        f"{claw_type}: validate task must be first in tasks list"
+    )


### PR DESCRIPTION
## Summary
- Wires `clawctl agent exec <name> <cmd...>` to per-type ansible playbooks that run the agent's native CLI on the remote host.
- Three per-type `exec.yaml` playbooks (openclaw, hermes, zeroclaw). openclaw mirrors `install.yaml`'s binary-discovery logic (per-agent path → `which` fallback) because openclaw is system-wide on existing hosts; hermes/zeroclaw have deterministic per-agent paths.
- Shared `core/agent_exec.py` dispatcher parses base64-tagged debug events (`EXEC_STDOUT=`/`EXEC_STDERR=`/`EXEC_RC=`) and returns `(stdout, stderr, rc)`. CLI forwards through `sanitize_passthrough()` (drops UAX#9 bidi codepoints, preserves whitespace) and propagates rc.
- No `--` required: `ignore_unknown_options=True` + `ctx.args` lets `clawctl agent exec myagent --version` work directly. `--` still accepted to forward `--help` to the remote.

Closes #413

## Testing

### Test Results
- [x] All tests pass (`uv run pytest`: 3201 passed, 6 skipped)
- [x] Linter passes (`uv run ruff check src tests`)
- [x] New tests: `tests/core/test_agent_exec.py` (15), `tests/cli/clawctl/agent/test_exec.py` (15), `tests/test_exec_binary_discovery.py` (11), bidi-passthrough cases in `tests/cli/output/test_sanitize.py`.

### Manual Integration Testing (against wolf-i fleet)

```
$ uv run clawctl agent exec wolf-i --version          # openclaw
OpenClaw 2026.3.13 (61d171a)

$ uv run clawctl agent exec espresso --version        # hermes
Hermes Agent v0.14.0 (2026.5.16)
Project: /home/espresso/.hermes/code
Python: 3.11.15
OpenAI SDK: 2.33.0
Update available: 4 commits behind — run 'hermes update'

$ uv run clawctl agent exec nemotron-alpha --version  # zeroclaw
zeroclaw 0.7.5

$ uv run clawctl agent exec does-not-exist --version  # unknown agent
Error: agent 'does-not-exist' not found
Hint:  clawctl agent get
(exit=1)

$ uv run clawctl agent exec wolf-i -- --bogus-flag    # nonzero rc propagation
error: unknown option '--bogus-flag'
(exit=1)
```

### Security Checklist
- [x] No hardcoded secrets; no shell interpolation (all argv via list).
- [x] `agent_name` validated Python-side AND playbook-side against `^[a-z][a-z0-9_-]{0,31}$`.
- [x] openclaw binary path: `..` segments rejected pre-check, then allowlist enforces per-agent path OR `/usr/local/bin/*` OR `/usr/bin/*`.
- [x] Discovery (`stat` / `which`) and exec all run as the agent user, NOT root.
- [x] `no_log: true` on the exec task (so `-- --api-key sk-xxx` doesn't reach journald) and on the failure-message tasks.
- [x] All remote-controlled stdout/stderr passes through `sanitize_passthrough()` before reaching the local terminal (strips UAX#9 bidi codepoints).

## ATX Review Summary

**Final Review: Rating 2/5 (iter-3) — closed out with followup commit (`028981f`) addressing NB2/NB3/NW3/NW7.**
Cost: $11.74 across 3 reviews. The followup is a test-completeness pass (no functional changes); per the [ITX skill 3-iteration ceiling] the PR is opened for human review rather than running a 4th cycle.

| Review | Rating | Blockers | Cost | Time | Notes |
|--------|--------|----------|------|------|-------|
| 1 | 2/5 | B1–B7 | $3.09 | 9m57s | 7 blockers across security, CLI UX, Ansible, test coverage |
| 2 | 3/5 | NB1 | $5.76 | 9m27s | iter-1 cleared 6/7; NB1 raised on missing structural test for openclaw allowlist |
| 3 | 2/5 | NB2, NB3 | $2.88 | 7m11s | NB1 partially cleared; NB2/NB3 = same-class structural-test completeness gaps |

<details>
<summary>Review 1 (Rating 2/5) — full blocker resolution table</summary>

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `exec.py:79-86` | stdout/stderr written without bidi sanitization → terminal hijack via U+202E | Fixed iter-1: added `sanitize_passthrough()` to `_sanitize.py`; called on both writes |
| B2 | `openclaw/exec.yaml:47` | allowlist accepts any path under `/home/` | Fixed iter-1: exact per-agent match OR `/usr/local/bin/` OR `/usr/bin/` |
| B3 | `openclaw/exec.yaml:26` | `which` runs as root, exec runs as agent — trust boundary mismatch | Fixed iter-1: removed play-level `become`; per-task `become_user: {{ agent_name }}` on stat/which |
| B4 | `exec.py:50-54` | `clawctl agent exec foo --version` (no `--`) fails with opaque Typer error | Fixed iter-1: `ignore_unknown_options=True` + `ctx.args` |
| B5 | `tests/...` | hermes/zeroclaw have zero coverage | Fixed iter-1: parametrized per-type tests in both core + CLI suites |
| B6 | `tests/cli/.../test_exec.py` | `AgentExecError` from core never asserted | Fixed iter-1: `test_exec_agent_exec_error_from_core` |
| B7 | `core/agent_exec.py:113` | `runner_on_failed` branch (msg + stderr) untested | Fixed iter-1: two new tests, one per sub-branch |

Warnings W1–W9 all addressed (uuid log_dir suffix, no_log, agent_name Python-side validation, alias path-traversal guard, least-privilege become, dead `runner_item_on_ok` filter removed, log_dir cleanup, AgentExecError hint).

</details>

<details>
<summary>Review 2 (Rating 3/5) — iter-1 followups</summary>

iter-1 cleared 6/7 blockers. Iter-2 raised:

- **NB1** (blocker): no structural regression test for openclaw exec.yaml allowlist task. **Fixed iter-3**: new `tests/test_exec_binary_discovery.py` parses the playbook YAML and asserts task names, ordering, `when:` clauses, and `become_user`.
- **NW1**: `startswith('/usr/local/bin/')` bypassable via `..` segments. **Fixed iter-3**: dedicated "Reject `..` segments" pre-check task ahead of the allowlist.
- **NW3**: `--help` silently swallowed by Typer; undocumented. **Fixed iter-3 followup**: callout in the Typer function docstring (the one rendered by `--help`).
- **NW4**: `_BIDI_ONLY_RE` built at runtime via `chr()` calls (escapes `test_source_is_pure_ascii` purity check). **Fixed iter-3**: rewrote as literal `\uXXXX`-escape pattern matching `_CONTROL_AND_BIDI_RE`'s style.
- **NW5**: stderr bidi sanitization had no CLI-layer integration test. **Fixed iter-3**: `test_exec_strips_bidi_from_remote_stderr`.
- **NW6**: chmod failure left orphan log_dir. **Fixed iter-3**: rmdir on chmod failure.
- **NW2** (install.yaml hardening): intentionally **out of scope** — separate playbook, not modified in this PR.

</details>

<details>
<summary>Review 3 (Rating 2/5) — iter-2 followups</summary>

iter-3 cleared NW1/4/5/6 and partially addressed NB1. Two new blockers and one warning required a followup commit (`028981f`):

- **NB2** (followup): `test_allowlist_rejects_dotdot_segments` only asserted 1 of 3 `when` sub-patterns. **Fixed**: now asserts each branch independently.
- **NB3** (followup): no structural test for `Validate agent_name` task in hermes/zeroclaw exec playbooks. **Fixed**: new parametrized `test_per_type_playbooks_validate_agent_name` over all three claw types.
- **NW3-iter3** (followup): `--help` note landed in module docstring (pydoc-only) not function docstring (CLI-visible). **Fixed**: moved.
- **NW7** (followup): fail tasks interpolated `{{ resolved_binary }}` into `msg` without `no_log: true`. **Fixed**: `no_log: true` on both fail tasks.
- **NW8** (deferred): bare `..` (no trailing `/`) slips the layer-1 pre-check. Layer-2 allowlist still blocks it (not absolute). Defense-in-depth gap, not exploitable.
- **NW9** (deferred): `/usr/local/bin/openclaw` symlinked to `/tmp/evil` is not detected. The first attempt at iter-3 used `realpath` normalization, which I had to revert: on wolf-i, `/usr/local/bin/openclaw` legitimately resolves to a node_modules `.mjs` file. The trust model (allowlist directories are root-controlled) is documented in the playbook comment. Bounded blast radius (binary runs as the agent user, not root).

</details>

## Callouts

- [DECISION] `--help` is intercepted by Typer / clawctl rather than forwarded to the agent binary. `--help` documented in the function docstring; users must type `-- --help` to forward.
  - Why: This is the standard Typer behavior; bypassing it would require swallowing every `--help` token in `ctx.args`, which surprises Typer users.
  - Reviewer: confirm acceptable.

- [DECISION] openclaw binary discovery uses a prefix allowlist (`/usr/local/bin/`, `/usr/bin/`, exact per-agent path) plus a `..`-segment rejection pre-check, NOT `realpath` normalization.
  - Why: iter-3's first attempt used `realpath`, but on wolf-i `/usr/local/bin/openclaw` is a symlink into `node_modules`. Strict `realpath` allowlist rejects every valid install. The current shape mirrors `install.yaml`'s allowlist (which uses the same prefixes) and adds the `..` guard.
  - Tradeoff: a `/usr/local/bin/X → /tmp/evil` symlink is not blocked. The allowlist directories are root-controlled on supported distros; this is the documented trust model. The exec runs as the agent user, not root.
  - Reviewer: flag if the trust model needs sharper documentation or a follow-up issue.

- [DECISION] NB2/NB3/NW3-iter3/NW7 fixed in a 4th commit (`028981f`) after the 3-iteration ATX ceiling. NW8/NW9 deferred per analysis above.
  - Why: NB2/NB3 are structural-test completeness gaps in tests I added in iter-3; the underlying security gates are unchanged and working. NW3-iter3/NW7 are 1-line hardenings of the iter-3 work.
  - Reviewer: I did not run a 4th ATX review on `028981f`; the changes are test-only + 2 `no_log` flags + 1 docstring move, all visible in the diff.

- [DECISION] Unknown agent exits 1 (not 2 as the plan specified).
  - Why: Reuses project-standard `safe_resolve_agent` → `emit_error` helper (defaults to exit 1). Empty-cmd and unsupported-type still exit 2 (plan-compliant).
  - Reviewer: confirm.

- [DECISION] `clawctl agent exec wolf-i -- openclaw --version` would run `openclaw openclaw --version` (binary auto-prepended). The CLI surface forwards `cmd_argv` as args to the hardcoded native binary, not as a full command line. Help-text examples reflect this.
  - Why: Matches the playbook contract (`argv: "{{ [binary] + cmd_argv }}"`). Saves users from typing the binary name twice.
  - Reviewer: confirm UX preference.

- [ENVIRONMENT] Manual tests executed against the live wolf-i fleet; the openclaw allowlist `..` and symlink decisions are informed by the actual wolf-i layout (system-wide install via node_modules symlink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
