### PR TITLE
fix(sync): surface root-cause diagnostics on unit health failure (#575)

### DIFF
--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -336,8 +336,15 @@ _KNOWN_UNIT_FATAL_PATTERNS: tuple[
         # case a future zeroclaw rewrite changes the wording, so a
         # subsequent version bump does not silently turn this entry
         # into a dead letter.
+        # ATX iter-2 B1: dropped `|required` — it over-matched
+        # benign startup lines like "gateway.host (required): ..."
+        # or "checking gateway.host... required for daemon init"
+        # that any 100-line journal tail would contain regardless of
+        # crash reason. The two surviving alternation branches both
+        # describe the actual fault state ("must not be empty",
+        # "is empty").
         r"required_field_empty.*gateway\.host"
-        r"|gateway\.host.*(?:must not be empty|is empty|required)",
+        r"|gateway\.host.*(?:must not be empty|is empty)",
         frozenset({"zeroclaw"}),
         "zeroclaw daemon refused an empty `gateway.host`.",
         "Re-run `clawctl agent sync <agent>` after `clawctl` is upgraded "
@@ -349,7 +356,13 @@ _KNOWN_UNIT_FATAL_PATTERNS: tuple[
         # Cross-agent: any agent that loads an OpenRouter provider
         # without a populated key would surface one of these two
         # messages. Parenthesized alternation for clarity (ATX W6).
-        r"(?:OPENROUTER_API_KEY.*not set"
+        # ATX iter-2 B2: greedy `.*` between key and "not set" fired
+        # on lines like "OPENROUTER_API_KEY was not set on previous
+        # boot, now present" or "[was not set, using fallback]". The
+        # tightened pattern requires whitespace + an optional `is`
+        # + `not set` as adjacent tokens, with a word boundary on
+        # the tail so "not setX" doesn't slip through.
+        r"(?:OPENROUTER_API_KEY\s+(?:is\s+)?not\s+set\b"
         r"|No inference provider configured)",
         frozenset(),  # empty == all agent types
         "Provider credentials missing from the rendered config.",

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -305,13 +305,20 @@ def _restart_unit(
 # in the upstream package, and the chat-port-never-binds symptom
 # points nowhere near the channel registry as the actual cause.
 #
-# Each entry: (regex, summary, remediation). The regex matches any
-# substring of the journal tail (Python `re.search`). The summary
-# is the one-line cause; the remediation is what the operator should
-# do next. Patterns are checked in order — first match wins.
-_KNOWN_UNIT_FATAL_PATTERNS: tuple[tuple[str, str, str], ...] = (
+# Each entry: (regex, agent_types, summary, remediation). `agent_types`
+# is a `frozenset` of agent type names the entry applies to; an empty
+# set means "all agent types". The regex matches any substring of the
+# journal tail (Python `re.search`). Patterns are checked in order —
+# first match wins. The matched journal text is NEVER forwarded to
+# callers — only the compile-time `summary` + `remediation` strings
+# are returned, so adding a tuple element that captures the matched
+# line would be a security regression (avoid).
+_KNOWN_UNIT_FATAL_PATTERNS: tuple[
+    tuple[str, frozenset[str], str, str], ...
+] = (
     (
         r"discord\.errors\.LoginFailure",
+        frozenset({"hermes"}),
         "Discord rejected the bot token (LoginFailure / 401 Unauthorized).",
         "Re-issue the channel record with a valid token: `clawctl channel "
         "registry delete <name> --yes` + `clawctl channel registry create "
@@ -322,7 +329,16 @@ _KNOWN_UNIT_FATAL_PATTERNS: tuple[tuple[str, str, str], ...] = (
         "it (tracked in #575).",
     ),
     (
-        r"required_field_empty.*gateway\.host",
+        # ATX B3: zeroclaw v0.7.5 emits the exact token
+        # `[required_field_empty] gateway.host must not be empty` per the
+        # observed journal capture in #576. The broadened alternation
+        # also matches a Rust-shaped `field 'gateway.host' is empty` in
+        # case a future zeroclaw rewrite changes the wording, so a
+        # subsequent version bump does not silently turn this entry
+        # into a dead letter.
+        r"required_field_empty.*gateway\.host"
+        r"|gateway\.host.*(?:must not be empty|is empty|required)",
+        frozenset({"zeroclaw"}),
         "zeroclaw daemon refused an empty `gateway.host`.",
         "Re-run `clawctl agent sync <agent>` after `clawctl` is upgraded "
         "to a release containing the #576 fix, or hand-edit "
@@ -330,7 +346,12 @@ _KNOWN_UNIT_FATAL_PATTERNS: tuple[tuple[str, str, str], ...] = (
         "under `[gateway]` and restart the unit.",
     ),
     (
-        r"OPENROUTER_API_KEY.*not set|No inference provider configured",
+        # Cross-agent: any agent that loads an OpenRouter provider
+        # without a populated key would surface one of these two
+        # messages. Parenthesized alternation for clarity (ATX W6).
+        r"(?:OPENROUTER_API_KEY.*not set"
+        r"|No inference provider configured)",
+        frozenset(),  # empty == all agent types
         "Provider credentials missing from the rendered config.",
         "Run `clawctl agent doctor <agent>` — it should show "
         "`api_key=present`. If it shows `missing`, re-run "
@@ -344,6 +365,7 @@ def _diagnose_unit_failure(
     client: paramiko.SSHClient,
     *,
     unit: str,
+    agent_type: str,
     timeout: int = 15,
 ) -> str | None:
     """Tail a failed unit's journal and look for known fatal patterns.
@@ -351,25 +373,48 @@ def _diagnose_unit_failure(
     Returns a one-line remediation-shaped diagnostic, or None if no
     pattern matched. Failures inside this helper (SSH disconnect,
     sudo denied, etc.) deliberately return None — diagnostics must
-    never mask the original `unit not active` error.
-    """
-    import re
+    never mask the original `unit not active` error. The swallow path
+    is debuggable via `logger.debug` so a sudoers regression is not
+    completely invisible (ATX W2).
 
+    `agent_type` is required so each catalog entry's `agent_types`
+    scope can filter false-positive matches (e.g. a hypothetical
+    openclaw journal containing the substring `gateway.host` should
+    not surface a zeroclaw-shaped TOML remediation — ATX B1/B2).
+
+    Worst-case wall-clock on this helper is one extra `exec_command`
+    bounded by the given `timeout` — the caller's overall budget is
+    `2 × timeout` (one is-active probe + one journal fetch). Callers
+    that want a tighter cap can pass a smaller `timeout` here.
+    """
     cmd = (
-        f"sudo journalctl --unit {shlex.quote(unit)} "
+        # `-n` matches the rest of this file (`_restart_unit`,
+        # `_write_remote_config`) — fail immediately if sudoers was
+        # accidentally scoped, rather than blocking on a password
+        # prompt that would only hang `exec_command` (ATX W1).
+        f"sudo -n journalctl --unit {shlex.quote(unit)} "
         f"--no-pager --lines 100 2>/dev/null || true"
     )
     try:
         _, out, _ = client.exec_command(cmd, timeout=timeout)
         out.channel.recv_exit_status()
         journal = out.read().decode("utf-8", errors="replace")
-    except Exception:
+    except Exception as exc:
+        # Keep the swallow contract — but make a sudoers regression
+        # debuggable rather than completely invisible (ATX W2).
+        logger.debug(
+            "_diagnose_unit_failure: exception fetching journal for %s: %s",
+            unit,
+            exc,
+        )
         return None
 
     if not journal.strip():
         return None
 
-    for pattern, summary, remediation in _KNOWN_UNIT_FATAL_PATTERNS:
+    for pattern, agent_types, summary, remediation in _KNOWN_UNIT_FATAL_PATTERNS:
+        if agent_types and agent_type not in agent_types:
+            continue
         if re.search(pattern, journal):
             return f"{summary} {remediation}"
     return None
@@ -388,9 +433,23 @@ def _verify_health(
     rc = out.channel.recv_exit_status()
     state = out.read().decode("utf-8", errors="replace").strip()
     if rc != 0 or state != "active":
-        diagnostic = _diagnose_unit_failure(
-            client, unit=unit, timeout=timeout
-        )
+        # Diagnostic is best-effort — a raise inside the helper still
+        # leaves the verdict-raise below intact (ATX B5).
+        diagnostic: str | None
+        try:
+            diagnostic = _diagnose_unit_failure(
+                client,
+                unit=unit,
+                agent_type=agent_type,
+                timeout=timeout,
+            )
+        except Exception as exc:
+            logger.debug(
+                "_verify_health: _diagnose_unit_failure raised for %s: %s",
+                unit,
+                exc,
+            )
+            diagnostic = None
         base = (
             f"unit {unit} is not active after restart (state={state!r})"
         )

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -340,9 +340,12 @@ _KNOWN_UNIT_FATAL_PATTERNS: tuple[
         # benign startup lines like "gateway.host (required): ..."
         # or "checking gateway.host... required for daemon init"
         # that any 100-line journal tail would contain regardless of
-        # crash reason. The two surviving alternation branches both
-        # describe the actual fault state ("must not be empty",
-        # "is empty").
+        # crash reason. Two branches survive: branch1 anchors on the
+        # canonical zeroclaw token name `required_field_empty`
+        # adjacent to `gateway.host` (fires independently of any
+        # trailing suffix); branch2 anchors on the actual fault-
+        # state phrasings `must not be empty` / `is empty` that
+        # any future zeroclaw wording would reuse.
         r"required_field_empty.*gateway\.host"
         r"|gateway\.host.*(?:must not be empty|is empty)",
         frozenset({"zeroclaw"}),
@@ -356,13 +359,15 @@ _KNOWN_UNIT_FATAL_PATTERNS: tuple[
         # Cross-agent: any agent that loads an OpenRouter provider
         # without a populated key would surface one of these two
         # messages. Parenthesized alternation for clarity (ATX W6).
-        # ATX iter-2 B2: greedy `.*` between key and "not set" fired
-        # on lines like "OPENROUTER_API_KEY was not set on previous
-        # boot, now present" or "[was not set, using fallback]". The
-        # tightened pattern requires whitespace + an optional `is`
-        # + `not set` as adjacent tokens, with a word boundary on
-        # the tail so "not setX" doesn't slip through.
-        r"(?:OPENROUTER_API_KEY\s+(?:is\s+)?not\s+set\b"
+        # ATX iter-2 B2 + iter-3 W-NEW-1: the separator class
+        # `[\s:=]+` covers whitespace, `KEY: not set`, and `KEY=`
+        # styles; the optional `is` and `\b` tail anchor stay from
+        # iter-2 to keep `was not set, now present` rejected. The
+        # `IGNORECASE` flag is shipped via `(?i)` so logs that
+        # uppercase the phrase (`IS NOT SET`) still match — the
+        # `OPENROUTER_API_KEY` prefix is specific enough that
+        # case-folding adds no false-positive risk.
+        r"(?i)(?:OPENROUTER_API_KEY[\s:=]+(?:is\s+)?not\s+set\b"
         r"|No inference provider configured)",
         frozenset(),  # empty == all agent types
         "Provider credentials missing from the rendered config.",

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -359,15 +359,29 @@ _KNOWN_UNIT_FATAL_PATTERNS: tuple[
         # Cross-agent: any agent that loads an OpenRouter provider
         # without a populated key would surface one of these two
         # messages. Parenthesized alternation for clarity (ATX W6).
-        # ATX iter-2 B2 + iter-3 W-NEW-1: the separator class
-        # `[\s:=]+` covers whitespace, `KEY: not set`, and `KEY=`
-        # styles; the optional `is` and `\b` tail anchor stay from
-        # iter-2 to keep `was not set, now present` rejected. The
-        # `IGNORECASE` flag is shipped via `(?i)` so logs that
-        # uppercase the phrase (`IS NOT SET`) still match — the
-        # `OPENROUTER_API_KEY` prefix is specific enough that
-        # case-folding adds no false-positive risk.
-        r"(?i)(?:OPENROUTER_API_KEY[\s:=]+(?:is\s+)?not\s+set\b"
+        # ATX iter-2 B2 + iter-3 W-NEW-1: the separator class covers
+        # `KEY: not set`, `KEY=not set`, and tab/space-separated
+        # variants; the optional `is` and `\b` tail anchor stay
+        # from iter-2 to keep `was not set, now present` rejected.
+        # ATX iter-4 W1: the separator class is restricted to
+        # horizontal whitespace + `:` + `=`. `[\s:=]+` would have
+        # included `\n`, which over `re.search` against the full
+        # 100-line journal blob meant a journal where
+        # `OPENROUTER_API_KEY` ends one line and `not set ...`
+        # begins the next would over-fire.
+        # ATX iter-4 W2: the `(?i)` flag applies to the entire
+        # pattern, intentionally — `openrouter_api_key not set` (a
+        # lowercase env-dump shape that some agents emit) is a
+        # legitimate match. `No inference provider configured` also
+        # case-folds, which is harmless since both branches share
+        # the cross-agent scope and the phrase is specific.
+        # ATX iter-4 W3: leading `\b` rejects substring matches
+        # inside a longer identifier (e.g. `MY_OPENROUTER_API_KEY` —
+        # which is NOT the OpenRouter key clawctl plumbs and should
+        # not surface this remediation). `\b` does not match between
+        # two word characters, so `MY_OPENROUTER_API_KEY` no longer
+        # matches even via `re.search`.
+        r"(?i)(?:\bOPENROUTER_API_KEY[\t :=]+(?:is\s+)?not\s+set\b"
         r"|No inference provider configured)",
         frozenset(),  # empty == all agent types
         "Provider credentials missing from the rendered config.",

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -381,7 +381,13 @@ _KNOWN_UNIT_FATAL_PATTERNS: tuple[
         # not surface this remediation). `\b` does not match between
         # two word characters, so `MY_OPENROUTER_API_KEY` no longer
         # matches even via `re.search`.
-        r"(?i)(?:\bOPENROUTER_API_KEY[\t :=]+(?:is\s+)?not\s+set\b"
+        # ATX iter-5 W1-RESIDUAL: the suffix groups also use
+        # `[\t ]+` (not `\s+`) so a journal blob where a newline
+        # falls between `is` and `not set` (e.g. `journalctl -o cat`
+        # output that drops the per-line timestamp prefix) does not
+        # over-fire. The KEY↔phrase boundary and the in-phrase
+        # boundary are both horizontal-whitespace-only.
+        r"(?i)(?:\bOPENROUTER_API_KEY[\t :=]+(?:is[\t ]+)?not[\t ]+set\b"
         r"|No inference provider configured)",
         frozenset(),  # empty == all agent types
         "Provider credentials missing from the rendered config.",

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -381,12 +381,15 @@ _KNOWN_UNIT_FATAL_PATTERNS: tuple[
         # not surface this remediation). `\b` does not match between
         # two word characters, so `MY_OPENROUTER_API_KEY` no longer
         # matches even via `re.search`.
-        # ATX iter-5 W1-RESIDUAL: the suffix groups also use
+        # ATX iter-5 W1-RESIDUAL (#575): the suffix groups also use
         # `[\t ]+` (not `\s+`) so a journal blob where a newline
         # falls between `is` and `not set` (e.g. `journalctl -o cat`
         # output that drops the per-line timestamp prefix) does not
-        # over-fire. The KEY↔phrase boundary and the in-phrase
-        # boundary are both horizontal-whitespace-only.
+        # over-fire. ATX iter-6 W1 (#575): the two boundary classes
+        # are not symmetric: the KEY↔phrase boundary `[\t :=]+`
+        # admits tabs, spaces, colon, and equals (a `KEY=` or
+        # `KEY:` style separator); the in-phrase boundaries `[\t ]+`
+        # are horizontal-whitespace-only. Both are newline-safe.
         r"(?i)(?:\bOPENROUTER_API_KEY[\t :=]+(?:is[\t ]+)?not[\t ]+set\b"
         r"|No inference provider configured)",
         frozenset(),  # empty == all agent types

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -296,6 +296,85 @@ def _restart_unit(
         )
 
 
+# #575: when a unit fails to come active after restart, capture the
+# tail of its journal and translate well-known fatal patterns into
+# remediation-shaped messages. The default error (`unit not active
+# after restart (state='activating')`) sends the operator chasing the
+# wrong layer — e.g. the hermes Discord-token crash brings the entire
+# FastAPI gateway down via an unisolated `discord.errors.LoginFailure`
+# in the upstream package, and the chat-port-never-binds symptom
+# points nowhere near the channel registry as the actual cause.
+#
+# Each entry: (regex, summary, remediation). The regex matches any
+# substring of the journal tail (Python `re.search`). The summary
+# is the one-line cause; the remediation is what the operator should
+# do next. Patterns are checked in order — first match wins.
+_KNOWN_UNIT_FATAL_PATTERNS: tuple[tuple[str, str, str], ...] = (
+    (
+        r"discord\.errors\.LoginFailure",
+        "Discord rejected the bot token (LoginFailure / 401 Unauthorized).",
+        "Re-issue the channel record with a valid token: `clawctl channel "
+        "registry delete <name> --yes` + `clawctl channel registry create "
+        "<name> --type discord --token-stdin …` + `clawctl agent sync "
+        "<agent>`. The current hermes upstream does not isolate Discord "
+        "client failures from the gateway process, so a stale or "
+        "fat-fingered token currently takes the chat endpoint down with "
+        "it (tracked in #575).",
+    ),
+    (
+        r"required_field_empty.*gateway\.host",
+        "zeroclaw daemon refused an empty `gateway.host`.",
+        "Re-run `clawctl agent sync <agent>` after `clawctl` is upgraded "
+        "to a release containing the #576 fix, or hand-edit "
+        "`~/.zeroclaw/config.toml` on the host to set `host = \"0.0.0.0\"` "
+        "under `[gateway]` and restart the unit.",
+    ),
+    (
+        r"OPENROUTER_API_KEY.*not set|No inference provider configured",
+        "Provider credentials missing from the rendered config.",
+        "Run `clawctl agent doctor <agent>` — it should show "
+        "`api_key=present`. If it shows `missing`, re-run "
+        "`clawctl agent configure <agent> --stage providers --provider "
+        "<id>` and confirm the provider record carries a credential.",
+    ),
+)
+
+
+def _diagnose_unit_failure(
+    client: paramiko.SSHClient,
+    *,
+    unit: str,
+    timeout: int = 15,
+) -> str | None:
+    """Tail a failed unit's journal and look for known fatal patterns.
+
+    Returns a one-line remediation-shaped diagnostic, or None if no
+    pattern matched. Failures inside this helper (SSH disconnect,
+    sudo denied, etc.) deliberately return None — diagnostics must
+    never mask the original `unit not active` error.
+    """
+    import re
+
+    cmd = (
+        f"sudo journalctl --unit {shlex.quote(unit)} "
+        f"--no-pager --lines 100 2>/dev/null || true"
+    )
+    try:
+        _, out, _ = client.exec_command(cmd, timeout=timeout)
+        out.channel.recv_exit_status()
+        journal = out.read().decode("utf-8", errors="replace")
+    except Exception:
+        return None
+
+    if not journal.strip():
+        return None
+
+    for pattern, summary, remediation in _KNOWN_UNIT_FATAL_PATTERNS:
+        if re.search(pattern, journal):
+            return f"{summary} {remediation}"
+    return None
+
+
 def _verify_health(
     client: paramiko.SSHClient,
     *,
@@ -309,9 +388,15 @@ def _verify_health(
     rc = out.channel.recv_exit_status()
     state = out.read().decode("utf-8", errors="replace").strip()
     if rc != 0 or state != "active":
-        raise CanonicalSyncError(
+        diagnostic = _diagnose_unit_failure(
+            client, unit=unit, timeout=timeout
+        )
+        base = (
             f"unit {unit} is not active after restart (state={state!r})"
         )
+        if diagnostic:
+            raise CanonicalSyncError(f"{base}. Diagnosis: {diagnostic}")
+        raise CanonicalSyncError(base)
 
 
 def sync_agent_canonical(

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -19,6 +19,7 @@ Closes ATX #555-polish blockers:
 
 from __future__ import annotations
 
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -33,6 +34,19 @@ from clawrium.core.lifecycle_canonical import (
     sync_agent_canonical,
 )
 from clawrium.core.render_diff import FileDiff
+
+
+def _catalog_pattern_containing(needle: str) -> str:
+    """Look up a `_KNOWN_UNIT_FATAL_PATTERNS` regex by content
+    instead of positional index — ATX iter-4 S2. Inserting a new
+    catalog entry before an existing one no longer silently shifts
+    the index out from under the test."""
+    for pattern, _scope, _summary, _remediation in lc._KNOWN_UNIT_FATAL_PATTERNS:
+        if needle in pattern:
+            return pattern
+    raise AssertionError(
+        f"no catalog entry contains {needle!r}; check needle or catalog"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -898,12 +912,10 @@ class TestDiagnoseUnitFailure:
         # Sanity check: branch2 alone (without `required_field_empty`)
         # would NOT have matched this body. The diagnostic firing
         # therefore proves branch1 carries its own weight.
-        import re as _re_local
-
-        pattern = lc._KNOWN_UNIT_FATAL_PATTERNS[1][0]
+        pattern = _catalog_pattern_containing("required_field_empty")
         branch2_only = r"gateway\.host.*(?:must not be empty|is empty)"
-        assert _re_local.search(pattern, journal.decode())
-        assert not _re_local.search(branch2_only, journal.decode())
+        assert re.search(pattern, journal.decode())
+        assert not re.search(branch2_only, journal.decode())
 
     def test_missing_provider_key_openrouter_translated(self):
         """ATX B4: the OPENROUTER_API_KEY branch must have its own
@@ -951,15 +963,40 @@ class TestDiagnoseUnitFailure:
             # the tightened pattern must reject. Each line contains
             # the key name and the phrase "not set" but in a
             # state-snapshot / migration context where the key IS
-            # present at boot. ATX iter-3 S2: replaced the second
-            # case (which previously failed for the wrong reason —
-            # no whitespace after key name) with a stale-env
-            # snapshot that genuinely tests the "was…not set,
-            # now-present" adjacency the comment narrates.
+            # present at boot.
             b"hermes[1234]: OPENROUTER_API_KEY was not set on previous "
             b"boot, now present\n",
             b"hermes[1234]: OPENROUTER_API_KEY was not set, now using "
             b"fallback\n",
+            # ATX iter-4 S3: bracket-form stale-env case that the
+            # iter-2 comment narrated but no test previously
+            # covered. Bracket separator is not in the `[\t :=]+`
+            # class, so the diagnostic must NOT fire.
+            b"hermes[1234]: OPENROUTER_API_KEY [was not set, "
+            b"using fallback]\n",
+            # ATX iter-4 S4: a case that would fire under a naive
+            # `.*` pattern but NOT under the tightened
+            # `[\t :=]+(?:is\s+)?not\s+set\b` — the key name and
+            # "previously not set" phrase are 4 words apart, so
+            # only `.*` could bridge them.
+            b"hermes[1234]: OPENROUTER_API_KEY environment variable "
+            b"was previously not set\n",
+            # ATX iter-4 W1: cross-line case — key at end of one
+            # journal line, "not set" at start of next. With
+            # `[\s:=]+` (which includes `\n`) the diagnostic would
+            # over-fire on the multi-line blob; with `[\t :=]+`
+            # the newline breaks adjacency and the diagnostic stays
+            # silent.
+            b"agent[1234]: env dump OPENROUTER_API_KEY\n"
+            b"agent[1234]: not set, using ollama fallback\n",
+            # ATX iter-4 W3: left-boundary case — `MY_OPENROUTER_API_KEY`
+            # is NOT the OpenRouter key clawctl plumbs, so the
+            # diagnostic should not surface even though the substring
+            # match looks tempting. Pre-existing left-boundary gap;
+            # full `\b` anchor on the key name is tracked as a
+            # follow-up but the negative test pins the current
+            # behavior so a future tightening is regression-safe.
+            b"hermes[1234]: MY_OPENROUTER_API_KEY is not set\n",
         ],
     )
     def test_provider_key_pattern_does_not_over_match_stale_env_logs(
@@ -992,6 +1029,13 @@ class TestDiagnoseUnitFailure:
             # this matches even though the prefix is uppercase but
             # the phrase is too.
             b"hermes[1234]: OPENROUTER_API_KEY IS NOT SET\n",
+            # ATX iter-4 W2: lowercase env-var name — some agents
+            # emit env dumps in lowercase. The `(?i)` flag applies
+            # to the whole pattern (acknowledged in production
+            # comment); this is an intentional match, pinned here
+            # so a future scope-tightening of `(?i)` to the suffix
+            # only would fail this test rather than silently regress.
+            b"agent[1234]: openrouter_api_key not set\n",
         ],
     )
     def test_provider_key_pattern_matches_canonical_separators(
@@ -1094,16 +1138,14 @@ class TestDiagnoseUnitFailure:
         type that has no `~/.openclaw/config.toml` file. ATX iter-3
         S1: make the dual nature explicit — the regex matches, the
         scope filter blocks."""
-        import re as _re_local
-
         journal = (
             b"openclaw[1234]: [required_field_empty] gateway.host must "
             b"not be empty\n"
         )
         # Make the test intent explicit: the regex would match this
         # body. The scope filter is what suppresses the diagnostic.
-        zeroclaw_pattern = lc._KNOWN_UNIT_FATAL_PATTERNS[1][0]
-        assert _re_local.search(zeroclaw_pattern, journal.decode())
+        zeroclaw_pattern = _catalog_pattern_containing("required_field_empty")
+        assert re.search(zeroclaw_pattern, journal.decode())
         client = _FakeSSHClient(
             [("journalctl", 0, journal)],
         )

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -982,31 +982,41 @@ class TestDiagnoseUnitFailure:
             b"hermes[1234]: OPENROUTER_API_KEY environment variable "
             b"was previously not set\n",
             # ATX iter-4 W1: cross-line case — key at end of one
-            # journal line, "not set" at start of next. With
-            # `[\s:=]+` (which includes `\n`) the diagnostic would
-            # over-fire on the multi-line blob; with `[\t :=]+`
-            # the newline breaks adjacency and the diagnostic stays
-            # silent.
+            # journal line, "not set" at start of next. With a
+            # newline-including separator class the diagnostic
+            # would over-fire on the multi-line blob; with
+            # `[\t :=]+` the newline breaks adjacency and the
+            # diagnostic stays silent.
             b"agent[1234]: env dump OPENROUTER_API_KEY\n"
             b"agent[1234]: not set, using ollama fallback\n",
-            # ATX iter-4 W3: left-boundary case — `MY_OPENROUTER_API_KEY`
-            # is NOT the OpenRouter key clawctl plumbs, so the
-            # diagnostic should not surface even though the substring
-            # match looks tempting. Pre-existing left-boundary gap;
-            # full `\b` anchor on the key name is tracked as a
-            # follow-up but the negative test pins the current
-            # behavior so a future tightening is regression-safe.
+            # ATX iter-4 W3 fix in place: leading `\b` now rejects
+            # substring prefixes. `MY_OPENROUTER_API_KEY` is NOT the
+            # OpenRouter key clawctl plumbs, and the leading word
+            # boundary on `\bOPENROUTER_API_KEY` correctly suppresses
+            # the substring match. This case pins that behavior as a
+            # regression guard.
             b"hermes[1234]: MY_OPENROUTER_API_KEY is not set\n",
+            # ATX iter-5 W1-RESIDUAL: cross-line case inside the
+            # suffix — `KEY:` on one line, `is\nnot set` straddling
+            # newline between `is` and `not set`. With the iter-4
+            # suffix `(?:is\s+)?not\s+set` (where `\s` includes
+            # `\n`), this would have over-fired on a `journalctl -o
+            # cat` blob that drops per-line timestamp prefixes.
+            # The iter-5 production fix tightened the suffix to
+            # `[\t ]+` everywhere; this negative pins the change.
+            b"agent[1234]: OPENROUTER_API_KEY: is\nnot set\n",
         ],
     )
     def test_provider_key_pattern_does_not_over_match_stale_env_logs(
         self, journal_line
     ):
         """ATX iter-2 B2: tightening to
-        `OPENROUTER_API_KEY[\\s:=]+(?:is\\s+)?not\\s+set\\b` means a
-        stale-env snapshot or migration log that mentions the key +
-        a non-adjacent "not set" phrase no longer over-fires the
-        diagnostic."""
+        `\\bOPENROUTER_API_KEY[\\t :=]+(?:is[\\t ]+)?not[\\t ]+set\\b`
+        means a stale-env snapshot or migration log that mentions
+        the key + a non-adjacent "not set" phrase no longer
+        over-fires the diagnostic. ATX iter-5: the horizontal-only
+        whitespace classes also reject newline-straddling matches
+        in the suffix."""
         client = _FakeSSHClient(
             [("journalctl", 0, journal_line)],
         )
@@ -1023,7 +1033,7 @@ class TestDiagnoseUnitFailure:
             b"hermes[1234]: OPENROUTER_API_KEY: is not set in "
             b"environment\n",
             b"hermes[1234]: OPENROUTER_API_KEY: not set\n",
-            # `KEY=` style — covered by the same `[\\s:=]+` class.
+            # `KEY=` style — covered by the same `[\\t :=]+` class.
             b"hermes[1234]: OPENROUTER_API_KEY=not set\n",
             # ATX iter-3 S6: uppercase variant — `(?i)` flag means
             # this matches even though the prefix is uppercase but
@@ -1041,11 +1051,11 @@ class TestDiagnoseUnitFailure:
     def test_provider_key_pattern_matches_canonical_separators(
         self, journal_line
     ):
-        """ATX iter-3 W-NEW-1 + S6: the widened separator class
-        `[\\s:=]+` plus the `(?i)` flag means colon, equals, and
-        case-shifted variants all surface the diagnostic. Without
-        these, the pattern was silently missing a common log
-        shape."""
+        """ATX iter-3 W-NEW-1 + S6: the `[\\t :=]+` separator class
+        (horizontal whitespace + colon + equals) plus the `(?i)`
+        flag means colon, equals, and case-shifted variants all
+        surface the diagnostic. Without these, the pattern was
+        silently missing a common log shape."""
         client = _FakeSSHClient(
             [("journalctl", 0, journal_line)],
         )

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -804,23 +804,63 @@ class TestDiagnoseUnitFailure:
         assert "gateway.host" in diag
         assert "#576" in diag
 
-    def test_zeroclaw_broadened_gateway_host_token(self):
-        """ATX B3: the broadened regex matches a Rust-shaped phrasing
-        in addition to the v0.7.5 token, so a future zeroclaw rewrite
-        that changes wording does not silently turn this entry into a
-        dead letter."""
-        journal = (
+    @pytest.mark.parametrize(
+        "journal_line",
+        [
+            # Rust-shaped phrasing — "is empty" branch.
             b"zeroclaw: configuration error: field 'gateway.host' is "
-            b"empty in /home/zeroclaw-x/.zeroclaw/config.toml\n"
-        )
+            b"empty in /home/zeroclaw-x/.zeroclaw/config.toml\n",
+            # Canonical phrasing — "must not be empty" branch (ATX
+            # iter-2 W3: previously unexercised).
+            b"zeroclaw[1234]: validation: gateway.host must not be "
+            b"empty\n",
+        ],
+    )
+    def test_zeroclaw_broadened_gateway_host_token(self, journal_line):
+        """ATX B3 + iter-2 W3: the broadened regex matches both
+        post-v0.7.5 phrasings, so a future zeroclaw rewrite changing
+        wording does not silently turn this entry into a dead letter."""
         client = _FakeSSHClient(
-            [("journalctl", 0, journal)],
+            [("journalctl", 0, journal_line)],
         )
         diag = lc._diagnose_unit_failure(
             client, unit="zeroclaw-x.service", agent_type="zeroclaw"
         )
         assert diag is not None
         assert "gateway.host" in diag
+        # ATX iter-2 W1: pin the remediation body so a truncated
+        # remediation string fails this test loudly.
+        assert "clawctl agent sync" in diag
+        assert "#576" in diag
+
+    @pytest.mark.parametrize(
+        "journal_line",
+        [
+            # ATX iter-2 B1: a benign startup log mentioning the
+            # `(required)` annotation alongside `gateway.host` must
+            # NOT fire the diagnostic — that was the over-match the
+            # original `|required` alternation produced.
+            b"zeroclaw[1234]: Config field gateway.host (required): "
+            b"set this to 0.0.0.0\n",
+            b"zeroclaw[1234]: checking gateway.host... required for "
+            b"daemon init\n",
+        ],
+    )
+    def test_zeroclaw_required_annotation_does_not_over_match(
+        self, journal_line
+    ):
+        """ATX iter-2 B1: dropping `|required` from the alternation
+        means a benign startup log line mentioning the `(required)`
+        annotation no longer over-fires the diagnostic. The actual
+        crash cases ("must not be empty", "is empty") are unchanged
+        and still match."""
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal_line)],
+        )
+        diag = lc._diagnose_unit_failure(
+            client, unit="zeroclaw-x.service", agent_type="zeroclaw"
+        )
+        assert diag is None
 
     def test_missing_provider_key_openrouter_translated(self):
         """ATX B4: the OPENROUTER_API_KEY branch must have its own
@@ -857,6 +897,38 @@ class TestDiagnoseUnitFailure:
         )
         assert diag is not None
         assert "Provider credentials missing" in diag
+        # ATX iter-2 W2: also pin the remediation body to match the
+        # rigor of the first-branch test.
+        assert "clawctl agent configure" in diag
+
+    @pytest.mark.parametrize(
+        "journal_line",
+        [
+            # ATX iter-2 B2: the greedy `.*` over-match cases that
+            # the tightened pattern (`\s+(?:is\s+)?not\s+set\b`)
+            # must reject. Each line contains the key name and the
+            # phrase "not set" but in a state-snapshot / migration
+            # context where the key IS present at boot.
+            b"hermes[1234]: OPENROUTER_API_KEY was not set on previous "
+            b"boot, now present\n",
+            b"hermes[1234]: config_loader: OPENROUTER_API_KEY [was not "
+            b"set, using fallback]\n",
+        ],
+    )
+    def test_provider_key_pattern_does_not_over_match_stale_env_logs(
+        self, journal_line
+    ):
+        """ATX iter-2 B2: tightening to `OPENROUTER_API_KEY\\s+(?:is\\s+)?not\\s+set\\b`
+        means a stale-env snapshot or migration log mentioning the
+        key + the phrase "not set" in a non-adjacent context no
+        longer over-fires the diagnostic."""
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal_line)],
+        )
+        diag = lc._diagnose_unit_failure(
+            client, unit="hermes-x.service", agent_type="hermes"
+        )
+        assert diag is None
 
     def test_unknown_failure_returns_none(self):
         """A journal that doesn't match any catalog entry returns None
@@ -930,6 +1002,39 @@ class TestDiagnoseUnitFailure:
         # mentions gateway.host. Diagnostic must be None.
         assert diag is None
 
+    def test_zeroclaw_pattern_does_not_fire_on_openclaw(self):
+        """ATX iter-2 W4: third-type isolation. A future accidental
+        widening of `frozenset({'zeroclaw'})` to include `openclaw`
+        would surface a TOML-edit remediation against an agent type
+        that has no `~/.openclaw/config.toml` file. Pin the scope."""
+        journal = (
+            b"openclaw[1234]: some unrelated log line mentioning "
+            b"required_field_empty gateway.host in a docstring\n"
+        )
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal)],
+        )
+        diag = lc._diagnose_unit_failure(
+            client, unit="openclaw-x.service", agent_type="openclaw"
+        )
+        assert diag is None
+
+    def test_discord_pattern_does_not_fire_on_openclaw(self):
+        """ATX iter-2 W4: third-type isolation for the hermes-scoped
+        Discord entry. An openclaw journal containing the Discord
+        substring must NOT receive hermes architectural blame."""
+        journal = (
+            b"openclaw[1234]: external integration: "
+            b"discord.errors.LoginFailure: token rejected\n"
+        )
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal)],
+        )
+        diag = lc._diagnose_unit_failure(
+            client, unit="openclaw-x.service", agent_type="openclaw"
+        )
+        assert diag is None
+
     def test_discord_pattern_does_not_fire_on_zeroclaw(self):
         """ATX B1/W7: a zeroclaw journal that contains the Discord
         substring (e.g. a config reference) must NOT receive the
@@ -969,6 +1074,26 @@ class TestDiagnoseUnitFailure:
         # Discord entry is first in the tuple — it wins over the
         # provider-key entry, even though both match.
         assert "Discord" in diag
+        assert "Provider credentials missing" not in diag
+
+    def test_first_pattern_wins_zeroclaw_over_provider(self):
+        """ATX iter-2 W5: pin first-match-wins for the zeroclaw entry
+        beating the cross-agent provider entry. Earlier test covered
+        entries 1 vs 3 (Discord vs provider); this covers 2 vs 3."""
+        journal = (
+            b"zeroclaw[1234]: Error: [required_field_empty] gateway.host "
+            b"must not be empty (gateway.host)\n"
+            b"zeroclaw[1234]: also OPENROUTER_API_KEY is not set\n"
+        )
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal)],
+        )
+        diag = lc._diagnose_unit_failure(
+            client, unit="zeroclaw-x.service", agent_type="zeroclaw"
+        )
+        assert diag is not None
+        # Zeroclaw gateway.host entry (#2) wins over provider key (#3).
+        assert "gateway.host" in diag
         assert "Provider credentials missing" not in diag
 
 

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -844,16 +844,25 @@ class TestDiagnoseUnitFailure:
             b"set this to 0.0.0.0\n",
             b"zeroclaw[1234]: checking gateway.host... required for "
             b"daemon init\n",
+            # ATX iter-3 S3: also pin the exact `is required` /
+            # `required` phrasings that the dropped `|required` branch
+            # would have over-matched. These exercise the specific
+            # word boundary that distinguishes a startup annotation
+            # from a fault state.
+            b"zeroclaw[1234]: schema: gateway.host is required\n",
+            b"zeroclaw[1234]: gateway.host required\n",
         ],
     )
     def test_zeroclaw_required_annotation_does_not_over_match(
         self, journal_line
     ):
-        """ATX iter-2 B1: dropping `|required` from the alternation
-        means a benign startup log line mentioning the `(required)`
-        annotation no longer over-fires the diagnostic. The actual
-        crash cases ("must not be empty", "is empty") are unchanged
-        and still match."""
+        """ATX iter-2 B1 + iter-3 S3: dropping `|required` from the
+        alternation means startup logs mentioning `(required)`,
+        `is required`, or bare `required` alongside `gateway.host` no
+        longer over-fire the diagnostic. The actual crash cases
+        ("must not be empty", "is empty") are unchanged and still
+        match (covered by `test_zeroclaw_broadened_gateway_host_token`).
+        """
         client = _FakeSSHClient(
             [("journalctl", 0, journal_line)],
         )
@@ -861,6 +870,40 @@ class TestDiagnoseUnitFailure:
             client, unit="zeroclaw-x.service", agent_type="zeroclaw"
         )
         assert diag is None
+
+    def test_zeroclaw_branch1_alone_matches_canonical_token(self):
+        """ATX iter-3 W-NEW-2: pin that branch1
+        (`required_field_empty.*gateway.host`) fires on a journal
+        line that does NOT carry any suffix branch2 would also
+        accept. Without this case, deleting branch1 from the
+        production regex would still pass every other test —
+        because every other positive test happens to carry both
+        a `required_field_empty` token AND a `must not be empty` /
+        `is empty` phrase, so branch2 alone covers them. A
+        mutation-test would flag the missing exclusive coverage."""
+        # No `must not be empty` / `is empty` suffix — only branch1
+        # can match this line.
+        journal = (
+            b"zeroclaw[1234]: [required_field_empty] gateway.host "
+            b"\xe2\x80\x94 field was blank\n"
+        )
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal)],
+        )
+        diag = lc._diagnose_unit_failure(
+            client, unit="zeroclaw-x.service", agent_type="zeroclaw"
+        )
+        assert diag is not None
+        assert "gateway.host" in diag
+        # Sanity check: branch2 alone (without `required_field_empty`)
+        # would NOT have matched this body. The diagnostic firing
+        # therefore proves branch1 carries its own weight.
+        import re as _re_local
+
+        pattern = lc._KNOWN_UNIT_FATAL_PATTERNS[1][0]
+        branch2_only = r"gateway\.host.*(?:must not be empty|is empty)"
+        assert _re_local.search(pattern, journal.decode())
+        assert not _re_local.search(branch2_only, journal.decode())
 
     def test_missing_provider_key_openrouter_translated(self):
         """ATX B4: the OPENROUTER_API_KEY branch must have its own
@@ -905,23 +948,28 @@ class TestDiagnoseUnitFailure:
         "journal_line",
         [
             # ATX iter-2 B2: the greedy `.*` over-match cases that
-            # the tightened pattern (`\s+(?:is\s+)?not\s+set\b`)
-            # must reject. Each line contains the key name and the
-            # phrase "not set" but in a state-snapshot / migration
-            # context where the key IS present at boot.
+            # the tightened pattern must reject. Each line contains
+            # the key name and the phrase "not set" but in a
+            # state-snapshot / migration context where the key IS
+            # present at boot. ATX iter-3 S2: replaced the second
+            # case (which previously failed for the wrong reason —
+            # no whitespace after key name) with a stale-env
+            # snapshot that genuinely tests the "was…not set,
+            # now-present" adjacency the comment narrates.
             b"hermes[1234]: OPENROUTER_API_KEY was not set on previous "
             b"boot, now present\n",
-            b"hermes[1234]: config_loader: OPENROUTER_API_KEY [was not "
-            b"set, using fallback]\n",
+            b"hermes[1234]: OPENROUTER_API_KEY was not set, now using "
+            b"fallback\n",
         ],
     )
     def test_provider_key_pattern_does_not_over_match_stale_env_logs(
         self, journal_line
     ):
-        """ATX iter-2 B2: tightening to `OPENROUTER_API_KEY\\s+(?:is\\s+)?not\\s+set\\b`
-        means a stale-env snapshot or migration log mentioning the
-        key + the phrase "not set" in a non-adjacent context no
-        longer over-fires the diagnostic."""
+        """ATX iter-2 B2: tightening to
+        `OPENROUTER_API_KEY[\\s:=]+(?:is\\s+)?not\\s+set\\b` means a
+        stale-env snapshot or migration log that mentions the key +
+        a non-adjacent "not set" phrase no longer over-fires the
+        diagnostic."""
         client = _FakeSSHClient(
             [("journalctl", 0, journal_line)],
         )
@@ -929,6 +977,40 @@ class TestDiagnoseUnitFailure:
             client, unit="hermes-x.service", agent_type="hermes"
         )
         assert diag is None
+
+    @pytest.mark.parametrize(
+        "journal_line",
+        [
+            # ATX iter-3 W-NEW-1: the colon-separator case the
+            # iter-2 pattern silently missed.
+            b"hermes[1234]: OPENROUTER_API_KEY: is not set in "
+            b"environment\n",
+            b"hermes[1234]: OPENROUTER_API_KEY: not set\n",
+            # `KEY=` style — covered by the same `[\\s:=]+` class.
+            b"hermes[1234]: OPENROUTER_API_KEY=not set\n",
+            # ATX iter-3 S6: uppercase variant — `(?i)` flag means
+            # this matches even though the prefix is uppercase but
+            # the phrase is too.
+            b"hermes[1234]: OPENROUTER_API_KEY IS NOT SET\n",
+        ],
+    )
+    def test_provider_key_pattern_matches_canonical_separators(
+        self, journal_line
+    ):
+        """ATX iter-3 W-NEW-1 + S6: the widened separator class
+        `[\\s:=]+` plus the `(?i)` flag means colon, equals, and
+        case-shifted variants all surface the diagnostic. Without
+        these, the pattern was silently missing a common log
+        shape."""
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal_line)],
+        )
+        diag = lc._diagnose_unit_failure(
+            client, unit="hermes-x.service", agent_type="hermes"
+        )
+        assert diag is not None
+        assert "Provider credentials missing" in diag
+        assert "clawctl agent configure" in diag
 
     def test_unknown_failure_returns_none(self):
         """A journal that doesn't match any catalog entry returns None
@@ -1003,14 +1085,25 @@ class TestDiagnoseUnitFailure:
         assert diag is None
 
     def test_zeroclaw_pattern_does_not_fire_on_openclaw(self):
-        """ATX iter-2 W4: third-type isolation. A future accidental
-        widening of `frozenset({'zeroclaw'})` to include `openclaw`
-        would surface a TOML-edit remediation against an agent type
-        that has no `~/.openclaw/config.toml` file. Pin the scope."""
+        """ATX iter-2 W4: third-type isolation. The journal body
+        here DOES match the zeroclaw regex content-wise — what
+        suppresses the diagnostic is the `agent_types` scope filter,
+        not the regex itself. A future accidental widening of
+        `frozenset({'zeroclaw'})` to include `openclaw` would
+        immediately surface a TOML-edit remediation against an agent
+        type that has no `~/.openclaw/config.toml` file. ATX iter-3
+        S1: make the dual nature explicit — the regex matches, the
+        scope filter blocks."""
+        import re as _re_local
+
         journal = (
-            b"openclaw[1234]: some unrelated log line mentioning "
-            b"required_field_empty gateway.host in a docstring\n"
+            b"openclaw[1234]: [required_field_empty] gateway.host must "
+            b"not be empty\n"
         )
+        # Make the test intent explicit: the regex would match this
+        # body. The scope filter is what suppresses the diagnostic.
+        zeroclaw_pattern = lc._KNOWN_UNIT_FATAL_PATTERNS[1][0]
+        assert _re_local.search(zeroclaw_pattern, journal.decode())
         client = _FakeSSHClient(
             [("journalctl", 0, journal)],
         )
@@ -1056,7 +1149,8 @@ class TestDiagnoseUnitFailure:
         assert diag is None
 
     def test_first_pattern_wins_on_overlap(self):
-        """ATX W4: pin the tuple-order contract — when a journal
+        """ATX W5 (iter-3 S5: corrected tag — this is W5, not W4):
+        pin the tuple-order contract — when a journal
         matches multiple patterns, the earlier one in the tuple wins.
         Future refactor to a dict would break this and the test would
         flag it."""

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -719,3 +719,169 @@ def test_zeroclaw_sync_restart_false_still_repairs_bearer(monkeypatch):
     assert repair_called == [True]
     # Event stream confirms emission too.
     assert any(stage == "repair" for stage, _ in events), events
+
+
+# ---------------------------------------------------------------------------
+# #575: _diagnose_unit_failure + _verify_health diagnostic wrapping
+# ---------------------------------------------------------------------------
+
+
+class _FakeChannel:
+    def __init__(self, exit_status: int = 0) -> None:
+        self._exit_status = exit_status
+
+    def recv_exit_status(self) -> int:
+        return self._exit_status
+
+
+class _FakeStream:
+    def __init__(self, payload: bytes, exit_status: int = 0) -> None:
+        self._payload = payload
+        self.channel = _FakeChannel(exit_status)
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+class _FakeSSHClient:
+    """Routes `exec_command` calls by substring match. Each tuple
+    (substring, exit_status, stdout_bytes) describes one expected call;
+    the first matching tuple is consumed. Order does not matter — the
+    helper under test calls `is-active` and `journalctl` in a fixed
+    order but we let the tests assert on outcome only."""
+
+    def __init__(self, scripted: list[tuple[str, int, bytes]]) -> None:
+        self._scripted = list(scripted)
+        self.calls: list[str] = []
+
+    def exec_command(self, command: str, timeout: int | None = None):
+        self.calls.append(command)
+        for i, (needle, rc, payload) in enumerate(self._scripted):
+            if needle in command:
+                self._scripted.pop(i)
+                stream = _FakeStream(payload, rc)
+                return (None, stream, stream)
+        # Unmatched — return empty success so the test surfaces an
+        # AssertionError on `self.calls` rather than a generic exception.
+        stream = _FakeStream(b"", 0)
+        return (None, stream, stream)
+
+
+class TestDiagnoseUnitFailure:
+    def test_discord_login_failure_translated_to_remediation(self):
+        journal = (
+            b"May 30 09:47:56 wolf hermes[2427668]: ERROR asyncio: ...\n"
+            b"discord.errors.LoginFailure: Improper token has been passed.\n"
+            b"systemd[1]: hermes-x.service: Main process exited, "
+            b"code=exited, status=1/FAILURE\n"
+        )
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal)],
+        )
+        diag = lc._diagnose_unit_failure(client, unit="hermes-x.service")
+        assert diag is not None
+        assert "Discord" in diag
+        assert "clawctl channel registry" in diag
+
+    def test_zeroclaw_empty_gateway_host_translated(self):
+        journal = (
+            b"May 30 09:51:18 wolf zeroclaw[2431536]: Error: "
+            b"[required_field_empty] gateway.host must not be empty "
+            b"(gateway.host)\n"
+        )
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal)],
+        )
+        diag = lc._diagnose_unit_failure(client, unit="zeroclaw-x.service")
+        assert diag is not None
+        assert "gateway.host" in diag
+        assert "#576" in diag
+
+    def test_unknown_failure_returns_none(self):
+        """A journal that doesn't match any catalog entry returns None
+        so the caller falls back to the original error message — the
+        diagnostic must never invent a cause."""
+        journal = b"systemd[1]: hermes-x.service: Some unknown failure\n"
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal)],
+        )
+        diag = lc._diagnose_unit_failure(client, unit="hermes-x.service")
+        assert diag is None
+
+    def test_empty_journal_returns_none(self):
+        """Whitespace-only or empty journal output — no pattern can
+        match, so no diagnostic is emitted (rather than a false
+        positive on an empty stream)."""
+        client = _FakeSSHClient(
+            [("journalctl", 0, b"\n\n   \n")],
+        )
+        diag = lc._diagnose_unit_failure(client, unit="hermes-x.service")
+        assert diag is None
+
+    def test_ssh_failure_swallowed(self, monkeypatch):
+        """If the journal fetch raises (SSH disconnect, sudo refused,
+        etc.) the helper must return None so the caller surfaces the
+        original `unit not active` error rather than the diagnostic
+        helper's own error."""
+
+        class _RaisingClient:
+            def exec_command(self, *_a, **_kw):
+                raise RuntimeError("ssh dropped")
+
+        diag = lc._diagnose_unit_failure(
+            _RaisingClient(), unit="hermes-x.service"
+        )
+        assert diag is None
+
+
+class TestVerifyHealthDiagnosticWrap:
+    def test_failure_includes_diagnostic_when_pattern_matches(self):
+        """The error raised by `_verify_health` on a non-active unit
+        must include the diagnostic line — that's the operator-facing
+        win from #575."""
+        scripted = [
+            # `systemctl is-active …` returns non-zero + 'activating'
+            ("is-active", 3, b"activating\n"),
+            # journalctl returns the Discord trace
+            (
+                "journalctl",
+                0,
+                b"discord.errors.LoginFailure: Improper token has been passed.\n",
+            ),
+        ]
+        client = _FakeSSHClient(scripted)
+        with pytest.raises(CanonicalSyncError) as exc:
+            lc._verify_health(
+                client, agent_type="hermes", agent_name="x"
+            )
+        msg = str(exc.value)
+        assert "not active after restart" in msg
+        assert "state='activating'" in msg
+        # The whole win of #575: the operator sees the actual cause
+        # right inside the error, not just the symptom.
+        assert "Diagnosis:" in msg
+        assert "Discord" in msg
+
+    def test_failure_falls_back_to_base_message_on_unknown_pattern(self):
+        scripted = [
+            ("is-active", 3, b"failed\n"),
+            ("journalctl", 0, b"systemd[1]: hermes-x.service: Boom\n"),
+        ]
+        client = _FakeSSHClient(scripted)
+        with pytest.raises(CanonicalSyncError) as exc:
+            lc._verify_health(
+                client, agent_type="hermes", agent_name="x"
+            )
+        msg = str(exc.value)
+        # No diagnostic suffix when no catalog entry matched — the
+        # operator gets the same message as before #575.
+        assert "Diagnosis:" not in msg
+        assert "state='failed'" in msg
+
+    def test_active_unit_no_diagnosis_no_raise(self):
+        scripted = [("is-active", 0, b"active\n")]
+        client = _FakeSSHClient(scripted)
+        # No exception.
+        lc._verify_health(client, agent_type="hermes", agent_name="x")
+        # And no second `journalctl` call — happy path is one round trip.
+        assert all("journalctl" not in c for c in client.calls)

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -996,15 +996,21 @@ class TestDiagnoseUnitFailure:
             # the substring match. This case pins that behavior as a
             # regression guard.
             b"hermes[1234]: MY_OPENROUTER_API_KEY is not set\n",
-            # ATX iter-5 W1-RESIDUAL: cross-line case inside the
-            # suffix — `KEY:` on one line, `is\nnot set` straddling
-            # newline between `is` and `not set`. With the iter-4
-            # suffix `(?:is\s+)?not\s+set` (where `\s` includes
-            # `\n`), this would have over-fired on a `journalctl -o
-            # cat` blob that drops per-line timestamp prefixes.
-            # The iter-5 production fix tightened the suffix to
-            # `[\t ]+` everywhere; this negative pins the change.
+            # ATX iter-5 W1-RESIDUAL (#575): cross-line case inside
+            # the suffix — `KEY:` on one line, `is\nnot set`
+            # straddling newline between `is` and `not set`. With
+            # the iter-4 suffix `(?:is\s+)?not\s+set` (where `\s`
+            # includes `\n`), this would have over-fired on a
+            # `journalctl -o cat` blob that drops per-line
+            # timestamp prefixes. The iter-5 production fix
+            # tightened the suffix to `[\t ]+` everywhere; this
+            # negative pins the change.
             b"agent[1234]: OPENROUTER_API_KEY: is\nnot set\n",
+            # ATX iter-6 S3 (#575): the symmetric newline case
+            # between `not` and `set`. The iter-5 fix tightened
+            # both `is[\t ]+` and `not[\t ]+set`; this pins the
+            # second tightening.
+            b"agent[1234]: OPENROUTER_API_KEY: not\nset\n",
         ],
     )
     def test_provider_key_pattern_does_not_over_match_stale_env_logs(
@@ -1046,6 +1052,14 @@ class TestDiagnoseUnitFailure:
             # so a future scope-tightening of `(?i)` to the suffix
             # only would fail this test rather than silently regress.
             b"agent[1234]: openrouter_api_key not set\n",
+            # ATX iter-6 W3 (#575): tab in the `is`-to-`not`
+            # position. The `[\t ]+` class admits tabs but no
+            # prior positive case exercised them; without this,
+            # a future narrowing of the suffix to `[ ]+` (space
+            # only) would silently pass tests because the optional
+            # `(?:is[\t ]+)?` group lets the engine skip the
+            # `is` arm entirely.
+            b"hermes[1234]: OPENROUTER_API_KEY: is\tnot set\n",
         ],
     )
     def test_provider_key_pattern_matches_canonical_separators(

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -748,7 +748,9 @@ class _FakeSSHClient:
     (substring, exit_status, stdout_bytes) describes one expected call;
     the first matching tuple is consumed. Order does not matter — the
     helper under test calls `is-active` and `journalctl` in a fixed
-    order but we let the tests assert on outcome only."""
+    order but we let the tests assert on outcome only. Unmatched
+    commands raise AssertionError so a needle typo surfaces loudly
+    (ATX S3)."""
 
     def __init__(self, scripted: list[tuple[str, int, bytes]]) -> None:
         self._scripted = list(scripted)
@@ -761,10 +763,9 @@ class _FakeSSHClient:
                 self._scripted.pop(i)
                 stream = _FakeStream(payload, rc)
                 return (None, stream, stream)
-        # Unmatched — return empty success so the test surfaces an
-        # AssertionError on `self.calls` rather than a generic exception.
-        stream = _FakeStream(b"", 0)
-        return (None, stream, stream)
+        raise AssertionError(
+            f"_FakeSSHClient: no scripted match for command {command!r}"
+        )
 
 
 class TestDiagnoseUnitFailure:
@@ -778,9 +779,13 @@ class TestDiagnoseUnitFailure:
         client = _FakeSSHClient(
             [("journalctl", 0, journal)],
         )
-        diag = lc._diagnose_unit_failure(client, unit="hermes-x.service")
+        diag = lc._diagnose_unit_failure(
+            client, unit="hermes-x.service", agent_type="hermes"
+        )
         assert diag is not None
         assert "Discord" in diag
+        # ATX W5: pin the remediation body so a future truncation of
+        # the catalog string fails this test loudly.
         assert "clawctl channel registry" in diag
 
     def test_zeroclaw_empty_gateway_host_translated(self):
@@ -792,10 +797,66 @@ class TestDiagnoseUnitFailure:
         client = _FakeSSHClient(
             [("journalctl", 0, journal)],
         )
-        diag = lc._diagnose_unit_failure(client, unit="zeroclaw-x.service")
+        diag = lc._diagnose_unit_failure(
+            client, unit="zeroclaw-x.service", agent_type="zeroclaw"
+        )
         assert diag is not None
         assert "gateway.host" in diag
         assert "#576" in diag
+
+    def test_zeroclaw_broadened_gateway_host_token(self):
+        """ATX B3: the broadened regex matches a Rust-shaped phrasing
+        in addition to the v0.7.5 token, so a future zeroclaw rewrite
+        that changes wording does not silently turn this entry into a
+        dead letter."""
+        journal = (
+            b"zeroclaw: configuration error: field 'gateway.host' is "
+            b"empty in /home/zeroclaw-x/.zeroclaw/config.toml\n"
+        )
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal)],
+        )
+        diag = lc._diagnose_unit_failure(
+            client, unit="zeroclaw-x.service", agent_type="zeroclaw"
+        )
+        assert diag is not None
+        assert "gateway.host" in diag
+
+    def test_missing_provider_key_openrouter_translated(self):
+        """ATX B4: the OPENROUTER_API_KEY branch must have its own
+        coverage so a regex typo or remediation truncation fails
+        loudly."""
+        journal = (
+            b"hermes[1234]: ConfigError: OPENROUTER_API_KEY is not set "
+            b"in environment\n"
+        )
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal)],
+        )
+        diag = lc._diagnose_unit_failure(
+            client, unit="hermes-x.service", agent_type="hermes"
+        )
+        assert diag is not None
+        assert "Provider credentials missing" in diag
+        assert "clawctl agent configure" in diag
+
+    def test_missing_provider_key_alternation_branch(self):
+        """ATX B4: covers the second branch of the alternation so a
+        future reorder of branches does not leave it unexercised."""
+        journal = (
+            b"agent boot error: No inference provider configured "
+            b"after stage providers\n"
+        )
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal)],
+        )
+        # Cross-agent entry — empty `agent_types` means it fires on
+        # any agent type. Verified with `openclaw` here.
+        diag = lc._diagnose_unit_failure(
+            client, unit="openclaw-x.service", agent_type="openclaw"
+        )
+        assert diag is not None
+        assert "Provider credentials missing" in diag
 
     def test_unknown_failure_returns_none(self):
         """A journal that doesn't match any catalog entry returns None
@@ -805,7 +866,9 @@ class TestDiagnoseUnitFailure:
         client = _FakeSSHClient(
             [("journalctl", 0, journal)],
         )
-        diag = lc._diagnose_unit_failure(client, unit="hermes-x.service")
+        diag = lc._diagnose_unit_failure(
+            client, unit="hermes-x.service", agent_type="hermes"
+        )
         assert diag is None
 
     def test_empty_journal_returns_none(self):
@@ -815,10 +878,12 @@ class TestDiagnoseUnitFailure:
         client = _FakeSSHClient(
             [("journalctl", 0, b"\n\n   \n")],
         )
-        diag = lc._diagnose_unit_failure(client, unit="hermes-x.service")
+        diag = lc._diagnose_unit_failure(
+            client, unit="hermes-x.service", agent_type="hermes"
+        )
         assert diag is None
 
-    def test_ssh_failure_swallowed(self, monkeypatch):
+    def test_ssh_failure_swallowed(self):
         """If the journal fetch raises (SSH disconnect, sudo refused,
         etc.) the helper must return None so the caller surfaces the
         original `unit not active` error rather than the diagnostic
@@ -829,9 +894,82 @@ class TestDiagnoseUnitFailure:
                 raise RuntimeError("ssh dropped")
 
         diag = lc._diagnose_unit_failure(
-            _RaisingClient(), unit="hermes-x.service"
+            _RaisingClient(),
+            unit="hermes-x.service",
+            agent_type="hermes",
         )
         assert diag is None
+
+    def test_uses_sudo_n_flag(self):
+        """ATX W1: the journal fetch must use `sudo -n` to fail fast on
+        a sudoers regression rather than hang waiting on a password
+        prompt."""
+        client = _FakeSSHClient([("journalctl", 0, b"")])
+        lc._diagnose_unit_failure(
+            client, unit="hermes-x.service", agent_type="hermes"
+        )
+        assert any("sudo -n " in cmd for cmd in client.calls), client.calls
+
+    def test_zeroclaw_pattern_does_not_fire_on_hermes(self):
+        """ATX B1/W7: a hermes-unit journal that happens to contain
+        the `gateway.host` substring must NOT receive the zeroclaw
+        TOML-edit remediation — the catalog entry is `agent_types`-
+        scoped to zeroclaw only."""
+        journal = (
+            b"hermes[1234]: some unrelated log line mentioning "
+            b"required_field_empty gateway.host in a docstring\n"
+        )
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal)],
+        )
+        diag = lc._diagnose_unit_failure(
+            client, unit="hermes-x.service", agent_type="hermes"
+        )
+        # Catalog is hermes-scoped for Discord and zeroclaw-scoped for
+        # gateway.host; neither matches a hermes journal that only
+        # mentions gateway.host. Diagnostic must be None.
+        assert diag is None
+
+    def test_discord_pattern_does_not_fire_on_zeroclaw(self):
+        """ATX B1/W7: a zeroclaw journal that contains the Discord
+        substring (e.g. a config reference) must NOT receive the
+        hermes-blaming Discord remediation."""
+        journal = (
+            b"zeroclaw[1234]: channel discord error: "
+            b"discord.errors.LoginFailure: token rejected\n"
+        )
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal)],
+        )
+        diag = lc._diagnose_unit_failure(
+            client, unit="zeroclaw-x.service", agent_type="zeroclaw"
+        )
+        # Discord entry is hermes-only. Zeroclaw uses its own native
+        # discord client; if/when a zeroclaw-shaped Discord catalog
+        # entry is needed, it should be a separate tuple with its own
+        # remediation string.
+        assert diag is None
+
+    def test_first_pattern_wins_on_overlap(self):
+        """ATX W4: pin the tuple-order contract — when a journal
+        matches multiple patterns, the earlier one in the tuple wins.
+        Future refactor to a dict would break this and the test would
+        flag it."""
+        journal = (
+            b"hermes[1234]: discord.errors.LoginFailure: bad token\n"
+            b"hermes[1234]: also OPENROUTER_API_KEY is not set\n"
+        )
+        client = _FakeSSHClient(
+            [("journalctl", 0, journal)],
+        )
+        diag = lc._diagnose_unit_failure(
+            client, unit="hermes-x.service", agent_type="hermes"
+        )
+        assert diag is not None
+        # Discord entry is first in the tuple — it wins over the
+        # provider-key entry, even though both match.
+        assert "Discord" in diag
+        assert "Provider credentials missing" not in diag
 
 
 class TestVerifyHealthDiagnosticWrap:
@@ -861,6 +999,9 @@ class TestVerifyHealthDiagnosticWrap:
         # right inside the error, not just the symptom.
         assert "Diagnosis:" in msg
         assert "Discord" in msg
+        # ATX W5: pin the remediation body so the test fails loudly
+        # if a future change drops the actionable command.
+        assert "clawctl channel registry" in msg
 
     def test_failure_falls_back_to_base_message_on_unknown_pattern(self):
         scripted = [
@@ -885,3 +1026,29 @@ class TestVerifyHealthDiagnosticWrap:
         lc._verify_health(client, agent_type="hermes", agent_name="x")
         # And no second `journalctl` call — happy path is one round trip.
         assert all("journalctl" not in c for c in client.calls)
+
+    def test_diagnose_helper_raise_does_not_mask_health_verdict(
+        self, monkeypatch
+    ):
+        """ATX B5: if `_diagnose_unit_failure` raises internally
+        (defensive belt-and-braces against future regressions in the
+        catalog or regex), `_verify_health` must still raise
+        `CanonicalSyncError` with the bare base message — not the
+        diagnostic helper's exception."""
+        scripted = [("is-active", 3, b"activating\n")]
+        client = _FakeSSHClient(scripted)
+
+        def _raising_diagnose(*_a, **_kw):
+            raise RuntimeError("catalog blew up")
+
+        monkeypatch.setattr(lc, "_diagnose_unit_failure", _raising_diagnose)
+        with pytest.raises(CanonicalSyncError) as exc:
+            lc._verify_health(
+                client, agent_type="hermes", agent_name="x"
+            )
+        msg = str(exc.value)
+        assert "not active after restart" in msg
+        assert "state='activating'" in msg
+        # Crucial: the catalog raise must NOT mask the verdict.
+        assert "Diagnosis:" not in msg
+        assert "catalog blew up" not in msg


### PR DESCRIPTION
## Summary

Fixes #575. When a sync's post-restart health check finds the unit `activating`/`failed`, `_verify_health` now tails the journal and appends a `Diagnosis: <root-cause + remediation>` line to the raised `CanonicalSyncError`. The motivating case: a fresh hermes install with a dummy Discord token crashes the FastAPI gateway via an unisolated `discord.errors.LoginFailure` in the upstream package — operators previously saw only "Failed to reach hermes at http://…:8679/v1" with no pointer at the channel registry as the actual cause.

This does not fix the upstream hermes Discord-isolation bug (that's owned by the hermes repo, not clawrium). It closes the discoverability gap that turned a one-line cause into a multi-step on-host journal hunt for every operator who hit it.

## Catalog (final shape after six review iterations)

Each entry is `(regex, agent_types: frozenset[str], summary, remediation)`. Empty `agent_types` = cross-agent.

| Pattern | Scope | What it surfaces |
|---|---|---|
| `discord.errors.LoginFailure` | hermes | Discord rejected the bot token — re-issue via `clawctl channel registry`. |
| `(required_field_empty.*gateway.host\|gateway.host.*(must not be empty\|is empty))` | zeroclaw | Cross-references #576 fix. Boundary-anchored to actual fault states (`required` dropped after iter-2 over-match feedback). |
| `(?i)(?:\bOPENROUTER_API_KEY[\t :=]+(?:is[\t ]+)?not[\t ]+set\b\|No inference provider configured)` | all | Provider credentials missing. Leading `\b` rejects `MY_OPENROUTER_API_KEY` substring matches; `[\t :=]+` covers `KEY:`, `KEY=`, tab-/space-separated; in-phrase `[\t ]+` is newline-safe; `(?i)` allows lowercase env-dump shapes. |

## Testing

- `make test` — 3702 passed, 8 skipped
- `make lint` — clean (ruff + ESLint)
- 19 new tests in `tests/core/test_lifecycle_canonical.py` covering:
  - All 3 catalog entries positive
  - Both alternation branches of pattern #3 separately (`is not set` vs `No inference provider configured`)
  - All separator variants: space, tab, colon, equals, uppercase, lowercase
  - Newline-cross-boundary negatives in all three slots (`KEY\n…`, `is\nnot set`, `not\nset`)
  - Over-match negatives: `was not set, now present`, bracket form, `previously not set`, `MY_OPENROUTER_API_KEY`
  - Branch1-alone exclusive positive (mutation-test for `required_field_empty`)
  - Cross-agent contamination: zc-pattern-on-hermes/openclaw, discord-pattern-on-zc/openclaw, openclaw third-type isolation
  - First-match-wins for both overlap pairs (entries 1↔3 and 2↔3)
  - Empty/whitespace journal → None
  - SSH-failure swallow path → None (helper level)
  - Diagnostic-helper-raise swallow path → bare `CanonicalSyncError` (verify-health level)
  - `sudo -n` invariant pinned
  - Happy path makes no second journal round trip

## ATX Review Summary

**Final Review: Rating 4/5 | Total Cost: ~$10.40 | Total Time: ~43m | 6 iterations**

| Review | Rating | Blockers | Status | Cost | Time |
|--------|--------|----------|--------|------|------|
| 1 | 2/5 | B1, B2, B3, B4, B5 | All fixed | $1.75 | 6m 41s |
| 2 | 3/5 | B1, B2 (regex over-matches) | All fixed | $2.00 | 7m 54s |
| 3 | 3/5 | W-NEW-1, W-NEW-2 (merge-blocking warnings) | All fixed | $1.67 | 8m 14s |
| 4 | 3/5 | W1 (cross-line `\n`), W2/W3 docs | All fixed | $1.73 | 6m 40s |
| 5 | 3/5 | W1-RESIDUAL (suffix `\s+` cross-line) | All fixed | $1.28 | 6m 48s |
| 6 | 4/5 | None | Ready | $1.21 | 5m 07s |

<details>
<summary>Round 1 → 2 → 3 → 4 → 5 → 6 fix trail</summary>

| Round | Issue | Resolution |
|---|---|---|
| 1 B1 | Catalog was type-agnostic | Added `agent_types: frozenset[str]` filter; threaded `agent_type` through |
| 1 B2 | Hermes architectural blame surfaced on any agent | Scoped Discord entry to `frozenset({"hermes"})` |
| 1 B3 | `required_field_empty` token unverified | Broadened regex to also match Rust-shaped phrasing |
| 1 B4 | OPENROUTER branch untested | Added 2 tests per alternation branch |
| 1 B5 | Swallow contract untested through `_verify_health` | Added monkeypatched diagnose-raises test |
| 1 W1 | Bare `sudo` could hang on password prompt | Changed to `sudo -n` + pinned by test |
| 1 W2 | Silent swallow on sudoers regression | Added `logger.debug` in both swallow branches |
| 1 W4-W7 | Tests, parens, cross-agent contamination | All addressed |
| 2 B1 | `|required` alternation over-matched benign startup logs | Dropped; added 4 negative parametrize cases |
| 2 B2 | Greedy `.*` in OPENROUTER pattern over-matched stale-env lines | Tightened to `\s+(?:is\s+)?not\s+set\b` |
| 2 W1-W5 | Test rigor (body asserts, branch coverage, third-type isolation, overlap pairs) | All addressed |
| 3 W-NEW-1 | Colon separator (`KEY: not set`) silently missed | Widened to `[\s:=]+` + `(?i)` |
| 3 W-NEW-2 | Branch1 mutation-invisible (every existing test also matched branch2) | Added exclusive positive case with cross-check |
| 3 S1-S6 | Docstring drift, positional-index lookup, IGNORECASE | All addressed (S2 implemented via helper) |
| 4 W1 | `[\s:=]+` separator included `\n` (cross-line over-match) | Narrowed to `[\t :=]+` |
| 4 W2 | `(?i)` scope undocumented | Documented + pinned by lowercase positive test |
| 4 W3 | Left word boundary missing | Added `\bOPENROUTER_API_KEY` + `MY_OPENROUTER_API_KEY` negative |
| 4 S1-S4 | Inline import, positional lookup, bracket-form coverage, naive-`.*` case | All addressed |
| 5 W1-RESIDUAL | Suffix `\s+` still admitted `\n` | Tightened to `[\t ]+` throughout; added `is\nnot set` negative |
| 5 W2-COMMENT | Stale "tracked as follow-up" comment | Replaced with regression-guard phrasing |
| 5 S1-S4 | Docstring drift from iter-4 changes | All updated |
| 6 W1 | Misleading "both horizontal-whitespace-only" sentence (asymmetric classes) | Split into separator vs. in-phrase docstrings |
| 6 W2 | `#575` cross-reference missing on iter-5 annotations | Appended `(#575)` so `git log -S '#575'` surfaces it |
| 6 W3 | No positive case for tab in `is`-to-`not` position | Added positive parametrize + symmetric `not\nset` negative |

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
