### PR TITLE
fix(render): default zeroclaw gateway.host to 0.0.0.0 when blank (#576)

### DIFF
--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -437,11 +437,19 @@ def build_render_inputs(agent_name: str) -> RenderInputs:
     if isinstance(gateway_blob, dict):
         # #576: zeroclaw's daemon refuses an empty `gateway.host`
         # (`required_field_empty: gateway.host must not be empty`), so a
-        # missing or empty value here would render `host = ""` in
-        # config.toml and brick `clawctl agent configure` on every fresh
-        # install. Default to `0.0.0.0` per the documented
-        # `features.web_ui.bind: wildcard` contract in AGENTS.md.
-        host_raw = _clean_secret(gateway_blob.get("host"))
+        # missing/empty/whitespace-only value here would render
+        # `host = ""` (or `host = "   "`) in config.toml and brick
+        # `clawctl agent configure` on every fresh install. Default to
+        # `0.0.0.0` per the documented `features.web_ui.bind: wildcard`
+        # contract in AGENTS.md.
+        #
+        # `.strip()` catches whitespace-only values that `_clean_secret`
+        # does not (it strips NUL/CR/LF only). The default only fires
+        # for zeroclaw in practice — `render_hermes` and the openclaw
+        # renderer never read `inputs.gateway.host`, so applying the
+        # default unconditionally here is safe and keeps the assembler
+        # agent-type-agnostic.
+        host_raw = _clean_secret(gateway_blob.get("host")).strip()
         gateway_input = GatewayInputs(
             # W6 (ATX #555 polish): NUL in host value would silently
             # truncate the TOML at parse time. Sanitize at assembly

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -435,12 +435,19 @@ def build_render_inputs(agent_name: str) -> RenderInputs:
     gateway_input: GatewayInputs | None = None
     gateway_blob = config_blob.get("gateway")
     if isinstance(gateway_blob, dict):
+        # #576: zeroclaw's daemon refuses an empty `gateway.host`
+        # (`required_field_empty: gateway.host must not be empty`), so a
+        # missing or empty value here would render `host = ""` in
+        # config.toml and brick `clawctl agent configure` on every fresh
+        # install. Default to `0.0.0.0` per the documented
+        # `features.web_ui.bind: wildcard` contract in AGENTS.md.
+        host_raw = _clean_secret(gateway_blob.get("host"))
         gateway_input = GatewayInputs(
             # W6 (ATX #555 polish): NUL in host value would silently
             # truncate the TOML at parse time. Sanitize at assembly
             # time, same as every other secret/identity string from
             # hosts.json.
-            host=_clean_secret(gateway_blob.get("host")),
+            host=host_raw or "0.0.0.0",
             port=int(gateway_blob.get("port", 0) or 0),
             # Same systemd-truncation hazard as api_server.key above.
             auth=_clean_secret(gateway_blob.get("auth")),

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -785,11 +785,29 @@ def test_hermes_atlassian_slug_collision_raises():
         render_hermes(inputs)
 
 
-def test_gateway_host_defaults_to_wildcard_when_missing_or_empty(stores):
+@pytest.mark.parametrize(
+    "host_value",
+    [
+        # The post-install seed shape — `host = ""` in hosts.json.
+        "",
+        # Whitespace-only: `_clean_secret` strips NUL/CR/LF but not
+        # spaces/tabs. `"   " or "0.0.0.0"` short-circuits to `"   "`
+        # without the `.strip()` guard, and the daemon refuses it the
+        # same way it refuses `""`. B1 from ATX review of the initial
+        # patch.
+        "   ",
+        "\t \t",
+        # NUL-contaminated host: `_clean_secret` strips the NUL to "",
+        # which then defaults via the same code path. Covers parity
+        # with the W6 sanitization at line ~447.
+        "\x00",
+    ],
+)
+def test_gateway_host_defaults_to_wildcard_when_blank(stores, host_value):
     """#576: zeroclaw's daemon refuses an empty `gateway.host`. The
     assembler must default to `0.0.0.0` (the documented wildcard bind)
-    so a fresh install whose hosts.json carries `gateway.host = ""` (or
-    no host key at all) still renders a config.toml the daemon accepts.
+    so a fresh install whose hosts.json carries any blank/whitespace
+    host value still renders a config.toml the daemon accepts.
     """
     stores.agent = (
         {"hostname": "host-1"},
@@ -798,8 +816,12 @@ def test_gateway_host_defaults_to_wildcard_when_missing_or_empty(stores):
             "agent_name": "alpha",
             "providers": [{"name": "or", "role": "primary", "model": ""}],
             "config": {
-                # Empty string — the post-install seed shape.
-                "gateway": {"host": "", "port": 40000, "auth": "tk", "bind": "lan"},
+                "gateway": {
+                    "host": host_value,
+                    "port": 40000,
+                    "auth": "tk",
+                    "bind": "lan",
+                },
             },
         },
     )
@@ -808,7 +830,10 @@ def test_gateway_host_defaults_to_wildcard_when_missing_or_empty(stores):
     inputs = build_render_inputs("alpha")
     assert inputs.gateway is not None and inputs.gateway.host == "0.0.0.0"
 
-    # Same assertion with the host key entirely absent from the dict.
+
+def test_gateway_host_defaults_to_wildcard_when_key_missing(stores):
+    """#576: same default fires when the `host` key is absent entirely,
+    not just empty. Covers the shape some legacy migrations produced."""
     stores.agent = (
         {"hostname": "host-1"},
         "zeroclaw",
@@ -820,14 +845,18 @@ def test_gateway_host_defaults_to_wildcard_when_missing_or_empty(stores):
             },
         },
     )
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
+    stores.provider_api_keys["or"] = "sk-1"
     inputs = build_render_inputs("alpha")
     assert inputs.gateway is not None and inputs.gateway.host == "0.0.0.0"
 
 
-def test_gateway_host_preserves_explicit_loopback(stores):
-    """#576: the default only fills in for empty/missing — an explicit
-    `127.0.0.1` (or any operator-chosen value) round-trips unchanged.
-    Prevents the default from masking an intentional loopback bind."""
+def test_gateway_host_default_round_trips_through_render_zeroclaw(stores):
+    """#576 / ATX W1: extend the default assertion to call the actual
+    `render_zeroclaw` Jinja path and confirm the rendered `config.toml`
+    contains `host = "0.0.0.0"` under `[gateway]`. The assembler-only
+    assertion above would stay green even if a template regression
+    dropped the field — the on-host daemon is what consumes this."""
     stores.agent = (
         {"hostname": "host-1"},
         "zeroclaw",
@@ -835,19 +864,79 @@ def test_gateway_host_preserves_explicit_loopback(stores):
             "agent_name": "alpha",
             "providers": [{"name": "or", "role": "primary", "model": ""}],
             "config": {
-                "gateway": {
-                    "host": "127.0.0.1",
-                    "port": 40000,
-                    "auth": "tk",
-                    "bind": "lan",
-                },
+                "gateway": {"host": "", "port": 40000, "auth": "tk", "bind": "lan"},
             },
         },
     )
     stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
     stores.provider_api_keys["or"] = "sk-1"
     inputs = build_render_inputs("alpha")
-    assert inputs.gateway is not None and inputs.gateway.host == "127.0.0.1"
+    rendered = render_zeroclaw(inputs)
+    toml_body = rendered.files[".zeroclaw/config.toml"]
+    # The rendered TOML must carry the wildcard bind under [gateway].
+    # An empty host (which the daemon refuses) would render as `host = ""`.
+    assert 'host = "0.0.0.0"' in toml_body
+    assert 'host = ""' not in toml_body
+
+
+def test_gateway_host_preserves_explicit_value(stores):
+    """#576: the default only fills in for blank/missing — an explicit
+    operator value round-trips unchanged. Loopback and a LAN IP are
+    both verified so the `or` path is not silently masking arbitrary
+    non-empty input."""
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
+    stores.provider_api_keys["or"] = "sk-1"
+    for explicit in ("127.0.0.1", "192.168.1.5"):
+        stores.agent = (
+            {"hostname": "host-1"},
+            "zeroclaw",
+            {
+                "agent_name": "alpha",
+                "providers": [{"name": "or", "role": "primary", "model": ""}],
+                "config": {
+                    "gateway": {
+                        "host": explicit,
+                        "port": 40000,
+                        "auth": "tk",
+                        "bind": "lan",
+                    },
+                },
+            },
+        )
+        inputs = build_render_inputs("alpha")
+        assert inputs.gateway is not None and inputs.gateway.host == explicit
+
+
+def test_hermes_render_ignores_gateway_host_default(stores):
+    """#576 / ATX W2: the `0.0.0.0` default is applied unconditionally
+    in `build_render_inputs` because no current renderer other than
+    zeroclaw reads `inputs.gateway.host`. This test pins that
+    invariant: a hermes agent with a blank `config.gateway.host` must
+    still render successfully and its output must not carry the
+    zeroclaw-shaped `[gateway]` block."""
+    stores.agent = (
+        {"hostname": "host-1"},
+        "hermes",
+        {
+            "agent_name": "alpha",
+            "providers": [{"name": "or", "role": "primary", "model": "m"}],
+            "config": {
+                "api_server": {"host": "0.0.0.0", "port": 8642, "key": "k"},
+                # Blank host — would brick zeroclaw, must not affect hermes.
+                "gateway": {"host": "", "port": 40000, "auth": "tk"},
+            },
+        },
+    )
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
+    stores.provider_api_keys["or"] = "sk-1"
+    inputs = build_render_inputs("alpha")
+    rendered = render_hermes(inputs)
+    for path, body in rendered.files.items():
+        # The zeroclaw-shaped `[gateway]` TOML block must not appear in
+        # any hermes output file.
+        assert "[gateway]" not in body, (
+            f"hermes render leaked zeroclaw [gateway] block into {path}"
+        )
 
 
 def test_clean_secret_applied_to_gateway_auth_and_api_server_key(stores):

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -785,6 +785,71 @@ def test_hermes_atlassian_slug_collision_raises():
         render_hermes(inputs)
 
 
+def test_gateway_host_defaults_to_wildcard_when_missing_or_empty(stores):
+    """#576: zeroclaw's daemon refuses an empty `gateway.host`. The
+    assembler must default to `0.0.0.0` (the documented wildcard bind)
+    so a fresh install whose hosts.json carries `gateway.host = ""` (or
+    no host key at all) still renders a config.toml the daemon accepts.
+    """
+    stores.agent = (
+        {"hostname": "host-1"},
+        "zeroclaw",
+        {
+            "agent_name": "alpha",
+            "providers": [{"name": "or", "role": "primary", "model": ""}],
+            "config": {
+                # Empty string — the post-install seed shape.
+                "gateway": {"host": "", "port": 40000, "auth": "tk", "bind": "lan"},
+            },
+        },
+    )
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
+    stores.provider_api_keys["or"] = "sk-1"
+    inputs = build_render_inputs("alpha")
+    assert inputs.gateway is not None and inputs.gateway.host == "0.0.0.0"
+
+    # Same assertion with the host key entirely absent from the dict.
+    stores.agent = (
+        {"hostname": "host-1"},
+        "zeroclaw",
+        {
+            "agent_name": "alpha",
+            "providers": [{"name": "or", "role": "primary", "model": ""}],
+            "config": {
+                "gateway": {"port": 40000, "auth": "tk", "bind": "lan"},
+            },
+        },
+    )
+    inputs = build_render_inputs("alpha")
+    assert inputs.gateway is not None and inputs.gateway.host == "0.0.0.0"
+
+
+def test_gateway_host_preserves_explicit_loopback(stores):
+    """#576: the default only fills in for empty/missing — an explicit
+    `127.0.0.1` (or any operator-chosen value) round-trips unchanged.
+    Prevents the default from masking an intentional loopback bind."""
+    stores.agent = (
+        {"hostname": "host-1"},
+        "zeroclaw",
+        {
+            "agent_name": "alpha",
+            "providers": [{"name": "or", "role": "primary", "model": ""}],
+            "config": {
+                "gateway": {
+                    "host": "127.0.0.1",
+                    "port": 40000,
+                    "auth": "tk",
+                    "bind": "lan",
+                },
+            },
+        },
+    )
+    stores.providers["or"] = {"name": "or", "type": "openrouter", "default_model": "m"}
+    stores.provider_api_keys["or"] = "sk-1"
+    inputs = build_render_inputs("alpha")
+    assert inputs.gateway is not None and inputs.gateway.host == "127.0.0.1"
+
+
 def test_clean_secret_applied_to_gateway_auth_and_api_server_key(stores):
     """W1: NUL/CR/LF in gateway.auth or api_server.key must be stripped
     before they hit the systemd EnvironmentFile."""

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -851,12 +851,18 @@ def test_gateway_host_defaults_to_wildcard_when_key_missing(stores):
     assert inputs.gateway is not None and inputs.gateway.host == "0.0.0.0"
 
 
-def test_gateway_host_default_round_trips_through_render_zeroclaw(stores):
-    """#576 / ATX W1: extend the default assertion to call the actual
-    `render_zeroclaw` Jinja path and confirm the rendered `config.toml`
-    contains `host = "0.0.0.0"` under `[gateway]`. The assembler-only
-    assertion above would stay green even if a template regression
-    dropped the field — the on-host daemon is what consumes this."""
+@pytest.mark.parametrize("host_value", ["", "   ", "\t \t"])
+def test_gateway_host_default_round_trips_through_render_zeroclaw(
+    stores, host_value
+):
+    """#576 / ATX W1 + iter-2 W: extend the default assertion to call
+    the actual `render_zeroclaw` Jinja path and confirm the rendered
+    `config.toml` contains `host = "0.0.0.0"` under `[gateway]`. The
+    assembler-only assertion above would stay green even if a template
+    regression rendered the pre-strip raw value — the on-host daemon
+    is what consumes this. Parametrized over the same blank set as the
+    assembler test so a whitespace-only input also has a Jinja-path
+    assertion."""
     stores.agent = (
         {"hostname": "host-1"},
         "zeroclaw",
@@ -864,7 +870,12 @@ def test_gateway_host_default_round_trips_through_render_zeroclaw(stores):
             "agent_name": "alpha",
             "providers": [{"name": "or", "role": "primary", "model": ""}],
             "config": {
-                "gateway": {"host": "", "port": 40000, "auth": "tk", "bind": "lan"},
+                "gateway": {
+                    "host": host_value,
+                    "port": 40000,
+                    "auth": "tk",
+                    "bind": "lan",
+                },
             },
         },
     )
@@ -874,9 +885,15 @@ def test_gateway_host_default_round_trips_through_render_zeroclaw(stores):
     rendered = render_zeroclaw(inputs)
     toml_body = rendered.files[".zeroclaw/config.toml"]
     # The rendered TOML must carry the wildcard bind under [gateway].
-    # An empty host (which the daemon refuses) would render as `host = ""`.
+    # An empty/whitespace host (which the daemon refuses) would render
+    # as `host = ""` or `host = "   "` respectively.
     assert 'host = "0.0.0.0"' in toml_body
     assert 'host = ""' not in toml_body
+    if host_value.strip() != host_value or host_value:
+        # The raw pre-strip value must not survive into the rendered
+        # TOML — guards against a future template change that bypasses
+        # the assembler's strip+default.
+        assert f'host = "{host_value}"' not in toml_body
 
 
 def test_gateway_host_preserves_explicit_value(stores):
@@ -931,6 +948,10 @@ def test_hermes_render_ignores_gateway_host_default(stores):
     stores.provider_api_keys["or"] = "sk-1"
     inputs = build_render_inputs("alpha")
     rendered = render_hermes(inputs)
+    # Pin the hermes output shape so the negative-only assertions below
+    # aren't vacuously true if a future refactor changes the file map.
+    assert ".hermes/.env" in rendered.files
+    assert "HERMES_INFERENCE_PROVIDER" in rendered.files[".hermes/.env"]
     for path, body in rendered.files.items():
         # The zeroclaw-shaped `[gateway]` TOML block must not appear in
         # any hermes output file.


### PR DESCRIPTION
## Summary

Fixes #576. Defaults zeroclaw's `gateway.host` to `0.0.0.0` in the canonical render when the value in `hosts.json` is empty, whitespace-only, or missing, so a fresh `clawctl agent create … --type zeroclaw` followed by `clawctl agent configure --stage providers …` no longer fails with `Configure playbook failed: failed` (root cause: daemon refuses empty host with `required_field_empty: gateway.host must not be empty`).

## Testing

- `make test` — 3673 passed, 8 skipped
- `make lint` — clean (ruff + ESLint)
- Coverage: new tests in `tests/core/test_render.py`
  - `test_gateway_host_defaults_to_wildcard_when_blank` (parametrized: empty / whitespace / tab / NUL)
  - `test_gateway_host_defaults_to_wildcard_when_key_missing`
  - `test_gateway_host_default_round_trips_through_render_zeroclaw` (parametrized: empty / whitespace — drives the full Jinja path)
  - `test_gateway_host_preserves_explicit_value` (127.0.0.1 + 192.168.1.5)
  - `test_hermes_render_ignores_gateway_host_default` (pins hermes non-regression)

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $4.83 | Total Time: ~18m**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3/5 | B1 | Fixed | $2.41 | 8m 28s | leader, lifecycle-state-machine, security, registry-manifest, test-coverage, docs-site |
| 2 | 4/5 | None | Ready | $2.42 | 10m | leader, lifecycle-state-machine, security, registry-manifest, test-coverage |

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `render.py:450` + `test_render.py` | `_clean_secret` strips only NUL/CR/LF — `"   "` survived and was passed through, producing `host = "   "` which the daemon rejects identically. | Fixed — applied `.strip()` before the `or` default; added whitespace + NUL parametrized cases. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `test_render.py` | Assertions stopped at `RenderInputs`; never drove Jinja. | Fixed — `test_gateway_host_default_round_trips_through_render_zeroclaw` calls `render_zeroclaw` and grep-asserts on the rendered TOML body. |
| W2 | `test_render.py` | No hermes non-regression — default is agent-type-agnostic. | Fixed — `test_hermes_render_ignores_gateway_host_default` pins the invariant. |
| W3 | `render.py:437-450` | No inline note that the default is zeroclaw-only-in-practice. | Fixed — comment block explicitly scopes the default to zeroclaw. |
| W4 | memory note | Conflated armv7l bind bug. | Acknowledged, deferred (out of code scope). |
| W5 | `AGENTS.md` | Agent list omits hermes. | Acknowledged, deferred (separate #555 polish). |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | NUL-contaminated host case | Folded into parametrized blank set. |
| S2 | Add LAN-IP non-blank case | Folded into `test_gateway_host_preserves_explicit_value`. |
| S3–S5 | Docs/comments cross-refs | Deferred. |

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**Blocking Issues:** None.

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W (iter-2) | `test_render.py:854-879` | Round-trip test used `host=""` only, not the whitespace variants. | Fixed — parametrized over `["", "   ", "\t \t"]`. |
| W (iter-2) | `test_render.py:910-939` | Hermes negative-assertion loop is vacuously green if the file map changes. | Fixed — added positive shape pin (`.hermes/.env` + `HERMES_INFERENCE_PROVIDER`) before the negative loop. |
| W (iter-2) | `render.py:426` | Pre-existing: `api_server.host` lacks `_clean_secret().strip()` — same bug class one function above. | Acknowledged, **out of scope for #576** — should be filed as a separate follow-up. |

**Suggestions:** parametrize `test_gateway_host_preserves_explicit_value`, add `\n`/`\r\n` cases, etc. Deferred — non-blocking.

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
