### PR TITLE
feat(render): F1+F2 build_render_inputs + pure renderers (#556)

### DIFF
--- a/.itx/556/01_EXECUTION.md
+++ b/.itx/556/01_EXECUTION.md
@@ -1,0 +1,52 @@
+# Issue #556 — Execution Log
+
+Subtask of #555: F1 + F2 deterministic `build_render_inputs` and pure
+`render_hermes / render_zeroclaw / render_openclaw`.
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-29T19:13:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx:execute 556
+```
+
+**Output**: New module `src/clawrium/core/render.py` (RenderInputs +
+build_render_inputs raising on missing attachment + pure renderers
+branching only on provider.type) plus comprehensive unit + idempotency
+tests in `tests/core/test_render.py`. Not wired into lifecycle.
+
+## ATX Review Iterations
+
+### Iteration 1 — Rating 2/5
+
+Cost ~$2.68 USD; 4 specialists; 10 blocking issues across renderer
+contracts, manifest fidelity, security, and test coverage:
+
+- **B1** `zai`/`vertex` accepted by build but missing from hermes/zeroclaw renderers
+- **B2** vertex emits bearer token as `GOOGLE_APPLICATION_CREDENTIALS` (must be a path)
+- **B3** render_zeroclaw missing `[autonomy] shell_env_passthrough` (mandatory grep gate)
+- **B4** render_openclaw output key `.openclaw/.env` should be `.openclaw/env`
+- **B5** `ChannelInputs` missing `allow_all_users` / `home_channel_name` / `home_channel_thread_id`
+- **B6** `GatewayInputs` missing `allow_public_bind`
+- **B7** YAML key injection via raw `integration.name` in `mcp_servers`
+- **B8** NUL-byte secrets pass truthiness check (need `_clean_secret`)
+- **B9** Slack render path entirely untested
+- **B10** Empty/null `provider_type` path untested
+
+### Iteration 2 — Infrastructure timeout
+
+ATX review timed out twice (12m, 18m) on the verification pass. All
+10 iter-1 blockers and most warnings (W2–W4, W6–W8) addressed in
+code + tests; local `make test` (3549 passed) and `make lint` clean.
+Per the `/itx:execute` skill's resilient-ATX contract, the PR opens
+with the iteration history documented and a Callout flagging the
+incomplete verification round.
+
+## Verification
+
+- `make test-py`: 3549 passed, 7 skipped
+- `make lint-py`: ruff clean

--- a/.itx/556/atx-session.json
+++ b/.itx/556/atx-session.json
@@ -1,0 +1,25 @@
+{
+  "session_id": "72364f52-a0ce-44dd-809e-3b24c83f6f93",
+  "transport": "cli",
+  "commit_sha": "pending-commit",
+  "iteration": 2,
+  "last_rating": 2,
+  "last_blockers": [
+    "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "B10"
+  ],
+  "blocker_status": {
+    "B1": "fixed",
+    "B2": "fixed",
+    "B3": "fixed",
+    "B4": "fixed",
+    "B5": "fixed",
+    "B6": "fixed",
+    "B7": "fixed",
+    "B8": "fixed",
+    "B9": "fixed",
+    "B10": "fixed"
+  },
+  "started_at": "2026-05-29T19:13:38Z",
+  "updated_at": "2026-05-29T19:48:00Z",
+  "iter_2_note": "Iter-2 verification pass timed out twice (12m, 18m). Closing the loop with documented fixes per AGENTS.md / itx:execute resilient-ATX contract."
+}

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -1,0 +1,964 @@
+"""Deterministic render-input assembly and pure rendering for agent configs.
+
+This module is the F1+F2 scaffolding for parent issue #555. It is the
+single source of truth for the canonical agent-config bundle:
+
+1. `build_render_inputs(agent_name)` assembles `RenderInputs` from
+   clawctl's own stores (providers.json + channels.json +
+   integrations.json + secrets.json + hosts.json attachment lists).
+   Any unresolved attachment raises `AgentConfigError` — there is no
+   "skip on missing" branch. This is the rule restated by #555's TL;DR.
+
+2. `render_hermes` / `render_zeroclaw` / `render_openclaw` are pure
+   functions of `RenderInputs` returning `RenderedFiles`. Templates
+   branch ONLY on `provider.type` (the value that comes from the
+   registry). They DO NOT branch on "is field X populated" — every
+   declared input flows to exactly one declared output. The functions
+   are also byte-deterministic: same inputs → byte-identical bytes.
+
+The module is intentionally NOT wired into `lifecycle.py` yet (see
+#555 plan F3+); that wiring lands in a follow-up. The contract here
+must stand alone so it can be exercised by unit + property tests
+before any production code paths depend on it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = [
+    "AgentConfigError",
+    "ProviderInputs",
+    "ChannelInputs",
+    "IntegrationInputs",
+    "APIServerInputs",
+    "GatewayInputs",
+    "RenderInputs",
+    "RenderedFiles",
+    "build_render_inputs",
+    "render_hermes",
+    "render_zeroclaw",
+    "render_openclaw",
+]
+
+
+# Provider types whose API key is stored as a single bearer secret in
+# secrets.json. Each one MUST also appear in the per-renderer support
+# table below so a successful `build_render_inputs` cannot hand the
+# renderer a provider it does not know how to emit. The renderers
+# enforce this with explicit raises.
+#
+# `vertex` is intentionally absent: GCP service-account auth uses a
+# filesystem path (`GOOGLE_APPLICATION_CREDENTIALS=/path/to.json`),
+# not a bearer string. Conflating the two would silently produce a
+# broken on-host config. Vertex support belongs in a follow-up that
+# extends the schema with a credential-kind field.
+_BEARER_API_KEY_TYPES = frozenset({"openrouter", "anthropic", "openai", "zai"})
+_LOCAL_ENDPOINT_TYPES = frozenset({"ollama"})
+
+# Per-agent-type supported provider sets. `build_render_inputs` checks
+# this so a hermes agent attached to a zai-only provider fails up-front
+# instead of crashing later inside `render_hermes`. The membership
+# matches the renderer dispatch tables further below.
+_AGENT_TYPE_PROVIDER_SUPPORT: dict[str, frozenset[str]] = {
+    "hermes": frozenset({"openrouter", "anthropic", "openai", "bedrock", "ollama"}),
+    "zeroclaw": frozenset({"openrouter", "anthropic", "openai", "ollama"}),
+    "openclaw": frozenset(
+        {"openrouter", "anthropic", "openai", "bedrock", "ollama", "zai"}
+    ),
+}
+
+
+def _clean_secret(value: str | None) -> str:
+    """Strip NUL/CR/LF from a secret before any truthiness check.
+
+    A NUL-only string (`'\\x00'`) is truthy in Python but causes
+    systemd's `EnvironmentFile` reader to silently truncate at the
+    NUL — every subsequent var is dropped from the unit's environment
+    with no error. CR/LF can split the value across lines and inject
+    arbitrary keys. Sanitize before guarding so a degenerate secret is
+    treated as missing, not "present but corrupt".
+    """
+    if not value:
+        return ""
+    return value.replace("\x00", "").replace("\r", "").replace("\n", "")
+
+
+class AgentConfigError(Exception):
+    """Raised when a declared attachment cannot be resolved.
+
+    `build_render_inputs` raises this on any missing provider record,
+    missing secret, missing channel record, or missing integration —
+    never silently skips. The message names the failed lookup so the
+    operator can fix the underlying record (provider attach, channel
+    create, secret set, etc.) and re-run.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Typed inputs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProviderInputs:
+    name: str
+    type: str
+    endpoint: str = ""
+    default_model: str = ""
+    region: str = ""
+    api_key: str = ""
+    aws_access_key: str = ""
+    aws_secret_key: str = ""
+
+
+@dataclass(frozen=True)
+class ChannelInputs:
+    name: str
+    type: str
+    bot_token: str = ""
+    app_token: str = ""
+    allowed_users: tuple[str, ...] = ()
+    allowed_guilds: tuple[str, ...] = ()
+    allowed_channels: tuple[str, ...] = ()
+    require_mention: bool = True
+    allow_all_users: bool = False
+    stream_mode: str = ""
+    home_channel: str = ""
+    home_channel_name: str = ""
+    home_channel_thread_id: str = ""
+
+
+@dataclass(frozen=True)
+class IntegrationInputs:
+    name: str
+    type: str
+    # Sorted tuple of (key, value) for deterministic iteration.
+    credentials: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class APIServerInputs:
+    host: str
+    port: int
+    key: str
+
+
+@dataclass(frozen=True)
+class GatewayInputs:
+    host: str = ""
+    port: int = 0
+    auth: str = ""
+    bind: str = ""
+    allow_public_bind: bool = True
+
+
+@dataclass(frozen=True)
+class RenderInputs:
+    agent_name: str
+    agent_type: str
+    provider: ProviderInputs
+    channels: tuple[ChannelInputs, ...] = ()
+    integrations: tuple[IntegrationInputs, ...] = ()
+    api_server: APIServerInputs | None = None
+    gateway: GatewayInputs | None = None
+
+
+@dataclass(frozen=True)
+class RenderedFiles:
+    """Bytes-equivalent string contents of every on-host config file.
+
+    Files are addressed by their relative path under the agent's home
+    directory on the host (e.g. `.hermes/.env`, `.hermes/config.yaml`).
+    """
+
+    files: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # Keys must be deterministically ordered; coerce to a sorted
+        # dict so callers comparing `rendered.files == rendered.files`
+        # across two invocations don't accidentally pass on dict-order
+        # differences before Python 3.7's insertion-order guarantee
+        # would otherwise mask a real drift.
+        object.__setattr__(
+            self,
+            "files",
+            dict(sorted(self.files.items())),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Assembly: build_render_inputs
+# ---------------------------------------------------------------------------
+
+
+def build_render_inputs(agent_name: str) -> RenderInputs:
+    """Assemble the canonical render bundle for one agent.
+
+    Resolves the agent via `hosts.json`, then loads the full provider /
+    channel / integration / secret records from clawctl's own stores.
+    Any missing attachment raises `AgentConfigError`.
+
+    No "if attached then include" branches: this function iterates the
+    declared attachment lists and raises on any unresolved name.
+    """
+    # Imports are deferred so the module is import-cheap for tests that
+    # patch the data-layer functions.
+    from clawrium.core.channels import (
+        get_agent_channels,
+        get_channel,
+        get_channel_token,
+    )
+    from clawrium.core.hosts import get_agent_by_name
+    from clawrium.core.integrations import (
+        INTEGRATION_TYPES,
+        get_agent_integrations,
+        get_integration,
+        get_integration_credentials,
+    )
+    from clawrium.core.provider_attachments import (
+        normalize as normalize_attachments,
+    )
+    from clawrium.core.providers import (
+        get_provider,
+        get_provider_api_key,
+        get_provider_aws_credentials,
+    )
+
+    resolved = get_agent_by_name(agent_name)
+    if resolved is None:
+        raise AgentConfigError(
+            f"agent {agent_name!r} not found in any host record"
+        )
+    host_record, agent_type, agent_record = resolved
+    hostname = host_record.get("hostname") or ""
+    # `get_agent_by_name` returns the dict-key match; the canonical
+    # agent_key used by channel / integration lookups is the same value
+    # the caller passed in (an agent is uniquely keyed by name in
+    # `host["agents"]`).
+    agent_key = agent_record.get("agent_name") or agent_name
+
+    # --- Provider ----------------------------------------------------------
+    raw_attachments = agent_record.get("providers") or []
+    attachments = normalize_attachments(raw_attachments, agent_type)
+    if not attachments:
+        raise AgentConfigError(
+            f"agent {agent_name!r} has no provider attached; "
+            f"run `clawctl agent provider attach <provider> --agent {agent_name}` first"
+        )
+
+    # Pick the primary attachment. For hermes this is the entry whose
+    # role == 'primary'; for single-provider agent types it's the only
+    # entry. Either way the result is a single provider name.
+    primary_name: str | None = None
+    for entry in attachments:
+        if isinstance(entry, dict):
+            if entry.get("role") == "primary":
+                primary_name = entry.get("name")
+                break
+        elif isinstance(entry, str):
+            primary_name = entry
+            break
+    if not primary_name:
+        raise AgentConfigError(
+            f"agent {agent_name!r} attachments do not yield a primary provider"
+        )
+
+    provider_record = get_provider(primary_name)
+    if provider_record is None:
+        raise AgentConfigError(
+            f"provider {primary_name!r} attached to agent {agent_name!r} "
+            f"is not registered in providers.json"
+        )
+    raw_type = provider_record.get("type")
+    provider_type = (raw_type or "").strip() if isinstance(raw_type, str) else ""
+    if not provider_type:
+        raise AgentConfigError(
+            f"provider {primary_name!r} has no type field"
+        )
+
+    # Per-agent-type provider compatibility gate. Catches misconfigurations
+    # like a hermes agent attached to a zai provider (which only openclaw
+    # renders) BEFORE the renderer fails with a less-actionable message.
+    supported = _AGENT_TYPE_PROVIDER_SUPPORT.get(agent_type, frozenset())
+    if provider_type not in supported:
+        raise AgentConfigError(
+            f"agent {agent_name!r} (type {agent_type}) does not support "
+            f"provider type {provider_type!r}. "
+            f"Supported types for {agent_type}: {sorted(supported)}"
+        )
+
+    api_key = ""
+    aws_access_key = ""
+    aws_secret_key = ""
+    if provider_type == "bedrock":
+        ak, sk = get_provider_aws_credentials(primary_name)
+        ak = _clean_secret(ak)
+        sk = _clean_secret(sk)
+        if not ak or not sk:
+            raise AgentConfigError(
+                f"bedrock provider {primary_name!r} is missing AWS credentials "
+                f"in secrets.json (expected AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY)"
+            )
+        aws_access_key = ak
+        aws_secret_key = sk
+    elif provider_type in _BEARER_API_KEY_TYPES:
+        key = _clean_secret(get_provider_api_key(primary_name))
+        if not key:
+            raise AgentConfigError(
+                f"provider {primary_name!r} (type {provider_type}) is missing "
+                f"API key in secrets.json"
+            )
+        api_key = key
+    elif provider_type in _LOCAL_ENDPOINT_TYPES:
+        # Local providers (ollama) need an endpoint, not an API key.
+        if not provider_record.get("endpoint"):
+            raise AgentConfigError(
+                f"provider {primary_name!r} (type {provider_type}) is missing "
+                f"endpoint in providers.json"
+            )
+    else:
+        # _AGENT_TYPE_PROVIDER_SUPPORT already filtered unsupported types
+        # for the requested agent type. A miss here means a supported
+        # type was added to the per-agent table without wiring its
+        # credential fetch — fail loudly so the next reviewer notices.
+        raise AgentConfigError(
+            f"provider {primary_name!r} has type {provider_type!r} which is "
+            f"declared supported for agent {agent_type} but has no credential "
+            f"fetch wired in build_render_inputs"
+        )
+
+    provider = ProviderInputs(
+        name=primary_name,
+        type=provider_type,
+        endpoint=provider_record.get("endpoint", "") or "",
+        default_model=provider_record.get("default_model", "") or "",
+        region=provider_record.get("region", "") or "",
+        api_key=api_key,
+        aws_access_key=aws_access_key,
+        aws_secret_key=aws_secret_key,
+    )
+
+    # --- Channels ----------------------------------------------------------
+    channel_inputs: list[ChannelInputs] = []
+    for channel_name in get_agent_channels(hostname, agent_key):
+        record = get_channel(channel_name)
+        if record is None:
+            raise AgentConfigError(
+                f"channel {channel_name!r} attached to agent {agent_name!r} "
+                f"is not registered in channels.json"
+            )
+        channel_type = record.get("type") or ""
+        bot_token = _clean_secret(get_channel_token(channel_name, "BOT_TOKEN"))
+        if not bot_token:
+            raise AgentConfigError(
+                f"channel {channel_name!r} (type {channel_type}) is missing BOT_TOKEN in secrets.json"
+            )
+        app_token = ""
+        if channel_type == "slack":
+            app_token = _clean_secret(get_channel_token(channel_name, "APP_TOKEN"))
+            if not app_token:
+                raise AgentConfigError(
+                    f"slack channel {channel_name!r} is missing APP_TOKEN in secrets.json"
+                )
+        cfg = record.get("config") or {}
+        channel_inputs.append(
+            ChannelInputs(
+                name=channel_name,
+                type=channel_type,
+                bot_token=bot_token,
+                app_token=app_token,
+                allowed_users=tuple(cfg.get("allowed_users", []) or []),
+                allowed_guilds=tuple(cfg.get("allowed_guilds", []) or []),
+                allowed_channels=tuple(cfg.get("allowed_channels", []) or []),
+                require_mention=bool(cfg.get("require_mention", True)),
+                allow_all_users=bool(cfg.get("allow_all_users", False)),
+                stream_mode=str(cfg.get("stream_mode", "") or ""),
+                home_channel=str(cfg.get("home_channel", "") or ""),
+                home_channel_name=str(cfg.get("home_channel_name", "") or ""),
+                home_channel_thread_id=str(
+                    cfg.get("home_channel_thread_id", "") or ""
+                ),
+            )
+        )
+    # Sort by name for byte-determinism.
+    channel_inputs.sort(key=lambda c: c.name)
+
+    # --- Integrations ------------------------------------------------------
+    integration_inputs: list[IntegrationInputs] = []
+    for integration_name in get_agent_integrations(hostname, agent_key):
+        record = get_integration(integration_name)
+        if record is None:
+            raise AgentConfigError(
+                f"integration {integration_name!r} attached to agent {agent_name!r} "
+                f"is not registered in integrations.json"
+            )
+        integration_type = record.get("type") or ""
+        raw_creds = get_integration_credentials(integration_name)
+        # Apply NUL/CR/LF sanitization before the required-field truthiness
+        # gate so a degenerate secret reads as missing, not present-but-corrupt.
+        creds_map = {k: _clean_secret(v) for k, v in raw_creds.items()}
+        # Verify every REQUIRED credential is present (and non-degenerate).
+        type_spec = INTEGRATION_TYPES.get(integration_type, {}) or {}
+        for cred_spec in type_spec.get("credentials", []) or []:
+            if cred_spec.get("required") and not creds_map.get(cred_spec["key"]):
+                raise AgentConfigError(
+                    f"integration {integration_name!r} (type {integration_type}) "
+                    f"is missing required credential {cred_spec['key']!r} in secrets.json"
+                )
+        integration_inputs.append(
+            IntegrationInputs(
+                name=integration_name,
+                type=integration_type,
+                credentials=tuple(sorted(creds_map.items())),
+            )
+        )
+    integration_inputs.sort(key=lambda i: i.name)
+
+    # --- API server / gateway (per-instance config knobs) -----------------
+    config_blob = agent_record.get("config") or {}
+    api_server_input: APIServerInputs | None = None
+    api_server_blob = config_blob.get("api_server")
+    if isinstance(api_server_blob, dict):
+        api_server_input = APIServerInputs(
+            host=str(api_server_blob.get("host", "")),
+            port=int(api_server_blob.get("port", 0) or 0),
+            key=str(api_server_blob.get("key", "")),
+        )
+
+    gateway_input: GatewayInputs | None = None
+    gateway_blob = config_blob.get("gateway")
+    if isinstance(gateway_blob, dict):
+        gateway_input = GatewayInputs(
+            host=str(gateway_blob.get("host", "")),
+            port=int(gateway_blob.get("port", 0) or 0),
+            auth=str(gateway_blob.get("auth", "")),
+            bind=str(gateway_blob.get("bind", "")),
+            allow_public_bind=bool(gateway_blob.get("allow_public_bind", True)),
+        )
+
+    return RenderInputs(
+        agent_name=agent_name,
+        agent_type=agent_type,
+        provider=provider,
+        channels=tuple(channel_inputs),
+        integrations=tuple(integration_inputs),
+        api_server=api_server_input,
+        gateway=gateway_input,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure renderers
+# ---------------------------------------------------------------------------
+
+
+def _shell_quote(value: str) -> str:
+    """POSIX single-quote shell escape. Matches the .env.j2 macro.
+
+    Embeds a single quote in a single-quoted string as: 'val'"'"'ue'.
+    Used for systemd EnvironmentFile values so `#` mid-value isn't
+    parsed as a comment and arbitrary content can't break the line.
+    """
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def _systemd_quote(value: str) -> str:
+    """Double-quote escape for systemd Environment= drop-ins."""
+    cleaned = value.replace("\r", "").replace("\n", "")
+    cleaned = cleaned.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{cleaned}"'
+
+
+def _toml_escape(value: str) -> str:
+    """Escape a value for use inside a TOML basic string."""
+    return (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+        .replace("\t", "\\t")
+    )
+
+
+def _yaml_quote(value: str) -> str:
+    """Single-quote escape for a YAML scalar.
+
+    Strips NUL / CR / LF first — YAML 1.1/1.2 prohibits NUL inside
+    scalars and most parsers silently truncate; CR/LF inside a
+    single-quoted scalar produces line-broken output that downstream
+    YAML readers (esp. PyYAML's C loader) handle inconsistently.
+    """
+    cleaned = value.replace("\x00", "").replace("\r", "").replace("\n", "")
+    return "'" + cleaned.replace("'", "''") + "'"
+
+
+def _integration_slug(name: str) -> str:
+    """Slug used in per-integration env var names (`GITHUB_TOKEN_<NAME>`)."""
+    upper = name.upper().replace("-", "_")
+    return "".join(c for c in upper if c.isalnum() or c == "_")
+
+
+# Provider env-var-name table, keyed on provider.type. Each entry is a
+# tuple of (env_var_name_for_api_key, inference_provider_value). The
+# table is the ONLY place provider.type matters at render time.
+_HERMES_PROVIDER_ENV = {
+    "openrouter": ("OPENROUTER_API_KEY", "openrouter"),
+    "anthropic": ("ANTHROPIC_API_KEY", "anthropic"),
+    "openai": ("OPENAI_API_KEY", "openai"),
+}
+
+
+def render_hermes(inputs: RenderInputs) -> RenderedFiles:
+    """Render hermes' on-host config files from canonical inputs.
+
+    Produces:
+      - `.hermes/.env`: systemd EnvironmentFile body.
+      - `.hermes/config.yaml`: model + auxiliary config.
+
+    Branches only on `inputs.provider.type`. Every field declared on
+    `inputs` flows into exactly one output line; the function does NOT
+    conditionally emit a section based on whether a hosts.json field
+    happened to be populated.
+    """
+    env_lines: list[str] = []
+    env_lines.append(
+        f"# Managed by clawrium (clawctl). Re-render with "
+        f"`clawctl agent configure {inputs.agent_name}`."
+    )
+
+    # --- Provider credentials (branch on provider.type only) -----------
+    ptype = inputs.provider.type
+    if ptype in _HERMES_PROVIDER_ENV:
+        env_var, inference_name = _HERMES_PROVIDER_ENV[ptype]
+        env_lines.append(f"{env_var}={_shell_quote(inputs.provider.api_key)}")
+        env_lines.append(f"HERMES_INFERENCE_PROVIDER={_shell_quote(inference_name)}")
+    elif ptype == "bedrock":
+        env_lines.append(f"AWS_ACCESS_KEY_ID={_shell_quote(inputs.provider.aws_access_key)}")
+        env_lines.append(f"AWS_SECRET_ACCESS_KEY={_shell_quote(inputs.provider.aws_secret_key)}")
+        env_lines.append(
+            f"AWS_DEFAULT_REGION={_shell_quote(inputs.provider.region or 'us-east-1')}"
+        )
+        env_lines.append("HERMES_INFERENCE_PROVIDER='bedrock'")
+    elif ptype == "ollama":
+        env_lines.append("HERMES_INFERENCE_PROVIDER='custom'")
+    else:
+        # `build_render_inputs` filters via _AGENT_TYPE_PROVIDER_SUPPORT,
+        # but callers may construct `RenderInputs` directly (tests,
+        # future programmatic configure flows). Raise loudly here so an
+        # unsupported provider type can never silently produce an
+        # incomplete on-host config.
+        raise AgentConfigError(
+            f"render_hermes does not support provider type {ptype!r}. "
+            f"Supported: {sorted(_HERMES_PROVIDER_ENV) + ['bedrock', 'ollama']}"
+        )
+
+    # --- API server block --------------------------------------------------
+    if inputs.api_server is not None:
+        env_lines.append("API_SERVER_ENABLED=1")
+        env_lines.append(f"API_SERVER_HOST={_shell_quote(inputs.api_server.host)}")
+        env_lines.append(f"API_SERVER_PORT={int(inputs.api_server.port)}")
+        env_lines.append(f"API_SERVER_KEY={_shell_quote(inputs.api_server.key)}")
+
+    # --- Channels (every attached channel renders all its tokens) ---------
+    for channel in inputs.channels:
+        if channel.type == "discord":
+            env_lines.append(f"DISCORD_BOT_TOKEN={_shell_quote(channel.bot_token)}")
+            env_lines.append(
+                f"DISCORD_ALLOWED_USERS={_shell_quote(','.join(channel.allowed_users))}"
+            )
+            env_lines.append(
+                f"DISCORD_ALLOWED_CHANNELS={_shell_quote(','.join(channel.allowed_channels))}"
+            )
+            env_lines.append(
+                f"DISCORD_REQUIRE_MENTION={_shell_quote(str(channel.require_mention).lower())}"
+            )
+            env_lines.append(
+                f"DISCORD_ALLOW_ALL_USERS={_shell_quote(str(channel.allow_all_users).lower())}"
+            )
+            env_lines.append(f"DISCORD_HOME_CHANNEL={_shell_quote(channel.home_channel)}")
+            env_lines.append(
+                f"DISCORD_HOME_CHANNEL_NAME={_shell_quote(channel.home_channel_name)}"
+            )
+            env_lines.append(
+                f"DISCORD_HOME_CHANNEL_THREAD_ID={_shell_quote(channel.home_channel_thread_id)}"
+            )
+        elif channel.type == "slack":
+            env_lines.append(f"SLACK_BOT_TOKEN={_shell_quote(channel.bot_token)}")
+            env_lines.append(f"SLACK_APP_TOKEN={_shell_quote(channel.app_token)}")
+            env_lines.append(
+                f"SLACK_ALLOWED_USERS={_shell_quote(','.join(channel.allowed_users))}"
+            )
+            env_lines.append(f"SLACK_HOME_CHANNEL={_shell_quote(channel.home_channel)}")
+            env_lines.append(
+                f"SLACK_HOME_CHANNEL_NAME={_shell_quote(channel.home_channel_name)}"
+            )
+        else:
+            raise AgentConfigError(
+                f"render_hermes: unsupported channel type {channel.type!r}"
+            )
+
+    # --- Integrations (per-name and bare GITHUB_TOKEN fallback) -----------
+    last_github_token = ""
+    for integration in inputs.integrations:
+        creds = dict(integration.credentials)
+        if integration.type == "github":
+            token = creds.get("GITHUB_TOKEN", "")
+            slug = _integration_slug(integration.name)
+            env_lines.append(f"GITHUB_TOKEN_{slug}={_shell_quote(token)}")
+            last_github_token = token
+        elif integration.type == "atlassian":
+            # Atlassian creds are emitted in config.yaml's mcp_servers block,
+            # not the env file. Skip here.
+            continue
+        elif integration.type == "linear":
+            env_lines.append(f"LINEAR_API_KEY={_shell_quote(creds.get('LINEAR_API_KEY', ''))}")
+        elif integration.type == "notion":
+            env_lines.append(f"NOTION_API_KEY={_shell_quote(creds.get('NOTION_API_KEY', ''))}")
+        elif integration.type == "gitlab":
+            env_lines.append(f"GITLAB_TOKEN={_shell_quote(creds.get('GITLAB_TOKEN', ''))}")
+            if "GITLAB_URL" in creds:
+                env_lines.append(f"GITLAB_URL={_shell_quote(creds['GITLAB_URL'])}")
+        elif integration.type == "git":
+            # git-identity creds go into ~/.gitconfig via a separate render;
+            # nothing for the env file.
+            continue
+        else:
+            raise AgentConfigError(
+                f"render_hermes: unsupported integration type {integration.type!r}"
+            )
+    if last_github_token:
+        env_lines.append(f"GITHUB_TOKEN={_shell_quote(last_github_token)}")
+
+    env_body = "\n".join(env_lines) + "\n"
+
+    # --- config.yaml -------------------------------------------------------
+    yaml_lines: list[str] = []
+    yaml_lines.append(
+        f"# Managed by clawrium (clawctl). Re-render with "
+        f"`clawctl agent configure {inputs.agent_name}`."
+    )
+    if ptype == "openrouter":
+        yaml_lines.append("model:")
+        yaml_lines.append('  provider: "openrouter"')
+        yaml_lines.append('  base_url: "https://openrouter.ai/api/v1"')
+        yaml_lines.append(f"  default: {_yaml_quote(inputs.provider.default_model)}")
+        yaml_lines.append("auxiliary:")
+        yaml_lines.append("  title_generation:")
+        yaml_lines.append('    model: "anthropic/claude-haiku-4.5"')
+    elif ptype == "anthropic":
+        yaml_lines.append("model:")
+        yaml_lines.append('  provider: "anthropic"')
+        yaml_lines.append(f"  default: {_yaml_quote(inputs.provider.default_model)}")
+        yaml_lines.append("auxiliary:")
+        yaml_lines.append("  title_generation:")
+        yaml_lines.append('    model: "claude-haiku-4-5-20251001"')
+    elif ptype == "openai":
+        yaml_lines.append("model:")
+        yaml_lines.append('  provider: "openai"')
+        yaml_lines.append(f"  default: {_yaml_quote(inputs.provider.default_model)}")
+        yaml_lines.append("auxiliary:")
+        yaml_lines.append("  title_generation:")
+        yaml_lines.append('    model: "gpt-5-nano"')
+    elif ptype == "bedrock":
+        yaml_lines.append("model:")
+        yaml_lines.append('  provider: "bedrock"')
+        yaml_lines.append(f"  default: {_yaml_quote(inputs.provider.default_model)}")
+        yaml_lines.append("bedrock:")
+        yaml_lines.append(f"  region: {_yaml_quote(inputs.provider.region or 'us-east-1')}")
+        yaml_lines.append("auxiliary:")
+        yaml_lines.append("  title_generation:")
+        yaml_lines.append('    model: "anthropic.claude-haiku-4-5-20251001-v1:0"')
+    elif ptype == "ollama":
+        endpoint = inputs.provider.endpoint.rstrip("/")
+        if not endpoint.endswith("/v1"):
+            endpoint = endpoint + "/v1"
+        yaml_lines.append("model:")
+        yaml_lines.append('  provider: "custom"')
+        yaml_lines.append(f"  base_url: {_yaml_quote(endpoint)}")
+        yaml_lines.append(f"  default: {_yaml_quote(inputs.provider.default_model)}")
+
+    # Atlassian integrations → mcp_servers entries (sorted by name).
+    atlassian = [i for i in inputs.integrations if i.type == "atlassian"]
+    if atlassian:
+        yaml_lines.append("mcp_servers:")
+        for integration in atlassian:
+            creds = dict(integration.credentials)
+            url = creds.get("ATLASSIAN_URL", "").rstrip("/")
+            email = creds.get("ATLASSIAN_EMAIL", "")
+            token = creds.get("ATLASSIAN_API_TOKEN", "")
+            # Use the env-var slug (alnum + underscore only). A naive
+            # `.replace('-', '_')` leaves CR/LF/colon/etc. in the key,
+            # enabling YAML key injection from a malicious or
+            # malformed integration name. The slug strips everything
+            # outside `[A-Z0-9_]`; lowercase here so YAML keys stay
+            # idiomatic snake_case.
+            slug = _integration_slug(integration.name).lower()
+            if not slug:
+                raise AgentConfigError(
+                    f"render_hermes: integration name {integration.name!r} "
+                    f"slugifies to empty — refusing to emit an unnamed YAML key"
+                )
+            yaml_lines.append(f"  {slug}:")
+            yaml_lines.append("    env:")
+            yaml_lines.append(f"      JIRA_URL: {_yaml_quote(url)}")
+            yaml_lines.append(f"      JIRA_USERNAME: {_yaml_quote(email)}")
+            yaml_lines.append(f"      JIRA_API_TOKEN: {_yaml_quote(token)}")
+            yaml_lines.append(f"      CONFLUENCE_URL: {_yaml_quote(url + '/wiki')}")
+            yaml_lines.append(f"      CONFLUENCE_USERNAME: {_yaml_quote(email)}")
+            yaml_lines.append(f"      CONFLUENCE_API_TOKEN: {_yaml_quote(token)}")
+
+    yaml_body = "\n".join(yaml_lines) + "\n"
+
+    return RenderedFiles(
+        files={
+            ".hermes/.env": env_body,
+            ".hermes/config.yaml": yaml_body,
+        }
+    )
+
+
+# Zeroclaw provider section table. Each entry: (kind_string,)
+_ZEROCLAW_PROVIDER_KINDS = frozenset(
+    {"anthropic", "openai", "ollama", "openrouter"}
+)
+
+
+def render_zeroclaw(inputs: RenderInputs) -> RenderedFiles:
+    """Render zeroclaw's config.toml + systemd env drop-in."""
+    ptype = inputs.provider.type
+
+    # --- config.toml -------------------------------------------------------
+    toml_lines: list[str] = []
+    toml_lines.append(
+        f"# Managed by clawrium (clawctl). Re-render with "
+        f"`clawctl agent configure {inputs.agent_name}`."
+    )
+    if ptype not in _ZEROCLAW_PROVIDER_KINDS:
+        raise AgentConfigError(
+            f"render_zeroclaw does not support provider type {ptype!r}. "
+            f"Supported: {sorted(_ZEROCLAW_PROVIDER_KINDS)}"
+        )
+    toml_lines.append(f'default_provider = "{_toml_escape(ptype)}"')
+    toml_lines.append(
+        f'default_model = "{_toml_escape(inputs.provider.default_model)}"'
+    )
+
+    toml_lines.append("")
+    toml_lines.append("[gateway]")
+    if inputs.gateway is None:
+        raise AgentConfigError(
+            f"render_zeroclaw requires gateway config for agent "
+            f"{inputs.agent_name!r} (port + host); none supplied"
+        )
+    toml_lines.append(f'host = "{_toml_escape(inputs.gateway.host)}"')
+    toml_lines.append(f"port = {int(inputs.gateway.port)}")
+    toml_lines.append(
+        f"allow_public_bind = {str(inputs.gateway.allow_public_bind).lower()}"
+    )
+    toml_lines.append("require_pairing = true")
+
+    toml_lines.append("")
+    toml_lines.append(f"[providers.models.{ptype}]")
+    toml_lines.append(f'kind = "{_toml_escape(ptype)}"')
+    toml_lines.append(f'model = "{_toml_escape(inputs.provider.default_model)}"')
+    if ptype == "ollama":
+        toml_lines.append(f'base_url = "{_toml_escape(inputs.provider.endpoint)}"')
+    else:
+        toml_lines.append(f'api_key = "{_toml_escape(inputs.provider.api_key)}"')
+
+    # Channels (discord only for zeroclaw today; slack is hermes-side).
+    for channel in inputs.channels:
+        if channel.type != "discord":
+            continue
+        toml_lines.append("")
+        toml_lines.append("[channels.discord]")
+        toml_lines.append("enabled = true")
+        toml_lines.append(f'bot_token = "{_toml_escape(channel.bot_token)}"')
+        guilds = ", ".join(f'"{_toml_escape(g)}"' for g in channel.allowed_guilds)
+        toml_lines.append(f"allowed_guilds = [{guilds}]")
+        users = ", ".join(f'"{_toml_escape(u)}"' for u in channel.allowed_users)
+        toml_lines.append(f"allowed_users = [{users}]")
+        toml_lines.append(f"mention_only = {str(channel.require_mention).lower()}")
+        # Only emit stream_mode when explicitly set; an empty string
+        # preserves the daemon's compiled "off" default. Defaulting to
+        # "partial" here would flip every legacy agent into streaming
+        # mode on first configure — a behavior change, not a render.
+        if channel.stream_mode:
+            toml_lines.append(
+                f'stream_mode = "{_toml_escape(channel.stream_mode)}"'
+            )
+
+    # `[autonomy] shell_env_passthrough` is a MANDATORY block: the
+    # configure playbook asserts its presence with `grep -qE
+    # '^shell_env_passthrough\\s*='` and fails the deploy if missing.
+    # Without listing GITHUB_TOKEN_<NAME> here, the zeroclaw sandbox
+    # strips integration tokens from the shell tool's environment even
+    # though the systemd drop-in injected them correctly.
+    passthrough = ["PATH", "HOME", "USER", "LANG"]
+    any_github = False
+    for integration in inputs.integrations:
+        if integration.type == "github":
+            slug = _integration_slug(integration.name)
+            passthrough.append(f"GITHUB_TOKEN_{slug}")
+            any_github = True
+    if any_github:
+        passthrough.append("GITHUB_TOKEN")
+    toml_lines.append("")
+    toml_lines.append("[autonomy]")
+    toml_lines.append(
+        "shell_env_passthrough = ["
+        + ", ".join(f'"{entry}"' for entry in passthrough)
+        + "]"
+    )
+
+    toml_body = "\n".join(toml_lines) + "\n"
+
+    # --- systemd env drop-in (integrations) -------------------------------
+    env_lines: list[str] = []
+    env_lines.append(
+        f"# Managed by clawrium (clawctl). Re-render with "
+        f"`clawctl agent configure {inputs.agent_name}`."
+    )
+    env_lines.append("[Service]")
+    last_github_token = ""
+    for integration in inputs.integrations:
+        if integration.type != "github":
+            continue
+        creds = dict(integration.credentials)
+        token = creds.get("GITHUB_TOKEN", "")
+        slug = _integration_slug(integration.name)
+        env_lines.append(
+            f"Environment=GITHUB_TOKEN_{slug}={_systemd_quote(token)}"
+        )
+        last_github_token = token
+    if last_github_token:
+        env_lines.append(
+            f"Environment=GITHUB_TOKEN={_systemd_quote(last_github_token)}"
+        )
+    env_body = "\n".join(env_lines) + "\n"
+
+    return RenderedFiles(
+        files={
+            ".zeroclaw/config.toml": toml_body,
+            ".zeroclaw/zeroclaw-env.conf": env_body,
+        }
+    )
+
+
+# Openclaw provider env-var table. `vertex` is intentionally absent:
+# `GOOGLE_APPLICATION_CREDENTIALS` is a path to an ADC JSON file, not a
+# bearer string. Emitting `inputs.provider.api_key` into it would
+# silently produce a broken config — GCP client libs reject token
+# strings. Vertex support belongs in a follow-up that extends the
+# credential schema with a credential-kind field (path vs bearer).
+_OPENCLAW_PROVIDER_ENV = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "zai": "ZAI_API_KEY",
+}
+_OPENCLAW_MODEL_PREFIX = {
+    "openrouter": "openrouter/",
+    "bedrock": "bedrock/",
+}
+
+
+def render_openclaw(inputs: RenderInputs) -> RenderedFiles:
+    """Render openclaw's `.env`."""
+    ptype = inputs.provider.type
+    env_lines: list[str] = []
+    env_lines.append(
+        f"# Managed by clawrium (clawctl). Re-render with "
+        f"`clawctl agent configure {inputs.agent_name}`."
+    )
+    if inputs.gateway is not None:
+        # Shell-quote `bind` so a CRLF-injected value can't smuggle an
+        # extra `KEY=VALUE` line into the EnvironmentFile.
+        env_lines.append(
+            f"OPENCLAW_GATEWAY_BIND={_shell_quote(inputs.gateway.bind or 'lan')}"
+        )
+        env_lines.append(f"OPENCLAW_GATEWAY_PORT={int(inputs.gateway.port or 40000)}")
+        env_lines.append(
+            f"OPENCLAW_GATEWAY_AUTH_MODE={'token' if inputs.gateway.auth else 'none'}"
+        )
+        env_lines.append(
+            f"OPENCLAW_GATEWAY_AUTH_TOKEN={_shell_quote(inputs.gateway.auth)}"
+        )
+
+    model_id = inputs.provider.default_model
+    prefix = _OPENCLAW_MODEL_PREFIX.get(ptype, "")
+    if prefix and not model_id.startswith(prefix):
+        model_id = prefix + model_id
+    env_lines.append(f"OPENCLAW_DEFAULT_MODEL={_shell_quote(model_id)}")
+
+    if ptype in _OPENCLAW_PROVIDER_ENV:
+        env_lines.append(
+            f"{_OPENCLAW_PROVIDER_ENV[ptype]}={_shell_quote(inputs.provider.api_key)}"
+        )
+    elif ptype == "bedrock":
+        env_lines.append(f"AWS_ACCESS_KEY_ID={_shell_quote(inputs.provider.aws_access_key)}")
+        env_lines.append(f"AWS_SECRET_ACCESS_KEY={_shell_quote(inputs.provider.aws_secret_key)}")
+    elif ptype == "ollama":
+        env_lines.append(f"OPENCLAW_OLLAMA_URL={_shell_quote(inputs.provider.endpoint)}")
+    else:
+        raise AgentConfigError(
+            f"render_openclaw does not support provider type {ptype!r}. "
+            f"Supported: {sorted(_OPENCLAW_PROVIDER_ENV) + ['bedrock', 'ollama']}"
+        )
+
+    for channel in inputs.channels:
+        if channel.type == "discord":
+            env_lines.append(f"DISCORD_BOT_TOKEN={_shell_quote(channel.bot_token)}")
+        elif channel.type == "slack":
+            env_lines.append(f"SLACK_BOT_TOKEN={_shell_quote(channel.bot_token)}")
+            env_lines.append(f"SLACK_APP_TOKEN={_shell_quote(channel.app_token)}")
+        else:
+            raise AgentConfigError(
+                f"render_openclaw: unsupported channel type {channel.type!r}"
+            )
+
+    last_github_token = ""
+    for integration in inputs.integrations:
+        creds = dict(integration.credentials)
+        if integration.type == "github":
+            token = creds.get("GITHUB_TOKEN", "")
+            slug = _integration_slug(integration.name)
+            env_lines.append(f"GITHUB_TOKEN_{slug}={_shell_quote(token)}")
+            last_github_token = token
+        elif integration.type == "gitlab":
+            env_lines.append(f"GITLAB_TOKEN={_shell_quote(creds.get('GITLAB_TOKEN', ''))}")
+            if "GITLAB_URL" in creds:
+                env_lines.append(f"GITLAB_URL={_shell_quote(creds['GITLAB_URL'])}")
+        elif integration.type == "atlassian":
+            url = creds.get("ATLASSIAN_URL", "").rstrip("/")
+            email = creds.get("ATLASSIAN_EMAIL", "")
+            token = creds.get("ATLASSIAN_API_TOKEN", "")
+            env_lines.append(f"JIRA_URL={_shell_quote(url)}")
+            env_lines.append(f"CONFLUENCE_URL={_shell_quote(url + '/wiki')}")
+            env_lines.append(f"JIRA_EMAIL={_shell_quote(email)}")
+            env_lines.append(f"CONFLUENCE_EMAIL={_shell_quote(email)}")
+            env_lines.append(f"JIRA_API_TOKEN={_shell_quote(token)}")
+            env_lines.append(f"CONFLUENCE_API_TOKEN={_shell_quote(token)}")
+        elif integration.type == "linear":
+            env_lines.append(
+                f"LINEAR_API_KEY={_shell_quote(creds.get('LINEAR_API_KEY', ''))}"
+            )
+        elif integration.type == "notion":
+            env_lines.append(
+                f"NOTION_API_KEY={_shell_quote(creds.get('NOTION_API_KEY', ''))}"
+            )
+        elif integration.type == "git":
+            continue
+        else:
+            raise AgentConfigError(
+                f"render_openclaw: unsupported integration type {integration.type!r}"
+            )
+    if last_github_token:
+        env_lines.append(f"GITHUB_TOKEN={_shell_quote(last_github_token)}")
+
+    env_body = "\n".join(env_lines) + "\n"
+    # Path is `.openclaw/env` (no leading dot on the filename) to match
+    # the configure playbook's lineinfile target. A dot-prefixed name
+    # would silently render to a file the playbook never reads.
+    return RenderedFiles(files={".openclaw/env": env_body})

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -423,7 +423,11 @@ def build_render_inputs(agent_name: str) -> RenderInputs:
         api_server_input = APIServerInputs(
             host=str(api_server_blob.get("host", "")),
             port=int(api_server_blob.get("port", 0) or 0),
-            key=str(api_server_blob.get("key", "")),
+            # `key` is the bearer the gateway enforces; a NUL byte would
+            # silently truncate the systemd EnvironmentFile after
+            # API_SERVER_KEY=, dropping every var below it. Sanitize at
+            # assembly time, same as provider/channel/integration secrets.
+            key=_clean_secret(api_server_blob.get("key")),
         )
 
     gateway_input: GatewayInputs | None = None
@@ -432,7 +436,8 @@ def build_render_inputs(agent_name: str) -> RenderInputs:
         gateway_input = GatewayInputs(
             host=str(gateway_blob.get("host", "")),
             port=int(gateway_blob.get("port", 0) or 0),
-            auth=str(gateway_blob.get("auth", "")),
+            # Same systemd-truncation hazard as api_server.key above.
+            auth=_clean_secret(gateway_blob.get("auth")),
             bind=str(gateway_blob.get("bind", "")),
             allow_public_bind=bool(gateway_blob.get("allow_public_bind", True)),
         )
@@ -573,9 +578,18 @@ def render_hermes(inputs: RenderInputs) -> RenderedFiles:
             env_lines.append(
                 f"DISCORD_REQUIRE_MENTION={_shell_quote(str(channel.require_mention).lower())}"
             )
-            env_lines.append(
-                f"DISCORD_ALLOW_ALL_USERS={_shell_quote(str(channel.allow_all_users).lower())}"
-            )
+            # CRITICAL: only emit `DISCORD_ALLOW_ALL_USERS` when the
+            # operator explicitly set it. The hermes daemon parses this
+            # var as a presence flag (Python `bool(os.environ.get(...))`
+            # treats any non-empty string — including `'false'` — as
+            # truthy), so unconditionally emitting `'false'` would
+            # silently open public Discord access on every agent on
+            # first configure. Mirrors the j2 template's
+            # `{% if discord.get('allow_all_users') %}` guard at
+            # hermes.env.j2:58. This is a real-world regression we
+            # cannot risk.
+            if channel.allow_all_users:
+                env_lines.append("DISCORD_ALLOW_ALL_USERS=true")
             env_lines.append(f"DISCORD_HOME_CHANNEL={_shell_quote(channel.home_channel)}")
             env_lines.append(
                 f"DISCORD_HOME_CHANNEL_NAME={_shell_quote(channel.home_channel_name)}"
@@ -682,6 +696,7 @@ def render_hermes(inputs: RenderInputs) -> RenderedFiles:
     atlassian = [i for i in inputs.integrations if i.type == "atlassian"]
     if atlassian:
         yaml_lines.append("mcp_servers:")
+        seen_slugs: set[str] = set()
         for integration in atlassian:
             creds = dict(integration.credentials)
             url = creds.get("ATLASSIAN_URL", "").rstrip("/")
@@ -699,6 +714,17 @@ def render_hermes(inputs: RenderInputs) -> RenderedFiles:
                     f"render_hermes: integration name {integration.name!r} "
                     f"slugifies to empty — refusing to emit an unnamed YAML key"
                 )
+            # Distinct integration names can slugify to the same YAML
+            # key (e.g. `my-atlassian` and `my_atlassian` both produce
+            # `my_atlassian`). PyYAML's last-wins semantics would
+            # silently drop one set of credentials. Fail loud instead.
+            if slug in seen_slugs:
+                raise AgentConfigError(
+                    f"render_hermes: atlassian integration names collide on "
+                    f"YAML key {slug!r}; rename one of the integrations to "
+                    f"differentiate after slugification"
+                )
+            seen_slugs.add(slug)
             yaml_lines.append(f"  {slug}:")
             yaml_lines.append("    env:")
             yaml_lines.append(f"      JIRA_URL: {_yaml_quote(url)}")

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -1,0 +1,814 @@
+"""Tests for clawrium.core.render — F1 (build_render_inputs) + F2 (renderers).
+
+Covers issue #556 DoD:
+  - every missing-input raises path for `build_render_inputs`
+  - idempotency property: pure renderers produce byte-identical output
+    across repeated invocations for the same inputs
+  - templates branch only on provider.type — verified by spot-checking
+    that the output of two inputs that differ ONLY in unused fields is
+    structurally identical, and that the output for each provider type
+    contains the expected type-specific env var keys.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clawrium.core import render
+from clawrium.core.render import (
+    AgentConfigError,
+    APIServerInputs,
+    ChannelInputs,
+    GatewayInputs,
+    IntegrationInputs,
+    ProviderInputs,
+    RenderInputs,
+    build_render_inputs,
+    render_hermes,
+    render_openclaw,
+    render_zeroclaw,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a minimal in-memory fake of every store build_render_inputs touches.
+# ---------------------------------------------------------------------------
+
+
+class _Stores:
+    """A bundle of fake-store responses, wired into the module via monkeypatch."""
+
+    def __init__(self) -> None:
+        self.agent: tuple[dict, str, dict] | None = None
+        self.providers: dict[str, dict] = {}
+        self.provider_api_keys: dict[str, str] = {}
+        self.provider_aws: dict[str, tuple[str, str]] = {}
+        self.channels: dict[str, dict] = {}
+        self.channel_tokens: dict[tuple[str, str], str] = {}
+        self.integrations: dict[str, dict] = {}
+        self.integration_creds: dict[str, dict[str, str]] = {}
+        self.agent_channels: list[str] = []
+        self.agent_integrations: list[str] = []
+
+
+@pytest.fixture
+def stores(monkeypatch) -> _Stores:
+    s = _Stores()
+
+    def _get_agent_by_name(name: str):
+        return s.agent
+
+    def _get_provider(name: str):
+        return s.providers.get(name)
+
+    def _get_provider_api_key(name: str):
+        return s.provider_api_keys.get(name)
+
+    def _get_provider_aws_credentials(name: str):
+        return s.provider_aws.get(name, (None, None))
+
+    def _get_agent_channels(host: str, agent_key: str):
+        return list(s.agent_channels)
+
+    def _get_channel(name: str):
+        return s.channels.get(name)
+
+    def _get_channel_token(name: str, key: str = "BOT_TOKEN"):
+        return s.channel_tokens.get((name, key))
+
+    def _get_agent_integrations(host: str, agent_key: str):
+        return list(s.agent_integrations)
+
+    def _get_integration(name: str):
+        return s.integrations.get(name)
+
+    def _get_integration_credentials(name: str):
+        return dict(s.integration_creds.get(name, {}))
+
+    # Patch every collaborator. The render module imports them lazily
+    # inside `build_render_inputs`, so monkeypatching the source module
+    # is enough.
+    monkeypatch.setattr(
+        "clawrium.core.hosts.get_agent_by_name", _get_agent_by_name
+    )
+    monkeypatch.setattr(
+        "clawrium.core.providers.get_provider", _get_provider
+    )
+    monkeypatch.setattr(
+        "clawrium.core.providers.get_provider_api_key", _get_provider_api_key
+    )
+    monkeypatch.setattr(
+        "clawrium.core.providers.get_provider_aws_credentials",
+        _get_provider_aws_credentials,
+    )
+    monkeypatch.setattr(
+        "clawrium.core.channels.get_agent_channels", _get_agent_channels
+    )
+    monkeypatch.setattr("clawrium.core.channels.get_channel", _get_channel)
+    monkeypatch.setattr(
+        "clawrium.core.channels.get_channel_token", _get_channel_token
+    )
+    monkeypatch.setattr(
+        "clawrium.core.integrations.get_agent_integrations",
+        _get_agent_integrations,
+    )
+    monkeypatch.setattr(
+        "clawrium.core.integrations.get_integration", _get_integration
+    )
+    monkeypatch.setattr(
+        "clawrium.core.integrations.get_integration_credentials",
+        _get_integration_credentials,
+    )
+    return s
+
+
+def _agent_record(
+    *,
+    providers: list | None = None,
+    config: dict | None = None,
+    agent_name: str = "alpha",
+):
+    return (
+        {"hostname": "host-1"},
+        "hermes",
+        {
+            "agent_name": agent_name,
+            "providers": providers or [],
+            "config": config or {},
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_render_inputs — missing-input paths
+# ---------------------------------------------------------------------------
+
+
+def test_missing_agent_raises(stores):
+    stores.agent = None
+    with pytest.raises(AgentConfigError, match="not found in any host"):
+        build_render_inputs("ghost")
+
+
+def test_no_provider_attached_raises(stores):
+    stores.agent = _agent_record(providers=[])
+    with pytest.raises(AgentConfigError, match="no provider attached"):
+        build_render_inputs("alpha")
+
+
+def test_provider_attachment_missing_primary_role_raises(stores):
+    # Hermes with all-auxiliary attachments → no primary.
+    stores.agent = _agent_record(
+        providers=[{"name": "or", "role": "vision", "model": ""}]
+    )
+    with pytest.raises(AgentConfigError, match="primary provider"):
+        build_render_inputs("alpha")
+
+
+def test_provider_not_registered_raises(stores):
+    stores.agent = _agent_record(
+        providers=[{"name": "or", "role": "primary", "model": ""}]
+    )
+    # No entry in providers store.
+    with pytest.raises(AgentConfigError, match="not registered in providers.json"):
+        build_render_inputs("alpha")
+
+
+def test_bearer_provider_missing_api_key_raises(stores):
+    stores.agent = _agent_record(
+        providers=[{"name": "or", "role": "primary", "model": ""}]
+    )
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "x"}
+    # No API key in secrets store.
+    with pytest.raises(AgentConfigError, match="missing API key"):
+        build_render_inputs("alpha")
+
+
+def test_bedrock_provider_missing_aws_creds_raises(stores):
+    stores.agent = _agent_record(
+        providers=[{"name": "br", "role": "primary", "model": ""}]
+    )
+    stores.providers["br"] = {"name": "br", "type": "bedrock", "default_model": "m"}
+    with pytest.raises(AgentConfigError, match="missing AWS credentials"):
+        build_render_inputs("alpha")
+
+
+def test_ollama_provider_missing_endpoint_raises(stores):
+    stores.agent = _agent_record(
+        providers=[{"name": "ol", "role": "primary", "model": ""}]
+    )
+    stores.providers["ol"] = {"name": "ol", "type": "ollama", "default_model": "m"}
+    with pytest.raises(AgentConfigError, match="missing endpoint"):
+        build_render_inputs("alpha")
+
+
+def test_unsupported_provider_type_raises(stores):
+    stores.agent = _agent_record(
+        providers=[{"name": "weird", "role": "primary", "model": ""}]
+    )
+    stores.providers["weird"] = {"name": "weird", "type": "wat", "default_model": "m"}
+    with pytest.raises(AgentConfigError, match="does not support provider type"):
+        build_render_inputs("alpha")
+
+
+@pytest.mark.parametrize("bad_type", ["", None, "   "])
+def test_empty_or_null_provider_type_raises(stores, bad_type):
+    """B10: providers.json record with missing/empty/whitespace type field."""
+    stores.agent = _agent_record(
+        providers=[{"name": "x", "role": "primary", "model": ""}]
+    )
+    stores.providers["x"] = {"name": "x", "type": bad_type, "default_model": "m"}
+    with pytest.raises(AgentConfigError, match="has no type field"):
+        build_render_inputs("alpha")
+
+
+def test_hermes_zai_provider_rejected_with_clear_message(stores):
+    """B1: hermes does not render zai. Reject upfront, not at render time."""
+    stores.agent = _agent_record(
+        providers=[{"name": "z", "role": "primary", "model": ""}]
+    )
+    stores.providers["z"] = {"name": "z", "type": "zai", "default_model": "m"}
+    stores.provider_api_keys["z"] = "zai-1"
+    with pytest.raises(AgentConfigError, match="does not support provider type"):
+        build_render_inputs("alpha")
+
+
+@pytest.mark.parametrize("aws", [(None, None), ("AKIA-1", ""), ("", "secret")])
+def test_bedrock_half_missing_aws_creds_raises(stores, aws):
+    """W8: any one half of AWS creds missing is treated as missing."""
+    stores.agent = _agent_record(
+        providers=[{"name": "br", "role": "primary", "model": ""}]
+    )
+    stores.providers["br"] = {"name": "br", "type": "bedrock", "default_model": "m"}
+    stores.provider_aws["br"] = aws
+    with pytest.raises(AgentConfigError, match="missing AWS credentials"):
+        build_render_inputs("alpha")
+
+
+def test_nul_only_api_key_is_treated_as_missing(stores):
+    """B8: a NUL-only secret is truthy in Python but must read as missing."""
+    stores.agent = _agent_record(
+        providers=[{"name": "or", "role": "primary", "model": ""}]
+    )
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
+    stores.provider_api_keys["or"] = "\x00\x00"
+    with pytest.raises(AgentConfigError, match="missing API key"):
+        build_render_inputs("alpha")
+
+
+def test_channel_attached_but_not_registered_raises(stores):
+    stores.agent = _agent_record(
+        providers=[{"name": "or", "role": "primary", "model": ""}]
+    )
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
+    stores.provider_api_keys["or"] = "sk-1"
+    stores.agent_channels = ["discord-x"]
+    with pytest.raises(AgentConfigError, match="not registered in channels.json"):
+        build_render_inputs("alpha")
+
+
+def test_channel_missing_bot_token_raises(stores):
+    stores.agent = _agent_record(
+        providers=[{"name": "or", "role": "primary", "model": ""}]
+    )
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
+    stores.provider_api_keys["or"] = "sk-1"
+    stores.agent_channels = ["discord-x"]
+    stores.channels["discord-x"] = {"name": "discord-x", "type": "discord", "config": {}}
+    with pytest.raises(AgentConfigError, match="missing BOT_TOKEN"):
+        build_render_inputs("alpha")
+
+
+def test_slack_missing_app_token_raises(stores):
+    stores.agent = _agent_record(
+        providers=[{"name": "or", "role": "primary", "model": ""}]
+    )
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
+    stores.provider_api_keys["or"] = "sk-1"
+    stores.agent_channels = ["slack-x"]
+    stores.channels["slack-x"] = {"name": "slack-x", "type": "slack", "config": {}}
+    stores.channel_tokens[("slack-x", "BOT_TOKEN")] = "xoxb-1"
+    with pytest.raises(AgentConfigError, match="missing APP_TOKEN"):
+        build_render_inputs("alpha")
+
+
+def test_integration_not_registered_raises(stores):
+    stores.agent = _agent_record(
+        providers=[{"name": "or", "role": "primary", "model": ""}]
+    )
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
+    stores.provider_api_keys["or"] = "sk-1"
+    stores.agent_integrations = ["gh-1"]
+    with pytest.raises(AgentConfigError, match="not registered in integrations.json"):
+        build_render_inputs("alpha")
+
+
+def test_integration_missing_required_credential_raises(stores):
+    stores.agent = _agent_record(
+        providers=[{"name": "or", "role": "primary", "model": ""}]
+    )
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
+    stores.provider_api_keys["or"] = "sk-1"
+    stores.agent_integrations = ["gh-1"]
+    stores.integrations["gh-1"] = {"name": "gh-1", "type": "github"}
+    # No GITHUB_TOKEN in creds.
+    with pytest.raises(AgentConfigError, match="missing required credential"):
+        build_render_inputs("alpha")
+
+
+def test_happy_path_assembles_full_bundle(stores):
+    stores.agent = _agent_record(
+        providers=[{"name": "or", "role": "primary", "model": ""}],
+        config={
+            "api_server": {"host": "0.0.0.0", "port": 8642, "key": "k" * 64},
+        },
+    )
+    stores.providers["or"] = {
+        "name": "or",
+        "type": "openrouter",
+        "default_model": "anthropic/claude-opus-4.7",
+    }
+    stores.provider_api_keys["or"] = "sk-or-1"
+    stores.agent_channels = ["discord-a"]
+    stores.channels["discord-a"] = {
+        "name": "discord-a",
+        "type": "discord",
+        "config": {
+            "allowed_users": ["u1"],
+            "allowed_guilds": ["g1"],
+            "require_mention": True,
+        },
+    }
+    stores.channel_tokens[("discord-a", "BOT_TOKEN")] = "discord-bot"
+    stores.agent_integrations = ["gh-a", "gh-b"]
+    stores.integrations["gh-a"] = {"name": "gh-a", "type": "github"}
+    stores.integrations["gh-b"] = {"name": "gh-b", "type": "github"}
+    stores.integration_creds["gh-a"] = {"GITHUB_TOKEN": "ghp_a"}
+    stores.integration_creds["gh-b"] = {"GITHUB_TOKEN": "ghp_b"}
+
+    inputs = build_render_inputs("alpha")
+    assert inputs.provider.name == "or"
+    assert inputs.provider.type == "openrouter"
+    assert inputs.provider.api_key == "sk-or-1"
+    assert len(inputs.channels) == 1
+    assert inputs.channels[0].bot_token == "discord-bot"
+    # Integrations sorted by name → gh-a, gh-b.
+    assert [i.name for i in inputs.integrations] == ["gh-a", "gh-b"]
+    assert inputs.api_server is not None
+    assert inputs.api_server.port == 8642
+
+
+# ---------------------------------------------------------------------------
+# Renderer idempotency / property tests
+# ---------------------------------------------------------------------------
+
+
+def _baseline_inputs(*, ptype: str = "openrouter") -> RenderInputs:
+    if ptype == "openrouter":
+        provider = ProviderInputs(
+            name="or",
+            type="openrouter",
+            default_model="anthropic/claude-opus-4.7",
+            api_key="sk-or-1",
+        )
+    elif ptype == "bedrock":
+        provider = ProviderInputs(
+            name="br",
+            type="bedrock",
+            default_model="anthropic.claude-opus-4-1-v1:0",
+            region="us-east-1",
+            aws_access_key="AKIA-1",
+            aws_secret_key="secret-1",
+        )
+    elif ptype == "ollama":
+        provider = ProviderInputs(
+            name="ol",
+            type="ollama",
+            default_model="llama3",
+            endpoint="http://10.0.0.5:11434",
+        )
+    elif ptype == "anthropic":
+        provider = ProviderInputs(
+            name="an",
+            type="anthropic",
+            default_model="claude-opus-4-7",
+            api_key="sk-ant-1",
+        )
+    elif ptype == "openai":
+        provider = ProviderInputs(
+            name="oa", type="openai", default_model="gpt-5", api_key="sk-oa-1"
+        )
+    else:
+        raise AssertionError(ptype)
+
+    return RenderInputs(
+        agent_name="alpha",
+        agent_type="hermes",
+        provider=provider,
+        channels=(
+            ChannelInputs(
+                name="discord-a",
+                type="discord",
+                bot_token="discord-bot",
+                allowed_users=("u1", "u2"),
+                allowed_guilds=("g1",),
+                require_mention=True,
+                home_channel="general",
+            ),
+        ),
+        integrations=(
+            IntegrationInputs(
+                name="gh-a",
+                type="github",
+                credentials=(("GITHUB_TOKEN", "ghp_a"),),
+            ),
+        ),
+        api_server=APIServerInputs(host="0.0.0.0", port=8642, key="k" * 64),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tkn", bind="lan"),
+    )
+
+
+@pytest.mark.parametrize(
+    "renderer,ptype",
+    [
+        (render_hermes, "openrouter"),
+        (render_hermes, "anthropic"),
+        (render_hermes, "openai"),
+        (render_hermes, "bedrock"),
+        (render_hermes, "ollama"),
+        (render_zeroclaw, "openrouter"),
+        (render_zeroclaw, "anthropic"),
+        (render_zeroclaw, "openai"),
+        (render_zeroclaw, "ollama"),
+        (render_openclaw, "openrouter"),
+        (render_openclaw, "anthropic"),
+        (render_openclaw, "openai"),
+        (render_openclaw, "bedrock"),
+        (render_openclaw, "ollama"),
+    ],
+)
+def test_renderer_is_idempotent(renderer, ptype):
+    """Property test: identical inputs → byte-identical outputs."""
+    if renderer is render_zeroclaw:
+        inputs = _zeroclaw_inputs(ptype=ptype)
+    else:
+        inputs = _baseline_inputs(ptype=ptype)
+    out1 = renderer(inputs)
+    out2 = renderer(inputs)
+    assert out1.files == out2.files
+    # And every file body is non-empty.
+    for path, body in out1.files.items():
+        assert body, f"{path} rendered empty"
+
+
+def test_hermes_openrouter_emits_expected_keys():
+    inputs = _baseline_inputs(ptype="openrouter")
+    out = render_hermes(inputs)
+    env = out.files[".hermes/.env"]
+    assert "OPENROUTER_API_KEY='sk-or-1'" in env
+    assert "HERMES_INFERENCE_PROVIDER='openrouter'" in env
+    yaml = out.files[".hermes/config.yaml"]
+    assert 'provider: "openrouter"' in yaml
+    assert "anthropic/claude-opus-4.7" in yaml
+
+
+def test_hermes_bedrock_emits_aws_keys_not_bearer():
+    inputs = _baseline_inputs(ptype="bedrock")
+    out = render_hermes(inputs)
+    env = out.files[".hermes/.env"]
+    assert "AWS_ACCESS_KEY_ID='AKIA-1'" in env
+    assert "AWS_SECRET_ACCESS_KEY='secret-1'" in env
+    assert "AWS_DEFAULT_REGION='us-east-1'" in env
+    # No bearer-key vars for bedrock.
+    assert "OPENROUTER_API_KEY" not in env
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_hermes_ollama_yaml_has_v1_suffix():
+    inputs = _baseline_inputs(ptype="ollama")
+    out = render_hermes(inputs)
+    yaml = out.files[".hermes/config.yaml"]
+    assert "http://10.0.0.5:11434/v1" in yaml
+
+
+def test_hermes_renders_integrations_in_input_order_and_bare_github_token():
+    """Renderer iterates input order; sorting is `build_render_inputs`' job."""
+    base = _baseline_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        channels=(),
+        integrations=(
+            IntegrationInputs(name="gh-a", type="github", credentials=(("GITHUB_TOKEN", "A"),)),
+            IntegrationInputs(name="gh-b", type="github", credentials=(("GITHUB_TOKEN", "B"),)),
+        ),
+        api_server=base.api_server,
+    )
+    env = render_hermes(inputs).files[".hermes/.env"]
+    pos_a = env.index("GITHUB_TOKEN_GH_A=")
+    pos_b = env.index("GITHUB_TOKEN_GH_B=")
+    assert pos_a < pos_b
+    # Bare GITHUB_TOKEN is the last entry's value (back-compat with skills
+    # hard-coding the canonical name; sort happens upstream).
+    assert "GITHUB_TOKEN='B'" in env
+
+
+def _zeroclaw_inputs(*, ptype: str = "openrouter") -> RenderInputs:
+    base = _baseline_inputs(ptype=ptype)
+    return RenderInputs(
+        agent_name=base.agent_name,
+        agent_type="zeroclaw",
+        provider=base.provider,
+        channels=base.channels,
+        integrations=base.integrations,
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, allow_public_bind=True),
+    )
+
+
+def test_zeroclaw_renders_discord_channel_and_mandatory_blocks():
+    inputs = _zeroclaw_inputs(ptype="openrouter")
+    out = render_zeroclaw(inputs)
+    toml = out.files[".zeroclaw/config.toml"]
+    assert 'default_provider = "openrouter"' in toml
+    assert "[channels.discord]" in toml
+    assert 'bot_token = "discord-bot"' in toml
+    assert "mention_only = true" in toml
+    # B3: configure.yaml greps `^shell_env_passthrough\s*=` — must exist.
+    assert "[autonomy]" in toml
+    assert "shell_env_passthrough" in toml
+    # B6: allow_public_bind in [gateway].
+    assert "allow_public_bind = true" in toml
+    # W7: file-key set is exactly the two expected paths.
+    assert set(out.files.keys()) == {
+        ".zeroclaw/config.toml",
+        ".zeroclaw/zeroclaw-env.conf",
+    }
+
+
+def test_zeroclaw_env_drop_in_carries_github_token():
+    """W6: assert content on `.zeroclaw/zeroclaw-env.conf`, not just config.toml."""
+    inputs = _zeroclaw_inputs(ptype="openrouter")
+    env = render_zeroclaw(inputs).files[".zeroclaw/zeroclaw-env.conf"]
+    assert "[Service]" in env
+    assert 'Environment=GITHUB_TOKEN_GH_A="ghp_a"' in env
+    assert 'Environment=GITHUB_TOKEN="ghp_a"' in env
+
+
+def test_zeroclaw_stream_mode_omitted_when_empty():
+    """W2: don't default to 'partial'; preserve daemon's 'off' default."""
+    base = _zeroclaw_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        channels=(
+            ChannelInputs(
+                name="discord-a",
+                type="discord",
+                bot_token="t",
+                stream_mode="",
+            ),
+        ),
+        gateway=base.gateway,
+    )
+    toml = render_zeroclaw(inputs).files[".zeroclaw/config.toml"]
+    assert "stream_mode" not in toml
+
+
+def test_zeroclaw_requires_gateway():
+    base = _zeroclaw_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        gateway=None,
+    )
+    with pytest.raises(AgentConfigError, match="requires gateway config"):
+        render_zeroclaw(inputs)
+
+
+def test_openclaw_openrouter_prefixes_model():
+    inputs = _baseline_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=inputs.agent_name,
+        agent_type="openclaw",
+        provider=inputs.provider,
+        channels=inputs.channels,
+        integrations=inputs.integrations,
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tk", bind="lan"),
+    )
+    env = render_openclaw(inputs).files[".openclaw/env"]
+    assert "OPENCLAW_DEFAULT_MODEL='openrouter/anthropic/claude-opus-4.7'" in env
+    assert "OPENROUTER_API_KEY='sk-or-1'" in env
+
+
+def test_render_no_branch_on_unset_optional_field():
+    """`render_hermes` must not branch on whether home_channel is empty.
+
+    Two inputs that differ only in unset/empty optional fields should
+    produce structurally identical output (same line count, same keys).
+    """
+    base = _baseline_inputs(ptype="openrouter")
+    # Variant: empty home_channel.
+    variant = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        channels=(
+            ChannelInputs(
+                name="discord-a",
+                type="discord",
+                bot_token="discord-bot",
+                allowed_users=base.channels[0].allowed_users,
+                allowed_guilds=base.channels[0].allowed_guilds,
+                require_mention=base.channels[0].require_mention,
+                home_channel="",
+            ),
+        ),
+        integrations=base.integrations,
+        api_server=base.api_server,
+        gateway=base.gateway,
+    )
+    a = render_hermes(base).files[".hermes/.env"].splitlines()
+    b = render_hermes(variant).files[".hermes/.env"].splitlines()
+    # Same number of lines — emission is unconditional.
+    assert len(a) == len(b)
+    # The DISCORD_HOME_CHANNEL line is present in both (empty quoted in variant).
+    assert any(line.startswith("DISCORD_HOME_CHANNEL=") for line in b)
+
+
+def test_renderers_reject_unsupported_provider_type_defensively():
+    bogus = RenderInputs(
+        agent_name="x",
+        agent_type="hermes",
+        provider=ProviderInputs(name="x", type="bogus"),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000),
+    )
+    with pytest.raises(AgentConfigError, match="does not support provider type"):
+        render_hermes(bogus)
+    with pytest.raises(AgentConfigError, match="does not support provider type"):
+        render_zeroclaw(bogus)
+    with pytest.raises(AgentConfigError, match="does not support provider type"):
+        render_openclaw(bogus)
+
+
+def test_hermes_slack_channel_emits_expected_keys():
+    """B9: slack render path coverage."""
+    base = _baseline_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        channels=(
+            ChannelInputs(
+                name="slack-a",
+                type="slack",
+                bot_token="xoxb-bot",
+                app_token="xapp-app",
+                allowed_users=("u1",),
+                home_channel="C123",
+                home_channel_name="general",
+            ),
+        ),
+        api_server=base.api_server,
+    )
+    env = render_hermes(inputs).files[".hermes/.env"]
+    assert "SLACK_BOT_TOKEN='xoxb-bot'" in env
+    assert "SLACK_APP_TOKEN='xapp-app'" in env
+    assert "SLACK_ALLOWED_USERS='u1'" in env
+    assert "SLACK_HOME_CHANNEL='C123'" in env
+    assert "SLACK_HOME_CHANNEL_NAME='general'" in env
+    assert "DISCORD_BOT_TOKEN" not in env
+
+
+def test_openclaw_slack_channel_emits_expected_keys():
+    """B9: slack render path coverage for openclaw."""
+    base = _baseline_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type="openclaw",
+        provider=base.provider,
+        channels=(
+            ChannelInputs(
+                name="slack-a", type="slack", bot_token="xoxb-1", app_token="xapp-1"
+            ),
+        ),
+        integrations=(),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tk", bind="lan"),
+    )
+    env = render_openclaw(inputs).files[".openclaw/env"]
+    assert "SLACK_BOT_TOKEN='xoxb-1'" in env
+    assert "SLACK_APP_TOKEN='xapp-1'" in env
+    assert "DISCORD_BOT_TOKEN" not in env
+
+
+def test_hermes_discord_emits_allow_all_users_and_home_channel_fields():
+    """B5: hermes discord must emit ALLOW_ALL_USERS / HOME_CHANNEL_{NAME,THREAD_ID}."""
+    base = _baseline_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        channels=(
+            ChannelInputs(
+                name="discord-a",
+                type="discord",
+                bot_token="t",
+                allow_all_users=True,
+                home_channel="C1",
+                home_channel_name="general",
+                home_channel_thread_id="T9",
+            ),
+        ),
+        api_server=base.api_server,
+    )
+    env = render_hermes(inputs).files[".hermes/.env"]
+    assert "DISCORD_ALLOW_ALL_USERS='true'" in env
+    assert "DISCORD_HOME_CHANNEL_NAME='general'" in env
+    assert "DISCORD_HOME_CHANNEL_THREAD_ID='T9'" in env
+
+
+def test_hermes_file_keys_are_exact_set():
+    """W7: any silent rename of an output path must fail tests."""
+    out = render_hermes(_baseline_inputs(ptype="openrouter"))
+    assert set(out.files.keys()) == {".hermes/.env", ".hermes/config.yaml"}
+
+
+def test_openclaw_file_keys_are_exact_set():
+    base = _baseline_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type="openclaw",
+        provider=base.provider,
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tk", bind="lan"),
+    )
+    out = render_openclaw(inputs)
+    assert set(out.files.keys()) == {".openclaw/env"}
+
+
+def test_yaml_quote_strips_nul_and_cr():
+    """W4: defense against NUL/CR injection through atlassian creds."""
+    base = _baseline_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        integrations=(
+            IntegrationInputs(
+                name="jira-a",
+                type="atlassian",
+                credentials=(
+                    ("ATLASSIAN_API_TOKEN", "tok\x00en\r"),
+                    ("ATLASSIAN_EMAIL", "a@b"),
+                    ("ATLASSIAN_URL", "https://co.atlassian.net"),
+                ),
+            ),
+        ),
+        api_server=base.api_server,
+    )
+    yaml = render_hermes(inputs).files[".hermes/config.yaml"]
+    assert "\x00" not in yaml
+    # The CR should have been stripped from the rendered scalar.
+    assert "'token\\r'" not in yaml
+    assert "JIRA_API_TOKEN: 'token'" in yaml or "JIRA_API_TOKEN: 'tokenen'" in yaml or "JIRA_API_TOKEN: 'token en'" in yaml or True  # value is sanitized
+    # And the mcp_servers key uses the slug, not raw name.
+    assert "  jira_a:" in yaml
+
+
+def test_atlassian_yaml_key_injection_blocked():
+    """B7: YAML key injection via integration name must not break out."""
+    base = _baseline_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        integrations=(
+            IntegrationInputs(
+                name="legit\ninjected_key",
+                type="atlassian",
+                credentials=(
+                    ("ATLASSIAN_API_TOKEN", "t"),
+                    ("ATLASSIAN_EMAIL", "e"),
+                    ("ATLASSIAN_URL", "https://x"),
+                ),
+            ),
+        ),
+        api_server=base.api_server,
+    )
+    yaml = render_hermes(inputs).files[".hermes/config.yaml"]
+    # The newline-bearing name is slugified; no smuggled key at the
+    # mcp_servers level. The slug strips characters outside [A-Z0-9_],
+    # collapsing the embedded \n into a single concatenated token.
+    assert "\n  injected_key:" not in yaml
+    assert "  legitinjected_key:" in yaml
+
+
+def test_render_module_exports():
+    # Sanity: public surface is what the issue calls for.
+    assert hasattr(render, "build_render_inputs")
+    assert hasattr(render, "render_hermes")
+    assert hasattr(render, "render_zeroclaw")
+    assert hasattr(render, "render_openclaw")
+    assert hasattr(render, "RenderInputs")
+    assert hasattr(render, "AgentConfigError")

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -724,9 +724,65 @@ def test_hermes_discord_emits_allow_all_users_and_home_channel_fields():
         api_server=base.api_server,
     )
     env = render_hermes(inputs).files[".hermes/.env"]
-    assert "DISCORD_ALLOW_ALL_USERS='true'" in env
+    # `DISCORD_ALLOW_ALL_USERS` is emitted as the unquoted token `true`
+    # (presence-flag semantics matching the j2 template) only when the
+    # operator explicitly opted in. See render.py comment.
+    assert "DISCORD_ALLOW_ALL_USERS=true" in env
     assert "DISCORD_HOME_CHANNEL_NAME='general'" in env
     assert "DISCORD_HOME_CHANNEL_THREAD_ID='T9'" in env
+
+
+def test_hermes_discord_omits_allow_all_users_when_false():
+    """B4 regression: never emit DISCORD_ALLOW_ALL_USERS=false; daemon
+    parses presence, not value, so `'false'` would silently open access."""
+    base = _baseline_inputs(ptype="openrouter")
+    env = render_hermes(base).files[".hermes/.env"]
+    assert "DISCORD_ALLOW_ALL_USERS" not in env
+
+
+def test_hermes_atlassian_slug_collision_raises():
+    """B3 regression: distinct integration names that slug-collide must
+    raise rather than silently last-wins-drop one set of credentials."""
+    base = _baseline_inputs(ptype="openrouter")
+    creds = (
+        ("ATLASSIAN_API_TOKEN", "t"),
+        ("ATLASSIAN_EMAIL", "e"),
+        ("ATLASSIAN_URL", "https://x"),
+    )
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        integrations=(
+            IntegrationInputs(name="my-atlassian", type="atlassian", credentials=creds),
+            IntegrationInputs(name="my_atlassian", type="atlassian", credentials=creds),
+        ),
+        api_server=base.api_server,
+    )
+    with pytest.raises(AgentConfigError, match="collide on YAML key"):
+        render_hermes(inputs)
+
+
+def test_clean_secret_applied_to_gateway_auth_and_api_server_key(stores):
+    """W1: NUL/CR/LF in gateway.auth or api_server.key must be stripped
+    before they hit the systemd EnvironmentFile."""
+    stores.agent = (
+        {"hostname": "host-1"},
+        "hermes",
+        {
+            "agent_name": "alpha",
+            "providers": [{"name": "or", "role": "primary", "model": ""}],
+            "config": {
+                "api_server": {"host": "0.0.0.0", "port": 8642, "key": "k\x00ey\r"},
+                "gateway": {"host": "0.0.0.0", "port": 40000, "auth": "tok\nen"},
+            },
+        },
+    )
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
+    stores.provider_api_keys["or"] = "sk-1"
+    inputs = build_render_inputs("alpha")
+    assert inputs.api_server is not None and inputs.api_server.key == "key"
+    assert inputs.gateway is not None and inputs.gateway.auth == "token"
 
 
 def test_hermes_file_keys_are_exact_set():
@@ -769,9 +825,10 @@ def test_yaml_quote_strips_nul_and_cr():
     )
     yaml = render_hermes(inputs).files[".hermes/config.yaml"]
     assert "\x00" not in yaml
-    # The CR should have been stripped from the rendered scalar.
-    assert "'token\\r'" not in yaml
-    assert "JIRA_API_TOKEN: 'token'" in yaml or "JIRA_API_TOKEN: 'tokenen'" in yaml or "JIRA_API_TOKEN: 'token en'" in yaml or True  # value is sanitized
+    assert "\r" not in yaml
+    # Concrete sanitized scalar: NUL + CR stripped, no other mangling.
+    # Input token "tok\x00en\r" → "token" after _yaml_quote's strip.
+    assert "JIRA_API_TOKEN: 'token'" in yaml
     # And the mcp_servers key uses the slug, not raw name.
     assert "  jira_a:" in yaml
 

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -398,6 +398,10 @@ def _baseline_inputs(*, ptype: str = "openrouter") -> RenderInputs:
         provider = ProviderInputs(
             name="oa", type="openai", default_model="gpt-5", api_key="sk-oa-1"
         )
+    elif ptype == "zai":
+        provider = ProviderInputs(
+            name="z", type="zai", default_model="glm-4.5", api_key="sk-zai-1"
+        )
     else:
         raise AssertionError(ptype)
 
@@ -445,6 +449,7 @@ def _baseline_inputs(*, ptype: str = "openrouter") -> RenderInputs:
         (render_openclaw, "openai"),
         (render_openclaw, "bedrock"),
         (render_openclaw, "ollama"),
+        (render_openclaw, "zai"),
     ],
 )
 def test_renderer_is_idempotent(renderer, ptype):
@@ -869,3 +874,188 @@ def test_render_module_exports():
     assert hasattr(render, "render_openclaw")
     assert hasattr(render, "RenderInputs")
     assert hasattr(render, "AgentConfigError")
+
+
+# ---------------------------------------------------------------------------
+# Iter-3 ATX coverage gap closures
+# ---------------------------------------------------------------------------
+
+
+def test_openclaw_zai_emits_zai_api_key():
+    """Iter-3 B1: pin the openclaw `zai` provider env-var emission."""
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(name="z", type="zai", default_model="glm-4.5", api_key="sk-zai-1"),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tk", bind="lan"),
+    )
+    env = render_openclaw(inputs).files[".openclaw/env"]
+    assert "ZAI_API_KEY='sk-zai-1'" in env
+
+
+def test_openclaw_atlassian_integration_emits_to_env():
+    """Iter-3 B2: pin all six env vars on openclaw's atlassian branch."""
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(name="or", type="openrouter", default_model="m", api_key="sk-1"),
+        integrations=(
+            IntegrationInputs(
+                name="atl",
+                type="atlassian",
+                credentials=(
+                    ("ATLASSIAN_API_TOKEN", "tk"),
+                    ("ATLASSIAN_EMAIL", "a@b"),
+                    ("ATLASSIAN_URL", "https://co.atlassian.net/"),
+                ),
+            ),
+        ),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, bind="lan"),
+    )
+    env = render_openclaw(inputs).files[".openclaw/env"]
+    # Trailing slash stripped before CONFLUENCE_URL derivation.
+    assert "JIRA_URL='https://co.atlassian.net'" in env
+    assert "CONFLUENCE_URL='https://co.atlassian.net/wiki'" in env
+    assert "JIRA_EMAIL='a@b'" in env
+    assert "CONFLUENCE_EMAIL='a@b'" in env
+    assert "JIRA_API_TOKEN='tk'" in env
+    assert "CONFLUENCE_API_TOKEN='tk'" in env
+
+
+@pytest.mark.parametrize("renderer", [render_hermes, render_openclaw])
+def test_renderer_unsupported_channel_type_raises(renderer):
+    """Iter-3 B3: cover both renderers' `else: raise` channel branches."""
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="hermes" if renderer is render_hermes else "openclaw",
+        provider=ProviderInputs(name="or", type="openrouter", default_model="m", api_key="sk-1"),
+        channels=(ChannelInputs(name="x", type="irc", bot_token="t"),),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, bind="lan"),
+    )
+    with pytest.raises(AgentConfigError, match="unsupported channel type"):
+        renderer(inputs)
+
+
+@pytest.mark.parametrize("renderer", [render_hermes, render_openclaw])
+def test_renderer_unsupported_integration_type_raises(renderer):
+    """Iter-3 B4: cover both renderers' `else: raise` integration branches."""
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="hermes" if renderer is render_hermes else "openclaw",
+        provider=ProviderInputs(name="or", type="openrouter", default_model="m", api_key="sk-1"),
+        integrations=(
+            IntegrationInputs(name="sf", type="salesforce", credentials=(("X", "Y"),)),
+        ),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, bind="lan"),
+    )
+    with pytest.raises(AgentConfigError, match="unsupported integration type"):
+        renderer(inputs)
+
+
+def test_shell_quote_escapes_single_quote():
+    """Iter-3 B5: every env var emission flows through `_shell_quote`.
+    A regression here silently breaks every EnvironmentFile."""
+    from clawrium.core.render import _shell_quote
+
+    # POSIX single-quote escape: close, embed escaped quote, reopen.
+    assert _shell_quote("it's") == "'it'\"'\"'s'"
+    # Adjacent quotes — double-embed.
+    assert _shell_quote("a''b") == "'a'\"'\"''\"'\"'b'"
+    # Plain value untouched aside from wrapping quotes.
+    assert _shell_quote("plain") == "'plain'"
+
+
+def test_hermes_bedrock_config_yaml_section_pinned():
+    """Iter-3 W1: pin the bedrock config.yaml content too, not just env."""
+    inputs = _baseline_inputs(ptype="bedrock")
+    yaml = render_hermes(inputs).files[".hermes/config.yaml"]
+    assert 'provider: "bedrock"' in yaml
+    assert "bedrock:" in yaml
+    assert "region:" in yaml
+    assert "anthropic.claude-haiku-4-5-20251001-v1:0" in yaml
+
+
+def test_openclaw_no_gateway_omits_gateway_vars():
+    """Iter-3 W2: optional gateway branch — assert no var leakage."""
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(name="or", type="openrouter", default_model="m", api_key="sk-1"),
+        gateway=None,
+    )
+    env = render_openclaw(inputs).files[".openclaw/env"]
+    for var in (
+        "OPENCLAW_GATEWAY_BIND",
+        "OPENCLAW_GATEWAY_PORT",
+        "OPENCLAW_GATEWAY_AUTH_MODE",
+        "OPENCLAW_GATEWAY_AUTH_TOKEN",
+    ):
+        assert var not in env
+
+
+def test_string_style_provider_attachment_resolves(stores):
+    """Iter-3 W3: list-of-strings provider attachment (singleton shape)."""
+    stores.agent = (
+        {"hostname": "host-1"},
+        "openclaw",
+        {
+            "agent_name": "alpha",
+            # List of strings, not list of dicts — the singleton shape
+            # used by zeroclaw/openclaw before Pattern A migration.
+            "providers": ["or"],
+            "config": {},
+        },
+    )
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
+    stores.provider_api_keys["or"] = "sk-1"
+    inputs = build_render_inputs("alpha")
+    assert inputs.provider.name == "or"
+
+
+def test_hermes_git_integration_produces_no_env_var():
+    """Iter-3 W4: git integration is intentionally skipped in env render."""
+    base = _baseline_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        integrations=(
+            IntegrationInputs(
+                name="me",
+                type="git",
+                credentials=(("GIT_USER_EMAIL", "a@b"), ("GIT_USER_NAME", "Me")),
+            ),
+        ),
+        api_server=base.api_server,
+    )
+    env = render_hermes(inputs).files[".hermes/.env"]
+    assert "GIT_USER_EMAIL" not in env
+    assert "GIT_USER_NAME" not in env
+    # GITHUB_TOKEN must not appear either (no github integration attached).
+    assert "GITHUB_TOKEN" not in env
+
+
+def test_hermes_atlassian_credentials_absent_from_env():
+    """Iter-3 W5: atlassian goes to config.yaml only, never to .env."""
+    base = _baseline_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        integrations=(
+            IntegrationInputs(
+                name="atl",
+                type="atlassian",
+                credentials=(
+                    ("ATLASSIAN_API_TOKEN", "tk"),
+                    ("ATLASSIAN_EMAIL", "e@x"),
+                    ("ATLASSIAN_URL", "https://x"),
+                ),
+            ),
+        ),
+        api_server=base.api_server,
+    )
+    env = render_hermes(inputs).files[".hermes/.env"]
+    assert "ATLASSIAN" not in env
+    assert "JIRA" not in env
+    assert "CONFLUENCE" not in env


### PR DESCRIPTION
## Summary

- Introduce `src/clawrium/core/render.py` — deterministic input assembly and pure renderers for agent configs (#555 F1 + F2).
- `build_render_inputs(agent_name)` assembles the full canonical bundle from providers/channels/integrations/secrets/hosts; raises `AgentConfigError` on any unresolved attachment (no silent skip).
- `render_hermes` / `render_zeroclaw` / `render_openclaw` are pure functions of `RenderInputs`. They branch only on `provider.type` — never on whether a hosts.json field is populated.
- Not wired into `lifecycle.py`; that lands in F3.

## Testing

- `make test-py`: 3565 passed, 7 skipped (45 new tests in `tests/core/test_render.py`)
- `make lint-py`: ruff clean
- Property tests cover idempotency: same `RenderInputs` → byte-identical `RenderedFiles` across every provider type × renderer combination.
- Missing-input raise paths: provider not attached, primary role missing, provider not registered, empty/null/whitespace `type`, bearer API key missing, bedrock AWS creds missing (whole + half-missing), ollama endpoint missing, unsupported provider type per agent-type, channel/integration not registered, NUL-only secrets.
- Security: YAML key injection via `integration.name` blocked (`_integration_slug` + non-empty assert + collision detection); NUL/CR/LF stripped from secrets (`_clean_secret`) and YAML scalars (`_yaml_quote`); systemd env var values shell-quoted; `_shell_quote` single-quote escape pattern pinned by dedicated unit test.

## ATX Review Summary

**Final round: 3 iterations exhausted; all 24 findings (10 iter-1 + 4 iter-2 + 10 iter-3) addressed in code or tests.**

| Review | Rating | Blocking Issues | Status | Cost | Time | Domain split |
|--------|--------|-----------------|--------|------|------|--------------|
| 1 | 2/5 | B1–B10 | All fixed | $2.68 | 10m | 4 specialists |
| 2 | mixed (TC 2, Sec 3, Reg 2, Lif 3) | B1–B4 | 3 fixed + 1 out-of-scope (documented) | $3.67 | 12m | 4 specialists |
| 3 | 2/5 (TC 2, Sec pass, Lif 3-4) | B1–B5 (all test-coverage) | All fixed | $2.67 | 7.5m | 4 specialists |

> Note: ATX `review request` CLI returns results inline and does not post to GitHub. Iteration evidence lives in `.itx/556/atx-session.json` and the individual commit messages. The atx-ci bot tag is included so future automated runs can correlate.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| #   | File / Line                                | Issue                                                                                                                              | Resolution |
|-----|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|------------|
| B1  | `render.py:49`, `render.py:460-475`, `render.py:620-643` | `zai`/`vertex` accepted by `build_render_inputs` but missing from `_HERMES_PROVIDER_ENV` and `_ZEROCLAW_PROVIDER_KINDS` — crashes at render time. | Removed `zai`/`vertex` from `_BEARER_API_KEY_TYPES`; added `_AGENT_TYPE_PROVIDER_SUPPORT` table so unsupported provider × agent-type combinations fail up-front with a clear message. |
| B2  | `render.py:715-716`                        | `render_openclaw` emitting raw bearer token as `GOOGLE_APPLICATION_CREDENTIALS` (which must be a filesystem path). | Removed `vertex` from `_OPENCLAW_PROVIDER_ENV` entirely; vertex needs a credential-kind schema field, deferred. |
| B3  | `render.py:645-650`, `configure.yaml:326-332` | `render_zeroclaw` missing `[autonomy] shell_env_passthrough` block — playbook `grep` assert would fail every deploy. | Emit `[autonomy] shell_env_passthrough = [...]` unconditionally; per-integration `GITHUB_TOKEN_<NAME>` entries appended. |
| B4  | `render.py:809`                            | Output key `.openclaw/.env` (dot-prefixed) — playbook writes to `.openclaw/env`. | Renamed `RenderedFiles` key to `.openclaw/env`. |
| B5  | `render.py:83-94`                          | `ChannelInputs` missing `allow_all_users`, `home_channel_name`, `home_channel_thread_id`. | Added all three fields. |
| B6  | `render.py:113-118`                        | `GatewayInputs` missing `allow_public_bind`. | Added field (default `True`); emitted in `render_zeroclaw`'s `[gateway]` block. |
| B7  | `render.py:599`                            | YAML key injection via `integration.name.replace('-', '_')` in `mcp_servers`. | Switched to `_integration_slug(name).lower()`; asserts non-empty. |
| B8  | `render.py:248-260, 297-306, 339-344`     | NUL-only secret is truthy in Python; passes `if not key:` guard. | Added `_clean_secret(value)` stripping NUL/CR/LF; applied before every required-field check. |
| B9  | `tests/core/test_render.py`                | Slack render path entirely untested in both `render_hermes` and `render_openclaw`. | Added `test_hermes_slack_channel_emits_expected_keys` + `test_openclaw_slack_channel_emits_expected_keys`. |
| B10 | `tests/core/test_render.py`                | Empty/null `provider_type` branch untested. | Parametrized `test_empty_or_null_provider_type_raises` over `["", None, "   "]`. |

</details>

<details>
<summary>Review 2 Details (mixed; specialist ratings TC 2/5, Sec 3/5, Reg 2/5, Lif 3/5)</summary>

| #  | File / Line                                    | Issue                                                                                                  | Resolution |
|----|-----------------------------------------------|--------------------------------------------------------------------------------------------------------|------------|
| B1 | `tests/core/test_render.py:774`               | `or True` terminus on JIRA_API_TOKEN NUL/CR-strip assertion — test was vacuously green.                | Replaced with concrete `assert "JIRA_API_TOKEN: 'token'" in yaml`. |
| B2 | `platform/registry/openclaw/templates/.env.j2:31-32` + `configure.yaml:304-318` | Live Jinja2 templates still emit vertex; render.py was fixed but legacy templates remain. | **Out-of-scope**: this PR is explicitly "not wired into lifecycle" (#556 DoD). Live templates remain in use until #555 plan F3 rips them out alongside the renderer wiring. Tracked under #555. |
| B3 | `render.py:684-710`                            | Atlassian YAML slug collision: `my-atlassian` and `my_atlassian` both slug to `my_atlassian`; PyYAML last-write-wins drops credentials. | Added seen-slug set before atlassian emit loop; raises `AgentConfigError("collide on YAML key")`. |
| B4 | `render.py:576-578`                            | `DISCORD_ALLOW_ALL_USERS` emitted unconditionally as `'false'`; hermes daemon parses presence (Python `bool('false')` is True), silently opening all-user access. | Wrapped in `if channel.allow_all_users:`; emits the bare token `true` only when explicitly opted in. Matches `hermes.env.j2:58` `{% if %}` guard. |

**Warning W1 also fixed**: `_clean_secret` now applied to `gateway.auth` + `api_server.key` in `build_render_inputs` (systemd EnvironmentFile truncation risk).

</details>

<details>
<summary>Review 3 Details (Rating 2/5 — all gaps were test-coverage on correctly-implemented production paths)</summary>

| #  | Gap                                                                                              | Resolution |
|----|--------------------------------------------------------------------------------------------------|------------|
| B1 | `render_openclaw` + `zai` provider untested (entry in both supported tables, no test).            | Added `ptype='zai'` to `_baseline_inputs`, added `(render_openclaw, 'zai')` to idempotency parametrize table, added `test_openclaw_zai_emits_zai_api_key`. |
| B2 | `render_openclaw` atlassian integration branch (6 env vars) had zero coverage.                    | Added `test_openclaw_atlassian_integration_emits_to_env` pinning every var. |
| B3 | Unsupported channel type `else: raise` branch untested in both renderers.                         | Added `test_renderer_unsupported_channel_type_raises` parametrized over both. |
| B4 | Unsupported integration type `else: raise` branch untested in both renderers.                     | Added `test_renderer_unsupported_integration_type_raises` parametrized over both. |
| B5 | `_shell_quote` single-quote escape never exercised by tests; correctness guarantee for every env file. | Added `test_shell_quote_escapes_single_quote` with adjacent-quote case. |
| W1 | Bedrock hermes config.yaml content unasserted.                                                    | Added `test_hermes_bedrock_config_yaml_section_pinned`. |
| W2 | Openclaw `gateway=None` branch untested.                                                          | Added `test_openclaw_no_gateway_omits_gateway_vars`. |
| W3 | List-of-strings provider attachment shape untested (singleton agents).                            | Added `test_string_style_provider_attachment_resolves`. |
| W4 | `git` integration silent `continue` untested.                                                    | Added `test_hermes_git_integration_produces_no_env_var`. |
| W5 | Atlassian credentials absent-from-env negative side untested.                                     | Added `test_hermes_atlassian_credentials_absent_from_env`. |

</details>

## Callouts

- [DECISION] Removed `vertex` from the supported set (was in iter-1 `_OPENCLAW_PROVIDER_ENV`).
  - Why: `GOOGLE_APPLICATION_CREDENTIALS` is a filesystem path to a service-account JSON file, not a bearer token. Emitting `inputs.provider.api_key` into it would silently produce a broken config — GCP client libraries reject token strings.
  - Alternatives considered: keep vertex with a wrong-type rendering (rejected — silent data loss); add `credential_kind` to provider schema (right answer, but out of scope for F1+F2 — belongs in a follow-up that touches the secrets schema).
  - Reviewer: confirm scope deferral or push back.

- [DECISION] Iter-2 B2 (live Jinja2 templates emit vertex) marked Out-of-scope.
  - Why: This PR is explicitly **not wired into lifecycle** (#556 DoD). The live `platform/registry/openclaw/templates/.env.j2` + `configure.yaml` are the F3-and-beyond surface; touching them here would re-introduce the silent-emission they're meant to be replaced by.
  - Alternatives considered: rip out vertex from the live templates in this PR (rejected — scope creep, would conflict with F3).
  - Tracking: parent #555 plan F3.

- [DECISION] Iter-3 left some warnings (W2 strip-and-proceed semantics, W3 `_toml_escape` C0 range, W5 stub `[autonomy]` block) deliberately unaddressed.
  - Why: W2 — `_clean_secret` treats degenerate input as missing (per documented contract), not as a transit-tamper error. Changing it to raise would block legitimately corrupted secrets that the operator would never recover from. W3 — TOML C0 escape is a forward-design item that should land alongside the full template port. W5 — emitting only `shell_env_passthrough` is intentional: the rest of `[autonomy]` (`auto_approve`, `max_*`, `forbidden_*`) ports in F3 alongside lifecycle wiring.
  - Reviewer: push back if any of these should be in-scope for this PR.

- [UNRESOLVED] ATX iter-3 leader rated 2/5 on a strict "no untested production branch" criterion.
  - Best guess applied: every iter-3 blocker was a missing test, not a production bug — all 10 added in commit `9c0c0bb`. The skill's 3-iteration ceiling has been hit; the PR ships with full ATX history documented per the resilient-ATX contract.
  - Reviewer: please re-run `atx review request` against `9c0c0bb` if you want a fresh rating.

- [ENVIRONMENT] Local frontend artifact directory `src/clawrium/gui/frontend` was missing in the worktree, blocking `uv sync` until I created an empty placeholder (not committed). Standard `make build-ui` would generate it; non-blocking for this PR.

- [TODO-FOLLOWUP] Full hermes config.yaml feature parity (auxiliary slot routing for hermes multi-provider, atlassian `command`/`args` block), full zeroclaw `[personality]` / `[agent]` / `[pacing]` parity, vertex credential-kind schema, and ripping the legacy live templates after F3 wiring.
  - Tracking: parent #555 plan items F3 / F6.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
