### PR TITLE
chore(release): v26.6.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ The website docs MUST follow `docs/host-preparation.md` exactly. Do not edit `we
 
 - Repository: https://github.com/ric03uec/clawrium
 - Project Board: https://github.com/users/ric03uec/projects/1
-- Version: 26.5.4
+- Version: 26.6.0
 
 ## Gateway Token Lifecycle (zeroclaw)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,7 +54,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.5.4
+ + clawrium==26.6.0
 ```
 
 ### Run Without Installing
@@ -101,7 +101,7 @@ Check the version:
 clawctl --version
 ```
 ```
-clawctl 26.5.4
+clawctl 26.6.0
 ```
 
 ## Initialize Clawrium

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawrium"
-version = "26.5.4"
+version = "26.6.0"
 description = "CLI tool for managing AI assistant fleets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "clawrium"
-version = "26.5.4"
+version = "26.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -44,15 +44,20 @@ clawctl --help
 ```
  Usage: clawctl [OPTIONS] COMMAND [ARGS]...
 
- Clawrium - Manage your AI assistant fleet
+ clawctl — manage your AI assistant fleet, kubectl-style.
 
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ init      Initialize Clawrium and check dependencies                         │
-│ host      Manage hosts in your fleet                                         │
-│ provider  Manage inference providers (LLM APIs)                              │
-│ agent     Manage agents in your fleet                                        │
-│ ps        Show fleet status across all hosts                                 │
-│ chat      Chat with a deployed agent                                         │
+│ service     System-level lifecycle ops (init, snapshot, ...)                 │
+│ host        Manage hosts in your fleet                                       │
+│ provider    Manage inference providers (LLM APIs)                            │
+│ integration Manage external service integrations                             │
+│ channel     Manage chat-channel attachables (Discord, Slack, ...)            │
+│ skill       Browse the skills catalog                                        │
+│ agent       Manage agents in your fleet                                      │
+│ tui         Launch the interactive TUI dashboard                             │
+│ gui         Launch the local web GUI dashboard                               │
+│ version     Show clawctl version and exit                                    │
+│ completion  Emit a shell-completion script                                   │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -143,7 +148,7 @@ homelab    192.168.1.100   x86_64         4       16.0          -
 Install OpenClaw on your host:
 
 ```bash
-clawctl agent create --type openclaw --host homelab --name my-assistant
+clawctl agent create my-assistant --type openclaw --host homelab
 ```
 ```
 Fetching openclaw manifest...

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -33,7 +33,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.5.4
+ + clawrium==26.6.0
 ```
 
 Verify installation:

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -62,7 +62,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.5.4
+ + clawrium==26.6.0
 ```
 
 ### Run Without Installing
@@ -109,7 +109,7 @@ Check the version:
 clawctl --version
 ```
 ```
-clawctl 26.5.4
+clawctl 26.6.0
 ```
 
 ## Initialize Clawrium

--- a/website/docs/scenarios/101.md
+++ b/website/docs/scenarios/101.md
@@ -10,7 +10,7 @@ Install an openclaw agent on a target host and have your first conversation.
 
 Before starting, you need:
 
-- **Control machine**: Your local computer with Python 3.11+ and `uv` installed
+- **Control machine**: Your local computer with Python 3.10+ and `uv` installed
 - **Target host**: A Linux machine (Ubuntu 24.04 recommended) accessible via SSH
 - **SSH access**: Ability to SSH to the target as a user with sudo privileges
 - **API key**: An Anthropic API key (get one at [console.anthropic.com](https://console.anthropic.com))
@@ -193,7 +193,7 @@ If `clawctl agent start` fails:
 If the chat session closes:
 
 1. Ensure the agent is running: `clawctl agent get`
-2. Check for API key issues in logs: `clawctl agent logs oc-default-mybox` (note: logs command is not yet implemented)
+2. Check the agent's systemd logs on the host directly via SSH (e.g. `ssh xclm@mybox -- journalctl --user -u openclaw-oc-default-mybox -n 200`); `clawctl agent logs` is not yet available.
 
 ## Next Steps
 

--- a/website/docs/scenarios/101.md
+++ b/website/docs/scenarios/101.md
@@ -43,7 +43,7 @@ Verify the installation:
 
 ```bash
 $ clawctl --version
-clawctl 26.5.4
+clawctl 26.6.0
 ```
 
 ## Step 2: Register the Host (first run — surface the manual setup)


### PR DESCRIPTION
## Summary
- Bump `clawrium` to **v26.6.0** (67 PRs / 266 commits since v26.5.4)
- Sync version mentions in `AGENTS.md`, `docs/installation.md`, and the website mirrors
- **Bundled docs fix** (commit 4e065e7): four pre-existing accuracy bugs in `website/docs/guides/quickstart.md` and `website/docs/scenarios/101.md` flagged by release review

## Highlights since v26.5.4

**Features**
- `feat(openclaw)` — native web UI via `features.web_ui` (#590)
- `feat(gui)` — Show Connection Token button for openclaw agents (#593)
- `feat(providers)` — refreshed model catalog + searchable model picker (#587)
- `feat(render)` — canonical deterministic agent-config render pipeline (mega #555, #556, #559)
- `feat(gui)` — cluster topology by host + edge focus mode
- `feat(macos)` — full macOS host support, 10-part series (#469): launchd lifecycle, Homebrew base, dscl bootstrap, install/configure/render on Darwin
- `feat(doctor,sync)` — `sync --dry-run --diff` + `doctor` health checks

**Fixes** (selection)
- `fix(gui)` — agent exec endpoint repaired across all agent types (#585)
- `fix(configure)` — openclaw `--stage providers` consults onboarding ledger (#577)
- `fix(render)` — zeroclaw `gateway.host` defaults to `0.0.0.0` (#576)
- Numerous ATX-review polish rounds on #555 / #560

## Bundled Doc Fixes (commit 4e065e7)

All four were already shipping in v26.5.4 — surfaced by the release review and folded into this PR at user request rather than blocking the release.

| File | Bug | Fix |
|------|-----|-----|
| `website/docs/guides/quickstart.md` | Fabricated `--help` output listing non-existent `init`/`ps`/`chat` commands | Replaced with verbatim block from `docs/installation.md` |
| `website/docs/guides/quickstart.md` | `agent create --name X` (no `--name` flag exists) | Positional form `agent create X --type ... --host ...` |
| `website/docs/scenarios/101.md` | Python prerequisite stated as `3.11+` | Corrected to `3.10+` (matches `pyproject.toml` / `docs/installation.md`) |
| `website/docs/scenarios/101.md` | Leaked `(note: logs command is not yet implemented)` annotation in published troubleshooting step | Replaced with actionable `journalctl`-via-SSH workaround |

## Testing
- [x] `make lint` passes (ruff + next lint)
- [x] `make test` passes (3775 Python tests + 250 GUI tests)
- [x] `uv sync` regenerates `uv.lock` cleanly
- [x] `agent create` signature verified against the running CLI (positional `NAME`, no `--name`)

Release housekeeping + targeted docs accuracy fixes.