### PR TITLE
docs: sync installation.md with website mirror

### DIFF
--- a/docs/guides/host-setup.md
+++ b/docs/guides/host-setup.md
@@ -1,0 +1,1 @@
+../host-preparation.md

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -135,7 +135,7 @@ Linux or macOS.
 On the macOS host you want to manage:
 
 1. **A user with `sudo` access** for the manual `xclm` setup. See
-   [Host Preparation](host-preparation.md) for the exact commands — macOS
+   [Host Preparation](guides/host-setup.md) for the exact commands — macOS
    uses `dscl`, `dseditgroup` (including the critical
    `com.apple.access_ssh` group membership), and `sudoers.d`. Password
    sudo is fine; you only run the commands once, interactively.
@@ -146,7 +146,7 @@ On the macOS host you want to manage:
 
 ### Register the host
 
-Follow [Host Preparation](host-preparation.md) — the same flow works for
+Follow [Host Preparation](guides/host-setup.md) — the same flow works for
 Linux and macOS hosts. In short:
 
 ```bash


### PR DESCRIPTION
## Summary

Fixes docs-drift detected 2026-05-30 where `website/docs/installation.md` diverged from source `docs/installation.md`.

### Changes

1. **Updated source `docs/installation.md`** to use website-compatible paths
   - Changed `host-preparation.md` → `guides/host-setup.md` (lines 138, 149)
   - Ensures links work in both source and website contexts

2. **Added symlink `docs/guides/host-setup.md`** → `../host-preparation.md`
   - Makes the source docs structure match the website structure
   - Links now resolve correctly in both `docs/` and `website/docs/` contexts

3. **Re-mirrored to `website/docs/installation.md`**
   - Now a verbatim copy of source (per mirror rules)
   - Only frontmatter and mirror-warning comment are website-specific additions

### Trigger commits

- e12ddc0 — Merge pull request #588
- b5f1541 — Merge pull request #587  
- facfd6a — feat(providers): refresh model catalog

### Mirror rule compliance

Per AGENTS.md: `docs/installation.md` MUST be mirrored verbatim into `website/docs/installation.md` (modulo Docusaurus frontmatter and mirror-warning comment).

### Test plan

- [x] `diff <(tail -n +1 docs/installation.md) <(tail -n +9 website/docs/installation.md)` shows verbatim match
- [ ] CI lint/tests pass (pre-existing GUI frontend build issue in scratch workspace, CI will validate)
- [ ] Website preview renders correctly
- [ ] Links resolve on both GitHub and Docusarius