### PR TITLE
fix(install): per-instance listener ports across all agent types (#533)

### DIFF
--- a/.itx/533/00_PLAN.md
+++ b/.itx/533/00_PLAN.md
@@ -1,0 +1,117 @@
+# Plan — Issue #533
+
+**Title**: Run any number of agents of any type on a host without port collisions
+**URL**: https://github.com/ric03uec/clawrium/issues/533
+**Labels**: type:bug, needs-triage
+
+## Overview
+
+Every per-agent network listener should pick its port the same way `hermes dashboard_port` already does in `install.py:574-615`: per-instance from a dedicated range, collision-checked against other agents on the host, preserved across reinstalls. Today three listeners exist; only one follows this pattern.
+
+| Listener | Current | Target |
+|---|---|---|
+| `hermes dashboard` | per-instance `45000+md5%2000`, collision walk, preserve | ✅ no change |
+| `hermes api_server` | literal `8642` everywhere | per-instance `8600+md5%100`, collision walk, preserve |
+| `openclaw / zeroclaw gateway` | `40000+md5%2000`, no collision check, no preserve | add collision walk + preserve; keep range |
+
+**Migration policy**: grandfather. On reinstall, if a port is already persisted in `hosts.json`, keep it. New installs get a freshly-picked port. Existing in-use agents (espresso, maurice, zeroclaw fleet) are not restarted.
+
+**Subtasks**: None — single task execution. The two listener families (hermes api_server, openclaw/zeroclaw gateway) share the same pattern and the same one helper.
+
+## Approach
+
+Extract a shared helper `_pick_per_instance_port(host, agent_name, base, span, port_field_path)` that:
+1. Reads the persisted port at `port_field_path` from the agent record (returns it if present — preservation).
+2. Otherwise computes a hash-based candidate (`base + md5(agent_name) % span`).
+3. Walks +1 (wrapping in `[base, base+span)`) past any port already in use by other agents on the host.
+4. Raises `InstallationError` with a clear message if all `span` slots are full.
+
+Apply it three places: hermes dashboard (refactor existing inline block), hermes api_server (new), openclaw/zeroclaw gateway (new). One helper, three callers, one canonical pattern.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `src/clawrium/core/install.py:563-615` | Extract `_pick_per_instance_port()` helper from the current dashboard-port block. Call it for: (a) openclaw/zeroclaw gateway (replaces `40000 + port_hash % 2000` at line 566, adds collision walk + preservation), (b) hermes dashboard (refactor existing into the helper), (c) hermes api_server (new, range `8600..8699`). |
+| `src/clawrium/core/install.py:674,1007` | Replace literal `"port": 8642` with the assigned `api_server_port`. |
+| `src/clawrium/core/lifecycle.py:1361-1375` | Replace literal `"port": 8642` (line 1371) in the legacy-shape reconstruction path. Read from `agent_record.config.api_server.port` if present; only fall back to assigning a new port (via the helper) if the field is missing — and persist that back. |
+| `src/clawrium/core/validation.py:887-1006` | `validate_hermes_health()` reads the port from the agent record. Update docstring example and the `curl -fsS http://127.0.0.1:<port>/health` line. |
+| `src/clawrium/core/chat_hermes.py:43` | Update docstring example URL (chat already reads the port from the agent record). |
+| `src/clawrium/platform/registry/hermes/templates/hermes.env.j2:43` | No change required (already uses `config.api_server.port \| default(8642)`). Optionally tighten the default to a sentinel that would obviously fail rather than the legacy literal. |
+| `src/clawrium/platform/registry/hermes/playbooks/configure.yaml:428,441-442` | No change required (already templatized). |
+| `src/clawrium/platform/registry/hermes/manifest.yaml:63,65,96,135` | Update onboarding `message:` strings and the `validate.command` curl probe — no longer reference "8642"; either templatize or use generic wording. |
+| `src/clawrium/platform/registry/openclaw/playbooks/install.yaml:145` | Replace `openclaw_port: "{{ 40000 + ((agent_name \| hash('md5') \| int(base=16)) % 2000) }}"` with `openclaw_port: "{{ config.gateway.port }}"`. `install.py` becomes the source of truth; the playbook reads from inventory vars (which `zeroclaw/configure.yaml:8` already does for `gateway_port`). |
+| `tests/test_install_ports.py` (new) | (1) Two hermes installs on same host → distinct api_server ports. (2) Reinstall preserves the api_server port. (3) Hash-colliding openclaw/zeroclaw names on same host → distinct gateway ports. (4) Port-pool exhaustion → `InstallationError` with helpful message. |
+| `tests/test_validation_hermes.py` (existing or new) | `validate_hermes_health()` builds the curl URL from the agent's persisted port, not 8642. |
+
+## Steps
+
+1. Extract `_pick_per_instance_port()` helper in `install.py`. Refactor the existing dashboard-port block to call it. **Run `make test`** — should be green (pure refactor, behavior unchanged).
+2. Apply helper to openclaw/zeroclaw gateway port assignment; persist `config.gateway.port` on first install + preserve on reinstall.
+3. Update `openclaw/playbooks/install.yaml:145` to read `config.gateway.port` from inventory instead of recomputing.
+4. **Run `make test`** — openclaw/zeroclaw paths still green.
+5. Apply helper to hermes `api_server` port (range `8600..8699`). Persist `config.api_server.port`.
+6. Update `install.py:674,1007` and `lifecycle.py:1371` to use the assigned port.
+7. Update `validation.py`, `chat_hermes.py` docstring, `manifest.yaml` messages.
+8. Add new tests in `tests/test_install_ports.py`. Update existing validation tests.
+9. **Run `make test` + `make lint`** — full green.
+10. Manual verification on `wolf-i`: delete the broken `clawctl-demo`, recreate, attach `dgx-spark`, sync, chat. Confirm a port other than 8642 is assigned and chat works while espresso is still on 8642.
+
+## Test Strategy
+
+- **Unit**: new `tests/test_install_ports.py` covering the helper directly + integration through install. ~80 LOC of tests.
+- **Validation**: extend `test_validation_hermes.py` to assert the templatized port appears in the rendered curl command.
+- **Manual end-to-end**: `clawctl-demo` on `wolf-i` becomes the live regression case. Demo recording (`/create-vhs`) is the downstream verification.
+- **Regression**: `make test` full suite + `make lint`.
+
+## Risks
+
+- **Legacy-shape reconstruction in `lifecycle.py:1371`** — hit only on corrupt/legacy `hosts.json`. Decision: if no port persisted, assign one via the helper and persist back so subsequent runs are stable. Document in the comment.
+- **Manifest `validate.command:135`** — `curl -fsS http://0.0.0.0:8642/health` runs during install validation. Options: templatize via Ansible vars at validate time, or drop the literal port check in favor of the configure-time health probe (which is already templatized). Lean toward templatize since the manifest already supports Jinja in some fields.
+- **Playbook coupling** — `openclaw/install.yaml:145` currently recomputes the port from `agent_name`. After this PR, `install.py` is the source of truth. Safe because clawctl re-syncs the playbook on each install; no cached-playbook-on-remote concern.
+- **Existing in-use agents** — espresso/maurice stay on 8642 (grandfathered). Two hermes on the same host today would already be broken; users hitting that need to delete + reinstall the conflicting agent. PR description must call this out.
+
+## ATX Review
+
+`mcp.review_enabled: true` per `.claude/itx-config.json` — request review via `mcp__atx__request_review` before commit. Iterate until rating > 3/5 with no blocking issues. Expected review topics: port-range choice (8600..8699 — only 100 slots, vs dashboard's 2000), helper signature, manifest-validate templating choice, migration documentation.
+
+## Estimated Size
+
+~120 LOC implementation + ~120 LOC tests across 8 files. Complexity:S.
+
+---
+
+## Prompt Log
+
+### Bug Creation
+
+**Stage**: bug-creation
+**Skill**: /itx:bug-new
+**Timestamp**: 2026-05-26T05:50:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+hermes api_server port is hardcoded to 8642 in install.py/lifecycle.py/validation.py/templates,
+causing TCP bind collisions when running multiple hermes instances on the same host.
+Discovered while recording a demo: clawctl-demo on wolf-i (host already running espresso on 8642)
+ended up with chat returning "Authentication failed: Hermes rejected Bearer ***" because SSH
+tunnel to wolf-i:8642 hits espresso's daemon, which rejects clawctl-demo's bearer.
+
+User clarification: each agent of any type needs to have a randomly selected port — scope
+broadened beyond hermes to cover openclaw/zeroclaw gateway port too.
+```
+
+**Output**: GitHub issue #533.
+
+### Planning
+
+**Stage**: planning
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-05-26T06:05:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-plan-create 533
+```
+
+**Output**: this plan; no subtasks (single-task execution); label transition to `planned`.

--- a/.itx/533/01_EXECUTION.md
+++ b/.itx/533/01_EXECUTION.md
@@ -1,0 +1,24 @@
+# Execution — Issue #533
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx-execute
+**Timestamp**: 2026-05-26T06:50:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 533
+
+Context: plan at .itx/533/00_PLAN.md. Single task. Grandfather migration —
+existing installs keep their current port. ATX via `atx` CLI (up to 3 rounds).
+Live verification on wolf-i (hermes/openclaw/zeroclaw). PR base main.
+```
+
+**Output**: implementation across `install.py`, `lifecycle.py`, `validation.py`,
+`chat_hermes.py`, hermes/openclaw manifests + playbooks + tests. ATX 3 rounds
+(rating 3 → 3 → 3-4, no remaining blockers). Live verification on wolf-i:
+clawctl-demo (hermes) got api_server.port=8691 (was colliding on 8642 against
+espresso); espresso preserved at 8642; chat session succeeded. port-test-oc
+(openclaw) and port-test-zc (zeroclaw) installed cleanly with picked gateway
+ports in 40000..41999.

--- a/.itx/533/atx-session.json
+++ b/.itx/533/atx-session.json
@@ -1,0 +1,18 @@
+{
+  "session_id": "000a86db-a082-47e7-8426-ffa1800a193b",
+  "transport": "cli",
+  "commit_sha": "",
+  "iteration": 3,
+  "last_rating": 4,
+  "last_blockers": [],
+  "remaining_warnings": [
+    "W-SEC-3: _safe_host_display() parity in install.py (deferred — alias validation at CLI blocks normal-path exploitation)",
+    "api_server.host 0.0.0.0 vs 127.0.0.1 mismatch (pre-existing, configure migration fixes it)",
+    "validate_hermes_health port range 1..65535 vs 8600..8699 (defensive only; range tightening = follow-up)",
+    "npm install ws idempotency (pre-existing)",
+    "openclaw_port undefined default (acceptable: config.gateway.port is always populated by install.py post-#533)",
+    "W8 configure-layer 'gateway not in config' assertion (helper guard already covers it; install-layer test sufficient)"
+  ],
+  "started_at": "2026-05-26T06:03:47Z",
+  "updated_at": "2026-05-26T06:50:00Z"
+}

--- a/src/clawrium/core/chat_hermes.py
+++ b/src/clawrium/core/chat_hermes.py
@@ -40,7 +40,8 @@ class HermesOpenAIBackend:
     """OpenAI-compatible HTTP chat client for hermes.
 
     `base_url` is the gateway origin including the `/v1` suffix
-    (e.g. `http://wolf-i.local:8642/v1`). The backend appends
+    (e.g. `http://wolf-i.local:8612/v1`; the port is per-instance, picked at
+    install time from 8600..8699 per issue #533). The backend appends
     `/chat/completions` for each request.
 
     `model` is forwarded as the OpenAI `model` field. Hermes ignores it for

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -73,6 +73,64 @@ class InstallationError(Exception):
     pass
 
 
+def _pick_per_instance_port(
+    host: dict,
+    agent_name: str,
+    base: int,
+    span: int,
+    port_field_path: tuple[str, ...],
+    preserved_port: int | None = None,
+) -> int:
+    """Pick a unique listener port for `agent_name` in `[base, base+span)`.
+
+    Issue #533: every per-agent listener (hermes dashboard, hermes api_server,
+    openclaw/zeroclaw gateway) picks its port the same way — hash the agent
+    name into the allocation window, walk +1 (wrapping) past collisions with
+    other agents on the same host, and preserve the port across reinstalls
+    via `preserved_port`.
+
+    `port_field_path` is the nested-key path under `host["agents"][<name>]
+    ["config"]` where each peer agent's port lives (e.g. `("gateway", "port")`
+    or `("api_server", "port")`). The helper reads each peer's port from that
+    path to build the collision set.
+    """
+    if (
+        isinstance(preserved_port, int)
+        and not isinstance(preserved_port, bool)
+        and base <= preserved_port < base + span
+    ):
+        return preserved_port
+
+    port_hash = int(hashlib.md5(agent_name.encode()).hexdigest(), 16)
+    candidate = base + (port_hash % span)
+
+    used_ports: set[int] = set()
+    for other_key, other_agent in host.get("agents", {}).items():
+        if other_key == agent_name or not isinstance(other_agent, dict):
+            continue
+        node: object = other_agent.get("config", {})
+        for segment in port_field_path:
+            if not isinstance(node, dict):
+                node = None
+                break
+            node = node.get(segment)
+        if isinstance(node, int) and not isinstance(node, bool):
+            used_ports.add(node)
+
+    for _ in range(span):
+        if candidate not in used_ports:
+            return candidate
+        candidate += 1
+        if candidate >= base + span:
+            candidate = base
+
+    raise InstallationError(
+        f"Port pool exhausted on {host['hostname']}: all {span} slots in "
+        f"{base}-{base + span - 1} are occupied. "
+        "Remove unused agents before installing another."
+    )
+
+
 class IncompleteInstallationError(InstallationError):
     """Raised when an incomplete installation already exists for an agent type."""
 
@@ -381,11 +439,22 @@ def run_installation(
     # has nothing to write back — without this capture the credentials would
     # silently disappear on every clean re-install at the same version.
     preserved_gateway = [None]
-    # Capture hermes dashboard port BEFORE set_installing() wipes the agent
-    # record. Re-install must not silently move the dashboard to a new port —
-    # the systemd unit was rendered against the original value and any open
-    # tunnels would break.
+    # Capture per-instance listener ports BEFORE set_installing() wipes the
+    # agent record (issue #533). Re-install must not silently move a listener
+    # to a new port — the systemd unit, any rendered config, and any open
+    # tunnels were all wired to the original value.
     preserved_dashboard_port = [None]
+    preserved_api_server_port = [None]
+    preserved_gateway_port = [None]
+    # Ports actually picked inside the set_installing lock (ATX iter-1 W2/W3).
+    # Computing them inside the updater closure ensures concurrent installs on
+    # the same host serialize through `_hosts_lock()` — without this, two
+    # parallel `clm agent install` could read the same empty `used_ports` set
+    # and both pick the same slot. The picks are also written onto the
+    # in-progress agent record so a third install sees them.
+    chosen_dashboard_port = [None]
+    chosen_api_server_port = [None]
+    chosen_gateway_port = [None]
 
     def set_installing(h: dict) -> dict:
         # Check for incomplete installation under lock (unless cleanup or resume)
@@ -447,6 +516,18 @@ def run_installation(
                 preserved_gateway[0] = (
                     h["agents"][chosen_name[0]].get("config", {}).get("gateway")
                 )
+                existing_gw_port = (
+                    h["agents"][chosen_name[0]]
+                    .get("config", {})
+                    .get("gateway", {})
+                    .get("port")
+                )
+                if (
+                    isinstance(existing_gw_port, int)
+                    and not isinstance(existing_gw_port, bool)
+                    and 40000 <= existing_gw_port <= 41999
+                ):
+                    preserved_gateway_port[0] = existing_gw_port
             if claw_name == "hermes":
                 existing_port = (
                     h["agents"][chosen_name[0]]
@@ -463,6 +544,22 @@ def run_installation(
                     and 45000 <= existing_port <= 46999
                 ):
                     preserved_dashboard_port[0] = existing_port
+                existing_api_port = (
+                    h["agents"][chosen_name[0]]
+                    .get("config", {})
+                    .get("api_server", {})
+                    .get("port")
+                )
+                # Accept the new 8600..8699 window. Legacy installs persisted
+                # port=8642 which is inside this window — they are grandfathered
+                # automatically (ATX iter-1 S1: dropped the explicit `or
+                # port == 8642` clause as it was already covered by the range).
+                if (
+                    isinstance(existing_api_port, int)
+                    and not isinstance(existing_api_port, bool)
+                    and 8600 <= existing_api_port <= 8699
+                ):
+                    preserved_api_server_port[0] = existing_api_port
             h["agents"][chosen_name[0]]["status"] = "installing"
             h["agents"][chosen_name[0]]["error"] = None
             h["agents"][chosen_name[0]]["version"] = matched_version  # Update version
@@ -486,6 +583,18 @@ def run_installation(
                     preserved_gateway[0] = (
                         h["agents"][chosen_name[0]].get("config", {}).get("gateway")
                     )
+                    existing_gw_port = (
+                        h["agents"][chosen_name[0]]
+                        .get("config", {})
+                        .get("gateway", {})
+                        .get("port")
+                    )
+                    if (
+                        isinstance(existing_gw_port, int)
+                        and not isinstance(existing_gw_port, bool)
+                        and 40000 <= existing_gw_port <= 41999
+                    ):
+                        preserved_gateway_port[0] = existing_gw_port
                 if claw_name == "hermes":
                     existing_port = (
                         h["agents"][chosen_name[0]]
@@ -500,6 +609,19 @@ def run_installation(
                         and 45000 <= existing_port <= 46999
                     ):
                         preserved_dashboard_port[0] = existing_port
+                    existing_api_port = (
+                        h["agents"][chosen_name[0]]
+                        .get("config", {})
+                        .get("api_server", {})
+                        .get("port")
+                    )
+                    # Accept new 8600..8699 window (legacy 8642 is inside it).
+                    if (
+                        isinstance(existing_api_port, int)
+                        and not isinstance(existing_api_port, bool)
+                        and 8600 <= existing_api_port <= 8699
+                    ):
+                        preserved_api_server_port[0] = existing_api_port
 
             h["agents"][chosen_name[0]] = {
                 "type": claw_name,
@@ -512,6 +634,56 @@ def run_installation(
             # NOTE: Onboarding NOT restored here - will be restored in set_installed()
             # after ansible succeeds to prevent status='failed' + onboarding='ready'
             # cleanup_failed=True ensures preserved_onboarding[0] is None (fresh install)
+
+        # ATX iter-1 W2/W3: pick per-instance listener ports inside the lock
+        # so concurrent installs on the same host serialize through their
+        # collision-walk. Persist the picks onto the in-progress agent record
+        # so a third install (which would call set_installing again) sees them.
+        # NOTE: concurrent installs on the same host could still collide on
+        # the in-flight ansible run if a third installer slips between two
+        # set_installing calls without either landing set_installed; the
+        # collision detection here is single-writer optimistic.
+        record = h["agents"][chosen_name[0]]
+        record.setdefault("config", {})
+        if claw_name in ("openclaw", "zeroclaw"):
+            chosen_gateway_port[0] = _pick_per_instance_port(
+                h,
+                chosen_name[0],
+                base=40000,
+                span=2000,
+                port_field_path=("gateway", "port"),
+                preserved_port=preserved_gateway_port[0],
+            )
+            record["config"].setdefault("gateway", {})["port"] = (
+                chosen_gateway_port[0]
+            )
+        if claw_name == "hermes":
+            chosen_dashboard_port[0] = _pick_per_instance_port(
+                h,
+                chosen_name[0],
+                base=45000,
+                span=2000,
+                port_field_path=("dashboard", "port"),
+                preserved_port=preserved_dashboard_port[0],
+            )
+            chosen_api_server_port[0] = _pick_per_instance_port(
+                h,
+                chosen_name[0],
+                base=8600,
+                span=100,
+                port_field_path=("api_server", "port"),
+                preserved_port=preserved_api_server_port[0],
+            )
+            record["config"]["dashboard"] = {
+                "enabled": True,
+                "host": "127.0.0.1",
+                "port": chosen_dashboard_port[0],
+            }
+            record["config"]["api_server"] = {
+                "enabled": True,
+                "host": "0.0.0.0",
+                "port": chosen_api_server_port[0],
+            }
         return h
 
     update_host(host["hostname"], set_installing)
@@ -560,70 +732,28 @@ def run_installation(
         / "templates"
     )
 
-    # Calculate unique port for this agent (matches playbook's calculation)
-    # This ensures config.gateway.port matches the openclaw_port ansible var
-    port_hash = int(hashlib.md5(agent_name.encode()).hexdigest(), 16)
-    openclaw_port = 40000 + (port_hash % 2000)
-
-    # Hermes dashboard port (issue #478 phase 2). Persisted to
-    # hosts.json.agents.<name>.config.dashboard.port so the web-ui resolver
-    # and `clm agent open` agree on the loopback port the dashboard binds to.
-    # On re-install we MUST preserve the existing port: the dashboard systemd
-    # unit was rendered against the original port and silently moving to a
-    # new value would break any running tunnels.
-    dashboard_port = None
-    if claw_name == "hermes":
-        # preserved_dashboard_port is captured inside set_installing() right
-        # before the agent record is wiped. Reading from `host` here would
-        # see the wiped record in test environments (where get_host returns
-        # the same dict that update_host mutates) and on the resume path.
-        if preserved_dashboard_port[0] is not None:
-            dashboard_port = preserved_dashboard_port[0]
-        else:
-            candidate = 45000 + (port_hash % 2000)
-            # Collision check: another agent on the same host may already own
-            # the candidate port. Bump by +1 (wrapping within the 45000..46999
-            # window) until free. Hash collisions are rare but possible
-            # because the openclaw port also uses md5(agent_name) % 2000.
-            used_ports: set[int] = set()
-            for other_key, other_agent in host.get("agents", {}).items():
-                if other_key == agent_name or not isinstance(other_agent, dict):
-                    continue
-                other_port = (
-                    other_agent.get("config", {}).get("dashboard", {}).get("port")
-                )
-                if isinstance(other_port, int) and not isinstance(other_port, bool):
-                    used_ports.add(other_port)
-            # Bounded loop with `for/else` exhaustion sentinel: if every slot
-            # in the 45000..46999 window is taken we MUST raise rather than
-            # silently land on a colliding port (ATX B1). Without the
-            # sentinel the loop exits with `candidate in used_ports` still
-            # true and the install proceeds with a broken dashboard.
-            for _ in range(2000):
-                if candidate not in used_ports:
-                    break
-                candidate += 1
-                if candidate > 46999:
-                    candidate = 45000
-            else:
-                raise InstallationError(
-                    "Dashboard port pool exhausted on "
-                    f"{host['hostname']} (all 2000 slots in "
-                    "45000-46999 are occupied). Remove unused hermes "
-                    "agents before installing another."
-                )
-            dashboard_port = candidate
+    # Per-instance listener ports (issue #533). Picked inside set_installing()
+    # under `_hosts_lock()` to avoid concurrent-install races (ATX iter-1 W2).
+    # `openclaw_port` is None for hermes (ATX iter-1 W3) so the 40000..41999
+    # pool isn't silently consumed by agents that never use it.
+    openclaw_port = chosen_gateway_port[0]
+    dashboard_port = chosen_dashboard_port[0]
+    api_server_port = chosen_api_server_port[0]
 
     # Generate auth token for gateway access
     import secrets
 
     gateway_auth_token = secrets.token_hex(24)  # 48-character hex token
 
-    # Build minimal config for templates
+    # Build minimal config for templates.
     # gateway.auth.mode must be explicitly "token" for full operator scopes
     # See: https://docs.openclaw.ai/gateway/security
-    config = {
-        "gateway": {
+    # ATX iter-1 W3: only openclaw/zeroclaw consume `config.gateway`; building
+    # it unconditionally (and reserving an openclaw_port slot for hermes)
+    # silently consumed the 40000..41999 pool with ghost allocations.
+    config: dict = {}
+    if claw_name in ("openclaw", "zeroclaw"):
+        config["gateway"] = {
             "mode": "local",
             "port": openclaw_port,
             "bind": "lan",
@@ -632,7 +762,6 @@ def run_installation(
                 "token": gateway_auth_token,
             },
         }
-    }
 
     # Hermes: generate (or reuse) the API_SERVER_KEY that gates the local
     # OpenAI-compatible gateway on 127.0.0.1:8642. Generated once on first
@@ -671,7 +800,7 @@ def run_installation(
         config["api_server"] = {
             "enabled": True,
             "host": "127.0.0.1",
-            "port": 8642,
+            "port": api_server_port,
             "key": hermes_api_server_key,
         }
         config["dashboard"] = {
@@ -1004,7 +1133,7 @@ def run_installation(
                     h["agents"][agent_name]["config"]["api_server"] = {
                         "enabled": True,
                         "host": "0.0.0.0",
-                        "port": 8642,
+                        "port": api_server_port,
                     }
 
                 # Persist hermes dashboard shape so the web_ui resolver and

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -1360,17 +1360,84 @@ def configure_agent(
             if not isinstance(existing_api_server, dict):
                 existing_api_server = {}
             merged_api_server = {**existing_api_server, **persisted_api_server}
+            # ATX iter-1 W6: range-validate the port before forwarding to
+            # Ansible. A hand-edited hosts.json with `port: 22` would
+            # otherwise propagate into the systemd ExecStart.
+            persisted_port = merged_api_server.get("port")
+            if not (
+                isinstance(persisted_port, int)
+                and not isinstance(persisted_port, bool)
+                and 8600 <= persisted_port <= 8699
+            ):
+                logger.warning(
+                    "Hermes api_server port %r outside documented window "
+                    "8600..8699 — picking a fresh per-instance port.",
+                    persisted_port,
+                )
+                from clawrium.core.install import _pick_per_instance_port
+
+                fresh = _pick_per_instance_port(
+                    host,
+                    unix_agent_name,
+                    base=8600,
+                    span=100,
+                    port_field_path=("api_server", "port"),
+                    preserved_port=None,
+                )
+                merged_api_server["port"] = fresh
             merged_api_server["key"] = api_server_key
             config_data["api_server"] = merged_api_server
         else:
             # hosts.json shape missing (legacy/corrupted); reconstruct defaults
             # alongside the token from secrets.json so the playbook can run.
+            # ATX iter-1 W1: legacy pre-#533 hermes daemons are actually bound
+            # to 8642 (the old hardcoded port). Prefer 8642 if it's free on
+            # this host so the running daemon is what `clm chat` reaches;
+            # only fall through to picking a fresh port when 8642 is taken
+            # by a co-tenant. Emit a warning either way so the operator
+            # knows a port assignment happened outside the install flow.
+            from clawrium.core.install import _pick_per_instance_port
+
+            # 8642 is in the 8600..8699 window, so passing it as
+            # preserved_port returns it verbatim when free.
+            reconstructed_port = _pick_per_instance_port(
+                host,
+                unix_agent_name,
+                base=8600,
+                span=100,
+                port_field_path=("api_server", "port"),
+                preserved_port=8642,
+            )
+            logger.warning(
+                "Hermes %s on %s has no api_server block in hosts.json — "
+                "reconstructing with port %d. If the live daemon is bound "
+                "to a different port, `clm chat` will fail until the daemon "
+                "is restarted on this port.",
+                unix_agent_name,
+                host["hostname"],
+                reconstructed_port,
+            )
             config_data["api_server"] = {
                 "enabled": True,
                 "host": "0.0.0.0",
-                "port": 8642,
+                "port": reconstructed_port,
                 "key": api_server_key,
             }
+
+            def _persist_reconstructed_api_server(h: dict) -> dict:
+                agents = h.get("agents") or {}
+                record = agents.get(agent_key)
+                if not isinstance(record, dict):
+                    return h
+                cfg = record.setdefault("config", {})
+                cfg["api_server"] = {
+                    "enabled": True,
+                    "host": "0.0.0.0",
+                    "port": reconstructed_port,
+                }
+                return h
+
+            update_host(host["hostname"], _persist_reconstructed_api_server)
 
         # Hermes Slack: merge persisted channels.slack shape from hosts.json
         # with anything passed in config_data, then hydrate the bot/app tokens

--- a/src/clawrium/core/validation.py
+++ b/src/clawrium/core/validation.py
@@ -894,7 +894,9 @@ def validate_hermes_health(
 
     1. ``hermes --version`` exits 0 (binary present and runnable).
     2. ``~/.hermes/.env`` exists (configure has been run at least once).
-    3. ``curl -fsS http://127.0.0.1:8642/health`` returns 200 (api_server up).
+    3. ``curl -fsS http://127.0.0.1:<api_server_port>/health`` returns 200
+       (api_server up). The port is read from
+       ``hosts.json.agents.<name>.config.api_server.port`` (issue #533).
 
     The api_server platform binds to loopback on the agent host by design,
     so the /health probe must be issued from inside that host. We use the
@@ -988,6 +990,19 @@ def validate_hermes_health(
     # Ansible's `shell` module defaults to /bin/sh (dash) which doesn't
     # support `set -o pipefail`; we don't need a pipefail since each check
     # captures its own rc into a sentinel line.
+    #
+    # Per-instance api_server port (issue #533): read from the persisted agent
+    # record. Fall back to legacy 8642 if missing — covers pre-#533 agents
+    # whose hosts.json shape predates the api_server block.
+    api_server_port = (
+        claw_record.get("config", {}).get("api_server", {}).get("port") or 8642
+    )
+    if not (
+        isinstance(api_server_port, int)
+        and not isinstance(api_server_port, bool)
+        and 1 <= api_server_port <= 65535
+    ):
+        api_server_port = 8642
     agent_home = f"/home/{claw_name}"
     shell_cmd = (
         f"sudo -u {claw_name} bash -c '"
@@ -999,7 +1014,7 @@ def validate_hermes_health(
         f"  echo ENV_CHECK; "
         f"  test -f {agent_home}/.hermes/.env && echo ENV_OK || echo ENV_MISSING; "
         f"  echo HEALTH_CHECK; "
-        f'  curl -fsS -o /dev/null -w "%{{http_code}}\\n" http://127.0.0.1:8642/health '
+        f'  curl -fsS -o /dev/null -w "%{{http_code}}\\n" http://127.0.0.1:{api_server_port}/health '
         f"     || echo CURL_FAILED"
         f"'"
     )

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -60,10 +60,12 @@ secrets:
 #              push identity files in this iteration. The wizard records this
 #              stage as SKIPPED and advances.
 #   channels   default `cli`. The api_server platform exposes an
-#              OpenAI-compatible HTTP API on 0.0.0.0:8642 (all interfaces,
-#              bearer-token protected via HERMES_API_SERVER_KEY) so
-#              `clm chat <hermes>` can reach it at http://<host-ip>:8642/v1
-#              from any clm machine on the LAN. External messaging gateways
+#              OpenAI-compatible HTTP API on 0.0.0.0:<api_server_port> (all
+#              interfaces, bearer-token protected via HERMES_API_SERVER_KEY)
+#              so `clm chat <hermes>` can reach it at
+#              http://<host-ip>:<api_server_port>/v1 from any clm machine on
+#              the LAN. The port is per-instance, picked at install time
+#              from 8600..8699 (issue #533). External messaging gateways
 #              (Discord/Slack/Telegram/etc.) are out of scope and tracked as a
 #              separate follow-up issue.
 #   validate   Composite shell-level check: `hermes --version` succeeds,
@@ -93,7 +95,7 @@ onboarding:
         - id: confirm_cli
           name: "Confirm CLI channel"
           type: confirm
-          message: "Hermes will expose its OpenAI-compatible API on all interfaces (0.0.0.0:8642), bearer-token protected, reachable at http://<host-ip>:8642/v1 from any clm machine on the LAN."
+          message: "Hermes will expose its OpenAI-compatible API on all interfaces, bearer-token protected, reachable at http://<host-ip>:<api_server_port>/v1 from any clm machine on the LAN. The port is per-instance (8600..8699); see `clm agent describe`."
           default: true
         - id: select_discord
           name: "Enable Discord channel (optional)"
@@ -132,7 +134,11 @@ onboarding:
         - id: health_check
           name: "Verify api_server /health returns 200"
           type: command
-          command: "curl -fsS http://0.0.0.0:8642/health"
+          # The actual port is per-instance (issue #533). This `command`
+          # field is descriptive — the live probe is run by
+          # validate_hermes_health() in src/clawrium/core/validation.py,
+          # which reads the port from hosts.json.
+          command: "curl -fsS http://0.0.0.0:<api_server_port>/health"
 
 # Note: The hermes installer is a single bash script served from
 # raw.githubusercontent.com at the pinned tag. The same script content is

--- a/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
@@ -140,9 +140,9 @@
         group: "{{ agent_name }}"
         mode: "0700"
 
-    - name: Calculate unique port (40000-42000 range)
+    - name: Resolve per-instance gateway port from inventory (issue #533)
       ansible.builtin.set_fact:
-        openclaw_port: "{{ 40000 + ((agent_name | hash('md5') | int(base=16)) % 2000) }}"
+        openclaw_port: "{{ config.gateway.port }}"
 
     # Skip on already-installed path: rewriting openclaw.json would rotate the
     # gateway token in the running daemon and invalidate the credentials cached
@@ -155,6 +155,12 @@
         group: "{{ agent_name }}"
         mode: "0600"
       when: not openclaw_already_installed
+      # ATX iter-1 B1: openclaw.json embeds the gateway bearer token.
+      # Every other secret-touching task in this playbook already carries
+      # `no_log: true`; this template write must too so `-v` ansible-runner
+      # logs don't leak the rendered file path / contents into the artifact
+      # directory.
+      no_log: true
 
     - name: Write exec approvals policy from template
       ansible.builtin.template:
@@ -254,6 +260,11 @@
         - gateway_token_result_stdout is not defined or
           gateway_token_result_stdout | length < 32 or
           not (gateway_token_result_stdout is regex('^[a-zA-Z0-9_-]+$'))
+      # ATX iter-2 B1: every adjacent task touching gateway_token_result_stdout
+      # carries no_log: true. At -v / -vvv, ansible-runner writes the
+      # evaluated when-condition into the artifacts directory before
+      # _cleanup_ansible_artifacts runs.
+      no_log: true
 
     - name: Copy device pairing script
       ansible.builtin.copy:
@@ -293,6 +304,9 @@
       when:
         - not openclaw_already_installed
         - device_credentials.deviceToken is not defined or device_credentials.deviceToken | length < 10
+      # ATX iter-1 W5: consistency with surrounding `no_log: true` tasks.
+      # `when` clause evaluation may surface the token length in verbose logs.
+      no_log: true
 
     - name: Clean up pairing script
       ansible.builtin.file:
@@ -307,6 +321,11 @@
     - name: Save all credentials to fact for retrieval
       ansible.builtin.set_fact:
         openclaw_gateway_token: "{{ gateway_token_result_stdout }}"
+        # ATX iter-1 W4: scheme is hardcoded `ws://`. Operators fronting the
+        # gateway with TLS need `wss://` here; today they get a confusing
+        # connection error from `clm chat <openclaw>`. Tracked as a known
+        # limitation; safe to address in a follow-up since openclaw deploys
+        # are LAN-only today (no TLS termination in the documented topology).
         openclaw_gateway_url: "ws://{{ ansible_host }}:{{ openclaw_port }}"
         openclaw_device_id: "{{ device_credentials.deviceId }}"
         openclaw_device_token: "{{ device_credentials.deviceToken }}"

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -2282,7 +2282,168 @@ class TestHermesBindMigration:
         assert success is True, error
         sent = captured["inventory"]["all"]["vars"]["config"]
         assert sent["api_server"]["host"] == "0.0.0.0"
+        # Issue #533: legacy-shape reconstruction picks a per-instance port
+        # in 8600..8699 and persists it back. ATX iter-2 W1: prefers 8642
+        # (the literal that pre-#533 hermes daemons are actually bound to)
+        # when free on the host, so the running daemon is what `clm chat`
+        # reaches without a daemon restart.
+        assert 8600 <= sent["api_server"]["port"] <= 8699
+        assert sent["api_server"]["port"] == 8642  # 8642 was free on this host
+
+
+class TestHermesApiServerPortIssue533:
+    """Tests for the api_server port validation/reconstruction branches added
+    in issue #533. See ATX iter-2 W1 (legacy reconstruct) and W6 (range check
+    on persisted port)."""
+
+    def _persisted_key_secret(self, key: str) -> dict:
+        return {"HERMES_API_SERVER_KEY": {"value": key}}
+
+    def test_configure_rejects_out_of_range_persisted_port_picks_fresh(
+        self, tmp_path: Path
+    ):
+        """ATX iter-2 W6: a hand-edited hosts.json with `api_server.port=22`
+        must NOT be forwarded to Ansible. lifecycle.py warns and picks a
+        fresh port in 8600..8699 via _pick_per_instance_port."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {
+                        "api_server": {
+                            "enabled": True,
+                            "host": "0.0.0.0",
+                            "port": 22,  # privileged port, hand-edited
+                        }
+                    },
+                }
+            },
+        }
+        config_data = {
+            "provider": {"name": "p", "type": "openrouter", "default_model": "x"},
+        }
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        captured = {}
+
+        def fake_run(**kwargs):
+            captured["inventory"] = kwargs["inventory"]
+            mock = MagicMock()
+            mock.status = "successful"
+            mock.events = []
+            return mock
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ),
+            patch("clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run),
+            patch("clawrium.core.lifecycle.update_host", return_value=True),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                return_value=self._persisted_key_secret("b" * 64),
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host", "hermes", config_data, agent_name="hermes-test"
+            )
+
+        assert success is True, error
+        sent = captured["inventory"]["all"]["vars"]["config"]
+        assert 8600 <= sent["api_server"]["port"] <= 8699
+        assert sent["api_server"]["port"] != 22
+
+    def test_configure_legacy_no_api_server_prefers_8642(self, tmp_path: Path):
+        """ATX iter-2 W1: legacy hermes records without an api_server block
+        are reconstructed with port=8642 (the pre-#533 literal that the live
+        daemon is bound to) when 8642 is free, plus update_host persists the
+        block back so subsequent configures are stable. B3 invariant: the
+        persisted block must NOT contain the bearer `key` field."""
+        host = {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {},  # no api_server block at all
+                }
+            },
+        }
+        config_data = {
+            "provider": {"name": "p", "type": "openrouter", "default_model": "x"},
+        }
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        captured = {"inventory": None, "update_calls": []}
+
+        def fake_run(**kwargs):
+            captured["inventory"] = kwargs["inventory"]
+            mock = MagicMock()
+            mock.status = "successful"
+            mock.events = []
+            return mock
+
+        def fake_update_host(_hostname, updater):
+            h_copy = {
+                "hostname": "test-host",
+                "agents": {
+                    "hermes-test": {
+                        "type": "hermes",
+                        "agent_name": "hermes-test",
+                        "config": {},
+                    }
+                },
+            }
+            mutated = updater(h_copy)
+            captured["update_calls"].append(mutated["agents"]["hermes-test"]["config"])
+            return True
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ),
+            patch("clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run),
+            patch(
+                "clawrium.core.lifecycle.update_host", side_effect=fake_update_host
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                return_value=self._persisted_key_secret("b" * 64),
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host", "hermes", config_data, agent_name="hermes-test"
+            )
+
+        assert success is True, error
+        sent = captured["inventory"]["all"]["vars"]["config"]
+        # Prefers 8642 (free on this single-agent host).
         assert sent["api_server"]["port"] == 8642
+        # B3 invariant: bearer key must not leak into the persisted block.
+        # update_calls captures every persisted snapshot — none may carry key.
+        for snapshot in captured["update_calls"]:
+            persisted = snapshot.get("api_server") or {}
+            assert "key" not in persisted
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2243,7 +2243,8 @@ def test_install_hermes_persists_zero_bind_in_hosts_json(monkeypatch, tmp_path):
     api_server = final["agents"]["hermes-test"]["config"]["api_server"]
     assert api_server["enabled"] is True
     assert api_server["host"] == "0.0.0.0"
-    assert api_server["port"] == 8642
+    # Issue #533: per-instance port from the 8600..8699 window.
+    assert 8600 <= api_server["port"] <= 8699
     # B3 invariant: bearer never lands in hosts.json
     assert "key" not in api_server
 

--- a/tests/test_install_ports.py
+++ b/tests/test_install_ports.py
@@ -1,0 +1,306 @@
+# Tests for issue #533: per-instance listener ports across all agent types.
+#
+# Covers the shared `_pick_per_instance_port` helper plus the three call sites
+# (hermes dashboard, hermes api_server, openclaw/zeroclaw gateway). The dashboard
+# regression suite already in tests/test_install.py exercises the install-time
+# wiring; this file focuses on the new helper directly and the two new ports.
+
+import hashlib
+
+import pytest
+
+from clawrium.core.install import InstallationError, _pick_per_instance_port
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for the helper
+# ---------------------------------------------------------------------------
+
+
+def _agent(port_path: tuple[str, ...], port: int) -> dict:
+    """Build an agent record dict that nests `port` under `config.<port_path>`."""
+    record: dict = {"type": "hermes", "status": "installed", "config": {}}
+    node = record["config"]
+    for seg in port_path[:-1]:
+        node[seg] = {}
+        node = node[seg]
+    node[port_path[-1]] = port
+    return record
+
+
+def test_helper_returns_preserved_port_in_window():
+    host = {"hostname": "h", "agents": {}}
+    got = _pick_per_instance_port(
+        host, "anything", base=8600, span=100,
+        port_field_path=("api_server", "port"),
+        preserved_port=8650,
+    )
+    assert got == 8650
+
+
+def test_helper_rejects_preserved_port_outside_window():
+    host = {"hostname": "h", "agents": {}}
+    # 9999 is outside 8600..8699 — must be ignored, helper picks via hash.
+    got = _pick_per_instance_port(
+        host, "agent-x", base=8600, span=100,
+        port_field_path=("api_server", "port"),
+        preserved_port=9999,
+    )
+    assert 8600 <= got <= 8699
+    expected = 8600 + (int(hashlib.md5(b"agent-x").hexdigest(), 16) % 100)
+    assert got == expected
+
+
+def test_helper_hash_collision_walks_to_next_free_port():
+    # Pre-occupy the natural hash slot for "agent-a".
+    natural = 8600 + (int(hashlib.md5(b"agent-a").hexdigest(), 16) % 100)
+    host = {
+        "hostname": "h",
+        "agents": {
+            "agent-other": _agent(("api_server", "port"), natural),
+        },
+    }
+    got = _pick_per_instance_port(
+        host, "agent-a", base=8600, span=100,
+        port_field_path=("api_server", "port"),
+    )
+    assert got != natural
+    assert 8600 <= got <= 8699
+
+
+def test_helper_wraps_at_top_of_window():
+    # Park the requesting agent's natural slot at 8699 so the walk has to wrap.
+    name = "wrap-me"
+    natural = 8600 + (int(hashlib.md5(name.encode()).hexdigest(), 16) % 100)
+    # Force the candidate to start at the top by making natural=8699 if possible.
+    # Instead of brute-forcing the name, occupy `natural` and the run will walk
+    # forward; either way collision walk must produce a port in the window.
+    host = {
+        "hostname": "h",
+        "agents": {
+            "occupier": _agent(("api_server", "port"), natural),
+        },
+    }
+    got = _pick_per_instance_port(
+        host, name, base=8600, span=100,
+        port_field_path=("api_server", "port"),
+    )
+    assert 8600 <= got <= 8699
+    assert got != natural
+
+
+def test_helper_raises_when_pool_exhausted():
+    host = {
+        "hostname": "h",
+        "agents": {
+            f"occ-{p}": _agent(("api_server", "port"), p)
+            for p in range(8600, 8700)
+        },
+    }
+    with pytest.raises(InstallationError, match="[Pp]ool exhausted"):
+        _pick_per_instance_port(
+            host, "new", base=8600, span=100,
+            port_field_path=("api_server", "port"),
+        )
+
+
+def test_helper_ignores_self_in_collision_set():
+    # Self-agent's own persisted port must not block self.
+    host = {
+        "hostname": "h",
+        "agents": {
+            "myself": _agent(("api_server", "port"), 8650),
+        },
+    }
+    # No preserved_port hint, but "myself" should still get a clean pick
+    # without colliding with its own old record.
+    got = _pick_per_instance_port(
+        host, "myself", base=8600, span=100,
+        port_field_path=("api_server", "port"),
+    )
+    assert 8600 <= got <= 8699
+
+
+def test_helper_ignores_other_agent_types_at_wrong_path():
+    # A peer that stores a port under config.gateway.port must NOT poison
+    # the api_server collision set.
+    host = {
+        "hostname": "h",
+        "agents": {
+            "openclaw-peer": _agent(("gateway", "port"), 8650),
+        },
+    }
+    got = _pick_per_instance_port(
+        host, "hermes-new", base=8600, span=100,
+        port_field_path=("api_server", "port"),
+    )
+    # Peer's gateway.port=8650 must not register as a collision.
+    expected = 8600 + (int(hashlib.md5(b"hermes-new").hexdigest(), 16) % 100)
+    assert got == expected
+
+
+# ---------------------------------------------------------------------------
+# Install-time integration: hermes api_server port
+# ---------------------------------------------------------------------------
+
+
+def test_install_hermes_api_server_port_assigned_and_persisted(monkeypatch, tmp_path):
+    from tests.test_install import _hermes_install_scaffold
+
+    run_installation, get_host, _c, _a = _hermes_install_scaffold(
+        monkeypatch, tmp_path
+    )
+    result = run_installation("hermes", "test-host", name="hermes-api")
+    assert result["success"] is True
+
+    api = get_host()["agents"]["hermes-api"]["config"]["api_server"]
+    assert 8600 <= api["port"] <= 8699
+    expected = 8600 + (int(hashlib.md5(b"hermes-api").hexdigest(), 16) % 100)
+    assert api["port"] == expected
+
+
+def test_install_hermes_api_server_port_preserved_on_reinstall(monkeypatch, tmp_path):
+    from tests.test_install import _hermes_install_scaffold
+
+    custom_port = 8677  # in-window but not the deterministic-hash value
+    preexisting = {
+        "hermes-keep": {
+            "type": "hermes",
+            "version": "2026.5.7",
+            "status": "installed",
+            "installed_at": "2026-01-01T00:00:00+00:00",
+            "config": {
+                "api_server": {
+                    "enabled": True,
+                    "host": "0.0.0.0",
+                    "port": custom_port,
+                },
+                "dashboard": {
+                    "enabled": True,
+                    "host": "127.0.0.1",
+                    "port": 45500,
+                },
+            },
+        }
+    }
+    run_installation, get_host, _c, _a = _hermes_install_scaffold(
+        monkeypatch, tmp_path, preexisting_agents=preexisting,
+    )
+    result = run_installation("hermes", "test-host", name="hermes-keep")
+    assert result["success"] is True
+
+    api = get_host()["agents"]["hermes-keep"]["config"]["api_server"]
+    assert api["port"] == custom_port
+
+
+def test_install_hermes_api_server_port_grandfathers_legacy_8642(monkeypatch, tmp_path):
+    """Pre-#533 hermes agents persisted port=8642. Reinstall must keep it,
+    not relocate them into the new 8600..8699 window."""
+    from tests.test_install import _hermes_install_scaffold
+
+    preexisting = {
+        "espresso-like": {
+            "type": "hermes",
+            "version": "2026.5.7",
+            "status": "installed",
+            "installed_at": "2026-01-01T00:00:00+00:00",
+            "config": {
+                "api_server": {
+                    "enabled": True,
+                    "host": "0.0.0.0",
+                    "port": 8642,
+                },
+                "dashboard": {
+                    "enabled": True,
+                    "host": "127.0.0.1",
+                    "port": 45500,
+                },
+            },
+        }
+    }
+    run_installation, get_host, _c, _a = _hermes_install_scaffold(
+        monkeypatch, tmp_path, preexisting_agents=preexisting,
+    )
+    result = run_installation("hermes", "test-host", name="espresso-like")
+    assert result["success"] is True
+    assert get_host()["agents"]["espresso-like"]["config"]["api_server"]["port"] == 8642
+
+
+def test_install_two_hermes_sequential_get_distinct_ports(monkeypatch, tmp_path):
+    """ATX iter-1 test-coverage gap: install two hermes agents back-to-back
+    on the same host and assert both api_server and dashboard ports are
+    distinct. This catches both the lock-coverage regression (W2) and the
+    in-progress-record-visibility regression (W3-related).
+    """
+    from tests.test_install import _hermes_install_scaffold
+
+    run_installation, get_host, _c, _a = _hermes_install_scaffold(
+        monkeypatch, tmp_path,
+    )
+
+    result_a = run_installation("hermes", "test-host", name="hermes-aaa")
+    assert result_a["success"] is True
+    api_a = get_host()["agents"]["hermes-aaa"]["config"]["api_server"]["port"]
+    dash_a = get_host()["agents"]["hermes-aaa"]["config"]["dashboard"]["port"]
+
+    result_b = run_installation("hermes", "test-host", name="hermes-bbb")
+    assert result_b["success"] is True
+    api_b = get_host()["agents"]["hermes-bbb"]["config"]["api_server"]["port"]
+    dash_b = get_host()["agents"]["hermes-bbb"]["config"]["dashboard"]["port"]
+
+    assert api_a != api_b
+    assert dash_a != dash_b
+    assert 8600 <= api_a <= 8699
+    assert 8600 <= api_b <= 8699
+    assert 45000 <= dash_a <= 46999
+    assert 45000 <= dash_b <= 46999
+
+
+def test_install_hermes_does_not_persist_gateway_block(monkeypatch, tmp_path):
+    """ATX iter-2 W4: hermes installs must not write `config.gateway` to
+    hosts.json — gateway config is only meaningful for openclaw/zeroclaw.
+    A regression unconditionally building the gateway block would silently
+    consume the 40000..41999 pool with ghost allocations."""
+    from tests.test_install import _hermes_install_scaffold
+
+    run_installation, get_host, _c, _a = _hermes_install_scaffold(
+        monkeypatch, tmp_path,
+    )
+    result = run_installation("hermes", "test-host", name="hermes-nogw")
+    assert result["success"] is True
+    assert "gateway" not in get_host()["agents"]["hermes-nogw"]["config"]
+
+
+def test_install_hermes_api_server_port_collision_picks_different(monkeypatch, tmp_path):
+    """Two hermes installs on the same host get distinct api_server ports."""
+    from tests.test_install import _hermes_install_scaffold
+
+    name_a = "hermes-aa"
+    natural_a = 8600 + (int(hashlib.md5(name_a.encode()).hexdigest(), 16) % 100)
+    preexisting = {
+        "first": {
+            "type": "hermes",
+            "version": "2026.5.7",
+            "status": "installed",
+            "config": {
+                "api_server": {
+                    "enabled": True,
+                    "host": "0.0.0.0",
+                    "port": natural_a,
+                },
+                "dashboard": {
+                    "enabled": True,
+                    "host": "127.0.0.1",
+                    "port": 45500,
+                },
+            },
+        }
+    }
+    run_installation, get_host, _c, _a = _hermes_install_scaffold(
+        monkeypatch, tmp_path, preexisting_agents=preexisting,
+    )
+    result = run_installation("hermes", "test-host", name=name_a)
+    assert result["success"] is True
+    new_port = get_host()["agents"][name_a]["config"]["api_server"]["port"]
+    assert new_port != natural_a
+    assert 8600 <= new_port <= 8699


### PR DESCRIPTION
## Summary

- Every per-agent network listener (hermes dashboard, hermes api_server, openclaw/zeroclaw gateway) now picks its port via a shared `_pick_per_instance_port()` helper — hash agent name into the window, collision-walk past peers on the host, preserve across reinstalls.
- hermes api_server moves from literal `8642` to the 8600..8699 window. Two hermes agents on the same host no longer collide on TCP bind.
- Port picks happen inside `set_installing()` so concurrent installs serialize through `_hosts_lock()`.
- Grandfather migration: existing installs at 8642 are inside the new 8600..8699 window, so reinstalls preserve them naturally. Not-touched agents keep their persisted port.

Closes #533

## Testing

### Test Results
- [x] All existing tests pass (`make test` — 3216 passed, 6 skipped)
- [x] Linter passes (`make lint-py`)
- [x] New tests added for new functionality

### New tests
- `tests/test_install_ports.py` (13 tests): helper unit tests (preservation, hash collision walk, wrap, pool exhaustion, self-exclusion, path-segment isolation) + install-layer integration (api_server port assigned/persisted, preserved on reinstall, grandfathers 8642, two sequential installs distinct, no gateway block on hermes).
- `tests/test_hermes_configure.py::TestHermesApiServerPortIssue533` (2 tests): out-of-range persisted port rejected and replaced; legacy no-api_server-block reconstruction prefers 8642 with B3 bearer-key invariant.
- Adjusted existing `test_install_hermes_persists_zero_bind_in_hosts_json` and `test_legacy_missing_api_server_block_uses_zero_bind_default` to the new port window.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (range-check on persisted port; helper rejects out-of-window preserved values)
- [x] No SQL injection, XSS, or command injection risks
- [x] `no_log: true` parity audited across all secret-touching openclaw playbook tasks

## ATX Review Summary

**Final Review: Rating 3-4/5 across 4 reviewer domains**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 3/5 | B1 (no_log on openclaw.json template) | Fixed |
| 2 | 3/5 | B1 (no_log on Validate gateway token format) | Fixed |
| 3 | 3-4/5 | None | Cleared |

> ATX iteration ceiling is 3 rounds (per `/itx-execute` spec). All blockers across iterations are resolved; advisory warnings from round 3 are documented in Callouts below.

<details>
<summary>Round 1 Details (Rating 3/5)</summary>

**Blockers:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `openclaw/install.yaml` | Missing `no_log: true` on openclaw.json template write — gateway bearer would leak at `-v` | Fixed — added `no_log: true` consistent with adjacent secret-touching tasks |

**Warnings:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `lifecycle.py` | Legacy reconstruction silently reassigned api_server port | Fixed — prefers 8642 (pre-#533 literal) when free, emits warning |
| W2 | `install.py` | Port-pick outside `_hosts_lock()` (race) | Fixed — moved inside `set_installing` updater; partial record written to expose pick to concurrent installs |
| W3 | `install.py` | `openclaw_port` allocated for hermes (ghost pool consumption) | Fixed — gateway config dict only built for `claw_name in ("openclaw","zeroclaw")` |
| W4 | `openclaw/install.yaml` | Hardcoded `ws://` scheme | Documented as known limitation; safe today (LAN-only) |
| W5 | `openclaw/install.yaml` | Missing `no_log: true` on validate device credentials | Fixed |
| W6 | `lifecycle.py` | Persisted api_server.port not range-validated | Fixed — out-of-range (e.g. 22) logs warning and replaces via helper |

**Suggestions:**

| # | Suggestion | Resolution |
|---|------------|------------|
| S1 | Drop dead `or port == 8642` clauses (8642 already in 8600..8699) | Fixed |
| S2 | `api_server.host` 0.0.0.0 / 127.0.0.1 divergence comment | Deferred — pre-existing, configure migration normalizes it |
| S3 | Manifest `health_check.command` literal placeholder | Mitigated with explanatory comment; renaming the field is a follow-up |
| S4 | Concurrent-install documentation | Fixed — inline NOTE added in `set_installing` |

</details>

<details>
<summary>Round 2 Details (Rating 3/5)</summary>

**Blockers:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `openclaw/install.yaml` | Missing `no_log: true` on "Validate gateway token format" — `when` clause evaluation leaks token at `-v`/`-vvv` | Fixed |

**Warnings (test-coverage gaps):**

| # | Warning | Resolution |
|---|---------|------------|
| W1 | W6 invalid-port branch had no test | Fixed — `test_configure_rejects_out_of_range_persisted_port_picks_fresh` |
| W2 | W1 legacy-reconstruct branch had no test | Fixed — `test_configure_legacy_no_api_server_prefers_8642` |
| W3 | Sequential two-hermes test didn't guard the W2 lock invariant | Acknowledged — concurrency test would need `ThreadPoolExecutor` + threading.Barrier in the install scaffold; sequential coverage + inline lock-coverage comment retained |
| W4 | W3 gateway-absence invariant unverified | Fixed — `test_install_hermes_does_not_persist_gateway_block` |
| W5 | Device PEM stored in hosts.json (pre-existing) | Tracked as follow-up (Callout) — out of scope for #533 |

</details>

<details>
<summary>Round 3 Details (Rating 3-4/5, no blockers)</summary>

All round-2 fixes confirmed. Advisory warnings remain (none blocking):

| # | Open warning | Why deferred |
|---|------|--------------|
| W-SEC-3 | `_safe_host_display()` parity missing in install.py | Alias validation at CLI blocks normal-path exploitation; lifecycle.py parity is a separate hardening pass |
| Core W1 | `api_server.host` 0.0.0.0 in hosts.json vs 127.0.0.1 sent to install playbook | Pre-existing; the configure migration check normalizes legacy 127.0.0.1 to 0.0.0.0. Cleaning up the install-time divergence is a follow-up |
| Core W2 | `validate_hermes_health` allows any 1..65535 | Defensive only — the live `/health` probe fails fast on a wrong port. Tightening to 8600..8699 follows the same pattern as `lifecycle.py` |
| Ansible W4 | `npm install ws` missing `creates:` guard | Pre-existing |
| Ansible W5 | `openclaw_port: "{{ config.gateway.port }}"` undefined-key behavior | install.py is now the canonical writer of `config.gateway.port` for openclaw/zeroclaw — `UndefinedError` would only fire on a manifest/inventory wiring bug that the lifecycle never produces |
| Test W6/W7/W8 | Boundary-value tests, configure-layer 8642-collision E2E, configure-layer no-gateway assertion | Helper unit tests already cover boundaries; test scaffolding for configure-layer collision is non-trivial and deferred |

</details>

## Live Agent Verification

All test agents installed on `wolf-i` (kevin skipped — known armv7l zeroclaw bind bug unrelated to #533).

### Hermes — primary regression case

`clawctl-demo` deleted and recreated against the new code, then provider attached, synced, and chatted.

| Agent | api_server.port | dashboard.port | Result |
|---|---|---|---|
| `clawctl-demo` (new install) | **8691** | **45191** | Picked from 8600..8699 window — no longer collides with espresso |
| `espresso` (grandfathered) | **8642** | **46583** | Unchanged from main — not touched by this PR |
| `maurice` (grandfathered) | **8643** | **45317** | Unchanged from main — not touched |

Espresso preserved at 8642 (inside new 8600..8699 window — grandfather works); clawctl-demo got a distinct port, so the TCP-bind collision is gone.

### Chat session transcript (clawctl-demo on port 8691)

```
$ printf 'hello\nwhat model are you?\n' | clawctl agent chat clawctl-demo
Connected target: clawctl-demo on wolf-i
Type /exit or press Ctrl+D to end. Use /reset to clear conversation history.
you> clawctl-demo> Hi! How can I help you today?
you> clawctl-demo> I'm running on the "gpt-oss:20b" model.
you> 
Chat ended.
```

No `Token mismatch` / `Authentication failed: Hermes rejected Bearer ***` — the SSH tunnel reached the right daemon on the right port.

### openclaw — reinstall preservation

| Step | gateway.port |
|---|---|
| `clawctl agent create port-test-oc -t openclaw -H wolf-i -y` | **40302** |
| `clawctl agent delete port-test-oc -y` + recreate | **40302** (same — hash-deterministic and now collision-checked) |

### zeroclaw

| Agent | gateway.port |
|---|---|
| `port-test-zc` (new install) | **41942** |
| `clawrium-d01` (grandfathered) | **41429** (unchanged from main) |

### Cleanup

`port-test-oc` and `port-test-zc` deleted. `clawctl-demo` left running for downstream demo recording. Existing fleet (espresso, maurice, clawrium-d01, nemotron-alpha/beta, wolf-i) untouched throughout.

## Callouts

- [DECISION] api_server window is 100 slots (8600..8699), not 2000 like dashboard.
  - Why: each port must be opened on the LAN firewall (api_server binds 0.0.0.0). A single host running 100 hermes instances is implausible, and a smaller window keeps the operator's firewall surface tight. Matches the plan's stated trade-off.
  - Reviewer: confirm if a wider window is preferred for high-density homelab use cases.

- [DECISION] Legacy reconstruction in `lifecycle.py` prefers literal 8642.
  - Why: pre-#533 hermes daemons are actually bound to 8642 on disk. Reaching a fresh per-instance port would require a daemon restart and silently break any in-flight chat sessions. Falling back to the hash-walk only when 8642 is taken by a co-tenant.
  - Alternatives considered: always pick fresh; emit a critical error and refuse to proceed. Both judged worse than a deterministic best-effort with a logged warning.

- [DECISION] No concurrency test for the `_hosts_lock()` invariant.
  - Why: `_hermes_install_scaffold` runs synchronously and doesn't model the file-locking layer. Sequential coverage + inline comment retained instead of pulling in `ThreadPoolExecutor`+`Barrier` for one assertion.
  - Tracking: candidate follow-up; not blocking #533.

- [TODO-FOLLOWUP] Device PEM + token still land in `hosts.json` for openclaw agents (security-reviewer W5, round 2).
  - Pre-existing — not introduced by #533. Migrating `device_token` / `device_private_key` to `secrets.json` (mirror `HERMES_API_SERVER_KEY` pattern) is a separate hardening pass.
  - Tracking: to be filed as a follow-up issue.

- [TODO-FOLLOWUP] Round-3 advisory warnings (W-SEC-3 parity, api_server.host mismatch, validate port-range tighten, npm idempotency, openclaw_port undefined guard).
  - Why deferred: each is either pre-existing, defensive-only, or covered by separate invariants already in code (see Round 3 details above).
  - Tracking: to be filed as follow-up issues.

- [ENVIRONMENT] Live verification ran against `wolf-i` only; `kevin` skipped because of a known armv7l zeroclaw bind bug unrelated to #533.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
