### PR TITLE
feat(providers): refresh model catalog + searchable model picker in provider modals

### DIFF
--- a/docs/agent-support/providers/anthropic.md
+++ b/docs/agent-support/providers/anthropic.md
@@ -23,6 +23,7 @@ Official Anthropic Claude API integration.
 | `claude-opus-4-5` | Claude Opus 4.5 (latest) | 200K |
 | `claude-opus-4-6` | Claude Opus 4.6 | 1M |
 | `claude-opus-4-7` | Claude Opus 4.7 | 1M |
+| `claude-opus-4-8` | Claude Opus 4.8 | 1M |
 | `claude-3-sonnet-20240229` | Claude Sonnet 3 | 200K |
 | `claude-3-5-sonnet-20240620` | Claude Sonnet 3.5 | 200K |
 | `claude-3-5-sonnet-20241022` | Claude Sonnet 3.5 v2 | 200K |

--- a/docs/agent-support/providers/bedrock.md
+++ b/docs/agent-support/providers/bedrock.md
@@ -9,14 +9,13 @@ Amazon Bedrock provides managed access to foundation models through AWS infrastr
 <!-- MODEL-TABLE:START -->
 | Model ID | Name | Context |
 |----------|------|---------|
-| `anthropic.claude-3-haiku-20240307-v1:0` | Claude Haiku 3 | 200K |
-| `anthropic.claude-3-5-haiku-20241022-v1:0` | Claude Haiku 3.5 | 200K |
+| `au.anthropic.claude-opus-4-6-v1` | AU Anthropic Claude Opus 4.6 | 1M |
+| `au.anthropic.claude-sonnet-4-6` | AU Anthropic Claude Sonnet 4.6 | 1M |
 | `anthropic.claude-haiku-4-5-20251001-v1:0` | Claude Haiku 4.5 | 200K |
+| `au.anthropic.claude-haiku-4-5-20251001-v1:0` | Claude Haiku 4.5 (AU) | 200K |
 | `eu.anthropic.claude-haiku-4-5-20251001-v1:0` | Claude Haiku 4.5 (EU) | 200K |
 | `global.anthropic.claude-haiku-4-5-20251001-v1:0` | Claude Haiku 4.5 (Global) | 200K |
 | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | Claude Haiku 4.5 (US) | 200K |
-| `anthropic.claude-opus-4-20250514-v1:0` | Claude Opus 4 | 200K |
-| `us.anthropic.claude-opus-4-20250514-v1:0` | Claude Opus 4 (US) | 200K |
 | `anthropic.claude-opus-4-1-20250805-v1:0` | Claude Opus 4.1 | 200K |
 | `us.anthropic.claude-opus-4-1-20250805-v1:0` | Claude Opus 4.1 (US) | 200K |
 | `anthropic.claude-opus-4-5-20251101-v1:0` | Claude Opus 4.5 | 200K |
@@ -30,23 +29,27 @@ Amazon Bedrock provides managed access to foundation models through AWS infrastr
 | `anthropic.claude-opus-4-7` | Claude Opus 4.7 | 1M |
 | `eu.anthropic.claude-opus-4-7` | Claude Opus 4.7 (EU) | 1M |
 | `global.anthropic.claude-opus-4-7` | Claude Opus 4.7 (Global) | 1M |
+| `jp.anthropic.claude-opus-4-7` | Claude Opus 4.7 (JP) | 1M |
 | `us.anthropic.claude-opus-4-7` | Claude Opus 4.7 (US) | 1M |
-| `anthropic.claude-3-5-sonnet-20240620-v1:0` | Claude Sonnet 3.5 | 200K |
-| `anthropic.claude-3-5-sonnet-20241022-v2:0` | Claude Sonnet 3.5 v2 | 200K |
-| `anthropic.claude-3-7-sonnet-20250219-v1:0` | Claude Sonnet 3.7 | 200K |
-| `anthropic.claude-sonnet-4-20250514-v1:0` | Claude Sonnet 4 | 200K |
-| `eu.anthropic.claude-sonnet-4-20250514-v1:0` | Claude Sonnet 4 (EU) | 200K |
-| `global.anthropic.claude-sonnet-4-20250514-v1:0` | Claude Sonnet 4 (Global) | 200K |
-| `us.anthropic.claude-sonnet-4-20250514-v1:0` | Claude Sonnet 4 (US) | 200K |
+| `anthropic.claude-opus-4-8` | Claude Opus 4.8 | 1M |
+| `au.anthropic.claude-opus-4-8` | Claude Opus 4.8 (AU) | 1M |
+| `eu.anthropic.claude-opus-4-8` | Claude Opus 4.8 (EU) | 1M |
+| `global.anthropic.claude-opus-4-8` | Claude Opus 4.8 (Global) | 1M |
+| `jp.anthropic.claude-opus-4-8` | Claude Opus 4.8 (JP) | 1M |
+| `us.anthropic.claude-opus-4-8` | Claude Opus 4.8 (US) | 1M |
 | `anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 | 200K |
+| `au.anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 (AU) | 200K |
 | `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 (EU) | 200K |
 | `global.anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 (Global) | 200K |
+| `jp.anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 (JP) | 200K |
 | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 (US) | 200K |
 | `anthropic.claude-sonnet-4-6` | Claude Sonnet 4.6 | 1M |
 | `eu.anthropic.claude-sonnet-4-6` | Claude Sonnet 4.6 (EU) | 1M |
 | `global.anthropic.claude-sonnet-4-6` | Claude Sonnet 4.6 (Global) | 1M |
+| `jp.anthropic.claude-sonnet-4-6` | Claude Sonnet 4.6 (JP) | 1M |
 | `us.anthropic.claude-sonnet-4-6` | Claude Sonnet 4.6 (US) | 1M |
 | `deepseek.r1-v1:0` | DeepSeek-R1 | 128K |
+| `us.deepseek.r1-v1:0` | DeepSeek-R1 (US) | 128K |
 | `deepseek.v3-v1:0` | DeepSeek-V3.1 | 163K |
 | `deepseek.v3.2` | DeepSeek-V3.2 | 163K |
 | `mistral.devstral-2-123b` | Devstral 2 123B | 256K |
@@ -58,18 +61,15 @@ Amazon Bedrock provides managed access to foundation models through AWS infrastr
 | `google.gemma-3-4b-it` | Gemma 3 4B IT | 128K |
 | `google.gemma-3-12b-it` | Google Gemma 3 12B | 131K |
 | `google.gemma-3-27b-it` | Google Gemma 3 27B Instruct | 202K |
-| `moonshot.kimi-k2-thinking` | Kimi K2 Thinking | 256K |
-| `moonshotai.kimi-k2.5` | Kimi K2.5 | 256K |
-| `meta.llama3-1-405b-instruct-v1:0` | Llama 3.1 405B Instruct | 128K |
+| `moonshot.kimi-k2-thinking` | Kimi K2 Thinking | 262K |
+| `moonshotai.kimi-k2.5` | Kimi K2.5 | 262K |
 | `meta.llama3-1-70b-instruct-v1:0` | Llama 3.1 70B Instruct | 128K |
 | `meta.llama3-1-8b-instruct-v1:0` | Llama 3.1 8B Instruct | 128K |
-| `meta.llama3-2-11b-instruct-v1:0` | Llama 3.2 11B Instruct | 128K |
-| `meta.llama3-2-1b-instruct-v1:0` | Llama 3.2 1B Instruct | 131K |
-| `meta.llama3-2-3b-instruct-v1:0` | Llama 3.2 3B Instruct | 131K |
-| `meta.llama3-2-90b-instruct-v1:0` | Llama 3.2 90B Instruct | 128K |
 | `meta.llama3-3-70b-instruct-v1:0` | Llama 3.3 70B Instruct | 128K |
 | `meta.llama4-maverick-17b-instruct-v1:0` | Llama 4 Maverick 17B Instruct | 1M |
+| `us.meta.llama4-maverick-17b-instruct-v1:0` | Llama 4 Maverick 17B Instruct (US) | 1M |
 | `meta.llama4-scout-17b-instruct-v1:0` | Llama 4 Scout 17B Instruct | 3M |
+| `us.meta.llama4-scout-17b-instruct-v1:0` | Llama 4 Scout 17B Instruct (US) | 3M |
 | `mistral.magistral-small-2509` | Magistral Small 1.2 | 128K |
 | `minimax.minimax-m2` | MiniMax M2 | 204K |
 | `minimax.minimax-m2.1` | MiniMax M2.1 | 204K |
@@ -85,7 +85,6 @@ Amazon Bedrock provides managed access to foundation models through AWS infrastr
 | `amazon.nova-2-lite-v1:0` | Nova 2 Lite | 128K |
 | `amazon.nova-lite-v1:0` | Nova Lite | 300K |
 | `amazon.nova-micro-v1:0` | Nova Micro | 128K |
-| `amazon.nova-premier-v1:0` | Nova Premier | 1M |
 | `amazon.nova-pro-v1:0` | Nova Pro | 300K |
 | `writer.palmyra-x4-v1:0` | Palmyra X4 | 122K |
 | `writer.palmyra-x5-v1:0` | Palmyra X5 | 1M |

--- a/docs/agent-support/providers/openai.md
+++ b/docs/agent-support/providers/openai.md
@@ -9,7 +9,6 @@ Official OpenAI API integration for GPT models.
 <!-- MODEL-TABLE:START -->
 | Model ID | Name | Context |
 |----------|------|---------|
-| `codex-mini-latest` | Codex Mini | 200K |
 | `gpt-3.5-turbo` | GPT-3.5-turbo | 16K |
 | `gpt-4` | GPT-4 | 8K |
 | `gpt-4-turbo` | GPT-4 Turbo | 128K |
@@ -43,6 +42,8 @@ Official OpenAI API integration for GPT models.
 | `gpt-5.4-pro` | GPT-5.4 Pro | 1M |
 | `gpt-5.4-mini` | GPT-5.4 mini | 400K |
 | `gpt-5.4-nano` | GPT-5.4 nano | 400K |
+| `gpt-5.5` | GPT-5.5 | 1M |
+| `gpt-5.5-pro` | GPT-5.5 Pro | 1M |
 | `chatgpt-image-latest` | chatgpt-image-latest | - |
 | `gpt-image-1` | gpt-image-1 | - |
 | `gpt-image-1-mini` | gpt-image-1-mini | - |

--- a/docs/agent-support/providers/openrouter.md
+++ b/docs/agent-support/providers/openrouter.md
@@ -7,43 +7,104 @@ OpenRouter provides unified access to multiple AI models through a single API.
 ## Supported Models
 
 <!-- MODEL-TABLE:START -->
+### Ai21
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `ai21/jamba-large-1.7` | Jamba Large 1.7 | 256K |
+
+### Aion Labs
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `aion-labs/aion-1.0` | Aion-1.0 | 131K |
+| `aion-labs/aion-1.0-mini` | Aion-1.0-Mini | 131K |
+| `aion-labs/aion-2.0` | Aion-2.0 | 131K |
+| `aion-labs/aion-rp-llama-3.1-8b` | Aion-RP 1.0 (8B) | 32K |
+
+### Alfredpros
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `alfredpros/codellama-7b-instruct-solidity` | CodeLLaMa 7B Instruct Solidity | 4K |
+
+### Allenai
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `allenai/olmo-3-32b-think` | Olmo 3 32B Think | 65K |
+
+### Amazon
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `amazon/nova-2-lite-v1` | Nova 2 Lite | 1M |
+| `amazon/nova-lite-v1` | Nova Lite 1.0 | 300K |
+| `amazon/nova-micro-v1` | Nova Micro 1.0 | 128K |
+| `amazon/nova-premier-v1` | Nova Premier 1.0 | 1M |
+| `amazon/nova-pro-v1` | Nova Pro 1.0 | 300K |
+
+### Anthracite Org
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `anthracite-org/magnum-v4-72b` | Magnum v4 72B | 16K |
+
 ### Anthropic
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `anthropic/claude-3.5-haiku` | Claude Haiku 3.5 | 200K |
-| `anthropic/claude-haiku-4.5` | Claude Haiku 4.5 | 200K |
+| `anthropic/claude-3-haiku` | Claude 3 Haiku | 200K |
+| `anthropic/claude-3.5-haiku` | Claude 3.5 Haiku | 200K |
+| `anthropic/claude-haiku-4.5` | Claude Haiku 4.5 (latest) | 200K |
 | `anthropic/claude-opus-4` | Claude Opus 4 | 200K |
-| `anthropic/claude-opus-4.1` | Claude Opus 4.1 | 200K |
-| `anthropic/claude-opus-4.5` | Claude Opus 4.5 | 200K |
+| `anthropic/claude-opus-4.1` | Claude Opus 4.1 (latest) | 200K |
+| `anthropic/claude-opus-4.5` | Claude Opus 4.5 (latest) | 200K |
 | `anthropic/claude-opus-4.6` | Claude Opus 4.6 | 1M |
+| `anthropic/claude-opus-4.6-fast` | Claude Opus 4.6 (Fast) | 1M |
 | `anthropic/claude-opus-4.7` | Claude Opus 4.7 | 1M |
-| `anthropic/claude-3.7-sonnet` | Claude Sonnet 3.7 | 200K |
-| `anthropic/claude-sonnet-4` | Claude Sonnet 4 | 200K |
-| `anthropic/claude-sonnet-4.5` | Claude Sonnet 4.5 | 1M |
+| `anthropic/claude-opus-4.7-fast` | Claude Opus 4.7 (Fast) | 1M |
+| `anthropic/claude-opus-4.8` | Claude Opus 4.8 | 1M |
+| `anthropic/claude-opus-4.8-fast` | Claude Opus 4.8 (Fast) | 1M |
+| `anthropic/claude-sonnet-4` | Claude Sonnet 4 | 1M |
+| `anthropic/claude-sonnet-4.5` | Claude Sonnet 4.5 (latest) | 1M |
 | `anthropic/claude-sonnet-4.6` | Claude Sonnet 4.6 | 1M |
 
 ### Arcee Ai
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `arcee-ai/trinity-large-preview:free` | Trinity Large Preview | 131K |
+| `arcee-ai/coder-large` | Coder Large | 32K |
+| `arcee-ai/maestro-reasoning` | Maestro Reasoning | 131K |
+| `arcee-ai/spotlight` | Spotlight | 131K |
 | `arcee-ai/trinity-large-thinking` | Trinity Large Thinking | 262K |
+| `arcee-ai/trinity-mini` | Trinity Mini | 131K |
+| `arcee-ai/virtuoso-large` | Virtuoso Large | 131K |
 
-### Black Forest Labs
+### Baidu
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `black-forest-labs/flux.2-flex` | FLUX.2 Flex | 67K |
-| `black-forest-labs/flux.2-klein-4b` | FLUX.2 Klein 4B | 40K |
-| `black-forest-labs/flux.2-max` | FLUX.2 Max | 46K |
-| `black-forest-labs/flux.2-pro` | FLUX.2 Pro | 46K |
+| `baidu/ernie-4.5-21b-a3b` | ERNIE 4.5 21B A3B | 120K |
+| `baidu/ernie-4.5-21b-a3b-thinking` | ERNIE 4.5 21B A3B Thinking | 131K |
+| `baidu/ernie-4.5-300b-a47b` | ERNIE 4.5 300B A47B  | 123K |
+| `baidu/ernie-4.5-vl-28b-a3b` | ERNIE 4.5 VL 28B A3B | 30K |
+| `baidu/ernie-4.5-vl-424b-a47b` | ERNIE 4.5 VL 424B A47B  | 123K |
+
+### Bytedance
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `bytedance/ui-tars-1.5-7b` | UI-TARS 7B  | 128K |
 
 ### Bytedance Seed
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `bytedance-seed/seedream-4.5` | Seedream 4.5 | 4K |
+| `bytedance-seed/seed-1.6` | Seed 1.6 | 262K |
+| `bytedance-seed/seed-1.6-flash` | Seed 1.6 Flash | 262K |
+| `bytedance-seed/seed-2.0-lite` | Seed-2.0-Lite | 262K |
+| `bytedance-seed/seed-2.0-mini` | Seed-2.0-Mini | 262K |
 
 ### Cognitivecomputations
 
@@ -51,115 +112,232 @@ OpenRouter provides unified access to multiple AI models through a single API.
 |----------|------|---------|
 | `cognitivecomputations/dolphin-mistral-24b-venice-edition:free` | Uncensored (free) | 32K |
 
+### Cohere
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `cohere/command-a` | Command A | 256K |
+| `cohere/command-r-08-2024` | Command R | 128K |
+| `cohere/command-r-plus-08-2024` | Command R+ | 128K |
+| `cohere/command-r7b-12-2024` | Command R7B | 128K |
+
+### Deepcogito
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `deepcogito/cogito-v2.1-671b` | Cogito v2.1 671B | 128K |
+
 ### Deepseek
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `deepseek/deepseek-r1-distill-llama-70b` | DeepSeek R1 Distill Llama 70B | 8K |
-| `deepseek/deepseek-chat-v3-0324` | DeepSeek V3 0324 | 16K |
-| `deepseek/deepseek-v3.1-terminus` | DeepSeek V3.1 Terminus | 131K |
-| `deepseek/deepseek-v3.1-terminus:exacto` | DeepSeek V3.1 Terminus (exacto) | 131K |
-| `deepseek/deepseek-v3.2` | DeepSeek V3.2 | 163K |
-| `deepseek/deepseek-v3.2-speciale` | DeepSeek V3.2 Speciale | 163K |
-| `deepseek/deepseek-chat-v3.1` | DeepSeek-V3.1 | 163K |
-| `deepseek/deepseek-r1` | DeepSeek: R1 | 64K |
+| `deepseek/deepseek-chat` | DeepSeek Chat | 128K |
+| `deepseek/deepseek-chat-v3-0324` | DeepSeek V3 0324 | 163K |
+| `deepseek/deepseek-chat-v3.1` | DeepSeek V3.1 | 163K |
+| `deepseek/deepseek-v3.1-terminus` | DeepSeek V3.1 Terminus | 163K |
+| `deepseek/deepseek-v3.2` | DeepSeek V3.2 | 131K |
+| `deepseek/deepseek-v3.2-exp` | DeepSeek V3.2 Exp | 163K |
+| `deepseek/deepseek-v4-flash` | DeepSeek V4 Flash | 1M |
+| `deepseek/deepseek-v4-flash:free` | DeepSeek V4 Flash (free) | 1M |
+| `deepseek/deepseek-v4-pro` | DeepSeek V4 Pro | 1M |
+| `deepseek/deepseek-r1` | R1 | 64K |
+| `deepseek/deepseek-r1-0528` | R1 0528 | 163K |
+| `deepseek/deepseek-r1-distill-llama-70b` | R1 Distill Llama 70B | 131K |
+| `deepseek/deepseek-r1-distill-qwen-32b` | R1 Distill Qwen 32B | 32K |
+
+### Essentialai
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `essentialai/rnj-1-instruct` | Rnj 1 Instruct | 32K |
 
 ### Google
 
 | Model ID | Name | Context |
 |----------|------|---------|
 | `google/gemini-2.0-flash-001` | Gemini 2.0 Flash | 1M |
+| `google/gemini-2.0-flash-lite-001` | Gemini 2.0 Flash Lite | 1M |
 | `google/gemini-2.5-flash` | Gemini 2.5 Flash | 1M |
-| `google/gemini-2.5-flash-lite` | Gemini 2.5 Flash Lite | 1M |
-| `google/gemini-2.5-flash-lite-preview-09-2025` | Gemini 2.5 Flash Lite Preview 09-25 | 1M |
-| `google/gemini-2.5-flash-preview-09-2025` | Gemini 2.5 Flash Preview 09-25 | 1M |
+| `google/gemini-2.5-flash-lite-preview-09-2025` | Gemini 2.5 Flash Lite Preview 09-2025 | 1M |
+| `google/gemini-2.5-flash-lite` | Gemini 2.5 Flash-Lite | 1M |
 | `google/gemini-2.5-pro` | Gemini 2.5 Pro | 1M |
 | `google/gemini-2.5-pro-preview-05-06` | Gemini 2.5 Pro Preview 05-06 | 1M |
-| `google/gemini-2.5-pro-preview-06-05` | Gemini 2.5 Pro Preview 06-05 | 1M |
+| `google/gemini-2.5-pro-preview` | Gemini 2.5 Pro Preview 06-05 | 1M |
 | `google/gemini-3-flash-preview` | Gemini 3 Flash Preview | 1M |
-| `google/gemini-3-pro-preview` | Gemini 3 Pro Preview | 1M |
+| `google/gemini-3.1-flash-lite` | Gemini 3.1 Flash Lite | 1M |
 | `google/gemini-3.1-flash-lite-preview` | Gemini 3.1 Flash Lite Preview | 1M |
 | `google/gemini-3.1-pro-preview` | Gemini 3.1 Pro Preview | 1M |
 | `google/gemini-3.1-pro-preview-customtools` | Gemini 3.1 Pro Preview Custom Tools | 1M |
-| `google/gemma-2-9b-it` | Gemma 2 9B | 8K |
+| `google/gemini-3.5-flash` | Gemini 3.5 Flash | 1M |
+| `google/gemma-2-27b-it` | Gemma 2 27B | 8K |
 | `google/gemma-3-12b-it` | Gemma 3 12B | 131K |
-| `google/gemma-3-12b-it:free` | Gemma 3 12B (free) | 32K |
-| `google/gemma-3-27b-it` | Gemma 3 27B | 96K |
-| `google/gemma-3-27b-it:free` | Gemma 3 27B (free) | 131K |
-| `google/gemma-3-4b-it` | Gemma 3 4B | 96K |
-| `google/gemma-3-4b-it:free` | Gemma 3 4B (free) | 32K |
-| `google/gemma-3n-e2b-it:free` | Gemma 3n 2B (free) | 8K |
+| `google/gemma-3-27b-it` | Gemma 3 27B | 131K |
+| `google/gemma-3-4b-it` | Gemma 3 4B | 131K |
 | `google/gemma-3n-e4b-it` | Gemma 3n 4B | 32K |
-| `google/gemma-3n-e4b-it:free` | Gemma 3n 4B (free) | 8K |
-| `google/gemma-4-26b-a4b-it` | Gemma 4 26B A4B | 262K |
-| `google/gemma-4-26b-a4b-it:free` | Gemma 4 26B A4B (free) | 262K |
-| `google/gemma-4-31b-it` | Gemma 4 31B | 262K |
+| `google/gemma-4-26b-a4b-it:free` | Gemma 4 26B A4B  (free) | 262K |
+| `google/gemma-4-26b-a4b-it` | Gemma 4 26B A4B IT | 262K |
 | `google/gemma-4-31b-it:free` | Gemma 4 31B (free) | 262K |
+| `google/gemma-4-31b-it` | Gemma 4 31B IT | 262K |
+| `google/lyria-3-clip-preview` | Lyria 3 Clip Preview | 1M |
+| `google/lyria-3-pro-preview` | Lyria 3 Pro Preview | 1M |
+| `google/gemini-2.5-flash-image` | Nano Banana | 32K |
+| `google/gemini-3.1-flash-image-preview` | Nano Banana 2 | 65K |
+| `google/gemini-3-pro-image-preview` | Nano Banana Pro (Gemini 3 Pro Image Preview) | 65K |
+
+### Gryphe
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `gryphe/mythomax-l2-13b` | MythoMax 13B | 4K |
+
+### Ibm Granite
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `ibm-granite/granite-4.0-h-micro` | Granite 4.0 Micro | 131K |
+| `ibm-granite/granite-4.1-8b` | Granite 4.1 8B | 131K |
 
 ### Inception
 
 | Model ID | Name | Context |
 |----------|------|---------|
 | `inception/mercury-2` | Mercury 2 | 128K |
-| `inception/mercury-edit-2` | Mercury Edit 2 | 128K |
+
+### Inclusionai
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `inclusionai/ling-2.6-1t` | Ling-2.6-1T | 262K |
+| `inclusionai/ling-2.6-flash` | Ling-2.6-flash | 262K |
+| `inclusionai/ring-2.6-1t` | Ring-2.6-1T | 262K |
+
+### Inflection
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `inflection/inflection-3-pi` | Inflection 3 Pi | 8K |
+| `inflection/inflection-3-productivity` | Inflection 3 Productivity | 8K |
+
+### Kwaipilot
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `kwaipilot/kat-coder-pro-v2` | KAT-Coder-Pro V2 | 256K |
 
 ### Liquid
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `liquid/lfm-2.5-1.2b-instruct:free` | LFM2.5-1.2B-Instruct (free) | 131K |
-| `liquid/lfm-2.5-1.2b-thinking:free` | LFM2.5-1.2B-Thinking (free) | 131K |
+| `liquid/lfm-2-24b-a2b` | LFM2-24B-A2B | 32K |
+| `liquid/lfm-2.5-1.2b-instruct:free` | LFM2.5-1.2B-Instruct (free) | 32K |
+| `liquid/lfm-2.5-1.2b-thinking:free` | LFM2.5-1.2B-Thinking (free) | 32K |
+
+### Mancer
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `mancer/weaver` | Weaver (alpha) | 8K |
 
 ### Meta Llama
 
 | Model ID | Name | Context |
 |----------|------|---------|
+| `meta-llama/llama-3-70b-instruct` | Llama 3 70B Instruct | 8K |
+| `meta-llama/llama-3-8b-instruct` | Llama 3 8B Instruct | 8K |
+| `meta-llama/llama-3.1-70b-instruct` | Llama 3.1 70B Instruct | 131K |
+| `meta-llama/llama-3.1-8b-instruct` | Llama 3.1 8B Instruct | 16K |
 | `meta-llama/llama-3.2-11b-vision-instruct` | Llama 3.2 11B Vision Instruct | 131K |
+| `meta-llama/llama-3.2-1b-instruct` | Llama 3.2 1B Instruct | 60K |
+| `meta-llama/llama-3.2-3b-instruct` | Llama 3.2 3B Instruct | 80K |
 | `meta-llama/llama-3.2-3b-instruct:free` | Llama 3.2 3B Instruct (free) | 131K |
-| `meta-llama/llama-3.3-70b-instruct:free` | Llama 3.3 70B Instruct (free) | 131K |
+| `meta-llama/llama-3.3-70b-instruct:free` | Llama 3.3 70B Instruct (free) | 65K |
+| `meta-llama/llama-4-maverick` | Llama 4 Maverick | 1M |
+| `meta-llama/llama-4-scout` | Llama 4 Scout | 327K |
+| `meta-llama/llama-guard-3-8b` | Llama Guard 3 8B | 131K |
+| `meta-llama/llama-guard-4-12b` | Llama Guard 4 12B | 163K |
+| `meta-llama/llama-3.3-70b-instruct` | Llama-3.3-70B-Instruct | 131K |
+
+### Microsoft
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `microsoft/phi-4` | Phi 4 | 16K |
+| `microsoft/phi-4-mini-instruct` | Phi 4 Mini Instruct | 128K |
+| `microsoft/wizardlm-2-8x22b` | WizardLM-2 8x22B | 65K |
 
 ### Minimax
 
 | Model ID | Name | Context |
 |----------|------|---------|
 | `minimax/minimax-m1` | MiniMax M1 | 1M |
-| `minimax/minimax-m2` | MiniMax M2 | 196K |
-| `minimax/minimax-m2.1` | MiniMax M2.1 | 204K |
-| `minimax/minimax-m2.5` | MiniMax M2.5 | 204K |
-| `minimax/minimax-m2.5:free` | MiniMax M2.5 (free) | 204K |
-| `minimax/minimax-m2.7` | MiniMax M2.7 | 204K |
+| `minimax/minimax-m2-her` | MiniMax M2-her | 65K |
+| `minimax/minimax-m2.5:free` | MiniMax M2.5 (free) | 196K |
 | `minimax/minimax-01` | MiniMax-01 | 1M |
+| `minimax/minimax-m2` | MiniMax-M2 | 196K |
+| `minimax/minimax-m2.1` | MiniMax-M2.1 | 196K |
+| `minimax/minimax-m2.5` | MiniMax-M2.5 | 196K |
+| `minimax/minimax-m2.7` | MiniMax-M2.7 | 196K |
 
 ### Mistralai
 
 | Model ID | Name | Context |
 |----------|------|---------|
 | `mistralai/codestral-2508` | Codestral 2508 | 256K |
-| `mistralai/devstral-2512` | Devstral 2 2512 | 262K |
-| `mistralai/devstral-medium-2507` | Devstral Medium | 131K |
-| `mistralai/devstral-small-2505` | Devstral Small | 128K |
-| `mistralai/devstral-small-2507` | Devstral Small 1.1 | 131K |
+| `mistralai/devstral-2512` | Devstral 2 | 262K |
+| `mistralai/devstral-medium` | Devstral Medium | 131K |
+| `mistralai/devstral-small` | Devstral Small 1.1 | 131K |
+| `mistralai/ministral-14b-2512` | Ministral 3 14B 2512 | 262K |
+| `mistralai/ministral-3b-2512` | Ministral 3 3B 2512 | 131K |
+| `mistralai/ministral-8b-2512` | Ministral 3 8B 2512 | 262K |
+| `mistralai/mistral-large` | Mistral Large | 128K |
+| `mistralai/mistral-large-2411` | Mistral Large 2.1 | 131K |
+| `mistralai/mistral-large-2407` | Mistral Large 2407 | 131K |
+| `mistralai/mistral-large-2512` | Mistral Large 3 | 262K |
 | `mistralai/mistral-medium-3` | Mistral Medium 3 | 131K |
-| `mistralai/mistral-medium-3.1` | Mistral Medium 3.1 | 262K |
-| `mistralai/mistral-small-3.1-24b-instruct` | Mistral Small 3.1 24B Instruct | 128K |
-| `mistralai/mistral-small-3.2-24b-instruct` | Mistral Small 3.2 24B Instruct | 96K |
+| `mistralai/mistral-medium-3.1` | Mistral Medium 3.1 | 131K |
+| `mistralai/mistral-medium-3-5` | Mistral Medium 3.5 | 262K |
+| `mistralai/mistral-nemo` | Mistral Nemo | 131K |
+| `mistralai/mistral-small-24b-instruct-2501` | Mistral Small 3 | 32K |
+| `mistralai/mistral-small-3.1-24b-instruct` | Mistral Small 3.1 24B | 128K |
+| `mistralai/mistral-small-3.2-24b-instruct` | Mistral Small 3.2 24B | 128K |
 | `mistralai/mistral-small-2603` | Mistral Small 4 | 262K |
+| `mistralai/mixtral-8x22b-instruct` | Mixtral 8x22B Instruct | 65K |
+| `mistralai/pixtral-large-2411` | Pixtral Large 2411 | 131K |
+| `mistralai/mistral-saba` | Saba | 32K |
+| `mistralai/voxtral-small-24b-2507` | Voxtral Small 24B 2507 | 32K |
 
 ### Moonshotai
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `moonshotai/kimi-k2` | Kimi K2 | 131K |
-| `moonshotai/kimi-k2-0905` | Kimi K2 Instruct 0905 | 262K |
-| `moonshotai/kimi-k2-0905:exacto` | Kimi K2 Instruct 0905 (exacto) | 262K |
+| `moonshotai/kimi-k2` | Kimi K2 0711 | 131K |
+| `moonshotai/kimi-k2-0905` | Kimi K2 0905 | 262K |
 | `moonshotai/kimi-k2-thinking` | Kimi K2 Thinking | 262K |
 | `moonshotai/kimi-k2.5` | Kimi K2.5 | 262K |
+| `moonshotai/kimi-k2.6` | Kimi K2.6 | 262K |
+| `moonshotai/kimi-k2.6:free` | Kimi K2.6 (free) | 262K |
+
+### Morph
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `morph/morph-v3-fast` | Morph V3 Fast | 81K |
+| `morph/morph-v3-large` | Morph V3 Large | 262K |
+
+### Nex Agi
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `nex-agi/deepseek-v3.1-nex-n1` | DeepSeek V3.1 Nex N1 | 131K |
 
 ### Nousresearch
 
 | Model ID | Name | Context |
 |----------|------|---------|
+| `nousresearch/hermes-2-pro-llama-3-8b` | Hermes 2 Pro - Llama-3 8B | 8K |
+| `nousresearch/hermes-3-llama-3.1-405b` | Hermes 3 405B Instruct | 131K |
 | `nousresearch/hermes-3-llama-3.1-405b:free` | Hermes 3 405B Instruct (free) | 131K |
+| `nousresearch/hermes-3-llama-3.1-70b` | Hermes 3 70B Instruct | 131K |
 | `nousresearch/hermes-4-405b` | Hermes 4 405B | 131K |
 | `nousresearch/hermes-4-70b` | Hermes 4 70B | 131K |
 
@@ -167,112 +345,250 @@ OpenRouter provides unified access to multiple AI models through a single API.
 
 | Model ID | Name | Context |
 |----------|------|---------|
+| `nvidia/llama-3.3-nemotron-super-49b-v1.5` | Llama 3.3 Nemotron Super 49B V1.5 | 131K |
+| `nvidia/nemotron-3-nano-30b-a3b` | Nemotron 3 Nano 30B A3B | 262K |
 | `nvidia/nemotron-3-nano-30b-a3b:free` | Nemotron 3 Nano 30B A3B (free) | 256K |
+| `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` | Nemotron 3 Nano Omni (free) | 256K |
 | `nvidia/nemotron-3-super-120b-a12b` | Nemotron 3 Super | 262K |
 | `nvidia/nemotron-3-super-120b-a12b:free` | Nemotron 3 Super (free) | 262K |
 | `nvidia/nemotron-nano-12b-v2-vl:free` | Nemotron Nano 12B 2 VL (free) | 128K |
+| `nvidia/nemotron-nano-9b-v2` | Nemotron Nano 9B V2 | 131K |
 | `nvidia/nemotron-nano-9b-v2:free` | Nemotron Nano 9B V2 (free) | 128K |
-| `nvidia/nemotron-nano-9b-v2` | nvidia-nemotron-nano-9b-v2 | 131K |
 
 ### Openai
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `openai/gpt-oss-120b` | GPT OSS 120B | 131K |
-| `openai/gpt-oss-120b:exacto` | GPT OSS 120B (exacto) | 131K |
-| `openai/gpt-oss-20b` | GPT OSS 20B | 131K |
-| `openai/gpt-oss-safeguard-20b` | GPT OSS Safeguard 20B | 131K |
+| `openai/gpt-audio` | GPT Audio | 128K |
+| `openai/gpt-audio-mini` | GPT Audio Mini | 128K |
+| `openai/gpt-chat-latest` | GPT Chat Latest | 400K |
+| `openai/gpt-3.5-turbo-0613` | GPT-3.5 Turbo (older v0613) | 4K |
+| `openai/gpt-3.5-turbo-16k` | GPT-3.5 Turbo 16k | 16K |
+| `openai/gpt-3.5-turbo-instruct` | GPT-3.5 Turbo Instruct | 4K |
+| `openai/gpt-3.5-turbo` | GPT-3.5-turbo | 16K |
+| `openai/gpt-4` | GPT-4 | 8K |
+| `openai/gpt-4-0314` | GPT-4 (older v0314) | 8K |
+| `openai/gpt-4-turbo` | GPT-4 Turbo | 128K |
+| `openai/gpt-4-1106-preview` | GPT-4 Turbo (older v1106) | 128K |
+| `openai/gpt-4-turbo-preview` | GPT-4 Turbo Preview | 128K |
 | `openai/gpt-4.1` | GPT-4.1 | 1M |
-| `openai/gpt-4.1-mini` | GPT-4.1 Mini | 1M |
-| `openai/gpt-4o-mini` | GPT-4o-mini | 128K |
+| `openai/gpt-4.1-mini` | GPT-4.1 mini | 1M |
+| `openai/gpt-4.1-nano` | GPT-4.1 nano | 1M |
+| `openai/gpt-4o` | GPT-4o | 128K |
+| `openai/gpt-4o-2024-05-13` | GPT-4o (2024-05-13) | 128K |
+| `openai/gpt-4o-2024-08-06` | GPT-4o (2024-08-06) | 128K |
+| `openai/gpt-4o-2024-11-20` | GPT-4o (2024-11-20) | 128K |
+| `openai/gpt-4o-search-preview` | GPT-4o Search Preview | 128K |
+| `openai/gpt-4o-mini` | GPT-4o mini | 128K |
+| `openai/gpt-4o-mini-2024-07-18` | GPT-4o-mini (2024-07-18) | 128K |
+| `openai/gpt-4o-mini-search-preview` | GPT-4o-mini Search Preview | 128K |
 | `openai/gpt-5` | GPT-5 | 400K |
-| `openai/gpt-5-chat` | GPT-5 Chat (latest) | 400K |
-| `openai/gpt-5-codex` | GPT-5 Codex | 400K |
+| `openai/gpt-5-chat` | GPT-5 Chat | 128K |
 | `openai/gpt-5-image` | GPT-5 Image | 400K |
+| `openai/gpt-5-image-mini` | GPT-5 Image Mini | 400K |
 | `openai/gpt-5-mini` | GPT-5 Mini | 400K |
 | `openai/gpt-5-nano` | GPT-5 Nano | 400K |
 | `openai/gpt-5-pro` | GPT-5 Pro | 400K |
+| `openai/gpt-5-codex` | GPT-5-Codex | 400K |
 | `openai/gpt-5.1` | GPT-5.1 | 400K |
 | `openai/gpt-5.1-chat` | GPT-5.1 Chat | 128K |
-| `openai/gpt-5.1-codex` | GPT-5.1-Codex | 400K |
-| `openai/gpt-5.1-codex-max` | GPT-5.1-Codex-Max | 400K |
-| `openai/gpt-5.1-codex-mini` | GPT-5.1-Codex-Mini | 400K |
+| `openai/gpt-5.1-codex` | GPT-5.1 Codex | 400K |
+| `openai/gpt-5.1-codex-max` | GPT-5.1 Codex Max | 400K |
+| `openai/gpt-5.1-codex-mini` | GPT-5.1 Codex mini | 400K |
 | `openai/gpt-5.2` | GPT-5.2 | 400K |
 | `openai/gpt-5.2-chat` | GPT-5.2 Chat | 128K |
+| `openai/gpt-5.2-codex` | GPT-5.2 Codex | 400K |
 | `openai/gpt-5.2-pro` | GPT-5.2 Pro | 400K |
-| `openai/gpt-5.2-codex` | GPT-5.2-Codex | 400K |
-| `openai/gpt-5.3-codex` | GPT-5.3-Codex | 400K |
+| `openai/gpt-5.3-chat` | GPT-5.3 Chat | 128K |
+| `openai/gpt-5.3-codex` | GPT-5.3 Codex | 400K |
 | `openai/gpt-5.4` | GPT-5.4 | 1M |
-| `openai/gpt-5.4-mini` | GPT-5.4 Mini | 400K |
-| `openai/gpt-5.4-nano` | GPT-5.4 Nano | 400K |
+| `openai/gpt-5.4-image-2` | GPT-5.4 Image 2 | 272K |
 | `openai/gpt-5.4-pro` | GPT-5.4 Pro | 1M |
+| `openai/gpt-5.4-mini` | GPT-5.4 mini | 400K |
+| `openai/gpt-5.4-nano` | GPT-5.4 nano | 400K |
+| `openai/gpt-5.5` | GPT-5.5 | 1M |
+| `openai/gpt-5.5-pro` | GPT-5.5 Pro | 1M |
+| `openai/gpt-oss-120b` | gpt-oss-120b | 131K |
 | `openai/gpt-oss-120b:free` | gpt-oss-120b (free) | 131K |
+| `openai/gpt-oss-20b` | gpt-oss-20b | 131K |
 | `openai/gpt-oss-20b:free` | gpt-oss-20b (free) | 131K |
-| `openai/o4-mini` | o4 Mini | 200K |
+| `openai/gpt-oss-safeguard-20b` | gpt-oss-safeguard-20b | 131K |
+| `openai/o1` | o1 | 200K |
+| `openai/o1-pro` | o1-pro | 200K |
+| `openai/o3` | o3 | 200K |
+| `openai/o3-mini-high` | o3 Mini High | 200K |
+| `openai/o3-deep-research` | o3-deep-research | 200K |
+| `openai/o3-mini` | o3-mini | 200K |
+| `openai/o3-pro` | o3-pro | 200K |
+| `openai/o4-mini-high` | o4 Mini High | 200K |
+| `openai/o4-mini` | o4-mini | 200K |
+| `openai/o4-mini-deep-research` | o4-mini-deep-research | 200K |
 
 ### Openrouter
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `openrouter/elephant-alpha` | Elephant (free) | 262K |
+| `openrouter/auto` | Auto Router | 2M |
+| `openrouter/bodybuilder` | Body Builder (beta) | 128K |
 | `openrouter/free` | Free Models Router | 200K |
+| `openrouter/owl-alpha` | Owl Alpha | 1M |
+| `openrouter/pareto-code` | Pareto Code Router | 2M |
+
+### Perceptron
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `perceptron/perceptron-mk1` | Perceptron Mk1 | 32K |
+
+### Perplexity
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `perplexity/sonar` | Sonar | 127K |
+| `perplexity/sonar-deep-research` | Sonar Deep Research | 128K |
+| `perplexity/sonar-pro` | Sonar Pro | 200K |
+| `perplexity/sonar-pro-search` | Sonar Pro Search | 200K |
+| `perplexity/sonar-reasoning-pro` | Sonar Reasoning Pro | 128K |
+
+### Poolside
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `poolside/laguna-m.1:free` | Laguna M.1 (free) | 262K |
+| `poolside/laguna-xs.2:free` | Laguna XS.2 (free) | 262K |
 
 ### Prime Intellect
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `prime-intellect/intellect-3` | Intellect 3 | 131K |
+| `prime-intellect/intellect-3` | INTELLECT-3 | 131K |
 
 ### Qwen
 
 | Model ID | Name | Context |
 |----------|------|---------|
+| `qwen/qwen-plus-2025-07-28` | Qwen Plus 0728 | 1M |
+| `qwen/qwen-plus-2025-07-28:thinking` | Qwen Plus 0728 (thinking) | 1M |
+| `qwen/qwen-plus` | Qwen-Plus | 1M |
+| `qwen/qwen-2.5-72b-instruct` | Qwen2.5 72B Instruct | 32K |
+| `qwen/qwen-2.5-7b-instruct` | Qwen2.5 7B Instruct | 32K |
 | `qwen/qwen-2.5-coder-32b-instruct` | Qwen2.5 Coder 32B Instruct | 32K |
 | `qwen/qwen2.5-vl-72b-instruct` | Qwen2.5 VL 72B Instruct | 32K |
-| `qwen/qwen3-235b-a22b-07-25` | Qwen3 235B A22B Instruct 2507 | 262K |
+| `qwen/qwen3-14b` | Qwen3 14B | 40K |
+| `qwen/qwen3-235b-a22b` | Qwen3 235B A22B | 131K |
+| `qwen/qwen3-235b-a22b-2507` | Qwen3 235B A22B Instruct 2507 | 262K |
 | `qwen/qwen3-235b-a22b-thinking-2507` | Qwen3 235B A22B Thinking 2507 | 262K |
+| `qwen/qwen3-30b-a3b` | Qwen3 30B A3B | 40K |
 | `qwen/qwen3-30b-a3b-instruct-2507` | Qwen3 30B A3B Instruct 2507 | 262K |
-| `qwen/qwen3-30b-a3b-thinking-2507` | Qwen3 30B A3B Thinking 2507 | 262K |
-| `qwen/qwen3-coder` | Qwen3 Coder | 262K |
-| `qwen/qwen3-coder:exacto` | Qwen3 Coder (exacto) | 131K |
+| `qwen/qwen3-30b-a3b-thinking-2507` | Qwen3 30B A3B Thinking 2507 | 131K |
+| `qwen/qwen3-32b` | Qwen3 32B | 40K |
+| `qwen/qwen3-8b` | Qwen3 8B | 40K |
 | `qwen/qwen3-coder-30b-a3b-instruct` | Qwen3 Coder 30B A3B Instruct | 160K |
-| `qwen/qwen3-coder-flash` | Qwen3 Coder Flash | 128K |
+| `qwen/qwen3-coder` | Qwen3 Coder 480B A35B | 262K |
+| `qwen/qwen3-coder:free` | Qwen3 Coder 480B A35B (free) | 262K |
+| `qwen/qwen3-coder-flash` | Qwen3 Coder Flash | 1M |
+| `qwen/qwen3-coder-next` | Qwen3 Coder Next | 262K |
+| `qwen/qwen3-coder-plus` | Qwen3 Coder Plus | 1M |
 | `qwen/qwen3-max` | Qwen3 Max | 262K |
+| `qwen/qwen3-max-thinking` | Qwen3 Max Thinking | 262K |
 | `qwen/qwen3-next-80b-a3b-instruct` | Qwen3 Next 80B A3B Instruct | 262K |
-| `qwen/qwen3-next-80b-a3b-thinking` | Qwen3 Next 80B A3B Thinking | 262K |
+| `qwen/qwen3-next-80b-a3b-instruct:free` | Qwen3 Next 80B A3B Instruct (free) | 262K |
+| `qwen/qwen3-next-80b-a3b-thinking` | Qwen3 Next 80B A3B Thinking | 131K |
+| `qwen/qwen3-vl-235b-a22b-instruct` | Qwen3 VL 235B A22B Instruct | 262K |
+| `qwen/qwen3-vl-235b-a22b-thinking` | Qwen3 VL 235B A22B Thinking | 131K |
+| `qwen/qwen3-vl-30b-a3b-instruct` | Qwen3 VL 30B A3B Instruct | 131K |
+| `qwen/qwen3-vl-30b-a3b-thinking` | Qwen3 VL 30B A3B Thinking | 131K |
+| `qwen/qwen3-vl-32b-instruct` | Qwen3 VL 32B Instruct | 131K |
+| `qwen/qwen3-vl-8b-instruct` | Qwen3 VL 8B Instruct | 131K |
+| `qwen/qwen3-vl-8b-thinking` | Qwen3 VL 8B Thinking | 131K |
 | `qwen/qwen3.5-397b-a17b` | Qwen3.5 397B A17B | 262K |
 | `qwen/qwen3.5-plus-02-15` | Qwen3.5 Plus 2026-02-15 | 1M |
+| `qwen/qwen3.5-plus-20260420` | Qwen3.5 Plus 2026-04-20 | 1M |
+| `qwen/qwen3.5-122b-a10b` | Qwen3.5-122B-A10B | 262K |
+| `qwen/qwen3.5-27b` | Qwen3.5-27B | 262K |
+| `qwen/qwen3.5-35b-a3b` | Qwen3.5-35B-A3B | 262K |
+| `qwen/qwen3.5-9b` | Qwen3.5-9B | 262K |
+| `qwen/qwen3.5-flash-02-23` | Qwen3.5-Flash | 1M |
+| `qwen/qwen3.6-27b` | Qwen3.6 27B | 262K |
+| `qwen/qwen3.6-35b-a3b` | Qwen3.6 35B A3B | 262K |
+| `qwen/qwen3.6-flash` | Qwen3.6 Flash | 1M |
+| `qwen/qwen3.6-max-preview` | Qwen3.6 Max Preview | 262K |
 | `qwen/qwen3.6-plus` | Qwen3.6 Plus | 1M |
-| `qwen/qwen3.5-flash-02-23` | Qwen: Qwen3.5-Flash | 1M |
+| `qwen/qwen3.7-max` | Qwen3.7 Max | 1M |
 
-### Sourceful
+### Rekaai
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `sourceful/riverflow-v2-fast-preview` | Riverflow V2 Fast Preview | 8K |
-| `sourceful/riverflow-v2-max-preview` | Riverflow V2 Max Preview | 8K |
-| `sourceful/riverflow-v2-standard-preview` | Riverflow V2 Standard Preview | 8K |
+| `rekaai/reka-edge` | Reka Edge | 16K |
+| `rekaai/reka-flash-3` | Reka Flash 3 | 65K |
+
+### Relace
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `relace/relace-apply-3` | Relace Apply 3 | 256K |
+| `relace/relace-search` | Relace Search | 256K |
+
+### Sao10K
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `sao10k/l3-lunaris-8b` | Llama 3 8B Lunaris | 8K |
+| `sao10k/l3-euryale-70b` | Llama 3 Euryale 70B v2.1 | 8K |
+| `sao10k/l3.1-70b-hanami-x1` | Llama 3.1 70B Hanami x1 | 16K |
+| `sao10k/l3.1-euryale-70b` | Llama 3.1 Euryale 70B v2.2 | 131K |
+| `sao10k/l3.3-euryale-70b` | Llama 3.3 Euryale 70B | 131K |
 
 ### Stepfun
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `stepfun/step-3.5-flash` | Step 3.5 Flash | 256K |
+| `stepfun/step-3.5-flash` | Step 3.5 Flash | 262K |
+| `stepfun/step-3.7-flash` | Step 3.7 Flash | 256K |
+
+### Switchpoint
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `switchpoint/router` | Switchpoint Router | 131K |
+
+### Tencent
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `tencent/hunyuan-a13b-instruct` | Hunyuan A13B Instruct | 131K |
+| `tencent/hy3-preview` | Hy3 preview | 262K |
+
+### Thedrummer
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `thedrummer/cydonia-24b-v4.1` | Cydonia 24B V4.1 | 131K |
+| `thedrummer/rocinante-12b` | Rocinante 12B | 32K |
+| `thedrummer/skyfall-36b-v2` | Skyfall 36B V2 | 32K |
+| `thedrummer/unslopnemo-12b` | UnslopNemo 12B | 32K |
+
+### Undi95
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `undi95/remm-slerp-l2-13b` | ReMM SLERP 13B | 6K |
+
+### Writer
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `writer/palmyra-x5` | Palmyra X5 | 1M |
 
 ### X Ai
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `x-ai/grok-3` | Grok 3 | 131K |
-| `x-ai/grok-3-beta` | Grok 3 Beta | 131K |
-| `x-ai/grok-3-mini` | Grok 3 Mini | 131K |
-| `x-ai/grok-3-mini-beta` | Grok 3 Mini Beta | 131K |
-| `x-ai/grok-4` | Grok 4 | 256K |
-| `x-ai/grok-4-fast` | Grok 4 Fast | 2M |
-| `x-ai/grok-4.1-fast` | Grok 4.1 Fast | 2M |
-| `x-ai/grok-4.20-beta` | Grok 4.20 Beta | 2M |
-| `x-ai/grok-4.20-multi-agent-beta` | Grok 4.20 Multi - Agent Beta | 2M |
-| `x-ai/grok-code-fast-1` | Grok Code Fast 1 | 256K |
+| `x-ai/grok-4.20` | Grok 4.20 | 2M |
+| `x-ai/grok-4.20-multi-agent` | Grok 4.20 Multi-Agent | 2M |
+| `x-ai/grok-4.3` | Grok 4.3 | 1M |
+| `x-ai/grok-build-0.1` | Grok Build 0.1 | 256K |
 
 ### Xiaomi
 
@@ -281,22 +597,54 @@ OpenRouter provides unified access to multiple AI models through a single API.
 | `xiaomi/mimo-v2-flash` | MiMo-V2-Flash | 262K |
 | `xiaomi/mimo-v2-omni` | MiMo-V2-Omni | 262K |
 | `xiaomi/mimo-v2-pro` | MiMo-V2-Pro | 1M |
+| `xiaomi/mimo-v2.5` | MiMo-V2.5 | 1M |
+| `xiaomi/mimo-v2.5-pro` | MiMo-V2.5-Pro | 1M |
 
 ### Z Ai
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `z-ai/glm-4.5` | GLM 4.5 | 128K |
-| `z-ai/glm-4.5-air` | GLM 4.5 Air | 128K |
-| `z-ai/glm-4.5-air:free` | GLM 4.5 Air (free) | 128K |
-| `z-ai/glm-4.5v` | GLM 4.5V | 64K |
-| `z-ai/glm-4.6` | GLM 4.6 | 200K |
-| `z-ai/glm-4.6:exacto` | GLM 4.6 (exacto) | 200K |
-| `z-ai/glm-4.7` | GLM-4.7 | 204K |
-| `z-ai/glm-4.7-flash` | GLM-4.7-Flash | 200K |
+| `z-ai/glm-4-32b` | GLM 4 32B  | 128K |
+| `z-ai/glm-4.5-air:free` | GLM 4.5 Air (free) | 131K |
+| `z-ai/glm-4.5` | GLM-4.5 | 131K |
+| `z-ai/glm-4.5-air` | GLM-4.5-Air | 131K |
+| `z-ai/glm-4.5v` | GLM-4.5V | 65K |
+| `z-ai/glm-4.6` | GLM-4.6 | 202K |
+| `z-ai/glm-4.6v` | GLM-4.6V | 131K |
+| `z-ai/glm-4.7` | GLM-4.7 | 202K |
+| `z-ai/glm-4.7-flash` | GLM-4.7-Flash | 202K |
 | `z-ai/glm-5` | GLM-5 | 202K |
 | `z-ai/glm-5-turbo` | GLM-5-Turbo | 202K |
 | `z-ai/glm-5.1` | GLM-5.1 | 202K |
+| `z-ai/glm-5v-turbo` | GLM-5V-Turbo | 202K |
+
+### ~Anthropic
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `~anthropic/claude-haiku-latest` | Anthropic Claude Haiku Latest | 200K |
+| `~anthropic/claude-sonnet-latest` | Anthropic Claude Sonnet Latest | 1M |
+| `~anthropic/claude-opus-latest` | Claude Opus Latest | 1M |
+
+### ~Google
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `~google/gemini-flash-latest` | Google Gemini Flash Latest | 1M |
+| `~google/gemini-pro-latest` | Google Gemini Pro Latest | 1M |
+
+### ~Moonshotai
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `~moonshotai/kimi-latest` | MoonshotAI Kimi Latest | 262K |
+
+### ~Openai
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `~openai/gpt-latest` | OpenAI GPT Latest | 1M |
+| `~openai/gpt-mini-latest` | OpenAI GPT Mini Latest | 400K |
 <!-- MODEL-TABLE:END -->
 
 ## Setup

--- a/docs/agent-support/providers/vertex.md
+++ b/docs/agent-support/providers/vertex.md
@@ -9,6 +9,19 @@ Google Cloud Vertex AI provides access to Gemini models.
 <!-- MODEL-TABLE:START -->
 | Model ID | Name | Context |
 |----------|------|---------|
+| `claude-3-5-haiku@20241022` | Claude Haiku 3.5 | 200K |
+| `claude-haiku-4-5@20251001` | Claude Haiku 4.5 | 200K |
+| `claude-opus-4@20250514` | Claude Opus 4 | 200K |
+| `claude-opus-4-1@20250805` | Claude Opus 4.1 | 200K |
+| `claude-opus-4-5@20251101` | Claude Opus 4.5 | 200K |
+| `claude-opus-4-6@default` | Claude Opus 4.6 | 1M |
+| `claude-opus-4-7@default` | Claude Opus 4.7 | 1M |
+| `claude-opus-4-8@default` | Claude Opus 4.8 | 1M |
+| `claude-3-5-sonnet@20241022` | Claude Sonnet 3.5 v2 | 200K |
+| `claude-3-7-sonnet@20250219` | Claude Sonnet 3.7 | 200K |
+| `claude-sonnet-4@20250514` | Claude Sonnet 4 | 200K |
+| `claude-sonnet-4-5@20250929` | Claude Sonnet 4.5 | 200K |
+| `claude-sonnet-4-6@default` | Claude Sonnet 4.6 | 1M |
 | `deepseek-ai/deepseek-v3.1-maas` | DeepSeek V3.1 | 163K |
 | `deepseek-ai/deepseek-v3.2-maas` | DeepSeek V3.2 | 163K |
 | `zai-org/glm-4.7-maas` | GLM-4.7 | 200K |
@@ -16,21 +29,19 @@ Google Cloud Vertex AI provides access to Gemini models.
 | `openai/gpt-oss-120b-maas` | GPT OSS 120B | 131K |
 | `openai/gpt-oss-20b-maas` | GPT OSS 20B | 131K |
 | `gemini-2.0-flash` | Gemini 2.0 Flash | 1M |
-| `gemini-2.0-flash-lite` | Gemini 2.0 Flash Lite | 1M |
+| `gemini-2.0-flash-lite` | Gemini 2.0 Flash-Lite | 1M |
 | `gemini-2.5-flash` | Gemini 2.5 Flash | 1M |
-| `gemini-2.5-flash-lite` | Gemini 2.5 Flash Lite | 1M |
 | `gemini-2.5-flash-lite-preview-06-17` | Gemini 2.5 Flash Lite Preview 06-17 | 65K |
-| `gemini-2.5-flash-lite-preview-09-2025` | Gemini 2.5 Flash Lite Preview 09-25 | 1M |
-| `gemini-2.5-flash-preview-04-17` | Gemini 2.5 Flash Preview 04-17 | 1M |
-| `gemini-2.5-flash-preview-05-20` | Gemini 2.5 Flash Preview 05-20 | 1M |
 | `gemini-2.5-flash-preview-09-2025` | Gemini 2.5 Flash Preview 09-25 | 1M |
+| `gemini-2.5-flash-lite` | Gemini 2.5 Flash-Lite | 1M |
 | `gemini-2.5-pro` | Gemini 2.5 Pro | 1M |
-| `gemini-2.5-pro-preview-05-06` | Gemini 2.5 Pro Preview 05-06 | 1M |
-| `gemini-2.5-pro-preview-06-05` | Gemini 2.5 Pro Preview 06-05 | 1M |
 | `gemini-3-flash-preview` | Gemini 3 Flash Preview | 1M |
 | `gemini-3-pro-preview` | Gemini 3 Pro Preview | 1M |
+| `gemini-3.1-flash-lite` | Gemini 3.1 Flash Lite | 1M |
+| `gemini-3.1-flash-lite-preview` | Gemini 3.1 Flash Lite Preview | 1M |
 | `gemini-3.1-pro-preview` | Gemini 3.1 Pro Preview | 1M |
 | `gemini-3.1-pro-preview-customtools` | Gemini 3.1 Pro Preview Custom Tools | 1M |
+| `gemini-3.5-flash` | Gemini 3.5 Flash | 1M |
 | `gemini-embedding-001` | Gemini Embedding 001 | 2K |
 | `gemini-flash-latest` | Gemini Flash Latest | 1M |
 | `gemini-flash-lite-latest` | Gemini Flash-Lite Latest | 1M |

--- a/docs/agent-support/providers/zai.md
+++ b/docs/agent-support/providers/zai.md
@@ -20,7 +20,7 @@ Zhipu AI (ZAI) BigModel platform provides access to GLM (General Language Model)
 | `glm-4.7-flashx` | GLM-4.7-FlashX | 200K |
 | `glm-5` | GLM-5 | 204K |
 | `glm-5.1` | GLM-5.1 | 200K |
-| `glm-5v-turbo` | glm-5v-turbo | 200K |
+| `glm-5v-turbo` | GLM-5V-Turbo | 200K |
 <!-- MODEL-TABLE:END -->
 
 ## Setup

--- a/gui/src/components/providers/add-provider-modal.test.tsx
+++ b/gui/src/components/providers/add-provider-modal.test.tsx
@@ -33,13 +33,21 @@ import type { ProviderTypesMap } from "@/lib/types";
 const providerTypes: ProviderTypesMap = {
   openai: {
     endpoint: "https://api.openai.com/v1",
-    models: ["gpt-4o"],
+    models: [
+      {
+        id: "gpt-4o",
+        name: "GPT-4o",
+        lab: "OpenAI",
+        context_window: 128000,
+        tags: ["multimodal"],
+      },
+    ],
     requires_api_key: true,
     requires_endpoint: false,
   },
   ollama: {
     endpoint: null,
-    models: null,
+    models: [],
     requires_api_key: false,
     requires_endpoint: true,
   },

--- a/gui/src/components/providers/add-provider-modal.tsx
+++ b/gui/src/components/providers/add-provider-modal.tsx
@@ -3,6 +3,7 @@
 import { useId, useState } from "react";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
+import { ModelComboBox } from "./model-combobox";
 import type {
   AcceleratorVendor,
   ProviderTypesMap,
@@ -158,27 +159,25 @@ export function AddProviderModal({
         )}
 
         {/* Default Model */}
-        {availableModels && availableModels.length > 0 && (
+        {availableModels.length > 0 && (
           <div>
             <label
               htmlFor={modelId}
               className="block text-xs font-medium text-secondary mb-1"
             >
               Default Model
+              <span className="ml-2 font-normal text-muted">
+                ({availableModels.length} available)
+              </span>
             </label>
-            <select
-              id={modelId}
+            <ModelComboBox
+              inputId={modelId}
               value={model}
-              onChange={(e) => setModel(e.target.value)}
-              className="w-full px-3 py-2 text-sm border border-default rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
-            >
-              <option value="">Select model...</option>
-              {availableModels.map((m) => (
-                <option key={m} value={m}>
-                  {m}
-                </option>
-              ))}
-            </select>
+              onChange={setModel}
+              options={availableModels}
+              groupByLab={type === "openrouter" || type === "bedrock" || type === "vertex"}
+              placeholder="Search models by id, name, lab, or tag..."
+            />
           </div>
         )}
 

--- a/gui/src/components/providers/edit-provider-modal.tsx
+++ b/gui/src/components/providers/edit-provider-modal.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useId, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
+import { ModelComboBox } from "./model-combobox";
 import type {
   AcceleratorVendor,
+  ModelInfo,
   Provider,
   ProviderTypesMap,
   ProviderUpdate,
@@ -38,8 +40,19 @@ export function EditProviderModal({
     useState<AcceleratorVendor>(initialAccelerator);
 
   const typeInfo = providerTypes[provider.type];
-  const availableModels = typeInfo?.models || provider.available_models || [];
   const isLocalInference = provider.type === "ollama";
+  const availableModels: ModelInfo[] = useMemo(() => {
+    if (isLocalInference) {
+      return (provider.available_models ?? []).map((id) => ({
+        id,
+        name: id,
+        lab: "Ollama",
+        context_window: 0,
+        tags: [],
+      }));
+    }
+    return typeInfo?.models ?? [];
+  }, [isLocalInference, provider.available_models, typeInfo]);
 
   const idPrefix = useId();
   const modelId = `${idPrefix}-model`;
@@ -81,27 +94,29 @@ export function EditProviderModal({
         </div>
 
         {/* Default Model */}
-        {availableModels && availableModels.length > 0 ? (
+        {availableModels.length > 0 ? (
           <div>
             <label
               htmlFor={modelId}
               className="block text-xs font-medium text-secondary mb-1"
             >
               Default Model
+              <span className="ml-2 font-normal text-muted">
+                ({availableModels.length} available)
+              </span>
             </label>
-            <select
-              id={modelId}
+            <ModelComboBox
+              inputId={modelId}
               value={model}
-              onChange={(e) => setModel(e.target.value)}
-              className="w-full px-3 py-2 text-sm border border-default rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
-            >
-              <option value="">Select model...</option>
-              {availableModels.map((m) => (
-                <option key={m} value={m}>
-                  {m}
-                </option>
-              ))}
-            </select>
+              onChange={setModel}
+              options={availableModels}
+              groupByLab={
+                provider.type === "openrouter" ||
+                provider.type === "bedrock" ||
+                provider.type === "vertex"
+              }
+              placeholder="Search models..."
+            />
           </div>
         ) : (
           <div>

--- a/gui/src/components/providers/model-combobox.test.tsx
+++ b/gui/src/components/providers/model-combobox.test.tsx
@@ -1,0 +1,339 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent, { type UserEvent } from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ModelComboBox } from "./model-combobox";
+import type { ModelInfo } from "@/lib/types";
+
+const models: ModelInfo[] = [
+  {
+    id: "gpt-4o",
+    name: "GPT-4o",
+    lab: "OpenAI",
+    context_window: 128000,
+    tags: ["multimodal", "tool-use"],
+  },
+  {
+    id: "gpt-4o-mini",
+    name: "GPT-4o mini",
+    lab: "OpenAI",
+    context_window: 128000,
+    tags: ["multimodal"],
+  },
+  {
+    id: "claude-sonnet-4-5",
+    name: "Claude Sonnet 4.5",
+    lab: "Anthropic",
+    context_window: 200000,
+    tags: ["reasoning"],
+  },
+];
+
+let user: UserEvent;
+
+beforeEach(() => {
+  user = userEvent.setup();
+});
+
+describe("ModelComboBox — rendering & display", () => {
+  it("renders all options when opened", async () => {
+    render(<ModelComboBox value="" onChange={() => {}} options={models} />);
+    await user.click(screen.getByRole("combobox"));
+    const listbox = screen.getByRole("listbox");
+    expect(within(listbox).getByText("gpt-4o")).toBeInTheDocument();
+    expect(within(listbox).getByText("gpt-4o-mini")).toBeInTheDocument();
+    expect(within(listbox).getByText("claude-sonnet-4-5")).toBeInTheDocument();
+  });
+
+  it("displays the controlled value when closed", () => {
+    // B1: closed-state displayValue path — selected?.id branch
+    render(
+      <ModelComboBox
+        value="claude-sonnet-4-5"
+        onChange={() => {}}
+        options={models}
+      />,
+    );
+    const input = screen.getByRole<HTMLInputElement>("combobox");
+    expect(input.value).toBe("claude-sonnet-4-5");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("clears the input for fresh search when opening with a selected value", async () => {
+    // B1: open path replaces selected display with empty query
+    render(
+      <ModelComboBox
+        value="claude-sonnet-4-5"
+        onChange={() => {}}
+        options={models}
+      />,
+    );
+    const input = screen.getByRole<HTMLInputElement>("combobox");
+    await user.click(input);
+    expect(input.value).toBe("");
+  });
+});
+
+describe("ModelComboBox — filtering", () => {
+  it("filters by lab name", async () => {
+    render(<ModelComboBox value="" onChange={() => {}} options={models} />);
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.type(input, "anthropic");
+    const listbox = screen.getByRole("listbox");
+    expect(within(listbox).getByText("claude-sonnet-4-5")).toBeInTheDocument();
+    // W2: assert both other models are gone
+    expect(within(listbox).queryByText("gpt-4o")).not.toBeInTheDocument();
+    expect(within(listbox).queryByText("gpt-4o-mini")).not.toBeInTheDocument();
+  });
+
+  it("filters by tag", async () => {
+    render(<ModelComboBox value="" onChange={() => {}} options={models} />);
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.type(input, "reasoning");
+    const listbox = screen.getByRole("listbox");
+    expect(within(listbox).getByText("claude-sonnet-4-5")).toBeInTheDocument();
+    expect(within(listbox).queryByText("gpt-4o")).not.toBeInTheDocument();
+  });
+
+  it("filters by display name", async () => {
+    // W1: covers m.name branch in matchModel
+    render(<ModelComboBox value="" onChange={() => {}} options={models} />);
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.type(input, "GPT-4o mini");
+    const listbox = screen.getByRole("listbox");
+    expect(within(listbox).getByText("gpt-4o-mini")).toBeInTheDocument();
+    expect(within(listbox).queryByText("claude-sonnet-4-5")).not.toBeInTheDocument();
+  });
+
+  it("shows empty-state when no models match", async () => {
+    render(<ModelComboBox value="" onChange={() => {}} options={models} />);
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.type(input, "nonexistent-xyz");
+    expect(
+      within(screen.getByRole("listbox")).getByText("No models match"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("ModelComboBox — grouping", () => {
+  it("groups by lab and renders lab headings", async () => {
+    render(
+      <ModelComboBox
+        value=""
+        onChange={() => {}}
+        options={models}
+        groupByLab
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    const listbox = screen.getByRole("listbox");
+    expect(within(listbox).getByText("OpenAI")).toBeInTheDocument();
+    expect(within(listbox).getByText("Anthropic")).toBeInTheDocument();
+  });
+});
+
+describe("ModelComboBox — selection", () => {
+  it("fires onChange with the model id when an option is clicked", async () => {
+    const onChange = vi.fn();
+    render(<ModelComboBox value="" onChange={onChange} options={models} />);
+    await user.click(screen.getByRole("combobox"));
+    // mouseDown is the production handler; fire it directly via pointer.
+    await user.pointer({
+      keys: "[MouseLeft]",
+      target: screen.getByText("claude-sonnet-4-5"),
+    });
+    expect(onChange).toHaveBeenCalledWith("claude-sonnet-4-5");
+  });
+
+  it("closes the listbox and resets the input after selection", async () => {
+    // W3: post-selection state
+    function Harness() {
+      const [v, setV] = require("react").useState("");
+      return (
+        <ModelComboBox value={v as string} onChange={setV} options={models} />
+      );
+    }
+    render(<Harness />);
+    await user.click(screen.getByRole("combobox"));
+    await user.pointer({
+      keys: "[MouseLeft]",
+      target: screen.getByText("gpt-4o-mini"),
+    });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.getByRole<HTMLInputElement>("combobox").value).toBe(
+      "gpt-4o-mini",
+    );
+  });
+});
+
+describe("ModelComboBox — keyboard navigation", () => {
+  it("ArrowDown + Enter selects the next option (ungrouped)", async () => {
+    const onChange = vi.fn();
+    render(
+      <ModelComboBox
+        value=""
+        onChange={onChange}
+        options={models}
+        groupByLab={false}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    await user.keyboard("{ArrowDown}{Enter}");
+    expect(onChange).toHaveBeenCalledWith("gpt-4o-mini");
+  });
+
+  it("ArrowUp clamps to the first option (ungrouped)", async () => {
+    // B3: ArrowUp boundary + Math.max clamp
+    const onChange = vi.fn();
+    render(
+      <ModelComboBox
+        value=""
+        onChange={onChange}
+        options={models}
+        groupByLab={false}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    await user.keyboard("{ArrowDown}{ArrowDown}{ArrowUp}{ArrowUp}{ArrowUp}{Enter}");
+    expect(onChange).toHaveBeenCalledWith("gpt-4o");
+  });
+
+  it("ArrowDown navigates across lab groups", async () => {
+    // W7: cross-group runningIdx accumulation
+    const onChange = vi.fn();
+    render(
+      <ModelComboBox
+        value=""
+        onChange={onChange}
+        options={models}
+        groupByLab
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    // visible order grouped & sorted by lab: Anthropic[claude-sonnet-4-5], OpenAI[gpt-4o, gpt-4o-mini]
+    // start at idx 0 (claude). ArrowDown → 1 (gpt-4o). Enter selects.
+    await user.keyboard("{ArrowDown}{Enter}");
+    expect(onChange).toHaveBeenCalledWith("gpt-4o");
+  });
+
+  it("Escape closes the listbox", async () => {
+    // B3: Escape handler
+    render(<ModelComboBox value="" onChange={() => {}} options={models} />);
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+});
+
+describe("ModelComboBox — disabled", () => {
+  it("disables the input and suppresses the dropdown", async () => {
+    // B4
+    render(
+      <ModelComboBox
+        value=""
+        onChange={() => {}}
+        options={models}
+        disabled
+      />,
+    );
+    const input = screen.getByRole<HTMLInputElement>("combobox");
+    expect(input).toBeDisabled();
+    // user.click is a no-op on disabled inputs, so trigger focus manually.
+    input.focus();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+});
+
+describe("ModelComboBox — click outside", () => {
+  it("closes the listbox when mousedown lands outside", async () => {
+    // B5
+    render(
+      <div>
+        <ModelComboBox value="" onChange={() => {}} options={models} />
+        <button type="button" data-testid="outside">
+          outside
+        </button>
+      </div>,
+    );
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    await user.pointer({
+      keys: "[MouseLeft]",
+      target: screen.getByTestId("outside"),
+    });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+});
+
+describe("ModelComboBox — accessibility", () => {
+  it("toggles aria-expanded and wires aria-controls to the listbox id", async () => {
+    // W4 + W5
+    render(
+      <ModelComboBox
+        value=""
+        onChange={() => {}}
+        options={models}
+        inputId="model-field"
+      />,
+    );
+    const input = screen.getByRole("combobox");
+    expect(input).toHaveAttribute("id", "model-field");
+    expect(input).toHaveAttribute("aria-expanded", "false");
+    expect(input).toHaveAttribute("aria-controls", "model-field-listbox");
+    await user.click(input);
+    expect(input).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("listbox")).toHaveAttribute(
+      "id",
+      "model-field-listbox",
+    );
+    await user.keyboard("{Escape}");
+    expect(input).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("marks the selected option with aria-selected=true", async () => {
+    // W4
+    render(
+      <ModelComboBox
+        value="claude-sonnet-4-5"
+        onChange={() => {}}
+        options={models}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    const selected = screen
+      .getAllByRole("option")
+      .find((el) => el.getAttribute("aria-selected") === "true");
+    expect(selected).toBeDefined();
+    expect(selected).toHaveTextContent("claude-sonnet-4-5");
+  });
+});
+
+describe("ModelComboBox — list capping", () => {
+  it("caps visible rows and shows a refine-search hint", async () => {
+    const many: ModelInfo[] = Array.from({ length: 200 }, (_, i) => ({
+      id: `m-${i}`,
+      name: `Model ${i}`,
+      lab: "Lab",
+      context_window: 0,
+      tags: [],
+    }));
+    render(
+      <ModelComboBox
+        value=""
+        onChange={() => {}}
+        options={many}
+        maxVisible={50}
+        groupByLab={false}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    const listbox = screen.getByRole("listbox");
+    expect(within(listbox).getByText("m-49")).toBeInTheDocument();
+    expect(within(listbox).queryByText("m-50")).not.toBeInTheDocument();
+    expect(within(listbox).getByText(/Showing 50 of 200/i)).toBeInTheDocument();
+  });
+});

--- a/gui/src/components/providers/model-combobox.tsx
+++ b/gui/src/components/providers/model-combobox.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { ModelInfo } from "@/lib/types";
+
+interface ModelComboBoxProps {
+  value: string;
+  onChange: (id: string) => void;
+  options: ModelInfo[];
+  placeholder?: string;
+  groupByLab?: boolean;
+  disabled?: boolean;
+  maxVisible?: number;
+  inputId?: string;
+}
+
+const DEFAULT_MAX_VISIBLE = 100;
+
+function matchModel(m: ModelInfo, query: string): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  if (m.id.toLowerCase().includes(q)) return true;
+  if (m.name.toLowerCase().includes(q)) return true;
+  if (m.lab.toLowerCase().includes(q)) return true;
+  return m.tags.some((t) => t.toLowerCase().includes(q));
+}
+
+export function ModelComboBox({
+  value,
+  onChange,
+  options,
+  placeholder = "Search models...",
+  groupByLab = true,
+  disabled = false,
+  maxVisible = DEFAULT_MAX_VISIBLE,
+  inputId,
+}: ModelComboBoxProps) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const generatedId = useId();
+  const fieldId = inputId ?? generatedId;
+
+  const selected = useMemo(
+    () => options.find((o) => o.id === value) ?? null,
+    [options, value],
+  );
+
+  const filtered = useMemo(() => {
+    if (!query) return options;
+    return options.filter((m) => matchModel(m, query));
+  }, [options, query]);
+
+  const grouped = useMemo(() => {
+    if (!groupByLab) return null;
+    const capped = filtered.slice(0, maxVisible);
+    const groups = new Map<string, ModelInfo[]>();
+    for (const m of capped) {
+      const arr = groups.get(m.lab) ?? [];
+      arr.push(m);
+      groups.set(m.lab, arr);
+    }
+    return Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b));
+  }, [filtered, maxVisible, groupByLab]);
+
+  // visible is the flat render-order list. Keyboard navigation indexes into it,
+  // so it MUST match the order in which renderRow is called (grouped order when
+  // groupByLab is true).
+  const visible = useMemo(() => {
+    if (grouped) return grouped.flatMap(([, models]) => models);
+    return filtered.slice(0, maxVisible);
+  }, [filtered, grouped, maxVisible]);
+
+  useEffect(() => {
+    if (activeIdx >= visible.length) setActiveIdx(0);
+  }, [visible.length, activeIdx]);
+
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  const handleSelect = useCallback(
+    (m: ModelInfo) => {
+      onChange(m.id);
+      setQuery("");
+      setOpen(false);
+    },
+    [onChange],
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setOpen(true);
+      setActiveIdx((i) => Math.min(i + 1, visible.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      if (open && visible[activeIdx]) {
+        e.preventDefault();
+        handleSelect(visible[activeIdx]);
+      }
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  const displayValue = open ? query : selected?.id ?? query;
+
+  let runningIdx = -1;
+  const renderRow = (m: ModelInfo) => {
+    runningIdx += 1;
+    const idx = runningIdx;
+    const isActive = idx === activeIdx;
+    const isSelected = m.id === value;
+    return (
+      <li
+        key={m.id}
+        role="option"
+        aria-selected={isSelected}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          handleSelect(m);
+        }}
+        onMouseEnter={() => setActiveIdx(idx)}
+        className={
+          "px-3 py-2 cursor-pointer text-sm flex items-baseline justify-between gap-3 " +
+          (isActive ? "bg-primary/10 " : "") +
+          (isSelected ? "font-medium " : "")
+        }
+      >
+        <div className="min-w-0 flex-1">
+          <div className="font-mono text-xs truncate text-primary-text">
+            {m.id}
+          </div>
+          {m.name && m.name !== m.id ? (
+            <div className="text-[11px] text-muted truncate">{m.name}</div>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          {m.context_window > 0 ? (
+            <span className="text-[10px] text-muted whitespace-nowrap">
+              {Math.round(m.context_window / 1000)}k
+            </span>
+          ) : null}
+          {m.tags.slice(0, 2).map((t) => (
+            <span
+              key={t}
+              className="text-[10px] px-1.5 py-0.5 rounded bg-panel text-secondary whitespace-nowrap"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+      </li>
+    );
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <input
+        id={fieldId}
+        type="text"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={`${fieldId}-listbox`}
+        aria-autocomplete="list"
+        value={displayValue}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+          setActiveIdx(0);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        autoComplete="off"
+        className="w-full px-3 py-2 text-sm border border-default rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary font-mono"
+      />
+      {open && !disabled ? (
+        <ul
+          ref={listRef}
+          id={`${fieldId}-listbox`}
+          role="listbox"
+          className="absolute z-50 mt-1 w-full max-h-72 overflow-auto bg-white border border-default rounded-lg shadow-lg"
+        >
+          {visible.length === 0 ? (
+            <li className="px-3 py-2 text-xs text-muted">No models match</li>
+          ) : grouped ? (
+            grouped.map(([lab, models]) => (
+              <li key={lab} className="py-1">
+                <div className="px-3 py-1 text-[10px] uppercase tracking-wide text-muted font-semibold bg-panel">
+                  {lab}
+                </div>
+                <ul role="group">{models.map(renderRow)}</ul>
+              </li>
+            ))
+          ) : (
+            visible.map(renderRow)
+          )}
+          {filtered.length > visible.length ? (
+            <li className="px-3 py-1 text-[10px] text-muted border-t border-default">
+              Showing {visible.length} of {filtered.length} — refine search to
+              see more
+            </li>
+          ) : null}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -177,9 +177,17 @@ export interface Provider {
   updated_at: string | null;
 }
 
+export interface ModelInfo {
+  id: string;
+  name: string;
+  lab: string;
+  context_window: number;
+  tags: string[];
+}
+
 export interface ProviderTypeInfo {
   endpoint: string | null;
-  models: string[] | null;
+  models: ModelInfo[];
   requires_api_key: boolean;
   requires_endpoint: boolean;
 }

--- a/src/clawrium/cli/clawctl/provider.py
+++ b/src/clawrium/cli/clawctl/provider.py
@@ -386,12 +386,16 @@ def get(
 
 
 def _emit_types(output: OutputFormat, *, no_headers: bool) -> None:
+    from clawrium.core.providers.models import get_model_count
+
     rows = [
         {
             "kind": "provider-type",
             "name": ptype,
             "endpoint": (cfg.get("endpoint") or ""),
-            "model_count": (len(cfg["models"]) if cfg.get("models") else 0),
+            "model_count": (
+                0 if ptype == "ollama" else get_model_count(ptype)
+            ),
         }
         for ptype, cfg in sorted(PROVIDER_MODELS.items())
     ]

--- a/src/clawrium/cli/provider.py
+++ b/src/clawrium/cli/provider.py
@@ -798,20 +798,21 @@ def _list_provider_types() -> None:
     """List all supported provider types."""
     console.print("[bold]Supported provider types:[/bold]\n")
 
+    from clawrium.core.providers.models import get_model_count
+
     for provider_type in _get_provider_types():
         config = PROVIDER_MODELS[provider_type]
         endpoint = config.get("endpoint")
-        models = config.get("models")
 
         if provider_type == "ollama":
             console.print(
                 f"  [cyan]{provider_type}[/cyan] - Self-hosted (dynamic model discovery)"
             )
         elif endpoint:
-            model_count = len(models) if models else 0
+            model_count = get_model_count(provider_type)
             console.print(f"  [cyan]{provider_type}[/cyan] - {model_count} models")
         else:
-            model_count = len(models) if models else 0
+            model_count = get_model_count(provider_type)
             console.print(
                 f"  [cyan]{provider_type}[/cyan] - {model_count} models (SDK-based)"
             )

--- a/src/clawrium/core/providers/models.json
+++ b/src/clawrium/core/providers/models.json
@@ -5,17 +5,6 @@
     "openai": {
       "models": [
         {
-          "id": "codex-mini-latest",
-          "name": "Codex Mini",
-          "lab": "OpenAI",
-          "context_window": 200000,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "multimodal"
-          ]
-        },
-        {
           "id": "gpt-3.5-turbo",
           "name": "GPT-3.5-turbo",
           "lab": "OpenAI",
@@ -395,6 +384,30 @@
           ]
         },
         {
+          "id": "gpt-5.5",
+          "name": "GPT-5.5",
+          "lab": "OpenAI",
+          "context_window": 1050000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "gpt-5.5-pro",
+          "name": "GPT-5.5 Pro",
+          "lab": "OpenAI",
+          "context_window": 1050000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
           "id": "chatgpt-image-latest",
           "name": "chatgpt-image-latest",
           "lab": "OpenAI",
@@ -742,6 +755,18 @@
           ]
         },
         {
+          "id": "claude-opus-4-8",
+          "name": "Claude Opus 4.8",
+          "lab": "Anthropic",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
           "id": "claude-3-sonnet-20240229",
           "name": "Claude Sonnet 3",
           "lab": "Anthropic",
@@ -851,8 +876,102 @@
     "openrouter": {
       "models": [
         {
+          "id": "aion-labs/aion-1.0",
+          "name": "Aion-1.0",
+          "lab": "Aion Labs",
+          "context_window": 131072,
+          "tags": [
+            "reasoning"
+          ]
+        },
+        {
+          "id": "aion-labs/aion-1.0-mini",
+          "name": "Aion-1.0-Mini",
+          "lab": "Aion Labs",
+          "context_window": 131072,
+          "tags": [
+            "reasoning",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "aion-labs/aion-2.0",
+          "name": "Aion-2.0",
+          "lab": "Aion Labs",
+          "context_window": 131072,
+          "tags": [
+            "reasoning"
+          ]
+        },
+        {
+          "id": "aion-labs/aion-rp-llama-3.1-8b",
+          "name": "Aion-RP 1.0 (8B)",
+          "lab": "Aion Labs",
+          "context_window": 32768,
+          "tags": [
+            "general"
+          ]
+        },
+        {
+          "id": "~anthropic/claude-haiku-latest",
+          "name": "Anthropic Claude Haiku Latest",
+          "lab": "~Anthropic",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "~anthropic/claude-sonnet-latest",
+          "name": "Anthropic Claude Sonnet Latest",
+          "lab": "~Anthropic",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openrouter/auto",
+          "name": "Auto Router",
+          "lab": "Openrouter",
+          "context_window": 2000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision",
+            "audio"
+          ]
+        },
+        {
+          "id": "openrouter/bodybuilder",
+          "name": "Body Builder (beta)",
+          "lab": "Openrouter",
+          "context_window": 128000,
+          "tags": [
+            "general"
+          ]
+        },
+        {
+          "id": "anthropic/claude-3-haiku",
+          "name": "Claude 3 Haiku",
+          "lab": "Anthropic",
+          "context_window": 200000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
           "id": "anthropic/claude-3.5-haiku",
-          "name": "Claude Haiku 3.5",
+          "name": "Claude 3.5 Haiku",
           "lab": "Anthropic",
           "context_window": 200000,
           "tags": [
@@ -863,7 +982,7 @@
         },
         {
           "id": "anthropic/claude-haiku-4.5",
-          "name": "Claude Haiku 4.5",
+          "name": "Claude Haiku 4.5 (latest)",
           "lab": "Anthropic",
           "context_window": 200000,
           "tags": [
@@ -887,7 +1006,7 @@
         },
         {
           "id": "anthropic/claude-opus-4.1",
-          "name": "Claude Opus 4.1",
+          "name": "Claude Opus 4.1 (latest)",
           "lab": "Anthropic",
           "context_window": 200000,
           "tags": [
@@ -899,7 +1018,7 @@
         },
         {
           "id": "anthropic/claude-opus-4.5",
-          "name": "Claude Opus 4.5",
+          "name": "Claude Opus 4.5 (latest)",
           "lab": "Anthropic",
           "context_window": 200000,
           "tags": [
@@ -922,6 +1041,18 @@
           ]
         },
         {
+          "id": "anthropic/claude-opus-4.6-fast",
+          "name": "Claude Opus 4.6 (Fast)",
+          "lab": "Anthropic",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
           "id": "anthropic/claude-opus-4.7",
           "name": "Claude Opus 4.7",
           "lab": "Anthropic",
@@ -934,10 +1065,46 @@
           ]
         },
         {
-          "id": "anthropic/claude-3.7-sonnet",
-          "name": "Claude Sonnet 3.7",
+          "id": "anthropic/claude-opus-4.7-fast",
+          "name": "Claude Opus 4.7 (Fast)",
           "lab": "Anthropic",
-          "context_window": 200000,
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "anthropic/claude-opus-4.8",
+          "name": "Claude Opus 4.8",
+          "lab": "Anthropic",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "anthropic/claude-opus-4.8-fast",
+          "name": "Claude Opus 4.8 (Fast)",
+          "lab": "Anthropic",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "~anthropic/claude-opus-latest",
+          "name": "Claude Opus Latest",
+          "lab": "~Anthropic",
+          "context_window": 1000000,
           "tags": [
             "reasoning",
             "tool-use",
@@ -949,7 +1116,7 @@
           "id": "anthropic/claude-sonnet-4",
           "name": "Claude Sonnet 4",
           "lab": "Anthropic",
-          "context_window": 200000,
+          "context_window": 1000000,
           "tags": [
             "reasoning",
             "tool-use",
@@ -959,7 +1126,7 @@
         },
         {
           "id": "anthropic/claude-sonnet-4.5",
-          "name": "Claude Sonnet 4.5",
+          "name": "Claude Sonnet 4.5 (latest)",
           "lab": "Anthropic",
           "context_window": 1000000,
           "tags": [
@@ -982,22 +1149,96 @@
           ]
         },
         {
+          "id": "alfredpros/codellama-7b-instruct-solidity",
+          "name": "CodeLLaMa 7B Instruct Solidity",
+          "lab": "Alfredpros",
+          "context_window": 4096,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "arcee-ai/coder-large",
+          "name": "Coder Large",
+          "lab": "Arcee Ai",
+          "context_window": 32768,
+          "tags": [
+            "general"
+          ]
+        },
+        {
           "id": "mistralai/codestral-2508",
           "name": "Codestral 2508",
           "lab": "Mistralai",
           "context_window": 256000,
           "tags": [
             "tool-use",
+            "multimodal"
+          ]
+        },
+        {
+          "id": "deepcogito/cogito-v2.1-671b",
+          "name": "Cogito v2.1 671B",
+          "lab": "Deepcogito",
+          "context_window": 128000,
+          "tags": [
+            "reasoning"
+          ]
+        },
+        {
+          "id": "cohere/command-a",
+          "name": "Command A",
+          "lab": "Cohere",
+          "context_window": 256000,
+          "tags": [
             "open-weights"
           ]
         },
         {
-          "id": "deepseek/deepseek-r1-distill-llama-70b",
-          "name": "DeepSeek R1 Distill Llama 70B",
-          "lab": "Deepseek",
-          "context_window": 8192,
+          "id": "cohere/command-r-08-2024",
+          "name": "Command R",
+          "lab": "Cohere",
+          "context_window": 128000,
           "tags": [
-            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "cohere/command-r-plus-08-2024",
+          "name": "Command R+",
+          "lab": "Cohere",
+          "context_window": 128000,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "cohere/command-r7b-12-2024",
+          "name": "Command R7B",
+          "lab": "Cohere",
+          "context_window": 128000,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "thedrummer/cydonia-24b-v4.1",
+          "name": "Cydonia 24B V4.1",
+          "lab": "Thedrummer",
+          "context_window": 131072,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "deepseek/deepseek-chat",
+          "name": "DeepSeek Chat",
+          "lab": "Deepseek",
+          "context_window": 128000,
+          "tags": [
+            "tool-use",
             "open-weights"
           ]
         },
@@ -1005,16 +1246,17 @@
           "id": "deepseek/deepseek-chat-v3-0324",
           "name": "DeepSeek V3 0324",
           "lab": "Deepseek",
-          "context_window": 16384,
+          "context_window": 163840,
           "tags": [
+            "tool-use",
             "open-weights"
           ]
         },
         {
-          "id": "deepseek/deepseek-v3.1-terminus",
-          "name": "DeepSeek V3.1 Terminus",
+          "id": "deepseek/deepseek-chat-v3.1",
+          "name": "DeepSeek V3.1",
           "lab": "Deepseek",
-          "context_window": 131072,
+          "context_window": 163840,
           "tags": [
             "reasoning",
             "tool-use",
@@ -1022,10 +1264,20 @@
           ]
         },
         {
-          "id": "deepseek/deepseek-v3.1-terminus:exacto",
-          "name": "DeepSeek V3.1 Terminus (exacto)",
-          "lab": "Deepseek",
+          "id": "nex-agi/deepseek-v3.1-nex-n1",
+          "name": "DeepSeek V3.1 Nex N1",
+          "lab": "Nex Agi",
           "context_window": 131072,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "deepseek/deepseek-v3.1-terminus",
+          "name": "DeepSeek V3.1 Terminus",
+          "lab": "Deepseek",
+          "context_window": 163840,
           "tags": [
             "reasoning",
             "tool-use",
@@ -1036,7 +1288,7 @@
           "id": "deepseek/deepseek-v3.2",
           "name": "DeepSeek V3.2",
           "lab": "Deepseek",
-          "context_window": 163840,
+          "context_window": 131072,
           "tags": [
             "reasoning",
             "tool-use",
@@ -1044,8 +1296,8 @@
           ]
         },
         {
-          "id": "deepseek/deepseek-v3.2-speciale",
-          "name": "DeepSeek V3.2 Speciale",
+          "id": "deepseek/deepseek-v3.2-exp",
+          "name": "DeepSeek V3.2 Exp",
           "lab": "Deepseek",
           "context_window": 163840,
           "tags": [
@@ -1055,10 +1307,10 @@
           ]
         },
         {
-          "id": "deepseek/deepseek-chat-v3.1",
-          "name": "DeepSeek-V3.1",
+          "id": "deepseek/deepseek-v4-flash",
+          "name": "DeepSeek V4 Flash",
           "lab": "Deepseek",
-          "context_window": 163840,
+          "context_window": 1048576,
           "tags": [
             "reasoning",
             "tool-use",
@@ -1066,10 +1318,21 @@
           ]
         },
         {
-          "id": "deepseek/deepseek-r1",
-          "name": "DeepSeek: R1",
+          "id": "deepseek/deepseek-v4-flash:free",
+          "name": "DeepSeek V4 Flash (free)",
           "lab": "Deepseek",
-          "context_window": 64000,
+          "context_window": 1048576,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "deepseek/deepseek-v4-pro",
+          "name": "DeepSeek V4 Pro",
+          "lab": "Deepseek",
+          "context_window": 1048576,
           "tags": [
             "reasoning",
             "tool-use",
@@ -1078,88 +1341,87 @@
         },
         {
           "id": "mistralai/devstral-2512",
-          "name": "Devstral 2 2512",
+          "name": "Devstral 2",
           "lab": "Mistralai",
           "context_window": 262144,
           "tags": [
             "tool-use",
+            "multimodal",
             "open-weights"
           ]
         },
         {
-          "id": "mistralai/devstral-medium-2507",
+          "id": "mistralai/devstral-medium",
           "name": "Devstral Medium",
           "lab": "Mistralai",
           "context_window": 131072,
           "tags": [
             "tool-use",
-            "open-weights"
+            "multimodal"
           ]
         },
         {
-          "id": "mistralai/devstral-small-2505",
-          "name": "Devstral Small",
-          "lab": "Mistralai",
-          "context_window": 128000,
-          "tags": [
-            "tool-use",
-            "open-weights"
-          ]
-        },
-        {
-          "id": "mistralai/devstral-small-2507",
+          "id": "mistralai/devstral-small",
           "name": "Devstral Small 1.1",
           "lab": "Mistralai",
           "context_window": 131072,
           "tags": [
             "tool-use",
+            "multimodal",
             "open-weights"
           ]
         },
         {
-          "id": "openrouter/elephant-alpha",
-          "name": "Elephant (free)",
-          "lab": "Openrouter",
-          "context_window": 262144,
+          "id": "baidu/ernie-4.5-21b-a3b",
+          "name": "ERNIE 4.5 21B A3B",
+          "lab": "Baidu",
+          "context_window": 120000,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "baidu/ernie-4.5-21b-a3b-thinking",
+          "name": "ERNIE 4.5 21B A3B Thinking",
+          "lab": "Baidu",
+          "context_window": 131072,
           "tags": [
             "reasoning",
-            "tool-use"
+            "open-weights"
           ]
         },
         {
-          "id": "black-forest-labs/flux.2-flex",
-          "name": "FLUX.2 Flex",
-          "lab": "Black Forest Labs",
-          "context_window": 67344,
+          "id": "baidu/ernie-4.5-300b-a47b",
+          "name": "ERNIE 4.5 300B A47B ",
+          "lab": "Baidu",
+          "context_window": 123000,
           "tags": [
-            "vision"
+            "open-weights"
           ]
         },
         {
-          "id": "black-forest-labs/flux.2-klein-4b",
-          "name": "FLUX.2 Klein 4B",
-          "lab": "Black Forest Labs",
-          "context_window": 40960,
+          "id": "baidu/ernie-4.5-vl-28b-a3b",
+          "name": "ERNIE 4.5 VL 28B A3B",
+          "lab": "Baidu",
+          "context_window": 30000,
           "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
             "open-weights",
             "vision"
           ]
         },
         {
-          "id": "black-forest-labs/flux.2-max",
-          "name": "FLUX.2 Max",
-          "lab": "Black Forest Labs",
-          "context_window": 46864,
+          "id": "baidu/ernie-4.5-vl-424b-a47b",
+          "name": "ERNIE 4.5 VL 424B A47B ",
+          "lab": "Baidu",
+          "context_window": 123000,
           "tags": [
-            "vision"
-          ]
-        },
-        {
-          "id": "black-forest-labs/flux.2-pro",
-          "name": "FLUX.2 Pro",
-          "lab": "Black Forest Labs",
-          "context_window": 46864,
-          "tags": [
+            "reasoning",
+            "multimodal",
+            "open-weights",
             "vision"
           ]
         },
@@ -1176,10 +1438,30 @@
           ]
         },
         {
-          "id": "z-ai/glm-4.5",
-          "name": "GLM 4.5",
+          "id": "z-ai/glm-4-32b",
+          "name": "GLM 4 32B ",
           "lab": "Z Ai",
           "context_window": 128000,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "z-ai/glm-4.5-air:free",
+          "name": "GLM 4.5 Air (free)",
+          "lab": "Z Ai",
+          "context_window": 131072,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "z-ai/glm-4.5",
+          "name": "GLM-4.5",
+          "lab": "Z Ai",
+          "context_window": 131072,
           "tags": [
             "reasoning",
             "tool-use",
@@ -1188,9 +1470,9 @@
         },
         {
           "id": "z-ai/glm-4.5-air",
-          "name": "GLM 4.5 Air",
+          "name": "GLM-4.5-Air",
           "lab": "Z Ai",
-          "context_window": 128000,
+          "context_window": 131070,
           "tags": [
             "reasoning",
             "tool-use",
@@ -1198,20 +1480,10 @@
           ]
         },
         {
-          "id": "z-ai/glm-4.5-air:free",
-          "name": "GLM 4.5 Air (free)",
-          "lab": "Z Ai",
-          "context_window": 128000,
-          "tags": [
-            "reasoning",
-            "open-weights"
-          ]
-        },
-        {
           "id": "z-ai/glm-4.5v",
-          "name": "GLM 4.5V",
+          "name": "GLM-4.5V",
           "lab": "Z Ai",
-          "context_window": 64000,
+          "context_window": 65536,
           "tags": [
             "reasoning",
             "tool-use",
@@ -1222,9 +1494,9 @@
         },
         {
           "id": "z-ai/glm-4.6",
-          "name": "GLM 4.6",
+          "name": "GLM-4.6",
           "lab": "Z Ai",
-          "context_window": 200000,
+          "context_window": 202752,
           "tags": [
             "reasoning",
             "tool-use",
@@ -1232,21 +1504,23 @@
           ]
         },
         {
-          "id": "z-ai/glm-4.6:exacto",
-          "name": "GLM 4.6 (exacto)",
+          "id": "z-ai/glm-4.6v",
+          "name": "GLM-4.6V",
           "lab": "Z Ai",
-          "context_window": 200000,
+          "context_window": 131072,
           "tags": [
             "reasoning",
             "tool-use",
-            "open-weights"
+            "multimodal",
+            "open-weights",
+            "vision"
           ]
         },
         {
           "id": "z-ai/glm-4.7",
           "name": "GLM-4.7",
           "lab": "Z Ai",
-          "context_window": 204800,
+          "context_window": 202752,
           "tags": [
             "reasoning",
             "tool-use",
@@ -1257,7 +1531,7 @@
           "id": "z-ai/glm-4.7-flash",
           "name": "GLM-4.7-Flash",
           "lab": "Z Ai",
-          "context_window": 200000,
+          "context_window": 202752,
           "tags": [
             "reasoning",
             "tool-use",
@@ -1292,50 +1566,134 @@
           "context_window": 202752,
           "tags": [
             "reasoning",
-            "tool-use",
-            "open-weights"
+            "tool-use"
           ]
         },
         {
-          "id": "openai/gpt-oss-120b",
-          "name": "GPT OSS 120B",
-          "lab": "Openai",
-          "context_window": 131072,
+          "id": "z-ai/glm-5v-turbo",
+          "name": "GLM-5V-Turbo",
+          "lab": "Z Ai",
+          "context_window": 202752,
           "tags": [
             "reasoning",
             "tool-use",
-            "open-weights"
+            "multimodal",
+            "vision"
           ]
         },
         {
-          "id": "openai/gpt-oss-120b:exacto",
-          "name": "GPT OSS 120B (exacto)",
+          "id": "openai/gpt-audio",
+          "name": "GPT Audio",
           "lab": "Openai",
-          "context_window": 131072,
+          "context_window": 128000,
           "tags": [
-            "reasoning",
             "tool-use",
-            "open-weights"
+            "multimodal",
+            "audio"
           ]
         },
         {
-          "id": "openai/gpt-oss-20b",
-          "name": "GPT OSS 20B",
+          "id": "openai/gpt-audio-mini",
+          "name": "GPT Audio Mini",
           "lab": "Openai",
-          "context_window": 131072,
+          "context_window": 128000,
           "tags": [
-            "reasoning",
             "tool-use",
-            "open-weights"
+            "multimodal",
+            "audio"
           ]
         },
         {
-          "id": "openai/gpt-oss-safeguard-20b",
-          "name": "GPT OSS Safeguard 20B",
+          "id": "openai/gpt-chat-latest",
+          "name": "GPT Chat Latest",
           "lab": "Openai",
-          "context_window": 131072,
+          "context_window": 400000,
           "tags": [
-            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-3.5-turbo-0613",
+          "name": "GPT-3.5 Turbo (older v0613)",
+          "lab": "Openai",
+          "context_window": 4095,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "openai/gpt-3.5-turbo-16k",
+          "name": "GPT-3.5 Turbo 16k",
+          "lab": "Openai",
+          "context_window": 16385,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "openai/gpt-3.5-turbo-instruct",
+          "name": "GPT-3.5 Turbo Instruct",
+          "lab": "Openai",
+          "context_window": 4095,
+          "tags": [
+            "general"
+          ]
+        },
+        {
+          "id": "openai/gpt-3.5-turbo",
+          "name": "GPT-3.5-turbo",
+          "lab": "Openai",
+          "context_window": 16385,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "openai/gpt-4",
+          "name": "GPT-4",
+          "lab": "Openai",
+          "context_window": 8191,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "openai/gpt-4-0314",
+          "name": "GPT-4 (older v0314)",
+          "lab": "Openai",
+          "context_window": 8191,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "openai/gpt-4-turbo",
+          "name": "GPT-4 Turbo",
+          "lab": "Openai",
+          "context_window": 128000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-4-1106-preview",
+          "name": "GPT-4 Turbo (older v1106)",
+          "lab": "Openai",
+          "context_window": 128000,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "openai/gpt-4-turbo-preview",
+          "name": "GPT-4 Turbo Preview",
+          "lab": "Openai",
+          "context_window": 128000,
+          "tags": [
             "tool-use"
           ]
         },
@@ -1352,7 +1710,7 @@
         },
         {
           "id": "openai/gpt-4.1-mini",
-          "name": "GPT-4.1 Mini",
+          "name": "GPT-4.1 mini",
           "lab": "Openai",
           "context_window": 1047576,
           "tags": [
@@ -1362,14 +1720,98 @@
           ]
         },
         {
-          "id": "openai/gpt-4o-mini",
-          "name": "GPT-4o-mini",
+          "id": "openai/gpt-4.1-nano",
+          "name": "GPT-4.1 nano",
+          "lab": "Openai",
+          "context_window": 1047576,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-4o",
+          "name": "GPT-4o",
           "lab": "Openai",
           "context_window": 128000,
           "tags": [
             "tool-use",
             "multimodal",
             "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-4o-2024-05-13",
+          "name": "GPT-4o (2024-05-13)",
+          "lab": "Openai",
+          "context_window": 128000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-4o-2024-08-06",
+          "name": "GPT-4o (2024-08-06)",
+          "lab": "Openai",
+          "context_window": 128000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-4o-2024-11-20",
+          "name": "GPT-4o (2024-11-20)",
+          "lab": "Openai",
+          "context_window": 128000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-4o-search-preview",
+          "name": "GPT-4o Search Preview",
+          "lab": "Openai",
+          "context_window": 128000,
+          "tags": [
+            "general"
+          ]
+        },
+        {
+          "id": "openai/gpt-4o-mini",
+          "name": "GPT-4o mini",
+          "lab": "Openai",
+          "context_window": 128000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-4o-mini-2024-07-18",
+          "name": "GPT-4o-mini (2024-07-18)",
+          "lab": "Openai",
+          "context_window": 128000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-4o-mini-search-preview",
+          "name": "GPT-4o-mini Search Preview",
+          "lab": "Openai",
+          "context_window": 128000,
+          "tags": [
+            "general"
           ]
         },
         {
@@ -1386,23 +1828,10 @@
         },
         {
           "id": "openai/gpt-5-chat",
-          "name": "GPT-5 Chat (latest)",
+          "name": "GPT-5 Chat",
           "lab": "Openai",
-          "context_window": 400000,
+          "context_window": 128000,
           "tags": [
-            "reasoning",
-            "multimodal",
-            "vision"
-          ]
-        },
-        {
-          "id": "openai/gpt-5-codex",
-          "name": "GPT-5 Codex",
-          "lab": "Openai",
-          "context_window": 400000,
-          "tags": [
-            "reasoning",
-            "tool-use",
             "multimodal",
             "vision"
           ]
@@ -1414,7 +1843,17 @@
           "context_window": 400000,
           "tags": [
             "reasoning",
-            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-5-image-mini",
+          "name": "GPT-5 Image Mini",
+          "lab": "Openai",
+          "context_window": 400000,
+          "tags": [
+            "reasoning",
             "multimodal",
             "vision"
           ]
@@ -1456,6 +1895,18 @@
           ]
         },
         {
+          "id": "openai/gpt-5-codex",
+          "name": "GPT-5-Codex",
+          "lab": "Openai",
+          "context_window": 400000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
           "id": "openai/gpt-5.1",
           "name": "GPT-5.1",
           "lab": "Openai",
@@ -1473,7 +1924,6 @@
           "lab": "Openai",
           "context_window": 128000,
           "tags": [
-            "reasoning",
             "tool-use",
             "multimodal",
             "vision"
@@ -1481,7 +1931,7 @@
         },
         {
           "id": "openai/gpt-5.1-codex",
-          "name": "GPT-5.1-Codex",
+          "name": "GPT-5.1 Codex",
           "lab": "Openai",
           "context_window": 400000,
           "tags": [
@@ -1493,7 +1943,7 @@
         },
         {
           "id": "openai/gpt-5.1-codex-max",
-          "name": "GPT-5.1-Codex-Max",
+          "name": "GPT-5.1 Codex Max",
           "lab": "Openai",
           "context_window": 400000,
           "tags": [
@@ -1505,7 +1955,7 @@
         },
         {
           "id": "openai/gpt-5.1-codex-mini",
-          "name": "GPT-5.1-Codex-Mini",
+          "name": "GPT-5.1 Codex mini",
           "lab": "Openai",
           "context_window": 400000,
           "tags": [
@@ -1533,6 +1983,17 @@
           "lab": "Openai",
           "context_window": 128000,
           "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-5.2-codex",
+          "name": "GPT-5.2 Codex",
+          "lab": "Openai",
+          "context_window": 400000,
+          "tags": [
             "reasoning",
             "tool-use",
             "multimodal",
@@ -1552,12 +2013,11 @@
           ]
         },
         {
-          "id": "openai/gpt-5.2-codex",
-          "name": "GPT-5.2-Codex",
+          "id": "openai/gpt-5.3-chat",
+          "name": "GPT-5.3 Chat",
           "lab": "Openai",
-          "context_window": 400000,
+          "context_window": 128000,
           "tags": [
-            "reasoning",
             "tool-use",
             "multimodal",
             "vision"
@@ -1565,7 +2025,7 @@
         },
         {
           "id": "openai/gpt-5.3-codex",
-          "name": "GPT-5.3-Codex",
+          "name": "GPT-5.3 Codex",
           "lab": "Openai",
           "context_window": 400000,
           "tags": [
@@ -1588,24 +2048,12 @@
           ]
         },
         {
-          "id": "openai/gpt-5.4-mini",
-          "name": "GPT-5.4 Mini",
+          "id": "openai/gpt-5.4-image-2",
+          "name": "GPT-5.4 Image 2",
           "lab": "Openai",
-          "context_window": 400000,
+          "context_window": 272000,
           "tags": [
             "reasoning",
-            "tool-use",
-            "multimodal",
-            "vision"
-          ]
-        },
-        {
-          "id": "openai/gpt-5.4-nano",
-          "name": "GPT-5.4 Nano",
-          "lab": "Openai",
-          "context_window": 400000,
-          "tags": [
-            "tool-use",
             "multimodal",
             "vision"
           ]
@@ -1623,8 +2071,68 @@
           ]
         },
         {
+          "id": "openai/gpt-5.4-mini",
+          "name": "GPT-5.4 mini",
+          "lab": "Openai",
+          "context_window": 400000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-5.4-nano",
+          "name": "GPT-5.4 nano",
+          "lab": "Openai",
+          "context_window": 400000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-5.5",
+          "name": "GPT-5.5",
+          "lab": "Openai",
+          "context_window": 1050000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/gpt-5.5-pro",
+          "name": "GPT-5.5 Pro",
+          "lab": "Openai",
+          "context_window": 1050000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
           "id": "google/gemini-2.0-flash-001",
           "name": "Gemini 2.0 Flash",
+          "lab": "Google",
+          "context_window": 1048576,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision",
+            "audio"
+          ]
+        },
+        {
+          "id": "google/gemini-2.0-flash-lite-001",
+          "name": "Gemini 2.0 Flash Lite",
           "lab": "Google",
           "context_window": 1048576,
           "tags": [
@@ -1648,21 +2156,8 @@
           ]
         },
         {
-          "id": "google/gemini-2.5-flash-lite",
-          "name": "Gemini 2.5 Flash Lite",
-          "lab": "Google",
-          "context_window": 1048576,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "multimodal",
-            "vision",
-            "audio"
-          ]
-        },
-        {
           "id": "google/gemini-2.5-flash-lite-preview-09-2025",
-          "name": "Gemini 2.5 Flash Lite Preview 09-25",
+          "name": "Gemini 2.5 Flash Lite Preview 09-2025",
           "lab": "Google",
           "context_window": 1048576,
           "tags": [
@@ -1674,8 +2169,8 @@
           ]
         },
         {
-          "id": "google/gemini-2.5-flash-preview-09-2025",
-          "name": "Gemini 2.5 Flash Preview 09-25",
+          "id": "google/gemini-2.5-flash-lite",
+          "name": "Gemini 2.5 Flash-Lite",
           "lab": "Google",
           "context_window": 1048576,
           "tags": [
@@ -1713,7 +2208,7 @@
           ]
         },
         {
-          "id": "google/gemini-2.5-pro-preview-06-05",
+          "id": "google/gemini-2.5-pro-preview",
           "name": "Gemini 2.5 Pro Preview 06-05",
           "lab": "Google",
           "context_window": 1048576,
@@ -1739,10 +2234,10 @@
           ]
         },
         {
-          "id": "google/gemini-3-pro-preview",
-          "name": "Gemini 3 Pro Preview",
+          "id": "google/gemini-3.1-flash-lite",
+          "name": "Gemini 3.1 Flash Lite",
           "lab": "Google",
-          "context_window": 1050000,
+          "context_window": 1048576,
           "tags": [
             "reasoning",
             "tool-use",
@@ -1791,8 +2286,21 @@
           ]
         },
         {
-          "id": "google/gemma-2-9b-it",
-          "name": "Gemma 2 9B",
+          "id": "google/gemini-3.5-flash",
+          "name": "Gemini 3.5 Flash",
+          "lab": "Google",
+          "context_window": 1048576,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision",
+            "audio"
+          ]
+        },
+        {
+          "id": "google/gemma-2-27b-it",
+          "name": "Gemma 2 27B",
           "lab": "Google",
           "context_window": 8192,
           "tags": [
@@ -1805,17 +2313,7 @@
           "lab": "Google",
           "context_window": 131072,
           "tags": [
-            "multimodal",
-            "open-weights",
-            "vision"
-          ]
-        },
-        {
-          "id": "google/gemma-3-12b-it:free",
-          "name": "Gemma 3 12B (free)",
-          "lab": "Google",
-          "context_window": 32768,
-          "tags": [
+            "tool-use",
             "multimodal",
             "open-weights",
             "vision"
@@ -1824,18 +2322,6 @@
         {
           "id": "google/gemma-3-27b-it",
           "name": "Gemma 3 27B",
-          "lab": "Google",
-          "context_window": 96000,
-          "tags": [
-            "tool-use",
-            "multimodal",
-            "open-weights",
-            "vision"
-          ]
-        },
-        {
-          "id": "google/gemma-3-27b-it:free",
-          "name": "Gemma 3 27B (free)",
           "lab": "Google",
           "context_window": 131072,
           "tags": [
@@ -1849,32 +2335,11 @@
           "id": "google/gemma-3-4b-it",
           "name": "Gemma 3 4B",
           "lab": "Google",
-          "context_window": 96000,
+          "context_window": 131072,
           "tags": [
             "multimodal",
             "open-weights",
             "vision"
-          ]
-        },
-        {
-          "id": "google/gemma-3-4b-it:free",
-          "name": "Gemma 3 4B (free)",
-          "lab": "Google",
-          "context_window": 32768,
-          "tags": [
-            "multimodal",
-            "open-weights",
-            "vision"
-          ]
-        },
-        {
-          "id": "google/gemma-3n-e2b-it:free",
-          "name": "Gemma 3n 2B (free)",
-          "lab": "Google",
-          "context_window": 8192,
-          "tags": [
-            "multimodal",
-            "open-weights"
           ]
         },
         {
@@ -1883,36 +2348,12 @@
           "lab": "Google",
           "context_window": 32768,
           "tags": [
-            "multimodal",
             "open-weights"
-          ]
-        },
-        {
-          "id": "google/gemma-3n-e4b-it:free",
-          "name": "Gemma 3n 4B (free)",
-          "lab": "Google",
-          "context_window": 8192,
-          "tags": [
-            "multimodal",
-            "open-weights"
-          ]
-        },
-        {
-          "id": "google/gemma-4-26b-a4b-it",
-          "name": "Gemma 4 26B A4B",
-          "lab": "Google",
-          "context_window": 262144,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "multimodal",
-            "open-weights",
-            "vision"
           ]
         },
         {
           "id": "google/gemma-4-26b-a4b-it:free",
-          "name": "Gemma 4 26B A4B (free)",
+          "name": "Gemma 4 26B A4B  (free)",
           "lab": "Google",
           "context_window": 262144,
           "tags": [
@@ -1924,8 +2365,8 @@
           ]
         },
         {
-          "id": "google/gemma-4-31b-it",
-          "name": "Gemma 4 31B",
+          "id": "google/gemma-4-26b-a4b-it",
+          "name": "Gemma 4 26B A4B IT",
           "lab": "Google",
           "context_window": 262144,
           "tags": [
@@ -1950,78 +2391,66 @@
           ]
         },
         {
-          "id": "x-ai/grok-3",
-          "name": "Grok 3",
-          "lab": "X Ai",
-          "context_window": 131072,
-          "tags": [
-            "tool-use"
-          ]
-        },
-        {
-          "id": "x-ai/grok-3-beta",
-          "name": "Grok 3 Beta",
-          "lab": "X Ai",
-          "context_window": 131072,
-          "tags": [
-            "tool-use"
-          ]
-        },
-        {
-          "id": "x-ai/grok-3-mini",
-          "name": "Grok 3 Mini",
-          "lab": "X Ai",
-          "context_window": 131072,
-          "tags": [
-            "reasoning",
-            "tool-use"
-          ]
-        },
-        {
-          "id": "x-ai/grok-3-mini-beta",
-          "name": "Grok 3 Mini Beta",
-          "lab": "X Ai",
-          "context_window": 131072,
-          "tags": [
-            "reasoning",
-            "tool-use"
-          ]
-        },
-        {
-          "id": "x-ai/grok-4",
-          "name": "Grok 4",
-          "lab": "X Ai",
-          "context_window": 256000,
-          "tags": [
-            "reasoning",
-            "tool-use"
-          ]
-        },
-        {
-          "id": "x-ai/grok-4-fast",
-          "name": "Grok 4 Fast",
-          "lab": "X Ai",
-          "context_window": 2000000,
+          "id": "google/gemma-4-31b-it",
+          "name": "Gemma 4 31B IT",
+          "lab": "Google",
+          "context_window": 262144,
           "tags": [
             "reasoning",
             "tool-use",
+            "multimodal",
+            "open-weights",
             "vision"
           ]
         },
         {
-          "id": "x-ai/grok-4.1-fast",
-          "name": "Grok 4.1 Fast",
-          "lab": "X Ai",
-          "context_window": 2000000,
+          "id": "~google/gemini-flash-latest",
+          "name": "Google Gemini Flash Latest",
+          "lab": "~Google",
+          "context_window": 1048576,
           "tags": [
             "reasoning",
             "tool-use",
-            "vision"
+            "multimodal",
+            "vision",
+            "audio"
           ]
         },
         {
-          "id": "x-ai/grok-4.20-beta",
-          "name": "Grok 4.20 Beta",
+          "id": "~google/gemini-pro-latest",
+          "name": "Google Gemini Pro Latest",
+          "lab": "~Google",
+          "context_window": 1048576,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision",
+            "audio"
+          ]
+        },
+        {
+          "id": "ibm-granite/granite-4.0-h-micro",
+          "name": "Granite 4.0 Micro",
+          "lab": "Ibm Granite",
+          "context_window": 131000,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "ibm-granite/granite-4.1-8b",
+          "name": "Granite 4.1 8B",
+          "lab": "Ibm Granite",
+          "context_window": 131072,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "x-ai/grok-4.20",
+          "name": "Grok 4.20",
           "lab": "X Ai",
           "context_window": 2000000,
           "tags": [
@@ -2032,8 +2461,8 @@
           ]
         },
         {
-          "id": "x-ai/grok-4.20-multi-agent-beta",
-          "name": "Grok 4.20 Multi - Agent Beta",
+          "id": "x-ai/grok-4.20-multi-agent",
+          "name": "Grok 4.20 Multi-Agent",
           "lab": "X Ai",
           "context_window": 2000000,
           "tags": [
@@ -2043,13 +2472,45 @@
           ]
         },
         {
-          "id": "x-ai/grok-code-fast-1",
-          "name": "Grok Code Fast 1",
+          "id": "x-ai/grok-4.3",
+          "name": "Grok 4.3",
+          "lab": "X Ai",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "x-ai/grok-build-0.1",
+          "name": "Grok Build 0.1",
           "lab": "X Ai",
           "context_window": 256000,
           "tags": [
             "reasoning",
-            "tool-use"
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "nousresearch/hermes-2-pro-llama-3-8b",
+          "name": "Hermes 2 Pro - Llama-3 8B",
+          "lab": "Nousresearch",
+          "context_window": 8192,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "nousresearch/hermes-3-llama-3.1-405b",
+          "name": "Hermes 3 405B Instruct",
+          "lab": "Nousresearch",
+          "context_window": 131072,
+          "tags": [
+            "open-weights"
           ]
         },
         {
@@ -2058,7 +2519,15 @@
           "lab": "Nousresearch",
           "context_window": 131072,
           "tags": [
-            "reasoning",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "nousresearch/hermes-3-llama-3.1-70b",
+          "name": "Hermes 3 70B Instruct",
+          "lab": "Nousresearch",
+          "context_window": 131072,
+          "tags": [
             "open-weights"
           ]
         },
@@ -2069,7 +2538,6 @@
           "context_window": 131072,
           "tags": [
             "reasoning",
-            "tool-use",
             "open-weights"
           ]
         },
@@ -2080,13 +2548,33 @@
           "context_window": 131072,
           "tags": [
             "reasoning",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "tencent/hunyuan-a13b-instruct",
+          "name": "Hunyuan A13B Instruct",
+          "lab": "Tencent",
+          "context_window": 131072,
+          "tags": [
+            "reasoning",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "tencent/hy3-preview",
+          "name": "Hy3 preview",
+          "lab": "Tencent",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
             "tool-use",
             "open-weights"
           ]
         },
         {
           "id": "prime-intellect/intellect-3",
-          "name": "Intellect 3",
+          "name": "INTELLECT-3",
           "lab": "Prime Intellect",
           "context_window": 131072,
           "tags": [
@@ -2096,8 +2584,45 @@
           ]
         },
         {
+          "id": "inflection/inflection-3-pi",
+          "name": "Inflection 3 Pi",
+          "lab": "Inflection",
+          "context_window": 8000,
+          "tags": [
+            "general"
+          ]
+        },
+        {
+          "id": "inflection/inflection-3-productivity",
+          "name": "Inflection 3 Productivity",
+          "lab": "Inflection",
+          "context_window": 8000,
+          "tags": [
+            "general"
+          ]
+        },
+        {
+          "id": "ai21/jamba-large-1.7",
+          "name": "Jamba Large 1.7",
+          "lab": "Ai21",
+          "context_window": 256000,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "kwaipilot/kat-coder-pro-v2",
+          "name": "KAT-Coder-Pro V2",
+          "lab": "Kwaipilot",
+          "context_window": 256000,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
           "id": "moonshotai/kimi-k2",
-          "name": "Kimi K2",
+          "name": "Kimi K2 0711",
           "lab": "Moonshotai",
           "context_window": 131072,
           "tags": [
@@ -2107,17 +2632,7 @@
         },
         {
           "id": "moonshotai/kimi-k2-0905",
-          "name": "Kimi K2 Instruct 0905",
-          "lab": "Moonshotai",
-          "context_window": 262144,
-          "tags": [
-            "tool-use",
-            "open-weights"
-          ]
-        },
-        {
-          "id": "moonshotai/kimi-k2-0905:exacto",
-          "name": "Kimi K2 Instruct 0905 (exacto)",
+          "name": "Kimi K2 0905",
           "lab": "Moonshotai",
           "context_window": 262144,
           "tags": [
@@ -2150,10 +2665,45 @@
           ]
         },
         {
+          "id": "moonshotai/kimi-k2.6",
+          "name": "Kimi K2.6",
+          "lab": "Moonshotai",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "moonshotai/kimi-k2.6:free",
+          "name": "Kimi K2.6 (free)",
+          "lab": "Moonshotai",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "liquid/lfm-2-24b-a2b",
+          "name": "LFM2-24B-A2B",
+          "lab": "Liquid",
+          "context_window": 32768,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
           "id": "liquid/lfm-2.5-1.2b-instruct:free",
           "name": "LFM2.5-1.2B-Instruct (free)",
           "lab": "Liquid",
-          "context_window": 131072,
+          "context_window": 32768,
           "tags": [
             "open-weights"
           ]
@@ -2162,9 +2712,124 @@
           "id": "liquid/lfm-2.5-1.2b-thinking:free",
           "name": "LFM2.5-1.2B-Thinking (free)",
           "lab": "Liquid",
-          "context_window": 131072,
+          "context_window": 32768,
           "tags": [
             "reasoning",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "poolside/laguna-m.1:free",
+          "name": "Laguna M.1 (free)",
+          "lab": "Poolside",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use"
+          ]
+        },
+        {
+          "id": "poolside/laguna-xs.2:free",
+          "name": "Laguna XS.2 (free)",
+          "lab": "Poolside",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "inclusionai/ling-2.6-1t",
+          "name": "Ling-2.6-1T",
+          "lab": "Inclusionai",
+          "context_window": 262144,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "inclusionai/ling-2.6-flash",
+          "name": "Ling-2.6-flash",
+          "lab": "Inclusionai",
+          "context_window": 262144,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "meta-llama/llama-3-70b-instruct",
+          "name": "Llama 3 70B Instruct",
+          "lab": "Meta Llama",
+          "context_window": 8192,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "meta-llama/llama-3-8b-instruct",
+          "name": "Llama 3 8B Instruct",
+          "lab": "Meta Llama",
+          "context_window": 8192,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "sao10k/l3-lunaris-8b",
+          "name": "Llama 3 8B Lunaris",
+          "lab": "Sao10K",
+          "context_window": 8192,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "sao10k/l3-euryale-70b",
+          "name": "Llama 3 Euryale 70B v2.1",
+          "lab": "Sao10K",
+          "context_window": 8192,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "sao10k/l3.1-70b-hanami-x1",
+          "name": "Llama 3.1 70B Hanami x1",
+          "lab": "Sao10K",
+          "context_window": 16000,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "meta-llama/llama-3.1-70b-instruct",
+          "name": "Llama 3.1 70B Instruct",
+          "lab": "Meta Llama",
+          "context_window": 131072,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "meta-llama/llama-3.1-8b-instruct",
+          "name": "Llama 3.1 8B Instruct",
+          "lab": "Meta Llama",
+          "context_window": 16384,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "sao10k/l3.1-euryale-70b",
+          "name": "Llama 3.1 Euryale 70B v2.2",
+          "lab": "Sao10K",
+          "context_window": 131072,
+          "tags": [
+            "tool-use",
             "open-weights"
           ]
         },
@@ -2180,10 +2845,100 @@
           ]
         },
         {
+          "id": "meta-llama/llama-3.2-1b-instruct",
+          "name": "Llama 3.2 1B Instruct",
+          "lab": "Meta Llama",
+          "context_window": 60000,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "meta-llama/llama-3.2-3b-instruct",
+          "name": "Llama 3.2 3B Instruct",
+          "lab": "Meta Llama",
+          "context_window": 80000,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
           "id": "meta-llama/llama-3.2-3b-instruct:free",
           "name": "Llama 3.2 3B Instruct (free)",
           "lab": "Meta Llama",
           "context_window": 131072,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "meta-llama/llama-3.3-70b-instruct:free",
+          "name": "Llama 3.3 70B Instruct (free)",
+          "lab": "Meta Llama",
+          "context_window": 65536,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "sao10k/l3.3-euryale-70b",
+          "name": "Llama 3.3 Euryale 70B",
+          "lab": "Sao10K",
+          "context_window": 131072,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+          "name": "Llama 3.3 Nemotron Super 49B V1.5",
+          "lab": "Nvidia",
+          "context_window": 131072,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "meta-llama/llama-4-maverick",
+          "name": "Llama 4 Maverick",
+          "lab": "Meta Llama",
+          "context_window": 1048576,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "meta-llama/llama-4-scout",
+          "name": "Llama 4 Scout",
+          "lab": "Meta Llama",
+          "context_window": 327680,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "meta-llama/llama-guard-3-8b",
+          "name": "Llama Guard 3 8B",
+          "lab": "Meta Llama",
+          "context_window": 131072,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "meta-llama/llama-guard-4-12b",
+          "name": "Llama Guard 4 12B",
+          "lab": "Meta Llama",
+          "context_window": 163840,
           "tags": [
             "multimodal",
             "open-weights",
@@ -2191,12 +2946,50 @@
           ]
         },
         {
-          "id": "meta-llama/llama-3.3-70b-instruct:free",
-          "name": "Llama 3.3 70B Instruct (free)",
+          "id": "meta-llama/llama-3.3-70b-instruct",
+          "name": "Llama-3.3-70B-Instruct",
           "lab": "Meta Llama",
           "context_window": 131072,
           "tags": [
             "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "google/lyria-3-clip-preview",
+          "name": "Lyria 3 Clip Preview",
+          "lab": "Google",
+          "context_window": 1048576,
+          "tags": [
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "google/lyria-3-pro-preview",
+          "name": "Lyria 3 Pro Preview",
+          "lab": "Google",
+          "context_window": 1048576,
+          "tags": [
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "arcee-ai/maestro-reasoning",
+          "name": "Maestro Reasoning",
+          "lab": "Arcee Ai",
+          "context_window": 131072,
+          "tags": [
+            "general"
+          ]
+        },
+        {
+          "id": "anthracite-org/magnum-v4-72b",
+          "name": "Magnum v4 72B",
+          "lab": "Anthracite Org",
+          "context_window": 16384,
+          "tags": [
             "open-weights"
           ]
         },
@@ -2208,15 +3001,6 @@
           "tags": [
             "reasoning",
             "tool-use"
-          ]
-        },
-        {
-          "id": "inception/mercury-edit-2",
-          "name": "Mercury Edit 2",
-          "lab": "Inception",
-          "context_window": 128000,
-          "tags": [
-            "reasoning"
           ]
         },
         {
@@ -2239,7 +3023,6 @@
             "reasoning",
             "tool-use",
             "multimodal",
-            "open-weights",
             "vision",
             "audio"
           ]
@@ -2247,6 +3030,30 @@
         {
           "id": "xiaomi/mimo-v2-pro",
           "name": "MiMo-V2-Pro",
+          "lab": "Xiaomi",
+          "context_window": 1048576,
+          "tags": [
+            "reasoning",
+            "tool-use"
+          ]
+        },
+        {
+          "id": "xiaomi/mimo-v2.5",
+          "name": "MiMo-V2.5",
+          "lab": "Xiaomi",
+          "context_window": 1048576,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision",
+            "audio"
+          ]
+        },
+        {
+          "id": "xiaomi/mimo-v2.5-pro",
+          "name": "MiMo-V2.5-Pro",
           "lab": "Xiaomi",
           "context_window": 1048576,
           "tags": [
@@ -2262,59 +3069,23 @@
           "context_window": 1000000,
           "tags": [
             "reasoning",
-            "tool-use",
-            "open-weights"
+            "tool-use"
           ]
         },
         {
-          "id": "minimax/minimax-m2",
-          "name": "MiniMax M2",
+          "id": "minimax/minimax-m2-her",
+          "name": "MiniMax M2-her",
           "lab": "Minimax",
-          "context_window": 196600,
+          "context_window": 65536,
           "tags": [
-            "reasoning",
-            "tool-use",
-            "open-weights"
-          ]
-        },
-        {
-          "id": "minimax/minimax-m2.1",
-          "name": "MiniMax M2.1",
-          "lab": "Minimax",
-          "context_window": 204800,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "open-weights"
-          ]
-        },
-        {
-          "id": "minimax/minimax-m2.5",
-          "name": "MiniMax M2.5",
-          "lab": "Minimax",
-          "context_window": 204800,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "open-weights"
+            "general"
           ]
         },
         {
           "id": "minimax/minimax-m2.5:free",
           "name": "MiniMax M2.5 (free)",
           "lab": "Minimax",
-          "context_window": 204800,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "open-weights"
-          ]
-        },
-        {
-          "id": "minimax/minimax-m2.7",
-          "name": "MiniMax M2.7",
-          "lab": "Minimax",
-          "context_window": 204800,
+          "context_window": 196608,
           "tags": [
             "reasoning",
             "tool-use",
@@ -2325,9 +3096,130 @@
           "id": "minimax/minimax-01",
           "name": "MiniMax-01",
           "lab": "Minimax",
-          "context_window": 1000000,
+          "context_window": 1000192,
+          "tags": [
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "minimax/minimax-m2",
+          "name": "MiniMax-M2",
+          "lab": "Minimax",
+          "context_window": 196608,
           "tags": [
             "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "minimax/minimax-m2.1",
+          "name": "MiniMax-M2.1",
+          "lab": "Minimax",
+          "context_window": 196608,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "minimax/minimax-m2.5",
+          "name": "MiniMax-M2.5",
+          "lab": "Minimax",
+          "context_window": 196608,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "minimax/minimax-m2.7",
+          "name": "MiniMax-M2.7",
+          "lab": "Minimax",
+          "context_window": 196608,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "mistralai/ministral-14b-2512",
+          "name": "Ministral 3 14B 2512",
+          "lab": "Mistralai",
+          "context_window": 262144,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "mistralai/ministral-3b-2512",
+          "name": "Ministral 3 3B 2512",
+          "lab": "Mistralai",
+          "context_window": 131072,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "mistralai/ministral-8b-2512",
+          "name": "Ministral 3 8B 2512",
+          "lab": "Mistralai",
+          "context_window": 262144,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "mistralai/mistral-large",
+          "name": "Mistral Large",
+          "lab": "Mistralai",
+          "context_window": 128000,
+          "tags": [
+            "tool-use",
+            "multimodal"
+          ]
+        },
+        {
+          "id": "mistralai/mistral-large-2411",
+          "name": "Mistral Large 2.1",
+          "lab": "Mistralai",
+          "context_window": 131072,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "mistralai/mistral-large-2407",
+          "name": "Mistral Large 2407",
+          "lab": "Mistralai",
+          "context_window": 131072,
+          "tags": [
+            "tool-use",
+            "multimodal"
+          ]
+        },
+        {
+          "id": "mistralai/mistral-large-2512",
+          "name": "Mistral Large 3",
+          "lab": "Mistralai",
+          "context_window": 262144,
+          "tags": [
             "tool-use",
             "multimodal",
             "open-weights",
@@ -2349,7 +3241,7 @@
           "id": "mistralai/mistral-medium-3.1",
           "name": "Mistral Medium 3.1",
           "lab": "Mistralai",
-          "context_window": 262144,
+          "context_window": 131072,
           "tags": [
             "tool-use",
             "multimodal",
@@ -2357,12 +3249,42 @@
           ]
         },
         {
+          "id": "mistralai/mistral-medium-3-5",
+          "name": "Mistral Medium 3.5",
+          "lab": "Mistralai",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "mistralai/mistral-nemo",
+          "name": "Mistral Nemo",
+          "lab": "Mistralai",
+          "context_window": 131072,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "mistralai/mistral-small-24b-instruct-2501",
+          "name": "Mistral Small 3",
+          "lab": "Mistralai",
+          "context_window": 32768,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
           "id": "mistralai/mistral-small-3.1-24b-instruct",
-          "name": "Mistral Small 3.1 24B Instruct",
+          "name": "Mistral Small 3.1 24B",
           "lab": "Mistralai",
           "context_window": 128000,
           "tags": [
-            "tool-use",
             "multimodal",
             "open-weights",
             "vision"
@@ -2370,9 +3292,9 @@
         },
         {
           "id": "mistralai/mistral-small-3.2-24b-instruct",
-          "name": "Mistral Small 3.2 24B Instruct",
+          "name": "Mistral Small 3.2 24B",
           "lab": "Mistralai",
-          "context_window": 96000,
+          "context_window": 128000,
           "tags": [
             "tool-use",
             "multimodal",
@@ -2394,6 +3316,99 @@
           ]
         },
         {
+          "id": "mistralai/mixtral-8x22b-instruct",
+          "name": "Mixtral 8x22B Instruct",
+          "lab": "Mistralai",
+          "context_window": 65536,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "~moonshotai/kimi-latest",
+          "name": "MoonshotAI Kimi Latest",
+          "lab": "~Moonshotai",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "morph/morph-v3-fast",
+          "name": "Morph V3 Fast",
+          "lab": "Morph",
+          "context_window": 81920,
+          "tags": [
+            "general"
+          ]
+        },
+        {
+          "id": "morph/morph-v3-large",
+          "name": "Morph V3 Large",
+          "lab": "Morph",
+          "context_window": 262144,
+          "tags": [
+            "general"
+          ]
+        },
+        {
+          "id": "gryphe/mythomax-l2-13b",
+          "name": "MythoMax 13B",
+          "lab": "Gryphe",
+          "context_window": 4096,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "google/gemini-2.5-flash-image",
+          "name": "Nano Banana",
+          "lab": "Google",
+          "context_window": 32768,
+          "tags": [
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "google/gemini-3.1-flash-image-preview",
+          "name": "Nano Banana 2",
+          "lab": "Google",
+          "context_window": 65536,
+          "tags": [
+            "reasoning",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "google/gemini-3-pro-image-preview",
+          "name": "Nano Banana Pro (Gemini 3 Pro Image Preview)",
+          "lab": "Google",
+          "context_window": 65536,
+          "tags": [
+            "reasoning",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "nvidia/nemotron-3-nano-30b-a3b",
+          "name": "Nemotron 3 Nano 30B A3B",
+          "lab": "Nvidia",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
           "id": "nvidia/nemotron-3-nano-30b-a3b:free",
           "name": "Nemotron 3 Nano 30B A3B (free)",
           "lab": "Nvidia",
@@ -2402,6 +3417,19 @@
             "reasoning",
             "tool-use",
             "open-weights"
+          ]
+        },
+        {
+          "id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+          "name": "Nemotron 3 Nano Omni (free)",
+          "lab": "Nvidia",
+          "context_window": 256000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision",
+            "audio"
           ]
         },
         {
@@ -2434,8 +3462,20 @@
           "tags": [
             "reasoning",
             "tool-use",
+            "multimodal",
             "open-weights",
             "vision"
+          ]
+        },
+        {
+          "id": "nvidia/nemotron-nano-9b-v2",
+          "name": "Nemotron Nano 9B V2",
+          "lab": "Nvidia",
+          "context_window": 131072,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
           ]
         },
         {
@@ -2445,6 +3485,209 @@
           "context_window": 128000,
           "tags": [
             "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "amazon/nova-2-lite-v1",
+          "name": "Nova 2 Lite",
+          "lab": "Amazon",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "amazon/nova-lite-v1",
+          "name": "Nova Lite 1.0",
+          "lab": "Amazon",
+          "context_window": 300000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "amazon/nova-micro-v1",
+          "name": "Nova Micro 1.0",
+          "lab": "Amazon",
+          "context_window": 128000,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "amazon/nova-premier-v1",
+          "name": "Nova Premier 1.0",
+          "lab": "Amazon",
+          "context_window": 1000000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "amazon/nova-pro-v1",
+          "name": "Nova Pro 1.0",
+          "lab": "Amazon",
+          "context_window": 300000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "allenai/olmo-3-32b-think",
+          "name": "Olmo 3 32B Think",
+          "lab": "Allenai",
+          "context_window": 65536,
+          "tags": [
+            "reasoning",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "~openai/gpt-latest",
+          "name": "OpenAI GPT Latest",
+          "lab": "~Openai",
+          "context_window": 1050000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "~openai/gpt-mini-latest",
+          "name": "OpenAI GPT Mini Latest",
+          "lab": "~Openai",
+          "context_window": 400000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openrouter/owl-alpha",
+          "name": "Owl Alpha",
+          "lab": "Openrouter",
+          "context_window": 1048756,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "writer/palmyra-x5",
+          "name": "Palmyra X5",
+          "lab": "Writer",
+          "context_window": 1040000,
+          "tags": [
+            "general"
+          ]
+        },
+        {
+          "id": "openrouter/pareto-code",
+          "name": "Pareto Code Router",
+          "lab": "Openrouter",
+          "context_window": 2000000,
+          "tags": [
+            "general"
+          ]
+        },
+        {
+          "id": "perceptron/perceptron-mk1",
+          "name": "Perceptron Mk1",
+          "lab": "Perceptron",
+          "context_window": 32768,
+          "tags": [
+            "reasoning",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "microsoft/phi-4",
+          "name": "Phi 4",
+          "lab": "Microsoft",
+          "context_window": 16384,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "microsoft/phi-4-mini-instruct",
+          "name": "Phi 4 Mini Instruct",
+          "lab": "Microsoft",
+          "context_window": 128000,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "mistralai/pixtral-large-2411",
+          "name": "Pixtral Large 2411",
+          "lab": "Mistralai",
+          "context_window": 131072,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen-plus-2025-07-28",
+          "name": "Qwen Plus 0728",
+          "lab": "Qwen",
+          "context_window": 1000000,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "qwen/qwen-plus-2025-07-28:thinking",
+          "name": "Qwen Plus 0728 (thinking)",
+          "lab": "Qwen",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use"
+          ]
+        },
+        {
+          "id": "qwen/qwen-plus",
+          "name": "Qwen-Plus",
+          "lab": "Qwen",
+          "context_window": 1000000,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "qwen/qwen-2.5-72b-instruct",
+          "name": "Qwen2.5 72B Instruct",
+          "lab": "Qwen",
+          "context_window": 32768,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "qwen/qwen-2.5-7b-instruct",
+          "name": "Qwen2.5 7B Instruct",
+          "lab": "Qwen",
+          "context_window": 32768,
+          "tags": [
             "tool-use",
             "open-weights"
           ]
@@ -2462,7 +3705,7 @@
           "id": "qwen/qwen2.5-vl-72b-instruct",
           "name": "Qwen2.5 VL 72B Instruct",
           "lab": "Qwen",
-          "context_window": 32768,
+          "context_window": 32000,
           "tags": [
             "multimodal",
             "open-weights",
@@ -2470,7 +3713,29 @@
           ]
         },
         {
-          "id": "qwen/qwen3-235b-a22b-07-25",
+          "id": "qwen/qwen3-14b",
+          "name": "Qwen3 14B",
+          "lab": "Qwen",
+          "context_window": 40960,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "qwen/qwen3-235b-a22b",
+          "name": "Qwen3 235B A22B",
+          "lab": "Qwen",
+          "context_window": 131072,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "qwen/qwen3-235b-a22b-2507",
           "name": "Qwen3 235B A22B Instruct 2507",
           "lab": "Qwen",
           "context_window": 262144,
@@ -2491,10 +3756,21 @@
           ]
         },
         {
+          "id": "qwen/qwen3-30b-a3b",
+          "name": "Qwen3 30B A3B",
+          "lab": "Qwen",
+          "context_window": 40960,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
           "id": "qwen/qwen3-30b-a3b-instruct-2507",
           "name": "Qwen3 30B A3B Instruct 2507",
           "lab": "Qwen",
-          "context_window": 262000,
+          "context_window": 262144,
           "tags": [
             "tool-use",
             "open-weights"
@@ -2504,7 +3780,7 @@
           "id": "qwen/qwen3-30b-a3b-thinking-2507",
           "name": "Qwen3 30B A3B Thinking 2507",
           "lab": "Qwen",
-          "context_window": 262000,
+          "context_window": 131072,
           "tags": [
             "reasoning",
             "tool-use",
@@ -2512,21 +3788,23 @@
           ]
         },
         {
-          "id": "qwen/qwen3-coder",
-          "name": "Qwen3 Coder",
+          "id": "qwen/qwen3-32b",
+          "name": "Qwen3 32B",
           "lab": "Qwen",
-          "context_window": 262144,
+          "context_window": 40960,
           "tags": [
+            "reasoning",
             "tool-use",
             "open-weights"
           ]
         },
         {
-          "id": "qwen/qwen3-coder:exacto",
-          "name": "Qwen3 Coder (exacto)",
+          "id": "qwen/qwen3-8b",
+          "name": "Qwen3 8B",
           "lab": "Qwen",
-          "context_window": 131072,
+          "context_window": 40960,
           "tags": [
+            "reasoning",
             "tool-use",
             "open-weights"
           ]
@@ -2542,10 +3820,49 @@
           ]
         },
         {
+          "id": "qwen/qwen3-coder",
+          "name": "Qwen3 Coder 480B A35B",
+          "lab": "Qwen",
+          "context_window": 262144,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "qwen/qwen3-coder:free",
+          "name": "Qwen3 Coder 480B A35B (free)",
+          "lab": "Qwen",
+          "context_window": 262000,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
           "id": "qwen/qwen3-coder-flash",
           "name": "Qwen3 Coder Flash",
           "lab": "Qwen",
-          "context_window": 128000,
+          "context_window": 1000000,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "qwen/qwen3-coder-next",
+          "name": "Qwen3 Coder Next",
+          "lab": "Qwen",
+          "context_window": 262144,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "qwen/qwen3-coder-plus",
+          "name": "Qwen3 Coder Plus",
+          "lab": "Qwen",
+          "context_window": 1000000,
           "tags": [
             "tool-use"
           ]
@@ -2553,6 +3870,15 @@
         {
           "id": "qwen/qwen3-max",
           "name": "Qwen3 Max",
+          "lab": "Qwen",
+          "context_window": 262144,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "qwen/qwen3-max-thinking",
+          "name": "Qwen3 Max Thinking",
           "lab": "Qwen",
           "context_window": 262144,
           "tags": [
@@ -2571,14 +3897,111 @@
           ]
         },
         {
+          "id": "qwen/qwen3-next-80b-a3b-instruct:free",
+          "name": "Qwen3 Next 80B A3B Instruct (free)",
+          "lab": "Qwen",
+          "context_window": 262144,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
           "id": "qwen/qwen3-next-80b-a3b-thinking",
           "name": "Qwen3 Next 80B A3B Thinking",
           "lab": "Qwen",
-          "context_window": 262144,
+          "context_window": 131072,
           "tags": [
             "reasoning",
             "tool-use",
             "open-weights"
+          ]
+        },
+        {
+          "id": "qwen/qwen3-vl-235b-a22b-instruct",
+          "name": "Qwen3 VL 235B A22B Instruct",
+          "lab": "Qwen",
+          "context_window": 262144,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3-vl-235b-a22b-thinking",
+          "name": "Qwen3 VL 235B A22B Thinking",
+          "lab": "Qwen",
+          "context_window": 131072,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3-vl-30b-a3b-instruct",
+          "name": "Qwen3 VL 30B A3B Instruct",
+          "lab": "Qwen",
+          "context_window": 131072,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3-vl-30b-a3b-thinking",
+          "name": "Qwen3 VL 30B A3B Thinking",
+          "lab": "Qwen",
+          "context_window": 131072,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3-vl-32b-instruct",
+          "name": "Qwen3 VL 32B Instruct",
+          "lab": "Qwen",
+          "context_window": 131072,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3-vl-8b-instruct",
+          "name": "Qwen3 VL 8B Instruct",
+          "lab": "Qwen",
+          "context_window": 131072,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3-vl-8b-thinking",
+          "name": "Qwen3 VL 8B Thinking",
+          "lab": "Qwen",
+          "context_window": 131072,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
           ]
         },
         {
@@ -2607,6 +4030,130 @@
           ]
         },
         {
+          "id": "qwen/qwen3.5-plus-20260420",
+          "name": "Qwen3.5 Plus 2026-04-20",
+          "lab": "Qwen",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3.5-122b-a10b",
+          "name": "Qwen3.5-122B-A10B",
+          "lab": "Qwen",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3.5-27b",
+          "name": "Qwen3.5-27B",
+          "lab": "Qwen",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3.5-35b-a3b",
+          "name": "Qwen3.5-35B-A3B",
+          "lab": "Qwen",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3.5-9b",
+          "name": "Qwen3.5-9B",
+          "lab": "Qwen",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3.5-flash-02-23",
+          "name": "Qwen3.5-Flash",
+          "lab": "Qwen",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3.6-27b",
+          "name": "Qwen3.6 27B",
+          "lab": "Qwen",
+          "context_window": 262140,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3.6-35b-a3b",
+          "name": "Qwen3.6 35B A3B",
+          "lab": "Qwen",
+          "context_window": 262140,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3.6-flash",
+          "name": "Qwen3.6 Flash",
+          "lab": "Qwen",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "qwen/qwen3.6-max-preview",
+          "name": "Qwen3.6 Max Preview",
+          "lab": "Qwen",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use"
+          ]
+        },
+        {
           "id": "qwen/qwen3.6-plus",
           "name": "Qwen3.6 Plus",
           "lab": "Qwen",
@@ -2619,10 +4166,151 @@
           ]
         },
         {
-          "id": "qwen/qwen3.5-flash-02-23",
-          "name": "Qwen: Qwen3.5-Flash",
+          "id": "qwen/qwen3.7-max",
+          "name": "Qwen3.7 Max",
           "lab": "Qwen",
           "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use"
+          ]
+        },
+        {
+          "id": "deepseek/deepseek-r1",
+          "name": "R1",
+          "lab": "Deepseek",
+          "context_window": 64000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "deepseek/deepseek-r1-0528",
+          "name": "R1 0528",
+          "lab": "Deepseek",
+          "context_window": 163840,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "deepseek/deepseek-r1-distill-llama-70b",
+          "name": "R1 Distill Llama 70B",
+          "lab": "Deepseek",
+          "context_window": 131072,
+          "tags": [
+            "reasoning",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "deepseek/deepseek-r1-distill-qwen-32b",
+          "name": "R1 Distill Qwen 32B",
+          "lab": "Deepseek",
+          "context_window": 32768,
+          "tags": [
+            "reasoning",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "undi95/remm-slerp-l2-13b",
+          "name": "ReMM SLERP 13B",
+          "lab": "Undi95",
+          "context_window": 6144,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "rekaai/reka-edge",
+          "name": "Reka Edge",
+          "lab": "Rekaai",
+          "context_window": 16384,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "rekaai/reka-flash-3",
+          "name": "Reka Flash 3",
+          "lab": "Rekaai",
+          "context_window": 65536,
+          "tags": [
+            "reasoning",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "relace/relace-apply-3",
+          "name": "Relace Apply 3",
+          "lab": "Relace",
+          "context_window": 256000,
+          "tags": [
+            "general"
+          ]
+        },
+        {
+          "id": "relace/relace-search",
+          "name": "Relace Search",
+          "lab": "Relace",
+          "context_window": 256000,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "inclusionai/ring-2.6-1t",
+          "name": "Ring-2.6-1T",
+          "lab": "Inclusionai",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use"
+          ]
+        },
+        {
+          "id": "essentialai/rnj-1-instruct",
+          "name": "Rnj 1 Instruct",
+          "lab": "Essentialai",
+          "context_window": 32768,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "thedrummer/rocinante-12b",
+          "name": "Rocinante 12B",
+          "lab": "Thedrummer",
+          "context_window": 32768,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "mistralai/mistral-saba",
+          "name": "Saba",
+          "lab": "Mistralai",
+          "context_window": 32768,
+          "tags": [
+            "tool-use",
+            "multimodal"
+          ]
+        },
+        {
+          "id": "bytedance-seed/seed-1.6",
+          "name": "Seed 1.6",
+          "lab": "Bytedance Seed",
+          "context_window": 262144,
           "tags": [
             "reasoning",
             "tool-use",
@@ -2631,42 +4319,108 @@
           ]
         },
         {
-          "id": "sourceful/riverflow-v2-fast-preview",
-          "name": "Riverflow V2 Fast Preview",
-          "lab": "Sourceful",
-          "context_window": 8192,
-          "tags": [
-            "open-weights",
-            "vision"
-          ]
-        },
-        {
-          "id": "sourceful/riverflow-v2-max-preview",
-          "name": "Riverflow V2 Max Preview",
-          "lab": "Sourceful",
-          "context_window": 8192,
-          "tags": [
-            "open-weights",
-            "vision"
-          ]
-        },
-        {
-          "id": "sourceful/riverflow-v2-standard-preview",
-          "name": "Riverflow V2 Standard Preview",
-          "lab": "Sourceful",
-          "context_window": 8192,
-          "tags": [
-            "open-weights",
-            "vision"
-          ]
-        },
-        {
-          "id": "bytedance-seed/seedream-4.5",
-          "name": "Seedream 4.5",
+          "id": "bytedance-seed/seed-1.6-flash",
+          "name": "Seed 1.6 Flash",
           "lab": "Bytedance Seed",
-          "context_window": 4096,
+          "context_window": 262144,
           "tags": [
-            "open-weights",
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "bytedance-seed/seed-2.0-lite",
+          "name": "Seed-2.0-Lite",
+          "lab": "Bytedance Seed",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "bytedance-seed/seed-2.0-mini",
+          "name": "Seed-2.0-Mini",
+          "lab": "Bytedance Seed",
+          "context_window": 262144,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "thedrummer/skyfall-36b-v2",
+          "name": "Skyfall 36B V2",
+          "lab": "Thedrummer",
+          "context_window": 32768,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "perplexity/sonar",
+          "name": "Sonar",
+          "lab": "Perplexity",
+          "context_window": 127072,
+          "tags": [
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "perplexity/sonar-deep-research",
+          "name": "Sonar Deep Research",
+          "lab": "Perplexity",
+          "context_window": 128000,
+          "tags": [
+            "reasoning"
+          ]
+        },
+        {
+          "id": "perplexity/sonar-pro",
+          "name": "Sonar Pro",
+          "lab": "Perplexity",
+          "context_window": 200000,
+          "tags": [
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "perplexity/sonar-pro-search",
+          "name": "Sonar Pro Search",
+          "lab": "Perplexity",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "perplexity/sonar-reasoning-pro",
+          "name": "Sonar Reasoning Pro",
+          "lab": "Perplexity",
+          "context_window": 128000,
+          "tags": [
+            "reasoning",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "arcee-ai/spotlight",
+          "name": "Spotlight",
+          "lab": "Arcee Ai",
+          "context_window": 131072,
+          "tags": [
+            "multimodal",
             "vision"
           ]
         },
@@ -2674,7 +4428,7 @@
           "id": "stepfun/step-3.5-flash",
           "name": "Step 3.5 Flash",
           "lab": "Stepfun",
-          "context_window": 256000,
+          "context_window": 262144,
           "tags": [
             "reasoning",
             "tool-use",
@@ -2682,13 +4436,24 @@
           ]
         },
         {
-          "id": "arcee-ai/trinity-large-preview:free",
-          "name": "Trinity Large Preview",
-          "lab": "Arcee Ai",
+          "id": "stepfun/step-3.7-flash",
+          "name": "Step 3.7 Flash",
+          "lab": "Stepfun",
+          "context_window": 256000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "switchpoint/router",
+          "name": "Switchpoint Router",
+          "lab": "Switchpoint",
           "context_window": 131072,
           "tags": [
-            "tool-use",
-            "open-weights"
+            "reasoning"
           ]
         },
         {
@@ -2703,6 +4468,28 @@
           ]
         },
         {
+          "id": "arcee-ai/trinity-mini",
+          "name": "Trinity Mini",
+          "lab": "Arcee Ai",
+          "context_window": 131072,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "bytedance/ui-tars-1.5-7b",
+          "name": "UI-TARS 7B ",
+          "lab": "Bytedance",
+          "context_window": 128000,
+          "tags": [
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
           "id": "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
           "name": "Uncensored (free)",
           "lab": "Cognitivecomputations",
@@ -2712,8 +4499,79 @@
           ]
         },
         {
+          "id": "thedrummer/unslopnemo-12b",
+          "name": "UnslopNemo 12B",
+          "lab": "Thedrummer",
+          "context_window": 32768,
+          "tags": [
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "arcee-ai/virtuoso-large",
+          "name": "Virtuoso Large",
+          "lab": "Arcee Ai",
+          "context_window": 131072,
+          "tags": [
+            "tool-use"
+          ]
+        },
+        {
+          "id": "mistralai/voxtral-small-24b-2507",
+          "name": "Voxtral Small 24B 2507",
+          "lab": "Mistralai",
+          "context_window": 32000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "audio"
+          ]
+        },
+        {
+          "id": "mancer/weaver",
+          "name": "Weaver (alpha)",
+          "lab": "Mancer",
+          "context_window": 8000,
+          "tags": [
+            "general"
+          ]
+        },
+        {
+          "id": "microsoft/wizardlm-2-8x22b",
+          "name": "WizardLM-2 8x22B",
+          "lab": "Microsoft",
+          "context_window": 65535,
+          "tags": [
+            "open-weights"
+          ]
+        },
+        {
+          "id": "openai/gpt-oss-120b",
+          "name": "gpt-oss-120b",
+          "lab": "Openai",
+          "context_window": 131072,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
           "id": "openai/gpt-oss-120b:free",
           "name": "gpt-oss-120b (free)",
+          "lab": "Openai",
+          "context_window": 131072,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "open-weights"
+          ]
+        },
+        {
+          "id": "openai/gpt-oss-20b",
+          "name": "gpt-oss-20b",
           "lab": "Openai",
           "context_window": 131072,
           "tags": [
@@ -2734,9 +4592,9 @@
           ]
         },
         {
-          "id": "nvidia/nemotron-nano-9b-v2",
-          "name": "nvidia-nemotron-nano-9b-v2",
-          "lab": "Nvidia",
+          "id": "openai/gpt-oss-safeguard-20b",
+          "name": "gpt-oss-safeguard-20b",
+          "lab": "Openai",
           "context_window": 131072,
           "tags": [
             "reasoning",
@@ -2745,8 +4603,113 @@
           ]
         },
         {
+          "id": "openai/o1",
+          "name": "o1",
+          "lab": "Openai",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/o1-pro",
+          "name": "o1-pro",
+          "lab": "Openai",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/o3",
+          "name": "o3",
+          "lab": "Openai",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/o3-mini-high",
+          "name": "o3 Mini High",
+          "lab": "Openai",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal"
+          ]
+        },
+        {
+          "id": "openai/o3-deep-research",
+          "name": "o3-deep-research",
+          "lab": "Openai",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/o3-mini",
+          "name": "o3-mini",
+          "lab": "Openai",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal"
+          ]
+        },
+        {
+          "id": "openai/o3-pro",
+          "name": "o3-pro",
+          "lab": "Openai",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/o4-mini-high",
+          "name": "o4 Mini High",
+          "lab": "Openai",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
           "id": "openai/o4-mini",
-          "name": "o4 Mini",
+          "name": "o4-mini",
+          "lab": "Openai",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "openai/o4-mini-deep-research",
+          "name": "o4-mini-deep-research",
           "lab": "Openai",
           "context_window": 200000,
           "tags": [
@@ -2761,22 +4724,24 @@
     "bedrock": {
       "models": [
         {
-          "id": "anthropic.claude-3-haiku-20240307-v1:0",
-          "name": "Claude Haiku 3",
+          "id": "au.anthropic.claude-opus-4-6-v1",
+          "name": "AU Anthropic Claude Opus 4.6",
           "lab": "AWS",
-          "context_window": 200000,
+          "context_window": 1000000,
           "tags": [
+            "reasoning",
             "tool-use",
             "multimodal",
             "vision"
           ]
         },
         {
-          "id": "anthropic.claude-3-5-haiku-20241022-v1:0",
-          "name": "Claude Haiku 3.5",
+          "id": "au.anthropic.claude-sonnet-4-6",
+          "name": "AU Anthropic Claude Sonnet 4.6",
           "lab": "AWS",
-          "context_window": 200000,
+          "context_window": 1000000,
           "tags": [
+            "reasoning",
             "tool-use",
             "multimodal",
             "vision"
@@ -2785,6 +4750,18 @@
         {
           "id": "anthropic.claude-haiku-4-5-20251001-v1:0",
           "name": "Claude Haiku 4.5",
+          "lab": "AWS",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
+          "name": "Claude Haiku 4.5 (AU)",
           "lab": "AWS",
           "context_window": 200000,
           "tags": [
@@ -2821,30 +4798,6 @@
         {
           "id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
           "name": "Claude Haiku 4.5 (US)",
-          "lab": "AWS",
-          "context_window": 200000,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "multimodal",
-            "vision"
-          ]
-        },
-        {
-          "id": "anthropic.claude-opus-4-20250514-v1:0",
-          "name": "Claude Opus 4",
-          "lab": "AWS",
-          "context_window": 200000,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "multimodal",
-            "vision"
-          ]
-        },
-        {
-          "id": "us.anthropic.claude-opus-4-20250514-v1:0",
-          "name": "Claude Opus 4 (US)",
           "lab": "AWS",
           "context_window": 200000,
           "tags": [
@@ -3011,6 +4964,18 @@
           ]
         },
         {
+          "id": "jp.anthropic.claude-opus-4-7",
+          "name": "Claude Opus 4.7 (JP)",
+          "lab": "AWS",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
           "id": "us.anthropic.claude-opus-4-7",
           "name": "Claude Opus 4.7 (US)",
           "lab": "AWS",
@@ -3023,43 +4988,10 @@
           ]
         },
         {
-          "id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-          "name": "Claude Sonnet 3.5",
+          "id": "anthropic.claude-opus-4-8",
+          "name": "Claude Opus 4.8",
           "lab": "AWS",
-          "context_window": 200000,
-          "tags": [
-            "tool-use",
-            "multimodal",
-            "vision"
-          ]
-        },
-        {
-          "id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-          "name": "Claude Sonnet 3.5 v2",
-          "lab": "AWS",
-          "context_window": 200000,
-          "tags": [
-            "tool-use",
-            "multimodal",
-            "vision"
-          ]
-        },
-        {
-          "id": "anthropic.claude-3-7-sonnet-20250219-v1:0",
-          "name": "Claude Sonnet 3.7",
-          "lab": "AWS",
-          "context_window": 200000,
-          "tags": [
-            "tool-use",
-            "multimodal",
-            "vision"
-          ]
-        },
-        {
-          "id": "anthropic.claude-sonnet-4-20250514-v1:0",
-          "name": "Claude Sonnet 4",
-          "lab": "AWS",
-          "context_window": 200000,
+          "context_window": 1000000,
           "tags": [
             "reasoning",
             "tool-use",
@@ -3068,10 +5000,10 @@
           ]
         },
         {
-          "id": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
-          "name": "Claude Sonnet 4 (EU)",
+          "id": "au.anthropic.claude-opus-4-8",
+          "name": "Claude Opus 4.8 (AU)",
           "lab": "AWS",
-          "context_window": 200000,
+          "context_window": 1000000,
           "tags": [
             "reasoning",
             "tool-use",
@@ -3080,10 +5012,10 @@
           ]
         },
         {
-          "id": "global.anthropic.claude-sonnet-4-20250514-v1:0",
-          "name": "Claude Sonnet 4 (Global)",
+          "id": "eu.anthropic.claude-opus-4-8",
+          "name": "Claude Opus 4.8 (EU)",
           "lab": "AWS",
-          "context_window": 200000,
+          "context_window": 1000000,
           "tags": [
             "reasoning",
             "tool-use",
@@ -3092,10 +5024,34 @@
           ]
         },
         {
-          "id": "us.anthropic.claude-sonnet-4-20250514-v1:0",
-          "name": "Claude Sonnet 4 (US)",
+          "id": "global.anthropic.claude-opus-4-8",
+          "name": "Claude Opus 4.8 (Global)",
           "lab": "AWS",
-          "context_window": 200000,
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "jp.anthropic.claude-opus-4-8",
+          "name": "Claude Opus 4.8 (JP)",
+          "lab": "AWS",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "us.anthropic.claude-opus-4-8",
+          "name": "Claude Opus 4.8 (US)",
+          "lab": "AWS",
+          "context_window": 1000000,
           "tags": [
             "reasoning",
             "tool-use",
@@ -3106,6 +5062,18 @@
         {
           "id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
           "name": "Claude Sonnet 4.5",
+          "lab": "AWS",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "au.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "name": "Claude Sonnet 4.5 (AU)",
           "lab": "AWS",
           "context_window": 200000,
           "tags": [
@@ -3130,6 +5098,18 @@
         {
           "id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
           "name": "Claude Sonnet 4.5 (Global)",
+          "lab": "AWS",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
+          "name": "Claude Sonnet 4.5 (JP)",
           "lab": "AWS",
           "context_window": 200000,
           "tags": [
@@ -3188,6 +5168,18 @@
           ]
         },
         {
+          "id": "jp.anthropic.claude-sonnet-4-6",
+          "name": "Claude Sonnet 4.6 (JP)",
+          "lab": "AWS",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
           "id": "us.anthropic.claude-sonnet-4-6",
           "name": "Claude Sonnet 4.6 (US)",
           "lab": "AWS",
@@ -3202,6 +5194,16 @@
         {
           "id": "deepseek.r1-v1:0",
           "name": "DeepSeek-R1",
+          "lab": "AWS",
+          "context_window": 128000,
+          "tags": [
+            "reasoning",
+            "tool-use"
+          ]
+        },
+        {
+          "id": "us.deepseek.r1-v1:0",
+          "name": "DeepSeek-R1 (US)",
           "lab": "AWS",
           "context_window": 128000,
           "tags": [
@@ -3327,7 +5329,7 @@
           "id": "moonshot.kimi-k2-thinking",
           "name": "Kimi K2 Thinking",
           "lab": "AWS",
-          "context_window": 256000,
+          "context_window": 262143,
           "tags": [
             "reasoning",
             "tool-use",
@@ -3338,22 +5340,12 @@
           "id": "moonshotai.kimi-k2.5",
           "name": "Kimi K2.5",
           "lab": "AWS",
-          "context_window": 256000,
+          "context_window": 262143,
           "tags": [
             "reasoning",
             "tool-use",
             "open-weights",
             "vision"
-          ]
-        },
-        {
-          "id": "meta.llama3-1-405b-instruct-v1:0",
-          "name": "Llama 3.1 405B Instruct",
-          "lab": "AWS",
-          "context_window": 128000,
-          "tags": [
-            "tool-use",
-            "open-weights"
           ]
         },
         {
@@ -3374,50 +5366,6 @@
           "tags": [
             "tool-use",
             "open-weights"
-          ]
-        },
-        {
-          "id": "meta.llama3-2-11b-instruct-v1:0",
-          "name": "Llama 3.2 11B Instruct",
-          "lab": "AWS",
-          "context_window": 128000,
-          "tags": [
-            "tool-use",
-            "multimodal",
-            "open-weights",
-            "vision"
-          ]
-        },
-        {
-          "id": "meta.llama3-2-1b-instruct-v1:0",
-          "name": "Llama 3.2 1B Instruct",
-          "lab": "AWS",
-          "context_window": 131000,
-          "tags": [
-            "tool-use",
-            "open-weights"
-          ]
-        },
-        {
-          "id": "meta.llama3-2-3b-instruct-v1:0",
-          "name": "Llama 3.2 3B Instruct",
-          "lab": "AWS",
-          "context_window": 131000,
-          "tags": [
-            "tool-use",
-            "open-weights"
-          ]
-        },
-        {
-          "id": "meta.llama3-2-90b-instruct-v1:0",
-          "name": "Llama 3.2 90B Instruct",
-          "lab": "AWS",
-          "context_window": 128000,
-          "tags": [
-            "tool-use",
-            "multimodal",
-            "open-weights",
-            "vision"
           ]
         },
         {
@@ -3443,8 +5391,32 @@
           ]
         },
         {
+          "id": "us.meta.llama4-maverick-17b-instruct-v1:0",
+          "name": "Llama 4 Maverick 17B Instruct (US)",
+          "lab": "AWS",
+          "context_window": 1000000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
           "id": "meta.llama4-scout-17b-instruct-v1:0",
           "name": "Llama 4 Scout 17B Instruct",
+          "lab": "AWS",
+          "context_window": 3500000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "open-weights",
+            "vision"
+          ]
+        },
+        {
+          "id": "us.meta.llama4-scout-17b-instruct-v1:0",
+          "name": "Llama 4 Scout 17B Instruct (US)",
           "lab": "AWS",
           "context_window": 3500000,
           "tags": [
@@ -3611,18 +5583,6 @@
           ]
         },
         {
-          "id": "amazon.nova-premier-v1:0",
-          "name": "Nova Premier",
-          "lab": "AWS",
-          "context_window": 1000000,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "multimodal",
-            "vision"
-          ]
-        },
-        {
           "id": "amazon.nova-pro-v1:0",
           "name": "Nova Pro",
           "lab": "AWS",
@@ -3779,6 +5739,160 @@
     "vertex": {
       "models": [
         {
+          "id": "claude-3-5-haiku@20241022",
+          "name": "Claude Haiku 3.5",
+          "lab": "Google",
+          "context_window": 200000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "claude-haiku-4-5@20251001",
+          "name": "Claude Haiku 4.5",
+          "lab": "Google",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "claude-opus-4@20250514",
+          "name": "Claude Opus 4",
+          "lab": "Google",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "claude-opus-4-1@20250805",
+          "name": "Claude Opus 4.1",
+          "lab": "Google",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "claude-opus-4-5@20251101",
+          "name": "Claude Opus 4.5",
+          "lab": "Google",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "claude-opus-4-6@default",
+          "name": "Claude Opus 4.6",
+          "lab": "Google",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "claude-opus-4-7@default",
+          "name": "Claude Opus 4.7",
+          "lab": "Google",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "claude-opus-4-8@default",
+          "name": "Claude Opus 4.8",
+          "lab": "Google",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "claude-3-5-sonnet@20241022",
+          "name": "Claude Sonnet 3.5 v2",
+          "lab": "Google",
+          "context_window": 200000,
+          "tags": [
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "claude-3-7-sonnet@20250219",
+          "name": "Claude Sonnet 3.7",
+          "lab": "Google",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "claude-sonnet-4@20250514",
+          "name": "Claude Sonnet 4",
+          "lab": "Google",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "claude-sonnet-4-5@20250929",
+          "name": "Claude Sonnet 4.5",
+          "lab": "Google",
+          "context_window": 200000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
+          "id": "claude-sonnet-4-6@default",
+          "name": "Claude Sonnet 4.6",
+          "lab": "Google",
+          "context_window": 1000000,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision"
+          ]
+        },
+        {
           "id": "deepseek-ai/deepseek-v3.1-maas",
           "name": "DeepSeek V3.1",
           "lab": "Google",
@@ -3858,7 +5972,7 @@
         },
         {
           "id": "gemini-2.0-flash-lite",
-          "name": "Gemini 2.0 Flash Lite",
+          "name": "Gemini 2.0 Flash-Lite",
           "lab": "Google",
           "context_window": 1048576,
           "tags": [
@@ -3871,19 +5985,6 @@
         {
           "id": "gemini-2.5-flash",
           "name": "Gemini 2.5 Flash",
-          "lab": "Google",
-          "context_window": 1048576,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "multimodal",
-            "vision",
-            "audio"
-          ]
-        },
-        {
-          "id": "gemini-2.5-flash-lite",
-          "name": "Gemini 2.5 Flash Lite",
           "lab": "Google",
           "context_window": 1048576,
           "tags": [
@@ -3908,45 +6009,6 @@
           ]
         },
         {
-          "id": "gemini-2.5-flash-lite-preview-09-2025",
-          "name": "Gemini 2.5 Flash Lite Preview 09-25",
-          "lab": "Google",
-          "context_window": 1048576,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "multimodal",
-            "vision",
-            "audio"
-          ]
-        },
-        {
-          "id": "gemini-2.5-flash-preview-04-17",
-          "name": "Gemini 2.5 Flash Preview 04-17",
-          "lab": "Google",
-          "context_window": 1048576,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "multimodal",
-            "vision",
-            "audio"
-          ]
-        },
-        {
-          "id": "gemini-2.5-flash-preview-05-20",
-          "name": "Gemini 2.5 Flash Preview 05-20",
-          "lab": "Google",
-          "context_window": 1048576,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "multimodal",
-            "vision",
-            "audio"
-          ]
-        },
-        {
           "id": "gemini-2.5-flash-preview-09-2025",
           "name": "Gemini 2.5 Flash Preview 09-25",
           "lab": "Google",
@@ -3960,34 +6022,21 @@
           ]
         },
         {
+          "id": "gemini-2.5-flash-lite",
+          "name": "Gemini 2.5 Flash-Lite",
+          "lab": "Google",
+          "context_window": 1048576,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision",
+            "audio"
+          ]
+        },
+        {
           "id": "gemini-2.5-pro",
           "name": "Gemini 2.5 Pro",
-          "lab": "Google",
-          "context_window": 1048576,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "multimodal",
-            "vision",
-            "audio"
-          ]
-        },
-        {
-          "id": "gemini-2.5-pro-preview-05-06",
-          "name": "Gemini 2.5 Pro Preview 05-06",
-          "lab": "Google",
-          "context_window": 1048576,
-          "tags": [
-            "reasoning",
-            "tool-use",
-            "multimodal",
-            "vision",
-            "audio"
-          ]
-        },
-        {
-          "id": "gemini-2.5-pro-preview-06-05",
-          "name": "Gemini 2.5 Pro Preview 06-05",
           "lab": "Google",
           "context_window": 1048576,
           "tags": [
@@ -4025,6 +6074,32 @@
           ]
         },
         {
+          "id": "gemini-3.1-flash-lite",
+          "name": "Gemini 3.1 Flash Lite",
+          "lab": "Google",
+          "context_window": 1048576,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision",
+            "audio"
+          ]
+        },
+        {
+          "id": "gemini-3.1-flash-lite-preview",
+          "name": "Gemini 3.1 Flash Lite Preview",
+          "lab": "Google",
+          "context_window": 1048576,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision",
+            "audio"
+          ]
+        },
+        {
           "id": "gemini-3.1-pro-preview",
           "name": "Gemini 3.1 Pro Preview",
           "lab": "Google",
@@ -4040,6 +6115,19 @@
         {
           "id": "gemini-3.1-pro-preview-customtools",
           "name": "Gemini 3.1 Pro Preview Custom Tools",
+          "lab": "Google",
+          "context_window": 1048576,
+          "tags": [
+            "reasoning",
+            "tool-use",
+            "multimodal",
+            "vision",
+            "audio"
+          ]
+        },
+        {
+          "id": "gemini-3.5-flash",
+          "name": "Gemini 3.5 Flash",
           "lab": "Google",
           "context_window": 1048576,
           "tags": [
@@ -4259,7 +6347,7 @@
         },
         {
           "id": "glm-5v-turbo",
-          "name": "glm-5v-turbo",
+          "name": "GLM-5V-Turbo",
           "lab": "Zhipu AI",
           "context_window": 200000,
           "tags": [

--- a/src/clawrium/core/providers/storage.py
+++ b/src/clawrium/core/providers/storage.py
@@ -49,92 +49,44 @@ PROVIDERS_FILE = "providers.json"
 # Provider name pattern: starts with letter, alphanumeric/underscore/hyphen, 1-64 chars
 PROVIDER_NAME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]{0,63}$")
 
-# Hardcoded model registry for supported providers
+# Provider type registry: endpoint defaults and auth requirements.
+# Model lists are sourced from the catalog at src/clawrium/core/providers/models.json
+# via clawrium.core.providers.models. Do not hardcode model IDs here.
 PROVIDER_MODELS: dict[str, dict] = {
     "openai": {
         "endpoint": "https://api.openai.com/v1",
-        "models": [
-            "gpt-4o",
-            "gpt-4o-mini",
-            "gpt-4-turbo",
-            "gpt-4",
-            "gpt-3.5-turbo",
-            "o1",
-            "o1-mini",
-            "o1-preview",
-        ],
+        "requires_api_key": True,
+        "requires_endpoint": False,
     },
     "anthropic": {
         "endpoint": "https://api.anthropic.com",
-        "models": [
-            "claude-opus-4-20250514",
-            "claude-sonnet-4-20250514",
-            "claude-3-5-sonnet-20241022",
-            "claude-3-5-haiku-20241022",
-            "claude-3-opus-20240229",
-            "claude-3-sonnet-20240229",
-            "claude-3-haiku-20240307",
-        ],
+        "requires_api_key": True,
+        "requires_endpoint": False,
     },
     "openrouter": {
         "endpoint": "https://openrouter.ai/api/v1",
-        "models": [
-            "anthropic/claude-opus-4",
-            "anthropic/claude-sonnet-4",
-            "openai/gpt-4o",
-            "openai/o1",
-            "openai/gpt-oss-120b",
-            "google/gemini-2.5-pro",
-            "meta-llama/llama-4-maverick",
-            "deepseek/deepseek-chat-v3",
-            "deepseek/deepseek-r1",
-            "qwen/qwen3-235b",
-            "z-ai/glm-4.5",
-            "z-ai/glm-4.5-air",
-            "moonshotai/kimi-k2",
-            "minimax/minimax-m1",
-        ],
+        "requires_api_key": True,
+        "requires_endpoint": False,
     },
     "bedrock": {
         "endpoint": None,  # Uses AWS SDK
-        "models": [
-            "anthropic.claude-opus-4-20250514-v1:0",
-            "anthropic.claude-sonnet-4-20250514-v1:0",
-            "anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "anthropic.claude-3-5-haiku-20241022-v1:0",
-            "anthropic.claude-3-haiku-20240307-v1:0",
-            "amazon.titan-text-express-v1",
-            "amazon.titan-text-lite-v1",
-            "meta.llama3-70b-instruct-v1:0",
-        ],
+        "requires_api_key": True,
+        "requires_endpoint": False,
     },
     "vertex": {
         "endpoint": None,  # Uses Google SDK, requires project_id
-        "models": [
-            "gemini-2.5-pro",
-            "gemini-2.5-flash",
-            "gemini-2.5-flash-lite",
-            "gemini-2.0-flash",
-            "gemini-1.5-pro",
-            "gemini-1.5-flash",
-        ],
+        "requires_api_key": True,
+        "requires_endpoint": False,
     },
     "zai": {
         "endpoint": "https://open.bigmodel.cn/api/paas/v4",
-        "models": [
-            "glm-4",
-            "glm-4-plus",
-            "glm-4-air",
-            "glm-4-airx",
-            "glm-4-flash",
-            "glm-4-long",
-            "glm-4v",
-            "glm-4v-plus",
-        ],
+        "requires_api_key": True,
+        "requires_endpoint": False,
     },
     "ollama": {
         "endpoint": None,  # User-provided
-        "models": None,  # Dynamic discovery via fetch_ollama_models()
+        "requires_api_key": False,
+        "requires_endpoint": True,
     },
 }
 
@@ -332,19 +284,29 @@ def validate_ollama_url(url: str) -> str:
 
 
 def get_models_for_type(provider_type: str) -> list[str] | None:
-    """Get available models for a provider type.
+    """Get available model IDs for a provider type.
 
     Args:
         provider_type: Provider type to get models for.
 
     Returns:
-        List of model names, or None for dynamic providers (like Ollama).
+        List of model ID strings, or None for dynamic providers (like Ollama).
 
     Raises:
         InvalidProviderTypeError: If type is not valid.
     """
     validate_provider_type(provider_type)
-    return PROVIDER_MODELS[provider_type]["models"]
+    if provider_type == "ollama":
+        return None
+    from clawrium.core.providers.models import (
+        ProviderNotFoundError,
+        get_model_ids_for_provider,
+    )
+
+    try:
+        return get_model_ids_for_provider(provider_type)
+    except ProviderNotFoundError:
+        return []
 
 
 def fetch_ollama_models(endpoint: str, timeout: int = 10) -> list[str]:

--- a/src/clawrium/gui/routes/providers.py
+++ b/src/clawrium/gui/routes/providers.py
@@ -113,14 +113,23 @@ async def list_providers():
 
 @router.get("/types")
 async def provider_types():
-    """Get available provider types and their model catalogs."""
+    """Get available provider types with rich model metadata from the catalog.
+
+    Ollama returns an empty model list — its models are populated per-instance
+    from the host's Ollama daemon via `available_models`, not from the catalog.
+    """
+    catalog = load_model_catalog()
     types = {}
     for ptype, info in PROVIDER_MODELS.items():
+        if ptype == "ollama":
+            models: list[dict] = []
+        else:
+            models = list(catalog["providers"].get(ptype, {}).get("models", []))
         types[ptype] = {
             "endpoint": info.get("endpoint"),
-            "models": info.get("models"),
-            "requires_api_key": ptype != "ollama",
-            "requires_endpoint": ptype == "ollama",
+            "models": models,
+            "requires_api_key": info.get("requires_api_key", ptype != "ollama"),
+            "requires_endpoint": info.get("requires_endpoint", ptype == "ollama"),
         }
     return {"types": types}
 

--- a/tests/test_cli_provider.py
+++ b/tests/test_cli_provider.py
@@ -579,7 +579,7 @@ class TestProviderBedrock:
                 "--type",
                 "bedrock",
                 "--model",
-                "anthropic.claude-sonnet-4-20250514-v1:0",
+                "anthropic.claude-sonnet-4-5-20250929-v1:0",
             ],
             input="AKIAIOSFODNN7EXAMPLE\nwJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n",
         )
@@ -600,7 +600,7 @@ class TestProviderBedrock:
         assert providers[0]["name"] == "my-bedrock"
         assert providers[0]["type"] == "bedrock"
         assert (
-            providers[0]["default_model"] == "anthropic.claude-sonnet-4-20250514-v1:0"
+            providers[0]["default_model"] == "anthropic.claude-sonnet-4-5-20250929-v1:0"
         )
         # AWS credentials should NOT be in providers.json (stored in secrets)
         assert "access_key" not in providers[0]
@@ -666,7 +666,7 @@ class TestProviderBedrock:
         bedrock_provider = {
             "name": "my-bedrock",
             "type": "bedrock",
-            "default_model": "anthropic.claude-sonnet-4-20250514-v1:0",
+            "default_model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "created_at": "2026-04-01T00:00:00+00:00",
             "updated_at": "2026-04-01T00:00:00+00:00",
         }
@@ -689,7 +689,7 @@ class TestProviderBedrock:
         bedrock_provider = {
             "name": "my-bedrock",
             "type": "bedrock",
-            "default_model": "anthropic.claude-sonnet-4-20250514-v1:0",
+            "default_model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "created_at": "2026-04-01T00:00:00+00:00",
             "updated_at": "2026-04-01T00:00:00+00:00",
         }
@@ -713,7 +713,7 @@ class TestProviderBedrock:
         bedrock_provider = {
             "name": "my-bedrock",
             "type": "bedrock",
-            "default_model": "anthropic.claude-sonnet-4-20250514-v1:0",
+            "default_model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "created_at": "2026-04-01T00:00:00+00:00",
             "updated_at": "2026-04-01T00:00:00+00:00",
         }
@@ -744,7 +744,7 @@ class TestProviderBedrock:
         bedrock_provider = {
             "name": "my-bedrock",
             "type": "bedrock",
-            "default_model": "anthropic.claude-sonnet-4-20250514-v1:0",
+            "default_model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "created_at": "2026-04-01T00:00:00+00:00",
             "updated_at": "2026-04-01T00:00:00+00:00",
         }
@@ -776,7 +776,7 @@ class TestProviderBedrock:
         bedrock_provider = {
             "name": "my-bedrock",
             "type": "bedrock",
-            "default_model": "anthropic.claude-sonnet-4-20250514-v1:0",
+            "default_model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "created_at": "2026-04-01T00:00:00+00:00",
             "updated_at": "2026-04-01T00:00:00+00:00",
         }

--- a/tests/test_core_providers.py
+++ b/tests/test_core_providers.py
@@ -635,7 +635,9 @@ class TestProviderModelsConstant:
         assert set(PROVIDER_MODELS.keys()) == expected
 
     def test_cloud_providers_have_models(self):
-        """Cloud providers have non-empty model lists."""
+        """Cloud providers have non-empty model lists in the catalog."""
+        from clawrium.core.providers.storage import get_models_for_type
+
         cloud_providers = [
             "openai",
             "anthropic",
@@ -645,13 +647,15 @@ class TestProviderModelsConstant:
             "zai",
         ]
         for provider_type in cloud_providers:
-            models = PROVIDER_MODELS[provider_type]["models"]
+            models = get_models_for_type(provider_type)
             assert isinstance(models, list)
             assert len(models) > 0, f"{provider_type} should have models"
 
     def test_ollama_has_no_hardcoded_models(self):
-        """Ollama provider has None for models (dynamic discovery)."""
-        assert PROVIDER_MODELS["ollama"]["models"] is None
+        """Ollama provider returns None for models (dynamic discovery)."""
+        from clawrium.core.providers.storage import get_models_for_type
+
+        assert get_models_for_type("ollama") is None
 
     def test_providers_with_endpoints(self):
         """Providers with fixed endpoints have them set."""

--- a/tests/test_gui_route_providers.py
+++ b/tests/test_gui_route_providers.py
@@ -254,3 +254,34 @@ def test_update_cloud_provider_skips_ollama_validation(monkeypatch):
     body = ProviderUpdate(endpoint="http://169.254.169.254/")
     asyncio.run(update_provider_endpoint("cloud", body))
     assert captured["result"]["endpoint"] == "http://169.254.169.254/"
+
+
+# ─── provider_types endpoint ────────────────────────────────────────
+
+
+def test_provider_types_returns_rich_model_metadata():
+    """`/types` returns full ModelInfo objects for cloud providers."""
+    result = asyncio.run(providers_mod.provider_types())
+    types = result["types"]
+
+    # All seven provider types are present
+    assert set(types.keys()) == {
+        "openai", "anthropic", "openrouter", "bedrock",
+        "vertex", "zai", "ollama",
+    }
+
+    # Cloud providers carry catalog-shaped models
+    openai_models = types["openai"]["models"]
+    assert isinstance(openai_models, list)
+    assert len(openai_models) > 0
+    first = openai_models[0]
+    for key in ("id", "name", "lab", "context_window", "tags"):
+        assert key in first, f"missing {key} in ModelInfo"
+
+    # Auth flags survive
+    assert types["openai"]["requires_api_key"] is True
+    assert types["ollama"]["requires_api_key"] is False
+    assert types["ollama"]["requires_endpoint"] is True
+
+    # Ollama yields an empty catalog (models populated per-instance)
+    assert types["ollama"]["models"] == []

--- a/website/docs/agent-support/providers/anthropic.md
+++ b/website/docs/agent-support/providers/anthropic.md
@@ -23,6 +23,7 @@ Official Anthropic Claude API integration.
 | `claude-opus-4-5` | Claude Opus 4.5 (latest) | 200K |
 | `claude-opus-4-6` | Claude Opus 4.6 | 1M |
 | `claude-opus-4-7` | Claude Opus 4.7 | 1M |
+| `claude-opus-4-8` | Claude Opus 4.8 | 1M |
 | `claude-3-sonnet-20240229` | Claude Sonnet 3 | 200K |
 | `claude-3-5-sonnet-20240620` | Claude Sonnet 3.5 | 200K |
 | `claude-3-5-sonnet-20241022` | Claude Sonnet 3.5 v2 | 200K |

--- a/website/docs/agent-support/providers/bedrock.md
+++ b/website/docs/agent-support/providers/bedrock.md
@@ -9,14 +9,13 @@ Amazon Bedrock provides managed access to foundation models through AWS infrastr
 <!-- MODEL-TABLE:START -->
 | Model ID | Name | Context |
 |----------|------|---------|
-| `anthropic.claude-3-haiku-20240307-v1:0` | Claude Haiku 3 | 200K |
-| `anthropic.claude-3-5-haiku-20241022-v1:0` | Claude Haiku 3.5 | 200K |
+| `au.anthropic.claude-opus-4-6-v1` | AU Anthropic Claude Opus 4.6 | 1M |
+| `au.anthropic.claude-sonnet-4-6` | AU Anthropic Claude Sonnet 4.6 | 1M |
 | `anthropic.claude-haiku-4-5-20251001-v1:0` | Claude Haiku 4.5 | 200K |
+| `au.anthropic.claude-haiku-4-5-20251001-v1:0` | Claude Haiku 4.5 (AU) | 200K |
 | `eu.anthropic.claude-haiku-4-5-20251001-v1:0` | Claude Haiku 4.5 (EU) | 200K |
 | `global.anthropic.claude-haiku-4-5-20251001-v1:0` | Claude Haiku 4.5 (Global) | 200K |
 | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | Claude Haiku 4.5 (US) | 200K |
-| `anthropic.claude-opus-4-20250514-v1:0` | Claude Opus 4 | 200K |
-| `us.anthropic.claude-opus-4-20250514-v1:0` | Claude Opus 4 (US) | 200K |
 | `anthropic.claude-opus-4-1-20250805-v1:0` | Claude Opus 4.1 | 200K |
 | `us.anthropic.claude-opus-4-1-20250805-v1:0` | Claude Opus 4.1 (US) | 200K |
 | `anthropic.claude-opus-4-5-20251101-v1:0` | Claude Opus 4.5 | 200K |
@@ -30,23 +29,27 @@ Amazon Bedrock provides managed access to foundation models through AWS infrastr
 | `anthropic.claude-opus-4-7` | Claude Opus 4.7 | 1M |
 | `eu.anthropic.claude-opus-4-7` | Claude Opus 4.7 (EU) | 1M |
 | `global.anthropic.claude-opus-4-7` | Claude Opus 4.7 (Global) | 1M |
+| `jp.anthropic.claude-opus-4-7` | Claude Opus 4.7 (JP) | 1M |
 | `us.anthropic.claude-opus-4-7` | Claude Opus 4.7 (US) | 1M |
-| `anthropic.claude-3-5-sonnet-20240620-v1:0` | Claude Sonnet 3.5 | 200K |
-| `anthropic.claude-3-5-sonnet-20241022-v2:0` | Claude Sonnet 3.5 v2 | 200K |
-| `anthropic.claude-3-7-sonnet-20250219-v1:0` | Claude Sonnet 3.7 | 200K |
-| `anthropic.claude-sonnet-4-20250514-v1:0` | Claude Sonnet 4 | 200K |
-| `eu.anthropic.claude-sonnet-4-20250514-v1:0` | Claude Sonnet 4 (EU) | 200K |
-| `global.anthropic.claude-sonnet-4-20250514-v1:0` | Claude Sonnet 4 (Global) | 200K |
-| `us.anthropic.claude-sonnet-4-20250514-v1:0` | Claude Sonnet 4 (US) | 200K |
+| `anthropic.claude-opus-4-8` | Claude Opus 4.8 | 1M |
+| `au.anthropic.claude-opus-4-8` | Claude Opus 4.8 (AU) | 1M |
+| `eu.anthropic.claude-opus-4-8` | Claude Opus 4.8 (EU) | 1M |
+| `global.anthropic.claude-opus-4-8` | Claude Opus 4.8 (Global) | 1M |
+| `jp.anthropic.claude-opus-4-8` | Claude Opus 4.8 (JP) | 1M |
+| `us.anthropic.claude-opus-4-8` | Claude Opus 4.8 (US) | 1M |
 | `anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 | 200K |
+| `au.anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 (AU) | 200K |
 | `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 (EU) | 200K |
 | `global.anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 (Global) | 200K |
+| `jp.anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 (JP) | 200K |
 | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | Claude Sonnet 4.5 (US) | 200K |
 | `anthropic.claude-sonnet-4-6` | Claude Sonnet 4.6 | 1M |
 | `eu.anthropic.claude-sonnet-4-6` | Claude Sonnet 4.6 (EU) | 1M |
 | `global.anthropic.claude-sonnet-4-6` | Claude Sonnet 4.6 (Global) | 1M |
+| `jp.anthropic.claude-sonnet-4-6` | Claude Sonnet 4.6 (JP) | 1M |
 | `us.anthropic.claude-sonnet-4-6` | Claude Sonnet 4.6 (US) | 1M |
 | `deepseek.r1-v1:0` | DeepSeek-R1 | 128K |
+| `us.deepseek.r1-v1:0` | DeepSeek-R1 (US) | 128K |
 | `deepseek.v3-v1:0` | DeepSeek-V3.1 | 163K |
 | `deepseek.v3.2` | DeepSeek-V3.2 | 163K |
 | `mistral.devstral-2-123b` | Devstral 2 123B | 256K |
@@ -58,18 +61,15 @@ Amazon Bedrock provides managed access to foundation models through AWS infrastr
 | `google.gemma-3-4b-it` | Gemma 3 4B IT | 128K |
 | `google.gemma-3-12b-it` | Google Gemma 3 12B | 131K |
 | `google.gemma-3-27b-it` | Google Gemma 3 27B Instruct | 202K |
-| `moonshot.kimi-k2-thinking` | Kimi K2 Thinking | 256K |
-| `moonshotai.kimi-k2.5` | Kimi K2.5 | 256K |
-| `meta.llama3-1-405b-instruct-v1:0` | Llama 3.1 405B Instruct | 128K |
+| `moonshot.kimi-k2-thinking` | Kimi K2 Thinking | 262K |
+| `moonshotai.kimi-k2.5` | Kimi K2.5 | 262K |
 | `meta.llama3-1-70b-instruct-v1:0` | Llama 3.1 70B Instruct | 128K |
 | `meta.llama3-1-8b-instruct-v1:0` | Llama 3.1 8B Instruct | 128K |
-| `meta.llama3-2-11b-instruct-v1:0` | Llama 3.2 11B Instruct | 128K |
-| `meta.llama3-2-1b-instruct-v1:0` | Llama 3.2 1B Instruct | 131K |
-| `meta.llama3-2-3b-instruct-v1:0` | Llama 3.2 3B Instruct | 131K |
-| `meta.llama3-2-90b-instruct-v1:0` | Llama 3.2 90B Instruct | 128K |
 | `meta.llama3-3-70b-instruct-v1:0` | Llama 3.3 70B Instruct | 128K |
 | `meta.llama4-maverick-17b-instruct-v1:0` | Llama 4 Maverick 17B Instruct | 1M |
+| `us.meta.llama4-maverick-17b-instruct-v1:0` | Llama 4 Maverick 17B Instruct (US) | 1M |
 | `meta.llama4-scout-17b-instruct-v1:0` | Llama 4 Scout 17B Instruct | 3M |
+| `us.meta.llama4-scout-17b-instruct-v1:0` | Llama 4 Scout 17B Instruct (US) | 3M |
 | `mistral.magistral-small-2509` | Magistral Small 1.2 | 128K |
 | `minimax.minimax-m2` | MiniMax M2 | 204K |
 | `minimax.minimax-m2.1` | MiniMax M2.1 | 204K |
@@ -85,7 +85,6 @@ Amazon Bedrock provides managed access to foundation models through AWS infrastr
 | `amazon.nova-2-lite-v1:0` | Nova 2 Lite | 128K |
 | `amazon.nova-lite-v1:0` | Nova Lite | 300K |
 | `amazon.nova-micro-v1:0` | Nova Micro | 128K |
-| `amazon.nova-premier-v1:0` | Nova Premier | 1M |
 | `amazon.nova-pro-v1:0` | Nova Pro | 300K |
 | `writer.palmyra-x4-v1:0` | Palmyra X4 | 122K |
 | `writer.palmyra-x5-v1:0` | Palmyra X5 | 1M |

--- a/website/docs/agent-support/providers/openai.md
+++ b/website/docs/agent-support/providers/openai.md
@@ -9,7 +9,6 @@ Official OpenAI API integration for GPT models.
 <!-- MODEL-TABLE:START -->
 | Model ID | Name | Context |
 |----------|------|---------|
-| `codex-mini-latest` | Codex Mini | 200K |
 | `gpt-3.5-turbo` | GPT-3.5-turbo | 16K |
 | `gpt-4` | GPT-4 | 8K |
 | `gpt-4-turbo` | GPT-4 Turbo | 128K |
@@ -43,6 +42,8 @@ Official OpenAI API integration for GPT models.
 | `gpt-5.4-pro` | GPT-5.4 Pro | 1M |
 | `gpt-5.4-mini` | GPT-5.4 mini | 400K |
 | `gpt-5.4-nano` | GPT-5.4 nano | 400K |
+| `gpt-5.5` | GPT-5.5 | 1M |
+| `gpt-5.5-pro` | GPT-5.5 Pro | 1M |
 | `chatgpt-image-latest` | chatgpt-image-latest | - |
 | `gpt-image-1` | gpt-image-1 | - |
 | `gpt-image-1-mini` | gpt-image-1-mini | - |

--- a/website/docs/agent-support/providers/openrouter.md
+++ b/website/docs/agent-support/providers/openrouter.md
@@ -7,43 +7,104 @@ OpenRouter provides unified access to multiple AI models through a single API.
 ## Supported Models
 
 <!-- MODEL-TABLE:START -->
+### Ai21
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `ai21/jamba-large-1.7` | Jamba Large 1.7 | 256K |
+
+### Aion Labs
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `aion-labs/aion-1.0` | Aion-1.0 | 131K |
+| `aion-labs/aion-1.0-mini` | Aion-1.0-Mini | 131K |
+| `aion-labs/aion-2.0` | Aion-2.0 | 131K |
+| `aion-labs/aion-rp-llama-3.1-8b` | Aion-RP 1.0 (8B) | 32K |
+
+### Alfredpros
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `alfredpros/codellama-7b-instruct-solidity` | CodeLLaMa 7B Instruct Solidity | 4K |
+
+### Allenai
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `allenai/olmo-3-32b-think` | Olmo 3 32B Think | 65K |
+
+### Amazon
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `amazon/nova-2-lite-v1` | Nova 2 Lite | 1M |
+| `amazon/nova-lite-v1` | Nova Lite 1.0 | 300K |
+| `amazon/nova-micro-v1` | Nova Micro 1.0 | 128K |
+| `amazon/nova-premier-v1` | Nova Premier 1.0 | 1M |
+| `amazon/nova-pro-v1` | Nova Pro 1.0 | 300K |
+
+### Anthracite Org
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `anthracite-org/magnum-v4-72b` | Magnum v4 72B | 16K |
+
 ### Anthropic
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `anthropic/claude-3.5-haiku` | Claude Haiku 3.5 | 200K |
-| `anthropic/claude-haiku-4.5` | Claude Haiku 4.5 | 200K |
+| `anthropic/claude-3-haiku` | Claude 3 Haiku | 200K |
+| `anthropic/claude-3.5-haiku` | Claude 3.5 Haiku | 200K |
+| `anthropic/claude-haiku-4.5` | Claude Haiku 4.5 (latest) | 200K |
 | `anthropic/claude-opus-4` | Claude Opus 4 | 200K |
-| `anthropic/claude-opus-4.1` | Claude Opus 4.1 | 200K |
-| `anthropic/claude-opus-4.5` | Claude Opus 4.5 | 200K |
+| `anthropic/claude-opus-4.1` | Claude Opus 4.1 (latest) | 200K |
+| `anthropic/claude-opus-4.5` | Claude Opus 4.5 (latest) | 200K |
 | `anthropic/claude-opus-4.6` | Claude Opus 4.6 | 1M |
+| `anthropic/claude-opus-4.6-fast` | Claude Opus 4.6 (Fast) | 1M |
 | `anthropic/claude-opus-4.7` | Claude Opus 4.7 | 1M |
-| `anthropic/claude-3.7-sonnet` | Claude Sonnet 3.7 | 200K |
-| `anthropic/claude-sonnet-4` | Claude Sonnet 4 | 200K |
-| `anthropic/claude-sonnet-4.5` | Claude Sonnet 4.5 | 1M |
+| `anthropic/claude-opus-4.7-fast` | Claude Opus 4.7 (Fast) | 1M |
+| `anthropic/claude-opus-4.8` | Claude Opus 4.8 | 1M |
+| `anthropic/claude-opus-4.8-fast` | Claude Opus 4.8 (Fast) | 1M |
+| `anthropic/claude-sonnet-4` | Claude Sonnet 4 | 1M |
+| `anthropic/claude-sonnet-4.5` | Claude Sonnet 4.5 (latest) | 1M |
 | `anthropic/claude-sonnet-4.6` | Claude Sonnet 4.6 | 1M |
 
 ### Arcee Ai
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `arcee-ai/trinity-large-preview:free` | Trinity Large Preview | 131K |
+| `arcee-ai/coder-large` | Coder Large | 32K |
+| `arcee-ai/maestro-reasoning` | Maestro Reasoning | 131K |
+| `arcee-ai/spotlight` | Spotlight | 131K |
 | `arcee-ai/trinity-large-thinking` | Trinity Large Thinking | 262K |
+| `arcee-ai/trinity-mini` | Trinity Mini | 131K |
+| `arcee-ai/virtuoso-large` | Virtuoso Large | 131K |
 
-### Black Forest Labs
+### Baidu
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `black-forest-labs/flux.2-flex` | FLUX.2 Flex | 67K |
-| `black-forest-labs/flux.2-klein-4b` | FLUX.2 Klein 4B | 40K |
-| `black-forest-labs/flux.2-max` | FLUX.2 Max | 46K |
-| `black-forest-labs/flux.2-pro` | FLUX.2 Pro | 46K |
+| `baidu/ernie-4.5-21b-a3b` | ERNIE 4.5 21B A3B | 120K |
+| `baidu/ernie-4.5-21b-a3b-thinking` | ERNIE 4.5 21B A3B Thinking | 131K |
+| `baidu/ernie-4.5-300b-a47b` | ERNIE 4.5 300B A47B  | 123K |
+| `baidu/ernie-4.5-vl-28b-a3b` | ERNIE 4.5 VL 28B A3B | 30K |
+| `baidu/ernie-4.5-vl-424b-a47b` | ERNIE 4.5 VL 424B A47B  | 123K |
+
+### Bytedance
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `bytedance/ui-tars-1.5-7b` | UI-TARS 7B  | 128K |
 
 ### Bytedance Seed
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `bytedance-seed/seedream-4.5` | Seedream 4.5 | 4K |
+| `bytedance-seed/seed-1.6` | Seed 1.6 | 262K |
+| `bytedance-seed/seed-1.6-flash` | Seed 1.6 Flash | 262K |
+| `bytedance-seed/seed-2.0-lite` | Seed-2.0-Lite | 262K |
+| `bytedance-seed/seed-2.0-mini` | Seed-2.0-Mini | 262K |
 
 ### Cognitivecomputations
 
@@ -51,115 +112,232 @@ OpenRouter provides unified access to multiple AI models through a single API.
 |----------|------|---------|
 | `cognitivecomputations/dolphin-mistral-24b-venice-edition:free` | Uncensored (free) | 32K |
 
+### Cohere
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `cohere/command-a` | Command A | 256K |
+| `cohere/command-r-08-2024` | Command R | 128K |
+| `cohere/command-r-plus-08-2024` | Command R+ | 128K |
+| `cohere/command-r7b-12-2024` | Command R7B | 128K |
+
+### Deepcogito
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `deepcogito/cogito-v2.1-671b` | Cogito v2.1 671B | 128K |
+
 ### Deepseek
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `deepseek/deepseek-r1-distill-llama-70b` | DeepSeek R1 Distill Llama 70B | 8K |
-| `deepseek/deepseek-chat-v3-0324` | DeepSeek V3 0324 | 16K |
-| `deepseek/deepseek-v3.1-terminus` | DeepSeek V3.1 Terminus | 131K |
-| `deepseek/deepseek-v3.1-terminus:exacto` | DeepSeek V3.1 Terminus (exacto) | 131K |
-| `deepseek/deepseek-v3.2` | DeepSeek V3.2 | 163K |
-| `deepseek/deepseek-v3.2-speciale` | DeepSeek V3.2 Speciale | 163K |
-| `deepseek/deepseek-chat-v3.1` | DeepSeek-V3.1 | 163K |
-| `deepseek/deepseek-r1` | DeepSeek: R1 | 64K |
+| `deepseek/deepseek-chat` | DeepSeek Chat | 128K |
+| `deepseek/deepseek-chat-v3-0324` | DeepSeek V3 0324 | 163K |
+| `deepseek/deepseek-chat-v3.1` | DeepSeek V3.1 | 163K |
+| `deepseek/deepseek-v3.1-terminus` | DeepSeek V3.1 Terminus | 163K |
+| `deepseek/deepseek-v3.2` | DeepSeek V3.2 | 131K |
+| `deepseek/deepseek-v3.2-exp` | DeepSeek V3.2 Exp | 163K |
+| `deepseek/deepseek-v4-flash` | DeepSeek V4 Flash | 1M |
+| `deepseek/deepseek-v4-flash:free` | DeepSeek V4 Flash (free) | 1M |
+| `deepseek/deepseek-v4-pro` | DeepSeek V4 Pro | 1M |
+| `deepseek/deepseek-r1` | R1 | 64K |
+| `deepseek/deepseek-r1-0528` | R1 0528 | 163K |
+| `deepseek/deepseek-r1-distill-llama-70b` | R1 Distill Llama 70B | 131K |
+| `deepseek/deepseek-r1-distill-qwen-32b` | R1 Distill Qwen 32B | 32K |
+
+### Essentialai
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `essentialai/rnj-1-instruct` | Rnj 1 Instruct | 32K |
 
 ### Google
 
 | Model ID | Name | Context |
 |----------|------|---------|
 | `google/gemini-2.0-flash-001` | Gemini 2.0 Flash | 1M |
+| `google/gemini-2.0-flash-lite-001` | Gemini 2.0 Flash Lite | 1M |
 | `google/gemini-2.5-flash` | Gemini 2.5 Flash | 1M |
-| `google/gemini-2.5-flash-lite` | Gemini 2.5 Flash Lite | 1M |
-| `google/gemini-2.5-flash-lite-preview-09-2025` | Gemini 2.5 Flash Lite Preview 09-25 | 1M |
-| `google/gemini-2.5-flash-preview-09-2025` | Gemini 2.5 Flash Preview 09-25 | 1M |
+| `google/gemini-2.5-flash-lite-preview-09-2025` | Gemini 2.5 Flash Lite Preview 09-2025 | 1M |
+| `google/gemini-2.5-flash-lite` | Gemini 2.5 Flash-Lite | 1M |
 | `google/gemini-2.5-pro` | Gemini 2.5 Pro | 1M |
 | `google/gemini-2.5-pro-preview-05-06` | Gemini 2.5 Pro Preview 05-06 | 1M |
-| `google/gemini-2.5-pro-preview-06-05` | Gemini 2.5 Pro Preview 06-05 | 1M |
+| `google/gemini-2.5-pro-preview` | Gemini 2.5 Pro Preview 06-05 | 1M |
 | `google/gemini-3-flash-preview` | Gemini 3 Flash Preview | 1M |
-| `google/gemini-3-pro-preview` | Gemini 3 Pro Preview | 1M |
+| `google/gemini-3.1-flash-lite` | Gemini 3.1 Flash Lite | 1M |
 | `google/gemini-3.1-flash-lite-preview` | Gemini 3.1 Flash Lite Preview | 1M |
 | `google/gemini-3.1-pro-preview` | Gemini 3.1 Pro Preview | 1M |
 | `google/gemini-3.1-pro-preview-customtools` | Gemini 3.1 Pro Preview Custom Tools | 1M |
-| `google/gemma-2-9b-it` | Gemma 2 9B | 8K |
+| `google/gemini-3.5-flash` | Gemini 3.5 Flash | 1M |
+| `google/gemma-2-27b-it` | Gemma 2 27B | 8K |
 | `google/gemma-3-12b-it` | Gemma 3 12B | 131K |
-| `google/gemma-3-12b-it:free` | Gemma 3 12B (free) | 32K |
-| `google/gemma-3-27b-it` | Gemma 3 27B | 96K |
-| `google/gemma-3-27b-it:free` | Gemma 3 27B (free) | 131K |
-| `google/gemma-3-4b-it` | Gemma 3 4B | 96K |
-| `google/gemma-3-4b-it:free` | Gemma 3 4B (free) | 32K |
-| `google/gemma-3n-e2b-it:free` | Gemma 3n 2B (free) | 8K |
+| `google/gemma-3-27b-it` | Gemma 3 27B | 131K |
+| `google/gemma-3-4b-it` | Gemma 3 4B | 131K |
 | `google/gemma-3n-e4b-it` | Gemma 3n 4B | 32K |
-| `google/gemma-3n-e4b-it:free` | Gemma 3n 4B (free) | 8K |
-| `google/gemma-4-26b-a4b-it` | Gemma 4 26B A4B | 262K |
-| `google/gemma-4-26b-a4b-it:free` | Gemma 4 26B A4B (free) | 262K |
-| `google/gemma-4-31b-it` | Gemma 4 31B | 262K |
+| `google/gemma-4-26b-a4b-it:free` | Gemma 4 26B A4B  (free) | 262K |
+| `google/gemma-4-26b-a4b-it` | Gemma 4 26B A4B IT | 262K |
 | `google/gemma-4-31b-it:free` | Gemma 4 31B (free) | 262K |
+| `google/gemma-4-31b-it` | Gemma 4 31B IT | 262K |
+| `google/lyria-3-clip-preview` | Lyria 3 Clip Preview | 1M |
+| `google/lyria-3-pro-preview` | Lyria 3 Pro Preview | 1M |
+| `google/gemini-2.5-flash-image` | Nano Banana | 32K |
+| `google/gemini-3.1-flash-image-preview` | Nano Banana 2 | 65K |
+| `google/gemini-3-pro-image-preview` | Nano Banana Pro (Gemini 3 Pro Image Preview) | 65K |
+
+### Gryphe
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `gryphe/mythomax-l2-13b` | MythoMax 13B | 4K |
+
+### Ibm Granite
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `ibm-granite/granite-4.0-h-micro` | Granite 4.0 Micro | 131K |
+| `ibm-granite/granite-4.1-8b` | Granite 4.1 8B | 131K |
 
 ### Inception
 
 | Model ID | Name | Context |
 |----------|------|---------|
 | `inception/mercury-2` | Mercury 2 | 128K |
-| `inception/mercury-edit-2` | Mercury Edit 2 | 128K |
+
+### Inclusionai
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `inclusionai/ling-2.6-1t` | Ling-2.6-1T | 262K |
+| `inclusionai/ling-2.6-flash` | Ling-2.6-flash | 262K |
+| `inclusionai/ring-2.6-1t` | Ring-2.6-1T | 262K |
+
+### Inflection
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `inflection/inflection-3-pi` | Inflection 3 Pi | 8K |
+| `inflection/inflection-3-productivity` | Inflection 3 Productivity | 8K |
+
+### Kwaipilot
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `kwaipilot/kat-coder-pro-v2` | KAT-Coder-Pro V2 | 256K |
 
 ### Liquid
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `liquid/lfm-2.5-1.2b-instruct:free` | LFM2.5-1.2B-Instruct (free) | 131K |
-| `liquid/lfm-2.5-1.2b-thinking:free` | LFM2.5-1.2B-Thinking (free) | 131K |
+| `liquid/lfm-2-24b-a2b` | LFM2-24B-A2B | 32K |
+| `liquid/lfm-2.5-1.2b-instruct:free` | LFM2.5-1.2B-Instruct (free) | 32K |
+| `liquid/lfm-2.5-1.2b-thinking:free` | LFM2.5-1.2B-Thinking (free) | 32K |
+
+### Mancer
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `mancer/weaver` | Weaver (alpha) | 8K |
 
 ### Meta Llama
 
 | Model ID | Name | Context |
 |----------|------|---------|
+| `meta-llama/llama-3-70b-instruct` | Llama 3 70B Instruct | 8K |
+| `meta-llama/llama-3-8b-instruct` | Llama 3 8B Instruct | 8K |
+| `meta-llama/llama-3.1-70b-instruct` | Llama 3.1 70B Instruct | 131K |
+| `meta-llama/llama-3.1-8b-instruct` | Llama 3.1 8B Instruct | 16K |
 | `meta-llama/llama-3.2-11b-vision-instruct` | Llama 3.2 11B Vision Instruct | 131K |
+| `meta-llama/llama-3.2-1b-instruct` | Llama 3.2 1B Instruct | 60K |
+| `meta-llama/llama-3.2-3b-instruct` | Llama 3.2 3B Instruct | 80K |
 | `meta-llama/llama-3.2-3b-instruct:free` | Llama 3.2 3B Instruct (free) | 131K |
-| `meta-llama/llama-3.3-70b-instruct:free` | Llama 3.3 70B Instruct (free) | 131K |
+| `meta-llama/llama-3.3-70b-instruct:free` | Llama 3.3 70B Instruct (free) | 65K |
+| `meta-llama/llama-4-maverick` | Llama 4 Maverick | 1M |
+| `meta-llama/llama-4-scout` | Llama 4 Scout | 327K |
+| `meta-llama/llama-guard-3-8b` | Llama Guard 3 8B | 131K |
+| `meta-llama/llama-guard-4-12b` | Llama Guard 4 12B | 163K |
+| `meta-llama/llama-3.3-70b-instruct` | Llama-3.3-70B-Instruct | 131K |
+
+### Microsoft
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `microsoft/phi-4` | Phi 4 | 16K |
+| `microsoft/phi-4-mini-instruct` | Phi 4 Mini Instruct | 128K |
+| `microsoft/wizardlm-2-8x22b` | WizardLM-2 8x22B | 65K |
 
 ### Minimax
 
 | Model ID | Name | Context |
 |----------|------|---------|
 | `minimax/minimax-m1` | MiniMax M1 | 1M |
-| `minimax/minimax-m2` | MiniMax M2 | 196K |
-| `minimax/minimax-m2.1` | MiniMax M2.1 | 204K |
-| `minimax/minimax-m2.5` | MiniMax M2.5 | 204K |
-| `minimax/minimax-m2.5:free` | MiniMax M2.5 (free) | 204K |
-| `minimax/minimax-m2.7` | MiniMax M2.7 | 204K |
+| `minimax/minimax-m2-her` | MiniMax M2-her | 65K |
+| `minimax/minimax-m2.5:free` | MiniMax M2.5 (free) | 196K |
 | `minimax/minimax-01` | MiniMax-01 | 1M |
+| `minimax/minimax-m2` | MiniMax-M2 | 196K |
+| `minimax/minimax-m2.1` | MiniMax-M2.1 | 196K |
+| `minimax/minimax-m2.5` | MiniMax-M2.5 | 196K |
+| `minimax/minimax-m2.7` | MiniMax-M2.7 | 196K |
 
 ### Mistralai
 
 | Model ID | Name | Context |
 |----------|------|---------|
 | `mistralai/codestral-2508` | Codestral 2508 | 256K |
-| `mistralai/devstral-2512` | Devstral 2 2512 | 262K |
-| `mistralai/devstral-medium-2507` | Devstral Medium | 131K |
-| `mistralai/devstral-small-2505` | Devstral Small | 128K |
-| `mistralai/devstral-small-2507` | Devstral Small 1.1 | 131K |
+| `mistralai/devstral-2512` | Devstral 2 | 262K |
+| `mistralai/devstral-medium` | Devstral Medium | 131K |
+| `mistralai/devstral-small` | Devstral Small 1.1 | 131K |
+| `mistralai/ministral-14b-2512` | Ministral 3 14B 2512 | 262K |
+| `mistralai/ministral-3b-2512` | Ministral 3 3B 2512 | 131K |
+| `mistralai/ministral-8b-2512` | Ministral 3 8B 2512 | 262K |
+| `mistralai/mistral-large` | Mistral Large | 128K |
+| `mistralai/mistral-large-2411` | Mistral Large 2.1 | 131K |
+| `mistralai/mistral-large-2407` | Mistral Large 2407 | 131K |
+| `mistralai/mistral-large-2512` | Mistral Large 3 | 262K |
 | `mistralai/mistral-medium-3` | Mistral Medium 3 | 131K |
-| `mistralai/mistral-medium-3.1` | Mistral Medium 3.1 | 262K |
-| `mistralai/mistral-small-3.1-24b-instruct` | Mistral Small 3.1 24B Instruct | 128K |
-| `mistralai/mistral-small-3.2-24b-instruct` | Mistral Small 3.2 24B Instruct | 96K |
+| `mistralai/mistral-medium-3.1` | Mistral Medium 3.1 | 131K |
+| `mistralai/mistral-medium-3-5` | Mistral Medium 3.5 | 262K |
+| `mistralai/mistral-nemo` | Mistral Nemo | 131K |
+| `mistralai/mistral-small-24b-instruct-2501` | Mistral Small 3 | 32K |
+| `mistralai/mistral-small-3.1-24b-instruct` | Mistral Small 3.1 24B | 128K |
+| `mistralai/mistral-small-3.2-24b-instruct` | Mistral Small 3.2 24B | 128K |
 | `mistralai/mistral-small-2603` | Mistral Small 4 | 262K |
+| `mistralai/mixtral-8x22b-instruct` | Mixtral 8x22B Instruct | 65K |
+| `mistralai/pixtral-large-2411` | Pixtral Large 2411 | 131K |
+| `mistralai/mistral-saba` | Saba | 32K |
+| `mistralai/voxtral-small-24b-2507` | Voxtral Small 24B 2507 | 32K |
 
 ### Moonshotai
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `moonshotai/kimi-k2` | Kimi K2 | 131K |
-| `moonshotai/kimi-k2-0905` | Kimi K2 Instruct 0905 | 262K |
-| `moonshotai/kimi-k2-0905:exacto` | Kimi K2 Instruct 0905 (exacto) | 262K |
+| `moonshotai/kimi-k2` | Kimi K2 0711 | 131K |
+| `moonshotai/kimi-k2-0905` | Kimi K2 0905 | 262K |
 | `moonshotai/kimi-k2-thinking` | Kimi K2 Thinking | 262K |
 | `moonshotai/kimi-k2.5` | Kimi K2.5 | 262K |
+| `moonshotai/kimi-k2.6` | Kimi K2.6 | 262K |
+| `moonshotai/kimi-k2.6:free` | Kimi K2.6 (free) | 262K |
+
+### Morph
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `morph/morph-v3-fast` | Morph V3 Fast | 81K |
+| `morph/morph-v3-large` | Morph V3 Large | 262K |
+
+### Nex Agi
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `nex-agi/deepseek-v3.1-nex-n1` | DeepSeek V3.1 Nex N1 | 131K |
 
 ### Nousresearch
 
 | Model ID | Name | Context |
 |----------|------|---------|
+| `nousresearch/hermes-2-pro-llama-3-8b` | Hermes 2 Pro - Llama-3 8B | 8K |
+| `nousresearch/hermes-3-llama-3.1-405b` | Hermes 3 405B Instruct | 131K |
 | `nousresearch/hermes-3-llama-3.1-405b:free` | Hermes 3 405B Instruct (free) | 131K |
+| `nousresearch/hermes-3-llama-3.1-70b` | Hermes 3 70B Instruct | 131K |
 | `nousresearch/hermes-4-405b` | Hermes 4 405B | 131K |
 | `nousresearch/hermes-4-70b` | Hermes 4 70B | 131K |
 
@@ -167,112 +345,250 @@ OpenRouter provides unified access to multiple AI models through a single API.
 
 | Model ID | Name | Context |
 |----------|------|---------|
+| `nvidia/llama-3.3-nemotron-super-49b-v1.5` | Llama 3.3 Nemotron Super 49B V1.5 | 131K |
+| `nvidia/nemotron-3-nano-30b-a3b` | Nemotron 3 Nano 30B A3B | 262K |
 | `nvidia/nemotron-3-nano-30b-a3b:free` | Nemotron 3 Nano 30B A3B (free) | 256K |
+| `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` | Nemotron 3 Nano Omni (free) | 256K |
 | `nvidia/nemotron-3-super-120b-a12b` | Nemotron 3 Super | 262K |
 | `nvidia/nemotron-3-super-120b-a12b:free` | Nemotron 3 Super (free) | 262K |
 | `nvidia/nemotron-nano-12b-v2-vl:free` | Nemotron Nano 12B 2 VL (free) | 128K |
+| `nvidia/nemotron-nano-9b-v2` | Nemotron Nano 9B V2 | 131K |
 | `nvidia/nemotron-nano-9b-v2:free` | Nemotron Nano 9B V2 (free) | 128K |
-| `nvidia/nemotron-nano-9b-v2` | nvidia-nemotron-nano-9b-v2 | 131K |
 
 ### Openai
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `openai/gpt-oss-120b` | GPT OSS 120B | 131K |
-| `openai/gpt-oss-120b:exacto` | GPT OSS 120B (exacto) | 131K |
-| `openai/gpt-oss-20b` | GPT OSS 20B | 131K |
-| `openai/gpt-oss-safeguard-20b` | GPT OSS Safeguard 20B | 131K |
+| `openai/gpt-audio` | GPT Audio | 128K |
+| `openai/gpt-audio-mini` | GPT Audio Mini | 128K |
+| `openai/gpt-chat-latest` | GPT Chat Latest | 400K |
+| `openai/gpt-3.5-turbo-0613` | GPT-3.5 Turbo (older v0613) | 4K |
+| `openai/gpt-3.5-turbo-16k` | GPT-3.5 Turbo 16k | 16K |
+| `openai/gpt-3.5-turbo-instruct` | GPT-3.5 Turbo Instruct | 4K |
+| `openai/gpt-3.5-turbo` | GPT-3.5-turbo | 16K |
+| `openai/gpt-4` | GPT-4 | 8K |
+| `openai/gpt-4-0314` | GPT-4 (older v0314) | 8K |
+| `openai/gpt-4-turbo` | GPT-4 Turbo | 128K |
+| `openai/gpt-4-1106-preview` | GPT-4 Turbo (older v1106) | 128K |
+| `openai/gpt-4-turbo-preview` | GPT-4 Turbo Preview | 128K |
 | `openai/gpt-4.1` | GPT-4.1 | 1M |
-| `openai/gpt-4.1-mini` | GPT-4.1 Mini | 1M |
-| `openai/gpt-4o-mini` | GPT-4o-mini | 128K |
+| `openai/gpt-4.1-mini` | GPT-4.1 mini | 1M |
+| `openai/gpt-4.1-nano` | GPT-4.1 nano | 1M |
+| `openai/gpt-4o` | GPT-4o | 128K |
+| `openai/gpt-4o-2024-05-13` | GPT-4o (2024-05-13) | 128K |
+| `openai/gpt-4o-2024-08-06` | GPT-4o (2024-08-06) | 128K |
+| `openai/gpt-4o-2024-11-20` | GPT-4o (2024-11-20) | 128K |
+| `openai/gpt-4o-search-preview` | GPT-4o Search Preview | 128K |
+| `openai/gpt-4o-mini` | GPT-4o mini | 128K |
+| `openai/gpt-4o-mini-2024-07-18` | GPT-4o-mini (2024-07-18) | 128K |
+| `openai/gpt-4o-mini-search-preview` | GPT-4o-mini Search Preview | 128K |
 | `openai/gpt-5` | GPT-5 | 400K |
-| `openai/gpt-5-chat` | GPT-5 Chat (latest) | 400K |
-| `openai/gpt-5-codex` | GPT-5 Codex | 400K |
+| `openai/gpt-5-chat` | GPT-5 Chat | 128K |
 | `openai/gpt-5-image` | GPT-5 Image | 400K |
+| `openai/gpt-5-image-mini` | GPT-5 Image Mini | 400K |
 | `openai/gpt-5-mini` | GPT-5 Mini | 400K |
 | `openai/gpt-5-nano` | GPT-5 Nano | 400K |
 | `openai/gpt-5-pro` | GPT-5 Pro | 400K |
+| `openai/gpt-5-codex` | GPT-5-Codex | 400K |
 | `openai/gpt-5.1` | GPT-5.1 | 400K |
 | `openai/gpt-5.1-chat` | GPT-5.1 Chat | 128K |
-| `openai/gpt-5.1-codex` | GPT-5.1-Codex | 400K |
-| `openai/gpt-5.1-codex-max` | GPT-5.1-Codex-Max | 400K |
-| `openai/gpt-5.1-codex-mini` | GPT-5.1-Codex-Mini | 400K |
+| `openai/gpt-5.1-codex` | GPT-5.1 Codex | 400K |
+| `openai/gpt-5.1-codex-max` | GPT-5.1 Codex Max | 400K |
+| `openai/gpt-5.1-codex-mini` | GPT-5.1 Codex mini | 400K |
 | `openai/gpt-5.2` | GPT-5.2 | 400K |
 | `openai/gpt-5.2-chat` | GPT-5.2 Chat | 128K |
+| `openai/gpt-5.2-codex` | GPT-5.2 Codex | 400K |
 | `openai/gpt-5.2-pro` | GPT-5.2 Pro | 400K |
-| `openai/gpt-5.2-codex` | GPT-5.2-Codex | 400K |
-| `openai/gpt-5.3-codex` | GPT-5.3-Codex | 400K |
+| `openai/gpt-5.3-chat` | GPT-5.3 Chat | 128K |
+| `openai/gpt-5.3-codex` | GPT-5.3 Codex | 400K |
 | `openai/gpt-5.4` | GPT-5.4 | 1M |
-| `openai/gpt-5.4-mini` | GPT-5.4 Mini | 400K |
-| `openai/gpt-5.4-nano` | GPT-5.4 Nano | 400K |
+| `openai/gpt-5.4-image-2` | GPT-5.4 Image 2 | 272K |
 | `openai/gpt-5.4-pro` | GPT-5.4 Pro | 1M |
+| `openai/gpt-5.4-mini` | GPT-5.4 mini | 400K |
+| `openai/gpt-5.4-nano` | GPT-5.4 nano | 400K |
+| `openai/gpt-5.5` | GPT-5.5 | 1M |
+| `openai/gpt-5.5-pro` | GPT-5.5 Pro | 1M |
+| `openai/gpt-oss-120b` | gpt-oss-120b | 131K |
 | `openai/gpt-oss-120b:free` | gpt-oss-120b (free) | 131K |
+| `openai/gpt-oss-20b` | gpt-oss-20b | 131K |
 | `openai/gpt-oss-20b:free` | gpt-oss-20b (free) | 131K |
-| `openai/o4-mini` | o4 Mini | 200K |
+| `openai/gpt-oss-safeguard-20b` | gpt-oss-safeguard-20b | 131K |
+| `openai/o1` | o1 | 200K |
+| `openai/o1-pro` | o1-pro | 200K |
+| `openai/o3` | o3 | 200K |
+| `openai/o3-mini-high` | o3 Mini High | 200K |
+| `openai/o3-deep-research` | o3-deep-research | 200K |
+| `openai/o3-mini` | o3-mini | 200K |
+| `openai/o3-pro` | o3-pro | 200K |
+| `openai/o4-mini-high` | o4 Mini High | 200K |
+| `openai/o4-mini` | o4-mini | 200K |
+| `openai/o4-mini-deep-research` | o4-mini-deep-research | 200K |
 
 ### Openrouter
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `openrouter/elephant-alpha` | Elephant (free) | 262K |
+| `openrouter/auto` | Auto Router | 2M |
+| `openrouter/bodybuilder` | Body Builder (beta) | 128K |
 | `openrouter/free` | Free Models Router | 200K |
+| `openrouter/owl-alpha` | Owl Alpha | 1M |
+| `openrouter/pareto-code` | Pareto Code Router | 2M |
+
+### Perceptron
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `perceptron/perceptron-mk1` | Perceptron Mk1 | 32K |
+
+### Perplexity
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `perplexity/sonar` | Sonar | 127K |
+| `perplexity/sonar-deep-research` | Sonar Deep Research | 128K |
+| `perplexity/sonar-pro` | Sonar Pro | 200K |
+| `perplexity/sonar-pro-search` | Sonar Pro Search | 200K |
+| `perplexity/sonar-reasoning-pro` | Sonar Reasoning Pro | 128K |
+
+### Poolside
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `poolside/laguna-m.1:free` | Laguna M.1 (free) | 262K |
+| `poolside/laguna-xs.2:free` | Laguna XS.2 (free) | 262K |
 
 ### Prime Intellect
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `prime-intellect/intellect-3` | Intellect 3 | 131K |
+| `prime-intellect/intellect-3` | INTELLECT-3 | 131K |
 
 ### Qwen
 
 | Model ID | Name | Context |
 |----------|------|---------|
+| `qwen/qwen-plus-2025-07-28` | Qwen Plus 0728 | 1M |
+| `qwen/qwen-plus-2025-07-28:thinking` | Qwen Plus 0728 (thinking) | 1M |
+| `qwen/qwen-plus` | Qwen-Plus | 1M |
+| `qwen/qwen-2.5-72b-instruct` | Qwen2.5 72B Instruct | 32K |
+| `qwen/qwen-2.5-7b-instruct` | Qwen2.5 7B Instruct | 32K |
 | `qwen/qwen-2.5-coder-32b-instruct` | Qwen2.5 Coder 32B Instruct | 32K |
 | `qwen/qwen2.5-vl-72b-instruct` | Qwen2.5 VL 72B Instruct | 32K |
-| `qwen/qwen3-235b-a22b-07-25` | Qwen3 235B A22B Instruct 2507 | 262K |
+| `qwen/qwen3-14b` | Qwen3 14B | 40K |
+| `qwen/qwen3-235b-a22b` | Qwen3 235B A22B | 131K |
+| `qwen/qwen3-235b-a22b-2507` | Qwen3 235B A22B Instruct 2507 | 262K |
 | `qwen/qwen3-235b-a22b-thinking-2507` | Qwen3 235B A22B Thinking 2507 | 262K |
+| `qwen/qwen3-30b-a3b` | Qwen3 30B A3B | 40K |
 | `qwen/qwen3-30b-a3b-instruct-2507` | Qwen3 30B A3B Instruct 2507 | 262K |
-| `qwen/qwen3-30b-a3b-thinking-2507` | Qwen3 30B A3B Thinking 2507 | 262K |
-| `qwen/qwen3-coder` | Qwen3 Coder | 262K |
-| `qwen/qwen3-coder:exacto` | Qwen3 Coder (exacto) | 131K |
+| `qwen/qwen3-30b-a3b-thinking-2507` | Qwen3 30B A3B Thinking 2507 | 131K |
+| `qwen/qwen3-32b` | Qwen3 32B | 40K |
+| `qwen/qwen3-8b` | Qwen3 8B | 40K |
 | `qwen/qwen3-coder-30b-a3b-instruct` | Qwen3 Coder 30B A3B Instruct | 160K |
-| `qwen/qwen3-coder-flash` | Qwen3 Coder Flash | 128K |
+| `qwen/qwen3-coder` | Qwen3 Coder 480B A35B | 262K |
+| `qwen/qwen3-coder:free` | Qwen3 Coder 480B A35B (free) | 262K |
+| `qwen/qwen3-coder-flash` | Qwen3 Coder Flash | 1M |
+| `qwen/qwen3-coder-next` | Qwen3 Coder Next | 262K |
+| `qwen/qwen3-coder-plus` | Qwen3 Coder Plus | 1M |
 | `qwen/qwen3-max` | Qwen3 Max | 262K |
+| `qwen/qwen3-max-thinking` | Qwen3 Max Thinking | 262K |
 | `qwen/qwen3-next-80b-a3b-instruct` | Qwen3 Next 80B A3B Instruct | 262K |
-| `qwen/qwen3-next-80b-a3b-thinking` | Qwen3 Next 80B A3B Thinking | 262K |
+| `qwen/qwen3-next-80b-a3b-instruct:free` | Qwen3 Next 80B A3B Instruct (free) | 262K |
+| `qwen/qwen3-next-80b-a3b-thinking` | Qwen3 Next 80B A3B Thinking | 131K |
+| `qwen/qwen3-vl-235b-a22b-instruct` | Qwen3 VL 235B A22B Instruct | 262K |
+| `qwen/qwen3-vl-235b-a22b-thinking` | Qwen3 VL 235B A22B Thinking | 131K |
+| `qwen/qwen3-vl-30b-a3b-instruct` | Qwen3 VL 30B A3B Instruct | 131K |
+| `qwen/qwen3-vl-30b-a3b-thinking` | Qwen3 VL 30B A3B Thinking | 131K |
+| `qwen/qwen3-vl-32b-instruct` | Qwen3 VL 32B Instruct | 131K |
+| `qwen/qwen3-vl-8b-instruct` | Qwen3 VL 8B Instruct | 131K |
+| `qwen/qwen3-vl-8b-thinking` | Qwen3 VL 8B Thinking | 131K |
 | `qwen/qwen3.5-397b-a17b` | Qwen3.5 397B A17B | 262K |
 | `qwen/qwen3.5-plus-02-15` | Qwen3.5 Plus 2026-02-15 | 1M |
+| `qwen/qwen3.5-plus-20260420` | Qwen3.5 Plus 2026-04-20 | 1M |
+| `qwen/qwen3.5-122b-a10b` | Qwen3.5-122B-A10B | 262K |
+| `qwen/qwen3.5-27b` | Qwen3.5-27B | 262K |
+| `qwen/qwen3.5-35b-a3b` | Qwen3.5-35B-A3B | 262K |
+| `qwen/qwen3.5-9b` | Qwen3.5-9B | 262K |
+| `qwen/qwen3.5-flash-02-23` | Qwen3.5-Flash | 1M |
+| `qwen/qwen3.6-27b` | Qwen3.6 27B | 262K |
+| `qwen/qwen3.6-35b-a3b` | Qwen3.6 35B A3B | 262K |
+| `qwen/qwen3.6-flash` | Qwen3.6 Flash | 1M |
+| `qwen/qwen3.6-max-preview` | Qwen3.6 Max Preview | 262K |
 | `qwen/qwen3.6-plus` | Qwen3.6 Plus | 1M |
-| `qwen/qwen3.5-flash-02-23` | Qwen: Qwen3.5-Flash | 1M |
+| `qwen/qwen3.7-max` | Qwen3.7 Max | 1M |
 
-### Sourceful
+### Rekaai
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `sourceful/riverflow-v2-fast-preview` | Riverflow V2 Fast Preview | 8K |
-| `sourceful/riverflow-v2-max-preview` | Riverflow V2 Max Preview | 8K |
-| `sourceful/riverflow-v2-standard-preview` | Riverflow V2 Standard Preview | 8K |
+| `rekaai/reka-edge` | Reka Edge | 16K |
+| `rekaai/reka-flash-3` | Reka Flash 3 | 65K |
+
+### Relace
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `relace/relace-apply-3` | Relace Apply 3 | 256K |
+| `relace/relace-search` | Relace Search | 256K |
+
+### Sao10K
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `sao10k/l3-lunaris-8b` | Llama 3 8B Lunaris | 8K |
+| `sao10k/l3-euryale-70b` | Llama 3 Euryale 70B v2.1 | 8K |
+| `sao10k/l3.1-70b-hanami-x1` | Llama 3.1 70B Hanami x1 | 16K |
+| `sao10k/l3.1-euryale-70b` | Llama 3.1 Euryale 70B v2.2 | 131K |
+| `sao10k/l3.3-euryale-70b` | Llama 3.3 Euryale 70B | 131K |
 
 ### Stepfun
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `stepfun/step-3.5-flash` | Step 3.5 Flash | 256K |
+| `stepfun/step-3.5-flash` | Step 3.5 Flash | 262K |
+| `stepfun/step-3.7-flash` | Step 3.7 Flash | 256K |
+
+### Switchpoint
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `switchpoint/router` | Switchpoint Router | 131K |
+
+### Tencent
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `tencent/hunyuan-a13b-instruct` | Hunyuan A13B Instruct | 131K |
+| `tencent/hy3-preview` | Hy3 preview | 262K |
+
+### Thedrummer
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `thedrummer/cydonia-24b-v4.1` | Cydonia 24B V4.1 | 131K |
+| `thedrummer/rocinante-12b` | Rocinante 12B | 32K |
+| `thedrummer/skyfall-36b-v2` | Skyfall 36B V2 | 32K |
+| `thedrummer/unslopnemo-12b` | UnslopNemo 12B | 32K |
+
+### Undi95
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `undi95/remm-slerp-l2-13b` | ReMM SLERP 13B | 6K |
+
+### Writer
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `writer/palmyra-x5` | Palmyra X5 | 1M |
 
 ### X Ai
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `x-ai/grok-3` | Grok 3 | 131K |
-| `x-ai/grok-3-beta` | Grok 3 Beta | 131K |
-| `x-ai/grok-3-mini` | Grok 3 Mini | 131K |
-| `x-ai/grok-3-mini-beta` | Grok 3 Mini Beta | 131K |
-| `x-ai/grok-4` | Grok 4 | 256K |
-| `x-ai/grok-4-fast` | Grok 4 Fast | 2M |
-| `x-ai/grok-4.1-fast` | Grok 4.1 Fast | 2M |
-| `x-ai/grok-4.20-beta` | Grok 4.20 Beta | 2M |
-| `x-ai/grok-4.20-multi-agent-beta` | Grok 4.20 Multi - Agent Beta | 2M |
-| `x-ai/grok-code-fast-1` | Grok Code Fast 1 | 256K |
+| `x-ai/grok-4.20` | Grok 4.20 | 2M |
+| `x-ai/grok-4.20-multi-agent` | Grok 4.20 Multi-Agent | 2M |
+| `x-ai/grok-4.3` | Grok 4.3 | 1M |
+| `x-ai/grok-build-0.1` | Grok Build 0.1 | 256K |
 
 ### Xiaomi
 
@@ -281,22 +597,54 @@ OpenRouter provides unified access to multiple AI models through a single API.
 | `xiaomi/mimo-v2-flash` | MiMo-V2-Flash | 262K |
 | `xiaomi/mimo-v2-omni` | MiMo-V2-Omni | 262K |
 | `xiaomi/mimo-v2-pro` | MiMo-V2-Pro | 1M |
+| `xiaomi/mimo-v2.5` | MiMo-V2.5 | 1M |
+| `xiaomi/mimo-v2.5-pro` | MiMo-V2.5-Pro | 1M |
 
 ### Z Ai
 
 | Model ID | Name | Context |
 |----------|------|---------|
-| `z-ai/glm-4.5` | GLM 4.5 | 128K |
-| `z-ai/glm-4.5-air` | GLM 4.5 Air | 128K |
-| `z-ai/glm-4.5-air:free` | GLM 4.5 Air (free) | 128K |
-| `z-ai/glm-4.5v` | GLM 4.5V | 64K |
-| `z-ai/glm-4.6` | GLM 4.6 | 200K |
-| `z-ai/glm-4.6:exacto` | GLM 4.6 (exacto) | 200K |
-| `z-ai/glm-4.7` | GLM-4.7 | 204K |
-| `z-ai/glm-4.7-flash` | GLM-4.7-Flash | 200K |
+| `z-ai/glm-4-32b` | GLM 4 32B  | 128K |
+| `z-ai/glm-4.5-air:free` | GLM 4.5 Air (free) | 131K |
+| `z-ai/glm-4.5` | GLM-4.5 | 131K |
+| `z-ai/glm-4.5-air` | GLM-4.5-Air | 131K |
+| `z-ai/glm-4.5v` | GLM-4.5V | 65K |
+| `z-ai/glm-4.6` | GLM-4.6 | 202K |
+| `z-ai/glm-4.6v` | GLM-4.6V | 131K |
+| `z-ai/glm-4.7` | GLM-4.7 | 202K |
+| `z-ai/glm-4.7-flash` | GLM-4.7-Flash | 202K |
 | `z-ai/glm-5` | GLM-5 | 202K |
 | `z-ai/glm-5-turbo` | GLM-5-Turbo | 202K |
 | `z-ai/glm-5.1` | GLM-5.1 | 202K |
+| `z-ai/glm-5v-turbo` | GLM-5V-Turbo | 202K |
+
+### ~Anthropic
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `~anthropic/claude-haiku-latest` | Anthropic Claude Haiku Latest | 200K |
+| `~anthropic/claude-sonnet-latest` | Anthropic Claude Sonnet Latest | 1M |
+| `~anthropic/claude-opus-latest` | Claude Opus Latest | 1M |
+
+### ~Google
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `~google/gemini-flash-latest` | Google Gemini Flash Latest | 1M |
+| `~google/gemini-pro-latest` | Google Gemini Pro Latest | 1M |
+
+### ~Moonshotai
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `~moonshotai/kimi-latest` | MoonshotAI Kimi Latest | 262K |
+
+### ~Openai
+
+| Model ID | Name | Context |
+|----------|------|---------|
+| `~openai/gpt-latest` | OpenAI GPT Latest | 1M |
+| `~openai/gpt-mini-latest` | OpenAI GPT Mini Latest | 400K |
 <!-- MODEL-TABLE:END -->
 
 ## Setup

--- a/website/docs/agent-support/providers/vertex.md
+++ b/website/docs/agent-support/providers/vertex.md
@@ -9,6 +9,19 @@ Google Cloud Vertex AI provides access to Gemini models.
 <!-- MODEL-TABLE:START -->
 | Model ID | Name | Context |
 |----------|------|---------|
+| `claude-3-5-haiku@20241022` | Claude Haiku 3.5 | 200K |
+| `claude-haiku-4-5@20251001` | Claude Haiku 4.5 | 200K |
+| `claude-opus-4@20250514` | Claude Opus 4 | 200K |
+| `claude-opus-4-1@20250805` | Claude Opus 4.1 | 200K |
+| `claude-opus-4-5@20251101` | Claude Opus 4.5 | 200K |
+| `claude-opus-4-6@default` | Claude Opus 4.6 | 1M |
+| `claude-opus-4-7@default` | Claude Opus 4.7 | 1M |
+| `claude-opus-4-8@default` | Claude Opus 4.8 | 1M |
+| `claude-3-5-sonnet@20241022` | Claude Sonnet 3.5 v2 | 200K |
+| `claude-3-7-sonnet@20250219` | Claude Sonnet 3.7 | 200K |
+| `claude-sonnet-4@20250514` | Claude Sonnet 4 | 200K |
+| `claude-sonnet-4-5@20250929` | Claude Sonnet 4.5 | 200K |
+| `claude-sonnet-4-6@default` | Claude Sonnet 4.6 | 1M |
 | `deepseek-ai/deepseek-v3.1-maas` | DeepSeek V3.1 | 163K |
 | `deepseek-ai/deepseek-v3.2-maas` | DeepSeek V3.2 | 163K |
 | `zai-org/glm-4.7-maas` | GLM-4.7 | 200K |
@@ -16,21 +29,19 @@ Google Cloud Vertex AI provides access to Gemini models.
 | `openai/gpt-oss-120b-maas` | GPT OSS 120B | 131K |
 | `openai/gpt-oss-20b-maas` | GPT OSS 20B | 131K |
 | `gemini-2.0-flash` | Gemini 2.0 Flash | 1M |
-| `gemini-2.0-flash-lite` | Gemini 2.0 Flash Lite | 1M |
+| `gemini-2.0-flash-lite` | Gemini 2.0 Flash-Lite | 1M |
 | `gemini-2.5-flash` | Gemini 2.5 Flash | 1M |
-| `gemini-2.5-flash-lite` | Gemini 2.5 Flash Lite | 1M |
 | `gemini-2.5-flash-lite-preview-06-17` | Gemini 2.5 Flash Lite Preview 06-17 | 65K |
-| `gemini-2.5-flash-lite-preview-09-2025` | Gemini 2.5 Flash Lite Preview 09-25 | 1M |
-| `gemini-2.5-flash-preview-04-17` | Gemini 2.5 Flash Preview 04-17 | 1M |
-| `gemini-2.5-flash-preview-05-20` | Gemini 2.5 Flash Preview 05-20 | 1M |
 | `gemini-2.5-flash-preview-09-2025` | Gemini 2.5 Flash Preview 09-25 | 1M |
+| `gemini-2.5-flash-lite` | Gemini 2.5 Flash-Lite | 1M |
 | `gemini-2.5-pro` | Gemini 2.5 Pro | 1M |
-| `gemini-2.5-pro-preview-05-06` | Gemini 2.5 Pro Preview 05-06 | 1M |
-| `gemini-2.5-pro-preview-06-05` | Gemini 2.5 Pro Preview 06-05 | 1M |
 | `gemini-3-flash-preview` | Gemini 3 Flash Preview | 1M |
 | `gemini-3-pro-preview` | Gemini 3 Pro Preview | 1M |
+| `gemini-3.1-flash-lite` | Gemini 3.1 Flash Lite | 1M |
+| `gemini-3.1-flash-lite-preview` | Gemini 3.1 Flash Lite Preview | 1M |
 | `gemini-3.1-pro-preview` | Gemini 3.1 Pro Preview | 1M |
 | `gemini-3.1-pro-preview-customtools` | Gemini 3.1 Pro Preview Custom Tools | 1M |
+| `gemini-3.5-flash` | Gemini 3.5 Flash | 1M |
 | `gemini-embedding-001` | Gemini Embedding 001 | 2K |
 | `gemini-flash-latest` | Gemini Flash Latest | 1M |
 | `gemini-flash-lite-latest` | Gemini Flash-Lite Latest | 1M |

--- a/website/docs/agent-support/providers/zai.md
+++ b/website/docs/agent-support/providers/zai.md
@@ -20,7 +20,7 @@ Zhipu AI (ZAI) BigModel platform provides access to GLM (General Language Model)
 | `glm-4.7-flashx` | GLM-4.7-FlashX | 200K |
 | `glm-5` | GLM-5 | 204K |
 | `glm-5.1` | GLM-5.1 | 200K |
-| `glm-5v-turbo` | glm-5v-turbo | 200K |
+| `glm-5v-turbo` | GLM-5V-Turbo | 200K |
 <!-- MODEL-TABLE:END -->
 
 ## Setup


### PR DESCRIPTION
## Summary

- **Refreshed model catalog** from `models.dev` (171→354 OpenRouter, +13 OpenAI/Anthropic/Vertex, Z.AI fully replaced with `glm-4.5`–`glm-5.1`, Bedrock now includes per-region inference profiles for Claude 4.x). Strings match the aggregator verbatim.
- **Fixed the long-standing Add Provider modal bug** where only a tiny hand-curated subset was selectable. Replaced the plain `<select>` with a searchable, lab-grouped combobox driven by the catalog.
- **Collapsed the dual source of truth.** `PROVIDER_MODELS` in `core/providers/storage.py` is now metadata-only (`endpoint`, `requires_api_key`, `requires_endpoint`). All model lookups (CLI, GUI, validation) flow through `core/providers/models` and the JSON catalog.
- **Ollama stays dynamic.** The catalog leaves Ollama empty; per-instance models are still populated from the host's `/api/tags` daemon and surfaced as `available_models` on the provider record.

## What changed by area

- `src/clawrium/core/providers/storage.py` — `PROVIDER_MODELS` reduced to metadata; `get_models_for_type` delegates to the catalog.
- `src/clawrium/core/providers/models.json` — regenerated via `scripts/refresh_model_catalog.py` (573 models total across 7 providers).
- `src/clawrium/gui/routes/providers.py` — `/api/providers/types` returns rich `ModelInfo[]` (`id`, `name`, `lab`, `context_window`, `tags`).
- `src/clawrium/cli/{provider,clawctl/provider}.py` — use `get_model_count` / catalog for counts.
- `gui/src/components/providers/model-combobox.tsx` — new component, lab grouping (auto-on for OpenRouter/Bedrock/Vertex), keyboard nav (↑/↓/Enter/Esc), click-outside-to-close, context-window + tag chips, capped at 100 visible with "refine search" hint, full ARIA wiring.
- `gui/src/components/providers/{add,edit}-provider-modal.tsx` — wired to the new combobox; Edit normalizes Ollama's `string[] available_models` into `ModelInfo[]`.
- `gui/src/lib/types.ts` — `ModelInfo` exported; `ProviderTypeInfo.models` is now `ModelInfo[]`.
- `docs/agent-support/providers/*.md` + `website/docs/agent-support/providers/*.md` — regenerated.

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — **3,753 pytest passed**, 2 skipped
- [x] Linter passes (`make lint`) — ruff clean, eslint clean
- [x] New tests added — **250 vitest passed** (combobox: 8 → 19 tests; new `/types` shape test in `test_gui_route_providers.py`)
- [x] TypeScript clean for changed files

### Test coverage notes
- New unit-test file `gui/src/components/providers/model-combobox.test.tsx` covers: controlled `value`, filter by id/name/lab/tag, lab grouping, click selection, keyboard selection across groups, ArrowUp clamp, Escape close, `disabled` state, click-outside, empty state, list capping, ARIA (`aria-expanded`/`aria-controls`/`aria-selected`), `inputId` wiring.
- New backend test `test_provider_types_returns_rich_model_metadata` pins the `/types` payload shape so a regression to the old `string[]` shape would fail loudly.
- Existing test `test_cli_provider.py` updated to use a still-valid Bedrock model id (the previously hardcoded `claude-sonnet-4-20250514-v1:0` no longer exists upstream).

### Manual testing
- Cold-loaded the GUI, opened Add Provider modal: OpenAI now lists 52 models filterable by lab/tag; OpenRouter lists 354 grouped by `openai/anthropic/qwen/...` with the refine-search hint past 100.
- Edit Provider modal: Ollama provider renders its host-discovered `available_models` through the same combobox; cloud providers render catalog models.
- CLI: `clm provider types` and `clawctl provider types` now show counts pulled from the catalog.

### Security checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — modal still validates name pattern; combobox is a controlled input
- [x] No SQL injection, XSS, or command injection risks — model metadata is rendered as text only
- [x] Dependencies are from trusted sources — only `models.dev` (already used) and existing `@testing-library/user-event`

## ATX Review Summary

**Final Review: Rating 5/5 (all blockers resolved)**

A stop hook ran an ATX review on the new `model-combobox.test.tsx` and flagged 5 blocking issues + 7 warnings. All have been addressed; the W7 fix surfaced a real component bug.

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 2/5 | B1, B2, B3, B4, B5 | All fixed |

> **Note**: ATX stop-hook review; per-agent cost/time not exposed.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `model-combobox.test.tsx` | Controlled `value` prop / `displayValue` logic never tested | Added two tests: closed-state shows `selected.id`, opening with selected value clears for fresh search |
| B2 | `model-combobox.test.tsx` | `fireEvent` used instead of `userEvent` throughout | Rewrote all tests with `userEvent.setup()` per spec; removed `fireEvent` |
| B3 | `model-combobox.test.tsx` | ArrowUp + Escape keyboard handlers had zero coverage | Added dedicated ArrowUp-clamp and Escape-closes-listbox tests |
| B4 | `model-combobox.test.tsx` | `disabled` prop behavior entirely untested | Added test: disabled input + focus does not open listbox |
| B5 | `model-combobox.test.tsx` | Click-outside-to-close untested | Added test using sibling button + `user.pointer({ keys: "[MouseLeft]" })` |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `model-combobox.test.tsx` | `matchModel` name-branch never exercised | Added filter-by-display-name test |
| W2 | `model-combobox.test.tsx` | Partial filter assertion in lab-filter test | Asserted both other models disappear |
| W3 | `model-combobox.test.tsx` | Post-selection state (close + revert) untested | Added test asserting listbox unmounts and input value updates to selected id |
| W4 | `model-combobox.test.tsx` | ARIA attributes never asserted | Added test for `aria-expanded`, `aria-controls`, `aria-selected` |
| W5 | `model-combobox.test.tsx` | `inputId` prop untested | Covered in the aria test (verifies `${inputId}-listbox`) |
| W6 | `model-combobox.test.tsx` | Listbox assertions not scoped with `within` | All listbox assertions now scoped to `within(screen.getByRole("listbox"))` |
| W7 | `model-combobox.tsx` | Grouped keyboard navigation untested | Surfaced a real bug: `visible[activeIdx]` used source order while `runningIdx` used grouped order. **Component fixed**: `visible` is now the flat render-order list (grouped flatmap), so Enter and the highlighted row always agree |

</details>

## Reviewer Notes

- **Forward-dated upstream IDs** (`gpt-5.5-pro`, `claude-opus-4-8`, `gemini-3.5-flash`, `glm-5.1`) come from `models.dev` verbatim. Per the design decision in this PR's planning, the aggregator is the source of truth; if any prove non-functional in production calls, the refresh script may need a "released-only" filter later (out of scope).
- **Stale `default_model` values** in existing `providers.json` files (e.g., users who saved `glm-4` will see Z.AI replaced upstream) — no silent rewrite. A "model not in catalog" warning on `clm provider get` would be a small follow-up; deliberately not bundled here.
- **No schema migration** to `providers.json`. `default_model` remains free-text — existing user configs continue to work.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>