### PR TITLE
fix(render): openclaw Jinja env template + openclaw.json baseline (#560)

### DIFF
--- a/.itx/560/01_EXECUTION.md
+++ b/.itx/560/01_EXECUTION.md
@@ -213,3 +213,54 @@ failures unchanged (pre-existing — Phases 1+2 carry the same baseline).
 **PR URL**: https://github.com/ric03uec/clawrium/pull/568 (stacked on
 PR #567 / Phase 2, which is merged into the base branch
 `issue-560-p1-drop-canonical-flag`).
+
+### Phase 3 — Round 3 Follow-up (user-requested "fix blockers")
+
+**Stage**: phase-3-execute-round-3-followup
+**Skill**: /itx:execute (continuation)
+**Timestamp**: 2026-05-29T20:45:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+fix blockers
+```
+
+**Output**: commit `5e0a3ca` addresses the Round 3 ATX blockers that
+had been previously deferred as out-of-scope. The user's explicit
+"fix blockers" instruction reclassified them as in-scope:
+
+- B2 (synthesized baseline schema provenance): expanded
+  `_openclaw_json_baseline` docstring documenting the legacy
+  `openclaw.json.j2` as the schema source of truth, every key path
+  flowing through the baseline, and explicitly anchoring Phase 4's
+  wolf-i live dry-run as the schema verification step.
+- B3 (rich-markup injection in `sync.py`): wrapped `agent_label`
+  interpolation with `rich.markup.escape`. Regression test
+  `test_sync_gateway_token_rotated_escapes_rich_markup_in_agent_key`
+  added against a hostile `[/yellow][bold red]INJECTED[/bold red]`
+  payload.
+- B4 (conditional re-pair violates #437): dropped `files_written`
+  qualifier from both the restart gate (now zeroclaw force-restarts
+  on no-drift) and the re-pair gate (now zeroclaw re-pairs
+  unconditionally on every `restart=True` sync). Honors AGENTS.md
+  §Gateway Token Lifecycle "no idempotent-skip path" invariant.
+  Regression test `test_canonical_sync_repairs_zeroclaw_even_with_no_drift`
+  added.
+- W1 (stale sync.py docstring): corrected to describe current re-pair
+  behavior rather than the pre-#566 gap.
+
+### Round 4 ATX (post-fix)
+
+ATX Round 4 ran but the reviewer ran against the wrong worktree
+(`clawrium-issue-560-p2`, Phase 2 branch) rather than this PR's
+`clawrium-issue-560-p3` worktree. Round 4 findings cross-reference
+against the Phase 2 diff, not Phase 3 — the round-3 in-scope fixes in
+commit `5e0a3ca` were not visible to that reviewer. PR comment
+explaining the confusion + status table:
+https://github.com/ric03uec/clawrium/pull/568#issuecomment-4581542372
+
+**Final state**: 5 commits on PR #568. All in-scope blockers across
+rounds 1-3 addressed with regression tests. 3624 tests pass (+23 net
+new); 45 baseline `tests/test_configure_zeroclaw.py` failures
+unchanged. `make lint` clean. PR ready for human review and Phase 4
+wolf-i live verify.

--- a/.itx/560/01_EXECUTION.md
+++ b/.itx/560/01_EXECUTION.md
@@ -113,3 +113,103 @@ be addressed in the same follow-up that retires the legacy
 **Final test counts**: 86 passed in `tests/core/test_render.py` (was 71 at PR open). `make lint` clean.
 
 **PR URL**: https://github.com/ric03uec/clawrium/pull/567 (stacked on PR #566 / Phase 1).
+
+## Phase 3 — Openclaw Templates
+
+**Stage**: phase-3-execute
+**Skill**: /itx:execute
+**Timestamp**: 2026-05-29T20:30:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+Execute Phase 3 of issue #560 in this worktree.
+
+Scope:
+- src/clawrium/platform/registry/openclaw/templates/.env.j2 audit (do NOT
+  modify — Phase 2 tactical lesson: legacy template consumed by Ansible
+  configure.yaml + install.yaml).
+- src/clawrium/platform/registry/openclaw/templates/openclaw.json (NEW —
+  JSON baseline; synthesized from legacy template defaults since wolf-i
+  is unreachable from execution context).
+- src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2 (do
+  NOT delete — legacy Ansible consumer).
+- Add NEW canonical templates alongside:
+  - openclaw-env.canonical.j2 (Jinja, F3 inputs, byte-equivalent to prior
+    list-of-strings render_openclaw env output).
+  - openclaw.json (real JSON baseline).
+- src/clawrium/core/render.py render_openclaw — refactor:
+  - Env path: importlib.resources + Jinja2 StrictUndefined / trim_blocks /
+    lstrip_blocks / keep_trailing_newline.
+  - JSON path: importlib.resources.read_text → json.loads → deep-update
+    the 5 clawctl-managed paths → json.dumps(indent=2, sort_keys=False).
+  - Validate provider/channel/integration types up-front (mirror hermes/
+    zeroclaw Phase 1+2 patterns); add dual-discord + dual-slack guards.
+
+Constraints:
+- ATX CLI only (/home/devashish/bin/atx). Not MCP.
+- All git commit + push use --no-verify.
+- Do not modify the existing openclaw .env.j2 or openclaw.json.j2.
+- Do not touch Phases 1 or 2 (already merged).
+```
+
+**Output**:
+- PR #568 opened, base `issue-560-p1-drop-canonical-flag` (which already
+  contains Phase 1 + Phase 2 merges via commit `7c3a357`).
+- 4 commits delivered:
+  - `ce2e2a5` — Phase 3 initial: canonical templates added; render_openclaw
+    refactored to importlib.resources + Jinja + JSON deep-update; legacy
+    templates carry cross-reference headers; 11 new tests (6 env byte-locks
+    + json byte-lock managed paths + daemon-section preservation +
+    dual-discord/dual-slack guards + no-discord empty block).
+  - `d6e0569` — Round 1 follow-ups: B3 (full JSON byte-lock fixture +
+    unmanaged-key completeness check), W4 (gateway=None preservation
+    test), S3 (drop inconsistent "LEGACY:" template comment label).
+  - `cd3a85b` — Round 2 follow-ups: B1 (unified `_OPENCLAW_DEFAULT_GATEWAY_PORT`
+    constant — env template + JSON now agree byte-for-byte on fallback
+    port), B3 (gitlab `has_gitlab_url` branch test), W1 (template no
+    longer emits empty `AUTH_TOKEN=` when auth is falsy), W2 (multi-guild
+    test), W3 (`git` skip test), S3 (model-prefix idempotency test).
+  - `2231b22` — Round 3 follow-up: B1 (CRITICAL silent-wipe fix —
+    `gateway.auth` flows into `openclaw.json` as
+    `{mode: token, token: <auth>}`; without this, F3 sync would have
+    wiped the install-time bearer on every run — exactly the bug class
+    #560 was opened to prevent). 2 regression tests.
+
+**Tactical choice (Callout)**: Mirrors Phase 2's exact pattern. The legacy
+`openclaw/.env.j2` and `openclaw/openclaw.json.j2` are still consumed by
+the Ansible-driven `clawctl agent configure` playbook (`configure.yaml:79,
+146`) and `agent install` playbook (`install.yaml:152`). Rewriting them
+to F3 input shape would break the legacy paths and their test suites.
+New canonical templates are added alongside under new filenames;
+cross-reference comments link them. Consolidation of the two template
+families is deferred to the same follow-up that retires the legacy
+Ansible configure path.
+
+**Synthesized baseline Callout**: The `openclaw.json` baseline was
+synthesized from the legacy `openclaw.json.j2`'s unconditional defaults
++ sensible values (wolf-i unreachable from execution context). Phase 4
+live dry-run on wolf-i will surface any drift. The synthesized baseline
+includes: `agents.defaults` (workspace, model, imageMaxDimensionPx,
+maxConcurrent, sandbox, heartbeat), `gateway` (mode, port=40000, bind,
+reload), `session` (dmScope, threadBindings, reset), `tools` (exec,
+deny=[browser]), `channels.discord` (enabled, allowFrom, guilds),
+`browser` (enabled=false), `env.shellEnv` (enabled, timeoutMs).
+
+### Phase 3 ATX Review Cycle Summary
+
+| Round | Rating | Total blockers | In-scope fixed | Out-of-scope deferred |
+|-------|--------|----------------|----------------|----------------------|
+| 1     | 2/5    | 4              | B3, W4, S3     | B1 (zeroclaw template), B2 (lifecycle.py), B4 (zeroclaw schema link) |
+| 2     | 2/5    | 3              | B1 (port unification), B3 (gitlab branch test), W1, W2, W3, S3 (model-prefix) | B2 (synthesized baseline — Phase 4 live verify), W4-W6, S1-S6 |
+| 3     | 2/5    | 4              | **B1 (gateway.auth silent-wipe fix)** + regression tests | B2 (Phase 4 wolf-i prerequisite), B3 (sync.py — Phase 1), B4 (lifecycle_canonical.py — Phase 1), W1/W4/W5/W6 (sync.py/lifecycle.py) |
+
+**Status**: `[ITX-STUCK]` after 3 ATX rounds. PR comment with full reasoning:
+https://github.com/ric03uec/clawrium/pull/568#issuecomment-4581496429
+
+**Final test counts**: 110 passed in `tests/core/test_render.py` (was 89
+at PR open). `make lint` clean. 45 baseline `tests/test_configure_zeroclaw.py`
+failures unchanged (pre-existing — Phases 1+2 carry the same baseline).
+
+**PR URL**: https://github.com/ric03uec/clawrium/pull/568 (stacked on
+PR #567 / Phase 2, which is merged into the base branch
+`issue-560-p1-drop-canonical-flag`).

--- a/src/clawrium/cli/clawctl/agent/sync.py
+++ b/src/clawrium/cli/clawctl/agent/sync.py
@@ -12,8 +12,10 @@ Phase lines (plan §6.10, post-#560):
     + final `synced (drift=0, took Xs)`
 
 Note: the legacy 5-phase sequence included `re-pairing gateway`. The
-canonical pipeline does not yet re-pair the zeroclaw gateway bearer;
-that gap is tracked separately (see PR #566 Callouts).
+canonical pipeline NOW re-pairs the zeroclaw gateway bearer on every
+sync invocation with `restart=True` (issue #437, restored in PR #568
+ATX round 3). The phase is emitted as a `repair` event rather than a
+numbered phase line so the user-visible sequence stays at 4 steps.
 
 Flags:
 - `--timeout 120` — 2-minute default; advisory (canonical pipeline
@@ -337,6 +339,7 @@ def sync(
             import json as _json
 
             from rich.console import Console
+            from rich.markup import escape as rich_escape
 
             console = Console()
 
@@ -350,8 +353,14 @@ def sync(
             except (_json.JSONDecodeError, TypeError):
                 pass
             if agent_label:
+                # `agent_label` originates from JSON-parsed daemon output;
+                # escape Rich markup metacharacters (`[`, `]`) before
+                # interpolating so a hostile or accidental `[bold]` in an
+                # agent_key cannot rewrite the rendered styling. Matches
+                # the pattern at cli/agent.py:145.
                 console.print(
-                    f"  [yellow]Gateway token rotated for {agent_label}. "
+                    f"  [yellow]Gateway token rotated for "
+                    f"{rich_escape(agent_label)}. "
                     f"Active chat sessions on other machines will need to "
                     f"reconnect.[/yellow]"
                 )

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -409,8 +409,33 @@ def sync_agent_canonical(
             )
             files_written.append(d.path)
 
-        if restart and files_written:
-            emit("restart", f"restarting {inputs.agent_type}-{agent_name}.service")
+        # Restart policy:
+        #
+        # - zeroclaw MUST restart on every sync regardless of
+        #   `files_written`, so the gateway bearer rotation downstream
+        #   (issue #437, see B1 comment below) runs every time. The
+        #   AGENTS.md "Gateway Token Lifecycle (zeroclaw)" section is
+        #   explicit: "There is no idempotent-skip path." A no-drift
+        #   sync that skipped restart would leave `hosts.json.gateway.auth`
+        #   permanently stale after any external daemon restart (host
+        #   reboot, `systemctl restart`, etc.).
+        # - Other agent types (hermes, openclaw) keep the file-drift-gated
+        #   restart so a true no-op sync stays cheap.
+        zeroclaw_force_restart = (
+            restart and inputs.agent_type == "zeroclaw" and not files_written
+        )
+        if restart and (files_written or zeroclaw_force_restart):
+            if zeroclaw_force_restart:
+                emit(
+                    "restart",
+                    f"restarting {inputs.agent_type}-{agent_name}.service "
+                    f"(no drift; zeroclaw bearer rotation requires restart)",
+                )
+            else:
+                emit(
+                    "restart",
+                    f"restarting {inputs.agent_type}-{agent_name}.service",
+                )
             _restart_unit(
                 client,
                 agent_type=inputs.agent_type,
@@ -432,15 +457,14 @@ def sync_agent_canonical(
     # systemd restarts. After a restart, the cached bearer in
     # hosts.json.gateway.auth is stale; the daemon will enforce a
     # freshly-minted token on its next request. Re-pair unconditionally
-    # whenever the daemon was actually restarted so `clawctl agent
-    # chat` reconnects against an authoritative bearer. The pair
-    # playbook is the single source of truth for the handshake — reuse
-    # `_zeroclaw_repair_after_start` rather than reimplementing.
-    if (
-        restart
-        and files_written
-        and inputs.agent_type == "zeroclaw"
-    ):
+    # whenever sync is operating on a zeroclaw with `restart=True` —
+    # AGENTS.md's "Gateway Token Lifecycle (zeroclaw)" explicitly
+    # forbids an idempotent-skip path here. The restart block above
+    # already force-restarts zeroclaw on no-drift sync for exactly this
+    # invariant. The pair playbook is the single source of truth for
+    # the handshake — reuse `_zeroclaw_repair_after_start` rather than
+    # reimplementing.
+    if restart and inputs.agent_type == "zeroclaw":
         from clawrium.core.lifecycle import _zeroclaw_repair_after_start
 
         emit("repair", f"re-pairing zeroclaw gateway for {agent_name}")

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -1045,6 +1045,22 @@ def _openclaw_json_baseline() -> str:
 
     Returns the raw text; `_render_openclaw_json` re-parses on every call so
     deep-updates don't mutate the shared baseline dict.
+
+    Baseline schema provenance: the structure mirrors the legacy
+    `openclaw.json.j2` Ansible template at
+    `src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2`,
+    which is the existing source of truth for the on-host file shape
+    (consumed by `install.yaml` and `configure.yaml`). Field names
+    (`agents.defaults.{workspace,model,sandbox,heartbeat}`, `gateway.{mode,
+    port,bind,reload,auth}`, `session.{dmScope,threadBindings,reset}`,
+    `tools.{exec,deny}`, `channels.discord.{enabled,allowFrom,guilds}`,
+    `browser.enabled`, `env.shellEnv.{enabled,timeoutMs}`) are copied
+    verbatim from that template's defaults. 00_PLAN.md Phase 4 closes
+    the schema verification loop with a live dry-run against wolf-i's
+    `~/.openclaw/openclaw.json`; if any key name diverges, the captured
+    live file replaces this synthesized baseline. Until Phase 4 runs,
+    treat the baseline as "best-effort match to the legacy Ansible
+    template" — silent no-op risk on unknown keys is non-zero.
     """
     from importlib.resources import files
 

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -880,6 +880,14 @@ _OPENCLAW_MODEL_PREFIX = {
     "bedrock": "bedrock/",
 }
 
+# Single source of truth for the openclaw gateway port fallback. Used by
+# BOTH the env template (`default_gateway_port` context var) AND
+# `_render_openclaw_json` so the env file and openclaw.json cannot
+# disagree on which port the daemon listens on. install.py always
+# provides a real port; this fallback only matters if `gateway` is
+# supplied without a port (defense in depth).
+_OPENCLAW_DEFAULT_GATEWAY_PORT = 40000
+
 
 def render_openclaw(inputs: RenderInputs) -> RenderedFiles:
     """Render openclaw's `.openclaw/env` (Jinja) + `.openclaw/openclaw.json`
@@ -981,6 +989,7 @@ def render_openclaw(inputs: RenderInputs) -> RenderedFiles:
         agent_name=inputs.agent_name,
         provider=inputs.provider,
         gateway=inputs.gateway,
+        default_gateway_port=_OPENCLAW_DEFAULT_GATEWAY_PORT,
         default_model_id=model_id,
         channels=inputs.channels,
         integrations=integration_views,
@@ -1071,7 +1080,7 @@ def _render_openclaw_json(
     # 2. gateway.port + 3. gateway.bind
     if gateway is not None:
         gw = baseline.setdefault("gateway", {})
-        gw["port"] = int(gateway.port or 18789)
+        gw["port"] = int(gateway.port or _OPENCLAW_DEFAULT_GATEWAY_PORT)
         gw["bind"] = gateway.bind or "lan"
 
     # 4. channels.discord.enabled + 5. channels.discord.allowFrom + guilds.

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -1077,11 +1077,23 @@ def _render_openclaw_json(
     model = defaults.setdefault("model", {})
     model["primary"] = provider_default_model
 
-    # 2. gateway.port + 3. gateway.bind
+    # 2. gateway.port + 3. gateway.bind + gateway.auth (managed bearer)
+    #
+    # Round 3 B1: `gateway.auth` MUST flow into the JSON. The legacy
+    # `openclaw.json.j2` writes the bearer to `gateway.auth.{mode,token}`
+    # via `install.yaml`; if F3 sync emitted the baseline verbatim
+    # (without auth), it would silently wipe the on-host bearer on every
+    # sync — exactly the silent-wipe class of bug #560 was opened to fix.
     if gateway is not None:
         gw = baseline.setdefault("gateway", {})
         gw["port"] = int(gateway.port or _OPENCLAW_DEFAULT_GATEWAY_PORT)
         gw["bind"] = gateway.bind or "lan"
+        if gateway.auth:
+            gw["auth"] = {"mode": "token", "token": gateway.auth}
+        else:
+            # Drop any stale auth block from the baseline (which has none)
+            # to keep the state explicit: no auth → no `gateway.auth` key.
+            gw.pop("auth", None)
 
     # 4. channels.discord.enabled + 5. channels.discord.allowFrom + guilds.
     channels = baseline.setdefault("channels", {})

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -868,12 +868,13 @@ def _render_zeroclaw_config_template(
 # silently produce a broken config — GCP client libs reject token
 # strings. Vertex support belongs in a follow-up that extends the
 # credential schema with a credential-kind field (path vs bearer).
-_OPENCLAW_PROVIDER_ENV = {
-    "anthropic": "ANTHROPIC_API_KEY",
-    "openai": "OPENAI_API_KEY",
-    "openrouter": "OPENROUTER_API_KEY",
-    "zai": "ZAI_API_KEY",
-}
+_OPENCLAW_SUPPORTED_PROVIDERS = frozenset(
+    {"openrouter", "anthropic", "openai", "bedrock", "ollama", "zai"}
+)
+_OPENCLAW_SUPPORTED_CHANNELS = frozenset({"discord", "slack"})
+_OPENCLAW_SUPPORTED_INTEGRATIONS = frozenset(
+    {"github", "atlassian", "linear", "notion", "gitlab", "git"}
+)
 _OPENCLAW_MODEL_PREFIX = {
     "openrouter": "openrouter/",
     "bedrock": "bedrock/",
@@ -881,100 +882,225 @@ _OPENCLAW_MODEL_PREFIX = {
 
 
 def render_openclaw(inputs: RenderInputs) -> RenderedFiles:
-    """Render openclaw's `.env`."""
+    """Render openclaw's `.openclaw/env` (Jinja) + `.openclaw/openclaw.json`
+    (JSON baseline deep-update).
+
+    Both files are loaded as canonical resources via `importlib.resources` so
+    the wheel ships them. Env is rendered from
+    `openclaw-env.canonical.j2`; JSON is loaded from `openclaw.json` baseline
+    and the five clawctl-managed paths are deep-updated from `inputs`:
+
+      - `channels.discord.enabled`
+      - `channels.discord.allowFrom` (from inputs.channels[discord].allowed_users)
+      - `channels.discord.guilds`    (nested reshape from allowed_guilds + allowed_channels)
+      - `gateway.port` + `gateway.bind`
+      - `agents.defaults.model.primary` (from inputs.provider.default_model + type prefix)
+
+    Every other key in the baseline is preserved byte-identically (modulo
+    `json.dumps` formatting), matching the silent-wipe-prevention contract
+    introduced for zeroclaw in #565.
+    """
     ptype = inputs.provider.type
-    env_lines: list[str] = []
-    env_lines.append(
-        f"# Managed by clawrium (clawctl). Re-render with "
-        f"`clawctl agent configure {inputs.agent_name}`."
-    )
-    if inputs.gateway is not None:
-        # Shell-quote `bind` so a CRLF-injected value can't smuggle an
-        # extra `KEY=VALUE` line into the EnvironmentFile.
-        env_lines.append(
-            f"OPENCLAW_GATEWAY_BIND={_shell_quote(inputs.gateway.bind or 'lan')}"
-        )
-        env_lines.append(f"OPENCLAW_GATEWAY_PORT={int(inputs.gateway.port or 40000)}")
-        env_lines.append(
-            f"OPENCLAW_GATEWAY_AUTH_MODE={'token' if inputs.gateway.auth else 'none'}"
-        )
-        env_lines.append(
-            f"OPENCLAW_GATEWAY_AUTH_TOKEN={_shell_quote(inputs.gateway.auth)}"
+    if ptype not in _OPENCLAW_SUPPORTED_PROVIDERS:
+        raise AgentConfigError(
+            f"render_openclaw does not support provider type {ptype!r}. "
+            f"Supported: {sorted(_OPENCLAW_SUPPORTED_PROVIDERS)}"
         )
 
+    # Up-front validation: channel + integration types, dual-discord +
+    # dual-slack guards (matches hermes/zeroclaw patterns from Phases 1+2).
+    seen_channel_types: dict[str, str] = {}
+    discord_channel: ChannelInputs | None = None
+    for channel in inputs.channels:
+        if channel.type not in _OPENCLAW_SUPPORTED_CHANNELS:
+            raise AgentConfigError(
+                f"render_openclaw: unsupported channel type {channel.type!r}. "
+                f"Supported: {sorted(_OPENCLAW_SUPPORTED_CHANNELS)}"
+            )
+        prior = seen_channel_types.get(channel.type)
+        if prior is not None:
+            raise AgentConfigError(
+                f"render_openclaw: agent {inputs.agent_name!r} has "
+                f"multiple {channel.type} channels attached "
+                f"({prior!r}, {channel.name!r}); openclaw emits one "
+                f"{channel.type.upper()}_BOT_TOKEN env var and the "
+                f"`channels.{channel.type}` block in openclaw.json holds "
+                f"one allowlist — detach one with `clawctl channel detach`."
+            )
+        seen_channel_types[channel.type] = channel.name
+        if channel.type == "discord":
+            discord_channel = channel
+
+    for integration in inputs.integrations:
+        if integration.type not in _OPENCLAW_SUPPORTED_INTEGRATIONS:
+            raise AgentConfigError(
+                f"render_openclaw: unsupported integration type "
+                f"{integration.type!r}. "
+                f"Supported: {sorted(_OPENCLAW_SUPPORTED_INTEGRATIONS)}"
+            )
+
+    # --- Build prefixed model id (used by both env + openclaw.json) -------
     model_id = inputs.provider.default_model
     prefix = _OPENCLAW_MODEL_PREFIX.get(ptype, "")
     if prefix and not model_id.startswith(prefix):
         model_id = prefix + model_id
-    env_lines.append(f"OPENCLAW_DEFAULT_MODEL={_shell_quote(model_id)}")
 
-    if ptype in _OPENCLAW_PROVIDER_ENV:
-        env_lines.append(
-            f"{_OPENCLAW_PROVIDER_ENV[ptype]}={_shell_quote(inputs.provider.api_key)}"
-        )
-    elif ptype == "bedrock":
-        env_lines.append(f"AWS_ACCESS_KEY_ID={_shell_quote(inputs.provider.aws_access_key)}")
-        env_lines.append(f"AWS_SECRET_ACCESS_KEY={_shell_quote(inputs.provider.aws_secret_key)}")
-    elif ptype == "ollama":
-        env_lines.append(f"OPENCLAW_OLLAMA_URL={_shell_quote(inputs.provider.endpoint)}")
-    else:
-        raise AgentConfigError(
-            f"render_openclaw does not support provider type {ptype!r}. "
-            f"Supported: {sorted(_OPENCLAW_PROVIDER_ENV) + ['bedrock', 'ollama']}"
-        )
-
-    for channel in inputs.channels:
-        if channel.type == "discord":
-            env_lines.append(f"DISCORD_BOT_TOKEN={_shell_quote(channel.bot_token)}")
-        elif channel.type == "slack":
-            env_lines.append(f"SLACK_BOT_TOKEN={_shell_quote(channel.bot_token)}")
-            env_lines.append(f"SLACK_APP_TOKEN={_shell_quote(channel.app_token)}")
-        else:
-            raise AgentConfigError(
-                f"render_openclaw: unsupported channel type {channel.type!r}"
-            )
-
+    # --- Integration views for the env template ---------------------------
+    integration_views: list[dict] = []
     last_github_token = ""
     for integration in inputs.integrations:
+        if integration.type == "git":
+            # `git` is a clientside-only identity integration; no env var.
+            continue
         creds = dict(integration.credentials)
+        view: dict = {"type": integration.type}
         if integration.type == "github":
-            token = creds.get("GITHUB_TOKEN", "")
             slug = _integration_slug(integration.name)
-            env_lines.append(f"GITHUB_TOKEN_{slug}={_shell_quote(token)}")
+            token = creds.get("GITHUB_TOKEN", "")
+            view["slug"] = slug
+            view["token"] = token
             last_github_token = token
         elif integration.type == "gitlab":
-            env_lines.append(f"GITLAB_TOKEN={_shell_quote(creds.get('GITLAB_TOKEN', ''))}")
-            if "GITLAB_URL" in creds:
-                env_lines.append(f"GITLAB_URL={_shell_quote(creds['GITLAB_URL'])}")
+            view["gitlab_token"] = creds.get("GITLAB_TOKEN", "")
+            view["has_gitlab_url"] = "GITLAB_URL" in creds
+            view["gitlab_url"] = creds.get("GITLAB_URL", "")
         elif integration.type == "atlassian":
             url = creds.get("ATLASSIAN_URL", "").rstrip("/")
-            email = creds.get("ATLASSIAN_EMAIL", "")
-            token = creds.get("ATLASSIAN_API_TOKEN", "")
-            env_lines.append(f"JIRA_URL={_shell_quote(url)}")
-            env_lines.append(f"CONFLUENCE_URL={_shell_quote(url + '/wiki')}")
-            env_lines.append(f"JIRA_EMAIL={_shell_quote(email)}")
-            env_lines.append(f"CONFLUENCE_EMAIL={_shell_quote(email)}")
-            env_lines.append(f"JIRA_API_TOKEN={_shell_quote(token)}")
-            env_lines.append(f"CONFLUENCE_API_TOKEN={_shell_quote(token)}")
+            view["atlassian_url"] = url
+            view["confluence_url"] = url + "/wiki"
+            view["atlassian_email"] = creds.get("ATLASSIAN_EMAIL", "")
+            view["atlassian_api_token"] = creds.get("ATLASSIAN_API_TOKEN", "")
         elif integration.type == "linear":
-            env_lines.append(
-                f"LINEAR_API_KEY={_shell_quote(creds.get('LINEAR_API_KEY', ''))}"
-            )
+            view["linear_api_key"] = creds.get("LINEAR_API_KEY", "")
         elif integration.type == "notion":
-            env_lines.append(
-                f"NOTION_API_KEY={_shell_quote(creds.get('NOTION_API_KEY', ''))}"
-            )
-        elif integration.type == "git":
-            continue
-        else:
-            raise AgentConfigError(
-                f"render_openclaw: unsupported integration type {integration.type!r}"
-            )
-    if last_github_token:
-        env_lines.append(f"GITHUB_TOKEN={_shell_quote(last_github_token)}")
+            view["notion_api_key"] = creds.get("NOTION_API_KEY", "")
+        integration_views.append(view)
 
-    env_body = "\n".join(env_lines) + "\n"
-    # Path is `.openclaw/env` (no leading dot on the filename) to match
-    # the configure playbook's lineinfile target. A dot-prefixed name
-    # would silently render to a file the playbook never reads.
-    return RenderedFiles(files={".openclaw/env": env_body})
+    env_body = _render_openclaw_template(
+        "openclaw-env.canonical.j2",
+        agent_name=inputs.agent_name,
+        provider=inputs.provider,
+        gateway=inputs.gateway,
+        default_model_id=model_id,
+        channels=inputs.channels,
+        integrations=integration_views,
+        last_github_token=last_github_token,
+    )
+
+    # --- openclaw.json: load baseline + deep-update managed paths ---------
+    json_body = _render_openclaw_json(
+        provider_default_model=model_id,
+        gateway=inputs.gateway,
+        discord_channel=discord_channel,
+    )
+
+    return RenderedFiles(
+        files={
+            ".openclaw/env": env_body,
+            ".openclaw/openclaw.json": json_body,
+        }
+    )
+
+
+@_functools.lru_cache(maxsize=4)
+def _openclaw_template(template_name: str):
+    """Load + compile an openclaw canonical template once per process."""
+    from importlib.resources import files
+
+    from jinja2 import Environment, StrictUndefined
+
+    template_path = files(
+        "clawrium.platform.registry.openclaw.templates"
+    ).joinpath(template_name)
+    template_source = template_path.read_text(encoding="utf-8")
+
+    env = Environment(
+        undefined=StrictUndefined,
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+        autoescape=False,
+    )
+    env.filters["shq"] = lambda v: _shell_quote(str(v))
+    return env.from_string(template_source)
+
+
+def _render_openclaw_template(template_name: str, **context) -> str:
+    """Render an openclaw canonical template via importlib.resources."""
+    return _openclaw_template(template_name).render(**context)
+
+
+@_functools.lru_cache(maxsize=1)
+def _openclaw_json_baseline() -> str:
+    """Load the openclaw.json baseline text once per process.
+
+    Returns the raw text; `_render_openclaw_json` re-parses on every call so
+    deep-updates don't mutate the shared baseline dict.
+    """
+    from importlib.resources import files
+
+    return (
+        files("clawrium.platform.registry.openclaw.templates")
+        .joinpath("openclaw.json")
+        .read_text(encoding="utf-8")
+    )
+
+
+def _render_openclaw_json(
+    *,
+    provider_default_model: str,
+    gateway: "GatewayInputs | None",
+    discord_channel: "ChannelInputs | None",
+) -> str:
+    """Deep-update the openclaw.json baseline with the 5 clawctl-managed paths.
+
+    Every other key in the baseline is preserved byte-for-byte (modulo
+    json.dumps formatting). Output uses `indent=2, sort_keys=False` to keep
+    section order stable for diffability.
+    """
+    import json
+
+    baseline = json.loads(_openclaw_json_baseline())
+
+    # 1. agents.defaults.model.primary
+    agents = baseline.setdefault("agents", {})
+    defaults = agents.setdefault("defaults", {})
+    model = defaults.setdefault("model", {})
+    model["primary"] = provider_default_model
+
+    # 2. gateway.port + 3. gateway.bind
+    if gateway is not None:
+        gw = baseline.setdefault("gateway", {})
+        gw["port"] = int(gateway.port or 18789)
+        gw["bind"] = gateway.bind or "lan"
+
+    # 4. channels.discord.enabled + 5. channels.discord.allowFrom + guilds.
+    channels = baseline.setdefault("channels", {})
+    discord = channels.setdefault(
+        "discord", {"enabled": False, "allowFrom": [], "guilds": {}}
+    )
+    if discord_channel is not None:
+        discord["enabled"] = True
+        discord["allowFrom"] = list(discord_channel.allowed_users)
+        # Reshape flat allowed_guilds[] + allowed_channels[] into the
+        # nested {<guild>: {users: [...], channels: {<chan>: {allow: true}}}}
+        # structure openclaw's daemon expects.
+        guilds_block: dict = {}
+        for guild_id in discord_channel.allowed_guilds:
+            guilds_block[guild_id] = {
+                "users": list(discord_channel.allowed_users),
+                "channels": {
+                    chan_id: {"allow": True}
+                    for chan_id in discord_channel.allowed_channels
+                },
+            }
+        discord["guilds"] = guilds_block
+    else:
+        # No discord channel attached → leave defaults (`enabled: false`,
+        # empty allowFrom, empty guilds). Baseline already has this shape;
+        # explicit reset prevents stale values surviving across renders.
+        discord["enabled"] = False
+        discord["allowFrom"] = []
+        discord["guilds"] = {}
+
+    return json.dumps(baseline, indent=2, sort_keys=False) + "\n"

--- a/src/clawrium/platform/registry/openclaw/templates/.env.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/.env.j2
@@ -1,3 +1,10 @@
+{# LEGACY: consumed by `clawctl agent configure` Ansible playbook
+   (platform/registry/openclaw/playbooks/configure.yaml). Uses the
+   pre-F3 `config.*` extravar shape. The canonical F3-input template
+   `openclaw-env.canonical.j2` (in this same directory) is used by
+   `clawrium.core.render.render_openclaw`. Consolidation of the two
+   template families is deferred — same lesson as Phase 2 / hermes
+   (#560 PR #567). #}
 {# Shell-safe quoting: single-quote values and escape embedded single quotes #}
 {# Uses POSIX shell quoting: 'val'"'"'ue' to embed a single quote in single-quoted string #}
 {%- macro shell_quote(value) -%}

--- a/src/clawrium/platform/registry/openclaw/templates/openclaw-env.canonical.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw-env.canonical.j2
@@ -5,8 +5,9 @@
    render_openclaw. 00_PLAN.md Phase 4 live dry-run on wolf-i closes the
    loop against the live daemon.
 
-   Distinct from `.env.j2` (still consumed by the legacy Ansible
-   `configure.yaml` playbook); see header comment on that file. #}
+   Distinct from `.env.j2` in this directory, which is still consumed by
+   the Ansible `configure.yaml` playbook — see header comment on that
+   file. #}
 # Managed by clawrium (clawctl). Re-render with `clawctl agent configure {{ agent_name }}`.
 {% if gateway is not none %}
 OPENCLAW_GATEWAY_BIND={{ (gateway.bind or 'lan') | shq }}

--- a/src/clawrium/platform/registry/openclaw/templates/openclaw-env.canonical.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw-env.canonical.j2
@@ -11,10 +11,13 @@
 # Managed by clawrium (clawctl). Re-render with `clawctl agent configure {{ agent_name }}`.
 {% if gateway is not none %}
 OPENCLAW_GATEWAY_BIND={{ (gateway.bind or 'lan') | shq }}
-OPENCLAW_GATEWAY_PORT={{ (gateway.port or 40000) | int }}
-OPENCLAW_GATEWAY_AUTH_MODE={% if gateway.auth %}token{% else %}none{% endif %}
-
+OPENCLAW_GATEWAY_PORT={{ (gateway.port or default_gateway_port) | int }}
+{% if gateway.auth %}
+OPENCLAW_GATEWAY_AUTH_MODE=token
 OPENCLAW_GATEWAY_AUTH_TOKEN={{ gateway.auth | shq }}
+{% else %}
+OPENCLAW_GATEWAY_AUTH_MODE=none
+{% endif %}
 {% endif %}
 OPENCLAW_DEFAULT_MODEL={{ default_model_id | shq }}
 {% if provider.type == 'anthropic' %}

--- a/src/clawrium/platform/registry/openclaw/templates/openclaw-env.canonical.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw-env.canonical.j2
@@ -1,0 +1,64 @@
+{# Canonical openclaw `.openclaw/env` template — F3 input shape.
+
+   See ../../core/render.py:render_openclaw. Byte-locks in
+   tests/core/test_render.py pin parity with the prior list-of-strings
+   render_openclaw. 00_PLAN.md Phase 4 live dry-run on wolf-i closes the
+   loop against the live daemon.
+
+   Distinct from `.env.j2` (still consumed by the legacy Ansible
+   `configure.yaml` playbook); see header comment on that file. #}
+# Managed by clawrium (clawctl). Re-render with `clawctl agent configure {{ agent_name }}`.
+{% if gateway is not none %}
+OPENCLAW_GATEWAY_BIND={{ (gateway.bind or 'lan') | shq }}
+OPENCLAW_GATEWAY_PORT={{ (gateway.port or 40000) | int }}
+OPENCLAW_GATEWAY_AUTH_MODE={% if gateway.auth %}token{% else %}none{% endif %}
+
+OPENCLAW_GATEWAY_AUTH_TOKEN={{ gateway.auth | shq }}
+{% endif %}
+OPENCLAW_DEFAULT_MODEL={{ default_model_id | shq }}
+{% if provider.type == 'anthropic' %}
+ANTHROPIC_API_KEY={{ provider.api_key | shq }}
+{% elif provider.type == 'openai' %}
+OPENAI_API_KEY={{ provider.api_key | shq }}
+{% elif provider.type == 'openrouter' %}
+OPENROUTER_API_KEY={{ provider.api_key | shq }}
+{% elif provider.type == 'zai' %}
+ZAI_API_KEY={{ provider.api_key | shq }}
+{% elif provider.type == 'bedrock' %}
+AWS_ACCESS_KEY_ID={{ provider.aws_access_key | shq }}
+AWS_SECRET_ACCESS_KEY={{ provider.aws_secret_key | shq }}
+{% elif provider.type == 'ollama' %}
+OPENCLAW_OLLAMA_URL={{ provider.endpoint | shq }}
+{% endif %}
+{% for channel in channels %}
+{% if channel.type == 'discord' %}
+DISCORD_BOT_TOKEN={{ channel.bot_token | shq }}
+{% elif channel.type == 'slack' %}
+SLACK_BOT_TOKEN={{ channel.bot_token | shq }}
+SLACK_APP_TOKEN={{ channel.app_token | shq }}
+{% endif %}
+{% endfor %}
+{% for integration in integrations %}
+{% if integration.type == 'github' %}
+GITHUB_TOKEN_{{ integration.slug }}={{ integration.token | shq }}
+{% elif integration.type == 'gitlab' %}
+GITLAB_TOKEN={{ integration.gitlab_token | shq }}
+{% if integration.has_gitlab_url %}
+GITLAB_URL={{ integration.gitlab_url | shq }}
+{% endif %}
+{% elif integration.type == 'atlassian' %}
+JIRA_URL={{ integration.atlassian_url | shq }}
+CONFLUENCE_URL={{ integration.confluence_url | shq }}
+JIRA_EMAIL={{ integration.atlassian_email | shq }}
+CONFLUENCE_EMAIL={{ integration.atlassian_email | shq }}
+JIRA_API_TOKEN={{ integration.atlassian_api_token | shq }}
+CONFLUENCE_API_TOKEN={{ integration.atlassian_api_token | shq }}
+{% elif integration.type == 'linear' %}
+LINEAR_API_KEY={{ integration.linear_api_key | shq }}
+{% elif integration.type == 'notion' %}
+NOTION_API_KEY={{ integration.notion_api_key | shq }}
+{% endif %}
+{% endfor %}
+{% if last_github_token %}
+GITHUB_TOKEN={{ last_github_token | shq }}
+{% endif %}

--- a/src/clawrium/platform/registry/openclaw/templates/openclaw.json
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw.json
@@ -19,7 +19,7 @@
   },
   "gateway": {
     "mode": "local",
-    "port": 18789,
+    "port": 40000,
     "bind": "lan",
     "reload": {
       "mode": "hybrid",

--- a/src/clawrium/platform/registry/openclaw/templates/openclaw.json
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw.json
@@ -1,0 +1,68 @@
+{
+  "agents": {
+    "defaults": {
+      "workspace": "~/.openclaw/workspace",
+      "model": {
+        "primary": ""
+      },
+      "imageMaxDimensionPx": 1200,
+      "maxConcurrent": 4,
+      "sandbox": {
+        "mode": "off",
+        "scope": "session"
+      },
+      "heartbeat": {
+        "every": "30m",
+        "target": "last"
+      }
+    }
+  },
+  "gateway": {
+    "mode": "local",
+    "port": 18789,
+    "bind": "lan",
+    "reload": {
+      "mode": "hybrid",
+      "debounceMs": 300
+    }
+  },
+  "session": {
+    "dmScope": "per-channel-peer",
+    "threadBindings": {
+      "enabled": true,
+      "idleHours": 24,
+      "maxAgeHours": 168
+    },
+    "reset": {
+      "mode": "daily",
+      "atHour": 4,
+      "idleMinutes": 120
+    }
+  },
+  "tools": {
+    "exec": {
+      "host": "gateway",
+      "security": "full",
+      "ask": "off"
+    },
+    "deny": [
+      "browser"
+    ]
+  },
+  "channels": {
+    "discord": {
+      "enabled": false,
+      "allowFrom": [],
+      "guilds": {}
+    }
+  },
+  "browser": {
+    "enabled": false
+  },
+  "env": {
+    "shellEnv": {
+      "enabled": true,
+      "timeoutMs": 15000
+    }
+  }
+}

--- a/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
@@ -1,3 +1,9 @@
+{# LEGACY: consumed by `clawctl agent configure` + `agent install` Ansible
+   playbooks (platform/registry/openclaw/playbooks/{configure,install}.yaml).
+   Uses the pre-F3 `config.*` extravar shape. The canonical F3-input path is
+   `openclaw.json` baseline + `render_openclaw` deep-update in
+   `clawrium.core.render`. Consolidation deferred — same lesson as Phase 2 /
+   hermes (#560 PR #567). #}
 {
 {% set agents = config.agents | default({}) %}
 {% set agents_defaults = agents.defaults | default({}) %}

--- a/tests/cli/clawctl/agent/test_sync.py
+++ b/tests/cli/clawctl/agent/test_sync.py
@@ -335,6 +335,78 @@ def test_canonical_sync_repairs_zeroclaw_gateway(monkeypatch, fleet_dir) -> None
     assert captured.get("repair_agent") == "test-agent"
 
 
+def test_canonical_sync_repairs_zeroclaw_even_with_no_drift(
+    monkeypatch, fleet_dir
+) -> None:
+    """PR #568 ATX round 3 B4 + AGENTS.md §Gateway Token Lifecycle:
+    a no-drift `clawctl agent sync` (zero files changed) on a zeroclaw
+    MUST still restart the service and re-pair the gateway bearer.
+    AGENTS.md explicitly forbids an idempotent-skip path here — without
+    this behavior, `hosts.json.gateway.auth` would go permanently stale
+    after any external daemon restart (host reboot, `systemctl restart`).
+    """
+    from clawrium.core import lifecycle_canonical
+    from clawrium.core.render import RenderInputs, ProviderInputs
+
+    captured: dict = {}
+
+    def fake_build(name):
+        return RenderInputs(
+            agent_type="zeroclaw",
+            agent_name=name,
+            provider=ProviderInputs(
+                name="p", type="anthropic", endpoint="", default_model="x"
+            ),
+        )
+
+    def fake_render(inputs):
+        from clawrium.core.render import RenderedFiles
+
+        return RenderedFiles(files={".zeroclaw/config.toml": "[gateway]\n"})
+
+    monkeypatch.setattr(lifecycle_canonical, "build_render_inputs", fake_build)
+    monkeypatch.setattr(
+        lifecycle_canonical, "_RENDERERS", {"zeroclaw": fake_render}
+    )
+    monkeypatch.setattr(
+        lifecycle_canonical,
+        "get_agent_by_name",
+        lambda n: ({"hostname": "test-host"}, n, {"type": "zeroclaw"}),
+    )
+    # No drift: diff returns an empty list — files_written stays empty.
+    monkeypatch.setattr(lifecycle_canonical, "diff_files", lambda **kw: [])
+    monkeypatch.setattr(
+        lifecycle_canonical, "_open_ssh", lambda host, timeout=15: MagicMock()
+    )
+    monkeypatch.setattr(lifecycle_canonical, "_atomic_write", lambda *a, **kw: None)
+
+    restart_calls: list[str] = []
+
+    def fake_restart(client, *, agent_type, agent_name):
+        restart_calls.append(agent_name)
+
+    monkeypatch.setattr(lifecycle_canonical, "_restart_unit", fake_restart)
+    monkeypatch.setattr(lifecycle_canonical, "_verify_health", lambda *a, **kw: None)
+
+    def fake_repair(hostname, *, agent_name, on_event, reason):
+        captured["repair_agent"] = agent_name
+        return True, None
+
+    from clawrium.core import lifecycle as lifecycle_mod
+
+    monkeypatch.setattr(
+        lifecycle_mod, "_zeroclaw_repair_after_start", fake_repair
+    )
+    from clawrium.core import onboarding as onboarding_mod
+
+    monkeypatch.setattr(onboarding_mod, "transition_state", lambda *a, **kw: True)
+
+    lifecycle_canonical.sync_agent_canonical("test-agent")
+    # Both restart AND re-pair must run despite zero file drift.
+    assert restart_calls == ["test-agent"]
+    assert captured.get("repair_agent") == "test-agent"
+
+
 def test_canonical_sync_propagates_repair_failure(monkeypatch, fleet_dir) -> None:
     """B1: if `_zeroclaw_repair_after_start` returns failure, the canonical
     sync must raise CanonicalSyncError (no silent write of stale bearer)."""
@@ -434,6 +506,56 @@ def test_sync_renders_gateway_token_rotated_as_yellow_notice(
     assert result.exit_code == 0, result.output
     assert "Gateway token rotated" in result.output
     assert "wise-hypatia" in result.output
+
+
+def test_sync_gateway_token_rotated_escapes_rich_markup_in_agent_key(
+    fleet_dir, monkeypatch
+) -> None:
+    """PR #568 ATX round 3 B3: an agent_key containing Rich markup
+    metacharacters (`[`, `]`) must be escaped before interpolation so
+    a hostile or accidental `[bold red]` cannot rewrite console styling
+    or smuggle a closing `[/yellow]` and break out of the notice block.
+    """
+    import json as _json
+
+    hostile_key = "evil[/yellow][bold red]INJECTED[/bold red]"
+
+    def fake_sync(name, *, force, restart, verify, on_event):
+        on_event(
+            "gateway_token_rotated",
+            _json.dumps(
+                {
+                    "agent_key": hostile_key,
+                    "old_prefix": "abc",
+                    "new_prefix": "def",
+                    "reason": "sync",
+                }
+            ),
+        )
+
+        class _R:
+            files_written = [".zeroclaw/config.toml"]
+            files_unchanged: list[str] = []
+
+        return _R()
+
+    monkeypatch.setattr(
+        "clawrium.core.lifecycle_canonical.sync_agent_canonical", fake_sync
+    )
+    result = runner.invoke(app, ["agent", "sync", "wise-hypatia"])
+    assert result.exit_code == 0, result.output
+    # The hostile substring `[bold red]INJECTED[/bold red]` must NOT
+    # appear as live markup in the rendered output. Rich's `escape()`
+    # converts `[` → `\[`, so the closing `[/yellow]` injection cannot
+    # close the outer notice prematurely. The literal text of the key
+    # is fine to surface to the operator (escaped form `\[` is what
+    # ends up in the rendered terminal output).
+    assert "INJECTED" in result.output
+    # Crucially: the visible "Gateway token rotated" + reconnect text
+    # must remain intact (i.e. the injection didn't break out of the
+    # notice).
+    assert "Gateway token rotated" in result.output
+    assert "reconnect" in result.output
 
 
 def test_open_ssh_translates_bad_host_key_to_canonical_error(monkeypatch) -> None:

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -2018,6 +2018,10 @@ _OPENCLAW_JSON_BYTE_LOCK = """\
     "reload": {
       "mode": "hybrid",
       "debounceMs": 300
+    },
+    "auth": {
+      "mode": "token",
+      "token": "tkn"
     }
   },
   "session": {
@@ -2345,3 +2349,53 @@ def test_openclaw_model_prefix_idempotent():
         # Critical: prefix must not appear twice.
         prefix = f"{ptype}/"
         assert env.count(prefix + prefix) == 0
+
+
+def test_openclaw_json_gateway_auth_survives_render_cycle():
+    """Round 3 B1: `gateway.auth` MUST flow through `_render_openclaw_json`.
+    Regression test for the silent-wipe class: if the renderer emitted the
+    baseline verbatim (no auth block), F3 sync would overwrite the
+    install-time bearer on every sync."""
+    import json
+
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="or", type="openrouter", default_model="m", api_key="sk-1"
+        ),
+        channels=(),
+        integrations=(),
+        gateway=GatewayInputs(
+            host="0.0.0.0",
+            port=40000,
+            auth="bearer-secret-xyz",
+            bind="lan",
+        ),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    assert blob["gateway"]["auth"] == {
+        "mode": "token",
+        "token": "bearer-secret-xyz",
+    }
+
+
+def test_openclaw_json_no_auth_omits_gateway_auth_block():
+    """Round 3 B1 corollary: `gateway.auth=""` must NOT emit a stale auth
+    block. Explicit absence keeps the state machine clean."""
+    import json
+
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="or", type="openrouter", default_model="m", api_key="sk-1"
+        ),
+        channels=(),
+        integrations=(),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="", bind="lan"),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    assert "auth" not in blob["gateway"]

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -1979,3 +1979,203 @@ def test_openclaw_json_no_discord_attached_emits_empty_block():
     assert blob["channels"]["discord"]["enabled"] is False
     assert blob["channels"]["discord"]["allowFrom"] == []
     assert blob["channels"]["discord"]["guilds"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 ATX Round 1 — B3 + W4 follow-ups.
+#
+# B3: full byte-lock for .openclaw/openclaw.json — pins json.dumps params,
+#     key ordering, and every unmanaged baseline key. Any drift fails CI
+#     with a clear diff (mirrors the env byte-lock pattern above).
+# W4: gateway=None must leave the baseline gateway block byte-identical.
+# ---------------------------------------------------------------------------
+
+
+_OPENCLAW_JSON_BYTE_LOCK = """\
+{
+  "agents": {
+    "defaults": {
+      "workspace": "~/.openclaw/workspace",
+      "model": {
+        "primary": "openrouter/anthropic/claude-opus-4.7"
+      },
+      "imageMaxDimensionPx": 1200,
+      "maxConcurrent": 4,
+      "sandbox": {
+        "mode": "off",
+        "scope": "session"
+      },
+      "heartbeat": {
+        "every": "30m",
+        "target": "last"
+      }
+    }
+  },
+  "gateway": {
+    "mode": "local",
+    "port": 40000,
+    "bind": "lan",
+    "reload": {
+      "mode": "hybrid",
+      "debounceMs": 300
+    }
+  },
+  "session": {
+    "dmScope": "per-channel-peer",
+    "threadBindings": {
+      "enabled": true,
+      "idleHours": 24,
+      "maxAgeHours": 168
+    },
+    "reset": {
+      "mode": "daily",
+      "atHour": 4,
+      "idleMinutes": 120
+    }
+  },
+  "tools": {
+    "exec": {
+      "host": "gateway",
+      "security": "full",
+      "ask": "off"
+    },
+    "deny": [
+      "browser"
+    ]
+  },
+  "channels": {
+    "discord": {
+      "enabled": true,
+      "allowFrom": [
+        "u1",
+        "u2"
+      ],
+      "guilds": {
+        "g1": {
+          "users": [
+            "u1",
+            "u2"
+          ],
+          "channels": {
+            "c1": {
+              "allow": true
+            },
+            "c2": {
+              "allow": true
+            }
+          }
+        }
+      }
+    }
+  },
+  "browser": {
+    "enabled": false
+  },
+  "env": {
+    "shellEnv": {
+      "enabled": true,
+      "timeoutMs": 15000
+    }
+  }
+}
+"""
+
+
+def test_openclaw_json_byte_lock():
+    """B3 (Round 1): full byte-equivalence lock for `.openclaw/openclaw.json`.
+    Pins json.dumps params (indent=2, sort_keys=False, trailing newline),
+    key ordering, and every unmanaged baseline key. Any drift fails CI."""
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="or",
+            type="openrouter",
+            default_model="anthropic/claude-opus-4.7",
+            api_key="sk-or-1",
+        ),
+        channels=(
+            ChannelInputs(
+                name="discord-a",
+                type="discord",
+                bot_token="discord-bot",
+                allowed_users=("u1", "u2"),
+                allowed_guilds=("g1",),
+                allowed_channels=("c1", "c2"),
+            ),
+        ),
+        integrations=(),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tkn", bind="lan"),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    assert body == _OPENCLAW_JSON_BYTE_LOCK
+
+
+def test_openclaw_json_gateway_none_preserves_baseline_gateway_block():
+    """W4 (Round 1): with gateway=None the baseline gateway block must
+    survive byte-identical — no managed-path mutation should leak into
+    the unmanaged sections."""
+    import json
+
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="or", type="openrouter", default_model="m", api_key="sk-1"
+        ),
+        channels=(),
+        integrations=(),
+        gateway=None,
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    # Baseline gateway block survives byte-identical when gateway=None.
+    assert blob["gateway"] == {
+        "mode": "local",
+        "port": 18789,
+        "bind": "lan",
+        "reload": {"mode": "hybrid", "debounceMs": 300},
+    }
+
+
+def test_openclaw_json_daemon_sections_unmanaged_baseline_keys_complete():
+    """B3 (Round 1) — strengthening: assert ALL unmanaged baseline keys
+    are present, not just a curated sample. Catches accidental baseline
+    truncation that the curated `daemon_sections_preserved` test misses."""
+    import json
+
+    inputs = _openclaw_inputs(ptype="openrouter")
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    # Top-level keys must be exactly the baseline set.
+    assert set(blob.keys()) == {
+        "agents",
+        "gateway",
+        "session",
+        "tools",
+        "channels",
+        "browser",
+        "env",
+    }
+    # agents.defaults unmanaged keys (model is managed).
+    assert set(blob["agents"]["defaults"].keys()) == {
+        "workspace",
+        "model",
+        "imageMaxDimensionPx",
+        "maxConcurrent",
+        "sandbox",
+        "heartbeat",
+    }
+    # gateway unmanaged keys survive (port + bind are managed).
+    assert blob["gateway"]["mode"] == "local"
+    assert blob["gateway"]["reload"] == {"mode": "hybrid", "debounceMs": 300}
+    # tools.deny baseline value.
+    assert blob["tools"]["deny"] == ["browser"]
+    # agents.defaults.workspace baseline value.
+    assert blob["agents"]["defaults"]["workspace"] == "~/.openclaw/workspace"
+    assert blob["agents"]["defaults"]["imageMaxDimensionPx"] == 1200
+    assert blob["agents"]["defaults"]["maxConcurrent"] == 4
+    assert blob["agents"]["defaults"]["sandbox"] == {
+        "mode": "off",
+        "scope": "session",
+    }

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -2130,9 +2130,11 @@ def test_openclaw_json_gateway_none_preserves_baseline_gateway_block():
     body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
     blob = json.loads(body)
     # Baseline gateway block survives byte-identical when gateway=None.
+    # Port matches `_OPENCLAW_DEFAULT_GATEWAY_PORT` so the baseline cannot
+    # disagree with the env-template fallback (Round 2 B1).
     assert blob["gateway"] == {
         "mode": "local",
-        "port": 18789,
+        "port": 40000,
         "bind": "lan",
         "reload": {"mode": "hybrid", "debounceMs": 300},
     }
@@ -2179,3 +2181,167 @@ def test_openclaw_json_daemon_sections_unmanaged_baseline_keys_complete():
         "mode": "off",
         "scope": "session",
     }
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 ATX Round 2 follow-ups.
+#
+# B1: covered by `test_openclaw_json_gateway_none_preserves_baseline_gateway_block`
+#     update (port now matches `_OPENCLAW_DEFAULT_GATEWAY_PORT` = 40000).
+# B3: `has_gitlab_url` branch — test token-only (URL absent) + token+URL.
+# W1: gateway.auth=None must NOT emit `OPENCLAW_GATEWAY_AUTH_TOKEN=`.
+# W2: multi-guild discord channel exercises the loop with 2+ guilds.
+# W3: `git` integration skip path emits no env var.
+# ---------------------------------------------------------------------------
+
+
+def test_openclaw_gitlab_integration_emits_token_and_optional_url():
+    """B3 (Round 2): exercises both branches of `has_gitlab_url` in the
+    canonical env template."""
+    base_provider = ProviderInputs(
+        name="or", type="openrouter", default_model="m", api_key="sk-1"
+    )
+    # Token-only: GITLAB_URL must be ABSENT.
+    inputs_no_url = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=base_provider,
+        integrations=(
+            IntegrationInputs(
+                name="gl",
+                type="gitlab",
+                credentials=(("GITLAB_TOKEN", "gl-t"),),
+            ),
+        ),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, bind="lan"),
+    )
+    env = render_openclaw(inputs_no_url).files[".openclaw/env"]
+    assert "GITLAB_TOKEN='gl-t'" in env
+    assert "GITLAB_URL" not in env
+
+    # Token + URL: both lines present.
+    inputs_with_url = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=base_provider,
+        integrations=(
+            IntegrationInputs(
+                name="gl",
+                type="gitlab",
+                credentials=(
+                    ("GITLAB_TOKEN", "gl-t"),
+                    ("GITLAB_URL", "https://gl.example.com"),
+                ),
+            ),
+        ),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, bind="lan"),
+    )
+    env = render_openclaw(inputs_with_url).files[".openclaw/env"]
+    assert "GITLAB_TOKEN='gl-t'" in env
+    assert "GITLAB_URL='https://gl.example.com'" in env
+
+
+def test_openclaw_gateway_auth_none_omits_auth_token_var():
+    """W1 (Round 2): when gateway.auth is empty, AUTH_TOKEN line must NOT
+    be emitted (a present-but-empty token would let the daemon enter
+    "token mode with empty token" and reject all requests)."""
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="or", type="openrouter", default_model="m", api_key="sk-1"
+        ),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="", bind="lan"),
+    )
+    env = render_openclaw(inputs).files[".openclaw/env"]
+    assert "OPENCLAW_GATEWAY_AUTH_MODE=none" in env
+    assert "OPENCLAW_GATEWAY_AUTH_TOKEN" not in env
+
+
+def test_openclaw_multi_guild_discord_renders_all_guilds():
+    """W2 (Round 2): two guilds in allowed_guilds must both materialize
+    as keys in channels.discord.guilds."""
+    import json
+
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="or", type="openrouter", default_model="m", api_key="sk-1"
+        ),
+        channels=(
+            ChannelInputs(
+                name="d",
+                type="discord",
+                bot_token="t",
+                allowed_users=("u1",),
+                allowed_guilds=("g1", "g2"),
+                allowed_channels=("c1",),
+            ),
+        ),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, bind="lan"),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    assert set(blob["channels"]["discord"]["guilds"].keys()) == {"g1", "g2"}
+    for guild_id in ("g1", "g2"):
+        assert blob["channels"]["discord"]["guilds"][guild_id]["users"] == ["u1"]
+        assert blob["channels"]["discord"]["guilds"][guild_id]["channels"] == {
+            "c1": {"allow": True}
+        }
+
+
+def test_openclaw_git_integration_skipped():
+    """W3 (Round 2): `git` integration is intentionally skipped in env
+    render (clientside identity; ~/.gitconfig render lives elsewhere)."""
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="or", type="openrouter", default_model="m", api_key="sk-1"
+        ),
+        integrations=(
+            IntegrationInputs(
+                name="me",
+                type="git",
+                credentials=(("GIT_USER_EMAIL", "a@b"), ("GIT_USER_NAME", "Me")),
+            ),
+        ),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, bind="lan"),
+    )
+    env = render_openclaw(inputs).files[".openclaw/env"]
+    assert "GIT_USER_EMAIL" not in env
+    assert "GIT_USER_NAME" not in env
+
+
+def test_openclaw_model_prefix_idempotent():
+    """Round 2 S3: pre-prefixed model id must NOT double up.
+    (`openrouter/m` stays `openrouter/m`, not `openrouter/openrouter/m`.)"""
+    for ptype, model_id in [
+        ("openrouter", "openrouter/anthropic/claude-opus-4.7"),
+        ("bedrock", "bedrock/anthropic.claude-opus-4-1-v1:0"),
+    ]:
+        if ptype == "openrouter":
+            p = ProviderInputs(
+                name="or", type=ptype, default_model=model_id, api_key="sk-1"
+            )
+        else:
+            p = ProviderInputs(
+                name="br",
+                type=ptype,
+                default_model=model_id,
+                region="us-east-1",
+                aws_access_key="AKIA-1",
+                aws_secret_key="secret-1",
+            )
+        inputs = RenderInputs(
+            agent_name="alpha",
+            agent_type="openclaw",
+            provider=p,
+            gateway=GatewayInputs(host="0.0.0.0", port=40000, bind="lan"),
+        )
+        env = render_openclaw(inputs).files[".openclaw/env"]
+        assert f"OPENCLAW_DEFAULT_MODEL='{model_id}'" in env
+        # Critical: prefix must not appear twice.
+        prefix = f"{ptype}/"
+        assert env.count(prefix + prefix) == 0

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -822,7 +822,7 @@ def test_openclaw_file_keys_are_exact_set():
         gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tk", bind="lan"),
     )
     out = render_openclaw(inputs)
-    assert set(out.files.keys()) == {".openclaw/env"}
+    assert set(out.files.keys()) == {".openclaw/env", ".openclaw/openclaw.json"}
 
 
 def test_yaml_quote_strips_nul_and_cr():
@@ -1698,3 +1698,284 @@ def test_hermes_discord_allow_all_users_byte_lock_atx_r4_w6():
     )
     env_default = render_hermes(inputs_default).files[".hermes/.env"]
     assert "DISCORD_ALLOW_ALL_USERS" not in env_default
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 (#560): Jinja-template regression locks for render_openclaw.
+#
+# Byte-for-byte expected outputs captured from the prior list-of-strings
+# implementation. Any drift in the new Jinja + json.loads/deep-update flow
+# MUST be intentional and surface here as a test failure with a clear diff.
+# ---------------------------------------------------------------------------
+
+
+def _openclaw_inputs(*, ptype: str) -> RenderInputs:
+    base = _baseline_inputs(ptype=ptype)
+    return RenderInputs(
+        agent_name=base.agent_name,
+        agent_type="openclaw",
+        provider=base.provider,
+        channels=base.channels,
+        integrations=base.integrations,
+        api_server=base.api_server,
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tkn", bind="lan"),
+    )
+
+
+_OPENCLAW_ENV_OPENROUTER = (
+    "# Managed by clawrium (clawctl). Re-render with `clawctl agent configure alpha`.\n"
+    "OPENCLAW_GATEWAY_BIND='lan'\n"
+    "OPENCLAW_GATEWAY_PORT=40000\n"
+    "OPENCLAW_GATEWAY_AUTH_MODE=token\n"
+    "OPENCLAW_GATEWAY_AUTH_TOKEN='tkn'\n"
+    "OPENCLAW_DEFAULT_MODEL='openrouter/anthropic/claude-opus-4.7'\n"
+    "OPENROUTER_API_KEY='sk-or-1'\n"
+    "DISCORD_BOT_TOKEN='discord-bot'\n"
+    "GITHUB_TOKEN_GH_A='ghp_a'\n"
+    "GITHUB_TOKEN='ghp_a'\n"
+)
+
+_OPENCLAW_ENV_ANTHROPIC = (
+    "# Managed by clawrium (clawctl). Re-render with `clawctl agent configure alpha`.\n"
+    "OPENCLAW_GATEWAY_BIND='lan'\n"
+    "OPENCLAW_GATEWAY_PORT=40000\n"
+    "OPENCLAW_GATEWAY_AUTH_MODE=token\n"
+    "OPENCLAW_GATEWAY_AUTH_TOKEN='tkn'\n"
+    "OPENCLAW_DEFAULT_MODEL='claude-opus-4-7'\n"
+    "ANTHROPIC_API_KEY='sk-ant-1'\n"
+    "DISCORD_BOT_TOKEN='discord-bot'\n"
+    "GITHUB_TOKEN_GH_A='ghp_a'\n"
+    "GITHUB_TOKEN='ghp_a'\n"
+)
+
+_OPENCLAW_ENV_OPENAI = (
+    "# Managed by clawrium (clawctl). Re-render with `clawctl agent configure alpha`.\n"
+    "OPENCLAW_GATEWAY_BIND='lan'\n"
+    "OPENCLAW_GATEWAY_PORT=40000\n"
+    "OPENCLAW_GATEWAY_AUTH_MODE=token\n"
+    "OPENCLAW_GATEWAY_AUTH_TOKEN='tkn'\n"
+    "OPENCLAW_DEFAULT_MODEL='gpt-5'\n"
+    "OPENAI_API_KEY='sk-oa-1'\n"
+    "DISCORD_BOT_TOKEN='discord-bot'\n"
+    "GITHUB_TOKEN_GH_A='ghp_a'\n"
+    "GITHUB_TOKEN='ghp_a'\n"
+)
+
+_OPENCLAW_ENV_BEDROCK = (
+    "# Managed by clawrium (clawctl). Re-render with `clawctl agent configure alpha`.\n"
+    "OPENCLAW_GATEWAY_BIND='lan'\n"
+    "OPENCLAW_GATEWAY_PORT=40000\n"
+    "OPENCLAW_GATEWAY_AUTH_MODE=token\n"
+    "OPENCLAW_GATEWAY_AUTH_TOKEN='tkn'\n"
+    "OPENCLAW_DEFAULT_MODEL='bedrock/anthropic.claude-opus-4-1-v1:0'\n"
+    "AWS_ACCESS_KEY_ID='AKIA-1'\n"
+    "AWS_SECRET_ACCESS_KEY='secret-1'\n"
+    "DISCORD_BOT_TOKEN='discord-bot'\n"
+    "GITHUB_TOKEN_GH_A='ghp_a'\n"
+    "GITHUB_TOKEN='ghp_a'\n"
+)
+
+_OPENCLAW_ENV_OLLAMA = (
+    "# Managed by clawrium (clawctl). Re-render with `clawctl agent configure alpha`.\n"
+    "OPENCLAW_GATEWAY_BIND='lan'\n"
+    "OPENCLAW_GATEWAY_PORT=40000\n"
+    "OPENCLAW_GATEWAY_AUTH_MODE=token\n"
+    "OPENCLAW_GATEWAY_AUTH_TOKEN='tkn'\n"
+    "OPENCLAW_DEFAULT_MODEL='llama3'\n"
+    "OPENCLAW_OLLAMA_URL='http://10.0.0.5:11434'\n"
+    "DISCORD_BOT_TOKEN='discord-bot'\n"
+    "GITHUB_TOKEN_GH_A='ghp_a'\n"
+    "GITHUB_TOKEN='ghp_a'\n"
+)
+
+_OPENCLAW_ENV_ZAI = (
+    "# Managed by clawrium (clawctl). Re-render with `clawctl agent configure alpha`.\n"
+    "OPENCLAW_GATEWAY_BIND='lan'\n"
+    "OPENCLAW_GATEWAY_PORT=40000\n"
+    "OPENCLAW_GATEWAY_AUTH_MODE=token\n"
+    "OPENCLAW_GATEWAY_AUTH_TOKEN='tkn'\n"
+    "OPENCLAW_DEFAULT_MODEL='glm-4.5'\n"
+    "ZAI_API_KEY='sk-zai-1'\n"
+    "DISCORD_BOT_TOKEN='discord-bot'\n"
+    "GITHUB_TOKEN_GH_A='ghp_a'\n"
+    "GITHUB_TOKEN='ghp_a'\n"
+)
+
+
+@pytest.mark.parametrize(
+    "ptype,expected",
+    [
+        ("openrouter", _OPENCLAW_ENV_OPENROUTER),
+        ("anthropic", _OPENCLAW_ENV_ANTHROPIC),
+        ("openai", _OPENCLAW_ENV_OPENAI),
+        ("bedrock", _OPENCLAW_ENV_BEDROCK),
+        ("ollama", _OPENCLAW_ENV_OLLAMA),
+        ("zai", _OPENCLAW_ENV_ZAI),
+    ],
+)
+def test_openclaw_env_byte_lock(ptype, expected):
+    """Phase 3: byte-equivalence lock for `.openclaw/env` across all 6
+    supported provider types. Any drift in the Jinja template must be
+    intentional and surface here with a clear diff."""
+    out = render_openclaw(_openclaw_inputs(ptype=ptype))
+    assert out.files[".openclaw/env"] == expected
+
+
+def test_openclaw_json_managed_paths_populated():
+    """Phase 3: assert all 5 clawctl-managed paths in openclaw.json are
+    deep-updated from inputs."""
+    import json
+
+    base = _baseline_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type="openclaw",
+        provider=base.provider,
+        channels=(
+            ChannelInputs(
+                name="discord-a",
+                type="discord",
+                bot_token="dt",
+                allowed_users=("u1", "u2"),
+                allowed_guilds=("g1",),
+                allowed_channels=("c1", "c2"),
+            ),
+        ),
+        integrations=(),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tkn", bind="lan"),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+
+    # 1. agents.defaults.model.primary (openrouter prefix applied)
+    assert (
+        blob["agents"]["defaults"]["model"]["primary"]
+        == "openrouter/anthropic/claude-opus-4.7"
+    )
+    # 2. gateway.port
+    assert blob["gateway"]["port"] == 40000
+    # 3. gateway.bind
+    assert blob["gateway"]["bind"] == "lan"
+    # 4. channels.discord.enabled + allowFrom
+    assert blob["channels"]["discord"]["enabled"] is True
+    assert blob["channels"]["discord"]["allowFrom"] == ["u1", "u2"]
+    # 5. channels.discord.guilds — nested reshape
+    assert blob["channels"]["discord"]["guilds"] == {
+        "g1": {
+            "users": ["u1", "u2"],
+            "channels": {
+                "c1": {"allow": True},
+                "c2": {"allow": True},
+            },
+        }
+    }
+
+
+def test_openclaw_json_daemon_sections_preserved():
+    """Phase 3: assert previously-unmanaged daemon sections survive the
+    render byte-identical (mirrors what #565 added for zeroclaw).
+
+    Sections asserted:
+      - env.shellEnv          (shellEnv enabled + timeoutMs)
+      - tools.exec            (host, security, ask)
+      - session.*             (dmScope, threadBindings, reset)
+      - agents.defaults.heartbeat
+      - browser               (enabled: false at minimum)
+    """
+    import json
+
+    inputs = _openclaw_inputs(ptype="openrouter")
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+
+    # env.shellEnv
+    assert blob["env"]["shellEnv"]["enabled"] is True
+    assert blob["env"]["shellEnv"]["timeoutMs"] == 15000
+
+    # tools.exec
+    assert blob["tools"]["exec"] == {
+        "host": "gateway",
+        "security": "full",
+        "ask": "off",
+    }
+
+    # session blocks
+    assert blob["session"]["dmScope"] == "per-channel-peer"
+    assert blob["session"]["threadBindings"] == {
+        "enabled": True,
+        "idleHours": 24,
+        "maxAgeHours": 168,
+    }
+    assert blob["session"]["reset"] == {
+        "mode": "daily",
+        "atHour": 4,
+        "idleMinutes": 120,
+    }
+
+    # agents.defaults.heartbeat
+    assert blob["agents"]["defaults"]["heartbeat"] == {
+        "every": "30m",
+        "target": "last",
+    }
+
+    # browser presence (enabled: false)
+    assert blob["browser"]["enabled"] is False
+
+
+def test_openclaw_dual_discord_channels_raises():
+    """Phase 3: two attached discord channels must raise — openclaw renders
+    one DISCORD_BOT_TOKEN env var and one channels.discord allowlist."""
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="or", type="openrouter", default_model="m", api_key="sk-1"
+        ),
+        channels=(
+            ChannelInputs(name="d1", type="discord", bot_token="t1"),
+            ChannelInputs(name="d2", type="discord", bot_token="t2"),
+        ),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, bind="lan"),
+    )
+    with pytest.raises(AgentConfigError, match="multiple discord channels"):
+        render_openclaw(inputs)
+
+
+def test_openclaw_dual_slack_channels_raises():
+    """Phase 3: two attached slack channels must raise — same shape as
+    dual-discord guard."""
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="or", type="openrouter", default_model="m", api_key="sk-1"
+        ),
+        channels=(
+            ChannelInputs(name="s1", type="slack", bot_token="b1", app_token="a1"),
+            ChannelInputs(name="s2", type="slack", bot_token="b2", app_token="a2"),
+        ),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, bind="lan"),
+    )
+    with pytest.raises(AgentConfigError, match="multiple slack channels"):
+        render_openclaw(inputs)
+
+
+def test_openclaw_json_no_discord_attached_emits_empty_block():
+    """Phase 3: with no discord channel attached, channels.discord must
+    have enabled=false + empty allowFrom + empty guilds."""
+    import json
+
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="or", type="openrouter", default_model="m", api_key="sk-1"
+        ),
+        channels=(),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, bind="lan"),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    assert blob["channels"]["discord"]["enabled"] is False
+    assert blob["channels"]["discord"]["allowFrom"] == []
+    assert blob["channels"]["discord"]["guilds"] == {}


### PR DESCRIPTION
## Summary

Phase 3 of #560. Refactors `render_openclaw` to follow the same canonical-template pattern landed for zeroclaw (#565) and hermes (Phase 2 / PR #567):

- New `openclaw-env.canonical.j2` Jinja template renders `.openclaw/env` byte-equivalent to the prior list-of-strings implementation across all 6 supported providers (openrouter, anthropic, openai, bedrock, ollama, zai).
- New `openclaw.json` JSON baseline is loaded + deep-updated with the 5 clawctl-managed paths (`channels.discord.enabled` / `allowFrom` / `guilds`, `gateway.port` + `gateway.bind`, `agents.defaults.model.primary`). Every other key survives byte-identical — same silent-wipe-prevention contract as #565.
- Up-front validation: unsupported provider/channel/integration types raise; new dual-discord and dual-slack guards added (mirrors hermes/zeroclaw).

Stacked on PR #567 (Phase 2). Base branch already contains the Phase 1 + Phase 2 merges.

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — 100 passed in `tests/core/test_render.py` (+11 net new). 45 pre-existing `tests/test_configure_zeroclaw.py` failures unchanged (called out in Phases 1+2 `01_EXECUTION.md`).
- [x] Linter passes (`make lint`)
- [x] New tests added for new functionality

### Test Coverage
- Files changed: `src/clawrium/core/render.py`, `src/clawrium/platform/registry/openclaw/templates/{openclaw-env.canonical.j2 (NEW), openclaw.json (NEW), .env.j2 (header comment), openclaw.json.j2 (header comment)}`, `tests/core/test_render.py`.
- New tests:
  - 6 byte-locks: `test_openclaw_env_byte_lock[openrouter|anthropic|openai|bedrock|ollama|zai]`.
  - `test_openclaw_json_managed_paths_populated` — all 5 managed paths.
  - `test_openclaw_json_daemon_sections_preserved` — env.shellEnv, tools.exec, session.*, agents.defaults.heartbeat, browser.
  - `test_openclaw_dual_discord_channels_raises` + `test_openclaw_dual_slack_channels_raises`.
  - `test_openclaw_json_no_discord_attached_emits_empty_block`.
- Coverage impact: increased.

### Manual Testing
N/A this PR — Phase 4 (live dry-run + apply on wolf-i) is out of scope for this stacked PR.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (provider type, channel type, integration type up-front validation; dual-channel-type guards)
- [x] No SQL injection, XSS, or command injection risks (shell-quote filter `shq` mirrors `_shell_quote`; JSON values dumped via `json.dumps`)
- [x] Dependencies are from trusted sources (no new dependencies — Jinja2 + stdlib `json`)

## Callouts

**1. Dual-family template coexistence (mirrors Phase 2 / PR #567).** The existing `.env.j2` and `openclaw.json.j2` Jinja templates are still consumed by the Ansible-driven `clawctl agent configure` (`configure.yaml:79, 146`) and `agent install` (`install.yaml:152`) playbooks. They use the pre-F3 `config.*` extravar shape. Rewriting them to F3 inputs would break the legacy path and its test suite. New canonical templates are added alongside; cross-reference comments on both legacy files link to the new canonical replacements. Consolidation of the two template families is deferred to the same follow-up that retires the legacy Ansible configure path.

**2. `openclaw.json` baseline is synthesized, not captured from wolf-i.** The plan called for capturing wolf-i's live `openclaw.json` as the baseline (111 lines). During execution I did not have access to wolf-i, so the baseline was synthesized from the legacy `openclaw.json.j2`'s unconditional structure + sensible defaults. Phase 4 live dry-run on wolf-i will surface any drift (only the 5 managed fields should diverge — any other drift indicates the synthesized baseline is wrong and needs to be replaced with the captured live file). The synthesized baseline includes: `agents.defaults` (workspace, model, imageMaxDimensionPx, maxConcurrent, sandbox, heartbeat), `gateway` (mode, port, bind, reload), `session` (dmScope, threadBindings, reset), `tools` (exec, deny=[browser]), `channels.discord` (enabled, allowFrom, guilds), `browser` (enabled=false), `env.shellEnv` (enabled, timeoutMs).

**3. No `commands.native` block in baseline.** The plan's daemon-section preservation list mentions `commands.native`, but neither the legacy `openclaw.json.j2` defaults nor the synthesized baseline carries one. If wolf-i's live file does (Phase 4 verify), the baseline can absorb the captured block verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)