### PR TITLE
docs(e2e): #555 three-agent lifecycle test report

### DIFF
--- a/.itx/555/E2E_REPORT.md
+++ b/.itx/555/E2E_REPORT.md
@@ -1,0 +1,71 @@
+# E2E Lifecycle Test Report — #555 canonical render
+
+Sequential five-step lifecycle (install → configure provider → configure channel → chat → destroy) executed against all three bundled agent types on host `wolf-i` (192.168.1.36), provider `clawrium-glm51` (openrouter / z-ai/glm-5), DUMMY Discord channel tokens (bot is not expected to connect).
+
+Branch: `e2e/555-lifecycle-three-agents` off `origin/main`. Run date: 2026-05-30.
+
+## Test matrix
+
+| Agent | Type | Install | Provider | Channel | Chat | Destroy |
+|-------|------|---------|----------|---------|------|---------|
+| e2e-hermes   | hermes   | ✅ | ✅ | ✅ | ❌ (#575) | ✅ |
+| e2e-zeroclaw | zeroclaw | ✅ | ❌ (#576) | ✅ (file rendered correctly) | ❌ (cascade from #576) | ✅ |
+| e2e-openclaw | openclaw | ✅ | ⚠️ (#577 — `--stage providers` blocked, `sync` worked) | ✅ | ✅ (real glm-5 reply) | ✅ |
+
+Legend: ✅ pass · ❌ fail · ⚠️ partial / required workaround.
+
+## Sub-issues filed
+
+- **#575** — [E2E] hermes chat: Discord LoginFailure on dummy token crashes entire gateway, blocks `/v1` chat
+- **#576** — [E2E] zeroclaw configure: `gateway.host` rendered as empty string, daemon refuses to start
+- **#577** — [E2E] openclaw configure `--stage providers`: stale identity gate blocks despite `onboarding.identity = complete`
+
+All three are linked as sub-issues under #555 via the GitHub sub-issues API and labelled `type:bug,agent-ready`.
+
+## Detailed observations
+
+### hermes (e2e-hermes)
+
+- `clawctl agent create … --type hermes` succeeds end-to-end. AGENTS.md note that the unit ships **disabled** until configure runs is current behavior (`systemctl is-enabled hermes-e2e-hermes.service` → `disabled` immediately after install; flips to `enabled` after the first sync).
+- `configure --stage providers --provider clawrium-glm51` works; `agent doctor` reports `Resolved provider: clawrium-glm51 (openrouter) api_key=present`.
+- Channel plumbing is correct: on-host `~/.hermes/.env` has `DISCORD_BOT_TOKEN`, `DISCORD_ALLOWED_USERS=740723459344302120`, `DISCORD_REQUIRE_MENTION=true`.
+- **Chat fails** because the dummy Discord token throws `discord.errors.LoginFailure: Improper token has been passed.`, which is **not isolated from the FastAPI gateway** — the entire process exits 1 and systemd restart-loops it, so the chat port (8679) never binds. `clawctl agent chat` shows `Connection failed: Failed to reach hermes at http://192.168.1.36:8679/v1`. Filed as **#575**.
+- Destroy is clean: registry record gone, systemd unit `not-found`, `/home/e2e-hermes/.hermes` removed.
+
+### zeroclaw (e2e-zeroclaw)
+
+- Install succeeds; unit is dropped **disabled** (per AGENTS.md, by design).
+- `configure --stage providers` returns `Configure playbook failed: failed`. On-host journal: `Error: [required_field_empty] gateway.host must not be empty (gateway.host)`. The rendered `~/.zeroclaw/config.toml` contains `host = ""` under `[gateway]`. Filed as **#576**.
+- Channel plumbing **is** rendered correctly: `[channels.discord]` block has `bot_token`, `allowed_users`, `mention_only = true`. So the channel rendering pipeline is fine — only the daemon start is blocked by #576.
+- Chat unreachable as a cascade: `clawctl agent chat e2e-zeroclaw` → `Gateway URL is missing. Re-run install/configure to capture gateway URL.`
+- Destroy clean: registry record gone, unit `could not be found`, `/home/e2e-zeroclaw/.zeroclaw` removed.
+
+### openclaw (e2e-openclaw)
+
+- Install succeeds; openclaw is the only one of the three whose unit ships **enabled** out of the gate.
+- `configure --stage providers --provider clawrium-glm51` fails: `agent 'e2e-openclaw' requires manual identity configuration ... tracked in #523`. Even after `configure --stage identity` runs successfully and `describe` shows `onboarding.identity complete`, the providers stage gate still refuses. `clawctl agent sync` works around the gate and writes the canonical config (`Resolved provider: clawrium-glm51 (openrouter) api_key=present`). Filed as **#577**.
+- Channel plumbing on-host:
+  - `~/.openclaw/env` → `DISCORD_BOT_TOKEN=…`
+  - `~/.openclaw/openclaw.json` → `channels.discord` = `{ enabled: true, allowFrom: ["740723459344302120"], guilds: {} }`
+- **Chat passes**: `clawctl agent chat e2e-openclaw` → `e2e-openclaw> Hey there! Nice to meet you.` after waiting ~30s for `0.0.0.0:41554` to bind. Real inference against `openrouter/z-ai/glm-5` confirmed.
+- Destroy clean: registry record gone, unit `could not be found`, `/home/e2e-openclaw/.openclaw` removed.
+
+## Cleanup confirmed
+
+- All 3 test agents deleted (`clawctl agent get` shows no `e2e-*` entries).
+- All 3 channel registry records deleted (`discord-e2e-hermes`, `discord-e2e-zeroclaw`, `discord-e2e-openclaw`).
+- On-host `/home/e2e-*/.<type>/` directories all `No such file or directory`.
+- On-host systemd units all `could not be found`.
+- Worktree ready for removal.
+
+## Callouts
+
+1. **#576 is a hard blocker on zeroclaw onboarding from clean state.** Empty `gateway.host` should default to `0.0.0.0` per the documented `features.web_ui.bind: wildcard` in AGENTS.md. Until fixed, every new zeroclaw install needs a manual `config.toml` edit.
+2. **#575 turns the Discord channel feature into a chat-killer on hermes.** The Discord client failure should be isolated from the FastAPI gateway (degraded platform, not process crash). Any stale token (rotated, revoked, fat-fingered) currently takes down chat — and `clawctl agent chat` surfaces only the symptom (`Failed to reach hermes`), not the cause.
+3. **#577 is the surface bug behind #555's core thesis.** The provider stage gate consults different state than the onboarding ledger does — same pattern as the conditional-emit bug #555 documents. Fixing this with `build_render_inputs` (F1 in #555) would dissolve the gate entirely.
+4. **Positive signal**: the canonical render pipeline (the F2/F3 layer of #555) **does write correct files** for all three agent types — channels, providers, env vars all match expectations on every agent. The remaining defects are at the boundaries: daemon startup contract (zeroclaw), platform isolation (hermes), and stage-gate state (openclaw). The render itself is sound.
+5. **Operational note**: openclaw takes ~30s to bind its gateway port after `systemctl start`. Clients (including `clawctl agent chat`) need to either poll or implement a startup grace, otherwise a fresh sync → immediate chat will fail with `Connect call failed`.
+
+## Final state
+
+End-to-end is **partially passing**: 1 of 3 agent types (openclaw) clears all five lifecycle steps with real inference confirmed; the other two are blocked by isolable bugs filed as **#575**, **#576**, **#577**. No test-environment failures (wolf-i was reachable throughout, secrets resolved cleanly, OpenRouter inference returned a real model completion when the gateway was actually serving). The canonical render in #555 is correctly populating files across all three agent types — the failure modes here are downstream of render: daemon startup contracts and process supervision, not the configuration plumbing #555 itself fixed.


### PR DESCRIPTION
# E2E Lifecycle Test Report — #555 canonical render

Sequential five-step lifecycle (install → configure provider → configure channel → chat → destroy) executed against all three bundled agent types on host `wolf-i` (192.168.1.36), provider `clawrium-glm51` (openrouter / z-ai/glm-5), DUMMY Discord channel tokens (bot is not expected to connect).

Branch: `e2e/555-lifecycle-three-agents` off `origin/main`. Initial run date: 2026-05-30. Post-fix re-validation date: 2026-05-30 (against main commit `060efca`, then on top of that with `#582` + `#583` in-tree fixes from companion branch `e2e/555-revalidate-post-fix`).

## Test matrix — FINAL (#582 + #583 also fixed in-tree on companion branch)

The matrix below is from an **actual end-to-end re-run on 2026-05-30**, first against main `060efca` (which surfaced two more regressions — #582 and #583), then against the same branch with #582 and #583 fixed in-tree on companion branch `e2e/555-revalidate-post-fix`. Full report: `.itx/555/E2E_REVALIDATE.md` on that branch.

| Agent | Type | Install | Provider | Channel | Chat | Destroy |
|-------|------|---------|----------|---------|------|---------|
| e2e-hermes   | hermes   | ✅ | ✅ | ✅ | ✅ `Hi there!` (post-#582 fix) | ✅ |
| e2e-zeroclaw | zeroclaw | ✅ | ✅ (post-#583, configure --stage providers works without workaround) | ✅ | ✅ `Hi there!` | ✅ |
| e2e-openclaw | openclaw | ✅ | ✅ (post-#583, configure --stage providers works without workaround) | ✅ | ✅ `Hey there! 👋` | ✅ |

**Score: 15 / 15 cells pass, 0 fail, 0 partial. Zero workarounds.**

**Legend:** ✅ pass · ❌ fail · ⚠️ partial / required workaround.

### What landed in companion branch on top of `060efca` to reach 15/15

**`fix(configure,render): close #582 + #583`** (commit `032620c`):

- **#582** — `core/render.py:build_render_inputs` now hydrates `HERMES_API_SERVER_KEY` from `secrets.json` when the `hosts.json` `api_server` blob carries only the non-sensitive shape (the post-#318 install.py contract). Without this, every `agent sync` on a fresh hermes install wrote `API_SERVER_KEY=''` into `~/.hermes/.env` and hermes upstream correctly refused to bind a wildcard interface — `/v1` never came up. The fix also indirectly closes the user-visible part of #575: with api_server now binding, the gateway's "exit if all platforms failed" path no longer fires when Discord LoginFailure happens; the async LoginFailure is non-fatal log noise rather than a process-killing exception.
- **#583** — two distinct root causes both buried under the same opaque `"Configure playbook failed: failed"`:
  1. The `toq` Jinja filter (added in `5ecb93b` for TOML-injection hardening) was registered only on the Python canonical renderer's Jinja env. The Ansible playbook renders the same template file via `ansible.builtin.template:` — that env had no `toq`. Fixed two ways: (a) a `filter_plugins/clawrium_filters.py` adjacent to the playbook with `ANSIBLE_FILTER_PLUGINS` plumbed via ansible-runner envvars, and (b) collapsed the dual-render entirely — `configure_agent` now pre-renders zeroclaw config.toml via the canonical Python path and the playbook deploys via `copy: content: ...`. One render path.
  2. openclaw's six `Verify .env credentials for <provider>` tasks used `lineinfile` with `check_mode: true` + `failed_when: <reg>.changed` to "verify presence". Broken since April (commit `ca24b50`) — lineinfile in check mode reports `changed=true` whenever the existing matched line differs from the placeholder `line:` value, which is every real run. Replaced with proper `command: grep -qE '^KEY=.+'` probes.
- **Observability** — extracted `_summarize_ansible_configure_failure(result, log_dir)` as a pure helper. Surfaces task name + msg/stderr on uncensored failures; surfaces task name + `ANSIBLE_NO_LOG=False` hint on all-censored failures (bearer-leak invariant preserved); surfaces recap stats + stdout/stderr tail on pre-task failures (parse/inventory/connection errors). No more `"Configure playbook failed: failed"` with an empty artifacts dir.

### Tests

- **8 new tests** in `tests/core/test_render.py` for the #582 hydration path (inline-wins, fallback, malformed-secret rejection, non-hermes guard, end-to-end via `render_hermes` asserting `API_SERVER_KEY='<hex>'` appears in `.hermes/.env`). The end-to-end test is the one that would have caught the original #582 regression at the render layer instead of needing an E2E run.
- **14 new tests** in `tests/core/test_configure_error_reporting.py` covering every branch of `_summarize_ansible_configure_failure` plus byte-parity between the Ansible `toq` filter and the Python `_toml_escape`.
- **3 existing tests** in `tests/test_lifecycle.py` updated to match the richer error format — bearer-leak invariants verbatim.

Full suite: **3737 Python tests pass, 8 skipped, 0 failed. 231 frontend tests pass.**

---

## Test matrix — POST-FIX (against main `060efca`, BEFORE #582 + #583 in-tree fixes)

This is what the re-validation found when run against main `060efca` (post-#580/#579/#581 merge) — before #582 and #583 were filed and fixed:

| Agent | Type | Install | Provider | Channel | Chat | Destroy |
|-------|------|---------|----------|---------|------|---------|
| e2e-hermes   | hermes   | ✅ | ✅ | ✅ | ❌ #582 (gateway still crashes) | ✅ |
| e2e-zeroclaw | zeroclaw | ✅ | ⚠️ #583 (configure --stage providers playbook fails, sync workaround) | ✅ | ✅ (real glm-5 reply, gateway.host=0.0.0.0 — #576 fix confirmed) | ✅ |
| e2e-openclaw | openclaw | ✅ | ⚠️ #577 ledger gate fix verified; subsequent playbook fails #583 (sync workaround) | ✅ | ✅ (real glm-5 reply) | ✅ |

12 / 15 cells passed, 1 hard fail, 2 partial with sync workaround. This is the state that motivated #582 and #583.

---

## Test matrix — INITIAL RUN (pre-fix, for historical context)

| Agent | Type | Install | Provider | Channel | Chat | Destroy |
|-------|------|---------|----------|---------|------|---------|
| e2e-hermes   | hermes   | ✅ | ✅ | ✅ | ❌ (#575) | ✅ |
| e2e-zeroclaw | zeroclaw | ✅ | ❌ (#576) | ✅ (file rendered correctly) | ❌ (cascade from #576) | ✅ |
| e2e-openclaw | openclaw | ✅ | ⚠️ (#577 — `--stage providers` blocked, `sync` worked) | ✅ | ✅ (real glm-5 reply) | ✅ |

## Sub-issues filed and resolved

| Sub-issue | Title | Resolved by | State |
|---|---|---|---|
| **#575** | hermes chat: Discord LoginFailure on dummy token crashes entire gateway, blocks `/v1` chat | PR #580 (initial), effectively closed by **#582 fix** (api_server binding restored → gateway "all platforms failed" path no longer fires) | CLOSED |
| **#576** | zeroclaw configure: `gateway.host` rendered as empty string, daemon refuses to start | PR #579 | CLOSED — holds in re-validation |
| **#577** | openclaw configure `--stage providers`: stale identity gate blocks despite `onboarding.identity = complete` | PR #581 | CLOSED — holds in re-validation |
| **#582** | hermes chat still broken post-#580: API_SERVER_KEY not hydrated in canonical render path; api_server refuses 0.0.0.0 without it | commit `032620c` on `e2e/555-revalidate-post-fix` | FIXED — see closing PR for that branch |
| **#583** | `configure --stage providers` playbook 'failed' with no events / empty artifacts dir (zeroclaw + openclaw) | commit `032620c` on `e2e/555-revalidate-post-fix` | FIXED — see closing PR for that branch |

All linked as sub-issues under #555. Labels: `type:bug`.

## Detailed observations (initial run)

### hermes (e2e-hermes)

- `clawctl agent create … --type hermes` succeeds end-to-end. AGENTS.md note that the unit ships **disabled** until configure runs is current behavior (`systemctl is-enabled hermes-e2e-hermes.service` → `disabled` immediately after install; flips to `enabled` after the first sync).
- `configure --stage providers --provider clawrium-glm51` works; `agent doctor` reports `Resolved provider: clawrium-glm51 (openrouter) api_key=present`.
- Channel plumbing is correct: on-host `~/.hermes/.env` has `DISCORD_BOT_TOKEN`, `DISCORD_ALLOWED_USERS=740723459344302120`, `DISCORD_REQUIRE_MENTION=true`.
- **Chat failed (initial run)** because the dummy Discord token threw `discord.errors.LoginFailure: Improper token has been passed.`, which was not isolated from the FastAPI gateway — the entire process exited 1 and systemd restart-looped it, so the chat port (8679) never bound. Filed as **#575**, addressed in **PR #580**; the user-visible symptom is fully closed by the **#582 fix** because api_server binding restored means the gateway no longer exits when only Discord fails.
- Destroy is clean.

### zeroclaw (e2e-zeroclaw)

- Install succeeds; unit is dropped **disabled** (per AGENTS.md, by design).
- `configure --stage providers` returned `Configure playbook failed: failed`. On-host journal: `Error: [required_field_empty] gateway.host must not be empty (gateway.host)`. The rendered `~/.zeroclaw/config.toml` contained `host = ""` under `[gateway]`. Filed as **#576**, fixed in **PR #579** (default to `0.0.0.0` when blank). The next layer (#583 `toq` filter + lineinfile verify) surfaced on the re-validation run and is fixed in companion branch.
- Channel plumbing was rendered correctly even at the time of the initial failure.
- Destroy clean.

### openclaw (e2e-openclaw)

- Install succeeds; openclaw is the only one of the three whose unit ships **enabled** out of the gate.
- `configure --stage providers --provider clawrium-glm51` failed in the initial run with the #523 identity gate. Even after `--stage identity` ran successfully and `describe` showed `onboarding.identity complete`, the providers stage gate still refused. `sync` workaround wrote the canonical config correctly. Filed as **#577**, fixed in **PR #581** (gate now consults onboarding ledger directly). Confirmed in re-validation. The next layer (#583 broken `lineinfile`-based verify task) surfaced and is fixed in companion branch.
- Destroy clean.

## Cleanup confirmed (all runs)

- `clawctl agent get` shows no `e2e-*` entries.
- All 3 channel registry records deleted.
- On-host `/home/e2e-*/.<type>/` directories all `No such file or directory`.
- On-host systemd units all `could not be found`.

## Callouts

1. **Render correctness was sound from day one**: the canonical render pipeline (the F2/F3 layer of #555) wrote correct files for all three agent types in every run — channels, providers, env vars all matched expectations. The failures were at the boundaries (daemon startup contract, platform isolation, stage-gate state, dual-render hazard for `toq` filter / `lineinfile` verify) — not the configuration plumbing #555 itself fixed.
2. **The two new regressions found in re-validation (#582 + #583) are both the same shape as the original #555 root cause**: a shared resource (HERMES_API_SERVER_KEY for #582, `zeroclaw-config.toml.j2` template for #583) reachable via two paths, where a fix added to one path wasn't propagated to the other. The companion-branch fixes for both collapse the dual-paths so the bug class can't recur via the same mechanism.
3. **Operational note (still applies)**: openclaw takes ~30s to bind its gateway port after `systemctl start`. Clients (including `clawctl agent chat`) need a startup grace, otherwise a fresh sync → immediate chat will fail with `Connect call failed`. Not a defect; documented for operator UX.
4. **Post-fix matrix is from an actual fresh re-run on 2026-05-30 against main `060efca`** plus the `032620c` companion-branch fixes. Full report at `.itx/555/E2E_REVALIDATE.md` on `e2e/555-revalidate-post-fix`.
