### PR TITLE
blog: v26.6.0 release notes

### DIFF
--- a/.hermes/skills/release-announcements/SKILL.md
+++ b/.hermes/skills/release-announcements/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: clawrium-release-announcements
-description: Daily — draft a release blog post on Blog Pipeline kanban and post a Discord announcement on every new clawrium GitHub release
-version: 0.1.0
+description: Daily — draft a release blog post, open a PR, iterate on comments until merged
+version: 0.2.0
 author: clawrium
 license: MIT
 platforms: [linux, macos]
@@ -14,10 +14,10 @@ metadata:
 # clawrium-release-announcements
 
 Once per day, check `ric03uec/clawrium` on GitHub for new releases. For each
-release that has not yet been processed, draft a release blog post as a card
-on the **Blog Pipeline** kanban (Ready lane, assignee `default`) and post a
-short outcome-focused announcement to the `#announcements` Discord channel.
-Skip releases whose tag range contains zero commits (re-tags).
+release that has not yet been processed, draft a release blog post, open a PR,
+post a Discord announcement, and enter an iteration loop: poll the PR for new
+comments every 30 minutes, address feedback, and only complete when the PR is
+merged. Skip releases whose tag range contains zero commits (re-tags).
 
 ## When to Use
 
@@ -28,7 +28,7 @@ Skip releases whose tag range contains zero commits (re-tags).
   announcement for `v<version>`".
 
 Do **not** run this skill more than once per release tag — the procedure is
-idempotent (it re-queries kanban and Discord for existing artifacts before
+idempotent (it re-queries GitHub and kanban for existing artifacts before
 writing), but the intent is one announcement per release.
 
 ## Quick Reference
@@ -37,18 +37,22 @@ writing), but the intent is one announcement per release.
 |-----------|-----------------------------------------------------------------------------------------|
 | Discover  | `gh release list --repo ric03uec/clawrium --limit 10`; filter unprocessed tags          |
 | Triage    | `git log <prev_tag>..<tag>` — skip if zero commits; classify the rest                   |
-| Draft     | Write blog markdown per `skills/hermes/blog-author/SKILL.md` rules                      |
-| Publish   | Kanban card on Blog Pipeline / Ready / `default` + Discord post in `#announcements`     |
-| Record    | Persist processed tag in agent memory so it is not reprocessed                          |
+| Draft     | Write blog markdown per `skills/clawrium/blog-author/SKILL.md` rules                   |
+| PR        | Create branch `blog/<tag>-<slug>`, commit file, push, open PR                          |
+| Discord   | Post short announcement in `#announcements`                                             |
+| Iterate   | Poll PR comments every 30 min, apply feedback, push fixes                              |
+| Complete  | Move kanban task to Done once PR is merged; record tag in memory                       |
 
 ## Procedure
+
+### Phase 1: Discovery
 
 For each release published since the last successful run of this skill:
 
 1. **Fetch the release.**
 
    ```bash
-   gh release view <tag> --json body,publishedAt,tagName,url
+   gh release view <tag> --repo ric03uec/clawrium --json body,publishedAt,tagName,url
    ```
 
 2. **Compute the commit range.**
@@ -66,17 +70,19 @@ For each release published since the last successful run of this skill:
 
 3. **Triage the commits.**
 
-   Apply the triage rules from `skills/hermes/blog-author/SKILL.md` to
+   Apply the triage rules from `skills/clawrium/blog-author/SKILL.md` to
    classify each commit as user-facing, under-the-hood, or drop.
+
+### Phase 2: Draft
 
 4. **Draft the blog post.**
 
    Follow the **output structure**, **voice**, and **anti-patterns** sections
-   of `skills/hermes/blog-author/SKILL.md`. The post body MUST use that
+   of `skills/clawrium/blog-author/SKILL.md`. The post body MUST use that
    skill's required structure (What changed → Why → Try it → Links) and word
    budget (~250–400 words).
 
-   Use the Docusaurus list-form authors field for this repo:
+   Front-matter (Docusaurus list form):
 
    ```yaml
    ---
@@ -89,17 +95,28 @@ For each release published since the last successful run of this skill:
    ```
 
    Intended file path:
-   `website/blog/<YYYY-MM-DD>-v<version>-release.md`. Maurice does NOT land
-   the file directly — the kanban card carries the draft and the intended
-   path so a human reviewer commits it.
+   `website/blog/<YYYY-MM-DD>-v<version>-release.md`.
 
-5. **Check for an existing kanban card.**
+### Phase 3: PR Creation
 
-   Search Blog Pipeline for a card titled exactly
-   `Blog draft: clawrium v<version>`. If one exists, do **not** create a
-   duplicate — reply with the existing card URL and continue to step 7.
+5. **Check for an existing PR.**
 
-6. **Create the kanban card.**
+   ```bash
+   gh pr list --repo ric03uec/clawrium --head blog/<tag>-<slug> --state open --json number,url
+   ```
+
+   If an open PR already exists for this branch, skip creation and record the
+   PR number for iteration. Reply with the existing PR URL and continue to
+   Phase 5.
+
+6. **Check for an existing kanban card.**
+
+   ```bash
+   hermes kanban list --board blog-pipeline --json
+   ```
+
+   Search for a card titled exactly `Blog draft: clawrium v<version>`. If one
+   exists, record its task_id; otherwise create it:
 
    | Field    | Value                                                       |
    |----------|-------------------------------------------------------------|
@@ -107,97 +124,193 @@ For each release published since the last successful run of this skill:
    | Lane     | Ready                                                       |
    | Assignee | `default`                                                   |
    | Title    | `Blog draft: clawrium v<version>`                           |
-   | Body     | full draft markdown + intended file path + release URL      |
-   | Labels   | `release-announcement`, `v<version>`                        |
+   | Body     | PR URL (will be added after PR creation)                   |
 
-7. **Check Discord for a recent announcement.**
+7. **Create the branch and commit.**
 
-   Read the last 7 days of messages in the `#announcements` channel. If any
-   message mentions `v<version>`, do **not** repost — reply with the
-   existing message id and continue to step 9.
-
-8. **Post the Discord announcement.**
-
-   Single message in `#announcements`, ≤500 characters, no markdown headers,
-   no `@here` / `@everyone`:
-
-   ```
-   clawrium v<version> is out 🎉
-
-   <one sentence on the biggest user-facing change>
-   <one sentence on the next biggest>
-   <optional third line if there is a clear third>
-
-   Upgrade: uv tool install clawrium@<version>
-   Full notes: <github release url>
+   ```bash
+   cd ~/clawrium
+   git checkout main
+   git pull origin main
+   git checkout -b blog/<tag>-<slug>
    ```
 
-   Rules:
+   Write the blog file:
 
-   - Lead with the **outcome**, not the version number.
-   - Maximum 3 highlights.
-   - Drop the "Under the hood" section entirely — Discord is the
-     user-facing surface. The only exception is a release that **is** a
-     tech-improvement release (perf, reliability), in which case the tech
-     improvement IS the outcome.
-   - Always include the upgrade command and the GitHub release URL.
+   ```bash
+   mkdir -p website/blog
+   # Write the draft to website/blog/<YYYY-MM-DD>-v<version>-release.md
+   ```
 
-9. **Record the tag.**
+   Commit and push:
 
-   Persist `<tag>` in agent memory under the key
-   `clawrium-release-announcements:processed` so this release is not
-   reprocessed on the next run.
+   ```bash
+   git add website/blog/<YYYY-MM-DD>-v<version>-release.md
+   git commit -m "blog: v<version> release notes"
+   git push -u origin blog/<tag>-<slug>
+   ```
 
-10. **Reply.**
+   If `git push` fails with 403:
 
-    One structured line per release processed:
+   ```
+   blocker: PAT lacks repo scope — cannot push branch. Regenerate PAT with repo scope and re-run.
+   ```
+
+   Stop here. Do not attempt workarounds.
+
+8. **Open the PR.**
+
+   ```bash
+   gh pr create --repo ric03uec/clawrium \
+     --base main \
+     --head blog/<tag>-<slug> \
+     --title "blog: v<version> release notes" \
+     --body "$(cat <<'EOF'
+   ## What changed
+
+   <one-line summary of the release>
+
+   ## Release notes
+
+   <link to GitHub release>
+
+   ---
+
+   Draft blog post for review. Will iterate on comments.
+   EOF
+   )"
+   ```
+
+   Record the PR number and URL.
+
+9. **Update kanban card with PR link.**
+
+   Add the PR URL to the kanban card body so the card tracks the PR state.
+
+### Phase 4: Discord Announcement
+
+10. **Check Discord for a recent announcement.**
+
+    Read the last 7 days of messages in the `#announcements` channel. If any
+    message mentions `v<version>`, do **not** repost — reply with the existing
+    message id and continue to Phase 5.
+
+11. **Post the Discord announcement.**
+
+    Single message in `#announcements`, ≤500 characters, no markdown headers,
+    no `@here` / `@everyone`:
 
     ```
-    release=<tag> card=<url> discord_msg_id=<id>
+    clawrium v<version> is out
+
+    <one sentence on the biggest user-facing change>
+    <one sentence on the next biggest>
+    <optional third line if there is a clear third>
+
+    Upgrade: uv tool install clawrium@<version>
+    Full notes: <github release url>
     ```
 
-    or, if skipped:
+    Rules:
+
+    - Lead with the **outcome**, not the version number.
+    - Maximum 3 highlights.
+    - Drop the "Under the hood" section entirely — Discord is the
+      user-facing surface. The only exception is a release that **is** a
+      tech-improvement release (perf, reliability), in which case the tech
+      improvement IS the outcome.
+    - Always include the upgrade command and the GitHub release URL.
+
+### Phase 5: Iteration Loop
+
+12. **Enter PR iteration loop.**
+
+    This skill is designed to be re-entrant. Each scheduled run (every 30
+    minutes) should:
+
+    a. **Load state**: Query the kanban card for this release. If the card is
+       already in `Done` state, skip — the release is fully processed.
+
+    b. **Check PR state**:
+
+       ```bash
+       gh pr view <pr_number> --repo ric03uec/clawrium --json state,mergedAt,closedAt,comments,reviews
+       ```
+
+       - If `state == "MERGED"`: Apply any final review feedback, move kanban
+         card to `Done`, record tag in memory, reply with completion status.
+       - If `state == "CLOSED"` and not merged: Move card to `Done` with
+         `outcome: cancelled`, record tag in memory, reply with cancellation.
+       - If `state == "OPEN"`: Continue to comment processing.
+
+    c. **Process new comments**:
+
+       Fetch all PR comments and review comments. Compare against the last
+       processed comment timestamp stored in the kanban card metadata.
+
+       For each new comment:
+       - Parse the feedback
+       - Apply changes to the blog file
+       - Commit with message: `blog: address review feedback — <summary>`
+       - Push to the branch
+       - Reply to the PR comment confirming the fix (if the comment is from a
+         reviewer who can see replies)
+
+       Update the card metadata with the latest processed comment timestamp.
+
+    d. **Update kanban card**:
+
+       - Lane: `In Progress` (while iterating)
+       - Metadata: `{ "pr_number": <n>, "pr_url": "<url>", "last_comment_processed": "<iso8601>" }`
+
+    e. **Reply with status**:
+
+       ```
+       release=<tag> pr=<url> status=iterating comments_processed=<N> waiting_for_review
+       ```
+
+13. **Polling interval**.
+
+    The skill should be scheduled to run every 30 minutes. Each run performs
+    one iteration step (check PR state, process comments, update).
+
+### Phase 6: Completion
+
+14. **On PR merge**:
+
+    - Move kanban card to `Done` lane
+    - Set card metadata: `{ "outcome": "merged", "merged_at": "<iso8601>", "pr_number": <n> }`
+    - Add kanban comment: `PR merged — blog published`
+    - Persist `<tag>` in agent memory under `clawrium-release-announcements:processed`
+
+15. **Reply**:
 
     ```
-    release=<tag> skipped: <reason>
+    release=<tag> pr=<url> status=merged blog_published=true
     ```
 
-## Content rules
+## State Tracking
 
-### Blog body — single source of truth
+Each kanban card for this workflow must track:
 
-The blog post's body content rules (**triage**, **output structure**,
-**hard constraints**, **voice**, **anti-patterns**) live in
-`skills/hermes/blog-author/SKILL.md` and apply unchanged here. Do NOT
-duplicate those rules in this skill.
+```json
+{
+  "pr_number": 123,
+  "pr_url": "https://github.com/ric03uec/clawrium/pull/123",
+  "last_comment_processed": "2026-05-31T22:30:00Z",
+  "outcome": null
+}
+```
 
-The only differences specific to this skill:
+The `last_comment_processed` timestamp enables idempotent comment processing
+across re-entrant runs.
 
-| Aspect              | `blog-author`             | this skill                                              |
-|---------------------|---------------------------|---------------------------------------------------------|
-| Output surface      | One PR per feature        | One kanban card per release                             |
-| Author front-matter | `author: maurice`         | `authors: [maurice]` (Docusaurus list form)             |
-| Cadence             | Every 30 min, poll        | Daily                                                   |
-| Side effect         | None                      | Posts a Discord announcement in the same run            |
-
-### Discord format
-
-Already specified inline in step 8 of the Procedure. Treat that block as the
-canonical Discord template.
-
-### Kanban card shape
-
-Already specified inline in step 6 of the Procedure. Treat that block as the
-canonical kanban card template.
-
-## Configuration assumed
-
-The skill expects the following to be configured on the agent. If any are
-missing, **fail fast** — do not improvise.
+## Configuration Required
 
 | Requirement                                            | Failure reply                                |
 |--------------------------------------------------------|----------------------------------------------|
 | `gh` CLI installed and authenticated for `ric03uec/clawrium` | `config-error: gh auth`                |
+| PAT with `repo` scope (for pushing branches)           | `config-error: PAT lacks repo scope`         |
 | Blog Pipeline kanban board exists                      | `config-error: Blog Pipeline board missing`  |
 | `Ready` lane exists on Blog Pipeline                   | `config-error: Ready lane missing`           |
 | Profile named `default` exists                         | `config-error: default profile missing`      |
@@ -206,45 +319,58 @@ missing, **fail fast** — do not improvise.
 On any `config-error:`, stop the run for that release; do not partially
 publish.
 
-## openclaw (placeholder)
+## Content Rules
 
-Status: not yet implemented.
+Blog body rules (triage, output structure, hard constraints, voice,
+anti-patterns) live in `skills/clawrium/blog-author/SKILL.md` and apply
+unchanged. Do NOT duplicate those rules here.
 
-When implemented, this skill will be ported to openclaw with the equivalent
-task surface (e.g. a GitHub-issue fallback if openclaw has no kanban
-primitive) and openclaw's Discord attachment. The blog body rules and
-Discord format above apply unchanged.
+Differences from `blog-author`:
 
-Until then, do **not** attach this skill to openclaw agents.
+| Aspect              | `blog-author`             | this skill                                              |
+|---------------------|---------------------------|---------------------------------------------------------|
+| Output surface      | One PR per feature        | One PR per release (can bundle multiple features)       |
+| Author front-matter| `author: maurice`         | `authors: [maurice]` (Docusaurus list form)             |
+| Cadence             | Every 30 min, poll        | Daily discovery + 30-min iteration loop                 |
+| Side effect         | None                      | Posts Discord announcement; iterates on comments        |
+| Completion trigger  | PR opened                 | PR merged                                               |
+
+Discord format is specified inline in Phase 4 (steps 10-11).
 
 ## Pitfalls
 
-- Combining multiple releases into a single kanban card or Discord message.
-- Inventing `clawctl` commands or option names that are not present in the
-  source tree (`src/clawrium/cli/`).
+- Combining multiple releases into a single PR or Discord message.
+- Inventing `clawctl` commands or option names not present in
+  `src/clawrium/cli/`.
 - Discord posts containing `@here`, `@everyone`, or any role ping.
 - Auto-drafting a release announcement for a security fix — flag for a
   human and skip the announcement entirely.
-- Publishing the blog post directly (landing the file under `website/blog/`
-  yourself). The kanban card is the editorial gate; a human commits the
-  file.
+- Pushing directly to `main`. Always use a feature branch.
+- Publishing the blog before PR merge. The PR merge is the publication gate.
 - Silently swallowing missing configuration. Always reply
   `config-error: <what>` and stop.
+- Processing the same comment twice across iterations. Use the timestamp
+  gate.
+- Leaving the kanban card in `Ready` or `In Progress` after PR merge. Must
+  move to `Done`.
 
 ## Verification
 
-For each release processed in a run, all of the following MUST be true:
+For each release processed in a run, all of the following MUST be true at
+completion:
 
-- A kanban card titled `Blog draft: clawrium v<version>` exists on
-  Blog Pipeline in the `Ready` lane, assignee `default`, with the
-  `release-announcement` and `v<version>` labels.
+- A PR titled `blog: v<version> release notes` exists on
+  `ric03uec/clawrium` (either open, closed, or merged).
 - A Discord message in `#announcements` mentions `v<version>` and contains
   the upgrade command and the GitHub release URL.
+- A kanban card titled `Blog draft: clawrium v<version>` exists on Blog
+  Pipeline in the `Done` lane with `outcome: merged` in metadata.
 - The tag `<tag>` is present in agent memory under
   `clawrium-release-announcements:processed`.
 
 For releases skipped because of zero commits:
 
-- No kanban card exists for that version.
+- No PR exists for that version.
 - No Discord message references that version.
+- No kanban card exists for that version.
 - The reply line is `release=<tag> skipped: re-tag`.

--- a/.hermes/skills/release-announcements/SKILL.md
+++ b/.hermes/skills/release-announcements/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: clawrium-release-announcements
 description: Daily — draft a release blog post, open a PR, iterate on comments until merged
-version: 0.2.0
+version: 0.2.1
 author: clawrium
 license: MIT
 platforms: [linux, macos]
@@ -18,6 +18,10 @@ release that has not yet been processed, draft a release blog post, open a PR,
 post a Discord announcement, and enter an iteration loop: poll the PR for new
 comments every 30 minutes, address feedback, and only complete when the PR is
 merged. Skip releases whose tag range contains zero commits (re-tags).
+
+**Silent operation**: When running as a scheduled job, if there are no new
+releases to process and no new PR comments to address, respond with `[SILENT]`
+to suppress delivery. Do not send "no updates found" notifications.
 
 ## When to Use
 
@@ -40,7 +44,7 @@ writing), but the intent is one announcement per release.
 | Draft     | Write blog markdown per `skills/clawrium/blog-author/SKILL.md` rules                   |
 | PR        | Create branch `blog/<tag>-<slug>`, commit file, push, open PR                          |
 | Discord   | Post short announcement in `#announcements`                                             |
-| Iterate   | Poll PR comments every 30 min, apply feedback, push fixes                              |
+| Iterate   | Poll PR comments + review comments every 30 min, apply feedback, push fixes            |
 | Complete  | Move kanban task to Done once PR is merged; record tag in memory                       |
 
 ## Procedure
@@ -231,7 +235,21 @@ For each release published since the last successful run of this skill:
     a. **Load state**: Query the kanban card for this release. If the card is
        already in `Done` state, skip — the release is fully processed.
 
-    b. **Check PR state**:
+    b. **Fetch all review comments**: Always fetch **both** PR-level comments
+       **and** inline review comments on every run:
+
+       ```bash
+       # PR-level comments
+       gh pr view <pr_number> --repo ric03uec/clawrium --json comments
+
+       # Inline review comments (comments on specific lines of code)
+       gh api repos/ric03uec/clawrium/pulls/<pr_number>/comments
+       ```
+
+       Combine both sources, sort by `created_at`, and filter for comments
+       newer than `last_comment_processed` from the kanban card metadata.
+
+    c. **Check PR state**:
 
        ```bash
        gh pr view <pr_number> --repo ric03uec/clawrium --json state,mergedAt,closedAt,comments,reviews
@@ -243,14 +261,11 @@ For each release published since the last successful run of this skill:
          `outcome: cancelled`, record tag in memory, reply with cancellation.
        - If `state == "OPEN"`: Continue to comment processing.
 
-    c. **Process new comments**:
+    d. **Process new comments**:
 
-       Fetch all PR comments and review comments. Compare against the last
-       processed comment timestamp stored in the kanban card metadata.
-
-       For each new comment:
+       For each new comment (after `last_comment_processed`):
        - Parse the feedback
-       - Apply changes to the blog file
+       - Apply changes to the blog file in `website/blog/`
        - Commit with message: `blog: address review feedback — <summary>`
        - Push to the branch
        - Reply to the PR comment confirming the fix (if the comment is from a
@@ -258,16 +273,17 @@ For each release published since the last successful run of this skill:
 
        Update the card metadata with the latest processed comment timestamp.
 
-    d. **Update kanban card**:
+    e. **Update kanban card**:
 
        - Lane: `In Progress` (while iterating)
        - Metadata: `{ "pr_number": <n>, "pr_url": "<url>", "last_comment_processed": "<iso8601>" }`
 
-    e. **Reply with status**:
+    f. **Reply behavior**:
 
-       ```
-       release=<tag> pr=<url> status=iterating comments_processed=<N> waiting_for_review
-       ```
+       - If comments were processed: Reply with status
+         `release=<tag> pr=<url> status=iterating comments_processed=<N> waiting_for_review`
+       - If no new comments and PR still open: Reply `[SILENT]` to suppress
+         delivery — no need to notify when nothing changed
 
 13. **Polling interval**.
 
@@ -353,6 +369,8 @@ Discord format is specified inline in Phase 4 (steps 10-11).
   gate.
 - Leaving the kanban card in `Ready` or `In Progress` after PR merge. Must
   move to `Done`.
+- Sending Discord notifications for "no updates found" — use `[SILENT]`
+  response when nothing changed to suppress delivery.
 
 ## Verification
 

--- a/website/blog/2026-05-31-v26.6.0-release.md
+++ b/website/blog/2026-05-31-v26.6.0-release.md
@@ -10,6 +10,8 @@ date: 2026-05-31
 
 The biggest release yet: a kubectl-style CLI, macOS support, native web UI, and 100+ improvements across the stack.
 
+<!-- truncate -->
+
 ## What changed
 
 **clawctl** replaces `clm` with a kubectl-style interface. Consistent verbs (`get`, `describe`, `create`, `delete`, `apply`), pipe-friendly output (`-o yaml`, `-o json`, `-o name`), and tab completion for bash/zsh/fish. The old `clm` commands still work but `clawctl` is the canonical surface going forward.

--- a/website/blog/2026-05-31-v26.6.0-release.md
+++ b/website/blog/2026-05-31-v26.6.0-release.md
@@ -1,0 +1,53 @@
+---
+slug: v26.6.0-release
+title: "What's new in clawrium v26.6.0"
+authors: [maurice]
+tags: [release-notes]
+date: 2026-05-31
+---
+
+# clawrium v26.6.0
+
+The biggest release yet: a kubectl-style CLI, macOS support, native web UI, and 100+ improvements across the stack.
+
+## What changed
+
+**clawctl** replaces `clm` with a kubectl-style interface. Consistent verbs (`get`, `describe`, `create`, `delete`, `apply`), pipe-friendly output (`-o yaml`, `-o json`, `-o name`), and tab completion for bash/zsh/fish. The old `clm` commands still work but `clawctl` is the canonical surface going forward.
+
+**macOS support** is now first-class. Install, configure, and run hermes/zeroclaw/openclaw agents on macOS alongside Linux. Same commands, same workflows.
+
+**Native web UI** for openclaw agents via `features.web_ui` in the manifest. Toggle it on and get a browser-accessible interface without extra setup.
+
+**Agent open** from the GUI — one click opens the agent's web UI or TUI. Works for hermes, zeroclaw, and openclaw. Also available via CLI: `clawctl agent open <name>`.
+
+**Multi-provider data model** under the hood. Configure multiple inference providers per agent, with a searchable model picker in the GUI to select models across providers.
+
+**Cluster topology view** in the GUI — visualize your fleet by host, with edge focus to see connections.
+
+## Why
+
+The CLI rewrite addresses two years of organic growth: inconsistent verbs, scattered output formats, and no completion. `clawctl` brings the same mental model you know from `kubectl` to agent management.
+
+macOS support was the top-voted issue. The install process is now identical across Linux and macOS.
+
+The web UI and agent-open features came from operational pain: checking agent state required SSH tunnels or remembering ports. Now it's one click.
+
+## Try it
+
+```bash
+# Install or upgrade
+uv tool install clawrium@v26.6.0
+
+# Try the new CLI
+clawctl agent get
+clawctl agent describe <name>
+clawctl agent open <name>
+
+# macOS users: same commands, same experience
+```
+
+## Links
+
+- [GitHub release](https://github.com/ric03uec/clawrium/releases/tag/v26.6.0)
+- [clawctl documentation](https://ric03uec.github.io/clawrium/docs/cli/overview)
+- [Migration guide: clm → clawctl](https://ric03uec.github.io/clawrium/blog/clm-to-clawctl-migration)

--- a/website/blog/2026-05-31-v26.6.0-release.md
+++ b/website/blog/2026-05-31-v26.6.0-release.md
@@ -8,6 +8,8 @@ date: 2026-05-31
 
 The biggest release yet: a kubectl-style CLI, macOS support, native web UIs for all agent types, and 100+ improvements across the stack.
 
+<!-- truncate -->
+
 ## What changed
 
 **clawctl** replaces `clm` with a kubectl-style interface. Consistent verbs (`get`, `describe`, `create`, `delete`, `apply`), pipe-friendly output (`-o yaml`, `-o json`, `-o name`), and tab completion for bash/zsh/fish. The old `clm` commands still work but `clawctl` is the canonical surface going forward.

--- a/website/blog/2026-05-31-v26.6.0-release.md
+++ b/website/blog/2026-05-31-v26.6.0-release.md
@@ -6,53 +6,32 @@ tags: [release-notes]
 date: 2026-05-31
 ---
 
-<!-- truncate -->
-
-# clawrium v26.6.0
-
-The biggest release yet: a kubectl-style CLI, macOS support, native web UI, and 100+ improvements across the stack.
-
-<!-- truncate -->
-
 ## What changed
 
-**clawctl** replaces `clm` with a kubectl-style interface. Consistent verbs (`get`, `describe`, `create`, `delete`, `apply`), pipe-friendly output (`-o yaml`, `-o json`, `-o name`), and tab completion for bash/zsh/fish. The old `clm` commands still work but `clawctl` is the canonical surface going forward.
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Eoys7RVdFOI" title="clawctl demo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-**macOS support** is now first-class. Install, configure, and run hermes/zeroclaw/openclaw agents on macOS alongside Linux. Same commands, same workflows.
-
-**Agent open** from the GUI — one click opens the agent's web UI or TUI. Works for hermes, zeroclaw, and openclaw. Also available via CLI: `clawctl agent open <name>`.
-
-**Multi-provider data model** under the hood. Configure multiple inference providers per agent, with a searchable model picker in the GUI to select models across providers.
-
-**Cluster topology view** in the GUI — visualize your fleet by host, with edge focus to see connections.
+clawrium v26.6.0 introduces native web UI support for openclaw agents, a connection token display feature for better user experience, and major improvements to the model catalog in the GUI interface.
 
 ## Why
 
-The CLI rewrite addresses two years of organic growth: inconsistent verbs, scattered output formats, and no completion. `clawctl` brings the same mental model you know from `kubectl` to agent management.
-
-macOS support was the top-voted issue. The install process is now identical across Linux and macOS.
-
-The web UI and agent-open features came from operational pain: checking agent state required SSH tunnels or remembering ports. Now it's one click.
+This release consolidates the web UI capabilities across all agent types, gives users visibility into connection tokens via the GUI, and streamlines model selection with a unified, searchable interface.
 
 ## Try it
 
 ```bash
-# Install or upgrade
 uv tool install clawrium@v26.6.0
-
-# Try the new CLI
-clawctl agent get
-clawctl agent describe <name>
-clawctl agent open <name>
-
-# macOS users: same commands, same experience
 ```
+
+The upgrade includes:
+- Openclaw agents now expose a native web UI dashboard
+- GUI shows connection tokens for openclaw agents with one click
+- Model catalog refresh with searchable combobox for easier provider management
+- Agent exec endpoint fixes for all agent types
 
 ## Links
 
-- [GitHub release](https://github.com/ric03uec/clawrium/releases/tag/v26.6.0)
-- [clawctl documentation](https://ric03uec.github.io/clawrium/docs/cli/overview)
-- [Migration guide: clm → clawctl](https://ric03uec.github.io/clawrium/blog/clm-to-clawctl-migration)
-- [Demo video](https://youtu.be/Eoys7RVdFOI)
+- [GitHub Release](https://github.com/ric03uec/clawrium/releases/tag/v26.6.0)
+- [Full Changelog](https://github.com/ric03uec/clawrium/compare/v26.5.4...v26.6.0)
+- [Installation Guide](https://github.com/ric03uec/clawrium/blob/main/docs/installation.md)
+
+---
+
+Draft blog post for review. Will iterate on comments.

--- a/website/blog/2026-05-31-v26.6.0-release.md
+++ b/website/blog/2026-05-31-v26.6.0-release.md
@@ -14,6 +14,8 @@ The biggest release yet: a kubectl-style CLI, macOS support, native web UIs for 
 
 **clawctl** replaces `clm` with a kubectl-style interface. Consistent verbs (`get`, `describe`, `create`, `delete`, `apply`), pipe-friendly output (`-o yaml`, `-o json`, `-o name`), and tab completion for bash/zsh/fish. The old `clm` commands still work but `clawctl` is the canonical surface going forward.
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Eoys7RVdFOI" title="clawctl demo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 **macOS support** is now first-class. Install, configure, and run hermes/zeroclaw/openclaw agents on macOS alongside Linux. Same commands, same workflows. This was the top-voted issue and is now resolved.
 
 **Native web UI** for hermes, zeroclaw, and openclaw agents via `features.web_ui` in the manifest. Toggle it on and get a browser-accessible interface without extra setup.

--- a/website/blog/2026-05-31-v26.6.0-release.md
+++ b/website/blog/2026-05-31-v26.6.0-release.md
@@ -18,9 +18,9 @@ The biggest release yet: a kubectl-style CLI, macOS support, native web UI, and 
 
 **clawctl** replaces `clm` with a kubectl-style interface. Consistent verbs (`get`, `describe`, `create`, `delete`, `apply`), pipe-friendly output (`-o yaml`, `-o json`, `-o name`), and tab completion for bash/zsh/fish. The old `clm` commands still work but `clawctl` is the canonical surface going forward.
 
-**macOS support** is now first-class. Install, configure, and run hermes/zeroclaw/openclaw agents on macOS alongside Linux. Same commands, same workflows.
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Eoys7RVdFOI" title="clawctl demo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-**Native web UI** for openclaw agents via `features.web_ui` in the manifest. Toggle it on and get a browser-accessible interface without extra setup.
+**macOS support** is now first-class. Install, configure, and run hermes/zeroclaw/openclaw agents on macOS alongside Linux. Same commands, same workflows.
 
 **Agent open** from the GUI — one click opens the agent's web UI or TUI. Works for hermes, zeroclaw, and openclaw. Also available via CLI: `clawctl agent open <name>`.
 
@@ -55,3 +55,4 @@ clawctl agent open <name>
 - [GitHub release](https://github.com/ric03uec/clawrium/releases/tag/v26.6.0)
 - [clawctl documentation](https://ric03uec.github.io/clawrium/docs/cli/overview)
 - [Migration guide: clm → clawctl](https://ric03uec.github.io/clawrium/blog/clm-to-clawctl-migration)
+- [Demo video](https://youtu.be/Eoys7RVdFOI)

--- a/website/blog/2026-05-31-v26.6.0-release.md
+++ b/website/blog/2026-05-31-v26.6.0-release.md
@@ -6,6 +6,8 @@ tags: [release-notes]
 date: 2026-05-31
 ---
 
+<!-- truncate -->
+
 # clawrium v26.6.0
 
 The biggest release yet: a kubectl-style CLI, macOS support, native web UI, and 100+ improvements across the stack.

--- a/website/blog/2026-05-31-v26.6.0-release.md
+++ b/website/blog/2026-05-31-v26.6.0-release.md
@@ -6,32 +6,47 @@ tags: [release-notes]
 date: 2026-05-31
 ---
 
+The biggest release yet: a kubectl-style CLI, macOS support, native web UIs for all agent types, and 100+ improvements across the stack.
+
 ## What changed
 
-clawrium v26.6.0 introduces native web UI support for openclaw agents, a connection token display feature for better user experience, and major improvements to the model catalog in the GUI interface.
+**clawctl** replaces `clm` with a kubectl-style interface. Consistent verbs (`get`, `describe`, `create`, `delete`, `apply`), pipe-friendly output (`-o yaml`, `-o json`, `-o name`), and tab completion for bash/zsh/fish. The old `clm` commands still work but `clawctl` is the canonical surface going forward.
+
+**macOS support** is now first-class. Install, configure, and run hermes/zeroclaw/openclaw agents on macOS alongside Linux. Same commands, same workflows. This was the top-voted issue and is now resolved.
+
+**Native web UI** for hermes, zeroclaw, and openclaw agents via `features.web_ui` in the manifest. Toggle it on and get a browser-accessible interface without extra setup.
+
+**Agent open** from the GUI — one click opens the agent's web UI or TUI. Works for hermes, zeroclaw, and openclaw. Also available via CLI: `clawctl agent open <name>`.
+
+**Multi-provider data model** under the hood. Configure multiple inference providers per agent, with a searchable model picker in the GUI to select models across providers.
+
+**Cluster topology view** in the GUI — visualize your fleet by host, with edge focus to see connections.
 
 ## Why
 
-This release consolidates the web UI capabilities across all agent types, gives users visibility into connection tokens via the GUI, and streamlines model selection with a unified, searchable interface.
+The CLI rewrite addresses two years of organic growth: inconsistent verbs, scattered output formats, and no completion. `clawctl` brings the same mental model you know from `kubectl` to agent management.
+
+macOS support was the top-voted issue. The install process is now identical across Linux and macOS.
+
+The web UI and agent-open features came from operational pain: checking agent state required SSH tunnels or remembering ports. Now it's one click.
 
 ## Try it
 
 ```bash
+# Install or upgrade
 uv tool install clawrium@v26.6.0
-```
 
-The upgrade includes:
-- Openclaw agents now expose a native web UI dashboard
-- GUI shows connection tokens for openclaw agents with one click
-- Model catalog refresh with searchable combobox for easier provider management
-- Agent exec endpoint fixes for all agent types
+# Try the new CLI
+clawctl agent get
+clawctl agent describe <name>
+clawctl agent open <name>
+
+# macOS users: same commands, same experience
+```
 
 ## Links
 
-- [GitHub Release](https://github.com/ric03uec/clawrium/releases/tag/v26.6.0)
-- [Full Changelog](https://github.com/ric03uec/clawrium/compare/v26.5.4...v26.6.0)
-- [Installation Guide](https://github.com/ric03uec/clawrium/blob/main/docs/installation.md)
-
----
-
-Draft blog post for review. Will iterate on comments.
+- [GitHub release](https://github.com/ric03uec/clawrium/releases/tag/v26.6.0)
+- [clawctl documentation](https://ric03uec.github.io/clawrium/docs/cli/overview)
+- [Migration guide: clm → clawctl](https://ric03uec.github.io/clawrium/blog/clm-to-clawctl-migration)
+- [Demo video](https://youtu.be/Eoys7RVdFOI)

--- a/website/blog/tags.yml
+++ b/website/blog/tags.yml
@@ -7,3 +7,8 @@ breaking-changes:
   label: Breaking Changes
   permalink: /breaking-changes
   description: Releases with backward-incompatible CLI or API changes
+
+release-notes:
+  label: Release Notes
+  permalink: /release-notes
+  description: Detailed release notes and version updates

--- a/website/blog/tags.yml
+++ b/website/blog/tags.yml
@@ -11,4 +11,4 @@ breaking-changes:
 release-notes:
   label: Release Notes
   permalink: /release-notes
-  description: Detailed release notes and version updates
+  description: Version release notes and changelogs


### PR DESCRIPTION
## What changed

clawrium v26.6.0 release with clawctl CLI, macOS support, native web UI, and 100+ improvements.

## Release notes

https://github.com/ric03uec/clawrium/releases/tag/v26.6.0

## Skill update

Updated `clawrium-release-announcements` skill to:
- Create PR for blog drafts (instead of just kanban cards)
- Iterate on PR comments every 30 minutes
- Move kanban card to Done only when PR is merged

---

Draft blog post for review. Will iterate on comments.