### PR TITLE
fix(configure): route providers stage through sync_agent state machine

### DIFF
--- a/.itx/541/02_EXECUTE.md
+++ b/.itx/541/02_EXECUTE.md
@@ -1,0 +1,25 @@
+# Execution — Issue #541
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-26T22:08:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx:execute 541 use atx CLI for review (atx review). MCP atx tools are unavailable.
+```
+
+**Output**: routed `clawctl agent configure --stage providers --provider X`
+through `sync_agent` (state-machine walk + Ansible push) instead of the
+`run_stage` placeholder. Added regression tests covering provider
+attachment, sync failure modes, registry/host-file IO failures, and the
+non-providers run_stage error paths.
+
+## ATX Review History
+
+| Iter | Rating | Blocking | Notes |
+|------|--------|----------|-------|
+| 1    | 2/5    | 7 (B1–B7) | Initial review — input validation, error handling, test coverage gaps |
+| 2    | 3/5    | 0 (W1–W5) | All B1–B7 closed; warnings on HostsFileCorruptedError catch, missing hints, fixture coupling |
+| 3    | 3/5    | 0 (W1–W6) | All iter-2 warnings addressed; new warnings on typer.Exit swallowing, str(OSError) path leak, run_stage coverage |
+| 4    | (skipped) | — | User opted out of further iteration to ship the PR |

--- a/src/clawrium/cli/clawctl/agent/configure.py
+++ b/src/clawrium/cli/clawctl/agent/configure.py
@@ -20,10 +20,11 @@ from typing import Optional
 
 import typer
 
-from clawrium.cli.clawctl._common import require_flag, stdin_is_tty
+from clawrium.cli.clawctl._common import stdin_is_tty
 from clawrium.cli.clawctl.agent._shared import resolve_agent_key, safe_resolve_agent
 from clawrium.cli.output import emit_error, stream_action
-from clawrium.core.lifecycle import LifecycleError
+from clawrium.core.hosts import HostsFileCorruptedError, update_host
+from clawrium.core.lifecycle import LifecycleError, sync_agent
 from clawrium.core.onboarding import (
     AgentNotFoundError,
     InvalidTransitionError,
@@ -32,6 +33,96 @@ from clawrium.core.onboarding import (
     get_onboarding_state,
     run_stage,
 )
+from clawrium.core.providers.storage import (
+    ProvidersFileCorruptedError,
+    get_provider,
+)
+
+
+def _attach_provider_for_configure(
+    agent_name: str, hostname: str, agent_key: str, provider_name: str
+) -> None:
+    """Write `agents.<key>.providers = [provider_name]` for issue #541.
+
+    Differs from `clawctl agent provider attach` in one critical way:
+    the verb is *replace*, not *append*. The customer outcome on #541
+    requires that `clawctl agent configure --stage providers --provider X`
+    can be called any number of times — including to switch the
+    attached provider — without manually detaching first. The
+    Pattern A `attach` surface refuses to replace by design (#426
+    single-provider invariant), so the configure path performs the
+    replacement inline.
+    """
+    # ATX iter-2 B3 / iter-3 W1+W4: broaden the catch so a missing,
+    # unreadable, or structurally malformed `providers.json` surfaces a
+    # clean message instead of a raw traceback. `str(OSError)` formats
+    # as `[Errno 2] ... '/home/<user>/.config/clawrium/providers.json'`
+    # — the full path including the username leaks. For OS-level
+    # exceptions, surface the type only and steer the operator to the
+    # canonical config path in the hint.
+    record: dict | None = None
+    try:
+        record = get_provider(provider_name)
+    except ProvidersFileCorruptedError as exc:
+        emit_error(
+            str(exc),
+            hint="check ~/.config/clawrium/providers.json (clawctl provider registry get)",
+        )
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        emit_error(
+            f"could not read providers file: {type(exc).__name__}",
+            hint="check ~/.config/clawrium/providers.json (clawctl provider registry get)",
+        )
+    except (KeyError, ValueError, TypeError) as exc:
+        emit_error(
+            f"providers file structurally invalid: {type(exc).__name__}",
+            hint="check ~/.config/clawrium/providers.json",
+        )
+    if not record:
+        emit_error(
+            f"provider {provider_name!r} not registered",
+            hint="clawctl provider registry get",
+        )
+
+    # ATX iter-2 B3: persist the canonical name from the registry record,
+    # not the raw CLI argument. `get_provider` is case- and shape-
+    # tolerant; downstream lifecycle code reads `agents.<n>.providers`
+    # and looks up the provider by *that* exact string.
+    canonical_name = record.get("name", provider_name)
+
+    def updater(h: dict) -> dict:
+        agents = h.get("agents", {})
+        if agent_key not in agents or not isinstance(agents[agent_key], dict):
+            raise LifecycleError(
+                f"agent record for {agent_name!r} missing from host {hostname!r}"
+            )
+        agents[agent_key]["providers"] = [canonical_name]
+        return h
+
+    # ATX iter-3 W1: `update_host` can raise `HostsFileCorruptedError`
+    # (malformed hosts.json) or `OSError` (atomic-write fs failure) in
+    # addition to `LifecycleError`. Catch the lot so a fs/IO failure
+    # surfaces a clean message rather than a raw traceback leaking
+    # `~/.config/clawrium/hosts.json` path internals.
+    try:
+        update_host(hostname, updater)
+    except LifecycleError as exc:
+        emit_error(
+            str(exc),
+            hint="clawctl agent get to verify state, then retry",
+        )
+    except HostsFileCorruptedError as exc:
+        emit_error(
+            str(exc),
+            hint="inspect ~/.config/clawrium/hosts.json before retrying",
+        )
+    except OSError as exc:
+        # ATX iter-3 W4: do not leak the absolute hosts.json path via
+        # `str(OSError)`. Surface the error type only.
+        emit_error(
+            f"could not write hosts.json: {type(exc).__name__}",
+            hint="inspect ~/.config/clawrium/hosts.json before retrying",
+        )
 
 
 class Stage(str, Enum):
@@ -115,9 +206,18 @@ def configure(
             hint="run a specific stage with --stage providers|identity|validate",
         )
 
-    # Provider stage requires provider flag (or TTY for prompt fallback).
+    # ATX iter-2 B1: `--provider` is unconditionally required when the
+    # providers stage is selected. `require_flag` defers on a TTY so
+    # without this guard a `--stage providers` invocation on an
+    # interactive terminal would fall through to the placeholder
+    # `run_stage` path, silently corrupting the onboarding record
+    # (exactly the bug #541 exists to fix).
     if stage is Stage.providers:
-        require_flag(provider, flag="--provider")
+        if not provider:
+            emit_error(
+                "missing required flag --provider",
+                hint="pass --provider <name> (see 'clawctl provider registry get')",
+            )
 
     # ATX iter-2 B1: `--personality` flowed into the verb signature but
     # nothing read it back out. Until `run_stage` accepts a personality
@@ -135,6 +235,100 @@ def configure(
     stream_action(
         resource=f"agent/{name}", message=f"configure stage={stage.value} on {hostname}"
     )
+
+    # Issue #541: the providers stage was previously routed through
+    # `run_stage`, which is a placeholder that only flips the per-stage
+    # status flag — it never pushes config to the host and never advances
+    # the onboarding state machine. That left the agent stuck at
+    # `state=pending` and blocked every subsequent stage (`identity`,
+    # `validate`) and `agent start`.
+    #
+    # Route `--stage providers --provider X` through the real reconcile
+    # path: write the attachment into `agents.<name>.providers` (Pattern A
+    # from #426/#509), then call `sync_agent`. `sync_agent` builds the
+    # provider overlay, walks the state machine (PENDING → PROVIDERS →
+    # ... → READY, honoring per-manifest `auto_skip`), and pushes the
+    # configuration via Ansible. This makes the verb idempotent on a
+    # `ready` agent (re-attaching the same or a different provider stays
+    # in `ready`) and unblocks the remaining stages.
+    if stage is Stage.providers and provider is not None:
+        # Ensure the onboarding record exists so `sync_agent`'s
+        # state-machine walk has something to transition. Mirrors the
+        # PENDING-recovery branch below for the non-providers path.
+        try:
+            get_onboarding_state(hostname, agent_key)
+        except OnboardingNotFoundError:
+            from clawrium.core.onboarding import initialize_onboarding
+
+            try:
+                initialize_onboarding(hostname, agent_key)
+            except AgentNotFoundError as exc:
+                emit_error(
+                    f"agent record disappeared during configure: {exc}",
+                    hint="rerun clawctl agent get to verify",
+                )
+
+        # ATX iter-3 W3: wrap the attach call so any unexpected
+        # exception (TypeError/ValueError/etc.) from registry handling
+        # surfaces as a clean CLI error rather than a raw traceback
+        # leaking config paths.
+        try:
+            _attach_provider_for_configure(name, hostname, agent_key, provider)
+        except (typer.Exit, SystemExit):
+            raise
+        except Exception as exc:
+            emit_error(
+                f"configure stage failed: {exc}",
+                hint=f"clawctl agent describe {name}",
+            )
+
+        def on_event(stage_evt: str, message: str) -> None:
+            # ATX iter-2 W1: forward all sync progress events (ansible
+            # phases take 30–60s; previously the operator saw a frozen
+            # cursor). Mirrors how `clawctl agent sync` surfaces events.
+            stream_action(resource=f"agent/{name}", message=f"[{stage_evt}] {message}")
+
+        # ATX iter-2 S6/W7 parity with the non-providers path: pre-bind
+        # `result` so a non-LifecycleError that escapes the try block
+        # does not raise `UnboundLocalError` at the `result.get(...)`
+        # check below.
+        result: dict = {}
+        try:
+            result = sync_agent(
+                hostname=hostname,
+                claw_name=agent_type,
+                agent_name=agent_key,
+                on_event=on_event,
+            )
+        except LifecycleError as exc:
+            emit_error(
+                f"configure stage failed: {exc}",
+                hint=f"clawctl agent describe {name}",
+            )
+        except (typer.Exit, SystemExit):
+            # ATX iter-3 W2: `emit_error` raises `typer.Exit`. If
+            # `sync_agent` (or any helper it calls) ever invokes
+            # `emit_error` internally, the bare `except Exception`
+            # below would re-wrap the exit into a vacuous "configure
+            # stage failed" message that masks the real cause. Let the
+            # exit propagate unmodified.
+            raise
+        except Exception as exc:  # ATX iter-2 B2: parity with non-providers path
+            emit_error(
+                f"configure stage failed: {exc}",
+                hint=f"clawctl agent describe {name}",
+            )
+
+        if not result.get("success"):
+            emit_error(
+                f"configure stage failed: {result.get('error') or 'unknown error'}",
+                hint=f"clawctl agent describe {name}",
+            )
+
+        stream_action(
+            resource=f"agent/{name}", message=f"stage {stage.value} complete"
+        )
+        return
 
     # ATX iter-1 B4: `get_onboarding_state` raises `OnboardingNotFoundError`
     # for any pre-onboarding-schema agent (or when install.py's Step 11
@@ -167,7 +361,10 @@ def configure(
     try:
         success = run_stage(agent_type, hostname, agent_key, stage.value)
     except LifecycleError as exc:
-        emit_error(f"configure stage failed: {exc}")
+        emit_error(
+            f"configure stage failed: {exc}",
+            hint=f"clawctl agent describe {name}",
+        )
     except InvalidTransitionError as exc:
         # ATX iter-2 W6: surface state-machine rejection distinctly from
         # opaque network/lifecycle errors so the operator knows the
@@ -176,8 +373,15 @@ def configure(
             f"configure stage rejected: {exc}",
             hint=f"clawctl agent describe {name}",
         )
+    except (typer.Exit, SystemExit):
+        # ATX iter-3 W2: do not re-wrap propagating CLI exits. See the
+        # matching branch in the providers path above.
+        raise
     except Exception as exc:  # core.onboarding may raise misc errors
-        emit_error(f"configure stage failed: {exc}")
+        emit_error(
+            f"configure stage failed: {exc}",
+            hint=f"clawctl agent describe {name}",
+        )
 
     if not success:
         emit_error(

--- a/tests/cli/clawctl/agent/test_configure_errors.py
+++ b/tests/cli/clawctl/agent/test_configure_errors.py
@@ -6,6 +6,9 @@ from typer.testing import CliRunner
 
 from clawrium.cli import app
 
+# `emit_error` writes to stderr. Current CliRunner (Click 8.2+) merges
+# stderr into `result.output` by default, which is what makes
+# "<text> in result.output" assertions on error paths work below.
 runner = CliRunner()
 
 
@@ -60,6 +63,53 @@ def test_configure_invalid_transition_surfaces_distinct_hint(
 
     monkeypatch.setattr("clawrium.cli.clawctl.agent.configure.run_stage", reject)
 
+    # Issue #541: `--stage providers --provider X` no longer routes
+    # through `run_stage`; it goes through `sync_agent`. Use a stage
+    # that still delegates to `run_stage` to exercise the W6 path.
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "configure",
+            "wise-hypatia",
+            "--stage",
+            "validate",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "stage rejected" in result.output
+    # W5: the remediation hint is the operationally meaningful part of
+    # the contract — assert it explicitly so it can't be silently
+    # deleted from configure.py.
+    assert "clawctl agent describe" in result.output
+
+
+def test_providers_stage_agent_not_found_during_init_surfaces_clean_error(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """B6 regression: the structurally identical race-recovery block in
+    the providers branch must surface the same clean error as the
+    non-providers path.
+    """
+    from clawrium.core.onboarding import AgentNotFoundError, OnboardingNotFoundError
+
+    def raise_missing(*_a, **_k):
+        raise OnboardingNotFoundError("no onboarding record")
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.get_onboarding_state",
+        raise_missing,
+    )
+
+    def init_race(*_args, **_kwargs):
+        raise AgentNotFoundError("agent 'wise-hypatia' vanished")
+
+    monkeypatch.setattr("clawrium.core.onboarding.initialize_onboarding", init_race)
+    # No `get_provider` stub needed — the test exits via emit_error in
+    # the initialize_onboarding race path *before*
+    # `_attach_provider_for_configure` (which is where `get_provider`
+    # would be called) is reached.
+
     result = runner.invoke(
         app,
         [
@@ -73,4 +123,77 @@ def test_configure_invalid_transition_surfaces_distinct_hint(
         ],
     )
     assert result.exit_code != 0
-    assert "stage rejected" in result.output
+    assert "agent record disappeared" in result.output
+
+
+def test_run_stage_lifecycle_error_surfaces_configure_failed_message(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """ATX iter-3 W6: `run_stage` raising `LifecycleError` in the
+    non-providers path must surface a clean 'configure stage failed'
+    message — the existing test only covers `InvalidTransitionError`.
+    """
+    from clawrium.core.lifecycle import LifecycleError
+    from clawrium.core.onboarding import OnboardingState
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.get_onboarding_state",
+        lambda *_a, **_k: OnboardingState.READY,
+    )
+
+    def raise_lifecycle(*_a, **_k):
+        raise LifecycleError("ansible exited 1")
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.run_stage", raise_lifecycle
+    )
+
+    result = runner.invoke(
+        app,
+        ["agent", "configure", "wise-hypatia", "--stage", "validate"],
+    )
+
+    assert result.exit_code != 0
+    assert "configure stage failed" in result.output
+    assert "ansible exited 1" in result.output
+
+
+def test_run_stage_returns_false_surfaces_did_not_complete(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """ATX iter-3 W6: `run_stage` returning `False` must surface a
+    'did not complete' message via the `success` guard.
+    """
+    from clawrium.core.onboarding import OnboardingState
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.get_onboarding_state",
+        lambda *_a, **_k: OnboardingState.READY,
+    )
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.run_stage",
+        lambda *_a, **_k: False,
+    )
+
+    result = runner.invoke(
+        app,
+        ["agent", "configure", "wise-hypatia", "--stage", "validate"],
+    )
+
+    assert result.exit_code != 0
+    assert "did not complete" in result.output
+
+
+def test_channels_stage_deprecation_fires_before_agent_lookup(fleet_dir) -> None:
+    """ATX iter-3 W5: the `--stage channels` deprecation guard is
+    hoisted above `safe_resolve_agent` so a typo'd agent name surfaces
+    the actionable deprecation hint, not a misleading 'agent not found'
+    error. Pin the ordering with a regression test.
+    """
+    result = runner.invoke(
+        app,
+        ["agent", "configure", "NO-SUCH-AGENT", "--stage", "channels"],
+    )
+    assert result.exit_code != 0
+    assert "deprecated" in result.output
+    assert "not found" not in result.output

--- a/tests/cli/clawctl/agent/test_configure_providers_state.py
+++ b/tests/cli/clawctl/agent/test_configure_providers_state.py
@@ -1,0 +1,524 @@
+"""Issue #541: `--stage providers --provider X` drives the onboarding
+state machine forward and is idempotent across re-runs.
+
+Before the fix, the v2 verb delegated to `core.onboarding.run_stage`,
+which is a placeholder — it flipped the per-stage `status` flag but
+never advanced the outer `state`, never pushed the provider config to
+the remote host, and silently corrupted the onboarding record by
+leaving `providers.provider_id = null` while marking the stage
+complete. That stranded the agent at `state=pending` and blocked
+every subsequent stage and `agent start`.
+
+The fix routes the providers stage through `sync_agent`, which is the
+same reconcile path that `clawctl agent sync` uses. These tests pin
+the new contract: the provider attachment lands in `agents.<n>.providers`
+(replace semantics, not append), `sync_agent` is invoked with the
+agent's key, and a sync failure surfaces a clean CLI error.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+from clawrium.core.hosts import HostsFileCorruptedError
+from clawrium.core.lifecycle import LifecycleError
+from clawrium.core.providers.storage import ProvidersFileCorruptedError
+
+# `emit_error` writes to stderr. Current CliRunner merges stderr into
+# `result.output` by default — that is what makes `"X in result.output"`
+# assertions on error paths work below.
+runner = CliRunner()
+
+
+def _read_hosts(fleet_dir: Path) -> list[dict]:
+    return json.loads((fleet_dir / "hosts.json").read_text())
+
+
+def _stub_sync_agent_success(monkeypatch, captured: dict[str, Any]) -> None:
+    def fake_sync_agent(**kwargs):
+        captured.update(kwargs)
+        return {
+            "success": True,
+            "agent": kwargs.get("agent_name"),
+            "host": kwargs.get("hostname"),
+            "operation": "sync",
+            "pid": None,
+            "started_at": None,
+            "error": None,
+        }
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.sync_agent",
+        fake_sync_agent,
+    )
+
+
+def _stub_provider_registry(monkeypatch, provider_name: str = "clawrium-glm51") -> None:
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.get_provider",
+        lambda name: {
+            "name": provider_name,
+            "type": "openai",
+            "endpoint": "https://example.invalid",
+            "default_model": "glm-5.1",
+        }
+        if name == provider_name
+        else None,
+    )
+
+
+def test_providers_stage_with_provider_writes_attachment_and_invokes_sync(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """`--stage providers --provider X` writes the attachment into
+    `agents.<key>.providers` and delegates to `sync_agent`.
+    """
+    _stub_provider_registry(monkeypatch)
+    captured: dict[str, Any] = {}
+    _stub_sync_agent_success(monkeypatch, captured)
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "configure",
+            "wise-hypatia",
+            "--stage",
+            "providers",
+            "--provider",
+            "clawrium-glm51",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "stage providers complete" in result.output
+
+    hosts = _read_hosts(fleet_dir)
+    agent_record = hosts[0]["agents"]["openclaw"]
+    assert agent_record["providers"] == ["clawrium-glm51"]
+
+    assert captured["agent_name"] == "openclaw"
+    assert captured["claw_name"] == "openclaw"
+    assert captured["hostname"] == "10.0.0.1"
+
+
+def test_providers_stage_replaces_existing_attachment(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """Idempotent re-assign: a second `--stage providers --provider Y` on
+    an agent that already has provider X attached replaces, not appends.
+    """
+    _stub_provider_registry(monkeypatch, provider_name="clawrium-glm52")
+    _stub_sync_agent_success(monkeypatch, {})
+
+    hosts_path = fleet_dir / "hosts.json"
+    hosts = json.loads(hosts_path.read_text())
+    hosts[0]["agents"]["openclaw"]["providers"] = ["clawrium-glm51"]
+    hosts_path.write_text(json.dumps(hosts))
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "configure",
+            "wise-hypatia",
+            "--stage",
+            "providers",
+            "--provider",
+            "clawrium-glm52",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    hosts_after = _read_hosts(fleet_dir)
+    assert hosts_after[0]["agents"]["openclaw"]["providers"] == ["clawrium-glm52"]
+
+
+def test_providers_stage_unknown_provider_fails_cleanly(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """Unknown provider name surfaces a 'not registered' error before
+    any sync runs. No `providers` attachment is written.
+    """
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.get_provider",
+        lambda _name: None,
+    )
+
+    called = {"sync": False}
+
+    def fake_sync_agent(**_kwargs):
+        called["sync"] = True
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.sync_agent", fake_sync_agent
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "configure",
+            "wise-hypatia",
+            "--stage",
+            "providers",
+            "--provider",
+            "bogus-provider",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "not registered" in result.output
+    assert called["sync"] is False
+    hosts = _read_hosts(fleet_dir)
+    assert "providers" not in hosts[0]["agents"]["openclaw"]
+
+
+def test_providers_stage_sync_failure_surfaces_clean_error(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """A `sync_agent` failure (e.g. Ansible push) surfaces as a clean
+    CLI error rather than a traceback.
+    """
+    _stub_provider_registry(monkeypatch)
+
+    def fake_sync_agent(**_kwargs):
+        return {
+            "success": False,
+            "agent": "openclaw",
+            "host": "10.0.0.1",
+            "operation": "sync",
+            "pid": None,
+            "started_at": None,
+            "error": "Configure failed: ansible push exited 2",
+        }
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.sync_agent", fake_sync_agent
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "configure",
+            "wise-hypatia",
+            "--stage",
+            "providers",
+            "--provider",
+            "clawrium-glm51",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "configure stage failed" in result.output
+    assert "ansible push exited 2" in result.output
+
+
+def test_providers_stage_sync_agent_lifecycle_error_surfaces_clean_error(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """B4: `sync_agent` raising `LifecycleError` (vs returning a dict
+    with success=False) is the live `except` path. Verify it surfaces a
+    clean message rather than a traceback.
+    """
+    _stub_provider_registry(monkeypatch)
+
+    def raising_sync(**_kwargs):
+        raise LifecycleError("ansible rc=2")
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.sync_agent", raising_sync
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "configure",
+            "wise-hypatia",
+            "--stage",
+            "providers",
+            "--provider",
+            "clawrium-glm51",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "configure stage failed" in result.output
+    assert "ansible rc=2" in result.output
+
+
+def test_providers_stage_corrupt_providers_file_surfaces_clean_error(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """B5: A corrupt `providers.json` must surface a clean error and
+    must NOT call `sync_agent` (the attachment never lands).
+    """
+
+    def raise_corrupt(_name):
+        raise ProvidersFileCorruptedError("malformed json near line 7")
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.get_provider", raise_corrupt
+    )
+
+    called = {"sync": False}
+
+    def fake_sync_agent(**_kwargs):
+        called["sync"] = True
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.sync_agent", fake_sync_agent
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "configure",
+            "wise-hypatia",
+            "--stage",
+            "providers",
+            "--provider",
+            "clawrium-glm51",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "malformed json" in result.output
+    assert "providers.json" in result.output
+    assert called["sync"] is False
+
+
+def test_providers_stage_update_host_corrupt_hosts_file_surfaces_clean_error(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """ATX iter-3 W1: `update_host` raising `HostsFileCorruptedError`
+    (malformed hosts.json) must surface a clean message — not a raw
+    traceback exposing config-dir paths.
+    """
+    _stub_provider_registry(monkeypatch)
+
+    def raise_corrupt(*_a, **_k):
+        raise HostsFileCorruptedError("hosts.json: schema mismatch")
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.update_host", raise_corrupt
+    )
+
+    called = {"sync": False}
+
+    def fake_sync_agent(**_kwargs):
+        called["sync"] = True
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.sync_agent", fake_sync_agent
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "configure",
+            "wise-hypatia",
+            "--stage",
+            "providers",
+            "--provider",
+            "clawrium-glm51",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "hosts.json" in result.output
+    assert called["sync"] is False
+
+
+def test_providers_stage_update_host_oserror_surfaces_clean_error(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """ATX iter-3 W6: the `OSError` arm of the broadened `update_host`
+    catch (e.g. read-only filesystem) must surface a clean message and
+    must NOT leak the absolute hosts.json path via `str(OSError)`.
+    """
+    _stub_provider_registry(monkeypatch)
+
+    def raise_oserror(*_a, **_k):
+        raise OSError("[Errno 30] Read-only file system: '/secret/path/hosts.json'")
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.update_host", raise_oserror
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "configure",
+            "wise-hypatia",
+            "--stage",
+            "providers",
+            "--provider",
+            "clawrium-glm51",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "could not write hosts.json" in result.output
+    # ATX iter-3 W4: confirm the leaking path is NOT in the error output.
+    assert "/secret/path/hosts.json" not in result.output
+
+
+def test_providers_stage_update_host_lifecycle_error_surfaces_clean_error(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """B7: `update_host` raising `LifecycleError` (e.g. agent record
+    raced away between resolve and write) must surface a clean error.
+    """
+    _stub_provider_registry(monkeypatch)
+
+    def raise_lifecycle(*_a, **_k):
+        raise LifecycleError("agent record missing from host")
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.update_host", raise_lifecycle
+    )
+
+    called = {"sync": False}
+
+    def fake_sync_agent(**_kwargs):
+        called["sync"] = True
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.sync_agent", fake_sync_agent
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "configure",
+            "wise-hypatia",
+            "--stage",
+            "providers",
+            "--provider",
+            "clawrium-glm51",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "agent record missing" in result.output
+    assert called["sync"] is False
+
+
+def test_providers_stage_sync_failure_without_error_field_uses_fallback(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """W6: When `sync_agent` returns `{'success': False}` with no
+    `error` key, the `'unknown error'` fallback must surface.
+    """
+    _stub_provider_registry(monkeypatch)
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.sync_agent",
+        lambda **_k: {"success": False},
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "configure",
+            "wise-hypatia",
+            "--stage",
+            "providers",
+            "--provider",
+            "clawrium-glm51",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "unknown error" in result.output
+
+
+def test_providers_stage_forwards_all_sync_events_to_user(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """W1/W7: the `on_event` callback forwards all sync progress lines,
+    not just warning-prefixed ones — operators need to see ansible
+    progress during the 30–60s push.
+    """
+    _stub_provider_registry(monkeypatch)
+
+    def streaming_sync(**kwargs):
+        on_event = kwargs.get("on_event")
+        assert on_event is not None
+        on_event("sync", "Configuring wise-hypatia...")
+        on_event("sync", "warning: could not write state=READY")
+        return {"success": True}
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.sync_agent", streaming_sync
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "configure",
+            "wise-hypatia",
+            "--stage",
+            "providers",
+            "--provider",
+            "clawrium-glm51",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Configuring wise-hypatia" in result.output
+    assert "could not write state=READY" in result.output
+
+
+def test_providers_stage_requires_provider_flag_on_tty(
+    fleet_dir, monkeypatch
+) -> None:
+    """B1: `--stage providers` without `--provider` must fail
+    unconditionally — without this guard the verb falls through to the
+    placeholder `run_stage` path and silently corrupts the onboarding
+    record. Patch both `stdin_is_tty` (in case the fixture binding
+    diverges from `configure.py`'s direct import — ATX iter-3 W3) and
+    `run_stage` (poison) so a regression that bypasses the guard fails
+    the test loudly instead of vacuously passing.
+    """
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.stdin_is_tty",
+        lambda *_a, **_k: True,
+    )
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.configure.run_stage",
+        lambda *_a, **_k: pytest.fail("regression: providers fell through to run_stage"),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "configure",
+            "wise-hypatia",
+            "--stage",
+            "providers",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--provider" in result.output


### PR DESCRIPTION
## Summary

- Route `clawctl agent configure --stage providers --provider X` through `sync_agent` (the same reconcile path `clawctl agent sync` uses) instead of the placeholder `core.onboarding.run_stage`. The placeholder only flipped a per-stage status flag — it never pushed config to the host and never advanced the outer onboarding `state`, stranding agents at `state=pending` and blocking every subsequent stage and `agent start`.
- Verb is idempotent on a `ready` agent (re-assigning the same or a different provider stays in `ready`), with replace-semantics on the `agents.<name>.providers` attachment.
- Added 13 new regression tests covering provider attachment write, sync failure modes, registry/host-file IO failures, fixture-binding regressions, and the previously-uncovered non-providers `run_stage` error paths.

REf #541

## Testing

### Test Results
- [x] All existing tests pass (`make test` — 3330 passed, 6 skipped)
- [x] Linter passes (`make lint`)
- [x] New tests added for new functionality (13 tests across 2 files)

### Test Coverage
- Files changed: `src/clawrium/cli/clawctl/agent/configure.py`, `tests/cli/clawctl/agent/test_configure_errors.py`
- New tests: `tests/cli/clawctl/agent/test_configure_providers_state.py`
- Coverage impact: increased — new branches (HostsFileCorruptedError/OSError on `update_host`, `run_stage` LifecycleError, `run_stage`→False fallback, channels-deprecation ordering, typer.Exit propagation) are now pinned

### Manual Testing
Not run end-to-end against a live remote host in this PR; covered by the test suite plus the existing live-path coverage on `sync_agent` (`test_sync_materializes_provider.py`, `test_sync_hermes_multi_provider.py`).

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation: `--provider` value resolved against `providers.json` registry, canonical name persisted (not raw CLI arg)
- [x] No SQL injection / XSS / command injection risks
- [x] Dependencies unchanged
- [x] `OSError` / `HostsFileCorruptedError` from filesystem layer no longer leak absolute paths through `str(exc)`

## ATX Review Summary

**Final Review: Rating 3/5**
**Total: 4 iterations attempted, 3 completed**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1-B7 (7) | All fixed | $2.31 | 7m37s | leader, cli-ux, core-lifecycle, security, test-coverage |
| 2 | 3/5 | None (W1-W5) | All warnings fixed | — | ~7m | leader, cli-ux, core-lifecycle |
| 3 | 3/5 | None (W1-W6) | All warnings fixed | — | ~7m | leader, cli-ux, core-lifecycle, security, test-coverage |
| 4 | — | — | Cancelled (user opted to ship) | — | — | — |

> **Note**: ATX iters 2 and 3 had specialists (security-reviewer, test-coverage-reviewer) fail with timeout/max-turns on some passes; warnings from responding specialists were addressed.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**
| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `configure.py:162` | TTY+`--stage providers`+no `--provider` fell through to placeholder `run_stage` | Made `--provider` unconditionally required when `--stage providers` |
| B2 | `configure.py:223` | providers branch missing broad exception catch from `sync_agent` | Added `except Exception` parity with non-providers path |
| B3 | `configure.py:57` | `get_provider` narrow catch leaked tracebacks; CLI arg (not canonical name) persisted | Broadened catch; persist `record["name"]` |
| B4 | `configure.py:230` | `sync_agent` LifecycleError raise path untested | Added test |
| B5 | `configure.py:58` | `ProvidersFileCorruptedError` path untested | Added test |
| B6 | `configure.py:207` | providers-path `AgentNotFoundError` recovery untested | Added test |
| B7 | `configure.py:76` | `update_host` LifecycleError untested | Added test |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Warnings:**
| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `configure.py:88` | `update_host` catch covered only `LifecycleError`; missing `HostsFileCorruptedError`/`OSError` | Added |
| W2 | `configure.py:261,263,316` | Bare `emit_error` calls missing remediation hints | Added `hint=f"clawctl agent describe {name}"` |
| W3 | conftest `stdin_not_tty` | Patches `_common.stdin_is_tty` but `configure.py` imports the symbol directly — fixture is silent no-op | Patched `configure` binding directly in our test |
| W4 | non-providers path | Non-providers stages skip gateway-token rotation | Deferred — pre-existing AGENTS.md spec gap, out of scope (see Callout) |
| W5 | test comment | Misleading "Provide a valid provider stub..." comment | Rewrote |

</details>

<details>
<summary>Review 3 Details (Rating 3/5)</summary>

**Warnings:**
| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `configure.py:60` | `record` unbound + narrow catch on `get_provider`; needs `KeyError`/`ValueError`/`TypeError` for malformed registry entries | Pre-bound `record=None`; added structural-error catch |
| W2 | `configure.py:265,330` | `typer.Exit` (which inherits from `Exception`) swallowed by bare `except Exception`, double-emitting "configure stage failed" | Added explicit `except (typer.Exit, SystemExit): raise` ahead of bare catch |
| W3 | `configure.py:245` | `_attach_provider_for_configure` unwrapped — unexpected exceptions escape with raw traceback | Wrapped call in try/except |
| W4 | `configure.py:62,95` | `str(OSError)` leaks absolute config-dir paths through stderr | Surface error type only; remediation in hint |
| W5 | test file | `--stage channels` deprecation hoist had no regression test | Added |
| W6 | test files | 3 untested branches: `run_stage` LifecycleError, `run_stage`→False, `update_host` OSError | Added 3 tests |

</details>

## Callouts

- [DECISION] `clawctl agent configure --stage providers --provider X` uses **replace** semantics on `agents.<name>.providers`, not append semantics like `clawctl agent provider attach`.
  - Why: customer outcome on #541 explicitly requires "any number of times" re-assignment without manual detach. The Pattern A `attach` surface enforces the single-provider invariant (#426) by refusing to replace, so the configure path performs the replacement inline.
  - Reviewer: confirm this is the intended UX boundary between `configure` and `attach`.
- [UNRESOLVED] ATX iter-3 W4 — non-providers stages (`identity`, `validate`) continue to route through `run_stage` and never invoke `sync_agent`, so gateway tokens are not rotated on those configure calls. AGENTS.md §"Gateway Token Lifecycle (zeroclaw)" states configure "always mints a fresh bearer" with "no idempotent-skip path."
  - Best guess applied: deferred — pre-existing gap, not introduced by this PR; widening scope to also rewire `identity`/`validate` materially expands the surface beyond the customer outcome on #541.
  - Reviewer: confirm this should be tracked as a separate follow-up issue against AGENTS.md or the non-providers stages.
- [ENVIRONMENT] ATX review was performed via the `atx review` CLI (MCP atx tools unavailable on this control machine). 4 iterations were attempted; iter-4 was cancelled at the user's request before completion. Final contract is iter-3 (Rating 3/5, no blockers).
- [TODO-FOLLOWUP] Pre-existing concerns flagged by ATX but **not addressed** in this PR:
  - `--stage` and `--provider` lack short forms (`-s`, `-p`). Tracking: to be filed.
  - `configure --help` lacks epilog examples covering the providers/identity/validate progression. Tracking: to be filed.
  - `_agent_type` local in `configure()` actually holds the raw dict key, not the agent type (stale name + comment). Tracking: to be filed.
  - The TTY interactive multi-stage flow (`clawctl agent configure <n>` with no `--stage`) emits "not yet exposed via clawctl" — full interactive UX is the v2 onboarding follow-up. Tracking: pre-existing, no new issue.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
