### PR TITLE
fix(secrets): key per-agent secrets by stable host key_id (#448)

### DIFF
--- a/.itx/448/00_PLAN.md
+++ b/.itx/448/00_PLAN.md
@@ -1,0 +1,122 @@
+# Issue #448 — Stable secrets keying via immutable `key_id`
+
+## Summary
+
+`secrets.json` keys per-agent entries as `<hostname>:<type>:<name>`, where `hostname` is mutable. When operators change a host's network coordinates (IP → DNS, LAN IP → Tailscale name, renumber), every per-agent secret on that host becomes silently unreachable on the next `configure`/`chat`/`sync`.
+
+Affected secret types: Discord bot tokens, Slack tokens, GitHub PATs, provider API keys (OpenRouter / Anthropic / OpenAI / Bedrock), hermes `HERMES_API_SERVER_KEY` bearer.
+
+This plan implements **stable keying via `host["key_id"]`** (per issue #448's proposed fix), with explicit scope expansion to cover all `get_instance_key` callsites and the env-file consistency invariant that triggered the original maurice-on-wolf-i breakage (separate context: chat 401 traced to drift between `secrets.json[192.168.1.36:hermes:maurice]` and the daemon's `.env` rendered from `wolf.tailf7742d.ts.net:hermes:maurice`).
+
+## Root cause
+
+`get_instance_key(host, type, name)` in `src/clawrium/core/secrets.py:225` accepts an arbitrary string and is called everywhere with `host["hostname"]`. Hostname is the network address of the host — operators routinely mutate it. `key_id` (initialized to `hostname` at `clawctl host create` time, `src/clawrium/cli/clawctl/host/create.py:110`) is *intended* to be stable but:
+
+1. Re-running `clawctl host create` against an existing host overwrites `key_id` to the new hostname.
+2. No callsite uses `key_id` today; they all use `hostname` directly.
+
+Result: any hostname mutation orphans every secret for every agent on that host.
+
+## Scope
+
+### In scope
+
+1. **All `get_instance_key` callsites switch to `host["key_id"]`.** Enumerated (current grep):
+   - `src/clawrium/core/install.py:364, 713, 775`
+   - `src/clawrium/core/lifecycle.py:312, 1380, 1535, 1611, 1722, 1745, 2284`
+   - `src/clawrium/cli/chat.py:743`
+   - Any others surfaced by a fresh grep at execution time
+2. **`clawctl host create` preserves `key_id` on re-record.** When `clawctl host create <ip> --alias <existing-alias>` is run against a host whose alias already exists, update `hostname`/`port`/`addresses` but preserve the existing `key_id`. Print a one-line notice: `host <alias>: hostname <old> → <new> (key_id preserved)`.
+3. **Env-file consistency invariant in `lifecycle.start_agent`** (hermes-specific, applies to other env-file-rendering agents if they exist). Before starting the daemon, compare the on-host env file's `API_SERVER_KEY` against `secrets.json[<key_id>:hermes:<name>].HERMES_API_SERVER_KEY.value`. On mismatch, trigger `configure_agent` (re-render + restart) before proceeding. **`secrets.json` is authoritative; on-host env files are derived.**
+4. **Doc updates**: `docs/agent-support/hermes.md` instance-key format → `<key_id>:hermes:<name>`; `docs/host-preparation.md` note on `key_id` immutability.
+5. **Tests** (see below).
+
+### Out of scope (deliberately excluded)
+
+- **Automatic in-code migration** of legacy `<hostname>:*` secrets entries. Per maintainer instruction: no migration code. Existing affected agents will be migrated manually on each affected machine. New installs use the stable keying from day one.
+- **Alias rename**: deliberately invalidates secrets (acknowledged by #448's out-of-scope note — alias rename is a deliberate identity change). Alias is not part of the key path; alias change has no effect on secret resolution. No work needed.
+- **Zeroclaw gateway bearer in `hosts.json.gateway.auth`**: governed by issue #437's rotation contract (always re-pair on configure/sync/restart). Untouched in this PR.
+- **`clawctl secrets migrate` command**: deferred. If users on other machines complain, file a follow-up.
+
+## Implementation phases
+
+### Phase 1 — `get_instance_key` callsite sweep
+
+Goal: every per-agent secret lookup keys by `host["key_id"]`, not `host["hostname"]`.
+
+1. Grep for `get_instance_key(` across `src/`; verify the inventory above is complete.
+2. For each callsite, change the first argument from `host["hostname"]` (or equivalent) to `host["key_id"]`. Use a defensive fallback for malformed records: `host.get("key_id") or host["hostname"]` — preserves legacy behavior when `key_id` is absent (e.g. hand-edited `hosts.json`); record this as a `[DECISION]` callout.
+3. Update `get_instance_key`'s docstring in `src/clawrium/core/secrets.py:225` to specify "stable host identifier (`host["key_id"]`); MUST NOT be `hostname` which is mutable."
+4. Update `secrets.py:__all__` exports unchanged.
+
+### Phase 2 — `clawctl host create` preserves `key_id`
+
+Goal: re-recording an existing host updates network coordinates without rotating its identifier.
+
+1. `src/clawrium/cli/clawctl/host/create.py`: before constructing the new record (around line 108-124), check if a host with the same `alias` already exists via `clawrium.core.hosts.get_host_by_key_id` or alias lookup.
+2. If existing: preserve `key_id` from the existing record; allow `hostname`, `port`, `addresses` to update. Emit notice via `stream_action`/`console`.
+3. If new: behavior unchanged — mint `key_id = hostname` as today.
+4. Add unit test: `tests/cli/clawctl/host/test_create_preserves_key_id.py`.
+
+### Phase 3 — Env-file consistency invariant in `start_agent`
+
+Goal: a `clawctl agent start` (and by extension `restart`) cannot leave the daemon running with a stale token.
+
+1. `src/clawrium/core/lifecycle.py:start_agent` (hermes branch only — zeroclaw uses a different bearer path): before invoking the start playbook, run a tiny ansible probe (`slurp` or `command: cat`) against `/home/<agent_name>/.hermes/.env` to read the current `API_SERVER_KEY` value.
+2. Compare with `secrets.json[<key_id>:hermes:<agent_name>].HERMES_API_SERVER_KEY.value`.
+3. On mismatch: log a notice and invoke `configure_agent(...)` before continuing to start. On match: proceed.
+4. On probe failure (host unreachable, file missing): log warning, proceed — start playbook will surface the real error.
+
+### Phase 4 — Documentation
+
+1. `docs/agent-support/hermes.md`: replace `<host>:hermes:<agent-name>` with `<key_id>:hermes:<agent-name>` and add one sentence: "`key_id` is the immutable host identifier set when the host was first registered via `clawctl host create`. It does not change when the host's `hostname` is updated."
+2. `docs/host-preparation.md`: note in the "Register the host" section: "`clawctl host create` mints an immutable `key_id` on first run. Re-running it on an existing alias updates the hostname/IP without rotating the `key_id` — your secrets stay reachable."
+
+### Phase 5 — Tests
+
+Required coverage:
+
+1. `tests/core/test_secrets_keying.py` (new): parametrized — for each callsite path in `install.py` / `lifecycle.py` / `chat.py`, verify the function reads from `secrets.json` keyed by `host["key_id"]`, not `host["hostname"]`.
+2. `tests/core/test_install_hermes.py`: extend — install on a host whose `hostname` changes between two runs (`key_id` stable); assert single `HERMES_API_SERVER_KEY` entry under `<key_id>:hermes:<name>`, value reused on second install.
+3. `tests/cli/clawctl/host/test_create_preserves_key_id.py` (new): re-running `clawctl host create` against an existing alias preserves `key_id` and only mutates `hostname` / `port` / `addresses`.
+4. `tests/integration/test_secrets_survive_hostname_change.py` (new): end-to-end mocked — install agent with Discord+GitHub+provider secrets, mutate `hosts.json.hostname`, run `configure` + `chat`, assert all secrets resolve. Covers the full #448 repro (not just hermes bearer).
+5. `tests/core/test_lifecycle_env_consistency.py` (new): hermes-specific — when on-host `.env`'s `API_SERVER_KEY` ≠ `secrets.json`'s `HERMES_API_SERVER_KEY`, `start_agent` invokes `configure_agent` before starting; when they match, it does not.
+
+No migration tests (no migration code).
+
+## ATX review
+
+Use ATX CLI (`atx review --pr <pr-number>`) for review per the skill's fallback chain (MCP unavailable in this session). Persist session metadata to `.itx/448/atx-session.json` after every iteration. Iteration ceiling: 3.
+
+## Acceptance criteria
+
+- [ ] All `get_instance_key` callsites pass `host["key_id"]`; no callsite passes `host["hostname"]` directly.
+- [ ] `clawctl host create` on an existing alias preserves `key_id`; CLI test asserts.
+- [ ] `lifecycle.start_agent` hermes branch reconciles env-file ↔ secrets.json before start; unit test asserts on both match + mismatch paths.
+- [ ] `make test` passes (Python + GUI).
+- [ ] `make lint` passes.
+- [ ] ATX review rating > 3/5 with no unresolved blockers, OR `[ITX-STUCK]` PR with documented Callouts after 3 iterations.
+- [ ] Docs updated.
+- [ ] PR body includes `## Callouts` section (per skill contract).
+- [ ] PR title and body reference both #448 (Closes) and the maurice/wolf-i incident as context.
+
+## Files expected to change
+
+- `src/clawrium/core/secrets.py` — docstring + (no behavior change to `get_instance_key`)
+- `src/clawrium/core/install.py` — callsite updates
+- `src/clawrium/core/lifecycle.py` — callsite updates + env-file consistency invariant
+- `src/clawrium/cli/chat.py` — callsite update
+- `src/clawrium/cli/clawctl/host/create.py` — preserve `key_id` on re-record
+- `docs/agent-support/hermes.md`
+- `docs/host-preparation.md`
+- `tests/core/test_secrets_keying.py` (new)
+- `tests/core/test_install_hermes.py` (extend)
+- `tests/cli/clawctl/host/test_create_preserves_key_id.py` (new)
+- `tests/integration/test_secrets_survive_hostname_change.py` (new)
+- `tests/core/test_lifecycle_env_consistency.py` (new)
+
+## Notes for executor
+
+- The plan was authored in a conversation between maintainer and Claude on 2026-05-28 after diagnosing a hermes 401 on agent `maurice` (host `wolf-i`, alias). Investigation traced to `secrets.json` containing two entries for the same agent (`wolf.tailf7742d.ts.net:hermes:maurice` ≠ `192.168.1.36:hermes:maurice`), with the daemon's `.env` rendered from the former and `clawctl agent chat` reading from the latter. The maintainer explicitly chose `key_id`-based stable keying (matching #448's proposal) over a uuid-based alternative.
+- The maintainer explicitly excluded code-level migration — the affected agents on the maintainer's machine will be migrated by hand.
+- No PR comment / interaction during execution. Surface decisions as PR Callouts per the skill's contract.

--- a/.itx/448/02_E2E_TEST_PLAN.md
+++ b/.itx/448/02_E2E_TEST_PLAN.md
@@ -1,0 +1,299 @@
+# Issue #448 — End-to-end manual test plan (wolf-i)
+
+> **Execution record (2026-05-29, against wolf-i).** Scenarios 2, 3, 6
+> executed against a throwaway hermes agent `test448` on wolf-i.
+> Scenario 3 failed on first run and surfaced a real defect: the
+> paramiko env-probe ran `grep` as `xclm` without `sudo`, so the
+> 0700-mode agent home made the file unreadable — the helper saw
+> empty stdout and returned the non-fatal "API_SERVER_KEY not present"
+> path, the reconcile never fired, the daemon kept enforcing the
+> corrupt bearer. Fix: `sudo -n grep ...` in the probe. After fix,
+> Scenarios 2 and 3 PASS end-to-end (bearer survives across stop/start,
+> drift is detected and reconciled, HTTP 200 with canonical bearer).
+> Scenario 1 (host re-record) and the IP→DNS migration in Scenario 2
+> were skipped to avoid mutating the live wolf-i record that 7 other
+> agents depend on — covered by unit tests
+> (`tests/cli/clawctl/host/test_create_preserves_key_id.py`,
+> `tests/core/test_secrets_keying.py`). Throwaway agent `test448`
+> removed cleanly; secret cleanup on remove went through the new
+> `key_id`-keyed slot and emitted "Cleaned up instance secrets".
+
+
+Branch under test: `issue-448-stable-secrets-keying` (PR #551, HEAD `643e884`).
+
+Goal: validate that the maurice/wolf-i breakage that motivated #448
+cannot reproduce on the patched code, and that no nearby behavior
+regressed. Pure unit/mock coverage is in place — this plan covers the
+parts that can only be exercised against a real host.
+
+## Pre-conditions
+
+1. wolf-i is reachable on **both** its old IP (`192.168.1.36`) and the
+   Tailscale DNS name (`wolf.tailf7742d.ts.net`). If it isn't, swap in
+   any two coordinates that both resolve to the same machine.
+2. You have an existing `hermes` agent named `maurice` installed on
+   wolf-i with a working provider key. (If you don't, the very first
+   scenario installs one.)
+3. **Back up local state first** — every scenario below mutates
+   `~/.config/clawrium/`:
+   ```bash
+   cp -r ~/.config/clawrium ~/.config/clawrium.backup-$(date +%s)
+   ```
+4. Install the branch:
+   ```bash
+   cd ~/workspace/ric03uec/clawrium-issue-448
+   uv tool install --editable . --force
+   clm --version   # confirm
+   ```
+5. Tail logs in another pane so you can correlate:
+   ```bash
+   ssh xclm@192.168.1.36 'journalctl -u hermes-maurice.service -f'
+   ```
+
+A failure in **any** scenario below means **do not merge**.
+
+---
+
+## Scenario 1 — `get_host` resolves by `key_id` after hostname mutation
+
+This is the smallest possible repro of the keying contract.
+
+```bash
+# 1a. Register wolf-i by IP (skip if already registered).
+clm host create 192.168.1.36 --user xclm --alias wolf-i
+jq '.[] | select(.alias=="wolf-i") | {hostname, key_id, alias}' \
+  ~/.config/clawrium/hosts.json
+```
+**Expect:** `hostname == "192.168.1.36"`, `key_id == "192.168.1.36"`.
+
+```bash
+# 1b. Re-record with the Tailscale DNS name.
+clm host create wolf.tailf7742d.ts.net --user xclm --alias wolf-i
+```
+**Expect:** Exit code 0. Output contains
+`hostname 192.168.1.36 → wolf.tailf7742d.ts.net (key_id preserved: 192.168.1.36)`.
+
+```bash
+# 1c. Inspect the record.
+jq '.[] | select(.alias=="wolf-i") | {hostname, key_id, addresses}' \
+  ~/.config/clawrium/hosts.json
+```
+**Expect:**
+- `hostname == "wolf.tailf7742d.ts.net"`
+- `key_id == "192.168.1.36"` ← unchanged, this is the whole point
+- exactly **one** entry in `addresses` has `is_primary: true`, and its
+  `address` is `wolf.tailf7742d.ts.net`
+- the old `192.168.1.36` entry is still in `addresses` but not primary
+
+**Fail conditions:** `key_id` changed; `addresses` list grew unbounded
+or lost a primary; exit code non-zero.
+
+---
+
+## Scenario 2 — secrets survive the hostname mutation (the #448 core fix)
+
+This is the canonical repro from the issue.
+
+```bash
+# 2a. Reset wolf-i to the IP coordinates and confirm an agent is
+# installed with a secret. Pick any agent type with secrets — the
+# original repro used hermes/maurice with HERMES_API_SERVER_KEY.
+clm host create 192.168.1.36 --user xclm --alias wolf-i
+clm agent get   # confirm maurice is installed
+
+# 2b. Note the bearer secrets.json holds for maurice.
+jq '."192.168.1.36:hermes:maurice".HERMES_API_SERVER_KEY.value' \
+  ~/.config/clawrium/secrets.json
+```
+**Expect:** a 64-char lowercase hex string. **Copy it** — call this
+`$BEFORE`.
+
+```bash
+# 2c. Chat works on the IP-form host.
+clm agent chat maurice -m "ping"
+```
+**Expect:** a response, exit code 0. No 401.
+
+```bash
+# 2d. Migrate hostname to DNS (the operation that historically broke).
+clm host create wolf.tailf7742d.ts.net --user xclm --alias wolf-i
+
+# 2e. Re-inspect secrets.json — the bearer must still be under the
+# OLD key (192.168.1.36:hermes:maurice), unchanged.
+jq '."192.168.1.36:hermes:maurice".HERMES_API_SERVER_KEY.value' \
+  ~/.config/clawrium/secrets.json
+```
+**Expect:** equal to `$BEFORE`. No new `wolf.tailf7742d.ts.net:hermes:maurice` entry.
+
+```bash
+# 2f. Chat after the migration — the actual proof.
+clm agent chat maurice -m "still here?"
+```
+**Expect:** a response, exit code 0. **A 401 here means the fix
+failed and the PR must not merge.**
+
+```bash
+# 2g. Sync and configure paths exercise the same lookup.
+clm agent sync maurice
+clm agent configure maurice --stage providers   # no-op if already complete
+```
+**Expect:** both succeed without any "missing or invalid" secret error.
+
+**Fail conditions:** any of 2c, 2f, 2g returns 401 or "DISCORD_BOT_TOKEN/
+HERMES_API_SERVER_KEY missing or invalid"; a duplicate secrets entry
+appears under the new hostname.
+
+---
+
+## Scenario 3 — env-file reconcile (Phase 3 invariant)
+
+This proves the new pre-start probe in `lifecycle.start_agent`
+actually reconciles `.env` drift instead of just looking like it does
+in unit tests.
+
+```bash
+# 3a. Force a deliberate drift: scribble a bogus bearer into the
+# on-host .env without going through configure.
+ssh xclm@wolf.tailf7742d.ts.net \
+  "sudo -u maurice sed -i 's|^API_SERVER_KEY=.*|API_SERVER_KEY='\\''deadbeef'\\''|' \
+   /home/maurice/.hermes/.env"
+ssh xclm@wolf.tailf7742d.ts.net \
+  "grep '^API_SERVER_KEY' /home/maurice/.hermes/.env"
+```
+**Expect:** `API_SERVER_KEY='deadbeef'`.
+
+```bash
+# 3b. Stop, then start. The pre-start probe must notice the drift,
+# trigger configure to re-render .env, and only then run start.
+clm agent stop maurice
+clm agent start maurice
+```
+**Expect:** the start output emits the line
+`API_SERVER_KEY drift detected between .env and secrets.json; reconfiguring before start`
+before the start playbook runs. Exit code 0.
+
+```bash
+# 3c. Confirm .env was re-rendered from secrets.json.
+ssh xclm@wolf.tailf7742d.ts.net \
+  "grep '^API_SERVER_KEY' /home/maurice/.hermes/.env"
+```
+**Expect:** equals `$BEFORE` from Scenario 2 (the secrets.json value),
+no longer `deadbeef`.
+
+```bash
+# 3d. Chat works.
+clm agent chat maurice -m "after reconcile"
+```
+**Expect:** response, exit code 0.
+
+**Fail conditions:** no drift-detection line; `.env` still says
+`deadbeef`; chat 401s.
+
+---
+
+## Scenario 4 — non-fatal probe on transient SSH failure
+
+Proves the probe doesn't synthesize a configure storm when the host
+is unreachable. (Pulls the cable, metaphorically.)
+
+```bash
+# 4a. Make the configured hostname unresolvable. Easiest: re-record
+# the alias to a bogus DNS name with no A record, then try to start.
+clm host create wolf-bogus-does-not-resolve.invalid \
+  --user xclm --alias wolf-i
+# This will fail at the SSH verify step inside host create — that's
+# fine; the test is whether start_agent's *probe* failure is silent.
+```
+
+If 4a errored out cleanly at host-create's SSH verify, you've already
+got the answer for that surface. The probe surface itself is harder
+to exercise without a privileged ssh-firewall setup. If you don't
+have one handy, the unit test
+(`test_probe_is_non_fatal_on_ssh_failure`) already covers this; mark
+Scenario 4 as "covered by unit test" in your run notes.
+
+---
+
+## Scenario 5 — recycled-IP smoke check (ATX iter-1 W2 — known follow-up)
+
+This scenario is **expected to fail** today and is documented as a
+follow-up in the PR. Run it so you know exactly what regression a
+later fix will address.
+
+```bash
+# 5a. After Scenarios 1-3, delete the wolf-i record entirely.
+clm host delete wolf-i --force
+
+# 5b. Register a *different* machine at the same old IP. (Use any
+# spare host whose IP you can temporarily assign to 192.168.1.36 —
+# or skip this scenario and mark "deferred per PR Callouts".)
+clm host create 192.168.1.36 --user xclm --alias different-host
+
+# 5c. Inspect secrets.json — the orphaned 192.168.1.36:hermes:maurice
+# entry from before will still be present and reachable by anything
+# that constructs that instance_key.
+jq 'keys[]' ~/.config/clawrium/secrets.json
+```
+**Expect (known gap):** the old `192.168.1.36:hermes:maurice` key is
+still there. The PR does **not** scan-and-warn on this; that's W2
+deferred. Document it in your run notes; do not block merge on it.
+
+---
+
+## Scenario 6 — regression sweep on adjacent surfaces
+
+These are the surfaces I touched but couldn't validate against a real
+host. Smoke them.
+
+```bash
+# 6a. clm secret list — routes through the modified get_installed_claw.
+clm agent secret list maurice
+```
+**Expect:** lists HERMES_API_SERVER_KEY (and any provider keys),
+shows the host identifier next to the agent name. (It now shows
+`key_id` instead of `hostname` for display — that's intentional.)
+
+```bash
+# 6b. clm agent get — host record rendering.
+clm agent get
+```
+**Expect:** maurice listed under wolf-i, no traceback.
+
+```bash
+# 6c. clm host get -o json — confirm shape is intact.
+clm host get -o json | jq '.[] | {name, hostname, key_id}'
+```
+**Expect:** every record has both `hostname` and `key_id` populated;
+no nulls.
+
+```bash
+# 6d. GUI smoke (if you run it).
+clm gui open
+# Click into maurice → confirm dashboard loads, no 500s in the GUI log.
+```
+
+**Fail conditions:** any traceback; missing fields; GUI 500.
+
+---
+
+## Post-test cleanup
+
+```bash
+# Restore your real config if any scenario corrupted it.
+mv ~/.config/clawrium ~/.config/clawrium.test-run
+mv ~/.config/clawrium.backup-* ~/.config/clawrium
+```
+
+If everything passed, throw away the backup; otherwise keep it.
+
+## Reporting
+
+After the run, append a comment to PR #551 with:
+- Pass / fail for each scenario.
+- For failures: the exact command, output, and `journalctl` excerpt.
+- Confirm `make test` and `make lint` still pass after any local edits
+  you made during testing.
+
+If Scenarios 1, 2, and 3 all pass, the #448 fix is validated against
+the original maurice/wolf-i breakage and the PR is ready to merge
+(modulo the iter-1 W2-W6 follow-ups documented in the PR Callouts).

--- a/docs/agent-support/hermes.md
+++ b/docs/agent-support/hermes.md
@@ -63,7 +63,7 @@ Hermes supports three channels managed by clawctl: a loopback OpenAI-compatible 
 | **Multi-provider** | ✅ | openrouter, anthropic, openai, ollama / custom |
 | **Memory (Markdown backend)** | ✅ | Two-file model: `MEMORY.md` (≤ 2200 chars), `USER.md` (≤ 1375 chars). See [memory.md](memory.md). |
 | **Pluggable memory backends** (Holographic / Honcho / Hindsight / Mem0 / Byterover / OpenViking) | 📋 | Deferred. clawctl's `memory` CLI sees only the default markdown backend in this iteration. |
-| **Secrets management** | ✅ | `HERMES_API_SERVER_KEY` persisted in `~/.config/clawrium/secrets.json` (NOT `hosts.json`) under the canonical instance key `<host>:hermes:<agent-name>` (single-colon, 3 components). `secrets.json` is chmod 0600 on creation. Per-agent secrets are isolated by instance key. |
+| **Secrets management** | ✅ | `HERMES_API_SERVER_KEY` persisted in `~/.config/clawrium/secrets.json` (NOT `hosts.json`) under the canonical instance key `<key_id>:hermes:<agent-name>` (single-colon, 3 components). `key_id` is the immutable host identifier set when the host was first registered via `clawctl host create`. It does not change when the host's `hostname` is updated (issue #448). `secrets.json` is chmod 0600 on creation. Per-agent secrets are isolated by instance key. |
 | **Auto-restart** | ✅ | Systemd unit `hermes-<agent_name>.service` with `Restart=on-failure`; systemd is the supervisor (no separate process). |
 | **Log streaming** | ✅ | `journalctl -u hermes-<agent_name>.service` on the agent host |
 | **Onboarding wizard** | ✅ | 4 stages: `providers` (required) → `identity` (auto-skipped) → `channels` (cli, discord, slack) → `validate` |
@@ -97,7 +97,7 @@ What happens:
 
 5. `clawctl` creates `~/.hermes/` (mode 0700), `~/.hermes/.env` (mode 0600, empty), and `~/.hermes/memories/` (mode 0700) under the agent user.
 6. A systemd unit `hermes-<agent-name>.service` is dropped, **disabled and not started**. Step 2 (configure) starts it.
-7. A 64-char lowercase-hex `HERMES_API_SERVER_KEY` is generated and persisted in `~/.config/clawrium/secrets.json` under the canonical instance key `<host>:hermes:<agent-name>` (single-colon, 3 components). Re-installing reuses the existing key. The 64-char-lowercase-hex format is validated on load; a hand-edit to an invalid format produces an error at next configure/start.
+7. A 64-char lowercase-hex `HERMES_API_SERVER_KEY` is generated and persisted in `~/.config/clawrium/secrets.json` under the canonical instance key `<key_id>:hermes:<agent-name>` (single-colon, 3 components). Re-installing reuses the existing key. The 64-char-lowercase-hex format is validated on load; a hand-edit to an invalid format produces an error at next configure/start.
 
 The full install takes about 10-12 minutes (uv venv, pip install, npm install, Playwright). Wrapped in an Ansible `async` poll so the SSH connection is reused per-poll.
 
@@ -176,7 +176,7 @@ curl -fsS http://127.0.0.1:8642/v1/chat/completions \
   }'
 ```
 
-Substitute the canonical instance key (`<host>:hermes:<agent-name>` — single colons) for your fleet. The `model` field is always `hermes-agent` — hermes routes to whatever upstream model is configured in `config.yaml`.
+Substitute the canonical instance key (`<key_id>:hermes:<agent-name>` — single colons) for your fleet. The `model` field is always `hermes-agent` — hermes routes to whatever upstream model is configured in `config.yaml`.
 
 #### Off-host access (loopback constraint)
 
@@ -209,7 +209,7 @@ clawctl agent delete <agent-name>    # stop, remove unit, rm ~/.hermes/, userdel
 
 - **Discord and Slack are the clawctl-managed messaging gateways today.** Telegram, WhatsApp, Signal, email, Matrix, Mattermost, Teams, Google Chat are tracked as separate follow-ups. See [Discord channel page → Hermes Configuration](channels/discord.md#hermes-configuration) and [Slack channel page → Hermes Configuration](channels/slack.md#hermes-configuration).
 - **Identity is hermes-managed by design.** Hermes owns `SOUL.md` and `AGENTS.md` inside `~/.hermes/`; the onboarding `identity` stage auto-skips. `SOUL.md` is editable via `clawctl agent memory write <name> SOUL.md`, which routes to `~/.hermes/SOUL.md` (other memories live under `~/.hermes/memories/`).
-- **Bearer token lives in `secrets.json`, not `hosts.json`.** As of PR #318, the canonical store for `HERMES_API_SERVER_KEY` is `~/.config/clawrium/secrets.json` keyed by `<host>:hermes:<agent-name>` (single-colon, 3 components). Provider keys use a different schema (`provider:<provider-name>`) in the same file.
+- **Bearer token lives in `secrets.json`, not `hosts.json`.** As of PR #318, the canonical store for `HERMES_API_SERVER_KEY` is `~/.config/clawrium/secrets.json` keyed by `<key_id>:hermes:<agent-name>` (single-colon, 3 components). Provider keys use a different schema (`provider:<provider-name>`) in the same file.
 - **Memory has hard size limits.** `MEMORY.md` ≤ 2200 chars, `USER.md` ≤ 1375 chars. Other filenames in `~/.hermes/memories/` are rejected by `clawctl agent memory edit`. See [memory.md](memory.md).
 - **Concurrent writes are visible-atomic.** Hermes' `memory_write.yaml` uses a stage-then-rename pattern (`rename(2)` within the same filesystem) so the running hermes daemon never observes a partial file. The pattern is visible-atomic, not crash-durable (no explicit `fsync`).
 

--- a/docs/host-preparation.md
+++ b/docs/host-preparation.md
@@ -37,6 +37,15 @@ On first run for that hostname, `clawctl` will:
    `authorized_keys` line.
 4. Exit non-zero with a "re-run after manual setup" message.
 
+> **`key_id` is immutable (issue #448).** The first successful
+> `clawctl host create` for an alias mints a stable `key_id` that
+> per-agent secrets (Discord tokens, provider API keys, hermes
+> `HERMES_API_SERVER_KEY`) are stored under. Re-running
+> `clawctl host create <new-ip-or-dns> --alias <existing-alias>`
+> updates the host's `hostname`, port, and address list **without**
+> rotating the `key_id` — every secret stays reachable. Renaming the
+> alias is a deliberate identity change and does invalidate secrets.
+
 ## Step 2 — Run the setup commands on the host
 
 SSH to the host as your existing sudo-capable user and paste the block that

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -1149,9 +1149,12 @@ def _run_channels_stage(
         if not host_data:
             console.print(f"[red]Error:[/red] Host '{host}' not found")
             return False
-        canonical_hostname = host_data["hostname"]
+        # Key by host_data["key_id"] (immutable, #448) so the secret lands
+        # in the same slot lifecycle.configure_agent will look up — even
+        # after the operator mutates the host's hostname (IP → DNS).
+        host_key = host_data.get("key_id") or host_data["hostname"]
         instance_key = get_instance_key(
-            canonical_hostname, claw_type, installed_name or claw_type
+            host_key, claw_type, installed_name or claw_type
         )
 
         # For hermes AND zeroclaw, configure_agent's hydration block reads
@@ -1328,9 +1331,12 @@ def _run_channels_stage(
         if not host_data:
             console.print(f"[red]Error:[/red] Host '{host}' not found")
             return False
-        canonical_hostname = host_data["hostname"]
+        # Key by host_data["key_id"] (immutable, #448) so the secret lands
+        # in the same slot lifecycle.configure_agent will look up — even
+        # after the operator mutates the host's hostname (IP → DNS).
+        host_key = host_data.get("key_id") or host_data["hostname"]
         instance_key = get_instance_key(
-            canonical_hostname, claw_type, installed_name or claw_type
+            host_key, claw_type, installed_name or claw_type
         )
 
         # For hermes, configure_agent's hydration block reads Slack tokens

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -740,7 +740,10 @@ def _build_hermes_backend(
     if not isinstance(hostname, str) or not hostname.strip():
         raise ValueError("Host primary address not found.")
 
-    instance_key = get_instance_key(hostname, agent_type, agent_name)
+    # Key secrets by host_record["key_id"] (immutable, #448) — `hostname`
+    # is the network dial target and may have mutated since install.
+    host_key = host_record.get("key_id") or hostname
+    instance_key = get_instance_key(host_key, agent_type, agent_name)
     secret_entry = get_instance_secrets(instance_key).get("HERMES_API_SERVER_KEY")
     # `.get("value")` not `["value"]`: a truthy-but-malformed entry (no
     # "value" field) would otherwise raise KeyError and escape the outer

--- a/src/clawrium/cli/clawctl/host/create.py
+++ b/src/clawrium/cli/clawctl/host/create.py
@@ -40,6 +40,7 @@ from clawrium.core.hosts import (
     HostsFileCorruptedError,
     add_host,
     get_host,
+    update_host,
 )
 from clawrium.core.keys import (
     generate_host_keypair,
@@ -91,6 +92,85 @@ def create(
             stream_action(
                 resource=f"host/{alias or hostname}",
                 message=f"already exists on {hostname}",
+            )
+            return
+        # Re-record path (issue #448): the alias resolves to an existing
+        # host whose `hostname` is being updated (IP → DNS, renumber,
+        # Tailscale migration). Preserve `key_id` so every per-agent
+        # secret stored under `<key_id>:<type>:<name>` stays reachable;
+        # mutate only the network coordinates. Reject re-records that
+        # also try to change `user`, since that's an identity change
+        # and not the case #448 is solving.
+        existing_alias = existing.get("alias")
+        if alias and existing_alias == alias:
+            if existing.get("user") != user:
+                emit_error(
+                    f"host alias {alias!r} already registered with a "
+                    f"different user ({existing.get('user')!r}); refusing "
+                    "to mutate identity on re-record",
+                    hint="clawctl host delete first if you really want to "
+                    "rotate the management user",
+                )
+            old_hostname = existing.get("hostname")
+            preserved_key_id = existing.get("key_id") or old_hostname
+            private_key = _ensure_host_keypair(preserved_key_id)
+            verified, os_family = _verify_xclm_access(hostname, port, private_key)
+            if not verified:
+                _print_manual_setup(hostname)
+                raise typer.Exit(code=1)
+
+            now = datetime.now(timezone.utc).isoformat()
+
+            def _rewrite(host: dict) -> dict:
+                host["hostname"] = hostname
+                host["port"] = port
+                host["os_family"] = os_family
+                host["key_id"] = preserved_key_id
+                addresses = host.get("addresses") or []
+                # De-primary existing entries and append the new dial
+                # target as primary. Duplicate-by-`address` is collapsed
+                # so re-recording the same value doesn't grow the list.
+                rebuilt = []
+                seen = False
+                for entry in addresses:
+                    if not isinstance(entry, dict):
+                        continue
+                    if entry.get("address") == hostname:
+                        seen = True
+                        entry["is_primary"] = True
+                        entry["added_at"] = entry.get("added_at") or now
+                    else:
+                        entry["is_primary"] = False
+                    rebuilt.append(entry)
+                if not seen:
+                    rebuilt.append(
+                        {
+                            "address": hostname,
+                            "is_primary": True,
+                            "label": None,
+                            "added_at": now,
+                        }
+                    )
+                host["addresses"] = rebuilt
+                metadata = host.get("metadata") or {}
+                metadata["last_seen"] = None
+                host["metadata"] = metadata
+                return host
+
+            # `update_host` looks up by the *current* hostname value in
+            # hosts.json; pass the old one, not the new one.
+            updated = update_host(old_hostname, _rewrite)
+            if not updated:
+                emit_error(
+                    f"failed to rewrite host record for alias {alias!r}",
+                    hint="check ~/.config/clawrium/hosts.json",
+                )
+            stream_action(
+                resource=f"host/{alias}",
+                message=(
+                    f"hostname {old_hostname} → {hostname} "
+                    f"(key_id preserved: {preserved_key_id})"
+                ),
             )
             return
         emit_error(

--- a/src/clawrium/core/health.py
+++ b/src/clawrium/core/health.py
@@ -207,7 +207,9 @@ def get_missing_secrets(claw_type: str, host: dict, claw_record: dict) -> list[s
         return []
 
     try:
-        instance_key = get_instance_key(host["hostname"], claw_type, claw_name)
+        instance_key = get_instance_key(
+            host.get("key_id") or host["hostname"], claw_type, claw_name
+        )
     except InvalidInstanceKeyComponentError:
         logger.warning(
             "Invalid instance key component for %s/%s/%s - skipping secret check",

--- a/src/clawrium/core/hosts.py
+++ b/src/clawrium/core/hosts.py
@@ -369,10 +369,15 @@ def remove_host(hostname: str) -> bool:
 
 
 def get_host(identifier: str) -> dict | None:
-    """Get a host by hostname or alias.
+    """Get a host by hostname, alias, or key_id.
+
+    `key_id` is the immutable host identifier (issue #448); matching it
+    here lets callers that hold a stable key (e.g. the value returned by
+    `get_installed_claw`) resolve back to the host record even after the
+    operator has mutated `hostname` (IP → DNS, renumbering, etc.).
 
     Args:
-        identifier: Hostname or alias to search for.
+        identifier: Hostname, alias, or key_id to search for.
 
     Returns:
         Host dictionary if found, None otherwise.
@@ -382,6 +387,8 @@ def get_host(identifier: str) -> dict | None:
         if host.get("hostname") == identifier:
             return host
         if host.get("alias") == identifier:
+            return host
+        if host.get("key_id") == identifier:
             return host
     return None
 

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -362,7 +362,9 @@ def run_installation(
                 agent_name = item.get("agent_name")
                 if agent_name:
                     instance_key = get_instance_key(
-                        host["hostname"], claw_name, agent_name
+                        host.get("key_id") or host["hostname"],
+                        claw_name,
+                        agent_name,
                     )
                     if instance_key in secrets:
                         del secrets[instance_key]
@@ -709,8 +711,12 @@ def run_installation(
     matched_entry = compat["matched_entry"]
     claw_sha256 = matched_entry.get("sha256", "")
 
-    # Load secrets for this agent instance
-    instance_key = get_instance_key(host["hostname"], claw_name, agent_name)
+    # Load secrets for this agent instance. Key by `host["key_id"]`
+    # (immutable identifier, issue #448) so the lookup survives any
+    # later mutation of `host["hostname"]` (IP → DNS, renumbering).
+    instance_key = get_instance_key(
+        host.get("key_id") or host["hostname"], claw_name, agent_name
+    )
     instance_secrets = get_instance_secrets(instance_key)
 
     # Map secret keys to ansible vars (uppercase SECRET_KEY -> lowercase secret_key)
@@ -769,10 +775,12 @@ def run_installation(
     # (enabled / host / port).
     hermes_api_server_key = None
     if claw_name == "hermes":
-        # Use canonical hostname (not the alias passed by the CLI) so the
-        # instance_key matches what lifecycle.configure_agent() will look up.
-        canonical_hostname = host["hostname"]
-        instance_key = get_instance_key(canonical_hostname, claw_name, agent_name)
+        # Key by host["key_id"] (immutable, #448) — not host["hostname"]
+        # (mutable network address) — so the bearer stored here remains
+        # reachable after IP/DNS renumbering. lifecycle.configure_agent()
+        # uses the same derivation when it looks the value back up.
+        host_key = host.get("key_id") or host["hostname"]
+        instance_key = get_instance_key(host_key, claw_name, agent_name)
         existing_entry = get_instance_secrets(instance_key).get("HERMES_API_SERVER_KEY")
         # `.get("value")` not `["value"]`: a truthy-but-malformed entry (no
         # "value" field, e.g. hand-edited secrets.json) would otherwise raise

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -477,7 +477,16 @@ def _hermes_env_token_matches_secrets(
                 key_filename=str(private_key),
                 timeout=10,
             )
-            cmd = f"grep -E '^API_SERVER_KEY=' {shlex.quote(env_path)} || true"
+            # xclm cannot read `/home/<agent>/.hermes/.env` directly
+            # (the agent home is typically 0700). xclm has passwordless
+            # sudo from `clawctl host create`, so `sudo -n` succeeds in
+            # the non-TTY paramiko exec channel; `-n` ensures we never
+            # block waiting for a password and surface a clean failure
+            # the outer except will swallow non-fatally.
+            cmd = (
+                "sudo -n grep -E '^API_SERVER_KEY=' "
+                f"{shlex.quote(env_path)} 2>/dev/null || true"
+            )
             _, stdout, _ = client.exec_command(cmd, timeout=10)
             raw = stdout.read().decode().strip()
         finally:

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -458,6 +458,17 @@ def _hermes_env_token_matches_secrets(
 
         client = paramiko.SSHClient()
         client.load_system_host_keys()
+        # ATX W1: after an IP→DNS migration the new hostname is unlikely
+        # to be in `known_hosts` yet, so the default RejectPolicy would
+        # raise and the outer except would silently return matches=True
+        # — defeating the entire reconcile invariant this helper exists
+        # for. WarningPolicy connects on unknown keys while logging,
+        # which is appropriate here because this is a *probe* whose
+        # only output is a string comparison against a value we already
+        # hold locally (no command execution, no payload). We do NOT
+        # use AutoAddPolicy — that would persist the new key without
+        # an MITM check.
+        client.set_missing_host_key_policy(paramiko.WarningPolicy())
         try:
             client.connect(
                 hostname=host.get("hostname"),

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Callable, TypedDict
 
 import ansible_runner
+import paramiko
 
 from clawrium.core.config import get_config_dir
 from clawrium.core.hosts import get_host, update_host, remove_agent_from_host
@@ -309,7 +310,12 @@ def _run_lifecycle_playbook(
     instance_key = None
     secret_vars = {}
     try:
-        instance_key = get_instance_key(hostname, agent_type, agent_name)
+        # Key by host["key_id"] (immutable, #448), falling back to the
+        # `hostname` parameter for hand-edited legacy records where
+        # `key_id` is absent. This guarantees secret lookups still
+        # resolve after operators mutate `hostname` (IP → DNS).
+        instance_host_key = host.get("key_id") or hostname
+        instance_key = get_instance_key(instance_host_key, agent_type, agent_name)
         instance_secrets = get_instance_secrets(instance_key)
         for key, entry in instance_secrets.items():
             secret_vars[key.lower()] = entry.get("value", "")
@@ -418,6 +424,77 @@ def _run_lifecycle_playbook(
         _cleanup_ansible_artifacts(operation_log_dir)
 
 
+def _hermes_env_token_matches_secrets(
+    host: dict, agent_name: str
+) -> tuple[bool, str | None]:
+    """Check on-host hermes .env API_SERVER_KEY against secrets.json.
+
+    Issue #448: ``secrets.json`` is the authoritative source for the
+    hermes bearer. If an operator (or a prior install on a different
+    machine) wrote the on-host ``.env`` from a different key, every
+    ``clawctl agent chat`` will 401 because the daemon enforces the
+    on-host value while the client reads the secrets.json value.
+
+    Returns:
+        (matches, error). ``matches`` is True when the on-host token
+        equals secrets.json. On any probe failure (host unreachable,
+        file missing, malformed line) returns ``(True, error)`` so the
+        caller does NOT redundantly reconfigure on transient issues —
+        the start playbook will surface the real error.
+    """
+    try:
+        import shlex
+
+        key_id = host.get("key_id") or host.get("hostname")
+        if not key_id:
+            return True, "host record missing key_id/hostname"
+        private_key = get_host_private_key(key_id)
+        if not private_key:
+            return True, "no SSH key for host"
+
+        os_family = host.get("os_family") or "linux"
+        home_root = "/Users" if os_family == "darwin" else "/home"
+        env_path = f"{home_root}/{agent_name}/.hermes/.env"
+
+        client = paramiko.SSHClient()
+        client.load_system_host_keys()
+        try:
+            client.connect(
+                hostname=host.get("hostname"),
+                port=int(host.get("port", 22)),
+                username=host.get("user", "xclm"),
+                key_filename=str(private_key),
+                timeout=10,
+            )
+            cmd = f"grep -E '^API_SERVER_KEY=' {shlex.quote(env_path)} || true"
+            _, stdout, _ = client.exec_command(cmd, timeout=10)
+            raw = stdout.read().decode().strip()
+        finally:
+            client.close()
+
+        if not raw:
+            return True, "API_SERVER_KEY not present in .env (will be rendered on configure)"
+
+        # Format: API_SERVER_KEY='<value>'  (rendered via shell_quote)
+        # Strip the leading key= and any surrounding single/double quotes.
+        value = raw.split("=", 1)[1].strip()
+        if (len(value) >= 2) and value[0] in ("'", '"') and value[-1] == value[0]:
+            value = value[1:-1]
+
+        host_key = host.get("key_id") or host.get("hostname", "")
+        instance_key = get_instance_key(host_key, "hermes", agent_name)
+        secret_entry = get_instance_secrets(instance_key).get("HERMES_API_SERVER_KEY")
+        expected = secret_entry.get("value") if isinstance(secret_entry, dict) else None
+        if not expected:
+            return True, "no HERMES_API_SERVER_KEY in secrets.json"
+
+        return value == expected, None
+    except Exception as exc:
+        # Probe failures are non-fatal: let the start playbook surface
+        # the real error rather than synthesizing a configure loop.
+        return True, str(exc)
+
+
 def start_agent(
     hostname: str,
     claw_name: str,
@@ -469,6 +546,55 @@ def start_agent(
             f"Cannot start {agent_key}: onboarding incomplete (state={state_value}). "
             f"Run 'clm agent configure {agent_display_name}' first."
         )
+
+    # Issue #448: env-file consistency invariant. For hermes, the
+    # daemon enforces the API_SERVER_KEY written into ~/.hermes/.env at
+    # configure time, while `clawctl agent chat` reads the bearer from
+    # secrets.json. If those drifted (e.g. the host's `hostname` was
+    # mutated after install and an older write left a stale .env), the
+    # next chat request returns 401 with no clear remediation.
+    # secrets.json is authoritative — reconcile by running configure
+    # before the start playbook.
+    if _resolve_agent_type(claw_name) == "hermes":
+        matches, probe_error = _hermes_env_token_matches_secrets(host, agent_key)
+        if not matches:
+            emit(
+                "start",
+                "API_SERVER_KEY drift detected between .env and "
+                "secrets.json; reconfiguring before start",
+            )
+            # Reuse the agent's persisted config so reconfigure
+            # re-renders .env with the canonical secrets.json bearer
+            # without altering any other field the operator set.
+            persisted_config = (
+                claw_record.get("config", {})
+                if isinstance(claw_record, dict)
+                else {}
+            )
+            cfg_success, cfg_error = configure_agent(
+                hostname,
+                claw_name,
+                persisted_config if isinstance(persisted_config, dict) else {},
+                agent_name=agent_key,
+                on_event=on_event,
+                reason="start-precheck",
+            )
+            if not cfg_success:
+                return {
+                    "success": False,
+                    "agent": agent_key,
+                    "host": hostname,
+                    "operation": "start",
+                    "pid": None,
+                    "started_at": None,
+                    "error": f"Pre-start reconfigure failed: {cfg_error}",
+                }
+        elif probe_error:
+            logger.debug(
+                "Hermes env-token probe inconclusive for %s: %s",
+                agent_key,
+                probe_error,
+            )
 
     emit("start", f"Starting {agent_key} on {hostname}...")
 
@@ -1378,7 +1504,9 @@ def configure_agent(
         # callers pass an alias. CLI paths today always resolve canonical, but
         # programmatic callers may not.
         instance_key = get_instance_key(
-            host["hostname"], resolved_type, unix_agent_name
+            host.get("key_id") or host["hostname"],
+            resolved_type,
+            unix_agent_name,
         )
         secret_entry = get_instance_secrets(instance_key).get("HERMES_API_SERVER_KEY")
         # `.get("value")` not `["value"]`: a truthy-but-malformed entry (no
@@ -1609,7 +1737,9 @@ def configure_agent(
 
             if discord_merged.get("enabled"):
                 discord_instance_key = get_instance_key(
-                    host["hostname"], resolved_type, unix_agent_name
+                    host.get("key_id") or host["hostname"],
+                    resolved_type,
+                    unix_agent_name,
                 )
                 discord_secret = get_instance_secrets(discord_instance_key).get(
                     "DISCORD_BOT_TOKEN"
@@ -1720,7 +1850,9 @@ def configure_agent(
     discord_bot_token = ""
     try:
         instance_key = get_instance_key(
-            host["hostname"], resolved_type, unix_agent_name
+            host.get("key_id") or host["hostname"],
+            resolved_type,
+            unix_agent_name,
         )
         instance_secrets = get_instance_secrets(instance_key)
         # ATX Round 2 W4: match the safe `.get("value")` pattern used
@@ -1743,7 +1875,9 @@ def configure_agent(
     slack_app_token = ""
     try:
         instance_key = get_instance_key(
-            host["hostname"], resolved_type, unix_agent_name
+            host.get("key_id") or host["hostname"],
+            resolved_type,
+            unix_agent_name,
         )
         instance_secrets = get_instance_secrets(instance_key)
         # ATX Round 2 W4: same safe-indexing pattern as Discord above.
@@ -2281,7 +2415,9 @@ def remove_agent(
 
     # Clean up per-instance secrets (Discord bot token, etc.)
     try:
-        instance_key = get_instance_key(host["hostname"], agent_type, unix_agent_name)
+        instance_key = get_instance_key(
+            host.get("key_id") or host["hostname"], agent_type, unix_agent_name
+        )
         remove_instance_secrets(instance_key)
         emit("remove", "Cleaned up instance secrets")
     except Exception as e:

--- a/src/clawrium/core/secrets.py
+++ b/src/clawrium/core/secrets.py
@@ -226,7 +226,12 @@ def get_instance_key(host: str, claw_type: str, claw_name: str) -> str:
     """Generate instance key from host, claw type, and claw name.
 
     Args:
-        host: Hostname where claw is installed.
+        host: Stable host identifier — pass `host_record["key_id"]`, NOT
+            `host_record["hostname"]`. `hostname` is the network address
+            (IP/DNS) and is mutable; if it changes, every per-agent
+            secret stored under the old hostname becomes unreachable
+            (issue #448). `key_id` is minted at `clawctl host create`
+            time and never rotates while the host record exists.
         claw_type: Type of claw (openclaw, zeroclaw, etc.).
         claw_name: Name of the claw instance.
 
@@ -254,7 +259,12 @@ def get_installed_claw(claw_name: str) -> tuple[str, str, str]:
         claw_name: Name of the claw instance (generated or user-provided).
 
     Returns:
-        Tuple of (hostname, claw_type, claw_name).
+        Tuple of (host_key, claw_type, claw_name). `host_key` is the
+        host's stable `key_id` (issue #448), with a fallback to
+        `hostname` for legacy records. Suitable for passing as the
+        first argument of `get_instance_key`. To resolve the host
+        record, pass `host_key` to `clawrium.core.hosts.get_host`
+        (which now matches `key_id` as well as `hostname`/`alias`).
 
     Raises:
         ClawNotFoundError: If claw with this name is not found in any host.
@@ -263,7 +273,12 @@ def get_installed_claw(claw_name: str) -> tuple[str, str, str]:
 
     hosts = load_hosts()
     for host in hosts:
-        hostname = host.get("hostname", "")
+        # Return the stable host identifier (`key_id`) — not `hostname` —
+        # so callers that build the secrets instance key (#448) stay
+        # bound to the host across `hostname` mutations (IP/DNS rename).
+        # Fall back to `hostname` for legacy records written before
+        # `key_id` was minted.
+        host_key = host.get("key_id") or host.get("hostname", "")
         agents = host.get("agents", {})
         for claw_type, claw_data in agents.items():
             # Check agent_name field, name field (legacy), or claw_type
@@ -272,7 +287,7 @@ def get_installed_claw(claw_name: str) -> tuple[str, str, str]:
             if claw_name in (agent_name, name, claw_type):
                 # Return the canonical name (agent_name > name > claw_type)
                 canonical_name = agent_name or name or claw_type
-                return (hostname, claw_type, canonical_name)
+                return (host_key, claw_type, canonical_name)
 
     raise AgentNotFoundError(
         f"Claw '{claw_name}' not found. Only installed claws can have secrets."

--- a/src/clawrium/gui/routes/agents.py
+++ b/src/clawrium/gui/routes/agents.py
@@ -579,7 +579,8 @@ async def _chat_hermes(
     hostname = host_record.get("hostname", "")
     agent_name = agent_record.get("agent_name") or agent_key
 
-    instance_key = get_instance_key(hostname, agent_type, agent_name)
+    host_key = host_record.get("key_id") or hostname
+    instance_key = get_instance_key(host_key, agent_type, agent_name)
     secret_entry = get_instance_secrets(instance_key).get("HERMES_API_SERVER_KEY")
     raw_token = secret_entry.get("value") if secret_entry else None
 
@@ -706,7 +707,8 @@ async def _chat_openclaw(
 
     hostname = host_record.get("hostname", "")
     agent_name = agent_record.get("agent_name") or agent_record.get("name") or ""
-    instance_key = get_instance_key(hostname, agent_type, agent_name)
+    host_key = host_record.get("key_id") or hostname
+    instance_key = get_instance_key(host_key, agent_type, agent_name)
     auth, private_key = _resolve_openclaw_credentials(instance_key, gateway)
 
     if not auth:

--- a/tests/cli/clawctl/host/test_create_delete.py
+++ b/tests/cli/clawctl/host/test_create_delete.py
@@ -321,12 +321,14 @@ def test_create_rejects_invalid_alias(
     assert "Error:" in result.output
 
 
-def test_create_alias_collision_with_different_hostname_fails(
+def test_create_alias_collision_with_different_hostname_re_records(
     fleet_dir, stdin_not_tty, mock_ssh_ok_linux
 ) -> None:
-    """Re-using an alias that already points at a different hostname must
-    fail loudly rather than overwriting the original record. (`--user` is
-    locked to `xclm` so this is the only path to the conflict branch.)"""
+    """Issue #448 changed the semantics here: re-using an alias that
+    already points at a different hostname is the canonical
+    IP→DNS/renumber path. The record is rewritten in place — `hostname`
+    and primary `addresses` entry move to the new value while `key_id`
+    is preserved so per-agent secrets remain reachable."""
     runner.invoke(
         app, ["host", "create", "192.168.1.100", "--user", "xclm", "--alias", "shared"]
     )
@@ -334,17 +336,19 @@ def test_create_alias_collision_with_different_hostname_fails(
     result = runner.invoke(
         app, ["host", "create", "10.0.0.99", "--user", "xclm", "--alias", "shared"]
     )
-    assert result.exit_code != 0
-    assert "already registered with different settings" in result.output
+    assert result.exit_code == 0, result.output
+    assert "key_id preserved" in result.output
 
-    # Original record is intact.
     from clawrium.core.hosts import get_host
 
-    record = get_host("192.168.1.100")
+    # Old hostname no longer resolves; alias points to new hostname; the
+    # original key_id (192.168.1.100) is still the secrets-keying
+    # anchor and resolves the same record via get_host's key_id branch.
+    assert get_host("192.168.1.100") is not None  # via key_id match
+    record = get_host("shared")
     assert record is not None
-    assert record.get("alias") == "shared"
-    # And the second IP was NOT persisted.
-    assert get_host("10.0.0.99") is None
+    assert record["hostname"] == "10.0.0.99"
+    assert record["key_id"] == "192.168.1.100"
 
 
 def test_create_idempotent_does_not_grow_hosts_json(

--- a/tests/cli/clawctl/host/test_create_preserves_key_id.py
+++ b/tests/cli/clawctl/host/test_create_preserves_key_id.py
@@ -1,0 +1,112 @@
+"""Regression coverage for issue #448.
+
+Re-running `clawctl host create` against an existing alias updates the
+host's `hostname` / `port` / `addresses` without rotating its `key_id`.
+The stable `key_id` is what `secrets.json` is keyed by — rotating it
+on every IP/DNS change orphans every per-agent secret on the host.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+from clawrium.core.hosts import get_host
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_ssh_ok_linux(monkeypatch):
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.host.create.test_ssh_connection",
+        lambda **_kw: (True, "Connection successful"),
+    )
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.host.create._detect_os_family",
+        lambda *_a, **_kw: "linux",
+    )
+
+
+def test_re_record_preserves_key_id_and_updates_hostname(
+    fleet_dir: Path, stdin_not_tty, mock_ssh_ok_linux
+) -> None:
+    # First create: IP-only registration.
+    first = runner.invoke(
+        app,
+        ["host", "create", "192.168.1.36", "--user", "xclm", "--alias", "maurice-host"],
+    )
+    assert first.exit_code == 0, first.output
+
+    before = get_host("maurice-host")
+    assert before is not None
+    assert before["key_id"] == "192.168.1.36"
+    assert before["hostname"] == "192.168.1.36"
+
+    # Operator migrates the host to a Tailscale DNS name — same machine,
+    # same alias. `clawctl host create <dns> --alias wolf-i` must
+    # rewrite hostname/addresses and preserve key_id.
+    second = runner.invoke(
+        app,
+        [
+            "host", "create", "wolf.tailf7742d.ts.net",
+            "--user", "xclm", "--alias", "maurice-host",
+        ],
+    )
+    assert second.exit_code == 0, second.output
+    assert "key_id preserved" in second.output
+
+    after = get_host("maurice-host")
+    assert after is not None
+    assert after["key_id"] == "192.168.1.36"  # unchanged
+    assert after["hostname"] == "wolf.tailf7742d.ts.net"
+    primaries = [a for a in after["addresses"] if a.get("is_primary")]
+    assert len(primaries) == 1
+    assert primaries[0]["address"] == "wolf.tailf7742d.ts.net"
+
+
+def test_re_record_rejected_when_user_would_change(
+    fleet_dir: Path, stdin_not_tty, mock_ssh_ok_linux
+) -> None:
+    first = runner.invoke(
+        app,
+        ["host", "create", "192.168.1.36", "--user", "xclm", "--alias", "maurice-host"],
+    )
+    assert first.exit_code == 0
+    # No way to actually change `user` since the CLI rejects non-xclm
+    # values up front; this test asserts the existing error path still
+    # fires (i.e. no regression where the re-record branch silently
+    # accepted a different user).
+    bogus = runner.invoke(
+        app,
+        ["host", "create", "192.168.1.37", "--user", "carol", "--alias", "maurice-host"],
+    )
+    assert bogus.exit_code != 0
+    assert "must be 'xclm'" in bogus.output
+
+
+def test_get_host_resolves_by_key_id(
+    fleet_dir: Path, stdin_not_tty, mock_ssh_ok_linux
+) -> None:
+    """Issue #448: get_host must accept the immutable key_id so callers
+    holding a stable identifier can resolve back to the host record after
+    a hostname mutation."""
+    runner.invoke(
+        app,
+        ["host", "create", "192.168.1.36", "--user", "xclm", "--alias", "maurice-host"],
+    )
+    runner.invoke(
+        app,
+        [
+            "host", "create", "wolf.tailf7742d.ts.net",
+            "--user", "xclm", "--alias", "maurice-host",
+        ],
+    )
+    # `key_id` ("192.168.1.36") is no longer the hostname, but get_host
+    # must still resolve it.
+    record = get_host("192.168.1.36")
+    assert record is not None
+    assert record["hostname"] == "wolf.tailf7742d.ts.net"

--- a/tests/core/test_lifecycle_env_consistency.py
+++ b/tests/core/test_lifecycle_env_consistency.py
@@ -1,0 +1,99 @@
+"""Issue #448 — hermes env/secrets reconcile invariant.
+
+`lifecycle.start_agent` for hermes probes the on-host `.env`'s
+`API_SERVER_KEY` before starting the daemon. If it disagrees with
+`secrets.json[<key_id>:hermes:<name>].HERMES_API_SERVER_KEY`, we
+reconfigure first — `secrets.json` is the authoritative source.
+
+The probe is intentionally non-fatal: on any failure (host
+unreachable, malformed line, etc.) it returns ``(True, error)`` so we
+do not synthesize a configure loop on transient issues.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from clawrium.core.lifecycle import _hermes_env_token_matches_secrets
+
+
+def _ssh_returning(stdout_bytes: bytes):
+    """Build a paramiko.SSHClient mock whose exec_command yields the
+    given bytes on stdout. MagicMock's default 3-tuple unpacking is
+    unreliable; construct the tuple explicitly."""
+    client = MagicMock()
+    stdout = MagicMock()
+    stdout.read.return_value = stdout_bytes
+    client.exec_command.return_value = (MagicMock(), stdout, MagicMock())
+    ssh_cls = MagicMock(return_value=client)
+    return ssh_cls
+
+
+def _host():
+    return {
+        "hostname": "wolf.example",
+        "key_id": "wolf-key",
+        "port": 22,
+        "user": "xclm",
+        "os_family": "linux",
+    }
+
+
+def test_probe_returns_match_when_values_agree():
+    with (
+        patch(
+            "clawrium.core.lifecycle.get_instance_secrets",
+            return_value={"HERMES_API_SERVER_KEY": {"value": "abc123"}},
+        ),
+        patch(
+            "clawrium.core.lifecycle.get_host_private_key",
+            return_value="/tmp/key",
+        ),
+        patch(
+            "clawrium.core.lifecycle.paramiko.SSHClient",
+            _ssh_returning(b"API_SERVER_KEY='abc123'\n"),
+        ),
+    ):
+        matches, error = _hermes_env_token_matches_secrets(_host(), "maurice")
+    assert matches is True
+    assert error is None
+
+
+def test_probe_returns_mismatch_when_values_differ():
+    """The maurice/wolf-i breakage: .env has the bearer rendered from a
+    previous hostname-keyed entry; secrets.json now holds the new key_id
+    entry. Mismatch → reconfigure."""
+    with (
+        patch(
+            "clawrium.core.lifecycle.get_instance_secrets",
+            return_value={"HERMES_API_SERVER_KEY": {"value": "new-token"}},
+        ),
+        patch(
+            "clawrium.core.lifecycle.get_host_private_key",
+            return_value="/tmp/key",
+        ),
+        patch(
+            "clawrium.core.lifecycle.paramiko.SSHClient",
+            _ssh_returning(b"API_SERVER_KEY='stale-token'\n"),
+        ),
+    ):
+        matches, error = _hermes_env_token_matches_secrets(_host(), "maurice")
+    assert matches is False
+    assert error is None
+
+
+def test_probe_is_non_fatal_on_ssh_failure():
+    with (
+        patch(
+            "clawrium.core.lifecycle.get_host_private_key",
+            return_value="/tmp/key",
+        ),
+        patch(
+            "clawrium.core.lifecycle.paramiko.SSHClient",
+            side_effect=RuntimeError("no route to host"),
+        ),
+    ):
+        matches, error = _hermes_env_token_matches_secrets(_host(), "maurice")
+    # Transient failure must not trigger a reconfigure storm.
+    assert matches is True
+    assert error is not None

--- a/tests/core/test_secrets_keying.py
+++ b/tests/core/test_secrets_keying.py
@@ -1,0 +1,69 @@
+"""Issue #448 — every per-agent secret callsite keys by host['key_id'].
+
+Pure unit coverage on the helper that everyone consumes
+(`get_instance_key`) plus a focused check on `get_installed_claw`,
+which is the resolver every CLI secret command routes through.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from clawrium.core.secrets import get_installed_claw, get_instance_key
+
+
+def _host(**over):
+    base = {
+        "hostname": "wolf.tailf7742d.ts.net",
+        "key_id": "192.168.1.36",
+        "agents": {
+            "hermes": {
+                "agent_name": "maurice",
+                "name": "maurice",
+                "type": "hermes",
+            }
+        },
+    }
+    base.update(over)
+    return base
+
+
+def test_get_installed_claw_returns_key_id_not_hostname():
+    """If hostname has drifted away from key_id (post-IP→DNS migration),
+    the resolver must return the stable key_id so secrets lookups land
+    in the original slot."""
+    with patch("clawrium.core.hosts.load_hosts", return_value=[_host()]):
+        host_key, claw_type, name = get_installed_claw("maurice")
+    assert host_key == "192.168.1.36"
+    assert claw_type == "hermes"
+    assert name == "maurice"
+
+
+def test_get_installed_claw_falls_back_to_hostname_when_key_id_missing():
+    """Legacy / hand-edited records without key_id must still resolve."""
+    host = _host()
+    host.pop("key_id")
+    with patch("clawrium.core.hosts.load_hosts", return_value=[host]):
+        host_key, _, _ = get_installed_claw("maurice")
+    assert host_key == "wolf.tailf7742d.ts.net"
+
+
+def test_instance_key_format():
+    assert (
+        get_instance_key("192.168.1.36", "hermes", "maurice")
+        == "192.168.1.36:hermes:maurice"
+    )
+
+
+def test_secrets_survive_hostname_mutation():
+    """Repro of the maurice/wolf-i breakage: store the secret under the
+    key_id slot, then mutate hostname; lookup must still find it."""
+    host = _host()
+    key_before = get_instance_key(
+        host.get("key_id") or host["hostname"], "hermes", "maurice"
+    )
+    host["hostname"] = "10.0.0.7"  # operator renumbered the network
+    key_after = get_instance_key(
+        host.get("key_id") or host["hostname"], "hermes", "maurice"
+    )
+    assert key_before == key_after

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -1278,7 +1278,9 @@ class TestSlackIntegration:
 
         assert result is True
 
-        instance_key = get_instance_key("192.168.1.100", "openclaw", "assistant")
+        # Issue #448: secrets are keyed by host["key_id"] (immutable),
+        # not host["hostname"]. The fixture sets key_id="work".
+        instance_key = get_instance_key("work", "openclaw", "assistant")
         secrets = load_secrets()
         assert instance_key in secrets
         assert "SLACK_BOT_TOKEN" in secrets[instance_key]
@@ -1311,7 +1313,7 @@ class TestSlackIntegration:
             ]
             _run_channels_stage("192.168.1.100", "openclaw", False, "assistant")
 
-        instance_key = get_instance_key("192.168.1.100", "openclaw", "assistant")
+        instance_key = get_instance_key("work", "openclaw", "assistant")
         instance_secrets = get_instance_secrets(instance_key)
         assert instance_secrets["SLACK_BOT_TOKEN"]["value"] == self.VALID_BOT_TOKEN
         assert instance_secrets["SLACK_APP_TOKEN"]["value"] == self.VALID_APP_TOKEN

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -622,7 +622,9 @@ def test_degraded_status_verifies_instance_key_argument(mock_host):
     # mock_host has hostname 192.168.1.100 and claw user opc-testhost
     mock_get_secrets.assert_called_once()
     call_args = mock_get_secrets.call_args[0][0]
-    assert call_args == "192.168.1.100:openclaw:opc-testhost"
+    # Issue #448: secrets are keyed by host["key_id"] ("testhost"),
+    # not host["hostname"], so renumbering the host doesn't orphan them.
+    assert call_args == "testhost:openclaw:opc-testhost"
     assert result["status"] == ClawStatus.DEGRADED
 
 

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -1214,8 +1214,11 @@ class TestHermesApiServerKeySecretsHygiene:
         assert "HERMES_API_SERVER_KEY" in error
 
     def test_configure_uses_canonical_hostname_for_instance_key(self, tmp_path: Path):
-        """Regression guard for commit 27d1ea8 + W1 from ATX iter 2: instance_key
-        must derive from host['hostname'], not the alias passed by the CLI."""
+        """Issue #448: instance_key derives from host['key_id'] (immutable),
+        with fallback to host['hostname'] for legacy records. This guards
+        both the original ATX-iter-2 W1 (must not key by the CLI alias)
+        and the #448 fix (must not key by the mutable hostname).
+        Fixture key_id="test", so the canonical key is `test:hermes:<name>`."""
         persisted_key = "e" * 64
         host = {
             "hostname": "192.168.1.100",  # canonical
@@ -1280,8 +1283,9 @@ class TestHermesApiServerKeySecretsHygiene:
         # instance_key passed to get_instance_secrets must be the canonical form.
         # Ignore additional calls (lifecycle queries secrets for other purposes).
         called_keys = [args[0] for args, _ in get_secrets_mock.call_args_list]
-        assert "192.168.1.100:hermes:hermes-test" in called_keys, called_keys
+        assert "test:hermes:hermes-test" in called_keys, called_keys
         assert "wolf-i:hermes:hermes-test" not in called_keys, called_keys
+        assert "192.168.1.100:hermes:hermes-test" not in called_keys, called_keys
 
 
 class TestConfigureYamlHandlerShape:

--- a/website/docs/guides/host-setup.md
+++ b/website/docs/guides/host-setup.md
@@ -45,6 +45,16 @@ On first run for that hostname, `clawctl` will:
    `authorized_keys` line.
 4. Exit non-zero with a "re-run after manual setup" message.
 
+:::note `key_id` is immutable (issue #448)
+The first successful `clawctl host create` for an alias mints a stable
+`key_id` that per-agent secrets (Discord tokens, provider API keys,
+hermes `HERMES_API_SERVER_KEY`) are stored under. Re-running
+`clawctl host create <new-ip-or-dns> --alias <existing-alias>` updates
+the host's `hostname`, port, and address list **without** rotating the
+`key_id` — every secret stays reachable. Renaming the alias is a
+deliberate identity change and does invalidate secrets.
+:::
+
 ## Step 2 — Run the setup commands on the host
 
 SSH to the host as your existing sudo-capable user and paste the block that


### PR DESCRIPTION
## Summary

- Key per-agent secrets by the immutable `host["key_id"]` so hostname mutations (IP → DNS, renumber, Tailscale migration) no longer orphan every secret on that host.
- `clawctl host create <new-coords> --alias <existing>` is now a re-record: rewrites hostname / port / addresses while preserving `key_id`.
- `lifecycle.start_agent` for hermes probes the on-host `.env`'s `API_SERVER_KEY` and reconfigures if it drifts from `secrets.json` (secrets.json is authoritative). Closes the 401-on-`clawctl agent chat` failure that surfaced #448 in the field.

## ATX Review Summary

**Final state: 1 iter-1 blocker fixed, 1 E2E defect fixed, 5 iter-1 warnings deferred to follow-ups. Iter-2 timed out and was not retried.**

| Review | Transport | Blocking issues | Status | Outcome |
|--------|-----------|-----------------|--------|---------|
| ATX iter-1 | CLI (`atx review request`) | W1 | Fixed in `643e884` | 6 warnings + 6 suggestions returned; W1 closed, W2-W6 deferred |
| ATX iter-2 | CLI (`atx review request`) | — | Timed out after 5m | Not retried (single E2E run pending; iter-2 would have re-reviewed the same diff) |
| E2E on wolf-i | manual | Phase 3 sudo defect | Fixed in `3f5998a` | Real defect surfaced; not catchable by unit tests |

> ATX MCP was unavailable in this session — used the CLI fallback per `/itx:execute` skill contract. ATX CLI does not expose per-agent model info or a 5-point rating in `--format text` output.

<details>
<summary>ATX iter-1 (CLI) — W1 fixed, W2-W6 deferred</summary>

**W1 — paramiko `RejectPolicy` silently no-opped the env-file probe post-migration** *(High — defeats Phase 3 invariant)*
The default policy raised `SSHException` on any new DNS name not in `~/.ssh/known_hosts`. The outer `except` swallowed it and returned `matches=True` — silently passing on the exact migration path the PR was written to fix.
**Resolution:** `client.set_missing_host_key_policy(paramiko.WarningPolicy())` (`643e884`). `AutoAddPolicy` rejected — too-permissive persistence of unknown keys.

**W2 — New host at recycled IP silently inherits old secrets** *(Deferred)*
A new machine registered at a recycled IP gets `key_id=<that-IP>` and would resolve any lingering `<that-IP>:*` entries from the prior occupant. Suggested follow-up: scan `secrets.json` on `clawctl host create` and warn on prefix collisions.

**W3 — `host.get("key_id") or host["hostname"]` raises `KeyError` if both missing** *(Deferred)*
A truncated/hand-edited record missing both fields crashes instead of routing through `InvalidInstanceKeyComponentError`. Quick harden: `or host.get("hostname", "")`. Not reachable from any code-driven path I could find.

**W4 — Legacy hosts without `key_id` get no runtime warning** *(Deferred)*
Operators with pre-`key_id` records remain silently at risk until they re-record. Suggested follow-up: log a one-shot warning on first fallback, or auto-populate `key_id = hostname` on first access and write back.

**W5 — Token-drift path double-starts the daemon** *(Deferred)*
On drift, `configure_agent` does a `systemctl restart` and then `_run_lifecycle_playbook("start")` runs anyway. Cosmetic — outcome is correct, the event stream is just noisier than ideal.

**W6 — `remove_agent` secret cleanup after hostname rename untested** *(Partially closed by E2E)*
E2E exercised the agent-delete path end-to-end and confirmed the cleanup routes through the new `key_id`-keyed slot ("Cleaned up instance secrets" event observed). Hostname-rename-then-delete combination still untested.

**Suggestions (S1-S6):** rename `test_configure_uses_canonical_hostname_for_instance_key` → `..._uses_key_id...`, rename misleading `hostname` locals in `cli/agent.py`, move `import shlex` to top-level, etc. All deferred — non-functional.

</details>

<details>
<summary>E2E on wolf-i — Phase 3 sudo defect fixed</summary>

Installed branch via `uv tool install --editable`, spun up throwaway `test448` hermes agent on wolf-i. First start-after-corrupt-`.env` did **not** emit the drift line, and the daemon continued enforcing the corrupt bearer. Root cause: paramiko exec channel ran `grep` as `xclm`, but `/home/<agent>/.hermes/.env` is unreadable by xclm (0700 home, owned by per-agent unix user). The helper's `grep ... || true` masked the permission failure, returned empty stdout, helper concluded "key not present" → non-fatal path → no reconcile.

**Resolution:** `sudo -n grep ...` in the probe (`3f5998a`). xclm has passwordless sudo from `clawctl host create`; `-n` ensures clean failure if sudo is somehow unavailable (which routes through the outer except as non-fatal — correct behavior).

After fix, against live wolf-i:
- Fresh install → `HERMES_API_SERVER_KEY` lands in `wolf-i:hermes:test448` (key_id slot, not hostname) ✅
- Bearer enforcement: good→200, none→401, wrong→401 ✅
- Corrupt `.env`, `stop`, `start` → drift line emitted, configure runs first, daemon enforces canonical bearer, `curl /v1/models` → 200 ✅
- `agent delete` cleans secrets via key_id slot ✅

Skipped: live host re-record (Scenario 1) and IP→DNS migration (Scenario 2 mid-section) — would mutate the live wolf-i record that 7 other agents depend on. Covered by `tests/cli/clawctl/host/test_create_preserves_key_id.py`.

Full plan + execution record: `.itx/448/02_E2E_TEST_PLAN.md`.

</details>

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — 3491 passed, 7 skipped
- [x] Linter passes (`make lint`) — Python + GUI clean
- [x] New tests added for new functionality
- [x] End-to-end validated on wolf-i (see ATX Review Summary above)

### Test Coverage
- New: `tests/core/test_secrets_keying.py`, `tests/core/test_lifecycle_env_consistency.py`, `tests/cli/clawctl/host/test_create_preserves_key_id.py`
- Updated: `tests/test_cli_agent_configure.py`, `tests/test_health.py`, `tests/test_hermes_configure.py`, `tests/cli/clawctl/host/test_create_delete.py`

### Manual Testing
Executed against wolf-i 2026-05-29. Throwaway `test448` hermes agent installed, scenarios run, defect found and fixed, agent removed cleanly. Other 10 agents on the fleet untouched. Per-host hand-migration recipe for pre-existing agents posted as a separate PR comment.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation: `_validate_instance_key_component` already gates key fragments; `key_id` flows through the same validator at construction time.
- [x] No SQL / XSS / command injection: the env-file probe uses `shlex.quote` on the env path and runs `sudo -n grep -E '^API_SERVER_KEY=' <quoted-path>` (read-only, no payload).
- [x] Paramiko host-key policy: `WarningPolicy` (not `AutoAddPolicy`) — connects on unknown key while logging; new fingerprints are not persisted without operator review.
- [x] Dependencies unchanged.

## Callouts

- [DECISION] `get_installed_claw` now returns `key_id` (with hostname fallback) instead of `hostname`.
  - Why: every CLI secret command routes through this helper and feeds the value straight into `get_instance_key`. Returning `key_id` here fixed the whole CLI tree in one edit rather than patching ~10 callsites individually. Display sites (`clawctl agent secret get`) now show the stable identifier, which is at worst equal to the hostname and at best the more meaningful value after a rename.
  - Reviewer: confirm this contract change is acceptable. The alternative was an expanded tuple (`(key_id, hostname, ...)`); rejected as more churn for callers that need both.

- [DECISION] `get_host` also matches by `key_id` now (alongside hostname/alias).
  - Why: callers holding `key_id` (e.g. `get_installed_claw` consumers in `cli/memory.py`, integration paths) need to resolve back to the host record after a hostname mutation. Adding the third match branch is local and cheap; the alternative (adding `host_key` as a fourth tuple element everywhere) was much more invasive.
  - Reviewer: this widens the lookup surface — confirm no caller relied on `get_host("<a-key_id-that-happens-not-to-match-any-hostname>")` returning `None`.

- [DECISION] Defensive `host.get("key_id") or host["hostname"]` fallback at every callsite rather than asserting `key_id` is always present.
  - Why: legacy `hosts.json` records and hand-edited entries may lack `key_id`. Preserves backward compatibility without an in-code migration step.
  - Alternatives considered: in-code migration writer (rejected per maintainer; "no migration code").

- [DECISION] `lifecycle.start_agent` env-file probe is non-fatal.
  - Why: an SSH timeout / unreachable host / unreadable `.env` should not synthesize a configure storm. The start playbook itself will surface the real failure.
  - How to apply: on any probe exception we return `(True, error)` — the caller logs at debug and proceeds to start.

- [DECISION] Probe uses `sudo -n grep` (E2E-discovered).
  - Why: agent home dirs are 0700, owned by the per-agent unix user. xclm cannot read `.env` directly. xclm has passwordless sudo; `-n` ensures we never block waiting for a password (instead we fail through the non-fatal outer except).
  - Reviewer: this is the change in `3f5998a`. Worth confirming the security tradeoff is acceptable (probe is read-only, fixed command, shell-quoted path).

- [DECISION] `clawctl host create` re-record path rejects `--user` mutation.
  - Why: rotating the management user is an identity change, not a network-coordinates change. The CLI already pins `--user xclm`, so this branch is defensive — but it's where a future widening would land.

- [UNRESOLVED] No automatic migration of legacy `<hostname>:*` entries in `secrets.json`.
  - Best guess applied: per maintainer instruction in `.itx/448/00_PLAN.md`, no migration code. New installs use stable keying; existing affected agents will be migrated by hand. Per-host `jq` recipe posted as a separate PR comment.
  - Reviewer: this is the deliberate trade-off. Every pre-existing agent on every fleet host will need its secret keys renamed after merge — silent breakage otherwise.

- [TODO-FOLLOWUP] ATX iter-1 W2-W6 (see expanded section above).
  - Tracking: file a single follow-up issue covering the recycled-IP warning, the legacy-record log, the double-start cosmetic, and the rename-then-delete test.

- [TODO-FOLLOWUP] Extend `tests/core/test_install_hermes.py` with a hostname-mutation install scenario, and add `tests/integration/test_secrets_survive_hostname_change.py`.
  - Why deferred: prioritized high-signal unit coverage. E2E run covered the install + reconcile + delete paths against a live daemon.

Co-Authored-By: Claude <noreply@anthropic.com>
