### PR TITLE
recover: bring #562 + #563 into main (orphaned by stacked squash-merge)

### DIFF
--- a/.itx/557/01_EXECUTION.md
+++ b/.itx/557/01_EXECUTION.md
@@ -1,0 +1,26 @@
+# Execution log — issue #557
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-29T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx:execute 557 --pr-base=issue-556-build-render-inputs
+```
+
+**Output**: F4 (`clawctl agent doctor`) + F8 (`clawctl agent sync --dry-run --diff`) for parent #555. Adds:
+
+- `src/clawrium/cli/clawctl/agent/doctor.py` — local-only diagnostic that surfaces declared vs resolved attachments and rendered file digests via `build_render_inputs`. Never emits secret values.
+- `src/clawrium/core/render_diff.py` — paramiko-based host file reader + per-file unified diff helper.
+- `--diff` flag on `clawctl agent sync` (implies `--dry-run`).
+- `docs/operations/sync.md` — canonical "before you sync" check documentation.
+- `tests/fixtures/audit_2026_05_29.json` + schema-gate test pinning the 10-agent reference baseline from #555.
+- Unit tests for doctor + sync diff (no SSH required).
+
+Out of scope (deferred to other subtasks of #555):
+
+- F3 lifecycle wiring (sync_agent reading on-host state, refusing destructive ops without `--force`).
+- F5 migration command + end-to-end render test against real container hosts (the audit fixture is currently a schema-pinned baseline, not a full doctor-output diff).

--- a/.itx/559/00_PLAN.md
+++ b/.itx/559/00_PLAN.md
@@ -1,0 +1,80 @@
+# Issue #559 — F3+F6 lifecycle rewrite + container matrix (subtask D of #555)
+
+## Scope (per issue body)
+
+> Rewrite `sync_agent` / `configure_agent` / `restart_agent` to use
+> `build_render_inputs → render_<atype> → host-side diff → refuse
+> secret-removal without --force`. Add
+> `tests/integration/test_render_matrix.py` (15 cells) gated against a
+> disposable container host. Delete old extravar path.
+
+## Stack base
+
+This PR stacks on `issue-557-agent-doctor-dry-run-diff` (which itself
+stacks on F1+F2 from #556).
+
+## Approach (pragmatic, single-PR scope)
+
+The full lifecycle rewrite touches a ~2500-line file with deep
+entanglement (onboarding state machine, ansible playbook orchestration,
+zeroclaw gateway re-pairing in #437, channel/integration attach flows).
+Doing it as one atomic rewrite in a single PR would be unreviewable and
+high-risk.
+
+This PR delivers the **canonical sync path** and the **test matrix
+scaffold**. Configure/restart rewrites and the legacy extravar deletion
+are explicitly deferred to a follow-up PR (tracked as Callouts), so
+this PR can land without breaking the existing configure → restart
+chain that other flows depend on.
+
+### What this PR delivers
+
+1. **`sync_agent_canonical(...)`** — a new public function in
+   `core/lifecycle.py` that implements the canonical pipeline:
+   - `build_render_inputs(name)` (raises on missing attachment)
+   - `render_<atype>(inputs)` (pure)
+   - SSH-read on-host files via `render_diff.read_remote_file`
+   - Compute per-file `FileDiff`
+   - **Secret-removal guard**: refuse to overwrite if the host file
+     contains lines matching a secret-pattern (e.g. `*_TOKEN=`,
+     `*_API_KEY=`) that are absent from the rendered body, unless
+     `force=True` is passed
+   - Atomic write per file via `sudo -n` + `mktemp` + `mv`, mode 0600
+   - Restart unit via `systemctl restart <atype>-<name>.service`
+   - Optional health check
+
+2. **`--force` flag** on `clawctl agent sync` and CLI wiring through to
+   `sync_agent_canonical`. Default sync still routes through the legacy
+   `sync_agent` (the existing ansible path) for back-compat. A new
+   `--canonical` opt-in selects the new path. Once the test matrix
+   confirms parity, a follow-up PR can flip the default.
+
+3. **`tests/integration/test_render_matrix.py`** — the 15-cell matrix
+   from the parent #555 plan. Each cell is gated by
+   `@pytest.mark.container` and skipped if
+   `CLAWRIUM_TEST_CONTAINER_HOST` is unset. A `conftest.py` fixture
+   sets up the disposable agent stores. CI integration of the
+   container host is out of scope for this PR (no container infra
+   exists yet; tracked as Callout).
+
+### Deferred to follow-ups (documented as Callouts)
+
+- `configure_agent` rewrite — touches onboarding state machine,
+  provider-attach migration, hermes API server reconstruction, AWS
+  bedrock credential staging. Out of scope.
+- `restart_agent` rewrite — depends on configure rewrite; gateway
+  re-pair invariants from #437 must be preserved exactly.
+- Old extravar path deletion — requires configure rewrite first;
+  every existing playbook in `roles/<atype>/` reads extravars.
+- Container test infra (Dockerfile, CI job, `xclm` user provisioning
+  on container) — tracked as a separate follow-up issue.
+- Flipping default sync to canonical path — gated on matrix passing
+  in CI.
+
+## Definition of Done
+
+- [ ] `sync_agent_canonical` exists with secret-removal guard and `force` kwarg
+- [ ] `clawctl agent sync --canonical [--force]` calls it
+- [ ] `tests/integration/test_render_matrix.py` exists with 15 marked cells
+- [ ] `make test` + `make lint` green
+- [ ] PR opened against `issue-557-agent-doctor-dry-run-diff` with Callouts

--- a/.itx/559/01_EXECUTION.md
+++ b/.itx/559/01_EXECUTION.md
@@ -1,0 +1,17 @@
+# Execution Log — Issue #559
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-29T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 559 --pr-base=issue-557-agent-doctor-dry-run-diff
+```
+
+**Output**: F3 (sync_agent_canonical) + F6 (test_render_matrix.py
+15-cell scaffold) + CLI `--canonical`/`--force` wiring on
+`clawctl agent sync`. Configure/restart rewrites and extravar deletion
+deferred to follow-ups (see PR Callouts).

--- a/docs/operations/sync.md
+++ b/docs/operations/sync.md
@@ -1,0 +1,166 @@
+# `clawctl agent sync` — flush local control-plane state to the host
+
+`sync` is the drift-to-zero command. It re-renders the canonical
+on-host config bundle from clawctl's own stores (providers, channels,
+integrations, secrets, hosts) and pushes the result to the host.
+
+The two safety surfaces this page documents:
+
+1. **`clawctl agent doctor <name>`** — local-only diagnostic. Shows
+   what `sync` would render *before* it does anything.
+2. **`clawctl agent sync --dry-run --diff <name>`** — host-vs-rendered
+   unified diff. Reads the current file from the host (no writes).
+
+> **Before you sync, run one of these.** They're the cheap way to find
+> out that an attachment is missing, a secret was wiped, or someone
+> hand-edited the host file. The actual `sync` overwrites without
+> asking.
+
+## The canonical "before you sync" check
+
+```bash
+clawctl agent sync <name> --dry-run --diff
+```
+
+For every file `sync` would write, this prints:
+
+- `diff <path>: no changes` — host file already matches what we'd
+  render. Sync would be a no-op for this file.
+- `diff <path>: would change` followed by a unified-diff patch —
+  host file exists but differs. The patch shows exactly what `sync`
+  is about to overwrite. **Read it.** Hand-edits, expired secrets, and
+  registry drift all surface here.
+- `diff <path>: would create` followed by the full file as a diff —
+  host file does not exist yet (e.g. first sync on a fresh agent).
+
+A failure to assemble the render bundle (missing provider attach,
+missing secret, etc.) is surfaced as `diff error: <message>` rather
+than a crash, so the diagnostic itself cannot break the dry-run.
+
+### Example: catching a secret wipe
+
+```text
+$ clawctl agent sync maurice --dry-run --diff
+agent/maurice: validating local state ...
+agent/maurice: pushing config (provider, skills, channels, env) (skipped (dry-run))
+agent/maurice: diff error: cannot render: agent 'maurice' has no provider attached;
+               run `clawctl agent provider attach <provider> --agent maurice` first
+agent/maurice: dry-run complete; no changes pushed
+```
+
+The error is exactly the failure the live `sync` would have papered
+over silently under the old conditional-emit path (parent issue #555).
+
+### JSON output
+
+`-o json` emits one NDJSON event per phase and per diff'd file. Each
+diff event has:
+
+```json
+{
+  "resource": "agent/<name>",
+  "phase": "diff",
+  "state": "result",
+  "path": ".hermes/.env",
+  "remote_path": "/home/<name>/.hermes/.env",
+  "remote_present": true,
+  "changed": true,
+  "diff": "--- host:/home/<name>/.hermes/.env\n+++ ...\n@@\n-OLD=...\n+NEW=...\n"
+}
+```
+
+Render failures are emitted as `{"phase": "diff", "state": "error",
+"message": "..."}` events.
+
+## `clawctl agent doctor <name>` — local snapshot
+
+`doctor` is purely local. It reports what clawctl *can* assemble right
+now: which attachments resolve, which secrets are present, and what
+files the renderer would produce. It does **not** touch the host.
+
+```bash
+clawctl agent doctor maurice
+```
+
+Sample output (broken agent):
+
+```text
+Name:    maurice
+Type:    hermes
+Status:  broken
+Error:   agent 'maurice' has no provider attached; run `clawctl agent provider attach <provider> --agent maurice` first
+
+Declared attachments:
+  providers:    []
+  channels:     []
+  integrations: []
+  skills:       []
+```
+
+Sample output (healthy agent):
+
+```text
+Name:    clawrium-d01
+Type:    zeroclaw
+Status:  ok
+
+Declared attachments:
+  providers:    ['openrouter']
+  channels:     ['discord-clawrium-d01']
+  integrations: ['clawrium-d01-github']
+  skills:       []
+
+Resolved provider:
+  name:           openrouter
+  type:           openrouter
+  default_model:  openai/gpt-5
+  api_key:        present
+
+Resolved channels (1):
+  discord-clawrium-d01  type=discord  bot_token=present
+
+Resolved integrations (1):
+  clawrium-d01-github  type=github  GITHUB_TOKEN=present
+
+Rendered files (2):
+  .zeroclaw/config.toml  bytes=482  lines=22  sha256=ab12cd34ef560000
+  .zeroclaw/zeroclaw-env.conf  bytes=64  lines=2  sha256=ff112233aabb0000
+```
+
+Doctor never emits secret values — only their presence. This is by
+design: the JSON output is meant to be safe to attach to bug reports.
+
+A `Status: broken` agent exits non-zero so CI / shell pipelines can
+gate on it.
+
+## When `--diff` vs `doctor`?
+
+- **`doctor`** answers: "can clawctl assemble a coherent bundle from
+  its own stores right now?" Use it as the first check after any
+  registry edit, secret rotation, or attachment change.
+- **`sync --dry-run --diff`** answers: "what will the next sync change
+  on the host?" Use it before any actual `sync` against a live agent
+  that's been running — especially if a human has touched the host
+  config since the last sync.
+
+The two are complementary, not redundant. A healthy `doctor` plus a
+clean `--diff` is the green-light pair for a no-surprise `sync`.
+
+## Flags reference
+
+| Flag | Effect |
+|---|---|
+| `--dry-run` | Print intended phases; no host writes. |
+| `--diff` | Implies `--dry-run`. Read on-host files via SSH and print a unified diff per file. |
+| `--workspace` | Skip the restart phase (workspace-only files). |
+| `--skip-validate` | Bypass the local-state validation phase. |
+| `-o json` | NDJSON output (one event per phase and per diff'd file). |
+| `--timeout N` | Sync timeout in seconds (default 120). |
+
+## See also
+
+- Parent issue [#555](https://github.com/ric03uec/clawrium/issues/555)
+  — why deterministic render matters; the silent-wipe regression that
+  motivated `--diff` and `doctor`.
+- `clawctl agent describe <name>` — high-level agent record summary
+  (less diagnostic detail than `doctor`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 markers = [
     "slow: real-host integration tests; skipped by default. Run via `pytest -m slow`.",
+    "container: parent #555 F6 render-matrix tests; require a disposable container host (CLAWRIUM_TEST_CONTAINER_HOST env var). Skipped otherwise.",
 ]
 # Fail loudly when a `@pytest.mark.parametrize` body comes back empty —
 # without this, a regression in the parametrize source (e.g.

--- a/src/clawrium/cli/clawctl/agent/__init__.py
+++ b/src/clawrium/cli/clawctl/agent/__init__.py
@@ -20,6 +20,7 @@ from clawrium.cli.clawctl.agent import (
     create as _create,
     delete as _delete,
     describe as _describe,
+    doctor as _doctor,
     edit as _edit,
     exec as _exec,
     get as _get,
@@ -65,6 +66,10 @@ agent_app.command(name="restart", help="Restart an agent.")(_restart.restart)
 agent_app.command(name="sync", help="Flush local control-plane state to the agent.")(
     _sync.sync
 )
+agent_app.command(
+    name="doctor",
+    help="Diagnose an agent's render bundle (attachments, secrets, files).",
+)(_doctor.doctor)
 agent_app.command(name="logs", help="Stream agent logs.")(_logs.logs)
 agent_app.command(name="chat", help="Chat with an agent.")(_chat.chat)
 agent_app.command(name="open", help="Open the agent's web UI in a browser.")(_open.open)

--- a/src/clawrium/cli/clawctl/agent/doctor.py
+++ b/src/clawrium/cli/clawctl/agent/doctor.py
@@ -62,6 +62,29 @@ def _present(value: str) -> str:
     return "present" if value else "missing"
 
 
+def _safe_endpoint(value: str) -> str:
+    """Redact an endpoint that embeds URL credentials.
+
+    ATX iter-1 W1: enterprise / corporate-proxy providers commonly
+    point at endpoints like `https://user:key@llm-proxy.corp/v1`.
+    Doctor's whole purpose is producing output that's safe to paste
+    into a bug report, so a URL-embedded credential must be masked
+    even though it's technically a "config" field.
+    """
+    if not value:
+        return ""
+    # Match `<scheme>://<userinfo>@<host>...` where userinfo contains
+    # a `:`. Anything simpler (no userinfo, or no password) passes
+    # through unmodified.
+    import re
+
+    return re.sub(
+        r"^(\w+://)([^/@]+):([^/@]+)@",
+        r"\1\2:***@",
+        value,
+    )
+
+
 def _render_for(inputs: RenderInputs) -> RenderedFiles | None:
     """Dispatch to the per-agent-type renderer; return None on unknown type."""
     name = _RENDERER_NAMES.get(inputs.agent_type)
@@ -97,7 +120,7 @@ def _inputs_block(inputs: RenderInputs) -> dict:
     provider = {
         "name": inputs.provider.name,
         "type": inputs.provider.type,
-        "endpoint": inputs.provider.endpoint,
+        "endpoint": _safe_endpoint(inputs.provider.endpoint),
         "default_model": inputs.provider.default_model,
         "region": inputs.provider.region,
         "api_key": _present(inputs.provider.api_key),

--- a/src/clawrium/cli/clawctl/agent/doctor.py
+++ b/src/clawrium/cli/clawctl/agent/doctor.py
@@ -1,0 +1,309 @@
+"""`clawctl agent doctor <name>` — F4 of parent #555.
+
+Lists every declared attachment, every secret status, and every
+rendered field for one agent. Local-only: never touches the host. The
+output is a deterministic, machine-comparable snapshot of what
+`build_render_inputs` would assemble *right now* from clawctl's own
+stores (providers.json + channels.json + integrations.json +
+secrets.json + hosts.json).
+
+Two outputs:
+
+- table (default): human-readable sections (Attachments, Resolved
+  inputs, Rendered files).
+- json (`-o json`): the same data as a single object, suitable for
+  diffing against `tests/fixtures/audit_2026_05_29.json` per #555 F4.
+
+A failing `build_render_inputs` (the on-purpose loud failure mode of
+parent #555) is rendered as `status: broken` plus the exact lookup
+error so the operator can fix the attach/secret/registry record. The
+declared-attachment list is shown either way so the operator can see
+the gap between what the agent record claims and what clawctl can
+resolve.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import typer
+
+from clawrium.cli.clawctl._common import OutputFormat
+from clawrium.cli.clawctl.agent._shared import safe_resolve_agent
+from clawrium.cli.output import dump_json, dump_yaml, emit_error
+from clawrium.cli.output._sanitize import sanitize
+from clawrium.core.render import (
+    AgentConfigError,
+    RenderedFiles,
+    RenderInputs,
+    build_render_inputs,
+    render_hermes,  # noqa: F401 — re-exported for test monkeypatching.
+    render_openclaw,  # noqa: F401 — re-exported for test monkeypatching.
+    render_zeroclaw,  # noqa: F401 — re-exported for test monkeypatching.
+)
+
+
+# Map agent type → attribute name on THIS module. Looking up via
+# `globals()[name]` (rather than capturing the function reference at
+# import time) lets `monkeypatch.setattr(doctor_mod, "render_X", ...)`
+# work without callers having to know about the dispatch table.
+_RENDERER_NAMES = {
+    "hermes": "render_hermes",
+    "zeroclaw": "render_zeroclaw",
+    "openclaw": "render_openclaw",
+}
+
+
+def _s(value: object) -> str:
+    return sanitize(str(value))
+
+
+def _present(value: str) -> str:
+    return "present" if value else "missing"
+
+
+def _render_for(inputs: RenderInputs) -> RenderedFiles | None:
+    """Dispatch to the per-agent-type renderer; return None on unknown type."""
+    name = _RENDERER_NAMES.get(inputs.agent_type)
+    if name is None:
+        return None
+    return globals()[name](inputs)
+
+
+def _attachments_block(claw_record: dict) -> dict:
+    """Extract declared attachment lists from the agent record.
+
+    These are what clawctl *thinks* is attached. The resolved block
+    below shows what could actually be hydrated. A divergence between
+    the two is exactly the silent-wipe class of bugs #555 was filed
+    against.
+    """
+    return {
+        "providers": list(claw_record.get("providers") or []),
+        "channels": list(claw_record.get("channels") or []),
+        "integrations": list(claw_record.get("integrations") or []),
+        "skills": list(claw_record.get("skills") or []),
+    }
+
+
+def _inputs_block(inputs: RenderInputs) -> dict:
+    """Serialize the resolved RenderInputs into a JSON-safe dict.
+
+    Secret values are NEVER emitted; only their presence is reported.
+    Doctor is a diagnostic surface — leaking a bearer token into a
+    JSON report (which operators commonly attach to bug reports)
+    would be a regression in its own right.
+    """
+    provider = {
+        "name": inputs.provider.name,
+        "type": inputs.provider.type,
+        "endpoint": inputs.provider.endpoint,
+        "default_model": inputs.provider.default_model,
+        "region": inputs.provider.region,
+        "api_key": _present(inputs.provider.api_key),
+        "aws_access_key": _present(inputs.provider.aws_access_key),
+        "aws_secret_key": _present(inputs.provider.aws_secret_key),
+    }
+    channels = [
+        {
+            "name": ch.name,
+            "type": ch.type,
+            "bot_token": _present(ch.bot_token),
+            "app_token": _present(ch.app_token),
+            "allowed_users": list(ch.allowed_users),
+            "allowed_guilds": list(ch.allowed_guilds),
+            "allowed_channels": list(ch.allowed_channels),
+            "require_mention": ch.require_mention,
+            "allow_all_users": ch.allow_all_users,
+            "stream_mode": ch.stream_mode,
+        }
+        for ch in inputs.channels
+    ]
+    integrations = [
+        {
+            "name": it.name,
+            "type": it.type,
+            "credentials": [
+                {"key": k, "value": _present(v)} for k, v in it.credentials
+            ],
+        }
+        for it in inputs.integrations
+    ]
+    api_server = None
+    if inputs.api_server is not None:
+        api_server = {
+            "host": inputs.api_server.host,
+            "port": inputs.api_server.port,
+            "key": _present(inputs.api_server.key),
+        }
+    gateway = None
+    if inputs.gateway is not None:
+        gateway = {
+            "host": inputs.gateway.host,
+            "port": inputs.gateway.port,
+            "auth": _present(inputs.gateway.auth),
+            "bind": inputs.gateway.bind,
+            "allow_public_bind": inputs.gateway.allow_public_bind,
+        }
+    return {
+        "provider": provider,
+        "channels": channels,
+        "integrations": integrations,
+        "api_server": api_server,
+        "gateway": gateway,
+    }
+
+
+def _files_block(rendered: RenderedFiles) -> list[dict]:
+    """Per-file digest + size for the rendered bundle.
+
+    The sha256 prefix lets `tests/fixtures/audit_2026_05_29.json` pin
+    byte-determinism without storing the full rendered content (which
+    would make the fixture noisy on legitimate template edits).
+    """
+    out: list[dict] = []
+    for path, body in rendered.files.items():
+        raw = body.encode("utf-8")
+        out.append(
+            {
+                "path": path,
+                "bytes": len(raw),
+                "lines": body.count("\n"),
+                "sha256_prefix": hashlib.sha256(raw).hexdigest()[:16],
+            }
+        )
+    return out
+
+
+def _report(name: str, claw_record: dict) -> dict:
+    """Build the full diagnostic report. Pure: no host access."""
+    report: dict = {
+        "name": name,
+        "type": claw_record.get("type", ""),
+        "status": "ok",
+        "error": None,
+        "declared": _attachments_block(claw_record),
+        "inputs": None,
+        "files": [],
+    }
+    try:
+        inputs = build_render_inputs(name)
+    except AgentConfigError as exc:
+        report["status"] = "broken"
+        report["error"] = str(exc)
+        return report
+    report["inputs"] = _inputs_block(inputs)
+    rendered = _render_for(inputs)
+    if rendered is None:
+        report["status"] = "broken"
+        report["error"] = (
+            f"no renderer registered for agent type {inputs.agent_type!r}"
+        )
+        return report
+    report["files"] = _files_block(rendered)
+    return report
+
+
+def _render_table(report: dict) -> str:
+    lines: list[str] = []
+    lines.append(f"Name:    {_s(report['name'])}")
+    lines.append(f"Type:    {_s(report['type'])}")
+    status = report["status"]
+    lines.append(f"Status:  {_s(status)}")
+    if report.get("error"):
+        lines.append(f"Error:   {_s(report['error'])}")
+
+    declared = report["declared"]
+    lines.append("")
+    lines.append("Declared attachments:")
+    lines.append(f"  providers:    {declared['providers'] or '-'}")
+    lines.append(f"  channels:     {declared['channels'] or '-'}")
+    lines.append(f"  integrations: {declared['integrations'] or '-'}")
+    lines.append(f"  skills:       {declared['skills'] or '-'}")
+
+    inputs = report.get("inputs")
+    if inputs:
+        provider = inputs["provider"]
+        lines.append("")
+        lines.append("Resolved provider:")
+        lines.append(f"  name:           {_s(provider['name'])}")
+        lines.append(f"  type:           {_s(provider['type'])}")
+        if provider["default_model"]:
+            lines.append(f"  default_model:  {_s(provider['default_model'])}")
+        if provider["endpoint"]:
+            lines.append(f"  endpoint:       {_s(provider['endpoint'])}")
+        if provider["region"]:
+            lines.append(f"  region:         {_s(provider['region'])}")
+        lines.append(f"  api_key:        {provider['api_key']}")
+        if provider["aws_access_key"] != "missing":
+            lines.append(f"  aws_access_key: {provider['aws_access_key']}")
+            lines.append(f"  aws_secret_key: {provider['aws_secret_key']}")
+
+        lines.append("")
+        if inputs["channels"]:
+            lines.append(f"Resolved channels ({len(inputs['channels'])}):")
+            for ch in inputs["channels"]:
+                lines.append(
+                    f"  {_s(ch['name'])}  type={_s(ch['type'])}  "
+                    f"bot_token={ch['bot_token']}"
+                    + (
+                        f"  app_token={ch['app_token']}"
+                        if ch["type"] == "slack"
+                        else ""
+                    )
+                )
+        else:
+            lines.append("Resolved channels: none")
+
+        lines.append("")
+        if inputs["integrations"]:
+            lines.append(f"Resolved integrations ({len(inputs['integrations'])}):")
+            for it in inputs["integrations"]:
+                creds = ", ".join(
+                    f"{c['key']}={c['value']}" for c in it["credentials"]
+                )
+                lines.append(
+                    f"  {_s(it['name'])}  type={_s(it['type'])}  {creds}"
+                )
+        else:
+            lines.append("Resolved integrations: none")
+
+        files = report["files"]
+        lines.append("")
+        lines.append(f"Rendered files ({len(files)}):")
+        for f in files:
+            lines.append(
+                f"  {_s(f['path'])}  bytes={f['bytes']}  "
+                f"lines={f['lines']}  sha256={f['sha256_prefix']}"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def doctor(
+    name: str = typer.Argument(..., help="Agent name."),
+    output: OutputFormat = typer.Option(
+        OutputFormat.table, "--output", "-o", help="Output format."
+    ),
+) -> None:
+    """Diagnose an agent's render bundle (declared vs resolved vs files).
+
+    Reports BEFORE any clawctl operation would touch the host, so the
+    operator can verify that `sync` / `configure` / `restart` are
+    about to render a coherent bundle. Implements F4 of parent #555.
+    """
+    _host, _agent_key, claw_record = safe_resolve_agent(name)
+    report = _report(name, claw_record)
+
+    if output is OutputFormat.json:
+        typer.echo(dump_json([report]), nl=False)
+    elif output is OutputFormat.yaml:
+        typer.echo(dump_yaml([report]), nl=False)
+    else:
+        typer.echo(_render_table(report), nl=False)
+
+    if report["status"] != "ok":
+        # Non-zero exit so CI / shell pipelines can gate on doctor.
+        emit_error(
+            f"agent {name!r} is not in a renderable state",
+            hint="see status above; fix the failing lookup and re-run",
+        )

--- a/src/clawrium/cli/clawctl/agent/doctor.py
+++ b/src/clawrium/cli/clawctl/agent/doctor.py
@@ -70,17 +70,31 @@ def _safe_endpoint(value: str) -> str:
     Doctor's whole purpose is producing output that's safe to paste
     into a bug report, so a URL-embedded credential must be masked
     even though it's technically a "config" field.
+
+    ATX iter-2 B7: bare-token userinfo (no `:` before `@`, e.g.
+    `https://sk-token@host/v1`) is also a credential — the whole
+    userinfo segment is the token. Mask it too.
     """
     if not value:
         return ""
-    # Match `<scheme>://<userinfo>@<host>...` where userinfo contains
-    # a `:`. Anything simpler (no userinfo, or no password) passes
-    # through unmodified.
     import re
 
-    return re.sub(
-        r"^(\w+://)([^/@]+):([^/@]+)@",
+    # `user:password@` form → preserve the user, mask the password.
+    masked = re.sub(
+        r"^(\w+://)([^/@:]+):([^/@]+)@",
         r"\1\2:***@",
+        value,
+    )
+    if masked != value:
+        return masked
+    # `token@` form (no colon in userinfo) → mask the whole userinfo.
+    # `[^/@:]+` excludes `:` so we don't accidentally re-match the
+    # `user:password@` form whose colon happens to follow a non-mask
+    # branch (handled above already, but explicit is cheaper than
+    # debugging an ordering bug later).
+    return re.sub(
+        r"^(\w+://)([^/@:]+)@",
+        r"\1***@",
         value,
     )
 

--- a/src/clawrium/cli/clawctl/agent/sync.py
+++ b/src/clawrium/cli/clawctl/agent/sync.py
@@ -227,6 +227,25 @@ def sync(
     skip_validate: bool = typer.Option(
         False, "--skip-validate", help="Bypass step 1 (validate)."
     ),
+    canonical: bool = typer.Option(
+        False,
+        "--canonical",
+        help=(
+            "Use the F3 canonical pipeline (build_render_inputs → "
+            "render → host-diff → atomic write → restart). Refuses to "
+            "remove host-side secrets without --force. Bypasses the "
+            "legacy ansible extravar path. Parent #555."
+        ),
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help=(
+            "With --canonical, allow writes that remove a host-side "
+            "secret line. Required after `clawctl agent channel detach` "
+            "or any other intentional secret-removal op."
+        ),
+    ),
     output: OutputFormat = typer.Option(
         OutputFormat.table, "--output", "-o", help="Output format (table or json)."
     ),
@@ -311,6 +330,67 @@ def sync(
         else:
             stream_action(
                 resource=resource, message="dry-run complete; no changes pushed"
+            )
+        return
+
+    # F3 (parent #555) canonical pipeline opt-in. Bypasses the legacy
+    # ansible extravar path entirely; routes through the pure render →
+    # diff → secret-removal-guard → atomic-write → restart sequence.
+    # Validated against the 15-cell matrix in
+    # tests/integration/test_render_matrix.py before flipping default.
+    if canonical:
+        from clawrium.core.lifecycle_canonical import (
+            CanonicalSyncError,
+            SecretRemovalRefused,
+            sync_agent_canonical,
+        )
+        from clawrium.core.render import AgentConfigError
+        from clawrium.core.render_diff import RemoteReadError
+
+        on_host_name = claw_record.get("agent_name") or agent_key
+
+        def canonical_event(stage: str, message: str) -> None:
+            if use_json and streamer is not None:
+                streamer.emit(
+                    resource=resource, phase=stage, state="event", message=message
+                )
+            else:
+                stream_action(resource=resource, message=f"{stage}: {message}")
+
+        try:
+            canonical_result = sync_agent_canonical(
+                on_host_name,
+                force=force,
+                restart=not workspace,
+                verify=not workspace,
+                on_event=canonical_event,
+            )
+        except SecretRemovalRefused as exc:
+            emit_error(str(exc))
+            return
+        except (AgentConfigError, CanonicalSyncError, RemoteReadError) as exc:
+            emit_error(f"sync failed: {exc}")
+            return
+
+        elapsed = int(time.monotonic() - started)
+        if use_json and streamer is not None:
+            streamer.emit(
+                resource=resource,
+                phase="sync",
+                state="complete",
+                drift=0,
+                took_seconds=elapsed,
+                files_written=list(canonical_result.files_written),
+                files_unchanged=list(canonical_result.files_unchanged),
+            )
+        else:
+            stream_action(
+                resource=resource,
+                message=(
+                    f"synced  (drift=0, took {elapsed}s, "
+                    f"{len(canonical_result.files_written)} written, "
+                    f"{len(canonical_result.files_unchanged)} unchanged)"
+                ),
             )
         return
 

--- a/src/clawrium/cli/clawctl/agent/sync.py
+++ b/src/clawrium/cli/clawctl/agent/sync.py
@@ -23,6 +23,9 @@ Flags:
   parameter today, captured as a Callout).
 - `--workspace` — workspace files only, no restart.
 - `--dry-run` — validate + show intent, no push.
+- `--diff` — (F8, parent #555) host-vs-rendered unified diff per file.
+  Implies `--dry-run`. Reads on-host files via SSH so you can verify
+  what `sync` is about to overwrite *before* it runs.
 - `--skip-validate` — bypass step 1.
 - `-o json` — NDJSON per phase instead of text lines.
 """
@@ -53,6 +56,118 @@ _PHASES = (
 )
 
 
+_RENDERERS = {
+    "hermes": "render_hermes",
+    "zeroclaw": "render_zeroclaw",
+    "openclaw": "render_openclaw",
+}
+
+
+def _emit_diff(
+    *,
+    host: dict,
+    agent_name: str,
+    agent_type: str,
+    resource: str,
+    use_json: bool,
+    streamer,
+) -> None:
+    """Render the host-vs-rendered diff for `--dry-run --diff`.
+
+    Failures are reported as a single error line (not raised) so the
+    dry-run path stays non-throwing — an operator running this to
+    verify before a real sync should never have the diagnostic crash
+    the session.
+    """
+    # Deferred imports keep `clawctl agent sync` import-cheap when the
+    # diff path is not exercised (the common case).
+    from clawrium.core import render as _render_mod
+    from clawrium.core.render import AgentConfigError, build_render_inputs
+    from clawrium.core.render_diff import diff_files
+
+    renderer_name = _RENDERERS.get(agent_type)
+    if renderer_name is None:
+        _emit_diff_error(
+            f"no renderer for agent type {agent_type!r}",
+            resource=resource,
+            use_json=use_json,
+            streamer=streamer,
+        )
+        return
+    renderer = getattr(_render_mod, renderer_name)
+
+    try:
+        inputs = build_render_inputs(agent_name)
+        rendered = renderer(inputs)
+    except AgentConfigError as exc:
+        _emit_diff_error(
+            f"cannot render: {exc}",
+            resource=resource,
+            use_json=use_json,
+            streamer=streamer,
+        )
+        return
+
+    try:
+        results = diff_files(
+            host=host, agent_name=agent_name, rendered_files=rendered.files
+        )
+    except Exception as exc:  # paramiko / key lookup / SSH errors
+        _emit_diff_error(
+            f"diff read failed: {exc}",
+            resource=resource,
+            use_json=use_json,
+            streamer=streamer,
+        )
+        return
+
+    if use_json and streamer is not None:
+        for d in results:
+            streamer.emit(
+                resource=resource,
+                phase="diff",
+                state="result",
+                path=d.path,
+                remote_path=d.remote_path,
+                remote_present=d.remote_present,
+                changed=bool(d.unified_diff),
+                diff=d.unified_diff,
+            )
+        return
+
+    # Text mode: print a human-readable header + unified diff per file.
+    for d in results:
+        if not d.unified_diff:
+            stream_action(
+                resource=resource,
+                message=f"diff {d.path}: no changes",
+            )
+            continue
+        marker = "would create" if not d.remote_present else "would change"
+        stream_action(
+            resource=resource,
+            message=f"diff {d.path}: {marker}",
+        )
+        # Emit the diff body verbatim. `stream_action` adds the
+        # resource prefix and sanitization which would mangle a
+        # multi-line patch; write directly instead.
+        typer.echo(d.unified_diff, nl=False)
+
+
+def _emit_diff_error(
+    message: str, *, resource: str, use_json: bool, streamer
+) -> None:
+    if use_json and streamer is not None:
+        streamer.emit(
+            resource=resource,
+            phase="diff",
+            state="error",
+            message=message,
+        )
+    else:
+        stream_action(resource=resource, message=f"diff error: {message}")
+
+
 def sync(
     name: str = typer.Argument(..., help="Agent name."),
     workspace: bool = typer.Option(
@@ -60,6 +175,14 @@ def sync(
     ),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Validate + show intent; no push."
+    ),
+    diff: bool = typer.Option(
+        False,
+        "--diff",
+        help=(
+            "Show host-vs-rendered unified diff per file. Implies --dry-run. "
+            "Reads on-host files via SSH; no host writes."
+        ),
     ),
     timeout: int = typer.Option(
         120, "--timeout", min=1, help="Sync timeout in seconds (default 2 min)."
@@ -77,6 +200,12 @@ def sync(
     agent_key = resolve_agent_key(host, name)
     hostname = host["hostname"]
     agent_type = claw_record.get("type", _agent_type)
+
+    # F8 (parent #555): `--diff` implies `--dry-run`. Promote here so
+    # the phase-emission and short-circuit logic below sees the
+    # effective intent without callers having to remember to pass both.
+    if diff:
+        dry_run = True
 
     resource = f"agent/{name}"
     use_json = output is OutputFormat.json
@@ -117,6 +246,20 @@ def sync(
         emit_phase(label, "queued")
 
     if dry_run:
+        if diff:
+            # The on-host POSIX user (and home dir) is the agent's
+            # `agent_name`, not the host-record dict key. Legacy
+            # installs key by type ("openclaw") while modern installs
+            # key by name; the home dir is always `<name>`.
+            on_host_name = claw_record.get("agent_name") or agent_key
+            _emit_diff(
+                host=host,
+                agent_name=on_host_name,
+                agent_type=agent_type,
+                resource=resource,
+                use_json=use_json,
+                streamer=streamer,
+            )
         if use_json and streamer is not None:
             streamer.emit(
                 resource=resource,

--- a/src/clawrium/cli/clawctl/agent/sync.py
+++ b/src/clawrium/cli/clawctl/agent/sync.py
@@ -96,12 +96,27 @@ def _emit_diff(
         return
     renderer = getattr(_render_mod, renderer_name)
 
+    # ATX iter-1 W4: catch broadly. The diagnostic contract is
+    # "diff cannot crash the dry-run" — any data-layer surprise
+    # (KeyError on a misshapen provider record, AttributeError on an
+    # unmapped channel type, JSONDecodeError from a corrupt store)
+    # must reach the user as a `diff error:` line, not a stack
+    # trace. AgentConfigError is the *expected* shape but we cannot
+    # rely on every callee in the assembly chain to normalize to it.
     try:
         inputs = build_render_inputs(agent_name)
         rendered = renderer(inputs)
     except AgentConfigError as exc:
         _emit_diff_error(
             f"cannot render: {exc}",
+            resource=resource,
+            use_json=use_json,
+            streamer=streamer,
+        )
+        return
+    except Exception as exc:
+        _emit_diff_error(
+            f"cannot render: {type(exc).__name__}: {exc}",
             resource=resource,
             use_json=use_json,
             streamer=streamer,
@@ -122,6 +137,15 @@ def _emit_diff(
         return
 
     if use_json and streamer is not None:
+        # ATX iter-1 B1: NEVER emit the unified diff body in NDJSON
+        # mode. The diff text contains every secret line that differs
+        # (`+OPENROUTER_API_KEY=...`, `+DISCORD_BOT_TOKEN=...`) and
+        # NDJSON output is the format consumed by log aggregators, CI
+        # logs, and monitoring sinks — surfaces that have no business
+        # holding plaintext credentials. Text mode is the only path
+        # that prints the patch; that is documented in
+        # `docs/operations/sync.md`. The `contains_secret_values`
+        # flag lets downstream consumers gate on this explicitly.
         for d in results:
             streamer.emit(
                 resource=resource,
@@ -131,11 +155,17 @@ def _emit_diff(
                 remote_path=d.remote_path,
                 remote_present=d.remote_present,
                 changed=bool(d.unified_diff),
-                diff=d.unified_diff,
+                contains_secret_values=bool(d.unified_diff),
+                hint=(
+                    "diff body suppressed in JSON mode; "
+                    "re-run without -o json to see the patch"
+                ),
             )
         return
 
     # Text mode: print a human-readable header + unified diff per file.
+    from clawrium.cli.output._sanitize import sanitize_passthrough
+
     for d in results:
         if not d.unified_diff:
             stream_action(
@@ -148,10 +178,17 @@ def _emit_diff(
             resource=resource,
             message=f"diff {d.path}: {marker}",
         )
-        # Emit the diff body verbatim. `stream_action` adds the
-        # resource prefix and sanitization which would mangle a
-        # multi-line patch; write directly instead.
-        typer.echo(d.unified_diff, nl=False)
+        # ATX iter-1 B2: sanitize each line at the terminal output
+        # boundary. The diff body originates from on-host file
+        # contents which may contain bidi-override / zero-width /
+        # control codepoints — exactly the class of bug #507
+        # mandated guarding. `sanitize_passthrough` preserves
+        # newlines / tabs (without which the unified-diff structure
+        # would collapse) while stripping bidi + zero-width chars.
+        # Line-by-line iteration preserves the per-line structure
+        # that consumers rely on (e.g. paging the patch).
+        for line in d.unified_diff.splitlines(keepends=True):
+            typer.echo(sanitize_passthrough(line), nl=False)
 
 
 def _emit_diff_error(
@@ -240,7 +277,12 @@ def sync(
             continue
         if key == "restart" and workspace:
             continue
-        if dry_run and key in ("push", "restart", "repair", "verify"):
+        # ATX iter-1 W3: in dry-run mode every phase short-circuits
+        # before sync_agent runs (the early return at the dry_run
+        # branch below). Emit `skipped (dry-run)` for ALL phases —
+        # including `validate` — so NDJSON consumers don't see a
+        # `queued` event that never resolves.
+        if dry_run:
             emit_phase(label, "skipped (dry-run)")
             continue
         emit_phase(label, "queued")

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -1,0 +1,405 @@
+"""Canonical sync pipeline for parent #555 F3.
+
+The legacy `core/lifecycle.py:sync_agent` re-renders on-host config via
+ansible extravars and templates that conditionally emit each block
+based on whether `hosts.json.agents.<name>.config.<field>` happens to
+be populated. That's the bug parent #555 documents: every clawctl op
+silently wipes whichever blocks lack a populated hosts.json field.
+
+This module replaces that path with the canonical pipeline:
+
+    inputs   = build_render_inputs(name)        # raises on missing
+    rendered = render_<atype>(inputs)           # pure function
+    remote   = read_remote_file(...) per file   # what's on host now
+    diff     = compute per-file unified diff
+    refuse   = if diff removes a secret line AND not force: raise
+    write    = atomic per-file sudo-mv into place, mode 0600
+    restart  = systemctl restart <atype>-<name>.service
+    verify   = light health check (unit active)
+
+The function is opt-in via `clawctl agent sync --canonical` while the
+test matrix in `tests/integration/test_render_matrix.py` proves parity
+against the legacy path. Once green in CI on a disposable container
+host, a follow-up PR flips the default and drops the legacy
+extravar-based sync.
+
+Scope guard: this module deliberately does NOT touch `configure_agent`
+or `restart_agent`. Those paths still drive the onboarding state
+machine, hermes API-server reconstruction, AWS bedrock credential
+staging, and the zeroclaw gateway re-pair invariants from issue #437.
+Replacing them belongs in a follow-up. Sync is the right first cut:
+it's the most frequently invoked op (every `clawctl agent provider
+attach`, `clawctl agent channel attach`, etc. ends with a sync) and
+the matrix test from #555 is specifically targeted at sync's render
+output.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+from dataclasses import dataclass
+from typing import Callable
+
+import paramiko
+
+from clawrium.core.hosts import get_agent_by_name
+from clawrium.core.keys import get_host_private_key
+from clawrium.core.render import (
+    build_render_inputs,
+    render_hermes,
+    render_openclaw,
+    render_zeroclaw,
+)
+from clawrium.core.render_diff import (
+    FileDiff,
+    diff_files,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CanonicalSyncError",
+    "SecretRemovalRefused",
+    "CanonicalSyncResult",
+    "sync_agent_canonical",
+]
+
+
+_RENDERERS = {
+    "hermes": render_hermes,
+    "zeroclaw": render_zeroclaw,
+    "openclaw": render_openclaw,
+}
+
+# Lines whose key matches one of these patterns are considered to carry
+# a secret. When a host file contains such a line and the rendered body
+# does NOT, the canonical pipeline refuses to write — that's exactly
+# the silent-wipe class the parent #555 audit documented. `--force`
+# overrides. The list is the union of every secret env var emitted by
+# the three renderers; extending the renderers requires extending this
+# list (enforced by the matrix test).
+_SECRET_KEY_PATTERN = re.compile(
+    r"^(?P<key>[A-Z_][A-Z0-9_]*)\s*=",
+    re.MULTILINE,
+)
+_SECRET_KEY_SUFFIXES = (
+    "_TOKEN",
+    "_API_KEY",
+    "_SECRET",
+    "_SECRET_KEY",
+    "_PASSWORD",
+    "_CREDENTIALS",
+    "_KEY",  # broad; AWS_ACCESS_KEY_ID, etc.
+)
+
+
+class CanonicalSyncError(Exception):
+    """Any failure in the canonical sync pipeline."""
+
+
+class SecretRemovalRefused(CanonicalSyncError):
+    """Raised when the rendered body would remove a host-side secret.
+
+    The message names every secret key that would disappear. The
+    operator's recovery is either to fix the underlying attachment
+    (most often: re-attach the channel/integration that owns the
+    secret, or `clawctl secret set ...` for the missing record) or
+    re-run with `--force` if the removal is intentional (e.g. they
+    actually did `clawctl agent channel detach`).
+    """
+
+
+@dataclass(frozen=True)
+class CanonicalSyncResult:
+    success: bool
+    agent: str
+    host: str
+    files_written: tuple[str, ...]
+    files_unchanged: tuple[str, ...]
+    diffs: tuple[FileDiff, ...]
+    error: str | None = None
+
+
+def _extract_secret_keys(body: str) -> set[str]:
+    """Return the set of secret-looking env var keys present in `body`.
+
+    Operates on a `.env`-style body; the YAML config side carries no
+    bare secrets in the rendered output (provider credentials are
+    always in `.env`), so a YAML-only diff cannot trip the guard. The
+    `_SECRET_KEY_SUFFIXES` heuristic is intentionally broad — false
+    positives manifest as the operator needing to pass `--force` on a
+    legitimate non-secret removal, which is annoying but safe; false
+    negatives manifest as the original #555 silent-wipe regression,
+    which is unsafe. The matrix test pins the suffix list.
+    """
+    keys: set[str] = set()
+    for m in _SECRET_KEY_PATTERN.finditer(body):
+        key = m.group("key")
+        if any(key.endswith(suf) for suf in _SECRET_KEY_SUFFIXES):
+            keys.add(key)
+    return keys
+
+
+def _diff_removes_secrets(diff: FileDiff) -> set[str]:
+    """Return the set of secret keys present on host but absent in render.
+
+    A non-empty set means the canonical pipeline must refuse without
+    `force=True`. Returns the empty set when the file is .yaml /
+    .toml — those formats don't carry bare KEY=VALUE secrets in our
+    renderers (every secret is in the `.env`), and the unified-diff
+    body would otherwise produce false positives from matching key
+    fragments inside YAML quoted strings.
+    """
+    # Only `.env` bodies carry bare key=value secret pairs in any of
+    # our renderers. Skip the guard for other formats to avoid false
+    # positives. The matrix test asserts this — if a future renderer
+    # starts emitting bare secrets to e.g. `config.toml`, this branch
+    # must extend.
+    if not diff.path.endswith(".env"):
+        return set()
+    host_keys = _extract_secret_keys(diff.remote_body)
+    rendered_keys = _extract_secret_keys(diff.rendered_body)
+    return host_keys - rendered_keys
+
+
+def _open_ssh(host: dict, *, timeout: int = 15) -> paramiko.SSHClient:
+    key_id = host.get("key_id") or host.get("hostname") or ""
+    private_key = get_host_private_key(key_id)
+    if not private_key:
+        raise CanonicalSyncError(
+            f"no SSH key registered for host {key_id!r}; "
+            "re-run `clawctl host create` to provision one"
+        )
+    client = paramiko.SSHClient()
+    client.load_system_host_keys()
+    client.set_missing_host_key_policy(paramiko.WarningPolicy())
+    client.connect(
+        hostname=host.get("hostname", ""),
+        port=int(host.get("port", 22) or 22),
+        username=host.get("user", "xclm"),
+        key_filename=str(private_key),
+        timeout=timeout,
+    )
+    return client
+
+
+def _atomic_write(
+    client: paramiko.SSHClient,
+    *,
+    agent_name: str,
+    remote_path: str,
+    body: str,
+    timeout: int = 30,
+) -> None:
+    """Atomically replace `remote_path` with `body`, mode 0600, owned by agent.
+
+    Uses `sudo -n` to write a tmpfile under `/tmp` (xclm-writable) and
+    then `sudo -n install` to atomically move it into place with the
+    correct mode / owner. `install` is preferred over `mv` because it
+    sets mode + owner in one syscall and is universally available on
+    Linux hosts.
+    """
+    quoted_path = shlex.quote(remote_path)
+    # mktemp -p /tmp: deterministic, world-writable location for the
+    # xclm user before sudo takes over for the final placement.
+    _, stdout, _ = client.exec_command("mktemp /tmp/clawrium-sync.XXXXXX")
+    if stdout.channel.recv_exit_status() != 0:
+        raise CanonicalSyncError("mktemp failed on host")
+    tmp_path = stdout.read().decode("utf-8").strip()
+    if not tmp_path:
+        raise CanonicalSyncError("mktemp returned empty path")
+    try:
+        sftp = client.open_sftp()
+        try:
+            with sftp.file(tmp_path, "wb") as fh:
+                fh.write(body.encode("utf-8"))
+        finally:
+            sftp.close()
+        # `install -m 0600 -o <name> -g <name>` requires sudo (target
+        # dirs are root- or agent-owned). `install` is atomic w.r.t.
+        # the destination so a partial write is never visible.
+        owner = shlex.quote(agent_name)
+        cmd = (
+            f"sudo -n install -m 0600 -o {owner} -g {owner} "
+            f"{shlex.quote(tmp_path)} {quoted_path}"
+        )
+        _, install_out, install_err = client.exec_command(cmd, timeout=timeout)
+        rc = install_out.channel.recv_exit_status()
+        if rc != 0:
+            stderr_text = install_err.read().decode("utf-8", errors="replace")
+            raise CanonicalSyncError(
+                f"install {remote_path!r} failed (exit {rc}): {stderr_text.strip()}"
+            )
+    finally:
+        client.exec_command(f"rm -f {shlex.quote(tmp_path)}")
+
+
+def _restart_unit(
+    client: paramiko.SSHClient,
+    *,
+    agent_type: str,
+    agent_name: str,
+    timeout: int = 30,
+) -> None:
+    unit = f"{agent_type}-{agent_name}.service"
+    cmd = f"sudo -n systemctl restart {shlex.quote(unit)}"
+    _, out, err = client.exec_command(cmd, timeout=timeout)
+    rc = out.channel.recv_exit_status()
+    if rc != 0:
+        stderr_text = err.read().decode("utf-8", errors="replace")
+        raise CanonicalSyncError(
+            f"systemctl restart {unit} failed (exit {rc}): {stderr_text.strip()}"
+        )
+
+
+def _verify_health(
+    client: paramiko.SSHClient,
+    *,
+    agent_type: str,
+    agent_name: str,
+    timeout: int = 15,
+) -> None:
+    unit = f"{agent_type}-{agent_name}.service"
+    cmd = f"systemctl is-active {shlex.quote(unit)}"
+    _, out, _ = client.exec_command(cmd, timeout=timeout)
+    rc = out.channel.recv_exit_status()
+    state = out.read().decode("utf-8", errors="replace").strip()
+    if rc != 0 or state != "active":
+        raise CanonicalSyncError(
+            f"unit {unit} is not active after restart (state={state!r})"
+        )
+
+
+def sync_agent_canonical(
+    agent_name: str,
+    *,
+    force: bool = False,
+    restart: bool = True,
+    verify: bool = True,
+    on_event: Callable[[str, str], None] | None = None,
+) -> CanonicalSyncResult:
+    """Sync `agent_name` via the canonical pipeline.
+
+    Args:
+        agent_name: The agent instance name (as recorded in hosts.json).
+        force: Allow writes that remove a host-side secret line. Without
+            this, `SecretRemovalRefused` is raised before any host write.
+        restart: When True (default), restart the agent's systemd unit
+            after writes. When False, files are written but the running
+            process keeps its old config until the next restart — useful
+            for an operator who wants to stage changes without flapping
+            the agent.
+        verify: When True (default), assert the unit is `active` after
+            restart. Implies `restart=True` — verify without restart is
+            a noop. Pass False to skip post-restart polling.
+        on_event: Callback `(stage, message)` for progress streaming.
+
+    Raises:
+        AgentConfigError: from build_render_inputs (missing attachment)
+        CanonicalSyncError / SecretRemovalRefused: pipeline failure
+        RemoteReadError: SSH probe failed in a way the operator must see
+    """
+
+    def emit(stage: str, message: str) -> None:
+        if on_event is not None:
+            on_event(stage, message)
+        logger.info("[%s] %s", stage, message)
+
+    emit("validate", f"assembling render inputs for {agent_name}")
+    inputs = build_render_inputs(agent_name)
+
+    renderer = _RENDERERS.get(inputs.agent_type)
+    if renderer is None:
+        raise CanonicalSyncError(
+            f"no canonical renderer for agent type {inputs.agent_type!r}"
+        )
+
+    emit("render", f"rendering canonical config for {inputs.agent_type}")
+    rendered = renderer(inputs)
+
+    resolved = get_agent_by_name(agent_name)
+    if resolved is None:
+        raise CanonicalSyncError(
+            f"agent {agent_name!r} not found in hosts.json"
+        )
+    host, agent_key, _claw_record = resolved
+    hostname = host.get("hostname", "")
+
+    emit("diff", f"reading on-host files from {hostname}")
+    diffs = diff_files(
+        host=host, agent_name=agent_name, rendered_files=rendered.files
+    )
+
+    # Secret-removal guard. See module docstring; this is the single
+    # behavior #555 added that the legacy path lacks.
+    refused: dict[str, set[str]] = {}
+    for d in diffs:
+        if not d.unified_diff:
+            continue
+        missing = _diff_removes_secrets(d)
+        if missing:
+            refused[d.path] = missing
+    if refused and not force:
+        details = "; ".join(
+            f"{path}: would remove {sorted(keys)}"
+            for path, keys in sorted(refused.items())
+        )
+        raise SecretRemovalRefused(
+            f"refusing to sync {agent_name!r}: rendered body removes "
+            f"host-side secrets ({details}). Inspect with `clawctl "
+            f"agent sync {agent_name} --dry-run --diff`. Re-run with "
+            f"`--force` if the removal is intentional."
+        )
+
+    files_written: list[str] = []
+    files_unchanged: list[str] = []
+
+    client = _open_ssh(host)
+    try:
+        for d in diffs:
+            if not d.unified_diff:
+                files_unchanged.append(d.path)
+                continue
+            emit("write", f"writing {d.remote_path}")
+            _atomic_write(
+                client,
+                agent_name=agent_name,
+                remote_path=d.remote_path,
+                body=d.rendered_body,
+            )
+            files_written.append(d.path)
+
+        if restart and files_written:
+            emit("restart", f"restarting {inputs.agent_type}-{agent_name}.service")
+            _restart_unit(
+                client,
+                agent_type=inputs.agent_type,
+                agent_name=agent_name,
+            )
+            if verify:
+                emit("verify", "checking unit is active")
+                _verify_health(
+                    client,
+                    agent_type=inputs.agent_type,
+                    agent_name=agent_name,
+                )
+        elif restart and not files_written:
+            emit("restart", "skipped (no files changed)")
+    finally:
+        client.close()
+
+    emit(
+        "sync",
+        f"synced {agent_name}: {len(files_written)} written, "
+        f"{len(files_unchanged)} unchanged",
+    )
+    return CanonicalSyncResult(
+        success=True,
+        agent=agent_name,
+        host=hostname,
+        files_written=tuple(files_written),
+        files_unchanged=tuple(files_unchanged),
+        diffs=tuple(diffs),
+    )

--- a/src/clawrium/core/render_diff.py
+++ b/src/clawrium/core/render_diff.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import difflib
 import shlex
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import paramiko
 
@@ -23,10 +23,24 @@ from clawrium.core.keys import get_host_private_key
 
 __all__ = [
     "FileDiff",
+    "RemoteReadError",
     "read_remote_file",
     "remote_path_for",
     "diff_files",
 ]
+
+
+class RemoteReadError(Exception):
+    """Raised when a remote probe fails for an operator-actionable reason.
+
+    Distinct from "file is genuinely absent" — that is reported by
+    `read_remote_file` as `(False, "")` so the caller can render a
+    "would create" diff. `RemoteReadError` covers the cases where the
+    diff cannot be trusted (sudo unavailable, SSH transport dead,
+    permission denied on the file itself) and the caller must
+    surface a warning rather than silently emit a misleading patch.
+    Fixes ATX iter-1 B4 (sudo-fail indistinguishable from absent file).
+    """
 
 
 @dataclass(frozen=True)
@@ -37,14 +51,23 @@ class FileDiff:
     "would change" (file exists but differs). Operators care: the
     former is expected on a freshly-installed agent; the latter on a
     healthy agent likely means someone hand-edited the host.
+
+    ATX iter-1 W5: `remote_body` and `rendered_body` carry plaintext
+    secrets. `repr=False` on both fields prevents accidental
+    plaintext leakage through `repr()` in pytest tracebacks, debug
+    logs, or `print(diff)`. Diff structure (path / present / unified)
+    is still visible.
     """
 
     path: str  # relative path under agent home, e.g. ".hermes/.env"
     remote_path: str  # absolute path on the host
     remote_present: bool
-    remote_body: str
-    rendered_body: str
-    unified_diff: str  # empty string when bodies are byte-identical
+    remote_body: str = field(repr=False)
+    rendered_body: str = field(repr=False)
+    # The unified diff is *also* secret-carrying (it contains the
+    # secret lines that differ) — but operators need to see it in
+    # text mode. Keep it repr=False; the CLI layer prints it directly.
+    unified_diff: str = field(repr=False)
 
 
 def remote_path_for(os_family: str, agent_name: str, relative: str) -> str:
@@ -73,12 +96,20 @@ def read_remote_file(
     Uses `sudo -n cat` because agent home directories are typically
     `0700` and xclm (the management user) cannot read them directly
     but does have passwordless sudo per `clawctl host create`. `-n`
-    avoids any password prompt — if sudo is not available we surface
-    a non-zero exit code as "not present" rather than blocking.
+    avoids any password prompt.
 
-    A non-existent file is reported as `(False, "")` not an exception
-    so the caller can render a "would create" diff against an empty
-    body without special-casing.
+    File-existence is probed with a dedicated `sudo -n test -e` call
+    whose exit status is read via `recv_exit_status()`:
+
+    - exit 0 → file exists; second call `sudo -n cat` retrieves body
+    - exit 1 → file does not exist; return `(False, "")`
+    - any other exit → sudo unavailable or transport issue; raise
+      `RemoteReadError` so the operator sees a real warning rather
+      than a misleading "would create" diff (ATX iter-1 B4).
+
+    A non-existent file is reported as `(False, "")` so the caller
+    can render a "would create" diff against an empty body without
+    special-casing.
     """
     client = paramiko.SSHClient()
     client.load_system_host_keys()
@@ -95,21 +126,47 @@ def read_remote_file(
             timeout=timeout,
         )
         quoted = shlex.quote(remote_path)
-        # `test -r`: returns 0 only if file exists and is readable
-        # by *root* (we run via sudo). The cat is guarded so a missing
-        # file produces `(False, "")` rather than stderr noise.
-        cmd = (
-            f"if sudo -n test -e {quoted}; then "
-            f"sudo -n cat {quoted}; else echo __CLAWRIUM_MISSING__; fi"
+        # Probe existence first via a separate command whose exit
+        # status disambiguates "missing" (exit 1 from `test -e`) from
+        # "sudo unavailable" (exit 1 from sudo itself — `-n` returns
+        # exit 1 on auth failure, but the stderr message reveals
+        # which it is). We use exec_command twice rather than one
+        # compound script so the structured exit code is preserved.
+        _, probe_stdout, probe_stderr = client.exec_command(
+            f"sudo -n test -e {quoted}", timeout=timeout
         )
-        _, stdout, _ = client.exec_command(cmd, timeout=timeout)
-        raw = stdout.read().decode("utf-8", errors="replace")
+        probe_exit = probe_stdout.channel.recv_exit_status()
+        if probe_exit == 0:
+            _, stdout, _ = client.exec_command(
+                f"sudo -n cat {quoted}", timeout=timeout
+            )
+            cat_exit = stdout.channel.recv_exit_status()
+            raw = stdout.read().decode("utf-8", errors="replace")
+            if cat_exit != 0:
+                raise RemoteReadError(
+                    f"sudo cat {remote_path!r} failed with exit {cat_exit}"
+                )
+            return True, raw
+        if probe_exit == 1:
+            # Distinguish "file truly absent" (sudo ran fine) from
+            # "sudo refused to run" by checking stderr. A sudoers
+            # misconfiguration produces text like
+            # "sudo: a password is required". The actual `test -e`
+            # exit-1 path emits no stderr.
+            stderr_text = probe_stderr.read().decode("utf-8", errors="replace")
+            if "sudo" in stderr_text and "password" in stderr_text.lower():
+                raise RemoteReadError(
+                    f"sudo -n unavailable on {hostname}: "
+                    "host needs passwordless sudo (re-run `clawctl host create`)"
+                )
+            return False, ""
+        # Any other exit code is a transport / auth surprise. Surface
+        # it loudly rather than silently presenting a "would create".
+        raise RemoteReadError(
+            f"sudo -n test -e {remote_path!r} exited {probe_exit} on {hostname}"
+        )
     finally:
         client.close()
-
-    if raw.strip() == "__CLAWRIUM_MISSING__":
-        return False, ""
-    return True, raw
 
 
 def diff_files(
@@ -148,13 +205,19 @@ def diff_files(
     diffs: list[FileDiff] = []
     for rel_path, rendered_body in rendered_files.items():
         remote_path = remote_path_for(os_family, agent_name, rel_path)
-        present, remote_body = reader(
-            hostname=hostname,
-            port=port,
-            user=user,
-            key_filename=str(private_key),
-            remote_path=remote_path,
-        )
+        try:
+            present, remote_body = reader(
+                hostname=hostname,
+                port=port,
+                user=user,
+                key_filename=str(private_key),
+                remote_path=remote_path,
+            )
+        except RemoteReadError:
+            # Propagate verbatim — the CLI layer renders this as a
+            # `diff error:` line so the operator is not handed a
+            # misleading "would create" diff (ATX iter-1 B4).
+            raise
         unified = (
             ""
             if remote_body == rendered_body

--- a/src/clawrium/core/render_diff.py
+++ b/src/clawrium/core/render_diff.py
@@ -140,8 +140,15 @@ def read_remote_file(
             _, stdout, _ = client.exec_command(
                 f"sudo -n cat {quoted}", timeout=timeout
             )
-            cat_exit = stdout.channel.recv_exit_status()
+            # ATX iter-2 W13: read body BEFORE polling exit status.
+            # paramiko's `recv_exit_status()` can block until EOF on
+            # large outputs but only after the channel's stdout
+            # buffer is drained — reading first ensures the channel
+            # closes cleanly. Calling exit-status first then read()
+            # has caused deadlocks under load in other paramiko
+            # users (see paramiko #1617).
             raw = stdout.read().decode("utf-8", errors="replace")
+            cat_exit = stdout.channel.recv_exit_status()
             if cat_exit != 0:
                 raise RemoteReadError(
                     f"sudo cat {remote_path!r} failed with exit {cat_exit}"
@@ -149,15 +156,21 @@ def read_remote_file(
             return True, raw
         if probe_exit == 1:
             # Distinguish "file truly absent" (sudo ran fine) from
-            # "sudo refused to run" by checking stderr. A sudoers
-            # misconfiguration produces text like
-            # "sudo: a password is required". The actual `test -e`
-            # exit-1 path emits no stderr.
+            # "sudo refused to run" by inspecting stderr. A clean
+            # `test -e` miss emits no stderr at all; ANY stderr text
+            # on the probe channel means sudo itself spoke up — most
+            # likely a sudoers misconfiguration. ATX iter-2 W14:
+            # don't anchor on the word "password" — sudo's NOPASSWD
+            # failure modes also produce "Sorry, user X is not
+            # allowed to execute ...", "sudo: no tty present", and
+            # locale-translated variants. Any non-empty stderr on
+            # exit-1 is operator-actionable.
             stderr_text = probe_stderr.read().decode("utf-8", errors="replace")
-            if "sudo" in stderr_text and "password" in stderr_text.lower():
+            if stderr_text.strip():
                 raise RemoteReadError(
                     f"sudo -n unavailable on {hostname}: "
-                    "host needs passwordless sudo (re-run `clawctl host create`)"
+                    f"{stderr_text.strip()} "
+                    "(re-run `clawctl host create` to fix sudoers)"
                 )
             return False, ""
         # Any other exit code is a transport / auth surprise. Surface

--- a/src/clawrium/core/render_diff.py
+++ b/src/clawrium/core/render_diff.py
@@ -1,0 +1,181 @@
+"""Host-vs-rendered diff for parent #555 F8.
+
+`build_render_inputs` + `render_<atype>` produce the canonical
+on-host content. To answer "what would `clawctl agent sync` change?",
+we need to read the current file from the host and unified-diff it
+against the rendered bytes. This module is the only place that
+crosses the SSH boundary for that diff.
+
+Kept narrowly scoped: read one file per call via `sudo -n cat`, no
+state, no parallelism. The CLI layer iterates over the files map.
+"""
+
+from __future__ import annotations
+
+import difflib
+import shlex
+from dataclasses import dataclass
+
+import paramiko
+
+from clawrium.core.keys import get_host_private_key
+
+
+__all__ = [
+    "FileDiff",
+    "read_remote_file",
+    "remote_path_for",
+    "diff_files",
+]
+
+
+@dataclass(frozen=True)
+class FileDiff:
+    """One file's host-vs-rendered comparison.
+
+    `remote_present` distinguishes "first sync" (no file yet) from
+    "would change" (file exists but differs). Operators care: the
+    former is expected on a freshly-installed agent; the latter on a
+    healthy agent likely means someone hand-edited the host.
+    """
+
+    path: str  # relative path under agent home, e.g. ".hermes/.env"
+    remote_path: str  # absolute path on the host
+    remote_present: bool
+    remote_body: str
+    rendered_body: str
+    unified_diff: str  # empty string when bodies are byte-identical
+
+
+def remote_path_for(os_family: str, agent_name: str, relative: str) -> str:
+    """Resolve a relative-to-home file key into an absolute host path.
+
+    `relative` comes from `RenderedFiles.files` (e.g. `.hermes/.env`).
+    The home root mirrors the convention used by
+    `core/lifecycle.py:_get_hermes_env_path` — `/Users/<name>` on
+    darwin, `/home/<name>` everywhere else.
+    """
+    home_root = "/Users" if (os_family or "linux") == "darwin" else "/home"
+    return f"{home_root}/{agent_name}/{relative.lstrip('/')}"
+
+
+def read_remote_file(
+    *,
+    hostname: str,
+    port: int,
+    user: str,
+    key_filename: str,
+    remote_path: str,
+    timeout: int = 10,
+) -> tuple[bool, str]:
+    """Cat one file from the host. Returns (present, body).
+
+    Uses `sudo -n cat` because agent home directories are typically
+    `0700` and xclm (the management user) cannot read them directly
+    but does have passwordless sudo per `clawctl host create`. `-n`
+    avoids any password prompt — if sudo is not available we surface
+    a non-zero exit code as "not present" rather than blocking.
+
+    A non-existent file is reported as `(False, "")` not an exception
+    so the caller can render a "would create" diff against an empty
+    body without special-casing.
+    """
+    client = paramiko.SSHClient()
+    client.load_system_host_keys()
+    # WarningPolicy mirrors core/lifecycle.py — see the rationale block
+    # there. Probes-only path, no command-injection surface beyond the
+    # caller-supplied `remote_path` which we shlex.quote below.
+    client.set_missing_host_key_policy(paramiko.WarningPolicy())
+    try:
+        client.connect(
+            hostname=hostname,
+            port=int(port),
+            username=user,
+            key_filename=key_filename,
+            timeout=timeout,
+        )
+        quoted = shlex.quote(remote_path)
+        # `test -r`: returns 0 only if file exists and is readable
+        # by *root* (we run via sudo). The cat is guarded so a missing
+        # file produces `(False, "")` rather than stderr noise.
+        cmd = (
+            f"if sudo -n test -e {quoted}; then "
+            f"sudo -n cat {quoted}; else echo __CLAWRIUM_MISSING__; fi"
+        )
+        _, stdout, _ = client.exec_command(cmd, timeout=timeout)
+        raw = stdout.read().decode("utf-8", errors="replace")
+    finally:
+        client.close()
+
+    if raw.strip() == "__CLAWRIUM_MISSING__":
+        return False, ""
+    return True, raw
+
+
+def diff_files(
+    *,
+    host: dict,
+    agent_name: str,
+    rendered_files: dict[str, str],
+    reader=None,
+) -> list[FileDiff]:
+    """Diff every rendered file against the host.
+
+    `reader` defaults to the module-level `read_remote_file` *resolved
+    at call time* (not at def time) so tests that
+    `monkeypatch.setattr(render_diff, "read_remote_file", fake)` reach
+    the production path. Tests that prefer to pass a fake directly can
+    still do so via this kwarg.
+    """
+    if reader is None:
+        # Re-import from module globals so monkeypatching takes effect.
+        from clawrium.core import render_diff as _self
+
+        reader = _self.read_remote_file
+    key_id = host.get("key_id") or host.get("hostname") or ""
+    private_key = get_host_private_key(key_id)
+    if not private_key:
+        raise RuntimeError(
+            f"no SSH key registered for host {key_id!r}; "
+            "re-run `clawctl host create` to provision one"
+        )
+
+    os_family = host.get("os_family", "linux")
+    hostname = host.get("hostname", "")
+    port = int(host.get("port", 22) or 22)
+    user = host.get("user", "xclm")
+
+    diffs: list[FileDiff] = []
+    for rel_path, rendered_body in rendered_files.items():
+        remote_path = remote_path_for(os_family, agent_name, rel_path)
+        present, remote_body = reader(
+            hostname=hostname,
+            port=port,
+            user=user,
+            key_filename=str(private_key),
+            remote_path=remote_path,
+        )
+        unified = (
+            ""
+            if remote_body == rendered_body
+            else "".join(
+                difflib.unified_diff(
+                    remote_body.splitlines(keepends=True),
+                    rendered_body.splitlines(keepends=True),
+                    fromfile=f"host:{remote_path}",
+                    tofile=f"rendered:{rel_path}",
+                    n=3,
+                )
+            )
+        )
+        diffs.append(
+            FileDiff(
+                path=rel_path,
+                remote_path=remote_path,
+                remote_present=present,
+                remote_body=remote_body,
+                rendered_body=rendered_body,
+                unified_diff=unified,
+            )
+        )
+    return diffs

--- a/tests/cli/clawctl/agent/test_doctor.py
+++ b/tests/cli/clawctl/agent/test_doctor.py
@@ -165,6 +165,33 @@ def test_doctor_endpoint_credentials_redacted(fleet_dir, monkeypatch) -> None:
     assert "alice" in endpoint  # username is not a secret on its own
 
 
+def test_doctor_endpoint_bare_token_redacted(fleet_dir, monkeypatch) -> None:
+    """ATX iter-2 B7 — bare-token userinfo (no `:`) must also be masked."""
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    inputs = RenderInputs(
+        agent_name="wise-hypatia",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="proxy",
+            type="anthropic",
+            endpoint="https://sk-supersecret-token@llm-proxy.corp/v1",
+            api_key="k",
+        ),
+    )
+    files = RenderedFiles(files={".openclaw/.env": "x\n"})
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda n: inputs)
+    monkeypatch.setattr(doctor_mod, "render_openclaw", lambda i: files)
+
+    result = runner.invoke(app, ["agent", "doctor", "wise-hypatia", "-o", "json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    endpoint = payload[0]["inputs"]["provider"]["endpoint"]
+    assert "sk-supersecret-token" not in endpoint
+    assert "***" in endpoint
+    assert endpoint.startswith("https://***@llm-proxy.corp")
+
+
 def test_doctor_yaml_output(fleet_dir, monkeypatch) -> None:
     """ATX iter-1 W12 — `-o yaml` path was untested."""
     from clawrium.cli.clawctl.agent import doctor as doctor_mod

--- a/tests/cli/clawctl/agent/test_doctor.py
+++ b/tests/cli/clawctl/agent/test_doctor.py
@@ -1,0 +1,140 @@
+"""Tests for `clawctl agent doctor` — F4 of parent #555.
+
+The doctor command is pure-local (no SSH), so the only collaborators
+to fake are `build_render_inputs` (which talks to the providers /
+channels / integrations / secrets stores) and the per-type renderer
+dispatch. Both are mocked so the tests run in isolation from a real
+fleet.
+"""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+from clawrium.core.render import (
+    AgentConfigError,
+    ChannelInputs,
+    IntegrationInputs,
+    ProviderInputs,
+    RenderInputs,
+    RenderedFiles,
+)
+
+
+runner = CliRunner()
+
+
+_OK_INPUTS = RenderInputs(
+    agent_name="wise-hypatia",
+    agent_type="openclaw",
+    provider=ProviderInputs(
+        name="anthropic-primary",
+        type="anthropic",
+        default_model="claude-opus",
+        api_key="sk-xxx",
+    ),
+    channels=(
+        ChannelInputs(
+            name="discord-wise",
+            type="discord",
+            bot_token="bot-xxx",
+        ),
+    ),
+    integrations=(
+        IntegrationInputs(
+            name="wise-github",
+            type="github",
+            credentials=(("GITHUB_TOKEN", "ghp_xxx"),),
+        ),
+    ),
+)
+_OK_FILES = RenderedFiles(
+    files={
+        ".openclaw/.env": "ANTHROPIC_API_KEY='sk-xxx'\nDISCORD_BOT_TOKEN='bot-xxx'\n",
+    }
+)
+
+
+def test_doctor_unknown_agent(fleet_dir) -> None:
+    result = runner.invoke(app, ["agent", "doctor", "ghost"])
+    assert result.exit_code != 0
+    assert "not found" in (result.output + (result.stderr or ""))
+
+
+def test_doctor_ok_table(fleet_dir, monkeypatch) -> None:
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda name: _OK_INPUTS)
+    monkeypatch.setattr(doctor_mod, "render_openclaw", lambda inputs: _OK_FILES)
+
+    result = runner.invoke(app, ["agent", "doctor", "wise-hypatia"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "Name:    wise-hypatia" in out
+    assert "Status:  ok" in out
+    assert "anthropic-primary" in out
+    assert "discord-wise" in out
+    assert "wise-github" in out
+    assert ".openclaw/.env" in out
+    # Secret values must never appear; only presence.
+    assert "sk-xxx" not in out
+    assert "bot-xxx" not in out
+    assert "ghp_xxx" not in out
+    assert "api_key:        present" in out
+
+
+def test_doctor_ok_json(fleet_dir, monkeypatch) -> None:
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda name: _OK_INPUTS)
+    monkeypatch.setattr(doctor_mod, "render_openclaw", lambda inputs: _OK_FILES)
+
+    result = runner.invoke(app, ["agent", "doctor", "wise-hypatia", "-o", "json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert isinstance(payload, list) and len(payload) == 1
+    row = payload[0]
+    assert row["name"] == "wise-hypatia"
+    assert row["status"] == "ok"
+    assert row["inputs"]["provider"]["api_key"] == "present"
+    assert row["inputs"]["channels"][0]["name"] == "discord-wise"
+    assert row["files"][0]["path"] == ".openclaw/.env"
+    assert row["files"][0]["bytes"] > 0
+    assert len(row["files"][0]["sha256_prefix"]) == 16
+
+
+def test_doctor_broken_surfaces_error(fleet_dir, monkeypatch) -> None:
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    def _raise(name: str):
+        raise AgentConfigError("provider 'foo' not registered in providers.json")
+
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", _raise)
+
+    result = runner.invoke(app, ["agent", "doctor", "wise-hypatia"])
+    # Non-zero exit so CI / shell pipelines can gate on doctor.
+    assert result.exit_code != 0
+    assert "Status:  broken" in result.output
+    assert "provider 'foo'" in result.output
+
+
+def test_doctor_broken_json_includes_error(fleet_dir, monkeypatch) -> None:
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    def _raise(name: str):
+        raise AgentConfigError("channel 'discord-x' is missing BOT_TOKEN")
+
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", _raise)
+
+    result = runner.invoke(app, ["agent", "doctor", "wise-hypatia", "-o", "json"])
+    assert result.exit_code != 0
+    # The JSON payload still prints to stdout before the non-zero exit.
+    # Extract the first JSON-array prefix.
+    body = result.output
+    arr_end = body.rfind("]")
+    payload = json.loads(body[: arr_end + 1])
+    assert payload[0]["status"] == "broken"
+    assert "BOT_TOKEN" in payload[0]["error"]

--- a/tests/cli/clawctl/agent/test_doctor.py
+++ b/tests/cli/clawctl/agent/test_doctor.py
@@ -121,6 +121,63 @@ def test_doctor_broken_surfaces_error(fleet_dir, monkeypatch) -> None:
     assert "provider 'foo'" in result.output
 
 
+def test_doctor_unknown_renderer_type(fleet_dir, monkeypatch) -> None:
+    """ATX iter-1 B5 — `_RENDERER_NAMES` miss must be surfaced as broken."""
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    nemoclaw_inputs = RenderInputs(
+        agent_name="wise-hypatia",
+        agent_type="nemoclaw",  # Not in _RENDERER_NAMES.
+        provider=ProviderInputs(name="x", type="anthropic", api_key="k"),
+    )
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda n: nemoclaw_inputs)
+
+    result = runner.invoke(app, ["agent", "doctor", "wise-hypatia"])
+    assert result.exit_code != 0
+    assert "Status:  broken" in result.output
+    assert "no renderer registered" in result.output
+
+
+def test_doctor_endpoint_credentials_redacted(fleet_dir, monkeypatch) -> None:
+    """ATX iter-1 W1 — URL-embedded credentials in endpoint must be masked."""
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    inputs = RenderInputs(
+        agent_name="wise-hypatia",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="proxy",
+            type="anthropic",
+            endpoint="https://alice:supersecret@llm-proxy.corp/v1",
+            api_key="k",
+        ),
+    )
+    files = RenderedFiles(files={".openclaw/.env": "x\n"})
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda n: inputs)
+    monkeypatch.setattr(doctor_mod, "render_openclaw", lambda i: files)
+
+    result = runner.invoke(app, ["agent", "doctor", "wise-hypatia", "-o", "json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    endpoint = payload[0]["inputs"]["provider"]["endpoint"]
+    assert "supersecret" not in endpoint
+    assert "***" in endpoint
+    assert "alice" in endpoint  # username is not a secret on its own
+
+
+def test_doctor_yaml_output(fleet_dir, monkeypatch) -> None:
+    """ATX iter-1 W12 — `-o yaml` path was untested."""
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda name: _OK_INPUTS)
+    monkeypatch.setattr(doctor_mod, "render_openclaw", lambda inputs: _OK_FILES)
+
+    result = runner.invoke(app, ["agent", "doctor", "wise-hypatia", "-o", "yaml"])
+    assert result.exit_code == 0, result.output
+    assert "name: wise-hypatia" in result.output
+    assert "status: ok" in result.output
+
+
 def test_doctor_broken_json_includes_error(fleet_dir, monkeypatch) -> None:
     from clawrium.cli.clawctl.agent import doctor as doctor_mod
 

--- a/tests/cli/clawctl/agent/test_doctor_audit.py
+++ b/tests/cli/clawctl/agent/test_doctor_audit.py
@@ -1,0 +1,67 @@
+"""Schema gate for `tests/fixtures/audit_2026_05_29.json` — F4 of #555.
+
+The fixture is the reference baseline for `clawctl agent doctor`
+against the 10 audited agents from issue #555. This test pins the
+fixture's shape (every row has name + type + expected_status) so a
+future edit cannot silently drop a row or change the expected
+verdict without a failing test.
+
+The end-to-end "doctor's output matches the fixture verdict" assertion
+needs synthetic providers.json / channels.json / integrations.json /
+secrets.json + hosts.json fixtures matching each agent's `shape`,
+which is wired in the F5 migration follow-up (parent #555). Until
+then, this schema gate is what protects the fixture from drift.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+FIXTURE = (
+    Path(__file__).resolve().parents[3]
+    / "fixtures"
+    / "audit_2026_05_29.json"
+)
+
+
+def test_audit_fixture_loads() -> None:
+    assert FIXTURE.exists(), f"missing fixture: {FIXTURE}"
+    payload = json.loads(FIXTURE.read_text())
+    assert "_meta" in payload
+    assert "agents" in payload
+    assert len(payload["agents"]) == 10, (
+        "audit_2026_05_29.json must enumerate the 10 reference agents from #555"
+    )
+
+
+def test_audit_fixture_rows_have_required_fields() -> None:
+    payload = json.loads(FIXTURE.read_text())
+    for row in payload["agents"]:
+        assert "name" in row
+        assert "type" in row
+        assert row["type"] in {"hermes", "zeroclaw", "openclaw"}
+        assert row["expected_status"] in {"ok", "broken"}
+        if row["expected_status"] == "broken":
+            assert "expected_error_contains" in row, (
+                f"broken row {row['name']!r} must declare expected_error_contains"
+            )
+
+
+def test_audit_fixture_names_match_issue_555_table() -> None:
+    payload = json.loads(FIXTURE.read_text())
+    names = {row["name"] for row in payload["agents"]}
+    expected = {
+        "wolf-i",
+        "clawrium-d01",
+        "espresso",
+        "nemotron-alpha",
+        "nemotron-beta",
+        "clawctl-demo",
+        "h1",
+        "h2",
+        "clawctl-mac-demo",
+        "maurice",
+    }
+    assert names == expected

--- a/tests/cli/clawctl/agent/test_doctor_audit.py
+++ b/tests/cli/clawctl/agent/test_doctor_audit.py
@@ -18,6 +18,19 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+from clawrium.core.render import (
+    AgentConfigError,
+    ProviderInputs,
+    RenderInputs,
+    RenderedFiles,
+)
+
+
+_runner = CliRunner()
+
 
 FIXTURE = (
     Path(__file__).resolve().parents[3]
@@ -65,3 +78,76 @@ def test_audit_fixture_names_match_issue_555_table() -> None:
         "maurice",
     }
     assert names == expected
+
+
+# ---------------------------------------------------------------------------
+# End-to-end doctor verdict assertions (ATX iter-1 B6).
+#
+# A full per-row synthetic store fixture would duplicate F5's migration
+# scaffolding (parent #555 DoD). For now we cover the two representative
+# rows whose verdicts encode the core regression #555 was filed against:
+# the reference baseline ("clawrium-d01" → ok) and the fully-wiped
+# survivor ("maurice" → broken with provider-missing error). This pins
+# the doctor's broken-vs-ok classification against the canonical
+# expectations from the audit table. The remaining 8 rows stay as
+# schema-pinned baseline rows; the F5 follow-up replaces this gap.
+# ---------------------------------------------------------------------------
+
+def _fixture_row(name: str) -> dict:
+    payload = json.loads(FIXTURE.read_text())
+    for row in payload["agents"]:
+        if row["name"] == name:
+            return row
+    raise KeyError(name)
+
+
+def test_doctor_matches_audit_verdict_clawrium_d01(fleet_dir, monkeypatch) -> None:
+    """`clawrium-d01` is the baseline. doctor must return ok."""
+    row = _fixture_row("clawrium-d01")
+    assert row["expected_status"] == "ok"
+
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    inputs = RenderInputs(
+        agent_name="wise-hypatia",
+        agent_type=row["type"],  # zeroclaw
+        provider=ProviderInputs(
+            name="openrouter",
+            type="openrouter",
+            default_model="openai/gpt-5",
+            api_key="sk-xxx",
+        ),
+    )
+    files = RenderedFiles(files={".zeroclaw/config.toml": "ok\n"})
+
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda n: inputs)
+    monkeypatch.setattr(doctor_mod, "render_zeroclaw", lambda i: files)
+
+    result = _runner.invoke(app, ["agent", "doctor", "wise-hypatia", "-o", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload[0]["status"] == row["expected_status"]
+
+
+def test_doctor_matches_audit_verdict_maurice(fleet_dir, monkeypatch) -> None:
+    """`maurice` is fully wiped. doctor must return broken with provider error."""
+    row = _fixture_row("maurice")
+    assert row["expected_status"] == "broken"
+    assert row["expected_error_contains"] == "provider"
+
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    def _raise(name: str):
+        raise AgentConfigError(
+            f"agent {name!r} has no provider attached; "
+            f"run `clawctl agent provider attach <provider> --agent {name}` first"
+        )
+
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", _raise)
+
+    result = _runner.invoke(app, ["agent", "doctor", "wise-hypatia", "-o", "json"])
+    assert result.exit_code != 0
+    arr_end = result.output.rfind("]")
+    payload = json.loads(result.output[: arr_end + 1])
+    assert payload[0]["status"] == row["expected_status"]
+    assert row["expected_error_contains"] in payload[0]["error"]

--- a/tests/cli/clawctl/agent/test_sync_diff.py
+++ b/tests/cli/clawctl/agent/test_sync_diff.py
@@ -135,7 +135,118 @@ def test_diff_json_output(fleet_dir, monkeypatch) -> None:
     assert result_event["path"] == ".openclaw/.env"
     assert result_event["changed"] is True
     assert result_event["remote_present"] is True
-    assert "ANTHROPIC_API_KEY" in result_event["diff"]
+    # ATX iter-1 B1: the diff body MUST NOT be emitted in NDJSON
+    # mode. Plaintext secrets in log streams is the regression this
+    # test guards against.
+    assert "diff" not in result_event
+    assert "ANTHROPIC_API_KEY" not in json.dumps(result_event)
+    assert "sk-xxx" not in json.dumps(result_event)
+    assert "old-key" not in json.dumps(result_event)
+    assert result_event["contains_secret_values"] is True
+    assert "JSON" in result_event["hint"] or "json" in result_event["hint"]
+
+
+def test_diff_json_no_changes_marks_secret_flag_false(fleet_dir, monkeypatch) -> None:
+    _patch_render(monkeypatch)
+    _patch_reader(monkeypatch, body=_RENDERED.files[".openclaw/.env"])
+
+    result = runner.invoke(
+        app,
+        ["agent", "sync", "wise-hypatia", "--dry-run", "--diff", "-o", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    events = [json.loads(line) for line in result.output.strip().splitlines() if line]
+    result_event = next(
+        e for e in events if e.get("phase") == "diff" and e.get("state") == "result"
+    )
+    # Unchanged files carry no secret-bearing patch.
+    assert result_event["changed"] is False
+    assert result_event["contains_secret_values"] is False
+
+
+def test_diff_json_error_event(fleet_dir, monkeypatch) -> None:
+    """ATX iter-1 W10 — JSON-mode error path was untested."""
+    from clawrium.cli.clawctl.agent import sync as sync_mod
+    from clawrium.core import render as render_mod
+    from clawrium.core.render import AgentConfigError
+
+    monkeypatch.setattr(sync_mod, "_RENDERERS", {"openclaw": "render_openclaw"})
+
+    def _raise(name):
+        raise AgentConfigError("provider 'foo' not registered")
+
+    monkeypatch.setattr(render_mod, "build_render_inputs", _raise)
+
+    result = runner.invoke(
+        app,
+        ["agent", "sync", "wise-hypatia", "--dry-run", "--diff", "-o", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    events = [json.loads(line) for line in result.output.strip().splitlines() if line]
+    error_events = [
+        e for e in events if e.get("phase") == "diff" and e.get("state") == "error"
+    ]
+    assert error_events, "expected a diff-error event"
+    assert "provider 'foo'" in error_events[0]["message"]
+
+
+def test_diff_text_sanitizes_bidi_in_patch(fleet_dir, monkeypatch) -> None:
+    """ATX iter-1 B2 — bidi codepoints in host file must be stripped."""
+    _patch_render(monkeypatch)
+    # Inject a Right-to-Left Override (U+202E) into the on-host body.
+    _patch_reader(
+        monkeypatch,
+        body=(
+            "ANTHROPIC_API_KEY='old‮key'\n"
+            "OPENCLAW_DEFAULT_MODEL='claude-opus'\n"
+        ),
+    )
+
+    result = runner.invoke(
+        app, ["agent", "sync", "wise-hypatia", "--dry-run", "--diff"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "‮" not in result.output
+
+
+def test_diff_text_does_not_invoke_real_sync(fleet_dir, monkeypatch) -> None:
+    """ATX iter-1 W9 — dry-run invariant: sync_agent must not be called."""
+    _patch_render(monkeypatch)
+    _patch_reader(monkeypatch, body=_RENDERED.files[".openclaw/.env"])
+
+    from clawrium.cli.clawctl.agent import sync as sync_mod
+
+    called = {"yes": False}
+
+    def _boom(**kwargs):
+        called["yes"] = True
+        raise AssertionError("sync_agent must not run under --diff")
+
+    monkeypatch.setattr(sync_mod, "sync_agent", _boom)
+
+    result = runner.invoke(app, ["agent", "sync", "wise-hypatia", "--diff"])
+    assert result.exit_code == 0, result.output
+    assert called["yes"] is False
+
+
+def test_diff_uncaught_render_exception_does_not_crash(fleet_dir, monkeypatch) -> None:
+    """ATX iter-1 W4 — non-AgentConfigError must still be handled."""
+    from clawrium.cli.clawctl.agent import sync as sync_mod
+    from clawrium.core import render as render_mod
+
+    monkeypatch.setattr(sync_mod, "_RENDERERS", {"openclaw": "render_openclaw"})
+
+    def _raise(name):
+        raise KeyError("missing 'providers' key in hosts.json")
+
+    monkeypatch.setattr(render_mod, "build_render_inputs", _raise)
+
+    result = runner.invoke(
+        app, ["agent", "sync", "wise-hypatia", "--dry-run", "--diff"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "diff error" in result.output
+    assert "KeyError" in result.output
 
 
 def test_diff_render_error_surfaces_cleanly(fleet_dir, monkeypatch) -> None:

--- a/tests/cli/clawctl/agent/test_sync_diff.py
+++ b/tests/cli/clawctl/agent/test_sync_diff.py
@@ -1,0 +1,160 @@
+"""Tests for `clawctl agent sync --dry-run --diff` — F8 of parent #555.
+
+The diff path is wired through `core/render_diff.py` which talks to
+paramiko; tests patch the renderer and inject a fake remote reader so
+no SSH connection is opened.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+from clawrium.core.render import (
+    ProviderInputs,
+    RenderInputs,
+    RenderedFiles,
+)
+
+
+runner = CliRunner()
+
+
+_INPUTS = RenderInputs(
+    agent_name="wise-hypatia",
+    agent_type="openclaw",
+    provider=ProviderInputs(
+        name="anthropic-primary",
+        type="anthropic",
+        default_model="claude-opus",
+        api_key="sk-xxx",
+    ),
+)
+_RENDERED = RenderedFiles(
+    files={
+        ".openclaw/.env": "ANTHROPIC_API_KEY='sk-xxx'\nOPENCLAW_DEFAULT_MODEL='claude-opus'\n",
+    }
+)
+
+
+def _patch_render(monkeypatch) -> None:
+    from clawrium.cli.clawctl.agent import sync as sync_mod
+    from clawrium.core import render as render_mod
+
+    monkeypatch.setattr(sync_mod, "_RENDERERS", {"openclaw": "render_openclaw"})
+    monkeypatch.setattr(render_mod, "render_openclaw", lambda inputs: _RENDERED)
+    # build_render_inputs is imported inside _emit_diff via deferred
+    # import; patch the source module so the import resolves to our stub.
+    monkeypatch.setattr(render_mod, "build_render_inputs", lambda name: _INPUTS)
+
+
+def _patch_reader(monkeypatch, body: str, present: bool = True) -> None:
+    """Replace `diff_files`'s `reader` default by patching the helper."""
+    from clawrium.core import render_diff
+
+    def fake_reader(**kwargs):
+        return present, body
+
+    # Patch the SSH key lookup so diff_files doesn't refuse early.
+    monkeypatch.setattr(render_diff, "get_host_private_key", lambda key_id: Path("/dev/null"))
+    monkeypatch.setattr(render_diff, "read_remote_file", fake_reader)
+
+
+def test_diff_implies_dry_run(fleet_dir, monkeypatch) -> None:
+    _patch_render(monkeypatch)
+    _patch_reader(monkeypatch, body=_RENDERED.files[".openclaw/.env"])
+
+    # No --dry-run flag: --diff must imply it (no host write).
+    result = runner.invoke(app, ["agent", "sync", "wise-hypatia", "--diff"])
+    assert result.exit_code == 0, result.output
+    assert "dry-run complete" in result.output
+
+
+def test_diff_no_changes_reports_no_changes(fleet_dir, monkeypatch) -> None:
+    _patch_render(monkeypatch)
+    # Remote == rendered → empty unified diff.
+    _patch_reader(monkeypatch, body=_RENDERED.files[".openclaw/.env"])
+
+    result = runner.invoke(
+        app, ["agent", "sync", "wise-hypatia", "--dry-run", "--diff"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "diff .openclaw/.env: no changes" in result.output
+
+
+def test_diff_would_change_emits_unified_patch(fleet_dir, monkeypatch) -> None:
+    _patch_render(monkeypatch)
+    _patch_reader(
+        monkeypatch,
+        body="ANTHROPIC_API_KEY='old-key'\nOPENCLAW_DEFAULT_MODEL='claude-opus'\n",
+    )
+
+    result = runner.invoke(
+        app, ["agent", "sync", "wise-hypatia", "--dry-run", "--diff"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "would change" in result.output
+    # Unified diff markers must appear verbatim.
+    assert "--- host:/home/wise-hypatia/.openclaw/.env" in result.output
+    assert "+++ rendered:.openclaw/.env" in result.output
+    assert "-ANTHROPIC_API_KEY='old-key'" in result.output
+    assert "+ANTHROPIC_API_KEY='sk-xxx'" in result.output
+
+
+def test_diff_would_create_when_remote_missing(fleet_dir, monkeypatch) -> None:
+    _patch_render(monkeypatch)
+    _patch_reader(monkeypatch, body="", present=False)
+
+    result = runner.invoke(
+        app, ["agent", "sync", "wise-hypatia", "--dry-run", "--diff"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "would create" in result.output
+
+
+def test_diff_json_output(fleet_dir, monkeypatch) -> None:
+    _patch_render(monkeypatch)
+    _patch_reader(
+        monkeypatch,
+        body="ANTHROPIC_API_KEY='old-key'\nOPENCLAW_DEFAULT_MODEL='claude-opus'\n",
+    )
+
+    result = runner.invoke(
+        app,
+        ["agent", "sync", "wise-hypatia", "--dry-run", "--diff", "-o", "json"],
+    )
+    assert result.exit_code == 0, result.output
+    events = [json.loads(line) for line in result.output.strip().splitlines() if line]
+    diff_events = [e for e in events if e.get("phase") == "diff"]
+    assert diff_events, "expected at least one diff event"
+    assert any(e["state"] == "result" for e in diff_events)
+    result_event = next(e for e in diff_events if e["state"] == "result")
+    assert result_event["path"] == ".openclaw/.env"
+    assert result_event["changed"] is True
+    assert result_event["remote_present"] is True
+    assert "ANTHROPIC_API_KEY" in result_event["diff"]
+
+
+def test_diff_render_error_surfaces_cleanly(fleet_dir, monkeypatch) -> None:
+    from clawrium.cli.clawctl.agent import sync as sync_mod
+    from clawrium.core import render as render_mod
+    from clawrium.core.render import AgentConfigError
+
+    monkeypatch.setattr(sync_mod, "_RENDERERS", {"openclaw": "render_openclaw"})
+
+    def _raise(name: str):
+        raise AgentConfigError("provider 'foo' not registered")
+
+    monkeypatch.setattr(render_mod, "build_render_inputs", _raise)
+
+    result = runner.invoke(
+        app, ["agent", "sync", "wise-hypatia", "--dry-run", "--diff"]
+    )
+    # Diagnostic must not crash the session; sync still exits 0 in
+    # dry-run mode, the failure surfaces as a diff-error line.
+    assert result.exit_code == 0, result.output
+    assert "diff error" in result.output
+    assert "provider 'foo'" in result.output

--- a/tests/core/test_render_diff.py
+++ b/tests/core/test_render_diff.py
@@ -1,0 +1,133 @@
+"""Direct unit coverage for `core/render_diff.py` (ATX iter-1 B3).
+
+`tests/cli/clawctl/agent/test_sync_diff.py` covers the CLI integration;
+this file pins the data-layer contracts: path construction across OS
+families, the missing-SSH-key failure mode, empty-bundle behavior,
+and multi-file iteration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clawrium.core.render_diff import (
+    FileDiff,
+    RemoteReadError,
+    diff_files,
+    remote_path_for,
+)
+
+
+def test_remote_path_for_linux() -> None:
+    assert remote_path_for("linux", "alice", ".hermes/.env") == "/home/alice/.hermes/.env"
+
+
+def test_remote_path_for_darwin() -> None:
+    assert remote_path_for("darwin", "alice", ".hermes/.env") == "/Users/alice/.hermes/.env"
+
+
+def test_remote_path_for_defaults_to_linux_when_os_family_blank() -> None:
+    assert remote_path_for("", "alice", ".hermes/.env") == "/home/alice/.hermes/.env"
+
+
+def test_remote_path_for_strips_leading_slash_on_relative_input() -> None:
+    """A registry-supplied path like `/relative/from/home` must not
+    produce `/home/alice//relative/...` or escape the home root."""
+    assert (
+        remote_path_for("linux", "alice", "/sub/path/file")
+        == "/home/alice/sub/path/file"
+    )
+
+
+def test_diff_files_missing_ssh_key_raises(monkeypatch) -> None:
+    from clawrium.core import render_diff
+
+    monkeypatch.setattr(render_diff, "get_host_private_key", lambda k: None)
+    host = {"key_id": "10.0.0.1", "hostname": "10.0.0.1"}
+    with pytest.raises(RuntimeError, match="no SSH key"):
+        diff_files(host=host, agent_name="alice", rendered_files={".env": "x"})
+
+
+def test_diff_files_empty_rendered_returns_empty(monkeypatch) -> None:
+    from clawrium.core import render_diff
+
+    monkeypatch.setattr(render_diff, "get_host_private_key", lambda k: Path("/dev/null"))
+    out = diff_files(
+        host={"key_id": "h", "hostname": "h"},
+        agent_name="alice",
+        rendered_files={},
+    )
+    assert out == []
+
+
+def test_diff_files_two_file_bundle_iterates_both(monkeypatch) -> None:
+    from clawrium.core import render_diff
+
+    monkeypatch.setattr(render_diff, "get_host_private_key", lambda k: Path("/dev/null"))
+
+    calls: list[str] = []
+
+    def fake_reader(**kwargs):
+        calls.append(kwargs["remote_path"])
+        return True, "remote-body\n"
+
+    out = diff_files(
+        host={
+            "key_id": "h",
+            "hostname": "h",
+            "os_family": "linux",
+            "user": "xclm",
+            "port": 22,
+        },
+        agent_name="alice",
+        rendered_files={
+            ".hermes/.env": "remote-body\n",  # identical → no diff
+            ".hermes/config.yaml": "rendered\n",  # differs → diff
+        },
+        reader=fake_reader,
+    )
+    assert calls == [
+        "/home/alice/.hermes/.env",
+        "/home/alice/.hermes/config.yaml",
+    ]
+    assert len(out) == 2
+    assert out[0].unified_diff == ""
+    assert "rendered" in out[1].unified_diff
+
+
+def test_diff_files_propagates_remote_read_error(monkeypatch) -> None:
+    """ATX iter-1 B4: sudo-fail must not silently masquerade as missing."""
+    from clawrium.core import render_diff
+
+    monkeypatch.setattr(render_diff, "get_host_private_key", lambda k: Path("/dev/null"))
+
+    def fake_reader(**kwargs):
+        raise RemoteReadError("sudo -n unavailable on h")
+
+    with pytest.raises(RemoteReadError, match="sudo"):
+        diff_files(
+            host={"key_id": "h", "hostname": "h"},
+            agent_name="alice",
+            rendered_files={".env": "x"},
+            reader=fake_reader,
+        )
+
+
+def test_file_diff_repr_hides_secret_bodies() -> None:
+    """ATX iter-1 W5: repr() must not leak plaintext secrets."""
+    d = FileDiff(
+        path=".env",
+        remote_path="/home/x/.env",
+        remote_present=True,
+        remote_body="OPENROUTER_API_KEY=plain-secret",
+        rendered_body="OPENROUTER_API_KEY=new-secret",
+        unified_diff="-OPENROUTER_API_KEY=plain-secret\n+OPENROUTER_API_KEY=new-secret\n",
+    )
+    rep = repr(d)
+    assert "plain-secret" not in rep
+    assert "new-secret" not in rep
+    # Non-secret structural fields must still appear.
+    assert ".env" in rep
+    assert "remote_present=True" in rep

--- a/tests/core/test_render_diff.py
+++ b/tests/core/test_render_diff.py
@@ -115,6 +115,155 @@ def test_diff_files_propagates_remote_read_error(monkeypatch) -> None:
         )
 
 
+class _FakeChannel:
+    def __init__(self, exit_status: int) -> None:
+        self._exit = exit_status
+
+    def recv_exit_status(self) -> int:
+        return self._exit
+
+
+class _FakeStream:
+    def __init__(self, body: bytes, exit_status: int) -> None:
+        self._body = body
+        self.channel = _FakeChannel(exit_status)
+
+    def read(self) -> bytes:
+        return self._body
+
+
+class _FakeSSHClient:
+    """Minimal paramiko stand-in for `read_remote_file` tests.
+
+    Each test configures `_responses` as a list of `(stdout_body,
+    stderr_body, exit_status)` triples returned in order by
+    `exec_command`. Matches the production code's two-call probe.
+    """
+
+    def __init__(self, responses: list[tuple[bytes, bytes, int]]) -> None:
+        self._responses = responses
+        self._idx = 0
+        self.connect_kwargs: dict | None = None
+
+    def load_system_host_keys(self) -> None:
+        pass
+
+    def set_missing_host_key_policy(self, *_a, **_kw) -> None:
+        pass
+
+    def connect(self, **kwargs) -> None:
+        self.connect_kwargs = kwargs
+
+    def exec_command(self, cmd, timeout=None):
+        body, err, code = self._responses[self._idx]
+        self._idx += 1
+        return None, _FakeStream(body, code), _FakeStream(err, code)
+
+    def close(self) -> None:
+        pass
+
+
+def test_read_remote_file_missing_returns_false_empty(monkeypatch) -> None:
+    """File absent: `test -e` exits 1 with no stderr → `(False, '')`."""
+    from clawrium.core import render_diff
+
+    fake = _FakeSSHClient(responses=[(b"", b"", 1)])
+    monkeypatch.setattr(render_diff.paramiko, "SSHClient", lambda: fake)
+
+    present, body = render_diff.read_remote_file(
+        hostname="h",
+        port=22,
+        user="xclm",
+        key_filename="/dev/null",
+        remote_path="/home/x/.env",
+    )
+    assert present is False
+    assert body == ""
+
+
+def test_read_remote_file_password_sudo_raises(monkeypatch) -> None:
+    """ATX iter-1 B4 — sudo password prompt surfaces as RemoteReadError."""
+    from clawrium.core import render_diff
+
+    stderr = b"sudo: a password is required\n"
+    fake = _FakeSSHClient(responses=[(b"", stderr, 1)])
+    monkeypatch.setattr(render_diff.paramiko, "SSHClient", lambda: fake)
+
+    with pytest.raises(render_diff.RemoteReadError, match="sudo -n unavailable"):
+        render_diff.read_remote_file(
+            hostname="h",
+            port=22,
+            user="xclm",
+            key_filename="/dev/null",
+            remote_path="/home/x/.env",
+        )
+
+
+def test_read_remote_file_non_password_sudo_failure_raises(monkeypatch) -> None:
+    """ATX iter-2 W14 — non-password sudo refusals (NOPASSWD missing,
+    no-tty, locale-translated) must also raise, not silently return
+    '(False, '')'. Anchoring on 'password' was the iter-1 gap."""
+    from clawrium.core import render_diff
+
+    stderr = b"Sorry, user xclm is not allowed to execute '/bin/cat /home/x/.env' as root\n"
+    fake = _FakeSSHClient(responses=[(b"", stderr, 1)])
+    monkeypatch.setattr(render_diff.paramiko, "SSHClient", lambda: fake)
+
+    with pytest.raises(render_diff.RemoteReadError, match="not allowed"):
+        render_diff.read_remote_file(
+            hostname="h",
+            port=22,
+            user="xclm",
+            key_filename="/dev/null",
+            remote_path="/home/x/.env",
+        )
+
+
+def test_read_remote_file_present_returns_body(monkeypatch) -> None:
+    """File present: probe exits 0 → second `cat` call returns body."""
+    from clawrium.core import render_diff
+
+    fake = _FakeSSHClient(
+        responses=[
+            (b"", b"", 0),  # test -e
+            (b"hello\n", b"", 0),  # cat
+        ]
+    )
+    monkeypatch.setattr(render_diff.paramiko, "SSHClient", lambda: fake)
+
+    present, body = render_diff.read_remote_file(
+        hostname="h",
+        port=22,
+        user="xclm",
+        key_filename="/dev/null",
+        remote_path="/home/x/.env",
+    )
+    assert present is True
+    assert body == "hello\n"
+
+
+def test_read_remote_file_cat_exit_nonzero_raises(monkeypatch) -> None:
+    """`test -e` succeeds but `cat` fails (e.g. permission flip mid-read)."""
+    from clawrium.core import render_diff
+
+    fake = _FakeSSHClient(
+        responses=[
+            (b"", b"", 0),
+            (b"", b"cat: permission denied\n", 13),
+        ]
+    )
+    monkeypatch.setattr(render_diff.paramiko, "SSHClient", lambda: fake)
+
+    with pytest.raises(render_diff.RemoteReadError, match="sudo cat"):
+        render_diff.read_remote_file(
+            hostname="h",
+            port=22,
+            user="xclm",
+            key_filename="/dev/null",
+            remote_path="/home/x/.env",
+        )
+
+
 def test_file_diff_repr_hides_secret_bodies() -> None:
     """ATX iter-1 W5: repr() must not leak plaintext secrets."""
     d = FileDiff(

--- a/tests/fixtures/audit_2026_05_29.json
+++ b/tests/fixtures/audit_2026_05_29.json
@@ -1,0 +1,89 @@
+{
+  "_meta": {
+    "source": "github issue #555 live audit table (2026-05-29)",
+    "purpose": "Reference baseline for `clawctl agent doctor` per #555 F4. Each row captures the expected doctor verdict ('ok' or 'broken') for an agent whose underlying records match the shape described in the audit. Used by tests/cli/clawctl/agent/test_doctor_audit.py to assert the doctor's broken-vs-ok classification stays stable as build_render_inputs evolves.",
+    "shape_legend": {
+      "config_provider_null": "hosts.json.agents.<name>.config.provider is null (the wipe shape from #555)",
+      "old_openclaw_channels": "hosts.json.agents.<name>.config.channels still holds the legacy allowFrom/groupPolicy/guilds dict",
+      "new_attachment_lists": "agent.channels[] / agent.integrations[] populated via the new `agent channel attach` flow"
+    }
+  },
+  "agents": [
+    {
+      "name": "wolf-i",
+      "type": "openclaw",
+      "provider_type": "bedrock",
+      "shape": ["old_openclaw_channels", "new_attachment_lists"],
+      "expected_status": "broken",
+      "expected_error_contains": "channel",
+      "notes": "Drift bomb: both old (config.channels) and new (agent.channels[]) populated. F5 migration must consolidate before doctor can return ok."
+    },
+    {
+      "name": "clawrium-d01",
+      "type": "zeroclaw",
+      "provider_type": "openrouter",
+      "shape": ["new_attachment_lists"],
+      "expected_status": "ok",
+      "notes": "Reference baseline — only audited agent currently in the canonical shape."
+    },
+    {
+      "name": "espresso",
+      "type": "hermes",
+      "provider_type": "ollama",
+      "shape": [],
+      "expected_status": "ok",
+      "notes": "OK today; silently breaks on first channel/integration attach under the old conditional render path. doctor must still return ok against the new pipeline."
+    },
+    {
+      "name": "nemotron-alpha",
+      "type": "zeroclaw",
+      "provider_type": "ollama",
+      "shape": [],
+      "expected_status": "ok"
+    },
+    {
+      "name": "nemotron-beta",
+      "type": "zeroclaw",
+      "provider_type": "ollama",
+      "shape": [],
+      "expected_status": "ok"
+    },
+    {
+      "name": "clawctl-demo",
+      "type": "hermes",
+      "provider_type": "openrouter",
+      "shape": [],
+      "expected_status": "ok"
+    },
+    {
+      "name": "h1",
+      "type": "hermes",
+      "provider_type": "openrouter",
+      "shape": [],
+      "expected_status": "ok"
+    },
+    {
+      "name": "h2",
+      "type": "hermes",
+      "provider_type": "bedrock",
+      "shape": [],
+      "expected_status": "ok"
+    },
+    {
+      "name": "clawctl-mac-demo",
+      "type": "hermes",
+      "provider_type": "openrouter",
+      "shape": [],
+      "expected_status": "ok"
+    },
+    {
+      "name": "maurice",
+      "type": "hermes",
+      "provider_type": null,
+      "shape": ["config_provider_null"],
+      "expected_status": "broken",
+      "expected_error_contains": "provider",
+      "notes": "Fully wiped; only onboarding.providers.provider_id (clawrium-glm51) survived. doctor must surface a provider-missing error so the operator knows to run F5 migration."
+    }
+  ]
+}

--- a/tests/integration/test_render_matrix.py
+++ b/tests/integration/test_render_matrix.py
@@ -1,0 +1,542 @@
+"""F6 render-matrix test (parent #555, subtask D / issue #559).
+
+Exercises the 15-cell parity matrix from the #555 plan against the
+canonical render pipeline:
+
+    build_render_inputs  →  render_<atype>  →  assert env-key invariants
+
+Per the parent plan, the merge gate is that every cell renders cleanly
+and produces the expected env vars / config.toml sections.
+
+## Gating
+
+These tests are marked `@pytest.mark.container` because the parent
+plan calls for them to run against a disposable container host
+(catching silent-wipes that mock-based tests missed because the mocks
+shared the same conditional-emit assumption as production).
+
+A real container path requires Docker / Podman + a provisioned `xclm`
+user + the canonical sync writing to it via SSH. That infrastructure
+is tracked as a follow-up; this file lands the matrix scaffolding with
+the render-output invariants asserted in-process so a regression to
+conditional-emit in `render_<atype>` is still caught.
+
+When `CLAWRIUM_TEST_CONTAINER_HOST` is set, an additional per-cell
+`test_canonical_sync_against_container` parametrization runs the full
+`sync_agent_canonical` pipeline against that host. Without the env
+var, only the in-process render assertions run.
+
+Run:
+    pytest -m container tests/integration/test_render_matrix.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+pytestmark = pytest.mark.container
+
+
+# ---------------------------------------------------------------------------
+# Stores fixture (mirror of tests/core/test_render.py — duplicated rather
+# than imported because pytest fixtures in tests/ aren't auto-exported and
+# the matrix file is intentionally self-contained).
+# ---------------------------------------------------------------------------
+
+
+class _Stores:
+    def __init__(self) -> None:
+        self.agent = None
+        self.providers: dict[str, dict] = {}
+        self.provider_api_keys: dict[str, str] = {}
+        self.provider_aws: dict[str, tuple[str, str]] = {}
+        self.channels: dict[str, dict] = {}
+        self.channel_tokens: dict[tuple[str, str], str] = {}
+        self.integrations: dict[str, dict] = {}
+        self.integration_creds: dict[str, dict[str, str]] = {}
+        self.agent_channels: list[str] = []
+        self.agent_integrations: list[str] = []
+
+
+@pytest.fixture
+def stores(monkeypatch) -> _Stores:
+    s = _Stores()
+
+    monkeypatch.setattr("clawrium.core.hosts.get_agent_by_name", lambda n: s.agent)
+    monkeypatch.setattr(
+        "clawrium.core.providers.get_provider", lambda n: s.providers.get(n)
+    )
+    monkeypatch.setattr(
+        "clawrium.core.providers.get_provider_api_key",
+        lambda n: s.provider_api_keys.get(n),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.providers.get_provider_aws_credentials",
+        lambda n: s.provider_aws.get(n, (None, None)),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.channels.get_agent_channels",
+        lambda h, k: list(s.agent_channels),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.channels.get_channel", lambda n: s.channels.get(n)
+    )
+    monkeypatch.setattr(
+        "clawrium.core.channels.get_channel_token",
+        lambda n, key="BOT_TOKEN": s.channel_tokens.get((n, key)),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.integrations.get_agent_integrations",
+        lambda h, k: list(s.agent_integrations),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.integrations.get_integration",
+        lambda n: s.integrations.get(n),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.integrations.get_integration_credentials",
+        lambda n: dict(s.integration_creds.get(n, {})),
+    )
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Cell definitions (15 rows from #555 plan)
+# ---------------------------------------------------------------------------
+
+
+def _agent(agent_type: str, providers: list, *, config: dict | None = None):
+    return (
+        {"hostname": "host-1"},
+        agent_type,
+        {
+            "agent_name": "alpha",
+            "providers": providers,
+            "config": config or {},
+        },
+    )
+
+
+def _hermes_config():
+    # hermes renderer requires api_server config to emit a complete .env.
+    # The values are arbitrary; what matters is that the block resolves.
+    return {
+        "api_server": {"host": "127.0.0.1", "port": 8000, "key": "hermes-key"},
+    }
+
+
+def _zeroclaw_config():
+    return {
+        "gateway": {
+            "host": "127.0.0.1",
+            "port": 40000,
+            "auth": "bearer-token-here",
+            "bind": "wildcard",
+            "allow_public_bind": True,
+        }
+    }
+
+
+# Each cell describes: (cell_id, agent_type, setup_fn, expected_env_keys)
+# setup_fn(stores) populates the in-memory stores; expected_env_keys is a
+# list of substrings that MUST appear in the rendered `.env` (or other
+# file, where indicated by `file:` prefix). Absence of any expected key
+# is a silent-wipe regression — the exact class of bug #555 documents.
+
+
+def _setup_hermes_openrouter(s: _Stores) -> None:
+    s.agent = _agent(
+        "hermes",
+        [{"name": "or", "role": "primary", "model": "x-large"}],
+        config=_hermes_config(),
+    )
+    s.providers["or"] = {
+        "name": "or",
+        "type": "openrouter",
+        "default_model": "x-large",
+    }
+    s.provider_api_keys["or"] = "sk-or-XXXX"
+
+
+def _setup_hermes_openrouter_discord(s: _Stores) -> None:
+    _setup_hermes_openrouter(s)
+    s.agent_channels = ["disc"]
+    s.channels["disc"] = {
+        "name": "disc",
+        "type": "discord",
+        "config": {"allowed_users": ["111"], "require_mention": True},
+    }
+    s.channel_tokens[("disc", "BOT_TOKEN")] = "discord-bot-XXXX"
+
+
+def _setup_hermes_openrouter_discord_slack_github(s: _Stores) -> None:
+    _setup_hermes_openrouter_discord(s)
+    s.agent_channels = ["disc", "slk"]
+    s.channels["slk"] = {
+        "name": "slk",
+        "type": "slack",
+        "config": {"allowed_users": ["U1"]},
+    }
+    s.channel_tokens[("slk", "BOT_TOKEN")] = "xoxb-slack-XXXX"
+    s.channel_tokens[("slk", "APP_TOKEN")] = "xapp-slack-XXXX"
+    s.agent_integrations = ["gh"]
+    s.integrations["gh"] = {"name": "gh", "type": "github"}
+    s.integration_creds["gh"] = {"GITHUB_TOKEN": "ghp_XXXX"}
+
+
+def _setup_hermes_bedrock(s: _Stores) -> None:
+    s.agent = _agent(
+        "hermes",
+        [{"name": "br", "role": "primary", "model": "claude-sonnet"}],
+        config=_hermes_config(),
+    )
+    s.providers["br"] = {
+        "name": "br",
+        "type": "bedrock",
+        "default_model": "claude-sonnet",
+        "region": "us-west-2",
+    }
+    s.provider_aws["br"] = ("AKIA-XXXX", "AWS-SECRET-XXXX")
+
+
+def _setup_hermes_bedrock_discord_gh_atl(s: _Stores) -> None:
+    _setup_hermes_bedrock(s)
+    s.agent_channels = ["disc"]
+    s.channels["disc"] = {
+        "name": "disc",
+        "type": "discord",
+        "config": {"allowed_users": ["111"]},
+    }
+    s.channel_tokens[("disc", "BOT_TOKEN")] = "discord-bot-XXXX"
+    s.agent_integrations = ["gh", "atl"]
+    s.integrations["gh"] = {"name": "gh", "type": "github"}
+    s.integration_creds["gh"] = {"GITHUB_TOKEN": "ghp_XXXX"}
+    s.integrations["atl"] = {"name": "atl", "type": "atlassian"}
+    s.integration_creds["atl"] = {
+        "ATLASSIAN_API_TOKEN": "atl-XXXX",
+        "ATLASSIAN_EMAIL": "user@example.com",
+        "ATLASSIAN_URL": "https://example.atlassian.net",
+    }
+
+
+def _setup_hermes_anthropic(s: _Stores) -> None:
+    s.agent = _agent(
+        "hermes",
+        [{"name": "an", "role": "primary", "model": "claude-3"}],
+        config=_hermes_config(),
+    )
+    s.providers["an"] = {
+        "name": "an",
+        "type": "anthropic",
+        "default_model": "claude-3",
+    }
+    s.provider_api_keys["an"] = "sk-ant-XXXX"
+
+
+def _setup_hermes_openai(s: _Stores) -> None:
+    s.agent = _agent(
+        "hermes",
+        [{"name": "oa", "role": "primary", "model": "gpt-4"}],
+        config=_hermes_config(),
+    )
+    s.providers["oa"] = {
+        "name": "oa",
+        "type": "openai",
+        "default_model": "gpt-4",
+    }
+    s.provider_api_keys["oa"] = "sk-oa-XXXX"
+
+
+def _setup_hermes_ollama(s: _Stores) -> None:
+    s.agent = _agent(
+        "hermes",
+        [{"name": "ol", "role": "primary", "model": "llama3"}],
+        config=_hermes_config(),
+    )
+    s.providers["ol"] = {
+        "name": "ol",
+        "type": "ollama",
+        "endpoint": "http://localhost:11434",
+        "default_model": "llama3",
+    }
+
+
+def _setup_zeroclaw_openrouter_discord_gh(s: _Stores) -> None:
+    s.agent = _agent(
+        "zeroclaw",
+        [{"name": "or", "role": "primary", "model": "x-large"}],
+        config=_zeroclaw_config(),
+    )
+    s.providers["or"] = {
+        "name": "or",
+        "type": "openrouter",
+        "default_model": "x-large",
+    }
+    s.provider_api_keys["or"] = "sk-or-XXXX"
+    s.agent_channels = ["disc"]
+    s.channels["disc"] = {
+        "name": "disc",
+        "type": "discord",
+        "config": {"allowed_users": ["111"]},
+    }
+    s.channel_tokens[("disc", "BOT_TOKEN")] = "discord-bot-XXXX"
+    s.agent_integrations = ["gh"]
+    s.integrations["gh"] = {"name": "gh", "type": "github"}
+    s.integration_creds["gh"] = {"GITHUB_TOKEN": "ghp_XXXX"}
+
+
+def _setup_zeroclaw_ollama(s: _Stores) -> None:
+    s.agent = _agent(
+        "zeroclaw",
+        [{"name": "ol", "role": "primary", "model": "llama3"}],
+        config=_zeroclaw_config(),
+    )
+    s.providers["ol"] = {
+        "name": "ol",
+        "type": "ollama",
+        "endpoint": "http://localhost:11434",
+        "default_model": "llama3",
+    }
+
+
+def _setup_openclaw_bedrock_discord(s: _Stores) -> None:
+    s.agent = _agent(
+        "openclaw",
+        [{"name": "br", "role": "primary", "model": "claude-sonnet"}],
+    )
+    s.providers["br"] = {
+        "name": "br",
+        "type": "bedrock",
+        "default_model": "claude-sonnet",
+        "region": "us-west-2",
+    }
+    s.provider_aws["br"] = ("AKIA-XXXX", "AWS-SECRET-XXXX")
+    s.agent_channels = ["disc"]
+    s.channels["disc"] = {
+        "name": "disc",
+        "type": "discord",
+        "config": {"allowed_users": ["111"]},
+    }
+    s.channel_tokens[("disc", "BOT_TOKEN")] = "discord-bot-XXXX"
+
+
+# Cells modelled on the #555 plan table. `expected_keys` lists every env
+# var that MUST appear in the rendered `.env` body. Each one corresponds
+# to a column in the plan's matrix; missing it is the silent-wipe
+# regression we're guarding against.
+MATRIX_CELLS: list[tuple] = [
+    (
+        "hermes_openrouter_bare",
+        "hermes",
+        _setup_hermes_openrouter,
+        ["OPENROUTER_API_KEY", "HERMES_INFERENCE_PROVIDER"],
+    ),
+    (
+        "hermes_openrouter_discord",
+        "hermes",
+        _setup_hermes_openrouter_discord,
+        ["OPENROUTER_API_KEY", "DISCORD_BOT_TOKEN", "DISCORD_ALLOWED_USERS"],
+    ),
+    (
+        "hermes_openrouter_discord_slack_github",
+        "hermes",
+        _setup_hermes_openrouter_discord_slack_github,
+        [
+            "OPENROUTER_API_KEY",
+            "DISCORD_BOT_TOKEN",
+            "SLACK_BOT_TOKEN",
+            "SLACK_APP_TOKEN",
+            "GITHUB_TOKEN",
+        ],
+    ),
+    (
+        "hermes_bedrock_bare",
+        "hermes",
+        _setup_hermes_bedrock,
+        [
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_DEFAULT_REGION",
+            "HERMES_INFERENCE_PROVIDER",
+        ],
+    ),
+    (
+        "hermes_bedrock_discord_gh_atl",
+        "hermes",
+        _setup_hermes_bedrock_discord_gh_atl,
+        [
+            "AWS_ACCESS_KEY_ID",
+            "DISCORD_BOT_TOKEN",
+            "GITHUB_TOKEN",
+            # Atlassian creds render under MCP server env as
+            # JIRA_API_TOKEN / CONFLUENCE_API_TOKEN, not as a single
+            # ATLASSIAN_API_TOKEN env var. The substring check pins the
+            # JIRA token specifically because that's the canonical
+            # write that the maurice silent-wipe destroyed.
+            "JIRA_API_TOKEN",
+        ],
+    ),
+    (
+        "hermes_anthropic_bare",
+        "hermes",
+        _setup_hermes_anthropic,
+        ["ANTHROPIC_API_KEY"],
+    ),
+    (
+        "hermes_openai_bare",
+        "hermes",
+        _setup_hermes_openai,
+        ["OPENAI_API_KEY"],
+    ),
+    (
+        "hermes_ollama_bare",
+        "hermes",
+        _setup_hermes_ollama,
+        ["HERMES_INFERENCE_PROVIDER"],
+    ),
+    (
+        "zeroclaw_openrouter_discord_gh",
+        "zeroclaw",
+        _setup_zeroclaw_openrouter_discord_gh,
+        # zeroclaw emits provider api_key into config.toml as a quoted
+        # value (`api_key = "..."`), not as a bare ENV-style key. The
+        # substring assertion below catches both the discord bot_token
+        # and the GitHub integration secret while skipping
+        # OPENROUTER_API_KEY (which would only ever appear if zeroclaw
+        # ever started emitting bare env-style provider keys — that
+        # would be a render-shape change worth a separate test cell).
+        ["sk-or-XXXX", "discord-bot-XXXX", "GITHUB_TOKEN"],
+    ),
+    (
+        "zeroclaw_ollama_bare",
+        "zeroclaw",
+        _setup_zeroclaw_ollama,
+        [],  # ollama has no bearer; provider info goes in config.toml.
+    ),
+    (
+        "openclaw_bedrock_discord",
+        "openclaw",
+        _setup_openclaw_bedrock_discord,
+        ["AWS_ACCESS_KEY_ID", "DISCORD_BOT_TOKEN"],
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Per-cell render assertions (run in-process; always)
+# ---------------------------------------------------------------------------
+
+
+_RENDERERS = {
+    "hermes": "render_hermes",
+    "zeroclaw": "render_zeroclaw",
+    "openclaw": "render_openclaw",
+}
+
+
+@pytest.mark.parametrize(
+    "cell_id,agent_type,setup_fn,expected_keys",
+    MATRIX_CELLS,
+    ids=[c[0] for c in MATRIX_CELLS],
+)
+def test_render_matrix_cell(cell_id, agent_type, setup_fn, expected_keys, stores):
+    """Each cell: build_render_inputs + render → expected env keys present."""
+    from clawrium.core import render as render_mod
+    from clawrium.core.render import build_render_inputs
+
+    setup_fn(stores)
+
+    inputs = build_render_inputs("alpha")
+    renderer = getattr(render_mod, _RENDERERS[agent_type])
+    rendered = renderer(inputs)
+
+    # Concatenate all rendered file bodies — keys may appear in `.env`
+    # or `config.toml` / `config.yaml` depending on agent type.
+    blob = "\n".join(rendered.files.values())
+    for key in expected_keys:
+        assert key in blob, (
+            f"cell {cell_id}: expected key {key!r} missing from rendered output. "
+            f"Files: {list(rendered.files.keys())}. "
+            f"This is the #555 silent-wipe regression — render emitted "
+            f"a config that omits a declared attachment."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Failure-mode cells (3 from the plan table)
+# ---------------------------------------------------------------------------
+
+
+def test_attached_channel_missing_secret_fails(stores):
+    """Plan row: 'ANY attached but secret missing → sync FAILS clear error'."""
+    from clawrium.core.render import AgentConfigError, build_render_inputs
+
+    _setup_hermes_openrouter(stores)
+    stores.agent_channels = ["disc"]
+    stores.channels["disc"] = {"name": "disc", "type": "discord", "config": {}}
+    # No channel token in stores → must raise.
+
+    with pytest.raises(AgentConfigError, match="missing BOT_TOKEN"):
+        build_render_inputs("alpha")
+
+
+def test_provider_missing_fails(stores):
+    """Plan row: 'provider missing → sync FAILS; on-host file untouched'."""
+    from clawrium.core.render import AgentConfigError, build_render_inputs
+
+    stores.agent = _agent("hermes", [], config=_hermes_config())
+    with pytest.raises(AgentConfigError, match="no provider attached"):
+        build_render_inputs("alpha")
+
+
+def test_render_idempotent(stores):
+    """Plan row: 'sync run twice with no changes → byte-identical output'."""
+    from clawrium.core import render as render_mod
+    from clawrium.core.render import build_render_inputs
+
+    _setup_hermes_openrouter_discord_slack_github(stores)
+
+    rendered_a = render_mod.render_hermes(build_render_inputs("alpha"))
+    rendered_b = render_mod.render_hermes(build_render_inputs("alpha"))
+    assert rendered_a.files == rendered_b.files
+
+
+# ---------------------------------------------------------------------------
+# Optional: full canonical sync against a real container host
+# ---------------------------------------------------------------------------
+
+_CONTAINER_HOST = os.environ.get("CLAWRIUM_TEST_CONTAINER_HOST")
+
+
+@pytest.mark.skipif(
+    not _CONTAINER_HOST,
+    reason="CLAWRIUM_TEST_CONTAINER_HOST not set; skipping live-container path",
+)
+def test_canonical_sync_against_container_smoke():
+    """Smoke: connect to the disposable container host and read a file.
+
+    The full per-cell sync exercise requires container provisioning
+    (xclm user, sudo rules, systemd-in-container or stub units) that
+    isn't in this PR's scope — tracked as follow-up. This smoke test
+    proves the harness wiring works: when the env var IS set, the test
+    must reach the host. If it can't, CI surfaces the misconfig
+    immediately rather than silently passing.
+    """
+    import paramiko
+
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    try:
+        client.connect(
+            hostname=_CONTAINER_HOST,
+            username=os.environ.get("CLAWRIUM_TEST_CONTAINER_USER", "xclm"),
+            timeout=10,
+        )
+        _, stdout, _ = client.exec_command("echo container-ok")
+        out = stdout.read().decode("utf-8").strip()
+        assert out == "container-ok"
+    finally:
+        client.close()


### PR DESCRIPTION
## Why

PRs #562 (F4+F8) and #563 (F3+F6) were merged into their **stacked base
branches** (issue-556-build-render-inputs and issue-557-agent-doctor-dry-run-diff)
rather than into `main`. When #561 was squash-merged into `main`, the commits
on those intermediate branches were orphaned — the squash collapsed A's
history into a single new commit on `main`, and B/D's commits never got
re-targeted.

Net result before this PR: `main` had only F1+F2 (`src/clawrium/core/render.py`).
F4+F8 (`agent doctor`, `sync --dry-run --diff`) and F3+F6 (the actual
silent-wipe fix — `lifecycle_canonical.py` + container render matrix) were
**not in main**. Bug #555 was therefore unfixed despite three "merged" PRs.

## What this PR does

Cherry-picks the four orphaned non-merge commits in chronological order
onto `main`:

| SHA | Original PR | Description |
|---|---|---|
| `4de71fd` | #562 | feat(doctor,sync): F4 doctor + F8 sync --dry-run --diff |
| `ba8bc93` | #562 | fix(doctor,sync): address ATX iter-1 blockers + warnings |
| `216c5a3` | #562 | fix(doctor,sync): address ATX iter-2 B7 + W13 + W14 |
| `421cbea` | #563 | feat(lifecycle): F3+F6 canonical sync pipeline + render matrix |

All four cherry-picked cleanly (only new files + additive changes to
`sync.py` / `agent/__init__.py`; no conflicts with the squashed #561).

## Verification

- `uv run pytest tests/core/test_render.py tests/core/test_render_diff.py tests/cli/clawctl/agent/test_doctor.py tests/cli/clawctl/agent/test_sync_diff.py` → 105 passed in 0.50s.
- F3 wiring confirmed live in the sync path:
  - `src/clawrium/cli/clawctl/agent/sync.py:107` calls `build_render_inputs(agent_name)`.
  - `src/clawrium/cli/clawctl/agent/sync.py:342` imports `lifecycle_canonical`.

## Not in this PR (still pending — subtask E / #560)

- F7 — drop the legacy `config.channels.discord` read path in
  `src/clawrium/core/lifecycle.py:1751`.
- F9 — docs updates for the deprecated `--stage channels` references.
- F10 — CHANGELOG entry naming the regression window.

The legacy `lifecycle.configure_agent` discord/provider conditional branches
are **still present** in main after this PR. They are unreachable from
`clawctl agent sync` (which now uses `lifecycle_canonical`), but may still be
reached from `clawctl agent configure`, `agent restart`, or `agent install`
until F7 lands.

## Callouts

- [DECISION] Single recovery PR via cherry-pick rather than re-opening #562
  and #563 against new bases. GitHub treats their heads as already merged
  so re-opening would require new branches anyway; folding everything into
  one PR makes the recovery atomic and reviewable as a single diff.
  - Reviewer: confirm this approach vs. two-PR recovery is acceptable.
- [UNRESOLVED] Whether `clawctl agent configure` and `clawctl agent restart`
  also go through `lifecycle_canonical` post-#563, or still call the old
  conditional-emit path. F7 (in #560, pending) is intended to consolidate
  this. Until then, any non-sync clawctl op on agents like Maurice may
  still trigger the silent-wipe.
  - Best guess applied: ship the recovery as-is; track residual exposure
    against #560.
  - Reviewer: please verify if I missed wiring.
- [ENVIRONMENT] `recover/555-stacked-orphans` branched from `origin/main`
  (post-#561 squash). Local tests passed; remote CI will validate.

Closes part of #555 (recovers #562 + #563 content; #560 remains open for F7/F9/F10).