### PR TITLE
chore(ux): simplify agent open and tunnel error paths

### DIFF
--- a/src/clawrium/cli/clawctl/agent/open.py
+++ b/src/clawrium/cli/clawctl/agent/open.py
@@ -48,20 +48,10 @@ def open(  # noqa: A001 — `open` matches plan §4 verb name
     if not needs_tunnel:
         url = f"http://127.0.0.1:{remote_port}"
     else:
-        from clawrium.core.web_ui_tunnel import TunnelError
         from clawrium.core.web_ui_tunnel import ensure as ensure_tunnel
 
-        try:
-            # owned=False: tunnel subprocess outlives CLI — no atexit cleanup.
-            local_port = ensure_tunnel(name, owned=False)
-        except TunnelError as exc:
-            emit_error(
-                f"tunnel setup failed for agent {name!r}: {exc}",
-                hint=(
-                    "check SSH config with 'clawctl host describe <host>'; "
-                    "use --print-url to get the URL for manual SSH forwarding"
-                ),
-            )
+        # owned=False: tunnel subprocess outlives CLI — no atexit cleanup.
+        local_port = ensure_tunnel(name, owned=False)
         url = f"http://127.0.0.1:{local_port}"
 
     if print_url:
@@ -69,9 +59,4 @@ def open(  # noqa: A001 — `open` matches plan §4 verb name
         return
 
     stream_action(resource=f"agent/{name}", message=f"opening {url}")
-    if not webbrowser.open(url):
-        typer.echo(f"Could not open browser. URL: {url}", err=True)
-        typer.echo(
-            "Hint:  re-run with --print-url to get the URL for manual use.",
-            err=True,
-        )
+    webbrowser.open(url)

--- a/src/clawrium/core/web_ui_tunnel.py
+++ b/src/clawrium/core/web_ui_tunnel.py
@@ -221,13 +221,7 @@ def _ssh_command(
         "-o",
         "ExitOnForwardFailure=yes",
         "-o",
-        # Strict mode (not accept-new): TOFU would let the first tunnel to a
-        # given host silently trust whichever server answers. AGENTS.md states
-        # the SSH key is the auth boundary — that only holds with mutual
-        # authentication enforced. `clawctl host create --bootstrap` populates
-        # known_hosts; if the host isn't there yet, ssh fails loudly and the
-        # user is told to run host-create first.
-        "StrictHostKeyChecking=yes",
+        "StrictHostKeyChecking=accept-new",
     ]
     if ssh_port:
         cmd += ["-p", str(ssh_port)]

--- a/src/clawrium/platform/registry/hermes/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/install.yaml
@@ -400,18 +400,6 @@
       no_log: true
       notify: Reload systemd
 
-    # ATX B4: validate dashboard_port falls within the per-instance allocation
-    # range (45000..46999) defined by install.py:_pick_per_instance_port. A
-    # misconfigured or colliding port would silently write a broken systemd
-    # unit; failing here surfaces the bug at provisioning time instead.
-    - name: Assert dashboard_port is within the allocated 45000-46999 range
-      ansible.builtin.assert:
-        that:
-          - dashboard_port is defined
-          - (dashboard_port | int) >= 45000
-          - (dashboard_port | int) <= 46999
-        fail_msg: "dashboard_port {{ dashboard_port | default('<unset>') }} is outside the 45000-46999 range allocated by install.py"
-
     # Companion dashboard unit. `PartOf=` makes systemd propagate stop/restart
     # from the gateway unit to this one automatically. The gateway unit's
     # `Also=` (above) is the symmetric enable/disable hook. ExecStart binds

--- a/tests/cli/clawctl/agent/test_open.py
+++ b/tests/cli/clawctl/agent/test_open.py
@@ -38,31 +38,17 @@ def test_open_print_url_local_host_skips_tunnel(fleet_dir, monkeypatch) -> None:
     assert browser_urls == []  # --print-url skips the browser
 
 
-def _browser_mock_success(browser_urls):
-    """ATX W1: success-path browser mock returns True so the headless-fallback
-    branch in open.py does NOT fire — otherwise success tests would silently
-    exercise the failure path and pass.
-    """
-
-    def _open(url):
-        browser_urls.append(url)
-        return True
-
-    return _open
-
-
 def test_open_local_host_opens_browser_no_tunnel(fleet_dir, monkeypatch) -> None:
     """Local agent: opens browser immediately, no tunnel needed."""
     resolved = SimpleNamespace(host="127.0.0.1", remote_port=12345)
     monkeypatch.setattr(
         "clawrium.cli.clawctl.agent.open.resolve_web_ui", lambda _: resolved
     )
-    browser_urls: list[str] = []
-    monkeypatch.setattr("webbrowser.open", _browser_mock_success(browser_urls))
+    browser_urls = []
+    monkeypatch.setattr("webbrowser.open", lambda url: browser_urls.append(url))
     result = runner.invoke(app, ["agent", "open", "wise-hypatia"])
     assert result.exit_code == 0
     assert browser_urls == ["http://127.0.0.1:12345"]
-    assert "Could not open browser" not in result.output
 
 
 def test_open_remote_host_uses_tunnel_unowned(fleet_dir, monkeypatch) -> None:
@@ -76,13 +62,12 @@ def test_open_remote_host_uses_tunnel_unowned(fleet_dir, monkeypatch) -> None:
         "clawrium.core.web_ui_tunnel.ensure",
         lambda agent_key, *, owned=True: (ensure_calls.append(owned), 45678)[1],
     )
-    browser_urls: list[str] = []
-    monkeypatch.setattr("webbrowser.open", _browser_mock_success(browser_urls))
+    browser_urls = []
+    monkeypatch.setattr("webbrowser.open", lambda url: browser_urls.append(url))
     result = runner.invoke(app, ["agent", "open", "wise-hypatia"])
     assert result.exit_code == 0
     assert "http://127.0.0.1:45678" in result.output
     assert browser_urls == ["http://127.0.0.1:45678"]
-    assert "Could not open browser" not in result.output
     # CLI must pass owned=False so tunnel outlives the process
     assert ensure_calls == [False]
 
@@ -105,42 +90,6 @@ def test_open_remote_print_url_no_block(fleet_dir, monkeypatch) -> None:
     assert "http://127.0.0.1:45678" in result.output
     assert browser_urls == []  # --print-url skips browser
     assert ensure_calls == [False]  # still unowned
-
-
-def test_open_remote_tunnel_error_emits_clean_message(fleet_dir, monkeypatch) -> None:
-    """ATX B1: TunnelError must surface as a clean emit_error, not a raw traceback."""
-    from clawrium.core.web_ui_tunnel import TunnelError
-
-    resolved = SimpleNamespace(host="10.0.0.1", remote_port=9999)
-    monkeypatch.setattr(
-        "clawrium.cli.clawctl.agent.open.resolve_web_ui", lambda _: resolved
-    )
-
-    def _raise(*_args, **_kwargs):
-        raise TunnelError("SSH user not configured for host; cannot establish tunnel.")
-
-    monkeypatch.setattr("clawrium.core.web_ui_tunnel.ensure", _raise)
-    monkeypatch.setattr("webbrowser.open", lambda _url: True)
-    result = runner.invoke(app, ["agent", "open", "wise-hypatia"])
-    assert result.exit_code != 0
-    # No raw traceback bubbled up
-    assert result.exception is None or isinstance(result.exception, SystemExit)
-    assert "tunnel setup failed" in result.output
-    assert "SSH user not configured" in result.output
-
-
-def test_open_local_headless_browser_fallback(fleet_dir, monkeypatch) -> None:
-    """ATX B2: webbrowser.open() returning False must surface a manual-URL hint."""
-    resolved = SimpleNamespace(host="127.0.0.1", remote_port=12345)
-    monkeypatch.setattr(
-        "clawrium.cli.clawctl.agent.open.resolve_web_ui", lambda _: resolved
-    )
-    monkeypatch.setattr("webbrowser.open", lambda _url: False)
-    result = runner.invoke(app, ["agent", "open", "wise-hypatia"])
-    assert result.exit_code == 0
-    assert "Could not open browser" in result.output
-    assert "http://127.0.0.1:12345" in result.output
-    assert "--print-url" in result.output
 
 
 def test_open_unknown_agent_errors(fleet_dir) -> None:

--- a/tests/test_web_ui_tunnel.py
+++ b/tests/test_web_ui_tunnel.py
@@ -107,14 +107,7 @@ def test_build_ssh_for_wildcard_resolves_to_remote_loopback():
     assert forward == "39211:127.0.0.1:40123"
 
 
-def test_build_ssh_for_enforces_strict_host_key_checking():
-    """ATX B5: SSH command MUST set `StrictHostKeyChecking=yes` — never `accept-new`.
-
-    `accept-new` allows TOFU on first connect, which silently undermines
-    the SSH-as-auth-boundary contract documented in AGENTS.md (a LAN MITM
-    on the first tunnel session would harvest the zeroclaw pairing bearer).
-    Regression-guards a code-only revert to `accept-new`.
-    """
+def test_build_ssh_for_uses_accept_new_host_key_checking():
     resolved = ResolvedUI(
         host="hermes.local",
         remote_port=45123,
@@ -122,8 +115,7 @@ def test_build_ssh_for_enforces_strict_host_key_checking():
         ssh_config={"user": "xclm"},
     )
     cmd = _build_ssh_for(resolved, local_port=39211)
-    assert "StrictHostKeyChecking=yes" in cmd
-    assert not any("accept-new" in arg for arg in cmd)
+    assert "StrictHostKeyChecking=accept-new" in cmd
 
 
 def test_build_ssh_for_consults_bind_address_map_wildcard(monkeypatch):


### PR DESCRIPTION
## Summary
- Drop `TunnelError` try/except in `clawctl agent open`; exceptions surface directly without a wrapped hint.
- Remove the headless-browser fallback message when `webbrowser.open` returns False.
- Switch SSH tunnel to `StrictHostKeyChecking=accept-new` (TOFU on first connect) instead of strict `yes`.
- Remove the hermes install playbook's `dashboard_port` 45000-46999 range assertion.
- Update/remove tests that pinned the previous behavior (incl. the strict-host-key regression guard).

## Testing

### Test Results
- [x] All existing tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New tests added for new functionality (test updated to assert `accept-new`)

### Test Coverage
- Files changed: `src/clawrium/cli/clawctl/agent/open.py`, `src/clawrium/core/web_ui_tunnel.py`, `src/clawrium/platform/registry/hermes/playbooks/install.yaml`, `tests/cli/clawctl/agent/test_open.py`, `tests/test_web_ui_tunnel.py`
- New tests: N/A (existing tests updated/removed)
- Coverage impact: decreased (removed error-path and headless-fallback tests)

### Manual Testing
N/A — change is mechanical (matches an externally-supplied patch).

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources

## Reviewer Notes
SSH `StrictHostKeyChecking=accept-new` permits TOFU on the first connection to a host. This reverses a prior regression guard (ATX B5) that pinned strict `yes`. Confirm this trade-off is acceptable before merging.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)