### PR TITLE
feat(gui): cluster topology by host and add edge focus

### DIFF
--- a/gui/src/components/topology/host-cluster-node.tsx
+++ b/gui/src/components/topology/host-cluster-node.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+
+import { type HostClusterNodeData } from "./topology-graph";
+
+export function HostClusterNode({ data }: NodeProps) {
+  const { hostname, alias, agentCount, hostColor, width, height, onHostClick } =
+    data as unknown as HostClusterNodeData;
+
+  return (
+    <div
+      style={{ width, height }}
+      className="relative rounded-xl"
+    >
+      <Handle
+        type="target"
+        position={Position.Bottom}
+        id="ssh"
+        className="!bg-transparent !border-0 !w-1 !h-1"
+      />
+      <div
+        className="absolute inset-0 rounded-xl border-2 border-dashed"
+        style={{ borderColor: "#EA580C", pointerEvents: "none" }}
+      />
+      <button
+        onClick={() => onHostClick?.(hostname)}
+        className="absolute left-4 top-3 flex items-baseline gap-2 hover:opacity-80 transition-opacity"
+      >
+        <span
+          className="inline-block w-2.5 h-2.5 rounded-full self-center"
+          style={{ backgroundColor: hostColor }}
+        />
+        <span className="text-base font-bold text-primary-text">{alias}</span>
+        <span className="text-[11px] text-muted">·</span>
+        <span className="text-[11px] text-muted truncate max-w-[280px]">
+          {hostname}
+        </span>
+        <span className="text-[11px] text-muted">·</span>
+        <span className="text-[11px] text-muted">
+          {agentCount} {agentCount === 1 ? "agent" : "agents"}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/gui/src/components/topology/index.ts
+++ b/gui/src/components/topology/index.ts
@@ -2,6 +2,7 @@ export { TopologyCanvas } from "./topology-canvas";
 export { ControlNode } from "./control-node";
 export { AgentNode } from "./agent-node";
 export { HostNode } from "./host-node";
+export { HostClusterNode } from "./host-cluster-node";
 export { ProviderNode } from "./provider-node";
 export { TopologyLegend } from "./topology-legend";
 export { AgentInfoModal } from "./agent-info-modal";

--- a/gui/src/components/topology/topology-canvas.tsx
+++ b/gui/src/components/topology/topology-canvas.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { type MouseEvent as ReactMouseEvent, useCallback, useEffect, useMemo, useState } from "react";
 import {
   ReactFlow,
   Background,
   Controls,
   useNodesState,
   useEdgesState,
+  type Node,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
@@ -14,6 +15,7 @@ import { type TopologyResponse, type TopologyAgent, type TopologyHost } from "@/
 import { ControlNode } from "./control-node";
 import { AgentNode } from "./agent-node";
 import { ProviderNode } from "./provider-node";
+import { HostClusterNode } from "./host-cluster-node";
 import { TopologyLegend } from "./topology-legend";
 import { AgentInfoModal } from "./agent-info-modal";
 import { HostInfoModal } from "./host-info-modal";
@@ -23,6 +25,7 @@ const nodeTypes = {
   control: ControlNode,
   agent: AgentNode,
   provider: ProviderNode,
+  "host-cluster": HostClusterNode,
 };
 
 function FleetSummaryCard({ data }: { data: TopologyResponse }) {
@@ -76,6 +79,7 @@ export function TopologyCanvas({ data }: TopologyCanvasProps) {
   const [selectedAgent, setSelectedAgent] = useState<TopologyAgent | null>(null);
   const [selectedAgentHost, setSelectedAgentHost] = useState<string>("");
   const [selectedHost, setSelectedHost] = useState<TopologyHost | null>(null);
+  const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
 
   const handleAgentClick = useCallback(
     (agent: TopologyAgent, hostAlias: string) => {
@@ -101,16 +105,57 @@ export function TopologyCanvas({ data }: TopologyCanvasProps) {
     return { initialNodes: nodes, initialEdges: edges };
   }, [data, handleAgentClick, handleHostClick]);
 
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
-  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+  // Toggle-focus only for agent and provider nodes; the modal still
+  // opens via its own button click that bubbles up.
+  const handleNodeClick = useCallback(
+    (_e: ReactMouseEvent, node: Node) => {
+      if (node.type !== "agent" && node.type !== "provider") return;
+      setFocusedNodeId((prev) => (prev === node.id ? null : node.id));
+    },
+    []
+  );
 
-  // useNodesState/useEdgesState consume their argument only at mount. The
-  // hook refetches every 30s and recomputes initialNodes/initialEdges via
-  // useMemo — without this effect, the canvas froze at first load.
+  const handlePaneClick = useCallback(() => setFocusedNodeId(null), []);
+
+  // Restyle edges based on focus: highlight connected edges, dim the rest.
+  const displayEdges = useMemo(() => {
+    if (!focusedNodeId) return initialEdges;
+    return initialEdges.map((edge) => {
+      const connected =
+        edge.source === focusedNodeId || edge.target === focusedNodeId;
+      if (!connected) {
+        return {
+          ...edge,
+          style: { ...edge.style, opacity: 0.12 },
+          animated: false,
+        };
+      }
+      return {
+        ...edge,
+        style: {
+          ...edge.style,
+          stroke: "#EA580C",
+          strokeWidth: 2.5,
+          opacity: 1,
+        },
+        animated: true,
+        zIndex: 1000,
+      };
+    });
+  }, [initialEdges, focusedNodeId]);
+
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(displayEdges);
+
+  // useNodesState/useEdgesState consume their argument only at mount.
+  // Recopy on every change so layout refetches and focus changes apply.
   useEffect(() => {
     setNodes(initialNodes);
-    setEdges(initialEdges);
-  }, [initialNodes, initialEdges, setNodes, setEdges]);
+  }, [initialNodes, setNodes]);
+
+  useEffect(() => {
+    setEdges(displayEdges);
+  }, [displayEdges, setEdges]);
 
   return (
     <div className="relative w-full h-[calc(100vh-12rem)] bg-surface rounded-xl border border-default overflow-hidden">
@@ -119,6 +164,8 @@ export function TopologyCanvas({ data }: TopologyCanvasProps) {
         edges={edges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
+        onNodeClick={handleNodeClick}
+        onPaneClick={handlePaneClick}
         nodeTypes={nodeTypes}
         fitView
         fitViewOptions={{ padding: 0.3 }}

--- a/gui/src/components/topology/topology-graph.test.ts
+++ b/gui/src/components/topology/topology-graph.test.ts
@@ -341,16 +341,26 @@ describe("computeTopology", () => {
     expect(agentEdge?.label).toBeUndefined();
   });
 
-  it("emits an SSH edge per agent from the control node", () => {
+  it("emits one SSH edge per host (control → host-cluster, not per-agent)", () => {
     const data = makeData([
-      { hostname: "h1", agents: [makeAgent({ agent_key: "x1" })] },
-      { hostname: "h2", agents: [makeAgent({ agent_key: "x2" })] },
+      {
+        hostname: "h1",
+        agents: [
+          makeAgent({ agent_key: "x1" }),
+          makeAgent({ agent_key: "x2" }),
+        ],
+      },
+      { hostname: "h2", agents: [makeAgent({ agent_key: "x3" })] },
     ]);
     const { edges } = computeTopology(data);
     const sshEdges = edges.filter((e) => e.source === "control");
+    // h1 has 2 agents but only ONE SSH edge from control.
     expect(sshEdges).toHaveLength(2);
     expect(sshEdges.every((e) => e.animated === true)).toBe(true);
-    expect(sshEdges.map((e) => e.target).sort()).toEqual(["agent-x1", "agent-x2"]);
+    expect(sshEdges.map((e) => e.target).sort()).toEqual([
+      "host-cluster-h1",
+      "host-cluster-h2",
+    ]);
     expect(sshEdges.every((e) => e.label === "SSH")).toBe(true);
   });
 
@@ -416,6 +426,173 @@ describe("computeTopology", () => {
       (providerNode!.data as { acceleratorVendor: string | null })
         .acceleratorVendor,
     ).toBe("amd");
+  });
+
+  it("filters out hosts with zero agents (no cluster, no agents, no SSH edge)", () => {
+    const data = makeData([
+      { hostname: "empty-host", agents: [] },
+      { hostname: "real-host", agents: [makeAgent({ agent_key: "x1" })] },
+    ]);
+
+    const { nodes, edges } = computeTopology(data);
+    const clusters = nodes.filter((n) => n.type === "host-cluster");
+    expect(clusters).toHaveLength(1);
+    expect(
+      (clusters[0].data as { hostname: string }).hostname
+    ).toBe("real-host");
+
+    // No agent or SSH edge should reference the empty host.
+    const agentNodes = nodes.filter((n) => n.type === "agent");
+    expect(agentNodes).toHaveLength(1);
+    expect(edges.filter((e) => e.source === "control")).toHaveLength(1);
+  });
+
+  it("emits one host-cluster node per non-empty host", () => {
+    const data = makeData([
+      { hostname: "host-a", agents: [makeAgent({ agent_key: "a1" })] },
+      {
+        hostname: "host-b",
+        agents: [
+          makeAgent({ agent_key: "b1" }),
+          makeAgent({ agent_key: "b2" }),
+        ],
+      },
+    ]);
+
+    const { nodes } = computeTopology(data);
+    const clusters = nodes.filter((n) => n.type === "host-cluster");
+    expect(clusters).toHaveLength(2);
+    expect(
+      clusters
+        .map((c) => (c.data as { hostname: string }).hostname)
+        .sort()
+    ).toEqual(["host-a", "host-b"]);
+    clusters.forEach((c) => {
+      const d = c.data as { width: number; height: number };
+      expect(d.width).toBeGreaterThan(0);
+      expect(d.height).toBeGreaterThan(0);
+    });
+  });
+
+  it("wraps to multiple internal rows when a cluster has more than 3 agents", () => {
+    const data = makeData([
+      {
+        hostname: "wolf",
+        agents: Array.from({ length: 7 }).map((_, i) =>
+          makeAgent({ agent_key: `w${i + 1}` })
+        ),
+      },
+    ]);
+
+    const { nodes } = computeTopology(data);
+    const agentNodes = nodes
+      .filter((n) => n.type === "agent")
+      .sort((a, b) => a.position.y - b.position.y || a.position.x - b.position.x);
+
+    // 7 agents in a 3-col grid → 3 internal rows (y values: y0, y1, y2)
+    const uniqueYs = Array.from(new Set(agentNodes.map((n) => n.position.y)));
+    expect(uniqueYs).toHaveLength(3);
+
+    // 3 agents on row 0, 3 on row 1, 1 on row 2.
+    const counts = uniqueYs.map(
+      (y) => agentNodes.filter((n) => n.position.y === y).length
+    );
+    expect(counts).toEqual([3, 3, 1]);
+  });
+
+  it("places every agent inside its host-cluster bounding box", () => {
+    const data = makeData([
+      {
+        hostname: "wolf",
+        agents: Array.from({ length: 7 }).map((_, i) =>
+          makeAgent({ agent_key: `w${i + 1}` })
+        ),
+      },
+      {
+        hostname: "mac",
+        agents: [
+          makeAgent({ agent_key: "m1" }),
+          makeAgent({ agent_key: "m2" }),
+          makeAgent({ agent_key: "m3" }),
+        ],
+      },
+    ]);
+
+    const { nodes } = computeTopology(data);
+    const clusters = nodes.filter((n) => n.type === "host-cluster");
+    const agentNodes = nodes.filter((n) => n.type === "agent");
+
+    clusters.forEach((cluster) => {
+      const cd = cluster.data as {
+        hostname: string;
+        width: number;
+        height: number;
+      };
+      // Look up the agents that should be inside this cluster by their
+      // declared hostname.
+      const owned = agentNodes.filter(
+        (n) => (n.data as { hostname: string }).hostname === cd.hostname
+      );
+      expect(owned.length).toBeGreaterThan(0);
+      owned.forEach((agent) => {
+        expect(agent.position.x).toBeGreaterThanOrEqual(cluster.position.x);
+        expect(agent.position.y).toBeGreaterThanOrEqual(cluster.position.y);
+        expect(agent.position.x + AGENT_NODE_WIDTH).toBeLessThanOrEqual(
+          cluster.position.x + cd.width
+        );
+        // Bottom edge — use a sentinel agent height that matches the layout
+        // constant in topology-graph.ts. We assert <= bottom of cluster.
+        expect(agent.position.y + 160).toBeLessThanOrEqual(
+          cluster.position.y + cd.height
+        );
+      });
+    });
+  });
+
+  it("wraps clusters onto a new canvas row when total width exceeds the budget", () => {
+    // Five hosts × 3 agents each → each cluster is ~720px wide. The
+    // greedy packer's CANVAS_WIDTH_TARGET (1500) fits 2 per row, so
+    // expect ≥ 2 distinct cluster Y positions.
+    const data = makeData(
+      Array.from({ length: 5 }).map((_, h) => ({
+        hostname: `host-${h}`,
+        agents: Array.from({ length: 3 }).map((_, a) =>
+          makeAgent({ agent_key: `h${h}-a${a}` })
+        ),
+      }))
+    );
+
+    const { nodes } = computeTopology(data);
+    const clusters = nodes.filter((n) => n.type === "host-cluster");
+    const uniqueYs = new Set(clusters.map((c) => c.position.y));
+    expect(uniqueYs.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it("places provider row below the cluster stack (dynamic Y)", () => {
+    // Multiple hosts means cluster Y values vary; provider Y must be
+    // below the deepest cluster bottom.
+    const data = makeData([
+      {
+        hostname: "wolf",
+        agents: Array.from({ length: 7 }).map((_, i) =>
+          makeAgent({ agent_key: `w${i + 1}` })
+        ),
+      },
+      {
+        hostname: "mac",
+        agents: [makeAgent({ agent_key: "m1" })],
+      },
+    ]);
+
+    const { nodes } = computeTopology(data);
+    const clusters = nodes.filter((n) => n.type === "host-cluster");
+    const providerNode = nodes.find((n) => n.type === "provider");
+    const deepestBottom = Math.max(
+      ...clusters.map(
+        (c) => c.position.y + (c.data as { height: number }).height
+      )
+    );
+    expect(providerNode!.position.y).toBeGreaterThan(deepestBottom);
   });
 
   it("passes hostGpuVendor to provider node data for NVIDIA detection", () => {

--- a/gui/src/components/topology/topology-graph.ts
+++ b/gui/src/components/topology/topology-graph.ts
@@ -10,15 +10,37 @@ import { AGENT_NODE_WIDTH } from "./agent-node";
 
 /* ─── Layout Constants ────────────────────────────────────────────── */
 
-/** Vertical row positions (top → bottom) */
-const AGENT_ROW_Y = 0;
-const PROVIDER_ROW_Y = 320;
-const CONTROL_ROW_Y = 560;
+/** Fixed agent card height used for cluster layout math. The rendered
+ * card height is roughly content-driven (~150-160px); this value is a
+ * conservative upper bound so the cluster border encloses all agents. */
+const AGENT_NODE_HEIGHT = 160;
 
-/** Horizontal spacing between agent cards */
-const AGENT_GAP = 36;
+/** Max agents per row within a single cluster before wrapping. */
+const MAX_AGENTS_PER_CLUSTER_ROW = 3;
 
-/** Horizontal spacing between provider nodes */
+/** Intra-cluster spacing between agent cards. */
+const AGENT_GAP_X = 36;
+const AGENT_GAP_Y = 20;
+
+/** Cluster padding (header occupies the extra top room). */
+const CLUSTER_PAD_X = 18;
+const CLUSTER_PAD_TOP = 44;
+const CLUSTER_PAD_BOTTOM = 18;
+
+/** Inter-cluster spacing on the canvas. */
+const CLUSTER_GAP_X = 56;
+const CLUSTER_GAP_Y = 48;
+
+/** Width budget used for greedy width-fit cluster packing. Clusters
+ * pack left-to-right until the next would exceed this width, then a
+ * new canvas row starts. */
+const CANVAS_WIDTH_TARGET = 1700;
+
+/** Vertical gaps between cluster stack, provider row, and control. */
+const PROVIDER_OFFSET_Y = 100;
+const CONTROL_OFFSET_Y = 220;
+
+/** Horizontal spacing between provider nodes. */
 const PROVIDER_SPACING = 200;
 
 const UNCONFIGURED_KEY = "__unconfigured__";
@@ -36,6 +58,16 @@ export interface ProviderNodeData {
   hostGpuVendor?: string | null;
   /** User-selected accelerator brand for local-inference providers. */
   acceleratorVendor?: AcceleratorVendor | null;
+}
+
+export interface HostClusterNodeData {
+  hostname: string;
+  alias: string;
+  agentCount: number;
+  hostColor: string;
+  width: number;
+  height: number;
+  onHostClick?: (hostname: string) => void;
 }
 
 export interface ComputeTopologyOptions {
@@ -56,6 +88,17 @@ interface ProviderAccumulator {
   agents: Array<{ hostname: string; agentKey: string; model: string | null }>;
 }
 
+interface ClusterLayout {
+  host: TopologyResponse["hosts"][number];
+  cols: number;
+  rows: number;
+  width: number;
+  height: number;
+  /** Canvas-absolute top-left of the cluster (set during packing). */
+  x: number;
+  y: number;
+}
+
 /* ─── Helpers ─────────────────────────────────────────────────────── */
 
 export function providerNodeKey(agent: TopologyAgent): string {
@@ -64,6 +107,66 @@ export function providerNodeKey(agent: TopologyAgent): string {
   const name = agent.provider || type;
   const endpoint = agent.provider_endpoint ?? "";
   return [type, name, endpoint].map(encodeURIComponent).join("|");
+}
+
+function measureCluster(agentCount: number): {
+  cols: number;
+  rows: number;
+  width: number;
+  height: number;
+} {
+  const cols = Math.min(agentCount, MAX_AGENTS_PER_CLUSTER_ROW);
+  const rows = Math.ceil(agentCount / cols);
+  const contentWidth =
+    cols * AGENT_NODE_WIDTH + Math.max(cols - 1, 0) * AGENT_GAP_X;
+  const contentHeight =
+    rows * AGENT_NODE_HEIGHT + Math.max(rows - 1, 0) * AGENT_GAP_Y;
+  return {
+    cols,
+    rows,
+    width: contentWidth + CLUSTER_PAD_X * 2,
+    height: contentHeight + CLUSTER_PAD_TOP + CLUSTER_PAD_BOTTOM,
+  };
+}
+
+/** Pack clusters greedily across canvas rows; centre each row on x=0. */
+function packClusters(clusters: ClusterLayout[]): void {
+  let cursorX = 0;
+  let cursorY = 0;
+  let rowMaxHeight = 0;
+
+  const rowEnds: number[] = [];
+  const rowWidths: number[] = [];
+
+  const flushRow = (endIdx: number) => {
+    const widthOfRow = cursorX === 0 ? 0 : cursorX - CLUSTER_GAP_X;
+    rowEnds.push(endIdx);
+    rowWidths.push(widthOfRow);
+  };
+
+  clusters.forEach((cluster, idx) => {
+    const wouldOverflow =
+      cursorX > 0 && cursorX + cluster.width > CANVAS_WIDTH_TARGET;
+    if (wouldOverflow) {
+      flushRow(idx);
+      cursorY += rowMaxHeight + CLUSTER_GAP_Y;
+      cursorX = 0;
+      rowMaxHeight = 0;
+    }
+    cluster.x = cursorX;
+    cluster.y = cursorY;
+    cursorX += cluster.width + CLUSTER_GAP_X;
+    if (cluster.height > rowMaxHeight) rowMaxHeight = cluster.height;
+  });
+  if (clusters.length > (rowEnds.at(-1) ?? 0)) flushRow(clusters.length);
+
+  // Centre each row on x=0.
+  let from = 0;
+  rowEnds.forEach((to, rowIdx) => {
+    const shift = -rowWidths[rowIdx] / 2;
+    for (let i = from; i < to; i++) clusters[i].x += shift;
+    from = to;
+  });
 }
 
 /* ─── Main Layout Function ────────────────────────────────────────── */
@@ -75,58 +178,72 @@ export function computeTopology(
   const nodes: Node[] = [];
   const edges: Edge[] = [];
 
-  // ─── Build host color map ─────────────────────────────────────────
-  const hostnames = data.hosts.map((h) => h.hostname);
-  const hostColorMap = buildHostColorMap(hostnames);
+  // Build host color map over all hosts (stable colours regardless of
+  // which hosts are populated).
+  const hostColorMap = buildHostColorMap(data.hosts.map((h) => h.hostname));
 
-  // ─── 1. Agent nodes (top row) ─────────────────────────────────────
-  // Flatten all agents across hosts into individual top-level nodes.
-  const allAgents: Array<{
-    agent: TopologyAgent;
-    hostname: string;
-    alias: string;
-    hardware: TopologyResponse["hosts"][0]["hardware"];
-    osFamily: TopologyResponse["hosts"][0]["os_family"];
-  }> = [];
+  // ─── 1. Host clusters + agent nodes ──────────────────────────────
+  // Hosts with zero agents are filtered out — they should not appear.
+  const populatedHosts = data.hosts.filter((h) => h.agents.length > 0);
 
-  data.hosts.forEach((host) => {
-    host.agents.forEach((agent) => {
-      allAgents.push({
-        agent,
+  const clusters: ClusterLayout[] = populatedHosts.map((host) => {
+    const { cols, rows, width, height } = measureCluster(host.agents.length);
+    return { host, cols, rows, width, height, x: 0, y: 0 };
+  });
+
+  packClusters(clusters);
+
+  let clustersBottom = 0;
+
+  clusters.forEach((cluster) => {
+    const { host, cols, x: cx, y: cy, width, height } = cluster;
+    const hostColor = getHostColor(hostColorMap, host.hostname);
+
+    nodes.push({
+      id: `host-cluster-${host.hostname}`,
+      type: "host-cluster",
+      position: { x: cx, y: cy },
+      data: {
         hostname: host.hostname,
         alias: host.alias,
-        hardware: host.hardware,
-        osFamily: host.os_family ?? null,
+        agentCount: host.agents.length,
+        hostColor,
+        width,
+        height,
+        onHostClick: opts.onHostClick,
+      } satisfies HostClusterNodeData,
+      zIndex: -1,
+      selectable: false,
+      draggable: false,
+    });
+
+    host.agents.forEach((agent, idx) => {
+      const col = idx % cols;
+      const row = Math.floor(idx / cols);
+      const ax = cx + CLUSTER_PAD_X + col * (AGENT_NODE_WIDTH + AGENT_GAP_X);
+      const ay = cy + CLUSTER_PAD_TOP + row * (AGENT_NODE_HEIGHT + AGENT_GAP_Y);
+      nodes.push({
+        id: `agent-${agent.agent_key}`,
+        type: "agent",
+        position: { x: ax, y: ay },
+        data: {
+          agent,
+          hostname: host.hostname,
+          hostAlias: host.alias,
+          hardware: host.hardware ?? null,
+          hostOsFamily: host.os_family ?? null,
+          hostColor,
+          onAgentClick: opts.onAgentClick,
+          onHostClick: opts.onHostClick,
+        },
       });
     });
+
+    const bottom = cy + height;
+    if (bottom > clustersBottom) clustersBottom = bottom;
   });
 
-  const totalAgentWidth =
-    allAgents.length * AGENT_NODE_WIDTH +
-    Math.max(allAgents.length - 1, 0) * AGENT_GAP;
-  let agentCursorX = -totalAgentWidth / 2;
-
-  allAgents.forEach(({ agent, hostname, alias, hardware, osFamily }) => {
-    const nodeId = `agent-${agent.agent_key}`;
-    nodes.push({
-      id: nodeId,
-      type: "agent",
-      position: { x: agentCursorX, y: AGENT_ROW_Y },
-      data: {
-        agent,
-        hostname,
-        hostAlias: alias,
-        hardware: hardware ?? null,
-        hostOsFamily: osFamily ?? null,
-        hostColor: getHostColor(hostColorMap, hostname),
-        onAgentClick: opts.onAgentClick,
-        onHostClick: opts.onHostClick,
-      },
-    });
-    agentCursorX += AGENT_NODE_WIDTH + AGENT_GAP;
-  });
-
-  // ─── 2. Provider nodes (middle row) ──────────────────────────────
+  // ─── 2. Provider nodes (below cluster stack) ─────────────────────
   const providerOrder: string[] = [];
   const providerMap = new Map<string, ProviderAccumulator>();
 
@@ -159,6 +276,7 @@ export function computeTopology(
     });
   });
 
+  const providerRowY = clustersBottom + PROVIDER_OFFSET_Y;
   const providerCount = providerOrder.length;
   const providerStartX = -((providerCount - 1) * PROVIDER_SPACING) / 2;
 
@@ -169,7 +287,7 @@ export function computeTopology(
     nodes.push({
       id: providerNodeId,
       type: "provider",
-      position: { x: providerStartX + idx * PROVIDER_SPACING, y: PROVIDER_ROW_Y },
+      position: { x: providerStartX + idx * PROVIDER_SPACING, y: providerRowY },
       data: {
         providerKey: pKey,
         name: acc.name,
@@ -183,7 +301,6 @@ export function computeTopology(
       } satisfies ProviderNodeData,
     });
 
-    // Edges: agent → provider
     acc.agents.forEach(({ agentKey }) => {
       const stroke = acc.unconfigured ? "#94A3B8" : "#475569";
       edges.push({
@@ -208,33 +325,33 @@ export function computeTopology(
     });
   });
 
-  // ─── 3. Control node (bottom row, minimal) ────────────────────────
+  // ─── 3. Control node + SSH edges ─────────────────────────────────
+  const controlRowY = providerRowY + CONTROL_OFFSET_Y;
   nodes.push({
     id: "control",
     type: "control",
-    position: { x: 0, y: CONTROL_ROW_Y },
+    position: { x: 0, y: controlRowY },
     data: { label: data.control.label, description: data.control.description },
   });
 
-  // Edges: control → agent (SSH, dashed + animated)
-  allAgents.forEach(({ agent }) => {
+  populatedHosts.forEach((host) => {
     edges.push({
-      id: `edge-control-${agent.agent_key}`,
+      id: `edge-control-${host.hostname}`,
       source: "control",
-      target: `agent-${agent.agent_key}`,
+      target: `host-cluster-${host.hostname}`,
       targetHandle: "ssh",
       type: "default",
       animated: true,
-      style: { stroke: "#0D9488", strokeWidth: 1, strokeDasharray: "5 3" },
+      style: { stroke: "#0D9488", strokeWidth: 1.5, strokeDasharray: "5 3" },
       markerEnd: {
         type: MarkerType.ArrowClosed,
         color: "#0D9488",
-        width: 12,
-        height: 12,
+        width: 14,
+        height: 14,
       },
       label: "SSH",
-      labelStyle: { fontSize: 9, fill: "#94A3B8" },
-      labelBgStyle: { fill: "#FFFFFF", fillOpacity: 0.8 },
+      labelStyle: { fontSize: 10, fill: "#475569" },
+      labelBgStyle: { fill: "#FFFFFF", fillOpacity: 0.85 },
       labelBgPadding: [3, 1] as [number, number],
     });
   });

--- a/gui/src/components/topology/topology-legend.tsx
+++ b/gui/src/components/topology/topology-legend.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+
 const LEGEND_ITEMS = [
   { label: "Running", color: "bg-status-running" },
   { label: "Degraded", color: "bg-status-warning" },
@@ -9,41 +11,60 @@ const LEGEND_ITEMS = [
 ];
 
 export function TopologyLegend() {
+  const [collapsed, setCollapsed] = useState(true);
+
   return (
-    <div className="absolute bottom-4 left-4 bg-white/90 backdrop-blur-sm border border-default rounded-lg px-4 py-3 shadow-sm z-10">
-      <div className="text-[10px] font-medium text-muted uppercase tracking-wide mb-2">
-        Status
-      </div>
-      <div className="flex items-center gap-4">
-        {LEGEND_ITEMS.map((item) => (
-          <div key={item.label} className="flex items-center gap-1.5">
-            <span className={`w-2 h-2 rounded-full ${item.color}`} />
-            <span className="text-xs text-secondary">{item.label}</span>
+    <div className="absolute bottom-4 left-4 bg-white/90 backdrop-blur-sm border border-default rounded-lg shadow-sm z-10 overflow-hidden">
+      <button
+        onClick={() => setCollapsed((c) => !c)}
+        className="w-full flex items-center justify-between gap-3 px-4 py-2 hover:bg-surface/50 transition-colors"
+        aria-expanded={!collapsed}
+      >
+        <span className="text-[10px] font-medium text-muted uppercase tracking-wide">
+          Status
+        </span>
+        <span
+          className="text-muted text-xs transition-transform"
+          style={{ transform: collapsed ? "rotate(0deg)" : "rotate(180deg)" }}
+          aria-hidden="true"
+        >
+          ▾
+        </span>
+      </button>
+      {!collapsed && (
+        <div className="px-4 pb-3">
+          <div className="flex items-center gap-4">
+            {LEGEND_ITEMS.map((item) => (
+              <div key={item.label} className="flex items-center gap-1.5">
+                <span className={`w-2 h-2 rounded-full ${item.color}`} />
+                <span className="text-xs text-secondary">{item.label}</span>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
-      <div className="mt-2 pt-2 border-t border-default space-y-1.5">
-        <div className="flex items-center gap-1.5">
-          <span className="w-4 border-t border-dashed border-primary" />
-          <span className="text-xs text-secondary">SSH connection</span>
+          <div className="mt-2 pt-2 border-t border-default space-y-1.5">
+            <div className="flex items-center gap-1.5">
+              <span className="w-4 border-t border-dashed border-primary" />
+              <span className="text-xs text-secondary">SSH connection</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="w-4 border-t border-solid border-slate-500" />
+              <span className="text-xs text-secondary">Agent &rarr; Provider</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="w-4 border-t border-dashed border-slate-400" />
+              <span className="text-xs text-secondary">Unconfigured connection</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="inline-block w-3 h-3 rounded border-2 border-primary/50 bg-white" />
+              <span className="text-xs text-secondary">Provider node</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="inline-block w-3 h-3 rounded border-2 border-dashed border-default bg-white" />
+              <span className="text-xs text-secondary">Unconfigured</span>
+            </div>
+          </div>
         </div>
-        <div className="flex items-center gap-1.5">
-          <span className="w-4 border-t border-solid border-slate-500" />
-          <span className="text-xs text-secondary">Agent &rarr; Provider</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <span className="w-4 border-t border-dashed border-slate-400" />
-          <span className="text-xs text-secondary">Unconfigured connection</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <span className="inline-block w-3 h-3 rounded border-2 border-primary/50 bg-white" />
-          <span className="text-xs text-secondary">Provider node</span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <span className="inline-block w-3 h-3 rounded border-2 border-dashed border-default bg-white" />
-          <span className="text-xs text-secondary">Unconfigured</span>
-        </div>
-      </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Group topology agents into per-host clusters with dotted-orange borders, header (`● alias · hostname · N agents`), and a 3-column intra-cluster grid; clusters greedy-pack across canvas rows and wrap when wider than ~1700px. Hosts with **0 agents are hidden entirely**.
- Replace the per-agent SSH edge fan-out with **one control→host edge per host**.
- Click an agent or provider to **focus its connections**: connected edges go bold orange and render on top (z=1000); other edges dim to 12% and stop animating. Toggle off by re-clicking the same node or clicking the canvas. Click-to-open-modal still works (highlight persists after the modal closes).
- Collapse the status legend to a `Status ▾` chip by default to reclaim canvas space.

## Testing

### Test Results
- [x] All existing tests pass (`make test` — 231/231 in `gui/`)
- [x] Linter passes (`npm run lint` — clean)
- [x] New tests added for new functionality (6 new cases in `topology-graph.test.ts`)

### Test Coverage
- Files changed: `gui/src/components/topology/{topology-graph.ts,topology-canvas.tsx,topology-legend.tsx,index.ts,host-cluster-node.tsx (new),topology-graph.test.ts}`
- New tests in `topology-graph.test.ts`:
  1. Filters out hosts with zero agents (no cluster, no agent, no SSH edge).
  2. Emits one `host-cluster` node per non-empty host.
  3. Internal wrap: 7 agents in a single cluster → 3 / 3 / 1 row counts.
  4. Every agent's position falls within its cluster's bounding box.
  5. Multi-cluster fleet wraps onto a new canvas row when total width exceeds the budget.
  6. Provider row Y is positioned below the deepest cluster bottom (dynamic, not hardcoded).
  - Updated SSH-edge test: asserts edges target `host-cluster-<hostname>` and count is per-host, not per-agent.
- Coverage impact: increased (new layout + focus paths covered).

### Manual Testing
- Built static export (`make build-ui`) and ran `clawctl gui` against the real fleet (3 hosts: wolf-i 7 agents, kevin 0 agents, mac-test 3 agents).
- Verified visually:
  - kevin (0 agents) is **not rendered**.
  - wolf-i renders as a 3×3 cluster (3+3+1), mac-test as 1×3, side-by-side.
  - Cluster border: 2px dashed `#EA580C`, header text base + bold, hostname + count small.
  - Two SSH edges from `control` to `host-cluster-wolf` and `host-cluster-mac-test`.
  - Clicking `clawrium-bedrock` provider lit its two consumer edges orange; rest dimmed.
  - Clicking an agent lit its single provider edge orange; rest dimmed.
  - Toggle behavior (same-node click / pane click) works.
  - Status legend collapses/expands on click.
- Screenshots captured in `tmp/screenshots/` (gitignored; not committed).

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — N/A, pure render-layer changes against an existing typed API response.
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources — no new deps added.

## Reviewer Notes
- `mcp.review_enabled = true` in `.claude/itx-config.json`, but the ATX MCP server was offline during this session — manual-review format used per the user's explicit request.
- The cluster wrap budget (`CANVAS_WIDTH_TARGET = 1700`) is a tunable constant in `topology-graph.ts`. Bump it to keep more clusters on one row for larger displays; lower it for narrower viewports.
- Agent card height is approximated as 160px for layout math — a conservative upper bound that lets the cluster border enclose the rendered cards. If the card grows significantly, bump `AGENT_NODE_HEIGHT` in the same file.
- Focus is purely a render-layer transform inside `TopologyCanvas`; `computeTopology` remains a pure function of `TopologyResponse`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)