### PR TITLE
docs(channels): F9+F10 drop --stage channels references + CHANGELOG (#560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,57 @@ Highlights:
 - New blog post:
   [`website/blog/2026-05-24-clawctl-kubectl-ux.md`](website/blog/2026-05-24-clawctl-kubectl-ux.md).
 
+### Fixed
+
+- **#555 — silent on-host config wipe on every `clawctl agent
+  sync|configure|restart|skill attach|channel attach|integration
+  attach`.** Templates emitted provider, channel, and integration
+  blocks conditionally on `hosts.json.agents.<n>.config.*` being
+  populated; when those fields were null (the common state after the
+  attachment-list refactor), every sync silently dropped the
+  `OPENROUTER_API_KEY`, `DISCORD_*`, `SLACK_*`, and integration env
+  vars from `~/.hermes/.env` and `[channels.discord]` /
+  `[providers.models.*]` blocks from `~/.zeroclaw/config.toml` while
+  reporting `drift=0`.
+
+  **Regression window:** from the conditional-emit commit that
+  introduced the `config.channels` / `config.provider` reads through
+  the F1–F6 canonical render pipeline (PR #556, #557, #559) and
+  legacy read-path drop (PR #566, #567, #568 — this release).
+
+  **Affected agents:** anyone whose
+  `hosts.json.agents.<n>.config.provider` or
+  `hosts.json.agents.<n>.config.channels` was ever null (the default
+  state when the agent was last attached using the new
+  `clawctl channel registry create` / `clawctl agent channel attach`
+  flow without a prior legacy-stage write).
+
+  **Recovery:**
+
+  ```bash
+  # 1. Re-derive provider_id / channels[] / integrations[] from
+  #    onboarding + secrets.json + on-host .env grep. Idempotent.
+  clawctl admin migrate-agent <agent-name>
+
+  # 2. Confirm the agent's declared attachments resolve cleanly.
+  clawctl agent doctor <agent-name>
+
+  # 3. Dry-run the sync to see exactly what will land on the host.
+  clawctl agent sync <agent-name> --dry-run --diff
+
+  # 4. Apply.
+  clawctl agent sync <agent-name>
+  ```
+
+  After this release, `clawctl agent sync` reads from clawctl's own
+  stores (`providers.json` + `channels.json` + `integrations.json` +
+  `secrets.json` + `hosts.json.agents.<n>.{provider_id, channels[],
+  integrations[]}`), renders the full canonical bundle deterministically,
+  and refuses to remove a host-side secret without `--force` or an
+  explicit detach. There is no `drift=0` success path that depends on
+  clawctl's own incomplete model — drift is computed against what's
+  actually on the host.
+
 ### Migration notes
 
 For each existing agent on each host:
@@ -97,3 +148,8 @@ clawctl agent sync <agent-name>
 
 Remote `clawctl agent chat` sessions will see a one-time 401 after the
 sync; reconnecting picks up the fresh bearer transparently.
+
+**Anyone who ran `clawctl agent sync|configure|restart` against an
+agent during the regression window:** follow the recovery sequence
+above to re-derive lost attachments and re-render the on-host config
+from the canonical pipeline.

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -193,8 +193,9 @@ If you need to reconfigure a specific stage:
 ```bash
 clawctl agent configure <agent-name> --stage providers
 clawctl agent configure <agent-name> --stage identity
-clawctl agent configure <agent-name> --stage channels
 ```
+
+> **Channels:** the `--stage channels` flow is deprecated (#555). Use `clawctl channel registry create` + `clawctl agent channel attach` instead. See [Channels → Configuration](agent-support/channels/index.md#configuration).
 
 ### Skip Prompts
 

--- a/docs/agent-support/channels/discord.md
+++ b/docs/agent-support/channels/discord.md
@@ -119,7 +119,7 @@ Once running, interact with the bot by:
 
 **"Token invalid"**
 - Regenerate token in Discord Developer Portal
-- Re-run: `clawctl agent configure <name> --stage channels`
+- Re-register the channel: `clawctl channel registry create <channel-name> --type discord --token-stdin <<<"$NEW_TOKEN"` then `clawctl agent sync <agent-name>` (the existing attachment picks up the new token)
 
 **"Missing permissions"**
 - Re-invite bot with correct permissions
@@ -148,67 +148,85 @@ Hermes uses a simpler configuration model than OpenClaw — env vars rendered di
 | `DISCORD_ALLOWED_CHANNELS` | no | Restrict bot to specific channel IDs (empty = any channel the bot was invited to) |
 | `DISCORD_REQUIRE_MENTION` | no | `true` (default): require `@mention` in guild channels; DMs always work |
 
-### Interactive setup (Hermes)
+### Setup (Hermes)
 
 ```bash
-clawctl agent configure <hermes-name> --stage channels
+# 1. Register the channel in the registry (one record, reusable across agents)
+clawctl channel registry create <channel-name> --type discord \
+  --token-stdin <<<"$BOT_TOKEN" \
+  --allowed-user 740723459344302120 \
+  --home-channel 1503238729962356777 \
+  --require-mention
+
+# 2. Attach the channel to the agent
+clawctl agent channel attach <channel-name> --agent <hermes-name>
+
+# 3. Sync the agent (renders ~/.hermes/.env and restarts the unit)
+clawctl agent sync <hermes-name>
 ```
 
-The wizard offers `cli`, `discord`, and `slack`. Pick `discord` and the CLI prompts for:
+Flags accepted by `clawctl channel registry create` (canonical fields, persisted in `~/.config/clawrium/channels.json`):
 
-| Prompt | Stored where | Required | Notes |
-|--------|--------------|:--------:|-------|
-| Discord bot token | `secrets.json` as `DISCORD_BOT_TOKEN` | yes | Masked input. Bearer token for the Discord gateway. |
-| Allowed Discord user IDs | `hosts.json` `channels.discord.allowed_users` | yes (or `all`) | Comma-separated IDs (17–19 digits). Use the literal string `all` to allow any user — you'll get a security warning + confirm prompt. |
-| Discord home channel ID | `hosts.json` `channels.discord.home_channel` | optional | Without this, hermes will nudge users to run `/sethome` on every cold start. |
-| Discord home channel name | `hosts.json` `channels.discord.home_channel_name` | optional | Defaults to `Home`. Display name only. |
-| Allowed channel IDs | `hosts.json` `channels.discord.allowed_channels` | optional | Restrict the bot to specific channels (comma-separated). Empty = any channel the bot is invited to. |
-| Require `@mention` to respond? | `hosts.json` `channels.discord.require_mention` | optional | Defaults to true. DMs always work regardless. |
+| Flag | Required | Notes |
+|------|:--------:|-------|
+| `--type discord` | yes | Channel type. |
+| `--token` / `--token-stdin` | yes | Bot token. Stored in `secrets.json` under `channel:<channel-name>`, never in `channels.json`. |
+| `--allowed-user <id>` | yes (repeatable) | Discord user IDs (17–19 digits). Hermes silently drops messages from non-allowlisted users. |
+| `--home-channel <id>` | optional | Default channel ID. Without this, hermes nudges users to run `/sethome` on every cold start. |
+| `--allowed-channel <id>` | optional (repeatable) | Restrict the bot to specific channels. Empty = any channel the bot is invited to. |
+| `--require-mention` / `--no-require-mention` | optional | Defaults to true. DMs always work regardless. |
 
-`clawctl` then runs the configure playbook which re-renders `~/.hermes/.env` with the `DISCORD_*` block and restarts `hermes-<name>.service`. Verification tasks confirm the token + an allowlist landed in the env file before the playbook reports success.
+`clawctl agent sync` re-renders `~/.hermes/.env` with the `DISCORD_*` block from the attached channel's registry record and restarts `hermes-<name>.service`. Verification confirms the token + allowlist landed in the env file before sync reports success.
 
 ### Resulting on-disk shape (Hermes)
 
-`hosts.json` (non-sensitive only):
+`channels.json` (non-sensitive only — one record per chat surface, reusable across agents):
 
 ```json
-"config": {
-  "api_server": {"enabled": true, "host": "127.0.0.1", "port": 8642},
-  "provider": {...},
-  "channels": {
-    "discord": {
-      "enabled": true,
+{
+  "<channel-name>": {
+    "name": "<channel-name>",
+    "type": "discord",
+    "config": {
       "allowed_users": ["740723459344302120"],
-      "allow_all_users": false,
       "home_channel": "1503238729962356777",
-      "home_channel_name": "Home",
       "require_mention": true
-    }
+    },
+    "created_at": "..."
   }
 }
 ```
 
-`secrets.json`:
+`hosts.json` carries only the attachment list:
 
 ```json
-"192.168.1.36:hermes:<name>": {
-  "HERMES_API_SERVER_KEY": {...},
-  "DISCORD_BOT_TOKEN": {"value": "<token>", "description": "Discord bot token", ...}
+"agents": {
+  "<hermes-name>": {
+    "channels": ["<channel-name>"]
+  }
 }
 ```
 
-The bot token **never** lands in `hosts.json` — the configure flow strips it from `config.channels.discord` before persisting (B3 invariant, mirrored from the `api_server.key` strip). Re-running `clawctl agent configure --stage channels` with the same token reuses it byte-identical (idempotency contract).
+`secrets.json` carries the bot token, keyed by channel name (B3 invariant):
+
+```json
+"channel:<channel-name>": {
+  "DISCORD_BOT_TOKEN": {"value": "<token>", "description": "Discord bot token"}
+}
+```
+
+The bot token **never** lands in `channels.json` or `hosts.json` — `clawctl channel registry create` strips it into `secrets.json` before persisting.
 
 ### Removal (Hermes)
 
-`clawctl agent delete <name> --force` purges the entire instance entry from `secrets.json`, including `DISCORD_BOT_TOKEN`. There is no separate "rotate Discord token" command — re-run the channels stage with a new token to overwrite.
+`clawctl agent channel detach <channel-name> --agent <hermes-name>` removes the attachment. `clawctl agent sync <hermes-name>` then re-renders `~/.hermes/.env` without the `DISCORD_*` block. To delete the channel from the registry (and its secret): `clawctl channel registry delete <channel-name> --yes --force`.
 
 ### Hermes-specific troubleshooting
 
 <details>
 <summary><strong>Bot is online but doesn't respond in the test channel</strong></summary>
 
-1. Confirm your Discord user ID is in `hosts.json` `channels.discord.allowed_users` (or `allow_all_users: true`). Hermes silently drops messages from non-allowlisted users.
+1. Confirm your Discord user ID is in the channel registry's `allowed_users` (run `clawctl channel registry describe <channel-name>`). Hermes silently drops messages from non-allowlisted users.
 2. If `require_mention` is true (default), the bot only responds to messages that `@mention` it directly in a guild channel. DMs always work.
 3. Confirm the bot has the right Discord permissions in the guild: Send Messages, Read Message History, Use Slash Commands.
 4. If `allowed_channels` is non-empty, the bot only responds in those channel IDs.
@@ -231,13 +249,13 @@ If you see nothing, temporarily bump `LOG_LEVEL=INFO` in `~/.hermes/.env` (manua
 <details>
 <summary><strong><code>DISCORD_ALLOW_ALL_USERS=true</code> is set and I want to lock it down</strong></summary>
 
-Re-run `clawctl agent configure <name> --stage channels`, pick `discord` again, and pass specific user IDs (not `all`) at the allowlist prompt. The new value overwrites the previous `channels.discord` block in `hosts.json`, and the next `~/.hermes/.env` render drops `DISCORD_ALLOW_ALL_USERS` entirely.
+Re-create the channel record with specific user IDs: `clawctl channel registry delete <channel-name> --yes --force` then `clawctl channel registry create <channel-name> --type discord --token-stdin <<<"$BOT_TOKEN" --allowed-user <id1> --allowed-user <id2>`. Re-attach with `clawctl agent channel attach <channel-name> --agent <name>` and `clawctl agent sync <name>` — the next `~/.hermes/.env` render drops `DISCORD_ALLOW_ALL_USERS` entirely.
 
 </details>
 
 ### Non-interactive flags (Hermes)
 
-Planned for a follow-up — interactive is the supported path in this release. For automation today, drive `clawctl agent configure --stage channels` via expect/pexpect, or set the values directly in `hosts.json` + `secrets.json` and re-run the stage to trigger a re-render.
+The `clawctl channel registry create` flags listed in [Setup (Hermes)](#setup-hermes) accept all values non-interactively, including `--token-stdin` for the bot token. Compose with `clawctl agent channel attach` and `clawctl agent sync` for fully scripted setup.
 
 ---
 
@@ -270,26 +288,37 @@ These wizard inputs land in `hosts.json` but are **not** rendered into `~/.zeroc
 
 If you set any of these via the wizard for a zeroclaw agent, they persist to `hosts.json` for forward compatibility but have no runtime effect.
 
-### Interactive setup (ZeroClaw)
+### Setup (ZeroClaw)
 
 ```bash
-clawctl agent configure <zeroclaw-name> --stage channels
+# 1. Register the channel in the registry
+clawctl channel registry create <channel-name> --type discord \
+  --token-stdin <<<"$BOT_TOKEN" \
+  --allowed-guild 987654321098765432 \
+  --allowed-user 740723459344302120 \
+  --require-mention \
+  --stream-mode partial
+
+# 2. Attach to the zeroclaw agent
+clawctl agent channel attach <channel-name> --agent <zeroclaw-name>
+
+# 3. Sync (renders ~/.zeroclaw/config.toml with [channels.discord] and restarts the unit)
+clawctl agent sync <zeroclaw-name>
 ```
 
-Prompts:
+Flags accepted (zeroclaw schema, per v0.7.5 upstream):
 
-| Prompt | Field |
-|---|---|
-| `Confirm CLI channel` | always-on; sets `confirm_cli = true` |
-| `Enable Discord channel (optional)` | persists `channels.discord.enabled` in `hosts.json` |
-| `Discord bot token` (masked) | persists to `secrets.json` as `DISCORD_BOT_TOKEN` |
-| `Allowed Discord user IDs` | `allowed_users` list |
-| `Allowed guild IDs` (optional) | `allowed_guilds` list |
-| `Reply to mentions only?` | `require_mention` → rendered as `reply_to_mentions_only` |
-| `Discord stream mode (off/partial/multi_message)` | `stream_mode` (default `partial`) |
-| `Delay between Discord messages in ms` (only when `stream_mode = multi_message`) | `multi_message_delay_ms` (10000–60000) |
+| Flag | Renders to TOML |
+|------|-----------------|
+| `--type discord` | gating |
+| `--token` / `--token-stdin` | `bot_token` (inline TOML; never in `channels.json`) |
+| `--allowed-user <id>` (repeatable) | `allowed_users = [...]` |
+| `--allowed-guild <id>` (repeatable) | `allowed_guilds = [...]` |
+| `--require-mention` / `--no-require-mention` | `mention_only = true/false` (default true) |
+| `--stream-mode <off\|partial\|multi_message>` | `stream_mode = "..."` |
+| `--stream-delay <ms>` | `draft_update_interval_ms` (partial) or `multi_message_delay_ms` (multi_message) |
 
-`clawctl` then runs the configure playbook, which re-renders `~/.zeroclaw/config.toml` with the `[channels.discord]` block, restarts `zeroclaw-<name>.service`, and verifies the block landed by grepping for `^bot_token =` in the file.
+`clawctl agent sync` re-renders `~/.zeroclaw/config.toml` with the `[channels.discord]` block from the attached channel's registry record, restarts `zeroclaw-<name>.service`, and verifies the block landed by grepping for `^bot_token =`.
 
 ### Streaming progress on long-running turns
 
@@ -314,29 +343,35 @@ draft_update_interval_ms = 750
 stream_mode = "partial"
 ```
 
-In `hosts.json` (agents.`<name>`.config.channels.discord):
+In `channels.json` (one record per chat surface):
 
 ```json
 {
-  "enabled": true,
-  "allowed_users": ["740723459344302120"],
-  "allowed_guilds": ["987654321098765432"],
-  "require_mention": true
+  "<channel-name>": {
+    "name": "<channel-name>",
+    "type": "discord",
+    "config": {
+      "allowed_users": ["740723459344302120"],
+      "allowed_guilds": ["987654321098765432"],
+      "require_mention": true,
+      "stream_mode": "partial"
+    }
+  }
 }
 ```
 
-`bot_token` is **never** stored in `hosts.json` — only `secrets.json` (mode 0600).
+`hosts.json` carries only the attachment list under `agents.<name>.channels[]`. `bot_token` lives **only** in `secrets.json` under `channel:<channel-name>:DISCORD_BOT_TOKEN` (mode 0600).
 
 ### Removal (ZeroClaw)
 
-Re-run `clawctl agent configure <name> --stage channels` and answer **No** to "Enable Discord channel?". On the next render, the `[channels.discord]` block disappears from `config.toml` and the daemon stops listening on Discord on restart. To also wipe the persisted token, manually remove the `DISCORD_BOT_TOKEN` entry from `secrets.json`.
+`clawctl agent channel detach <channel-name> --agent <name>` then `clawctl agent sync <name>`. On the next render, the `[channels.discord]` block disappears from `config.toml` and the daemon stops listening on Discord on restart. To also wipe the channel from the registry (and its token): `clawctl channel registry delete <channel-name> --yes --force`.
 
 ### ZeroClaw-specific troubleshooting
 
 <details>
 <summary><strong>Bot connects but doesn't reply to my messages</strong></summary>
 
-1. Confirm your Discord user ID is in `~/.zeroclaw/config.toml` under `[channels.discord]` `allowed_users` — empty array means **allow all users** (zeroclaw upstream convention), but if you populated it with other IDs, yours must be in the list.
+1. Confirm your Discord user ID is in the channel registry's `allowed_users` (run `clawctl channel registry describe <channel-name>`). The rendered `~/.zeroclaw/config.toml` under `[channels.discord]` `allowed_users` must contain your ID — empty array means **allow all users** (zeroclaw upstream convention).
 2. If `reply_to_mentions_only = true`, the bot only responds when @-mentioned.
 3. Check the Discord Developer Portal: the bot must have `Message Content Intent` and `Server Members Intent` enabled (zeroclaw upstream requirement).
 
@@ -349,7 +384,7 @@ Re-run `clawctl agent configure <name> --stage channels` and answer **No** to "E
 ssh <agent-host> "sudo journalctl -u zeroclaw-<name>.service -n 200 --no-pager | grep -iE 'discord|channel'"
 ```
 
-If the daemon logged a token error, rotate the bot token in the Discord Developer Portal and re-run `clawctl agent configure <name> --stage channels` to push the new value.
+If the daemon logged a token error, rotate the bot token in the Discord Developer Portal, re-create the channel record (`clawctl channel registry delete` then `clawctl channel registry create` with the new token), re-attach if needed, and `clawctl agent sync <name>` to push the new value.
 
 </details>
 

--- a/docs/agent-support/channels/index.md
+++ b/docs/agent-support/channels/index.md
@@ -35,22 +35,29 @@ An agent uses:
 
 ## Configuration
 
-Channels are configured during agent onboarding:
+Channels are managed in two steps:
 
-```bash
-clawctl agent configure <agent-name>
-# Select channel during the channels stage
-```
+1. **Register the channel** in the channel registry (one record per chat surface, reusable across agents):
 
-## Switching Channels
+   ```bash
+   clawctl channel registry create <channel-name> --type discord --token-stdin <<<"$BOT_TOKEN"
+   # or for slack:
+   clawctl channel registry create <channel-name> --type slack \
+     --token-stdin <<<"$BOT_TOKEN" --app-token "$APP_TOKEN"
+   ```
 
-To change an agent's channel:
+2. **Attach the channel to an agent**:
 
-```bash
-clawctl agent configure <agent-name> --stage channels
-```
+   ```bash
+   clawctl agent channel attach <channel-name> --agent <agent-name>
+   clawctl agent sync <agent-name>
+   ```
 
-Note: Some agents (like ZeroClaw) only support CLI and cannot switch channels.
+To detach: `clawctl agent channel detach <channel-name> --agent <agent-name>` followed by `clawctl agent sync <agent-name>`.
+
+> **Deprecated:** `clawctl agent configure --stage channels` and writes to `hosts.json.agents.<name>.config.channels.*` are no longer supported. The canonical attachment list is `hosts.json.agents.<name>.channels[]` (see #555).
+
+Note: Some agents (like ZeroClaw) only support CLI and cannot attach chat channels.
 
 ---
 

--- a/docs/agent-support/channels/slack.md
+++ b/docs/agent-support/channels/slack.md
@@ -41,7 +41,7 @@ Without these, you **cannot DM the bot**:
 - ✅ `im:write` - Bot MUST be able to write to DMs (⚠️ see security note below — applies to both OpenClaw and Hermes)
 - ✅ `chat:write` - Bot MUST be able to send messages
 
-> **⚠️ Security note on `im:write` (applies to OpenClaw *and* Hermes):** This scope lets the bot *initiate* unsolicited DMs to **any** workspace member — neither OpenClaw's `allowFrom` nor Hermes' `SLACK_ALLOWED_USERS` gate outbound messages. A compromised agent host or leaked `xoxb-` token can DM-spam or phish the entire workspace. Mitigations: keep the host hardened; treat the bot token as a high-value secret; rotate the token immediately on suspicion (Slack API → **OAuth & Permissions** → **Rotate Tokens** → re-run `clawctl agent configure <name> --stage channels` with the new bearer); audit `users:read` calls in your workspace's Slack audit log if you suspect abuse.
+> **⚠️ Security note on `im:write` (applies to OpenClaw *and* Hermes):** This scope lets the bot *initiate* unsolicited DMs to **any** workspace member — neither OpenClaw's `allowFrom` nor Hermes' `SLACK_ALLOWED_USERS` gate outbound messages. A compromised agent host or leaked `xoxb-` token can DM-spam or phish the entire workspace. Mitigations: keep the host hardened; treat the bot token as a high-value secret; rotate the token immediately on suspicion (Slack API → **OAuth & Permissions** → **Rotate Tokens** → re-create the channel record (`clawctl channel registry delete <channel-name> --yes --force` then `clawctl channel registry create <channel-name> --type slack ...` with the new bearer) and `clawctl agent sync <name>`); audit `users:read` calls in your workspace's Slack audit log if you suspect abuse.
 
 ### Required Event Subscriptions
 Without these, the bot **will not receive your DMs**:
@@ -178,18 +178,19 @@ Slack will prompt you to invite the bot to the channel.
 3. The ID starts with `U` (e.g., `U01ABC2DEF`)
 4. This goes in the `allowFrom` list during configuration
 
-### Step 7: Configure in Clawrium
+### Step 7: Register and attach in Clawrium
 
 ```bash
-clawctl agent configure <agent-name>
-# Select "slack" when prompted for channel
-# Enter your Bot Token, App Token, and User ID
-```
+# 1. Register the channel in the registry
+clawctl channel registry create <channel-name> --type slack \
+  --token-stdin <<<"$SLACK_BOT_TOKEN" \
+  --app-token "$SLACK_APP_TOKEN" \
+  --allowed-user U01ABC2DEF3 \
+  --home-channel C01234567890
 
-Or reconfigure just the channels stage:
-
-```bash
-clawctl agent configure <agent-name> --stage channels
+# 2. Attach to the agent and sync
+clawctl agent channel attach <channel-name> --agent <agent-name>
+clawctl agent sync <agent-name>
 ```
 
 ---
@@ -277,7 +278,7 @@ Hermes uses a simpler configuration model — env vars rendered directly into `~
 | `im:write` | **DMs** | **Slack won't allow users to message the bot** |
 | `users:read` | All | Bot cannot look up user info for allowlist checks |
 
-> **⚠️ Security note on `im:write`:** This scope also permits the bot to *initiate* unsolicited DMs to **any** workspace member — the `SLACK_ALLOWED_USERS` allowlist only gates inbound commands, not outbound messages. A compromised agent host or leaked bot token could DM-spam or phish the entire workspace. Keep the agent host hardened and the `xoxb-` bot token in `secrets.json` only. **On suspicion of leakage:** rotate via Slack API → **OAuth & Permissions** → **Rotate Tokens**, then re-run `clawctl agent configure <name> --stage channels` with the new bearer.
+> **⚠️ Security note on `im:write`:** This scope also permits the bot to *initiate* unsolicited DMs to **any** workspace member — the `SLACK_ALLOWED_USERS` allowlist only gates inbound commands, not outbound messages. A compromised agent host or leaked bot token could DM-spam or phish the entire workspace. Keep the agent host hardened and the `xoxb-` bot token in `secrets.json` only. **On suspicion of leakage:** rotate via Slack API → **OAuth & Permissions** → **Rotate Tokens**, then re-create the channel record (`clawctl channel registry delete <channel-name> --yes --force` then `clawctl channel registry create <channel-name> --type slack ...` with the new bearer) and `clawctl agent sync <name>`.
 
 ### Required event subscriptions
 
@@ -299,54 +300,61 @@ Hermes uses a simpler configuration model — env vars rendered directly into `~
 
 Hermes uses **Socket Mode** — the bot maintains an outbound WebSocket to Slack, so no public endpoint or ingress is required on the agent host.
 
-### Interactive setup (Hermes)
+### Setup (Hermes)
 
 ```bash
-clawctl agent configure <hermes-name> --stage channels
+# 1. Register the channel in the registry
+clawctl channel registry create <channel-name> --type slack \
+  --token-stdin <<<"$SLACK_BOT_TOKEN" \
+  --app-token "$SLACK_APP_TOKEN" \
+  --allowed-user U01ABC2DEF3 \
+  --home-channel C01234567890
+
+# 2. Attach and sync
+clawctl agent channel attach <channel-name> --agent <hermes-name>
+clawctl agent sync <hermes-name>
 ```
 
-The wizard offers `cli`, `discord`, and `slack`. Pick `slack` and the CLI prompts for:
+Flags accepted by `clawctl channel registry create --type slack`:
 
-| Prompt | Stored where | Required | Notes |
-|--------|--------------|:--------:|-------|
-| Slack Bot Token | `secrets.json` as `SLACK_BOT_TOKEN` | yes | Masked input. Must start with `xoxb-`. |
-| Slack App Token | `secrets.json` as `SLACK_APP_TOKEN` | yes | Masked input. Must start with `xapp-`. |
-| Allowed Slack user IDs | `hosts.json` `channels.slack.allowed_users` | yes | Comma-separated Member IDs (format: `U` + 8+ alphanumeric chars). |
-| Slack home channel ID | `hosts.json` `channels.slack.home_channel` | optional | Channel for cron/scheduled messages. Format: `C` + alphanumeric. |
-| Slack home channel name | `hosts.json` `channels.slack.home_channel_name` | optional | Display name for the home channel. |
+| Flag | Required | Notes |
+|------|:--------:|-------|
+| `--token` / `--token-stdin` | yes | Bot User OAuth Token. Stored in `secrets.json` under `channel:<channel-name>:SLACK_BOT_TOKEN`. Must start with `xoxb-`. |
+| `--app-token` | yes | App-Level Token for Socket Mode. Stored in `secrets.json` under `channel:<channel-name>:SLACK_APP_TOKEN`. Must start with `xapp-`. |
+| `--allowed-user <id>` (repeatable) | yes | Slack Member IDs (format: `U` + 8+ alphanumeric chars). |
+| `--home-channel <id>` | optional | Channel ID for cron/scheduled messages. Format: `C` + alphanumeric. |
 
-`clawctl` then runs the configure playbook which re-renders `~/.hermes/.env` with the `SLACK_*` block and restarts `hermes-<name>.service`.
+`clawctl agent sync` re-renders `~/.hermes/.env` with the `SLACK_*` block from the attached channel's registry record and restarts `hermes-<name>.service`.
 
 ### Resulting on-disk shape (Hermes)
 
-`hosts.json` (non-sensitive only):
+`channels.json` (non-sensitive — one record per chat surface):
 
 ```json
-"config": {
-  "api_server": {"enabled": true, "host": "127.0.0.1", "port": 8642},
-  "provider": {...},
-  "channels": {
-    "slack": {
-      "enabled": true,
+{
+  "<channel-name>": {
+    "name": "<channel-name>",
+    "type": "slack",
+    "config": {
       "allowed_users": ["U01ABC2DEF3"],
-      "home_channel": "C01234567890",
-      "home_channel_name": "general"
+      "home_channel": "C01234567890"
     }
   }
 }
 ```
 
+`hosts.json` carries the attachment list under `agents.<name>.channels[]`.
+
 `secrets.json`:
 
 ```json
-"192.168.1.36:hermes:<name>": {
-  "HERMES_API_SERVER_KEY": {...},
-  "SLACK_BOT_TOKEN": {"value": "xoxb-...", "description": "Slack bot token", ...},
-  "SLACK_APP_TOKEN": {"value": "xapp-...", "description": "Slack app token", ...}
+"channel:<channel-name>": {
+  "SLACK_BOT_TOKEN": {"value": "xoxb-...", "description": "Slack bot token"},
+  "SLACK_APP_TOKEN": {"value": "xapp-...", "description": "Slack app token"}
 }
 ```
 
-Both tokens **never** land in `hosts.json` — the configure flow stores them exclusively in `secrets.json` (B3 invariant). Re-running `clawctl agent configure --stage channels` with the same tokens reuses them byte-identical.
+Both tokens **never** land in `channels.json` or `hosts.json` — `clawctl channel registry create` stores them exclusively in `secrets.json` (B3 invariant). Re-creating the channel record with the same tokens reuses them byte-identical.
 
 ### Rendered `.env` (Slack block, Hermes)
 
@@ -363,14 +371,14 @@ SLACK_HOME_CHANNEL_NAME=general
 
 ### Removal (Hermes)
 
-`clawctl agent delete <name> --force` purges the entire instance entry from `secrets.json`, including both Slack tokens. There is no separate "rotate Slack token" command — re-run the channels stage with new tokens to overwrite.
+`clawctl agent channel detach <channel-name> --agent <hermes-name>` then `clawctl agent sync <hermes-name>` drops the `SLACK_*` block from `~/.hermes/.env`. To wipe the channel record and its tokens entirely: `clawctl channel registry delete <channel-name> --yes --force`. To rotate tokens without dropping the attachment: re-create the channel record with new tokens, then `clawctl agent sync <hermes-name>`.
 
 ### Hermes-specific troubleshooting
 
 <details>
 <summary><strong>Bot connects but gets `missing_scope` errors</strong></summary>
 
-Hermes logs will show errors like `slack_bolt: missing_scope: channels:read`. Go to your Slack app's **OAuth & Permissions** > **Scopes** and add the missing scope. Then **reinstall the app** to your workspace (Slack requires reinstall after scope changes). You do NOT need to re-run `clawctl agent configure` — the tokens remain valid after reinstall.
+Hermes logs will show errors like `slack_bolt: missing_scope: channels:read`. Go to your Slack app's **OAuth & Permissions** > **Scopes** and add the missing scope. Then **reinstall the app** to your workspace (Slack requires reinstall after scope changes). You do NOT need to re-create the channel record — the tokens remain valid after reinstall.
 
 </details>
 
@@ -417,15 +425,14 @@ Go to **OAuth & Permissions** → **Scopes** → **Bot Token Scopes** and confir
 **If any are missing:** Add them → Reinstall app to workspace.
 
 ### 4. Verify User Allowlist (Hermes only)
-Your Slack Member ID must be in the allowed users list. Replace `<name>` with your hermes agent name:
+Your Slack Member ID must be in the channel record's `allowed_users` list:
 ```bash
-AGENT=<name>
-cat ~/.config/clawrium/hosts.json | jq --arg n "$AGENT" '.[] | select(.agents[$n]) | .agents[$n].config.channels.slack.allowed_users'
+clawctl channel registry describe <channel-name>
 ```
 
 **Find your Member ID:** Slack profile → ⋯ (three dots) → Copy Member ID
 
-**If your ID is missing:** Run `clawctl agent configure <name> --stage channels` and add your ID.
+**If your ID is missing:** Re-create the channel record (`clawctl channel registry delete <channel-name> --yes --force` then `clawctl channel registry create <channel-name> --type slack ... --allowed-user <your-id>`), re-attach if needed, and `clawctl agent sync <name>`.
 
 ### 5. Check Agent Logs
 ```bash

--- a/docs/agent-support/hermes.md
+++ b/docs/agent-support/hermes.md
@@ -47,8 +47,8 @@ Hermes supports three channels managed by clawctl: a loopback OpenAI-compatible 
 | Channel | Status | Notes |
 |---------|:------:|-------|
 | **Local OpenAI-compatible HTTP API** (`POST /v1/chat/completions`, `GET /v1/models`, `GET /health`) | ✅ | Bound to loopback on the agent host. See [Use the local API](#3-use-the-local-openai-compatible-api). |
-| **[Discord](channels/discord.md)** | ✅ | clawctl-managed via `clawctl agent configure <name> --stage channels`. Token in `secrets.json` (B3 invariant); non-sensitive config in `hosts.json`. See [Discord channel page → Hermes Configuration](channels/discord.md#hermes-configuration). |
-| **[Slack](channels/slack.md)** | ✅ | Socket Mode (no public endpoint). clawctl-managed via `clawctl agent configure <name> --stage channels`. Both tokens in `secrets.json`; non-sensitive config in `hosts.json`. See [Slack channel page → Hermes Configuration](channels/slack.md#hermes-configuration). |
+| **[Discord](channels/discord.md)** | ✅ | clawctl-managed via `clawctl channel registry create` + `clawctl agent channel attach`. Token in `secrets.json` (B3 invariant); non-sensitive config in `channels.json`. See [Discord channel page → Setup (Hermes)](channels/discord.md#setup-hermes). |
+| **[Slack](channels/slack.md)** | ✅ | Socket Mode (no public endpoint). clawctl-managed via `clawctl channel registry create` + `clawctl agent channel attach`. Both tokens in `secrets.json`; non-sensitive config in `channels.json`. See [Slack channel page → Setup (Hermes)](channels/slack.md#setup-hermes). |
 | **`clawctl agent chat <hermes-name>`** | ✅ | Supported via the OpenAI-compatible HTTP backend (`HermesOpenAIBackend`). Connects to `http://<host>:8642/v1` using the bearer token from `secrets.json`. |
 | **Telegram / WhatsApp / Signal** | 📋 | Deferred |
 | **Email / Matrix / Mattermost / Teams / Google Chat** | 📋 | Deferred |

--- a/docs/agent-support/openclaw.md
+++ b/docs/agent-support/openclaw.md
@@ -130,7 +130,7 @@ clawctl agent chat my-assistant
 <summary><strong>"Discord bot token invalid"</strong></summary>
 
 1. Verify the bot token in Discord Developer Portal
-2. Re-run: `clawctl agent configure <name> --stage channels`
+2. Re-create the channel record (`clawctl channel registry delete <channel-name> --yes --force` then `clawctl channel registry create <channel-name> --type discord --token-stdin <<<"$BOT_TOKEN" ...`), re-attach if needed (`clawctl agent channel attach <channel-name> --agent <name>`), and `clawctl agent sync <name>`
 3. Ensure the bot has proper server permissions
 </details>
 

--- a/docs/agent-support/zeroclaw.md
+++ b/docs/agent-support/zeroclaw.md
@@ -64,7 +64,7 @@ ZeroClaw's only chat surface is the daemon's own WebSocket endpoint at `GET /ws/
 |---------|:------:|-------|
 | **`clawctl agent chat <zeroclaw-name>`** | ✅ | Connects to `ws://<host>:42617/ws/chat` with `Authorization: Bearer <paired-token>`. See [Use the WebSocket chat surface](#3-use-the-websocket-chat-surface). |
 | **OpenAI-compatible HTTP API** | ❌ | Not exposed by upstream ZeroClaw. Use [Hermes](hermes.md) when an OpenAI-style HTTP endpoint is required. |
-| **[Discord](channels/discord.md)** | ✅ | Native — rendered as `[channels.discord]` in `config.toml`. Bot token is **inline TOML**, not env-based (differs from hermes). Schema follows zeroclaw v0.7.5 upstream: `bot_token`, `allowed_guilds`, `allowed_users`, `reply_to_mentions_only`, `draft_update_interval_ms`. Configure via `clawctl agent configure <name> --stage channels`. |
+| **[Discord](channels/discord.md)** | ✅ | Native — rendered as `[channels.discord]` in `config.toml`. Bot token is **inline TOML**, not env-based (differs from hermes). Schema follows zeroclaw v0.7.5 upstream: `bot_token`, `allowed_guilds`, `allowed_users`, `reply_to_mentions_only`, `draft_update_interval_ms`. Configure via `clawctl channel registry create <channel-name> --type discord ...` + `clawctl agent channel attach <channel-name> --agent <name>`. |
 | **Slack** | ❌ | Not supported (use [OpenClaw](openclaw.md) or [Hermes](hermes.md)). Tracked as a follow-up. |
 | **Web / WhatsApp / Telegram / Email / Matrix** | ❌ | Not supported. |
 

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -102,21 +102,24 @@ onboarding:
           type: confirm
           message: "Enable Discord messaging for this agent?"
           default: false
-        # When select_discord=yes, the CLI prompts interactively for the bot
-        # token, allowed-user IDs, optional home channel, optional allowed
-        # channel allowlist, and require-mention toggle. Token persists to
-        # secrets.json under DISCORD_BOT_TOKEN; the rest land in hosts.json
-        # under config.channels.discord.
+        # DEPRECATED (#555): the `--stage channels` interactive flow has been
+        # retired. Channels are now first-class attachables — see
+        # `clawctl channel registry create --type discord` and
+        # `clawctl agent channel attach`. Token persists to secrets.json under
+        # channel:<name>:DISCORD_BOT_TOKEN; non-sensitive config lives in
+        # channels.json. The agent attachment list is
+        # hosts.json.agents.<name>.channels[].
         - id: select_slack
           name: "Enable Slack channel (optional)"
           type: confirm
           message: "Enable Slack messaging (Socket Mode) for this agent?"
           default: false
-        # When select_slack=yes, the CLI prompts interactively for the bot
-        # token (xoxb-), app token (xapp-), allowed-user IDs, optional home
-        # channel, and home channel name. Tokens persist to secrets.json
-        # under SLACK_BOT_TOKEN and SLACK_APP_TOKEN; the rest land in
-        # hosts.json under config.channels.slack.
+        # DEPRECATED (#555): the `--stage channels` interactive flow has been
+        # retired. Use `clawctl channel registry create --type slack` and
+        # `clawctl agent channel attach`. Tokens persist to secrets.json under
+        # channel:<name>:{SLACK_BOT_TOKEN,SLACK_APP_TOKEN}; non-sensitive
+        # config lives in channels.json. The agent attachment list is
+        # hosts.json.agents.<name>.channels[].
 
     validate:
       required: true

--- a/src/clawrium/platform/registry/zeroclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/manifest.yaml
@@ -83,14 +83,15 @@ onboarding:
           type: confirm
           message: "Enable Discord messaging for this agent?"
           default: false
-        # When select_discord=yes, the CLI prompts interactively for the bot
-        # token, allowed-user IDs, optional allowed-guild allowlist, and
-        # reply-to-mentions-only toggle. Token persists to secrets.json under
-        # DISCORD_BOT_TOKEN; the rest land in hosts.json under
-        # config.channels.discord and are rendered into ~/.zeroclaw/config.toml
-        # as a [channels.discord] table (zeroclaw v0.7.5 docs/book/src/channels/
-        # chat-others.md). Note: bot_token lives in TOML inline — zeroclaw does
-        # not consume DISCORD_BOT_TOKEN as an env var.
+        # DEPRECATED (#555): the `--stage channels` interactive flow has been
+        # retired. Use `clawctl channel registry create --type discord` and
+        # `clawctl agent channel attach`. Token persists to secrets.json under
+        # channel:<name>:DISCORD_BOT_TOKEN. The agent attachment list lives at
+        # hosts.json.agents.<name>.channels[]; the canonical render pipeline
+        # emits a [channels.discord] table in ~/.zeroclaw/config.toml from
+        # that source (zeroclaw v0.7.5 docs/book/src/channels/chat-others.md).
+        # Note: bot_token lives in TOML inline — zeroclaw does not consume
+        # DISCORD_BOT_TOKEN as an env var.
 
     validate:
       description: "Verify installation"


### PR DESCRIPTION
## Summary

Final cleanup for parent #555: drop legacy `--stage channels` references from user-facing docs, update manifest comments, and add a CHANGELOG entry documenting the regression window + recovery sequence.

- **F9 — Docs:** Replace `clawctl agent configure <name> --stage channels` and `hosts.json.agents.<n>.config.channels.*` references across `docs/agent-support/channels/{index,discord,slack}.md`, `docs/agent-support/{hermes,zeroclaw,openclaw}.md`, and `docs/agent-onboarding.md` with the new attachment workflow (`clawctl channel registry create` → `clawctl agent channel attach` → `clawctl agent sync`).
- **F10 — CHANGELOG:** New `### Fixed` entry under Unreleased naming the #555 regression window, recovery commands (`migrate-agent` → `doctor` → `sync --dry-run --diff` → `sync`), and affected agent shape.
- **F7 (scoped) — Manifests:** Repoint deprecated comments in hermes + zeroclaw manifests from the `--stage channels` interactive flow to the new attachment workflow. The j2-template + playbook drop is deferred — see Callouts.

## Testing

### Test Results
- [x] `make lint` passes
- [ ] `make test` — 45 pre-existing failures in `tests/test_configure_zeroclaw.py` (Jinja `'gateway' is undefined`), confirmed present on clean main pre-change. No new failures introduced by this PR (changes are docs + comments only — no executable code paths touched).

### Test Coverage
- Files changed: docs + CHANGELOG + manifest comments
- New tests: N/A (docs-only PR)
- Coverage impact: unchanged

### Manual Testing
- `grep -rn "config\.channels\|--stage channels" docs/` — remaining hits are intentional deprecation notes in `docs/agent-onboarding.md` and `docs/agent-support/channels/index.md`.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation N/A (docs-only)
- [x] No SQL/XSS/command-injection surface
- [x] No dependency changes

## Callouts

- [DECISION] F7 was scoped down to manifest-comment cleanup. The j2 template (`hermes.env.j2`, `zeroclaw-config.toml.j2`, `openclaw.json.j2`) and Ansible playbook (`configure.yaml` for hermes + zeroclaw) `config.channels.discord` reads are **not** dropped in this PR.
  - Why: those templates remain the live render path for `clawctl agent configure` (which is the wizard flow, not gated by `--canonical`). Removing the reads without first re-routing `configure_agent` to consume `agent.channels[]` would break the wizard. The parent #555 plan gates F7 on "subtask C migration applied fleet-wide" (operational, not just code-merged), and per `.itx/560/00_PLAN.md` "Out of scope" the broader configure-flow refactor was intentionally deferred. PRs #566/#567/#568 already drove the canonical sync pipeline to default; the wizard refactor is the remaining piece.
  - Alternatives considered: routing `configure_agent` to `build_render_inputs` and passing a `channels` extra_var to ansible — too large for a docs-focused PR and risks breaking the wizard without dedicated tests.
  - Reviewer: confirm or push back. Tracking the remaining work as a follow-up: re-route `lifecycle.configure_agent` to read from `agent.channels[]` via `build_render_inputs`, update j2 templates accordingly, then drop the `config.channels.discord` reads in the playbook conditionals.

- [UNRESOLVED] `make test` reports 45 pre-existing failures in `tests/test_configure_zeroclaw.py` (Jinja `'gateway' is undefined`).
  - Best guess applied: confirmed via `git stash` that the failures exist on a clean main (commit fd97f17). Not caused by this PR. No code paths touched.
  - Reviewer: please verify the pre-existing failure mode is being tracked elsewhere; this PR ships without addressing it.

- [ENVIRONMENT] ATX MCP was not invoked for this PR (docs-only change, manual review path chosen).

- [TODO-FOLLOWUP] j2 templates (`hermes.env.j2`, `zeroclaw-config.toml.j2`, `openclaw.json.j2`) and playbook conditionals still read `config.channels.discord`. Drop after configure-flow refactor.
  - Tracking: to be filed (cross-link to parent #555 F7 once filed).

- [TODO-FOLLOWUP] `docs/agent-onboarding.md` describes the broader interactive wizard. A full reorganization to document the registry-based flow front-and-center is a future doc improvement.
  - Tracking: to be filed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
