### PR TITLE
feat(core): hermes multi-provider data model + lifecycle bridge (#501 Phase 1)

### DIFF
--- a/.itx/501/00_PLAN.md
+++ b/.itx/501/00_PLAN.md
@@ -239,3 +239,22 @@ https://github.com/ric03uec/clawrium/issues/501 plan only first. read the latest
 **Output**: High-level implementation plan for issue #501. Scoped to hermes-only multi-provider support with primary + 9 auxiliary slot mapping, asymmetric singleton (zeroclaw/openclaw stay singleton), `set-role` as a new hermes-only verb, and `--model` defaulting to the provider's `default_model`. Confirmed upstream slot list and provider→env-var mapping against `NousResearch/hermes-agent@v2026.5.7`.
 
 </details>
+
+## Execution
+
+**Stage**: execute
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-25T22:50:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 501
+```
+
+**Output**: Phase 1 of plan executed and shipped as PR #532. Added
+`core/provider_attachments.py` (normalization + validation), split the
+lifecycle provider bridge by agent type so hermes builds `config.providers`
+while zeroclaw/openclaw retain the singleton path. 36 new tests, all 3237
+existing tests pass, lint clean. ATX review (1 iteration, 3/5, no blockers)
+— in-diff items W5/W6/S2/S3 addressed; W1-W4 flagged as pre-existing and
+out of scope.

--- a/.itx/501/00_PLAN.md
+++ b/.itx/501/00_PLAN.md
@@ -1,0 +1,241 @@
+# Issue #501 — Multi-provider attachments for hermes (primary + auxiliary slots)
+
+## What's supported today across the three agent types
+
+| Agent type | Provider attachment | Multi-provider use? | Auxiliary roles? |
+|---|---|---|---|
+| **zeroclaw** | `agent.providers: [name]`, singleton enforced (`agent provider attach` rejects second; `lifecycle.py:957-966` re-asserts) | No — the gateway daemon binds one inference target. | None. |
+| **openclaw** | Same singleton attachment via `agent.providers`. `config.provider` overlay = single dict. | No — openclaw templates assume one provider. | None. |
+| **hermes** | Same singleton attachment today. `hermes.env.j2` emits the single active provider's API key; `hermes-config.yaml.j2` hardcodes per-`provider_type` `auxiliary.title_generation.model` only. | **Should be multi.** Upstream supports many keys in `.env` and 9 auxiliary slots per `hermes_cli/config.py:716-794`. | **9 slots, defined upstream.** |
+
+**Conclusion:** the multi-provider concept lives entirely on the hermes side. openclaw and zeroclaw stay singleton (their existing constraint stands). Scope this issue to hermes; preserve the singleton invariant on the other two.
+
+## Upstream surface confirmed (hermes v2026.5.7)
+
+### Auxiliary slots (9 total)
+
+From `NousResearch/hermes-agent/hermes_cli/config.py:716-794`:
+
+| Slot | Default timeout | Extra fields |
+|---|---|---|
+| `vision` | 120s | `download_timeout`, `extra_body` |
+| `web_extract` | 360s | — |
+| `compression` | 120s | — |
+| `session_search` | 30s | `max_concurrency: 3` |
+| `skills_hub` | 30s | — |
+| `approval` | 30s | — |
+| `mcp` | 30s | — |
+| `title_generation` | 30s | — |
+| `curator` | 600s | — |
+
+Each slot shape: `{ provider, model, base_url, api_key, timeout, extra_body }`.
+
+`auxiliary.<slot>.provider` is **not enum-restricted**: any provider name resolves against the top-level `providers:` dict (or `custom_providers`). `"auto"` means inherit the main chat provider/credentials. clawctl can pass any of its own provider-type names here.
+
+### Provider types clawctl currently supports
+
+From `src/clawrium/core/providers/models.json`: `anthropic`, `bedrock`, `ollama`, `openai`, `openrouter`, `vertex`, `zai` (7 types).
+
+The hermes env template today emits credentials for 5 of 7 — `anthropic`, `openai`, `openrouter`, `bedrock`, `ollama`. **`vertex` and `zai` are gaps on the hermes path today**, pre-existing — flag as a follow-up; not in scope here.
+
+### Provider → env-var mapping
+
+| clawctl provider type | Env var(s) | Notes |
+|---|---|---|
+| `anthropic` | `ANTHROPIC_API_KEY` | |
+| `openai` | `OPENAI_API_KEY` | |
+| `openrouter` | `OPENROUTER_API_KEY` | upstream's default path |
+| `bedrock` | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` | secret pair |
+| `ollama` | *(none)* | local; base_url instead |
+| `vertex` | not emitted | gap (out of scope) |
+| `zai` | not emitted | gap (out of scope) |
+
+## Current command surface relevant to this change
+
+- `clawctl agent provider attach <name> --agent <a>` — singleton-enforced (`agent/provider.py:106-118`).
+- `clawctl agent provider detach <name> --agent <a>` — preserves `config.provider` as last-known-good (deliberate, #426).
+- `clawctl agent provider get --agent <a>` — table/json/yaml/name output.
+- `clawctl agent configure <a>` `providers` stage runs `provider_select` + `provider_test` from the manifest (same wiring for all three agent types).
+- `lifecycle.py:945-1024` bridges `agent.providers` (attach list) → `config.provider` (the dict templates read), with the singleton check at 957-966.
+- Hermes templates: `hermes.env.j2` (env file) + `hermes-config.yaml.j2` (YAML config). Both currently single-provider.
+
+## Proposed changes
+
+### 1. Data model (versioned schema bump)
+
+Today: `agent.providers: ["my-anthropic"]` (list of names, singleton).
+
+Proposed (hermes only): `agent.providers: [{ "name": "my-anthropic", "role": "primary", "model": "claude-…" }, { "name": "dgx-ollama", "role": "compression", "model": "qwen-…" }]`.
+
+- Invariants: exactly one `role: primary`; auxiliary roles unique within the list; `role` ∈ {`primary`, `vision`, `web_extract`, `compression`, `session_search`, `skills_hub`, `approval`, `mcp`, `title_generation`, `curator`} (10 values total — primary + 9 upstream slots).
+- Migration: on load, list-of-strings → `[{name, role: "primary", model: <provider.default_model>}]`. Forward-only.
+- For zeroclaw/openclaw the storage shape stays list-of-strings; migration is gated on agent type. Their singleton invariant is preserved end-to-end.
+
+### 2. CLI surface
+
+Asymmetric by design: hermes-only multi; zeroclaw/openclaw retain singleton.
+
+```
+clawctl agent provider attach <provider-name> \
+    --agent <a> \
+    [--role <role>] \
+    [--model <model-id>]
+
+clawctl agent provider detach <provider-name> --agent <a>
+
+clawctl agent provider set-role <provider-name> \
+    --agent <a> \
+    --role <role>
+
+clawctl agent provider get --agent <a> [--output table|json|yaml|name]
+```
+
+**Decisions locked:**
+
+- **Q1 — asymmetric singleton:** keep. hermes allows multi; zeroclaw and openclaw retain their singleton invariant (existing error path unchanged). `--role` is rejected when target agent is not hermes.
+- **Q2 — `set-role` as a new verb:** keep. hermes-specific, fine to introduce a new verb not present on `skill`/`integration`/`channel`. Rejected on non-hermes agents.
+- **Q3 — `--model` default:** defaults to the provider's `default_model` from `~/.config/clawrium/providers.json` when omitted. Explicit override per attachment supported via `--model`.
+
+**Behavior details:**
+
+- `attach`: `--role` defaults to `primary` if no primary yet; required when primary exists. Rejects role collision (auxiliary slot already filled) with a hint pointing at `set-role`.
+- `detach`: rejects detaching `primary` unless another attachment is first promoted via `set-role`.
+- `set-role`: hermes-only; supports promoting an auxiliary to primary (the old primary must be moved or detached first to keep the exactly-one-primary invariant).
+- `get`: extend rows with `ROLE` and `MODEL` columns; json/yaml shape gains `role` and `model` keys.
+
+### 3. Configure stage extension
+
+The manifest `providers` stage today is `provider_select` + `provider_test`. For hermes, drive an extended interactive flow that:
+
+1. Picks the primary provider (existing flow).
+2. Loops offering to attach auxiliary providers to each of the 9 slots (skippable; default no).
+3. Runs `provider_test` against the **primary** plus each newly attached auxiliary attachment.
+
+Prefer a manifest hint (`onboarding.stages.providers.multi: true`) over a new task type, to keep the task-type vocabulary stable while the dispatcher branches on the hint. zeroclaw/openclaw manifests stay without the hint and behave as today.
+
+### 4. Reconcile / lifecycle bridge
+
+`core/lifecycle.py:945-1024` — split the bridge by agent type:
+
+- zeroclaw/openclaw: unchanged singleton path.
+- hermes: drop the singleton check; build a `config.providers` list (one entry per attachment with name/type/role/model/endpoint/credentials reference). Continue to populate `config.provider` from the primary entry for back-compat with the bridge contract.
+
+`_run_providers_stage` in `cli/agent.py:402+` stores the **primary** provider name into `providers_stage.provider_id` (existing single-provider invariant in onboarding state). Auxiliary attachments are tracked solely in `agent.providers` — no schema change to onboarding state.
+
+### 5. Template changes
+
+**`templates/hermes.env.j2`:**
+
+- Replace the single `if/elif provider.type` ladder with a loop over `config.providers`. Emit each provider type's expected env var (`OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AWS_ACCESS_KEY_ID/SECRET/REGION` for bedrock). Skip Ollama (no key).
+- Key conflict policy: if two attachments share the same provider type (e.g. two Anthropic keys), the **primary wins**; warn at configure time.
+- Keep `HERMES_INFERENCE_PROVIDER` driven by primary.
+
+**`templates/hermes-config.yaml.j2`:**
+
+- `model.default` and `model.provider` driven by primary attachment.
+- Replace the hardcoded `auxiliary.title_generation.model` block with a generated `auxiliary:` block iterating all non-primary attachments and emitting `<slot>.provider` + `<slot>.model` matching upstream `hermes_cli/config.py:716-794` shape.
+- Slots without an attachment: omit entirely (hermes falls back to its default).
+
+### 6. Validation
+
+- Reuse `provider_test` per attachment in the configure flow.
+- Post-deploy `/health` probe unchanged.
+- Per-slot smoke (a chat call exercising each auxiliary provider through hermes) — defer to follow-up unless cheap.
+
+## Files to modify
+
+- `src/clawrium/cli/clawctl/agent/provider.py` — extend `attach`/`detach`/`get`, add `set-role`. Branch on agent type for hermes-only behavior.
+- `src/clawrium/core/lifecycle.py` — split provider-bridge by agent type; build `config.providers` for hermes.
+- `src/clawrium/core/hosts.py` — schema migration helper for hermes provider attachments.
+- `src/clawrium/cli/agent.py` (`_run_providers_stage`, `_sync_provider_config`) — multi-attach interactive flow + sync payload extension for hermes.
+- `src/clawrium/platform/registry/hermes/manifest.yaml` — slot enumeration + `multi: true` hint.
+- `src/clawrium/platform/registry/hermes/templates/hermes.env.j2` — loop over providers.
+- `src/clawrium/platform/registry/hermes/templates/hermes-config.yaml.j2` — render `auxiliary.<slot>` from attachments.
+- `src/clawrium/platform/registry/hermes/playbooks/configure.yaml` — pass the providers list through to Ansible vars.
+- Tests under `tests/` — provider attach/detach/set-role, lifecycle bridge, env+config template rendering.
+- `docs/installation.md` + hermes docs — multi-provider configure walkthrough.
+
+## Test strategy
+
+- Unit: schema migration round-trip; attach with/without role; primary-detach rejection; multi-type env emission; auxiliary-slot YAML emission for each provider type; non-hermes agent rejects `--role` and `set-role`.
+- Snapshot: render `.env` and `config.yaml` for fixture (primary=anthropic + compression=ollama@DGX + title_generation=openai).
+- Integration (per AC): hermes on a non-DGX host, cloud anthropic primary + DGX-hosted ollama in `compression`; verify `/health` and exercise the compression path.
+
+## Risks / open questions
+
+1. **Singleton enforcement in lifecycle.py is a hard error today.** Removing it for hermes risks regressions if `agent.providers` contains stale entries from a failed attach. Mitigation: schema migration normalizes stray list-of-strings to a single primary record before the bridge runs.
+2. **Credential conflicts when two attachments share a type.** Hermes' `.env` has one slot per env-var name; can't carry two `ANTHROPIC_API_KEY`s. "Primary wins" must be explicit and surfaced at configure time. Per-slot credential overrides would require upstream support and are out of scope.
+3. **`config.provider` (singular) is still read by openclaw/zeroclaw templates** — keep populated for hermes too (from primary) to avoid breaking the bridge contract.
+4. **No fallback chain** (explicitly out of scope in the issue). Slot-to-provider mapping is 1:1.
+5. **`vertex` and `zai` provider types** are clawctl-supported but not emitted by the hermes env template today. Pre-existing gap; not in scope. Flag as a follow-up.
+6. **Repo-wide `clm` → `clawctl` drift** in comments and manifest text (e.g. `manifest.yaml:17,43,50,51`, `agent/provider.py:5`). Cosmetic; out of scope, track as cleanup.
+
+## High-level execution workflow
+
+Five phases, one PR each. Phases 1–3 are independently mergeable; 4 depends on 1+3; 5 closes the issue.
+
+### Phase 1 — Schema + data model foundation
+Goal: `agent.providers` holds objects for hermes, strings for others, no user-visible change.
+1. Migration in `core/hosts.py`: hermes list-of-strings → `[{name, role: "primary", model: <provider.default_model>}]`.
+2. Validation helpers: enforce role uniqueness + exactly-one-primary for hermes.
+3. Bridge in `lifecycle.py` branches on agent type; hermes path builds `config.providers` + still populates `config.provider` from primary.
+4. Verify: existing tests pass; new tests for migration + bridge.
+
+### Phase 2 — CLI surface
+Goal: attach/detach/set-role/get work end-to-end on storage.
+1. Extend `cli/clawctl/agent/provider.py`: `--role`, `--model` on `attach`; new `set-role`; extended `detach` (primary-protected); extended `get` output.
+2. Gate multi-attach + `set-role` on agent type — reject `--role`/`set-role` for non-hermes.
+3. Verify: CLI tests for each path; manual smoke on a hermes instance.
+
+### Phase 3 — Template rewrites
+Goal: rendered `.env` and `config.yaml` reflect all attachments.
+1. Rewrite `hermes.env.j2` — loop providers, emit per-type keys, "primary wins" on duplicates.
+2. Rewrite `hermes-config.yaml.j2` — `model.default`/`model.provider` from primary, `auxiliary.<slot>` per non-primary.
+3. Update `playbooks/configure.yaml` to pass `providers` list through.
+4. Verify: snapshot tests for representative fixtures; render-locally smoke.
+
+### Phase 4 — Configure stage UX
+Goal: `clawctl agent configure <hermes>` walks the user through auxiliary attachments.
+1. Add `onboarding.stages.providers.multi: true` to hermes manifest.
+2. Extend `_run_providers_stage` to loop offering each of the 9 slots.
+3. Run `provider_test` per attachment.
+4. Verify: interactive smoke on a real hermes agent; VHS demo for docs.
+
+### Phase 5 — Validate end-to-end + docs
+Goal: AC met.
+1. Real-environment test: non-DGX host, anthropic primary + DGX-hosted ollama in `compression`; `/health` + compression-path call hits DGX.
+2. Update `docs/installation.md` and hermes docs.
+3. PR + ATX review + merge.
+
+### Critical path / unknowns
+
+- Before Phase 3: re-verify upstream slot names against `hermes_cli/config.py` at the pinned version — typos in `auxiliary.<slot>` are silent (hermes validates lazily per #501 body).
+- Before Phase 5: confirm DGX endpoint reachable from the target hermes host.
+
+## Suggested subtasks
+
+1. Schema migration + `agent.providers` shape extension (Phase 1).
+2. CLI surface extension (Phase 2).
+3. Configure-stage multi-attach interactive flow (Phase 4).
+4. Template rewrites (Phase 3).
+5. Tests + docs (cross-phase + Phase 5).
+
+---
+
+<details>
+<summary>Prompt Log</summary>
+
+## Planning
+
+**Stage**: plan
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-05-25T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+https://github.com/ric03uec/clawrium/issues/501 plan only first. read the latest command surface area and find wout what needs to be done for this. no file creation or anything. plan only first. find out whats supported for all the tree agent types supported by clawrium
+```
+
+**Output**: High-level implementation plan for issue #501. Scoped to hermes-only multi-provider support with primary + 9 auxiliary slot mapping, asymmetric singleton (zeroclaw/openclaw stay singleton), `set-role` as a new hermes-only verb, and `--model` defaulting to the provider's `default_model`. Confirmed upstream slot list and provider→env-var mapping against `NousResearch/hermes-agent@v2026.5.7`.
+
+</details>

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -18,7 +18,9 @@ import ansible_runner
 from clawrium.core.config import get_config_dir
 from clawrium.core.hosts import get_host, update_host, remove_agent_from_host
 from clawrium.core import keys as core_keys
+from clawrium.core import provider_attachments as _pa
 from clawrium.core.onboarding import OnboardingState
+from clawrium.core.providers import storage as _provider_storage
 from clawrium.core.secrets import (
     get_instance_key,
     get_instance_secrets,
@@ -950,33 +952,33 @@ def sync_agent(
     # before pushing to the remote. `detach` intentionally does NOT strip
     # `config.provider` — once a provider lands in config it is
     # last-known-good across subsequent syncs (design decision on #426).
-    attached_providers = claw_record.get("providers") or []
-    provider_overlay: dict | None = None
-    provider_name_for_state: str | None = None
-    if attached_providers:
-        if len(attached_providers) > 1:
-            # `attach` enforces the single-provider invariant; reaching
-            # this branch means hosts.json was hand-edited. Fail loudly
-            # rather than silently picking index 0.
-            raise LifecycleError(
-                f"agent '{agent_key}' has {len(attached_providers)} providers "
-                f"attached; single-provider invariant requires exactly one. "
-                f"Detach extras with 'clawctl agent provider detach <name> "
-                f"--agent {agent_key}'."
-            )
-        from clawrium.core.providers.storage import get_provider
+    #
+    # Issue #501: hermes alone supports N attachments (primary + 9
+    # auxiliary slots); zeroclaw/openclaw keep the singleton invariant.
+    # Normalization handles both legacy list-of-strings and the new
+    # list-of-objects shape transparently.
+    raw_attachments = claw_record.get("providers") or []
+    attachments = _pa.normalize(raw_attachments, agent_type)
+    try:
+        _pa.validate(attachments, agent_type)
+    except _pa.AttachmentError as exc:
+        raise LifecycleError(
+            f"agent '{agent_key}' has invalid provider attachments: {exc}. "
+            f"Inspect with 'clawctl agent provider get --agent {agent_key}'."
+        ) from exc
 
-        provider_name = attached_providers[0]
-        provider_record = get_provider(provider_name)
+    provider_overlay: dict | None = None
+    provider_overlays: list[dict] | None = None
+    provider_name_for_state: str | None = None
+
+    def _build_overlay(provider_name: str) -> dict:
+        provider_record = _provider_storage.get_provider(provider_name)
         if provider_record is None:
             raise LifecycleError(
                 f"attached provider '{provider_name}' not registered. "
                 f"Run 'clawctl provider registry get' to list available providers."
             )
-        # Shape mirrors the legacy `_sync_provider_config` builder
-        # (src/clawrium/cli/agent.py:360-374) so configure_agent's
-        # validation block (~lines 1266-1296) accepts the dict unchanged.
-        provider_overlay = {
+        overlay = {
             "name": provider_record.get("name", ""),
             "type": provider_record.get("type", "ollama"),
             "endpoint": provider_record.get("endpoint", ""),
@@ -986,9 +988,55 @@ def sync_agent(
         # are meaningful (no-limit signals on some APIs); a falsy check
         # would silently drop them. ATX iter-1 S1.
         if provider_record.get("context_window") is not None:
-            provider_overlay["context_window"] = provider_record["context_window"]
+            overlay["context_window"] = provider_record["context_window"]
         if provider_record.get("max_tokens") is not None:
-            provider_overlay["max_tokens"] = provider_record["max_tokens"]
+            overlay["max_tokens"] = provider_record["max_tokens"]
+        return overlay
+
+    if attachments and _pa.supports_multi_provider(agent_type):
+        # Hermes path: build a config.providers list (one overlay per
+        # attachment, carrying role + per-attachment model) and also
+        # populate config.provider from the primary so the bridge
+        # contract with downstream readers (templates, validators) is
+        # preserved unchanged for back-compat. Phase 1 wires the data
+        # model; template rewrites land in Phase 3.
+        provider_overlays = []
+        for entry in attachments:
+            # ATX W5: validate() above guarantees every hermes entry is
+            # a dict — but if normalize() ever regresses, silently
+            # skipping non-dicts would leave the agent with no primary,
+            # no state-machine walk, and a config rendered with empty
+            # provider fields that Ansible would happily push. Fail loud.
+            if not isinstance(entry, dict):
+                raise LifecycleError(
+                    f"agent '{agent_key}' has non-dict provider attachment "
+                    f"after normalization: {entry!r}. Inspect with "
+                    f"'clawctl agent provider get --agent {agent_key}'."
+                )
+            overlay = _build_overlay(entry["name"])
+            overlay["role"] = entry.get("role", "")
+            # Per-attachment model override; falls back to provider's
+            # default_model when the attachment didn't specify one.
+            # Always set `model` explicitly so template authors can
+            # read a single field regardless of whether the operator
+            # supplied an override.
+            attachment_model = entry.get("model") or overlay.get("default_model", "")
+            overlay["model"] = attachment_model
+            provider_overlays.append(overlay)
+            if entry.get("role") == _pa.PRIMARY_ROLE:
+                provider_overlay = {
+                    k: v for k, v in overlay.items() if k not in ("role",)
+                }
+                provider_name_for_state = entry["name"]
+    elif attachments:
+        # Singleton path (zeroclaw/openclaw). normalize() guarantees
+        # list-of-strings shape here; validate() guarantees len<=1.
+        provider_name = attachments[0]
+        if not isinstance(provider_name, str):
+            raise LifecycleError(
+                f"agent '{agent_key}' provider attachment shape unexpected"
+            )
+        provider_overlay = _build_overlay(provider_name)
         provider_name_for_state = provider_name
 
     onboarding = claw_record.get("onboarding", {})
@@ -1137,6 +1185,22 @@ def sync_agent(
     if provider_overlay is not None:
         existing_config = dict(existing_config)
         existing_config["provider"] = provider_overlay
+    if provider_overlays is not None:
+        # Issue #501: hermes-only multi-provider overlay. Carries
+        # per-attachment role + model so the configure playbook can
+        # render `auxiliary.<slot>` in hermes-config.yaml.j2 (Phase 3).
+        # `config.provider` stays populated above from the primary so
+        # existing readers continue to function unchanged in Phase 1.
+        #
+        # TODO(#501 Phase 3): when hermes-config.yaml.j2 renders
+        # `auxiliary.<slot>` per non-primary attachment, configure_agent
+        # must also hydrate per-attachment API keys into ansible_vars.
+        # Today only the primary's `provider_api_key` is loaded
+        # (lifecycle.py configure path), so every auxiliary slot would
+        # render with an empty key. Block the Phase 3 template work on
+        # this hydration to avoid a silent misconfigure at first use.
+        existing_config = dict(existing_config)
+        existing_config["providers"] = provider_overlays
 
     if not existing_config:
         # install.py always writes config.gateway, so this branch

--- a/src/clawrium/core/provider_attachments.py
+++ b/src/clawrium/core/provider_attachments.py
@@ -1,0 +1,199 @@
+"""Provider-attachment data model for agents.
+
+Centralizes the shape of `agent.providers` across agent types. For
+hermes (issue #501), an attachment is a dict `{name, role, model}`
+where `role` is `primary` or one of nine upstream auxiliary slots.
+For zeroclaw and openclaw, attachments stay as bare provider-name
+strings (singleton invariant preserved).
+
+Storage may carry either the legacy list-of-strings shape or the new
+list-of-objects shape; `normalize()` returns the canonical form for
+the agent type. Validation enforces the per-agent invariants. Callers
+should normalize before reading and validate before writing.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+__all__ = [
+    "HERMES_AGENT_TYPE",
+    "PRIMARY_ROLE",
+    "AUXILIARY_SLOTS",
+    "VALID_ROLES",
+    "AttachmentError",
+    "supports_multi_provider",
+    "normalize",
+    "validate",
+    "get_primary",
+    "get_auxiliary",
+]
+
+
+HERMES_AGENT_TYPE = "hermes"
+PRIMARY_ROLE = "primary"
+
+# Upstream auxiliary slots from NousResearch/hermes-agent
+# hermes_cli/config.py:716-794 (v2026.5.7). Order is not significant
+# at the data layer but kept deterministic for predictable rendering.
+AUXILIARY_SLOTS: tuple[str, ...] = (
+    "vision",
+    "web_extract",
+    "compression",
+    "session_search",
+    "skills_hub",
+    "approval",
+    "mcp",
+    "title_generation",
+    "curator",
+)
+
+VALID_ROLES: frozenset[str] = frozenset((PRIMARY_ROLE, *AUXILIARY_SLOTS))
+
+
+class AttachmentError(ValueError):
+    """Raised when provider attachments violate per-agent invariants."""
+
+
+def supports_multi_provider(agent_type: str | None) -> bool:
+    """Return True iff the agent type allows multiple provider attachments."""
+    return agent_type == HERMES_AGENT_TYPE
+
+
+def normalize(
+    raw: object, agent_type: str | None
+) -> list[dict] | list[str]:
+    """Return the canonical attachment list for an agent type.
+
+    For hermes: returns list of `{name, role, model}` dicts. Legacy
+    list-of-strings input is migrated forward (first string becomes
+    `role=primary`, additional strings get no role and will fail
+    validation — but that branch only fires on hand-edited records;
+    the live `attach` surface enforces singleton today).
+
+    For other agent types: returns list of provider-name strings.
+    Object-shape entries are reduced back to their `name` field so
+    a downgrade direction stays representable for non-hermes paths.
+
+    Non-list / falsy input returns an empty list.
+    """
+    if not isinstance(raw, list):
+        return []
+
+    if supports_multi_provider(agent_type):
+        out: list[dict] = []
+        primary_assigned = False
+        for entry in raw:
+            if isinstance(entry, str):
+                role = PRIMARY_ROLE if not primary_assigned else ""
+                if role == PRIMARY_ROLE:
+                    primary_assigned = True
+                out.append({"name": entry, "role": role, "model": ""})
+            elif isinstance(entry, dict) and isinstance(entry.get("name"), str):
+                role = entry.get("role", "")
+                if not isinstance(role, str):
+                    role = ""
+                if role == PRIMARY_ROLE:
+                    primary_assigned = True
+                model = entry.get("model", "")
+                if not isinstance(model, str):
+                    model = ""
+                out.append({"name": entry["name"], "role": role, "model": model})
+        return out
+
+    # Singleton / list-of-strings agent types.
+    out_str: list[str] = []
+    for entry in raw:
+        if isinstance(entry, str):
+            out_str.append(entry)
+        elif isinstance(entry, dict) and isinstance(entry.get("name"), str):
+            out_str.append(entry["name"])
+    return out_str
+
+
+def validate(attachments: Iterable[object], agent_type: str | None) -> None:
+    """Enforce per-agent invariants on a normalized attachment list.
+
+    For hermes:
+      - every entry has a non-empty `name`
+      - every entry's `role` is in VALID_ROLES (empty role rejected)
+      - exactly one entry has `role == primary` (when the list is non-empty)
+      - auxiliary roles are unique across the list
+
+    For other agent types:
+      - at most one attachment (existing singleton invariant)
+    """
+    items = list(attachments)
+
+    if not supports_multi_provider(agent_type):
+        if len(items) > 1:
+            # Phrase "single-provider invariant" pinned for back-compat:
+            # the openclaw/zeroclaw error message used to be raised
+            # directly from lifecycle.py with this exact phrase, and
+            # tests + docs reference it.
+            raise AttachmentError(
+                f"agent type '{agent_type}' has {len(items)} providers attached; "
+                f"single-provider invariant requires exactly one"
+            )
+        return
+
+    if not items:
+        return
+
+    primary_count = 0
+    seen_aux: set[str] = set()
+    for entry in items:
+        if not isinstance(entry, dict):
+            raise AttachmentError(
+                f"hermes provider attachment must be an object, got {type(entry).__name__}"
+            )
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            raise AttachmentError("hermes provider attachment requires non-empty 'name'")
+        role = entry.get("role")
+        if role not in VALID_ROLES:
+            raise AttachmentError(
+                f"hermes provider attachment {name!r} has invalid role {role!r}; "
+                f"expected one of {sorted(VALID_ROLES)}"
+            )
+        if role == PRIMARY_ROLE:
+            primary_count += 1
+        else:
+            if role in seen_aux:
+                raise AttachmentError(
+                    f"hermes auxiliary slot {role!r} already filled; "
+                    f"each slot accepts one provider"
+                )
+            seen_aux.add(role)
+
+    if primary_count != 1:
+        raise AttachmentError(
+            f"hermes requires exactly one primary provider, found {primary_count}"
+        )
+
+
+def get_primary(attachments: Iterable[object]) -> dict | None:
+    """Return the primary attachment dict for hermes, or None.
+
+    Accepts a normalized hermes attachment list (list of dicts). For
+    other shapes (list of strings) returns None — non-hermes agents
+    have no notion of "primary" beyond the singleton itself.
+    """
+    for entry in attachments:
+        if isinstance(entry, dict) and entry.get("role") == PRIMARY_ROLE:
+            return entry
+    return None
+
+
+def get_auxiliary(attachments: Iterable[object]) -> list[dict]:
+    """Return all non-primary hermes attachments in input order."""
+    out: list[dict] = []
+    for entry in attachments:
+        if (
+            isinstance(entry, dict)
+            and isinstance(entry.get("role"), str)
+            and entry.get("role")
+            and entry["role"] != PRIMARY_ROLE
+        ):
+            out.append(entry)
+    return out

--- a/tests/cli/clawctl/agent/test_sync_hermes_multi_provider.py
+++ b/tests/cli/clawctl/agent/test_sync_hermes_multi_provider.py
@@ -1,0 +1,198 @@
+"""Issue #501 — sync_agent for hermes builds `config.providers` from
+multi-provider attachments and still populates `config.provider` from
+the primary for back-compat with downstream readers.
+
+Mirrors the structure of test_sync_materializes_provider.py but
+targets the hermes-only branch added in Phase 1.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from clawrium.core.lifecycle import LifecycleError, sync_agent
+
+
+def _hermes_host(*, attachments: list, state: str = "ready") -> dict:
+    return {
+        "hostname": "192.168.1.100",
+        "key_id": "test",
+        "agent_name": "xclm",
+        "port": 22,
+        "agents": {
+            "test-hermes": {
+                "type": "hermes",
+                "onboarding": {"state": state},
+                "config": {"gateway": {"port": 45000}},
+                "providers": attachments,
+            }
+        },
+    }
+
+
+def _provider_record(name: str, ptype: str = "anthropic") -> dict:
+    return {
+        "name": name,
+        "type": ptype,
+        "endpoint": f"https://api.{ptype}.example",
+        "default_model": f"{ptype}-default-model",
+    }
+
+
+def test_hermes_multi_attachment_builds_providers_list_and_primary_overlay():
+    """Hermes with primary + auxiliary attachments: bridge materializes
+    `config.providers` (one overlay per attachment with role) and
+    `config.provider` (the primary overlay, role-stripped) so
+    Phase-1 readers keep working unchanged."""
+    host = _hermes_host(
+        attachments=[
+            {"name": "anth", "role": "primary", "model": "claude-opus"},
+            {"name": "dgx", "role": "compression", "model": "qwen-coder"},
+        ]
+    )
+
+    by_name = {
+        "anth": _provider_record("anth", "anthropic"),
+        "dgx": _provider_record("dgx", "ollama"),
+    }
+
+    captured: dict = {}
+
+    def fake_configure(hostname, claw_name, config_data, **kwargs):
+        captured["config_data"] = config_data
+        return (True, None)
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch(
+            "clawrium.core.providers.storage.get_provider",
+            side_effect=lambda n: by_name.get(n),
+        ),
+        patch("clawrium.core.onboarding.complete_stage", return_value=True),
+        patch("clawrium.core.onboarding.transition_state", return_value=True),
+        patch("clawrium.core.onboarding.can_skip_stage", return_value=True),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "hermes")
+
+    assert result["success"] is True
+    cfg = captured["config_data"]
+
+    # config.provider mirrors primary, with no `role` field leaked.
+    primary = cfg["provider"]
+    assert primary["name"] == "anth"
+    assert primary["type"] == "anthropic"
+    assert "role" not in primary
+
+    # config.providers carries both attachments, each with role + model.
+    providers = cfg["providers"]
+    assert isinstance(providers, list) and len(providers) == 2
+
+    primary_entry = next(p for p in providers if p["role"] == "primary")
+    aux_entry = next(p for p in providers if p["role"] == "compression")
+    assert primary_entry["name"] == "anth"
+    assert primary_entry["model"] == "claude-opus"
+    assert aux_entry["name"] == "dgx"
+    assert aux_entry["type"] == "ollama"
+    assert aux_entry["model"] == "qwen-coder"
+
+
+def test_hermes_legacy_list_of_strings_migrates_to_primary():
+    """A hermes agent record predating #501 stores providers as a
+    list of strings. The bridge must migrate first-string → primary
+    and emit a single-entry config.providers list."""
+    host = _hermes_host(attachments=["anth"])
+
+    captured: dict = {}
+
+    def fake_configure(hostname, claw_name, config_data, **kwargs):
+        captured["config_data"] = config_data
+        return (True, None)
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch(
+            "clawrium.core.providers.storage.get_provider",
+            return_value=_provider_record("anth", "anthropic"),
+        ),
+        patch("clawrium.core.onboarding.complete_stage", return_value=True),
+        patch("clawrium.core.onboarding.transition_state", return_value=True),
+        patch("clawrium.core.onboarding.can_skip_stage", return_value=True),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "hermes")
+
+    assert result["success"] is True
+    providers = captured["config_data"]["providers"]
+    assert len(providers) == 1
+    assert providers[0]["name"] == "anth"
+    assert providers[0]["role"] == "primary"
+
+
+def test_hermes_attachment_model_falls_back_to_provider_default():
+    """When the attachment has no `model` override, the rendered
+    overlay carries the provider's `default_model`."""
+    host = _hermes_host(
+        attachments=[{"name": "anth", "role": "primary", "model": ""}]
+    )
+
+    captured: dict = {}
+
+    def fake_configure(hostname, claw_name, config_data, **kwargs):
+        captured["config_data"] = config_data
+        return (True, None)
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch(
+            "clawrium.core.providers.storage.get_provider",
+            return_value=_provider_record("anth", "anthropic"),
+        ),
+        patch("clawrium.core.onboarding.complete_stage", return_value=True),
+        patch("clawrium.core.onboarding.transition_state", return_value=True),
+        patch("clawrium.core.onboarding.can_skip_stage", return_value=True),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "hermes")
+
+    assert result["success"] is True
+    providers = captured["config_data"]["providers"]
+    assert providers[0]["model"] == "anthropic-default-model"
+
+
+def test_hermes_invalid_attachment_state_raises_lifecycle_error():
+    """Hand-edited hosts.json with two primaries must fail loudly with
+    a LifecycleError pointing at the attach surface for remediation."""
+    host = _hermes_host(
+        attachments=[
+            {"name": "anth", "role": "primary", "model": ""},
+            {"name": "other", "role": "primary", "model": ""},
+        ]
+    )
+
+    with patch("clawrium.core.lifecycle.get_host", return_value=host):
+        with pytest.raises(LifecycleError) as exc_info:
+            sync_agent("192.168.1.100", "hermes")
+
+    msg = str(exc_info.value)
+    assert "invalid provider attachments" in msg
+    assert "exactly one primary" in msg
+    assert "clawctl agent provider get" in msg
+
+
+def test_hermes_duplicate_auxiliary_slot_rejected():
+    host = _hermes_host(
+        attachments=[
+            {"name": "anth", "role": "primary", "model": ""},
+            {"name": "a", "role": "compression", "model": ""},
+            {"name": "b", "role": "compression", "model": ""},
+        ]
+    )
+
+    with patch("clawrium.core.lifecycle.get_host", return_value=host):
+        with pytest.raises(LifecycleError) as exc_info:
+            sync_agent("192.168.1.100", "hermes")
+
+    assert "already filled" in str(exc_info.value)

--- a/tests/core/test_provider_attachments.py
+++ b/tests/core/test_provider_attachments.py
@@ -1,0 +1,202 @@
+"""Unit tests for the provider-attachment data model (issue #501).
+
+Covers normalization between the legacy list-of-strings shape and the
+new list-of-objects shape, plus per-agent-type invariant validation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clawrium.core import provider_attachments as pa
+
+
+class TestSupportsMultiProvider:
+    def test_hermes_supports_multi(self):
+        assert pa.supports_multi_provider("hermes") is True
+
+    def test_singleton_agent_types(self):
+        assert pa.supports_multi_provider("openclaw") is False
+        assert pa.supports_multi_provider("zeroclaw") is False
+        assert pa.supports_multi_provider(None) is False
+
+
+class TestNormalizeHermes:
+    def test_empty_list_returns_empty(self):
+        assert pa.normalize([], "hermes") == []
+
+    def test_non_list_returns_empty(self):
+        assert pa.normalize(None, "hermes") == []
+        assert pa.normalize("not-a-list", "hermes") == []
+        assert pa.normalize({"name": "x"}, "hermes") == []
+
+    def test_legacy_strings_migrate_first_as_primary(self):
+        out = pa.normalize(["my-anth"], "hermes")
+        assert out == [{"name": "my-anth", "role": "primary", "model": ""}]
+
+    def test_legacy_strings_additional_have_empty_role(self):
+        # Multi-string legacy shape only arises from hand-edited hosts.json.
+        # First string becomes primary; the rest land with empty role and
+        # will fail validate(), surfacing the bad state to the operator.
+        out = pa.normalize(["a", "b"], "hermes")
+        assert out[0] == {"name": "a", "role": "primary", "model": ""}
+        assert out[1] == {"name": "b", "role": "", "model": ""}
+
+    def test_object_shape_preserved(self):
+        raw = [
+            {"name": "anth", "role": "primary", "model": "claude-opus"},
+            {"name": "dgx", "role": "compression", "model": "qwen"},
+        ]
+        assert pa.normalize(raw, "hermes") == raw
+
+    def test_object_missing_fields_default_to_empty(self):
+        raw = [{"name": "anth"}]
+        out = pa.normalize(raw, "hermes")
+        assert out == [{"name": "anth", "role": "", "model": ""}]
+
+    def test_object_without_name_dropped(self):
+        raw = [{"role": "primary"}, {"name": "ok", "role": "primary"}]
+        out = pa.normalize(raw, "hermes")
+        assert out == [{"name": "ok", "role": "primary", "model": ""}]
+
+
+class TestNormalizeSingleton:
+    def test_strings_passthrough(self):
+        assert pa.normalize(["p1"], "openclaw") == ["p1"]
+        assert pa.normalize(["p1"], "zeroclaw") == ["p1"]
+
+    def test_objects_downgrade_to_names(self):
+        raw = [{"name": "p1", "role": "primary", "model": "x"}]
+        assert pa.normalize(raw, "openclaw") == ["p1"]
+
+    def test_non_list_returns_empty(self):
+        assert pa.normalize(None, "openclaw") == []
+
+
+class TestValidateHermes:
+    def test_empty_ok(self):
+        pa.validate([], "hermes")
+
+    def test_exactly_one_primary_ok(self):
+        pa.validate(
+            [{"name": "a", "role": "primary", "model": ""}],
+            "hermes",
+        )
+
+    def test_primary_plus_auxiliary_ok(self):
+        pa.validate(
+            [
+                {"name": "a", "role": "primary", "model": ""},
+                {"name": "b", "role": "compression", "model": ""},
+                {"name": "c", "role": "vision", "model": ""},
+            ],
+            "hermes",
+        )
+
+    def test_missing_primary_rejected(self):
+        with pytest.raises(pa.AttachmentError, match="exactly one primary"):
+            pa.validate(
+                [{"name": "a", "role": "compression", "model": ""}],
+                "hermes",
+            )
+
+    def test_two_primaries_rejected(self):
+        with pytest.raises(pa.AttachmentError, match="exactly one primary"):
+            pa.validate(
+                [
+                    {"name": "a", "role": "primary", "model": ""},
+                    {"name": "b", "role": "primary", "model": ""},
+                ],
+                "hermes",
+            )
+
+    def test_duplicate_auxiliary_slot_rejected(self):
+        with pytest.raises(pa.AttachmentError, match="already filled"):
+            pa.validate(
+                [
+                    {"name": "a", "role": "primary", "model": ""},
+                    {"name": "b", "role": "compression", "model": ""},
+                    {"name": "c", "role": "compression", "model": ""},
+                ],
+                "hermes",
+            )
+
+    def test_invalid_role_rejected(self):
+        with pytest.raises(pa.AttachmentError, match="invalid role"):
+            pa.validate(
+                [{"name": "a", "role": "bogus", "model": ""}],
+                "hermes",
+            )
+
+    def test_empty_role_rejected(self):
+        with pytest.raises(pa.AttachmentError, match="invalid role"):
+            pa.validate(
+                [{"name": "a", "role": "", "model": ""}],
+                "hermes",
+            )
+
+    def test_empty_name_rejected(self):
+        with pytest.raises(pa.AttachmentError, match="non-empty 'name'"):
+            pa.validate(
+                [{"name": "", "role": "primary", "model": ""}],
+                "hermes",
+            )
+
+    def test_non_dict_entry_rejected(self):
+        with pytest.raises(pa.AttachmentError, match="must be an object"):
+            pa.validate(["just-a-string"], "hermes")
+
+
+class TestValidateSingleton:
+    def test_empty_ok(self):
+        pa.validate([], "openclaw")
+
+    def test_one_attachment_ok(self):
+        pa.validate(["p1"], "openclaw")
+
+    def test_two_attachments_rejected(self):
+        with pytest.raises(pa.AttachmentError, match="single-provider invariant"):
+            pa.validate(["a", "b"], "zeroclaw")
+
+
+class TestPrimaryAccessors:
+    def test_get_primary_returns_entry(self):
+        items = [
+            {"name": "a", "role": "primary", "model": "m"},
+            {"name": "b", "role": "compression", "model": ""},
+        ]
+        assert pa.get_primary(items) == items[0]
+
+    def test_get_primary_none_when_absent(self):
+        assert pa.get_primary([]) is None
+        assert pa.get_primary([{"name": "x", "role": "compression"}]) is None
+
+    def test_get_auxiliary_returns_non_primary(self):
+        items = [
+            {"name": "a", "role": "primary", "model": ""},
+            {"name": "b", "role": "compression", "model": ""},
+            {"name": "c", "role": "vision", "model": ""},
+        ]
+        aux = pa.get_auxiliary(items)
+        assert [e["name"] for e in aux] == ["b", "c"]
+
+    def test_get_auxiliary_skips_empty_role(self):
+        items = [{"name": "x", "role": "", "model": ""}]
+        assert pa.get_auxiliary(items) == []
+
+
+class TestSlotEnumeration:
+    def test_nine_upstream_slots(self):
+        # Locked against hermes v2026.5.7 hermes_cli/config.py:716-794.
+        # If upstream adds a slot, this test should fail loudly so the
+        # contract is re-verified explicitly.
+        assert len(pa.AUXILIARY_SLOTS) == 9
+        assert "compression" in pa.AUXILIARY_SLOTS
+        assert "title_generation" in pa.AUXILIARY_SLOTS
+        assert "curator" in pa.AUXILIARY_SLOTS
+
+    def test_valid_roles_includes_primary_and_all_slots(self):
+        assert pa.PRIMARY_ROLE in pa.VALID_ROLES
+        for slot in pa.AUXILIARY_SLOTS:
+            assert slot in pa.VALID_ROLES
+        assert len(pa.VALID_ROLES) == 10


### PR DESCRIPTION
## Summary

Phase 1 of issue #501. Lays the schema + lifecycle-bridge foundation
for hermes multi-provider attachments (primary + 9 upstream auxiliary
slots) while preserving the singleton invariant for zeroclaw/openclaw.

- New `core/provider_attachments.py` module — canonical normalization
  between legacy list-of-strings and the new list-of-objects shape,
  per-agent invariant validation, primary/auxiliary accessors. Slot
  list pinned against hermes `v2026.5.7` `hermes_cli/config.py:716-794`.
- `core/lifecycle.py` sync bridge now branches by agent type. Hermes
  builds `config.providers` (one overlay per attachment, with role +
  per-attachment model) and still populates `config.provider` from
  the primary for back-compat with downstream readers. Legacy
  list-of-strings records on disk migrate forward transparently.
- Singleton path for non-hermes agents is preserved; the
  "single-provider invariant" error phrase is kept verbatim so
  existing operator muscle-memory and tests continue to match.
- Tests: 31 unit tests for `provider_attachments`, plus 5 hermes-
  specific bridge tests covering legacy migration, multi-attachment
  overlay shape, model fallback, and validation rejection paths.

This is intentionally a thin foundational PR. Phases 2 (CLI surface),
3 (template rewrites + auxiliary API-key hydration), 4 (configure UX),
and 5 (DGX end-to-end + docs) are tracked in
`.itx/501/00_PLAN.md` and each lands as its own PR.

## ATX Review Summary

**Final Review: Rating 3/5 (one iteration; no blockers)**
**Total Cost: $2.10 | Total Time: 8m 24s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3/5 | None | Ready (W5, W6, S2, S3 in-diff items addressed; W1–W4 are pre-existing) | $2.10 | 8m24s | leader, security-reviewer, core-lifecycle-reviewer |

<details>
<summary>Review 1 details</summary>

**Blocking issues:** none.

**Warnings:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `lifecycle.py:1732` | `resolved_type` lacks an allowlist, allowing path traversal if `hosts.json` is hand-edited | Out-of-scope — pre-existing, not introduced by this diff. Suggest filing a dedicated security follow-up. |
| W2 | `lifecycle.py:1784` | `ansible_vars.update(extra_vars)` can silently overwrite security-sensitive keys | Out-of-scope — pre-existing, not introduced by this diff. |
| W3 | `cli/agent.py` | `on_event` message printed without `rich_escape()` | Out-of-scope — pre-existing in cli/agent.py, not in this PR's diff. |
| W4 | `lifecycle.py:94-103` | `gateway_token_rotated` payload contains token prefixes | Out-of-scope — pre-existing event-payload shape, not in this PR's diff. |
| W5 | `lifecycle.py:1006` | Silent skip of non-dict entries inside the hermes attachment loop could mask a `normalize()` regression | **Fixed** — replaced `continue` with an explicit `LifecycleError` that points at `clawctl agent provider get`. |
| W6 | `lifecycle.py:1617-1633` | When Phase 3 lands, every auxiliary slot would silently render with an empty API key because `configure_agent` only hydrates the primary's key | **Acknowledged** — added a `TODO(#501 Phase 3)` comment at the provider_overlays write site so the dependency is impossible to miss when the template rewrite lands. |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Validate SSH port at host level | Out-of-scope — pre-existing host-record concern. |
| S2 | Remove unreachable `isinstance(existing_config, dict)` guard | **Fixed.** |
| S3 | Move deferred `provider_attachments` + `providers.storage` imports to module top | **Fixed.** Imports are now top-level (module-bound), and the storage module is imported as `_provider_storage` so existing `patch("clawrium.core.providers.storage.get_provider", ...)` tests continue to work without modification. |
| S4 | `hermes/playbooks/configure.yaml` `/health` task lacks `no_log: true` | Out-of-scope — playbook hygiene parity item, not in this PR's diff. |
| S5 | Two Ansible `command:` strings should be `argv:` | Out-of-scope — pre-existing, not in this PR's diff. |

</details>

## Testing

- [x] All existing tests pass (`make test`) — 3237 passed, 6 skipped
- [x] Linter passes (`make lint-py`) — clean
- [x] New tests added — 31 unit + 5 integration

### Test Coverage

- Files changed: `src/clawrium/core/lifecycle.py`, `src/clawrium/core/provider_attachments.py` (new)
- New tests: `tests/core/test_provider_attachments.py` (31 cases), `tests/cli/clawctl/agent/test_sync_hermes_multi_provider.py` (5 cases)
- Coverage impact: increased on lifecycle.py and the new module

### Manual Testing

**Live agent E2E run — passed.** Validated the bridge contract against
a real hermes v2026.5.7 instance (`espresso` on wolf-i):

1. Backed up `~/.config/clawrium/hosts.json`.
2. Hand-edited `espresso`'s `agent.providers` from the legacy
   `["local-inx"]` to the new object shape
   `[{"name": "local-inx", "role": "primary", "model": ""}]`.
3. Ran `clawctl agent sync espresso` from this branch.

Result: sync succeeded in 25s, `drift=0`, gateway re-paired, health
verified, agent stayed `ready`:

```
agent/espresso: validating local state ...
agent/espresso: pushing config (provider, skills, channels, env) ...
agent/espresso: restarting unit ...
agent/espresso: re-pairing gateway ...
agent/espresso: verifying health ...
agent/espresso: synced  (drift=0, took 25s)
```

Post-sync `hosts.json` shape on the agent record matched the Phase 1
contract exactly:

- `agent.providers` → preserved in the new object shape.
- `config.provider` → populated from the primary
  (`name=local-inx`, `type=ollama`, `default_model=qwen3-coder:30b-128k`,
  `model=qwen3-coder:30b-128k`). Back-compat contract for existing
  template readers upheld.
- `config.providers` → new list with `role: "primary"` and
  `model` populated from the provider's `default_model` (the
  attachment had `model: ""`, exercising the fallback path
  introduced in this PR).

**Not validated live (out of Phase 1 scope, deferred):** expressing an
auxiliary attachment through the CLI (Phase 2) and the hermes templates
actually rendering `auxiliary.<slot>` blocks (Phase 3). Phase 5 in the
plan covers the full primary+auxiliary E2E against a DGX-hosted ollama
once Phases 2–3 land.

### Security Checklist

- [x] No hardcoded secrets or credentials introduced
- [x] No new user-provided input paths added — Phase 1 only changes the
  internal data representation; the existing `attach` CLI gate is
  unchanged
- [x] No SQL injection, XSS, or command injection risks (Python module
  + tests only)
- [x] No new external dependencies

## Callouts

- [DECISION] PR scoped to Phase 1 only rather than executing all five
  phases in one PR.
  - Why: `.itx/501/00_PLAN.md` explicitly states "Five phases, one PR
    each. Phases 1–3 are independently mergeable; 4 depends on 1+3;
    5 closes the issue." Honoring that structure is the project standard.
  - Alternatives considered: a single mega-PR covering all five phases;
    rejected as it would defeat the plan's mergeability guarantees and
    make review intractable.
  - Reviewer: confirm or push back on the phasing approach.

- [DECISION] `config.providers` is added alongside `config.provider`
  rather than replacing it.
  - Why: existing template readers (`hermes-config.yaml.j2`,
    `hermes.env.j2`, validation in `configure_agent`) consume
    `config.provider`. Phase 3 will rewrite those templates to read
    `config.providers`; until then, keeping both populated preserves
    back-compat for any partial deployment.
  - Reviewer: confirm.

- [DECISION] `provider_attachments.normalize()` migrates a legacy
  hermes list-of-strings by making the **first** string `role=primary`
  and giving subsequent strings empty role (which then fails `validate()`).
  - Why: legacy hermes records on disk today have at most one provider
    (the existing `attach` enforces singleton across all agent types),
    so the first-string-becomes-primary path is the only one that fires
    in practice. The empty-role branch is a defensive landing-zone for
    hand-edited multi-string records, which surfaces via `validate()`
    with a clear "exactly one primary" error rather than silently
    promoting an arbitrary entry.
  - Reviewer: confirm.

- [DECISION] W1–W4 from ATX review marked out-of-scope rather than
  fixed in this PR.
  - Why: these are pre-existing concerns in code paths this PR does
    not touch (resolved_type allowlisting, extra_vars overwrite, Rich
    markup escaping in cli/agent.py, token-prefix event payload). Folding
    them in would expand the diff well beyond Phase 1 scope and conflate
    feature work with security cleanup.
  - Reviewer: suggest filing a dedicated security follow-up issue
    bundling W1–W4 (and S4–S5) for a separate PR.

- [TODO-FOLLOWUP] Phase 3 template rewrites must hydrate auxiliary
  provider API keys into `ansible_vars` before rendering
  `hermes-config.yaml.j2`.
  - Tracking: noted with an in-source `TODO(#501 Phase 3)` comment at
    `lifecycle.py` next to the `existing_config["providers"]` write,
    so the Phase 3 PR cannot miss it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

