### PR TITLE
feat(openclaw): enable native web UI via features.web_ui manifest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ Rules (issue #437):
 
 ## Native Dashboards (issues #478, #491)
 
-Two agent types ship a native web UI today: **hermes** (issue #478) and **zeroclaw** (issue #491). The manifest's `features.web_ui` block is the single gate — `clawctl agent open <name>` and the GUI's **Open Agent UI** button both consult the resolver in `src/clawrium/core/web_ui.py`, which returns `None` for any agent whose manifest does not declare `features.web_ui`.
+Three agent types ship a native web UI today: **hermes** (issue #478), **zeroclaw** (issue #491), and **openclaw**. The manifest's `features.web_ui` block is the single gate — `clawctl agent open <name>` and the GUI's **Open Agent UI** button both consult the resolver in `src/clawrium/core/web_ui.py`, which returns `None` for any agent whose manifest does not declare `features.web_ui`.
 
 **Hermes** (issue #478) runs the dashboard in a separate systemd unit on the agent host:
 
@@ -125,11 +125,13 @@ The hermes dashboard binds `127.0.0.1:<port>` only (`features.web_ui.bind: loopb
 
 **Zeroclaw** (issue #491) does not run a separate dashboard unit — the gateway daemon itself serves the SPA on the same port as `config.gateway.port` (`features.web_ui.bind: wildcard`, port persisted under `gateway.port`). install.py picks the per-instance gateway port in `40000..41999`.
 
-**Auth boundary (both agent types).** There is no in-process auth on the dashboard: the **SSH key Ansible already uses for the host is the auth boundary**. Anyone with shell access to the agent host could reach the dashboard directly, so layering a token wall on top would not raise the security floor. Zeroclaw's `0.0.0.0` bind is an upstream property; this trust model still holds because reachability is gated at the network/SSH layer.
+**Openclaw** uses the same shape as zeroclaw: the SPA is served by `openclaw gateway run` on the same port as `config.gateway.port` (`features.web_ui.bind: wildcard`, port persisted under `gateway.port`). install.py picks the per-instance gateway port in `40000..41999` via the same allocator branch as zeroclaw. Unlike zeroclaw, openclaw is intentionally NOT in `_PAIRING_AGENT_TYPES` (see `gui/routes/fleet.py`) — its WebSocket auth uses the gateway bearer token already stored in `hosts.json.agents.<name>.config.gateway.auth.token`, which the user pastes into the SPA's login form on first open. A dedicated pairing UX for openclaw is a follow-up.
+
+**Auth boundary (hermes / zeroclaw).** There is no in-process auth on the dashboard for hermes or zeroclaw: the **SSH key Ansible already uses for the host is the auth boundary**. Anyone with shell access to the agent host could reach the dashboard directly, so layering a token wall on top would not raise the security floor. Zeroclaw's `0.0.0.0` bind is an upstream property; this trust model still holds because reachability is gated at the network/SSH layer. Openclaw additionally requires the gateway bearer token at the WebSocket handshake — see the openclaw section above.
 
 **Tunnel reuse.** The tunnel manager at `src/clawrium/core/web_ui_tunnel.py` is idempotent — a second invocation for a live tunnel reuses the existing local port (state at `~/.config/clawrium/tunnels/<agent_key>.json`, PID + cmdline-guarded). The GUI auto-reaps tunnels idle > 30 minutes; CLI tunnels close on `Ctrl-C` or process exit. The remote target is always loopback regardless of `bind`: both `BIND_ADDRESS_MAP["loopback"]` and `BIND_ADDRESS_MAP["wildcard"]` resolve to `127.0.0.1`, because the SSH local-forward terminates on the remote loopback interface — reachable for both bind modes.
 
-**No `default_port` in bundled manifests.** Both hermes and zeroclaw manifests omit `features.web_ui.default_port`. install.py always persists a per-instance port at `port_field`; a manifest-wide default would silently collide on hosts running multiple agents of the same type. The resolver surfaces a missing persisted port as "no UI available" rather than inventing one. Third-party manifests may still opt into `default_port` — the schema accepts it.
+**No `default_port` in bundled manifests.** Hermes, zeroclaw, and openclaw manifests all omit `features.web_ui.default_port`. install.py always persists a per-instance port at `port_field`; a manifest-wide default would silently collide on hosts running multiple agents of the same type. The resolver surfaces a missing persisted port as "no UI available" rather than inventing one. Third-party manifests may still opt into `default_port` — the schema accepts it.
 
 ## Tech Stack
 

--- a/gui/src/components/agent-detail/agent-header.tsx
+++ b/gui/src/components/agent-detail/agent-header.tsx
@@ -34,7 +34,7 @@ export function AgentHeader({ agent }: AgentHeaderProps) {
   //     so the user gets feedback that the system is trying.
   //   - permanent no-UI (`reason` says "does not expose") → button is
   //     hidden entirely; rendering a perma-disabled button on every
-  //     nemoclaw / openclaw page was the previous UX regression.
+  //     nemoclaw page was the previous UX regression.
   const webUI = useAgentWebUI(agent.agent_key, agent.status);
   const webUIPermanentlyUnavailable =
     webUI.data?.available === false &&

--- a/gui/src/hooks/use-agent.ts
+++ b/gui/src/hooks/use-agent.ts
@@ -40,7 +40,7 @@ export function useAgentWebUI(key: string, status: string) {
     //     polling too: agent type is permanently no-UI; no amount of
     //     refetching changes that. The previous unconditional 30s
     //     interval kept hitting the endpoint forever for every
-    //     nemoclaw / openclaw / etc. fleet member.
+    //     nemoclaw / etc. fleet member.
     //   - available=false with a transient reason (tunnel error,
     //     daemon not reachable, etc.) → keep the 30s retry so a
     //     blip clears itself.

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -2739,8 +2739,8 @@ def open_ui(
     browser at the local end of the tunnel. The tunnel runs until you
     Ctrl-C.
 
-    Hermes and zeroclaw expose a native UI today; agents whose manifests
-    do not declare `features.web_ui` (e.g. openclaw) print a hard-error.
+    Hermes, zeroclaw, and openclaw expose a native UI today; agents whose
+    manifests do not declare `features.web_ui` print a hard-error.
     """
     import signal
     import webbrowser

--- a/src/clawrium/platform/registry/openclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/openclaw/manifest.yaml
@@ -14,6 +14,29 @@ features:
   # Chat dispatch resolves to the WebSocket gateway client for openclaw.
   chat:
     type: websocket
+  # Native control UI served by the openclaw gateway itself (no separate
+  # systemd unit) on the same port as `config.gateway.port`. Upstream
+  # docs: https://docs.openclaw.ai/web/control-ui — the SPA is served
+  # automatically by `openclaw gateway run`, so no config flag is needed
+  # to enable it. `bind: wildcard` mirrors zeroclaw: the gateway binds
+  # `lan` (0.0.0.0), and the SSH tunnel still targets remote loopback
+  # via BIND_ADDRESS_MAP. No `default_port` because install.py picks a
+  # per-instance gateway port in 40000..41999 (same allocator path as
+  # zeroclaw, see install.py ~L645) and persists it under
+  # `gateway.port` — a manifest-wide default would silently collide on
+  # a host running multiple openclaw instances.
+  #
+  # Auth caveat: the SPA authenticates over the gateway WebSocket using
+  # the bearer token already stored in hosts.json.agents.<name>.config.
+  # gateway.auth.token. Today the user pastes that token into the SPA's
+  # login form on first open — openclaw's auth flow differs from
+  # zeroclaw's pairing-code handshake, so openclaw is intentionally NOT
+  # added to `_PAIRING_AGENT_TYPES` in gui/routes/fleet.py. A dedicated
+  # pairing UX for openclaw can land as a follow-up.
+  web_ui:
+    enabled: true
+    bind: wildcard
+    port_field: gateway.port
 
 # Secrets configuration
 # Note: Provider-specific API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)

--- a/tests/test_cli_agent_open.py
+++ b/tests/test_cli_agent_open.py
@@ -15,8 +15,17 @@ from clawrium.core.web_ui import ResolvedUI
 runner = CliRunner()
 
 
-def _seed_hosts(config_dir: Path, agent_type: str) -> None:
-    """Write a minimal hosts.json with one agent of the given type."""
+def _seed_hosts(
+    config_dir: Path,
+    agent_type: str,
+    config: dict | None = None,
+) -> None:
+    """Write a minimal hosts.json with one agent of the given type.
+
+    `config` overrides the agent's `config` block — pass e.g.
+    `{"gateway": {"port": 40456}}` for tests that need a persisted port
+    so the fixture stays coherent with what install.py would write.
+    """
     hosts = [
         {
             "hostname": "192.168.1.100",
@@ -28,7 +37,7 @@ def _seed_hosts(config_dir: Path, agent_type: str) -> None:
                     "type": agent_type,
                     "agent_name": "demo",
                     "name": "demo",
-                    "config": {},
+                    "config": config or {},
                 }
             },
         }
@@ -38,14 +47,18 @@ def _seed_hosts(config_dir: Path, agent_type: str) -> None:
 
 
 def test_open_rejects_agent_without_web_ui_feature(isolated_config: Path):
-    """openclaw has no `features.web_ui` in its manifest → resolver returns
-    None → CLI exits with a clear "does not declare a native web UI" error.
+    """When the resolver returns None (manifest does not declare
+    `features.web_ui`) → CLI exits with a clear "does not declare a
+    native web UI" error.
 
-    The hermes-only gate was dropped in #491 (zeroclaw also exposes a UI);
-    the manifest's `features.web_ui` block is now the only gate.
+    The hermes-only gate was dropped in #491 (zeroclaw also exposes a UI),
+    and openclaw joined the UI-bearing set after that. All three bundled
+    agent types now declare `features.web_ui`, so this test patches the
+    resolver directly to exercise the manifest-not-declared code path.
     """
     _seed_hosts(isolated_config, "openclaw")
-    result = runner.invoke(app, ["agent", "open", "demo"])
+    with patch("clawrium.core.web_ui.resolve", return_value=None):
+        result = runner.invoke(app, ["agent", "open", "demo"])
     assert result.exit_code == 1
     assert "does not declare" in result.output.lower()
     assert "native web ui" in result.output.lower()
@@ -289,3 +302,40 @@ def test_open_remote_zeroclaw_spawns_tunnel_with_wildcard_bind(isolated_config: 
     assert result.exit_code == 0, result.output
     mock_ensure.assert_called_once_with("demo")
     mock_browser.assert_called_once_with("http://127.0.0.1:39211/")
+
+
+def test_open_remote_openclaw_spawns_tunnel_with_wildcard_bind(isolated_config: Path):
+    """openclaw resolves with `bind='wildcard'` (mirror of zeroclaw) and
+    still tunnels to remote loopback. Regression anchor for the openclaw
+    parity work that landed `features.web_ui` in the manifest.
+
+    Seed mirrors what install.py persists at first install (gateway port
+    in 40000..41999): even though the resolver is patched below, the
+    fixture stays internally coherent — a less-mocked variant of this
+    test (real resolver) would resolve to the same `ResolvedUI`.
+    """
+    _seed_hosts(isolated_config, "openclaw", {"gateway": {"port": 40456}})
+    resolved = ResolvedUI(
+        host="oc.local",
+        remote_port=40456,
+        bind="wildcard",
+        ssh_config={"user": "xclm"},
+    )
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=resolved),
+        patch(
+            "clawrium.core.health.check_claw_health",
+            return_value=_running_health(agent_type="openclaw", host="oc.local"),
+        ),
+        patch("clawrium.core.web_ui_tunnel.ensure", return_value=39212) as mock_ensure,
+        patch("clawrium.core.web_ui_tunnel.close"),
+        patch("webbrowser.open") as mock_browser,
+        patch("threading.Event") as mock_event_cls,
+    ):
+        mock_event_cls.return_value.wait.return_value = None
+        result = runner.invoke(app, ["agent", "open", "demo"])
+
+    assert result.exit_code == 0, result.output
+    mock_ensure.assert_called_once_with("demo")
+    mock_browser.assert_called_once_with("http://127.0.0.1:39212/")

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -72,10 +72,21 @@ def test_web_ui_404_for_unknown_agent(isolated_config: Path):
     assert resp.status_code == 404
 
 
-def test_web_ui_returns_unavailable_for_non_hermes(isolated_config: Path):
+def test_web_ui_returns_unavailable_when_manifest_lacks_feature(
+    isolated_config: Path,
+):
+    """When `features.web_ui` is absent, the endpoint returns
+    `available: false` with the agent_type embedded in the reason.
+
+    All three bundled agent types now declare `features.web_ui`, so this
+    test patches the resolver to None to exercise the no-feature code
+    path. The seeded agent is openclaw merely to keep the rest of the
+    fixture stable.
+    """
     _seed_hosts(isolated_config, "openclaw")
-    with TestClient(app) as client:
-        resp = client.get("/api/fleet/agents/demo/web-ui")
+    with patch("clawrium.core.web_ui.resolve", return_value=None):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo/web-ui")
     assert resp.status_code == 200
     body = resp.json()
     assert body["available"] is False
@@ -106,6 +117,38 @@ def test_web_ui_returns_tunnel_url_for_remote_hermes(isolated_config: Path):
     assert body == {
         "available": True,
         "local_url": "http://127.0.0.1:54321/",
+        "reason": None,
+    }
+    mock_ensure.assert_called_once_with("demo")
+
+
+def test_web_ui_returns_tunnel_url_for_remote_openclaw(isolated_config: Path):
+    """openclaw resolves with `bind='wildcard'` and a persisted gateway
+    port; the route returns `available: true` with a local tunnel URL.
+
+    Mirror of the hermes positive test above — anchors the openclaw
+    parity work added with `features.web_ui` in the manifest.
+    """
+    _seed_hosts(isolated_config, "openclaw", {"gateway": {"port": 40456}})
+    resolved = ResolvedUI(
+        host="192.168.1.100",
+        remote_port=40456,
+        bind="wildcard",
+        ssh_config={"user": "xclm"},
+    )
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=resolved),
+        patch("clawrium.core.web_ui_tunnel.ensure", return_value=54322) as mock_ensure,
+    ):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo/web-ui")
+            assert "demo" in fleet_mod.WEB_UI_LAST_ACCESS
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {
+        "available": True,
+        "local_url": "http://127.0.0.1:54322/",
         "reason": None,
     }
     mock_ensure.assert_called_once_with("demo")
@@ -239,8 +282,29 @@ def test_pairing_code_400_for_non_pairing_agent_type(isolated_config: Path):
     assert "pairing handshake" in resp.json()["detail"].lower()
 
 
-def test_pairing_code_400_when_manifest_lacks_web_ui(isolated_config: Path):
-    """openclaw has no features.web_ui — resolver returns None."""
+def test_pairing_code_400_for_openclaw_not_in_pairing_types(isolated_config: Path):
+    """openclaw declares features.web_ui (so resolve() returns a valid
+    ResolvedUI) but is intentionally NOT in `_PAIRING_AGENT_TYPES` —
+    openclaw uses a gateway bearer token, not zeroclaw's pairing-code
+    handshake. The earlier guard at fleet.py:402 fires first and returns
+    400 with "pairing handshake" in the detail before the
+    "no native web UI" branch is reached.
+    """
+    _seed_hosts(isolated_config, "openclaw", {"gateway": {"port": 40456}})
+    with TestClient(app) as client:
+        resp = client.post("/api/fleet/agents/demo/pairing-code")
+    assert resp.status_code == 400
+    assert "pairing handshake" in resp.json()["detail"].lower()
+
+
+def test_pairing_code_400_when_resolver_returns_none(isolated_config: Path):
+    """When resolve() returns None for a pairing-type agent, the manifest
+    check fires (after the _PAIRING_AGENT_TYPES guard) and returns 400.
+
+    Seeds zeroclaw (a pairing type) so the _PAIRING_AGENT_TYPES guard
+    passes, then patches resolve to None to exercise the no-features.web_ui
+    branch independently of any real manifest.
+    """
     _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config())
     with patch("clawrium.core.web_ui.resolve", return_value=None):
         with TestClient(app) as client:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1389,10 +1389,23 @@ def test_hermes_manifest_declares_web_ui():
     assert "default_port" not in web_ui
 
 
-def test_openclaw_manifest_does_not_declare_web_ui():
-    """openclaw does not opt into the native-UI mechanism."""
+def test_openclaw_manifest_declares_web_ui_via_gateway_port():
+    """openclaw opts into the native-UI mechanism via gateway.port.
+
+    Mirrors zeroclaw: the openclaw gateway daemon serves its control SPA
+    on the same port as `config.gateway.port`, so `port_field` resolves
+    to that path. No `default_port`: install.py picks a per-instance
+    port at install time (the same 40000..41999 allocator branch as
+    zeroclaw) and persists it under `gateway.port`, so a manifest-wide
+    default would silently collide on hosts running multiple openclaw
+    instances.
+    """
     manifest = load_manifest("openclaw")
-    assert "web_ui" not in manifest.get("features", {})
+    web_ui = manifest.get("features", {}).get("web_ui", {})
+    assert web_ui.get("enabled") is True
+    assert web_ui.get("bind") == "wildcard"
+    assert web_ui.get("port_field") == "gateway.port"
+    assert "default_port" not in web_ui
 
 
 def test_zeroclaw_manifest_declares_web_ui():

--- a/tests/test_web_ui_resolver.py
+++ b/tests/test_web_ui_resolver.py
@@ -65,15 +65,51 @@ def test_resolve_hermes_uses_persisted_port(monkeypatch):
     assert resolved.remote_port == 45123
 
 
-def test_resolve_openclaw_returns_none(monkeypatch):
-    """openclaw's manifest does not declare `features.web_ui`."""
+def test_resolve_openclaw_returns_gateway_port(monkeypatch):
+    """openclaw resolves to its persisted `gateway.port` (mirror of zeroclaw).
+
+    The openclaw gateway daemon serves its control SPA on the same port
+    as the WebSocket gateway (`config.gateway.port`), so the resolver
+    must return that persisted value with `bind: wildcard` — the SSH
+    tunnel still targets remote loopback via BIND_ADDRESS_MAP.
+    """
+    agent_record = {
+        "agent_name": "oc",
+        "type": "openclaw",
+        "config": {"gateway": {"port": 40456}},
+    }
+    _patch_agent(
+        monkeypatch,
+        host=_host("oc.local"),
+        agent_type="openclaw",
+        agent_record=agent_record,
+    )
+
+    resolved = resolve("oc")
+
+    assert isinstance(resolved, ResolvedUI)
+    assert resolved.host == "oc.local"
+    assert resolved.remote_port == 40456
+    assert resolved.bind == "wildcard"
+    assert resolved.ssh_config.get("user") == "xclm"
+
+
+def test_resolve_openclaw_without_persisted_port_returns_none(monkeypatch, caplog):
+    """openclaw without persisted `gateway.port` resolves to None.
+
+    Same rationale as the hermes/zeroclaw equivalents: install.py picks
+    a per-instance port, so inventing a default would silently serve a
+    different instance's UI on hosts with multiple openclaw agents.
+    """
     _patch_agent(
         monkeypatch,
         host=_host(),
         agent_type="openclaw",
         agent_record={"agent_name": "oc", "type": "openclaw", "config": {}},
     )
-    assert resolve("oc") is None
+    with caplog.at_level("WARNING", logger="clawrium.core.web_ui"):
+        assert resolve("oc") is None
+    assert any("gateway.port" in rec.message for rec in caplog.records)
 
 
 def test_resolve_zeroclaw_returns_gateway_port(monkeypatch):


### PR DESCRIPTION
## Summary

Adds `features.web_ui` to the bundled openclaw manifest so the GUI's **Open Agent UI** button and `clm agent open` work for openclaw agents — matching the parity zeroclaw landed in #491. The openclaw gateway daemon already serves its control SPA on the same port as `config.gateway.port` ([upstream docs](https://docs.openclaw.ai/web/control-ui)), and `install.py` already allocates that port per-instance in `40000..41999` via the same allocator branch as zeroclaw. The manifest declaration was the only missing piece.

- **`bind: wildcard`** mirrors zeroclaw; the SSH tunnel still targets remote loopback via `BIND_ADDRESS_MAP`.
- **No `default_port`** — `install.py` is the sole source of truth; a manifest-wide default would silently collide on hosts running multiple openclaw instances.
- **Not in `_PAIRING_AGENT_TYPES`** — openclaw's WebSocket auth uses the gateway bearer token already stored at `hosts.json.agents.<name>.config.gateway.auth.token`, not zeroclaw's pairing-code handshake. Users paste the token into the SPA's login form on first open. A dedicated pairing UX for openclaw is a follow-up.

Also updates `AGENTS.md` "Native Dashboards" (two → three agent types, new openclaw paragraph documenting the auth caveat), the CLI docstring at `agent.py:2742-2743`, and two GUI comments that previously used openclaw as the "no-UI" example.

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — 3765 passed, 2 skipped
- [x] Linter passes (`make lint-py` + `make lint-ui`)
- [x] New tests added for new functionality

### New tests
- `test_openclaw_manifest_declares_web_ui_via_gateway_port` (test_registry.py) — replaces the prior `_does_not_declare_web_ui` anchor
- `test_resolve_openclaw_returns_gateway_port` + `test_resolve_openclaw_without_persisted_port_returns_none` (test_web_ui_resolver.py) — mirror the zeroclaw resolver tests
- `test_open_remote_openclaw_spawns_tunnel_with_wildcard_bind` (test_cli_agent_open.py) — mirrors the zeroclaw CLI test, anchors the wildcard-bind tunnel path
- `test_web_ui_returns_tunnel_url_for_remote_openclaw` (test_gui_routes_fleet.py) — mirrors the hermes GUI route happy-path test
- `test_pairing_code_400_for_openclaw_not_in_pairing_types` (test_gui_routes_fleet.py) — anchors the new state transition where openclaw now passes the manifest gate and hits `_PAIRING_AGENT_TYPES` first

### Manual testing
Not yet exercised end-to-end against a live openclaw agent — the SPA login UX (paste bearer token from hosts.json) is an inherited upstream property; documenting the workflow surface is a follow-up.

### Security checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources

## ATX Review Summary

**Final Review: Rating 3/5 → all listed blockers fixed**
**Total Cost: ~$3.82 | Total Time: ~17m | 3 review rounds**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1, B2 | All fixed | ~\$2.63 | 8m40s | leader, gui-frontend, test-coverage, security, registry-manifest |
| 2 | mixed (cli-typer 5/5; test-coverage 2/5 stale-read) | — | Resolved by re-staging | — | — | leader, cli-typer, test-coverage |
| 3 | 3/5 | B1 | Fixed | ~\$1.19 | 6m21s | leader, security, test-coverage |

> **Note**: ATX does not expose model information per agent. Review 2's verdict was an artifact of one specialist reading pre-diff files; resolved by staging the changes before iter 3.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_cli_agent_open.py` | Missing positive openclaw test for wildcard-bind tunnel path | Fixed — added `test_open_remote_openclaw_spawns_tunnel_with_wildcard_bind` |
| B2 | `tests/test_gui_routes_fleet.py` | Missing positive GUI route test returning tunnel URL for openclaw | Fixed — added `test_web_ui_returns_tunnel_url_for_remote_openclaw` |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `gui/src/components/agent-detail/agent-header.tsx`, `use-agent.ts` | Fragile `reason.includes("does not expose")` substring guard | Acknowledged — backend `permanent: bool` is a follow-up |
| W2 | `src/clawrium/cli/agent.py:2743` | Stale docstring calling out openclaw as no-UI example | Fixed — updated docstring |
| W3 | `tests/test_registry.py` | Duplicate manifest assertion near line 268 vs canonical anchor at 1409 | Fixed — removed duplicate |
| W4 | `src/clawrium/core/web_ui.py:224` | Pre-existing `web_ui["port_field"]` KeyError risk | Acknowledged — pre-existing, follow-up |

</details>

<details>
<summary>Review 3 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_gui_routes_fleet.py` | New `_PAIRING_AGENT_TYPES` 400 path for openclaw uncovered (post-diff openclaw now passes the manifest gate, hits the pairing-type guard first) | Fixed — added `test_pairing_code_400_for_openclaw_not_in_pairing_types` |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `src/clawrium/gui/routes/fleet.py:421` | gateway.auth schema divergence (zeroclaw string vs openclaw nested dict) undocumented | Acknowledged — inline comment is a follow-up; this PR does not add openclaw to `_PAIRING_AGENT_TYPES`, so the implicit dual-gate is not triggered |
| W2 | `src/clawrium/core/web_ui.py:215` | Resolver does not validate `bind` against `BIND_ADDRESS_MAP` | Out-of-scope — `_validate_web_ui` in `registry.py` already constrains `bind` to a closed enum at manifest-validation time |

**Suggestions:**

| # | File | Suggestion | Action |
|---|------|------------|--------|
| S1 | `tests/test_web_ui_resolver.py` | Assert `ssh_config.user` in the new openclaw positive test | Fixed |
| S2 | `tests/test_cli_agent_open.py` | `_seed_hosts` should accept a `config` arg for fixture coherence | Fixed — extended helper, openclaw test now seeds `{"gateway": {"port": 40456}}` |
| S3 | `tests/test_gui_routes_fleet.py:243` | Stale docstring/name on `test_pairing_code_400_when_manifest_lacks_web_ui` | Fixed — renamed to `_when_resolver_returns_none` with accurate docstring |
| S4 | `src/clawrium/core/web_ui_tunnel.py:90` | Pre-existing `agent_key.replace('/', '_')` allows newlines in state filenames | Out-of-scope — pre-existing |

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>