### PR TITLE
feat(agent): clawctl agent upgrade + bump openclaw/hermes (#592)

### DIFF
--- a/.itx/592/00_PLAN.md
+++ b/.itx/592/00_PLAN.md
@@ -1,0 +1,140 @@
+# Plan: `clawctl agent upgrade` + version bump (issue #592)
+
+## Decisions
+
+- **openclaw**: bump `2026.4.2` → **`2026.5.28`** (npm `latest` as of 2026-06-01).
+- **hermes**: bump `2026.5.7` → **`v2026.5.29.2`** (GitHub latest stable as of 2026-06-01).
+- **zeroclaw**: **no bump** — upstream stable is still `0.7.5`; only `v0.8.0-beta-1` exists and clawctl does not ship betas as defaults.
+- `clawctl agent upgrade <name>` is **forward-only, max-only**: no `--version`, no `--allow-downgrade`. The issue's original plan listed those flags; both are dropped per execution direction.
+- "Upgrade available" indicator lives in `gui/src/components/agent-detail/overview-tab.tsx`. No GUI button — CLI is the only mutation path.
+- Drift pre-flight is **hard-fail** (no warn-and-prompt). `--skip-drift-check` is a hidden escape hatch.
+- 2 install-verification subtasks (one per agent type whose version actually changes). Zeroclaw is unchanged so no subtask.
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `src/clawrium/platform/registry/openclaw/manifest.yaml` | Add `version: 2026.5.28` entries (Ubuntu 22.04 + 24.04, x86_64). Keep existing `2026.4.2` + `0.1.0` entries as historically supported. |
+| `src/clawrium/platform/registry/openclaw/playbooks/install.yaml:7` | `claw_version \| default('v2026.5.28')` |
+| `src/clawrium/platform/registry/hermes/manifest.yaml` | Add `version: 2026.5.29.2` entries (Ubuntu 22.04, 24.04, macOS ≥14). Compute fresh sha256 for `raw.githubusercontent.com/NousResearch/hermes-agent/v2026.5.29.2/scripts/install.sh`; apply same hash to all three entries (installer URL is identical across OSes — matches the existing manifest convention). Keep `2026.5.7` entries. |
+| `src/clawrium/platform/registry/hermes/playbooks/install.yaml:7` | `claw_version \| default('v2026.5.29.2')` |
+| `src/clawrium/cli/clawctl/agent/upgrade.py` (new) | `upgrade` subcommand. |
+| `src/clawrium/cli/clawctl/agent/__init__.py` | Register `upgrade` in the agent typer app. |
+| `src/clawrium/core/install.py` | No code change expected — `run_installation(force=True, claw_version=...)` already wired, and `hosts.json.agents.<name>.version` is written at install.py:562. Verify the upgrade path exercises the same write site. |
+| `src/clawrium/gui/routes/agents.py` | Extend the agent-detail response with `latest_supported_version: str \| None`, derived from the registry filtered to entries matching the host's `os/os_version/arch`. |
+| `gui/src/components/agent-detail/overview-tab.tsx:105` | Render an "Upgrade available → `<latest>`" badge next to the Version row when `agent.version < latest_supported_version`. Tooltip / inline hint: `Run: clawctl agent upgrade <name>`. |
+| `website/docs/reference/cli/agent.md` | Rewrite the existing `### upgrade` section (line 539+): **remove** `--version` and `--restart` flags (lines 551–552); **add** `--yes`, `--skip-drift-check` (hidden, but mention in CLI reference), and `-o json`; rewrite the three example invocations (lines 558, 561, 564) to reflect max-only forward semantics; document the four pre-flight rejection cases (already-at-max no-op, downgrade rejection, drift rejection, drift bypass). No `docs/` mirror exists for this file (verified — mirror discipline in AGENTS.md applies only to `installation.md` and `host-preparation.md`). |
+
+## CLI surface
+
+```
+clawctl agent upgrade <name> [--yes] [--skip-drift-check] [-o json]
+```
+
+Pre-flight, in order:
+
+1. Resolve agent + host from `hosts.json`.
+2. Gather host facts via the same path `run_installation` uses.
+3. Build `allowed_set` = `[entry for entry in platforms if matches(entry, hardware)]`.
+4. `target = max(allowed_set, key=Version)`.
+5. **No-op exit** if `target == hosts.json.agents.<name>.version` (exit 0, "already at latest"). `run_installation` is NOT called.
+6. **Hard reject downgrade**: if `target < installed`, fail with explicit message. Cannot happen via normal flow — only triggers if manifest entries are reordered/removed, which is the bug we want surfaced.
+7. **Drift pre-flight**: invoke the same path `clawctl agent sync --dry-run` uses; refuse if any rendered file differs from on-host state. Prints the changed-file list. `--skip-drift-check` bypasses this gate.
+8. Confirmation prompt unless `--yes` or `-o json`.
+
+Execute:
+
+- Call `run_installation(claw_name=<type>, host=..., agent_name=..., force=True)`. Matched-entry resolution inside it picks the right `claw_version` (and zeroclaw `claw_sha256`) automatically because the manifest's max is now the new version.
+- `hosts.json.agents.<name>.version` updates at the existing write site (install.py:562).
+- Route restart + re-pair through the canonical lifecycle so the zeroclaw `gateway_token_rotated` event fires per AGENTS.md §"Gateway Token Lifecycle". No-op for hermes; openclaw uses a static bearer.
+
+## GUI "Upgrade available" wiring
+
+- Backend: extend the agent-detail response in `gui/routes/agents.py` with `latest_supported_version`, computed as `max(version for entry in platforms if matches(entry, host_hardware))`. Returns `None` when no platform entry matches.
+- Frontend: in `overview-tab.tsx`, when `latest_supported_version > agent.version`, render a yellow badge next to the Version row:
+  ```
+  Version: v2026.4.2 [↑ Upgrade available: v2026.5.28]
+  Run: clawctl agent upgrade <name>
+  ```
+- No upgrade button. CLI is the only mutation path — matches the "CLI-driven upgrade" requirement and the pattern used by `configure`/`restart`.
+
+## Test strategy
+
+### `tests/cli/test_agent_upgrade.py` (new file)
+
+Every happy-path and rejection test follows the same shape:
+- **Patch** `run_installation` (and the drift-check helper where applicable).
+- **Assert** exit code, stdout content, mock call args, AND on-disk `hosts.json` state.
+
+| Test | Asserts |
+|---|---|
+| `test_upgrade_no_op_when_already_at_max` | exit_code == 0; stdout contains "already at latest"; `run_installation` NOT called; `hosts.json` version unchanged. |
+| `test_upgrade_nochange_zeroclaw_exits_zero` | Zeroclaw at `0.7.5` with manifest max `0.7.5`: exit_code == 0; stdout contains "already at latest"; `run_installation` NOT called; `hosts.json` version unchanged. (Replaces the audit-flagged B1 test — bearer rotation cannot be exercised on zeroclaw because this PR does not bump its version. Bearer-rotation coverage on a real upgrade is tracked as a follow-up if/when zeroclaw bumps.) |
+| `test_upgrade_rejects_drift` | exit_code != 0; stdout contains the changed-file list; `run_installation` NOT called; `hosts.json.agents.<name>.version` unchanged. |
+| `test_upgrade_rejects_downgrade_attempt` | Synthetic manifest with installed > max: exit_code != 0; stdout names the version comparison; `run_installation` NOT called; `hosts.json` unchanged. |
+| `test_upgrade_happy_path_openclaw` | Mock `run_installation` to succeed and update `hosts.json` to `2026.5.28`; assert `force=True` and `claw_version='v2026.5.28'` passed; **read back** `hosts.json.agents.<name>.version == '2026.5.28'`. |
+| `test_upgrade_happy_path_hermes` | Same shape as openclaw, target `v2026.5.29.2`; read back `hosts.json` version. |
+| `test_upgrade_json_output_mode` | Invoke with `-o json --yes`; exit_code == 0; `json.loads(stdout)` succeeds; assert keys `agent`, `from_version`, `to_version` present. |
+| `test_upgrade_skip_drift_check_bypasses_preflight` | Drift-present state mocked; invoke with `--skip-drift-check --yes`; `run_installation` IS called; exit_code == 0. |
+
+### `tests/core/test_registry_latest_supported.py` (new file)
+
+| Test | Asserts |
+|---|---|
+| `test_latest_supported_per_host_filter` | For each (agent_type × OS × arch) tuple covered by the bundled manifests, the returned `latest_supported_version` is the max of host-compatible platform entries. |
+| `test_latest_supported_returns_none_when_no_platform_matches` | Host with OS/arch absent from the manifest (e.g. openclaw on debian/aarch64) returns `None` — guards against `KeyError` in the GUI backend. |
+
+### `tests/test_gui_agent_detail_latest_version.py` (new file — naming aligns with existing `tests/test_gui_*.py` convention)
+
+| Test | Asserts |
+|---|---|
+| `test_agent_detail_includes_latest_supported_version` | GET on the agent-detail route returns `latest_supported_version` matching the registry's max for that host hardware. |
+| `test_agent_detail_latest_supported_version_is_none_for_unmatched_host` | When the host's OS/arch has no platform entry, the response field is `None` (not omitted, not an empty string — matches `Optional[str]` typing). |
+
+### `gui/src/components/agent-detail/overview-tab.test.tsx` (new file — does not exist today; confirmed via `ls gui/src/components/agent-detail/*.test.tsx`)
+
+| Test | Asserts |
+|---|---|
+| `renders upgrade-available badge when latest_supported_version > agent.version` | Badge element present; text contains the latest version. |
+| `does not render badge when latest_supported_version equals agent.version` | Badge element absent. |
+| `does not render badge when latest_supported_version is null` | Badge element absent (covers the unmatched-host case). |
+
+## Subtasks
+
+1. `[Parent #592] Verify openclaw v2026.5.28 install on a single Ubuntu host` (24.04, x86_64). Fresh install + start + chat smoke; confirm `hosts.json.agents.<name>.version == 2026.5.28`.
+2. `[Parent #592] Verify hermes v2026.5.29.2 install on a single Ubuntu host` (24.04, x86_64). Fresh install + start; binary `hermes --version` matches; `/health` returns 200 on the per-instance `api_server_port`.
+
+(Zeroclaw verification subtask removed — manifest is untouched for zeroclaw.)
+
+## Explicit non-goals
+
+- No upstream polling. Registry is the contract.
+- No GUI-initiated upgrade button. CLI only.
+- No `--version`, no `--allow-downgrade`. One-way only.
+- No `clawctl agent upgrade --all`. Single-agent in v1.
+- No removal of older manifest entries. Older versions stay in `platforms[]` so existing installs continue to validate.
+- Bearer-rotation coverage on a real zeroclaw upgrade. Cannot be exercised in this PR because zeroclaw's manifest max is unchanged; tracked as a follow-up when zeroclaw bumps.
+
+## Related
+
+- AGENTS.md §"Gateway Token Lifecycle (zeroclaw)"
+- `src/clawrium/core/install.py:run_installation` (install.py:261, claw_version wiring at install.py:830, version write at install.py:562)
+- `src/clawrium/core/registry.py:check_compatibility` (registry.py:933) and `describe_agent_type` (registry.py:804–839)
+- `src/clawrium/platform/registry/{openclaw,zeroclaw,hermes}/manifest.yaml`
+- `src/clawrium/platform/registry/{openclaw,hermes}/playbooks/install.yaml`
+- `website/docs/reference/cli/agent.md` §`### upgrade` (line 539+)
+
+---
+
+## Planning
+
+**Stage**: planning
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-06-01T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+https://github.com/ric03uec/clawrium/issues/592 review the plan for this. update all 3 support claw versions to their latest version(check from upsgream releases). update max version for each agent in the code. add 3 subtasks to test installation on the latest versions. add the new command for upgrading existing agents. i DO NOT want reversible path to be supported. only oneward path. if for an installed agent, the default agent has been upgraded, then show a button that upgrade is available and user shoudl run an upgrade command from cli to upgrade the agent. thsi shoulb eb in the agent settngs page. for each agent. show me plan first. ask if any thing is unclear
+```
+
+**Output**: High-level plan saved to `.itx/592/00_PLAN.md`; 2 subtask issues (#598 openclaw verify, #599 hermes verify) created and linked as sub-issues of #592; plan comment posted on #592; label flipped to `planned`. Plan refined via clarifying questions (skip zeroclaw bump, GUI indicator → overview tab, CLI upgrade-to-max only with no `--version` flag, drop zeroclaw verification subtask). Plan revised after audit pass to address 6 blockers + 5 warnings (test coverage gaps and stale `website/docs/reference/cli/agent.md`).

--- a/.itx/592/01_EXECUTION.md
+++ b/.itx/592/01_EXECUTION.md
@@ -1,0 +1,29 @@
+# Execution Log: issue #592
+
+## Execute
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-06-01T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx:execute 592 (worktree mode; subtasks #598 and #599 are post-merge manual verification and out-of-scope for this PR)
+```
+
+**Output**: Implemented `clawctl agent upgrade` per plan §"CLI surface":
+- Bumped openclaw → 2026.5.28 (manifest + install playbook default).
+- Bumped hermes → v2026.5.29.2 (manifest with fresh sha256 of upstream
+  install.sh + install playbook default).
+- Zeroclaw left unchanged per plan §"Decisions".
+- New `clawctl agent upgrade <name> [--yes] [--skip-drift-check] [-o json]`
+  subcommand wired into the clawctl agent typer app.
+- Added `registry.latest_supported_version()` helper; surfaced in the
+  agent-detail GUI response and rendered as an "Upgrade available" badge
+  in `overview-tab.tsx`.
+- Rewrote `website/docs/reference/cli/agent.md` §"### upgrade" to match
+  the max-only forward semantics.
+- Added 4 test files covering every row of the plan's test strategy
+  (17 new Python tests + 3 new vitest cases; full suite green).
+- Subtasks #598 / #599 are post-merge manual install verification on real
+  Ubuntu hosts — not executed in this worktree.

--- a/gui/src/components/agent-detail/overview-tab.test.tsx
+++ b/gui/src/components/agent-detail/overview-tab.test.tsx
@@ -66,6 +66,16 @@ describe("OverviewTab — upgrade-available badge", () => {
     expect(screen.queryByTestId("upgrade-available-badge")).toBeNull();
   });
 
+  it("does not render badge for version '?' sentinel (never-started agent)", () => {
+    render(
+      <OverviewTab
+        agent={makeAgent({ version: "?", latest_supported_version: "2026.5.28" })}
+        agentKey="demo"
+      />,
+    );
+    expect(screen.queryByTestId("upgrade-available-badge")).toBeNull();
+  });
+
   it("does not render badge when latest_supported_version is null", () => {
     render(
       <OverviewTab

--- a/gui/src/components/agent-detail/overview-tab.test.tsx
+++ b/gui/src/components/agent-detail/overview-tab.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import type { AgentDetail, AgentSkills } from "@/lib/types";
+
+const agentSkillsState: {
+  data: AgentSkills | undefined;
+  isLoading: boolean;
+  error: unknown;
+  refetch: () => void;
+} = { data: undefined, isLoading: false, error: null, refetch: vi.fn() };
+
+vi.mock("@/hooks", () => ({
+  useAgentSkills: () => agentSkillsState,
+}));
+
+import { OverviewTab } from "./overview-tab";
+
+function makeAgent(overrides: Partial<AgentDetail> = {}): AgentDetail {
+  return {
+    agent_key: "demo",
+    agent_name: "demo",
+    agent_type: "openclaw",
+    host: "192.168.1.100",
+    host_alias: "box",
+    host_os_family: "linux",
+    status: "running",
+    model: "-",
+    uptime: "1m",
+    gateway_url: null,
+    provider: "",
+    provider_type: "",
+    addresses: [],
+    version: "2026.4.2",
+    device_id: "",
+    onboarding_step: "ready",
+    gateway_port: null,
+    latest_supported_version: "2026.5.28",
+    ...overrides,
+  } as AgentDetail;
+}
+
+describe("OverviewTab — upgrade-available badge", () => {
+  beforeEach(() => {
+    agentSkillsState.data = { installed: [], available: [] } as unknown as AgentSkills;
+  });
+
+  it("renders upgrade-available badge when latest_supported_version > agent.version", () => {
+    render(<OverviewTab agent={makeAgent()} agentKey="demo" />);
+    const badge = screen.getByTestId("upgrade-available-badge");
+    expect(badge).toBeTruthy();
+    expect(badge.textContent).toContain("2026.5.28");
+    expect(badge.textContent).toContain("clawctl agent upgrade demo");
+  });
+
+  it("does not render badge when latest_supported_version equals agent.version", () => {
+    render(
+      <OverviewTab
+        agent={makeAgent({
+          version: "2026.5.28",
+          latest_supported_version: "2026.5.28",
+        })}
+        agentKey="demo"
+      />,
+    );
+    expect(screen.queryByTestId("upgrade-available-badge")).toBeNull();
+  });
+
+  it("does not render badge when latest_supported_version is null", () => {
+    render(
+      <OverviewTab
+        agent={makeAgent({ latest_supported_version: null })}
+        agentKey="demo"
+      />,
+    );
+    expect(screen.queryByTestId("upgrade-available-badge")).toBeNull();
+  });
+});

--- a/gui/src/components/agent-detail/overview-tab.tsx
+++ b/gui/src/components/agent-detail/overview-tab.tsx
@@ -102,7 +102,11 @@ export function OverviewTab({ agent, agentKey }: OverviewTabProps) {
           <InfoRow label="Name" value={agent.agent_name} />
           <InfoRow label="Type" value={agent.agent_type} />
           <InfoRow label="Host" value={agent.host_alias || agent.host} />
-          <InfoRow label="Version" value={agent.version || "—"} />
+          <VersionRow
+            version={agent.version}
+            latestSupportedVersion={agent.latest_supported_version}
+            agentName={agent.agent_name}
+          />
           <InfoRow label="Status" value={agent.status} />
           <InfoRow label="Uptime" value={agent.uptime || "—"} />
           {agent.gateway_url && (
@@ -122,6 +126,57 @@ function InfoRow({ label, value }: { label: string; value: string }) {
     <div>
       <span className="text-muted text-xs block">{label}</span>
       <span className="text-primary-text font-mono text-xs">{value}</span>
+    </div>
+  );
+}
+
+function isNewerVersion(latest: string, current: string): boolean {
+  const parse = (v: string) => v.replace(/^v/, "").split(".").map((n) => parseInt(n, 10) || 0);
+  const a = parse(latest);
+  const b = parse(current);
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const ai = a[i] ?? 0;
+    const bi = b[i] ?? 0;
+    if (ai > bi) return true;
+    if (ai < bi) return false;
+  }
+  return false;
+}
+
+function VersionRow({
+  version,
+  latestSupportedVersion,
+  agentName,
+}: {
+  version: string;
+  latestSupportedVersion: string | null;
+  agentName: string;
+}) {
+  const upgradeAvailable =
+    !!latestSupportedVersion &&
+    !!version &&
+    isNewerVersion(latestSupportedVersion, version);
+
+  return (
+    <div data-testid="version-row">
+      <span className="text-muted text-xs block">Version</span>
+      <span className="text-primary-text font-mono text-xs">
+        {version || "—"}
+      </span>
+      {upgradeAvailable && (
+        <div
+          data-testid="upgrade-available-badge"
+          className="mt-1 inline-flex flex-col gap-0.5"
+        >
+          <span className="text-xs bg-amber-50 text-amber-700 px-2 py-0.5 rounded-full font-mono">
+            ↑ Upgrade available: {latestSupportedVersion}
+          </span>
+          <span className="text-xs text-muted font-mono">
+            Run: clawctl agent upgrade {agentName}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/gui/src/components/agent-detail/overview-tab.tsx
+++ b/gui/src/components/agent-detail/overview-tab.tsx
@@ -153,9 +153,14 @@ function VersionRow({
   latestSupportedVersion: string | null;
   agentName: string;
 }) {
+  // `version === '?'` is the legacy sentinel from `cli/tui/data.py` for
+  // agents that have never started — `parseInt('?', 10) || 0` would
+  // resolve to 0 and falsely trip the badge for every agent in that
+  // state. ATX W2 (issue #592).
+  const versionKnown = !!version && version !== "?";
   const upgradeAvailable =
     !!latestSupportedVersion &&
-    !!version &&
+    versionKnown &&
     isNewerVersion(latestSupportedVersion, version);
 
   return (

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -66,6 +66,9 @@ export interface AgentDetail extends AgentSummary {
   device_id: string;
   onboarding_step: string;
   gateway_port: number | null;
+  // Max manifest version compatible with this host's hardware. `null`
+  // when the host's os/arch has no matching platform entry. Issue #592.
+  latest_supported_version: string | null;
 }
 
 export interface ActionResponse {

--- a/src/clawrium/cli/clawctl/agent/__init__.py
+++ b/src/clawrium/cli/clawctl/agent/__init__.py
@@ -37,6 +37,7 @@ from clawrium.cli.clawctl.agent import (
     start as _start,
     stop as _stop,
     sync as _sync,
+    upgrade as _upgrade,
 )
 
 __all__ = ["agent_app"]
@@ -66,6 +67,10 @@ agent_app.command(name="restart", help="Restart an agent.")(_restart.restart)
 agent_app.command(name="sync", help="Flush local control-plane state to the agent.")(
     _sync.sync
 )
+agent_app.command(
+    name="upgrade",
+    help="Upgrade an agent to the manifest's max supported version.",
+)(_upgrade.upgrade)
 agent_app.command(
     name="doctor",
     help="Diagnose an agent's render bundle (attachments, secrets, files).",

--- a/src/clawrium/cli/clawctl/agent/upgrade.py
+++ b/src/clawrium/cli/clawctl/agent/upgrade.py
@@ -1,0 +1,202 @@
+"""`clawctl agent upgrade <name>` — forward-only upgrade to manifest max.
+
+Bumps an installed agent to the highest manifest version compatible with
+its host hardware. No version pinning, no downgrade path: the manifest is
+the contract. Issue #592.
+
+Pre-flight (hard fail on any rejection):
+
+1. Resolve agent + host from `hosts.json`.
+2. Compute `target = latest_supported_version(agent_type, host_hardware)`.
+3. **No-op** if `target == installed`. Exit 0; `run_installation` not called.
+4. **Reject downgrade** if `target < installed`. Cannot occur via normal
+   flow — surfaces as a hard error when a manifest is reordered/removed.
+5. **Drift check**: refuse if any rendered file differs from on-host state.
+   `--skip-drift-check` bypasses (hidden escape hatch).
+6. Confirmation prompt unless `--yes` or `-o json`.
+
+Execute:
+
+- `run_installation(claw_name=<type>, hostname=..., name=..., force=True)`.
+  Matched-entry resolution inside it picks `target` automatically because
+  the manifest's max is the new version.
+- `hosts.json.agents.<name>.version` updates at the existing write site
+  (`core/install.py:562`).
+- The canonical lifecycle drives restart + re-pair (per AGENTS.md
+  §"Gateway Token Lifecycle (zeroclaw)").
+"""
+
+from __future__ import annotations
+
+import json
+
+import typer
+from packaging.version import InvalidVersion, Version
+
+from clawrium.cli.clawctl._common import OutputFormat, confirm_destructive
+from clawrium.cli.clawctl.agent._shared import resolve_agent_key, safe_resolve_agent
+from clawrium.cli.output import emit_error, stream_action
+
+
+def _parse(v: str) -> Version:
+    try:
+        return Version(v)
+    except InvalidVersion:
+        return Version("0.0.0")
+
+
+_RENDERERS = {
+    "hermes": "render_hermes",
+    "zeroclaw": "render_zeroclaw",
+    "openclaw": "render_openclaw",
+}
+
+
+def _drift_files(host: dict, agent_name: str, agent_type: str) -> list[str]:
+    """Return the list of file paths that differ between rendered and host.
+
+    Raises on render/SSH errors so the caller can surface a clean failure.
+    """
+    from clawrium.core import render as _render_mod
+    from clawrium.core.render import build_render_inputs
+    from clawrium.core.render_diff import diff_files
+
+    renderer_name = _RENDERERS.get(agent_type)
+    if renderer_name is None:
+        raise RuntimeError(f"no renderer for agent type {agent_type!r}")
+    renderer = getattr(_render_mod, renderer_name)
+
+    inputs = build_render_inputs(agent_name)
+    rendered = renderer(inputs)
+    results = diff_files(
+        host=host, agent_name=agent_name, rendered_files=rendered.files
+    )
+    return [d.path for d in results if d.unified_diff]
+
+
+def upgrade(
+    name: str = typer.Argument(..., help="Agent name."),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip confirmation prompt."
+    ),
+    skip_drift_check: bool = typer.Option(
+        False,
+        "--skip-drift-check",
+        help="Bypass the drift pre-flight gate.",
+        hidden=True,
+    ),
+    output: OutputFormat = typer.Option(
+        OutputFormat.table, "--output", "-o", help="Output format (table or json)."
+    ),
+) -> None:
+    """Upgrade an installed agent to the manifest's max supported version."""
+    from clawrium.core.install import InstallationError, run_installation
+    from clawrium.core.registry import latest_supported_version
+
+    host, agent_type, claw_record = safe_resolve_agent(name)
+    agent_key = resolve_agent_key(host, name)
+    agent_type = claw_record.get("type", agent_type)
+
+    installed = str(claw_record.get("version") or "")
+    if not installed:
+        emit_error(
+            f"agent {name!r} has no installed version recorded",
+            hint="clawctl agent describe " + name,
+        )
+
+    hardware = host.get("hardware", {})
+    target = latest_supported_version(agent_type, hardware)
+    if target is None:
+        emit_error(
+            f"no platform entry in {agent_type!r} manifest matches host hardware",
+            hint="check the host's os/os_version/arch facts",
+        )
+
+    use_json = output is OutputFormat.json
+    resource = f"agent/{name}"
+    hostname = host.get("hostname", "")
+    on_host_name = claw_record.get("agent_name") or agent_key
+
+    installed_v = _parse(installed)
+    target_v = _parse(target)
+
+    if target_v == installed_v:
+        msg = f"already at latest ({installed})"
+        if use_json:
+            typer.echo(
+                json.dumps(
+                    {
+                        "agent": name,
+                        "from_version": installed,
+                        "to_version": installed,
+                        "status": "no-op",
+                    }
+                )
+            )
+        else:
+            stream_action(resource=resource, message=msg)
+        return
+
+    if target_v < installed_v:
+        emit_error(
+            f"refusing downgrade: installed {installed} > manifest max {target}",
+            hint="manifest entries may have been removed; restore them or reinstall",
+        )
+
+    if not skip_drift_check:
+        try:
+            changed = _drift_files(host, on_host_name, agent_type)
+        except Exception as exc:
+            emit_error(
+                f"drift check failed: {type(exc).__name__}: {exc}",
+                hint="re-run with --skip-drift-check to bypass",
+            )
+        if changed:
+            stream_action(
+                resource=resource,
+                message=(
+                    f"drift detected ({len(changed)} file(s) differ from rendered "
+                    f"state); refusing upgrade"
+                ),
+            )
+            for path in changed:
+                stream_action(resource=resource, message=f"  drift: {path}")
+            emit_error(
+                "host state has drifted from rendered config",
+                hint="run `clawctl agent sync` first, or pass --skip-drift-check",
+            )
+
+    if not use_json:
+        confirm_destructive(
+            prompt=f"Upgrade {name} from {installed} to {target}?",
+            yes=yes,
+        )
+
+    try:
+        result = run_installation(
+            claw_name=agent_type,
+            hostname=hostname,
+            name=on_host_name,
+            force=True,
+        )
+    except InstallationError as exc:
+        emit_error(f"upgrade failed: {exc}")
+        return
+
+    if use_json:
+        typer.echo(
+            json.dumps(
+                {
+                    "agent": name,
+                    "from_version": installed,
+                    "to_version": result.get("version") or target,
+                    "status": "upgraded",
+                }
+            )
+        )
+    else:
+        to_version = result.get("version") or target
+        stream_action(
+            resource=resource,
+            message=f"upgraded {installed} → {to_version}",
+        )

--- a/src/clawrium/cli/clawctl/agent/upgrade.py
+++ b/src/clawrium/cli/clawctl/agent/upgrade.py
@@ -165,6 +165,10 @@ def upgrade(
         )
 
     if not skip_drift_check:
+        # Pre-init so `changed` is bound even if `emit_error` were ever
+        # to become non-NoReturn (it raises typer.Exit today, but the
+        # invariant should not be implicit). ATX iter-2 S1.
+        changed: list[str] = []
         try:
             changed = _drift_files(host, on_host_name, agent_type)
         except Exception as exc:
@@ -224,8 +228,16 @@ def upgrade(
             if not use_json:
                 stream_action(resource=resource, message=f"{stage}: {message}")
 
+        # ATX iter-2 W1 (issue #592): `restart_agent` signals failure
+        # through *both* a raised LifecycleError (host/onboarding pre-
+        # flight) and a `{"success": False, "error": str}` return on
+        # the stop-fail / repair-fail branches (lifecycle.py:914-926
+        # and :781-795). Without checking the return dict, a failed
+        # re-pair silently falls through to the "upgraded" success
+        # output — exactly the silent-stale-bearer trap AGENTS.md
+        # §"Gateway Token Lifecycle" calls out.
         try:
-            restart_agent(
+            restart_result = restart_agent(
                 hostname=hostname,
                 claw_name=agent_type,
                 agent_name=on_host_name,
@@ -234,6 +246,12 @@ def upgrade(
         except LifecycleError as exc:
             emit_error(
                 f"upgrade installed but post-install restart failed: {exc}",
+                hint="run `clawctl agent restart` to rotate the gateway token",
+            )
+        if not restart_result.get("success"):
+            emit_error(
+                "upgrade installed but post-install restart failed: "
+                f"{restart_result.get('error') or 'unknown lifecycle error'}",
                 hint="run `clawctl agent restart` to rotate the gateway token",
             )
 

--- a/src/clawrium/cli/clawctl/agent/upgrade.py
+++ b/src/clawrium/cli/clawctl/agent/upgrade.py
@@ -51,6 +51,16 @@ _RENDERERS = {
     "openclaw": "render_openclaw",
 }
 
+# Agent types whose gateway requires a bearer-token re-pair on lifecycle
+# operations (AGENTS.md §"Gateway Token Lifecycle (zeroclaw)"). The
+# upgrade path force-reinstalls the binary, restarts the unit, and the
+# daemon mints a fresh bearer — `hosts.json.gateway.auth` must be
+# rewritten atomically or remote `clawctl agent chat` sessions will get
+# a clean 401. ATX B2 (issue #592): drive the rotation by calling
+# `lifecycle.restart_agent` after the install playbook returns; that
+# helper already emits the `gateway_token_rotated` event.
+_PAIRING_AGENT_TYPES = {"zeroclaw"}
+
 
 def _drift_files(host: dict, agent_name: str, agent_type: str) -> list[str]:
     """Return the list of file paths that differ between rendered and host.
@@ -104,7 +114,18 @@ def upgrade(
             hint="clawctl agent describe " + name,
         )
 
-    hardware = host.get("hardware", {})
+    # ATX B3 (issue #592): `core/install.py:set_installing()` stamps the
+    # target version into `hosts.json` BEFORE Ansible runs. A failed
+    # playbook leaves `version=<new_target>` with `status="failed"`. If
+    # we naively trust the version field, a retry would compare
+    # installed==target and exit as a no-op, permanently trapping the
+    # operator. Treat any non-installed status as "version is unreliable
+    # for the no-op decision" and let `run_installation(force=True)`
+    # drive the retry. The fix-forward is to call install regardless.
+    install_status = str(claw_record.get("status") or "").lower()
+    failed_retry = install_status == "failed"
+
+    hardware = host.get("hardware") or {}
     target = latest_supported_version(agent_type, hardware)
     if target is None:
         emit_error(
@@ -120,7 +141,7 @@ def upgrade(
     installed_v = _parse(installed)
     target_v = _parse(target)
 
-    if target_v == installed_v:
+    if target_v == installed_v and not failed_retry:
         msg = f"already at latest ({installed})"
         if use_json:
             typer.echo(
@@ -137,7 +158,7 @@ def upgrade(
             stream_action(resource=resource, message=msg)
         return
 
-    if target_v < installed_v:
+    if target_v < installed_v and not failed_retry:
         emit_error(
             f"refusing downgrade: installed {installed} > manifest max {target}",
             hint="manifest entries may have been removed; restore them or reinstall",
@@ -172,6 +193,12 @@ def upgrade(
             yes=yes,
         )
 
+    if failed_retry and not use_json:
+        stream_action(
+            resource=resource,
+            message="retrying upgrade after previous failed install (status=failed)",
+        )
+
     try:
         result = run_installation(
             claw_name=agent_type,
@@ -182,6 +209,33 @@ def upgrade(
     except InstallationError as exc:
         emit_error(f"upgrade failed: {exc}")
         return
+
+    # ATX B2 (issue #592): zeroclaw's install playbook does NOT pair
+    # (see `core/install.py:1069`); the bearer token lives in the
+    # configure path. After a forced reinstall the daemon mints a new
+    # bearer and `hosts.json.gateway.auth` falls out of sync. Route
+    # through `lifecycle.restart_agent`, which rotates the bearer and
+    # emits a `gateway_token_rotated` event per AGENTS.md §"Gateway
+    # Token Lifecycle".
+    if agent_type in _PAIRING_AGENT_TYPES:
+        from clawrium.core.lifecycle import LifecycleError, restart_agent
+
+        def _emit_lifecycle(stage: str, message: str) -> None:
+            if not use_json:
+                stream_action(resource=resource, message=f"{stage}: {message}")
+
+        try:
+            restart_agent(
+                hostname=hostname,
+                claw_name=agent_type,
+                agent_name=on_host_name,
+                on_event=_emit_lifecycle,
+            )
+        except LifecycleError as exc:
+            emit_error(
+                f"upgrade installed but post-install restart failed: {exc}",
+                hint="run `clawctl agent restart` to rotate the gateway token",
+            )
 
     if use_json:
         typer.echo(

--- a/src/clawrium/core/registry.py
+++ b/src/clawrium/core/registry.py
@@ -1038,6 +1038,42 @@ def check_compatibility(
     }
 
 
+def latest_supported_version(claw_name: str, hardware: dict) -> str | None:
+    """Return the max manifest version compatible with the host hardware.
+
+    Filters platform entries to those whose os/os_version/arch match the
+    host (same matching rules as `check_compatibility`), then returns the
+    max `version`. Returns None if no platform entry matches.
+    """
+    try:
+        manifest = load_manifest(claw_name)
+    except ManifestNotFoundError:
+        return None
+
+    versions: list[Version] = []
+    for platform in manifest.get("platforms", []):
+        if platform.get("os") != hardware.get("os"):
+            continue
+        try:
+            if not _version_matches(
+                spec=platform.get("os_version", ""),
+                actual=hardware.get("os_version", ""),
+            ):
+                continue
+        except ValueError:
+            continue
+        if platform.get("arch") != hardware.get("architecture"):
+            continue
+        try:
+            versions.append(Version(platform["version"]))
+        except (InvalidVersion, KeyError):
+            continue
+
+    if not versions:
+        return None
+    return str(max(versions))
+
+
 # ---------------------------------------------------------------------------
 # Hermes version parsing
 #

--- a/src/clawrium/core/registry.py
+++ b/src/clawrium/core/registry.py
@@ -1039,11 +1039,19 @@ def check_compatibility(
 
 
 def latest_supported_version(claw_name: str, hardware: dict) -> str | None:
-    """Return the max manifest version compatible with the host hardware.
+    """Return the max manifest version compatible with the host's OS+arch.
 
-    Filters platform entries to those whose os/os_version/arch match the
-    host (same matching rules as `check_compatibility`), then returns the
-    max `version`. Returns None if no platform entry matches.
+    This is a *narrower* filter than `check_compatibility`: it considers
+    only `os`, `os_version`, and `arch`, and intentionally ignores the
+    `requirements` block (`min_memory_mb`, `gpu_required`, dependency
+    versions). The intent is to answer "which manifest versions can
+    target this host's platform triple?" for the GUI's "Upgrade
+    available" indicator — a richer compatibility verdict (memory, GPU,
+    dependency depth) is left to `check_compatibility`, which the
+    install / upgrade execution paths already invoke.
+
+    Returns the max compatible `version`, or None if no platform entry
+    matches the host's OS/arch.
     """
     try:
         manifest = load_manifest(claw_name)

--- a/src/clawrium/gui/routes/fleet.py
+++ b/src/clawrium/gui/routes/fleet.py
@@ -201,7 +201,20 @@ async def agent_detail(agent_key: str, host: str | None = None):
         if agent_key in agents:
             detail = await asyncio.to_thread(get_agent_detail, agent_key, hostname)
             if detail:
-                return _agent_to_dict(detail)
+                payload = _agent_to_dict(detail)
+                # Issue #592: surface the registry-derived max version for
+                # this host's hardware so the overview tab can render an
+                # "upgrade available" indicator. None when the host's
+                # os/arch has no matching platform entry.
+                from clawrium.core.registry import latest_supported_version
+
+                try:
+                    payload["latest_supported_version"] = latest_supported_version(
+                        detail["agent_type"], h.get("hardware", {})
+                    )
+                except Exception:
+                    payload["latest_supported_version"] = None
+                return payload
 
     raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
 

--- a/src/clawrium/gui/routes/fleet.py
+++ b/src/clawrium/gui/routes/fleet.py
@@ -209,8 +209,12 @@ async def agent_detail(agent_key: str, host: str | None = None):
                 from clawrium.core.registry import latest_supported_version
 
                 try:
+                    # `.get("hardware", {})` does NOT fall back when the
+                    # value is explicitly `null` in hosts.json (pre-fact-
+                    # detection hosts). Use `or {}` to coerce. ATX W3
+                    # (issue #592).
                     payload["latest_supported_version"] = latest_supported_version(
-                        detail["agent_type"], h.get("hardware", {})
+                        detail["agent_type"], h.get("hardware") or {}
                     )
                 except Exception:
                     payload["latest_supported_version"] = None

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -191,3 +191,41 @@ platforms:
         ripgrep: "*"
         ffmpeg: "*"
         uv: "*"
+  - version: "2026.5.29.2"
+    os: ubuntu
+    os_version: "24.04"
+    arch: x86_64
+    sha256: "82978b9ed77fc851d9f0dc5009e69790424e344ea3e856a5948bd78b30981481"
+    requirements:
+      min_memory_mb: 2048
+      gpu_required: false
+      dependencies:
+        python: ">=3.11"
+        ripgrep: "*"
+        ffmpeg: "*"
+        uv: "*"
+  - version: "2026.5.29.2"
+    os: ubuntu
+    os_version: "22.04"
+    arch: x86_64
+    sha256: "82978b9ed77fc851d9f0dc5009e69790424e344ea3e856a5948bd78b30981481"
+    requirements:
+      min_memory_mb: 2048
+      gpu_required: false
+      dependencies:
+        python: ">=3.11"
+        ripgrep: "*"
+        ffmpeg: "*"
+        uv: "*"
+  - version: "2026.5.29.2"
+    os: macos
+    os_version: ">=14"
+    arch: arm64
+    sha256: "82978b9ed77fc851d9f0dc5009e69790424e344ea3e856a5948bd78b30981481"
+    requirements:
+      min_memory_mb: 2048
+      gpu_required: false
+      dependencies:
+        ripgrep: "*"
+        ffmpeg: "*"
+        uv: "*"

--- a/src/clawrium/platform/registry/hermes/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/install.yaml
@@ -4,7 +4,7 @@
   tasks:
     - name: Normalize target Hermes version (strip leading 'v')
       ansible.builtin.set_fact:
-        hermes_target_version: "{{ (claw_version | default('v2026.5.7')) | regex_replace('^v', '') }}"
+        hermes_target_version: "{{ (claw_version | default('v2026.5.29.2')) | regex_replace('^v', '') }}"
 
     - name: Resolve Hermes git tag for installer (always 'v'-prefixed)
       ansible.builtin.set_fact:

--- a/src/clawrium/platform/registry/openclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/openclaw/manifest.yaml
@@ -144,3 +144,21 @@ platforms:
       gpu_required: false
       dependencies:
         nodejs: ">=18.0.0"
+  - version: "2026.5.28"
+    os: ubuntu
+    os_version: "24.04"
+    arch: x86_64
+    requirements:
+      min_memory_mb: 2048
+      gpu_required: false
+      dependencies:
+        nodejs: ">=20.0.0"
+  - version: "2026.5.28"
+    os: ubuntu
+    os_version: "22.04"
+    arch: x86_64
+    requirements:
+      min_memory_mb: 2048
+      gpu_required: false
+      dependencies:
+        nodejs: ">=18.0.0"

--- a/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
@@ -4,7 +4,7 @@
   tasks:
     - name: Normalize target OpenClaw version
       ansible.builtin.set_fact:
-        openclaw_target_version: "{{ (claw_version | default('v2026.4.2')) | regex_replace('^v', '') }}"
+        openclaw_target_version: "{{ (claw_version | default('v2026.5.28')) | regex_replace('^v', '') }}"
 
     - name: Create agent user
       ansible.builtin.user:

--- a/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
@@ -100,7 +100,15 @@
         group: "{{ agent_name }}"
         force: yes
         timeout: 30
-        checksum: "{{ installer_checksum | default(omit) }}"
+        # Variable name must match `claw_sha256` injected by
+        # `core/install.py` (issue #592 ATX B1). Older revisions used
+        # `installer_checksum` which never resolved, silently dropping
+        # the checksum gate via `default(omit)`. Manifest entries that
+        # omit the `sha256:` field still bypass verification — adding
+        # it per platform entry is tracked as a separate hardening
+        # follow-up because the openclaw installer URL is unpinned and
+        # the digest rotates upstream without a manifest bump.
+        checksum: "{{ ('sha256:' + claw_sha256) if claw_sha256 else omit }}"
       when: not openclaw_already_installed
 
     - name: Install OpenClaw CLI runtime

--- a/tests/cli/test_agent_upgrade.py
+++ b/tests/cli/test_agent_upgrade.py
@@ -322,6 +322,47 @@ def test_upgrade_zeroclaw_invokes_restart_agent_for_bearer_rotation(
     mock_restart.assert_called_once()
 
 
+def test_upgrade_zeroclaw_surfaces_failed_restart_as_error(
+    isolated_config: Path, _patch_drift_clean
+):
+    """ATX iter-2 W1: a `success=False` return from `restart_agent` must
+
+    NOT fall through as a silent "upgraded" success. The bearer rotation
+    guarantee in AGENTS.md is conditional on confirmed restart success.
+    """
+    _write_host(isolated_config, "zeroclaw", "0.6.0")
+
+    def _fake_install(*args, **kwargs):
+        return {
+            "success": True,
+            "agent": "zeroclaw",
+            "version": "0.7.5",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+        }
+
+    def _fake_restart_failed(*args, **kwargs):
+        return {
+            "success": False,
+            "agent": "zeroclaw",
+            "host": "192.168.1.100",
+            "error": "systemd unit failed to come up",
+        }
+
+    with patch(
+        "clawrium.core.install.run_installation", side_effect=_fake_install
+    ), patch(
+        "clawrium.core.lifecycle.restart_agent", side_effect=_fake_restart_failed
+    ):
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+    assert result.exit_code != 0, result.output
+    assert "restart failed" in result.output.lower()
+    assert "systemd unit failed to come up" in result.output
+
+
 def test_upgrade_openclaw_does_not_invoke_restart_agent(
     isolated_config: Path, _patch_drift_clean
 ):

--- a/tests/cli/test_agent_upgrade.py
+++ b/tests/cli/test_agent_upgrade.py
@@ -246,6 +246,114 @@ def test_upgrade_json_output_mode(isolated_config: Path, _patch_drift_clean):
     assert payload["to_version"] == "2026.5.28"
 
 
+def test_upgrade_retries_after_previous_failed_install(
+    isolated_config: Path, _patch_drift_clean
+):
+    """ATX B3: a prior failed install leaves version=target+status=failed.
+
+    Without the failed-status retry path the no-op shortcut would trap
+    the operator forever. Confirm the retry path calls run_installation
+    even when installed == manifest max.
+    """
+    _write_host(isolated_config, "openclaw", "2026.5.28")
+    # Flip the status to 'failed' to simulate the trap.
+    data = json.loads((isolated_config / "hosts.json").read_text())
+    data[0]["agents"]["test-agent"]["status"] = "failed"
+    (isolated_config / "hosts.json").write_text(json.dumps(data))
+
+    def _fake_install(*args, **kwargs):
+        return {
+            "success": True,
+            "agent": "openclaw",
+            "version": "2026.5.28",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+        }
+
+    with patch(
+        "clawrium.core.install.run_installation", side_effect=_fake_install
+    ) as mock_install:
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+    assert result.exit_code == 0, result.output
+    mock_install.assert_called_once()
+    assert "already at latest" not in result.output.lower()
+
+
+def test_upgrade_zeroclaw_invokes_restart_agent_for_bearer_rotation(
+    isolated_config: Path, _patch_drift_clean
+):
+    """ATX B2: zeroclaw install never re-pairs; upgrade must drive the
+
+    canonical lifecycle via `restart_agent` so the bearer rotates and
+    `gateway_token_rotated` fires per AGENTS.md.
+    """
+    _write_host(isolated_config, "zeroclaw", "0.6.0")
+
+    def _fake_install(*args, **kwargs):
+        return {
+            "success": True,
+            "agent": "zeroclaw",
+            "version": "0.7.5",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+        }
+
+    def _fake_restart(*args, **kwargs):
+        return {
+            "success": True,
+            "agent": kwargs.get("agent_name") or "zeroclaw",
+            "host": kwargs.get("hostname", ""),
+            "error": None,
+        }
+
+    with patch(
+        "clawrium.core.install.run_installation", side_effect=_fake_install
+    ), patch(
+        "clawrium.core.lifecycle.restart_agent", side_effect=_fake_restart
+    ) as mock_restart:
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+    assert result.exit_code == 0, result.output
+    mock_restart.assert_called_once()
+
+
+def test_upgrade_openclaw_does_not_invoke_restart_agent(
+    isolated_config: Path, _patch_drift_clean
+):
+    """openclaw is intentionally NOT in `_PAIRING_AGENT_TYPES` — its
+
+    bearer is a static install-time token (see AGENTS.md §"Native
+    Dashboards"). The post-install restart path must NOT fire for it.
+    """
+    _write_host(isolated_config, "openclaw", "2026.4.2")
+
+    def _fake_install(*args, **kwargs):
+        return {
+            "success": True,
+            "agent": "openclaw",
+            "version": "2026.5.28",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+        }
+
+    with patch(
+        "clawrium.core.install.run_installation", side_effect=_fake_install
+    ), patch(
+        "clawrium.core.lifecycle.restart_agent",
+        side_effect=AssertionError("restart_agent must not be called for openclaw"),
+    ):
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+    assert result.exit_code == 0, result.output
+
+
 def test_upgrade_skip_drift_check_bypasses_preflight(isolated_config: Path):
     """`--skip-drift-check` means the drift helper is never called."""
     _write_host(isolated_config, "openclaw", "2026.4.2")

--- a/tests/cli/test_agent_upgrade.py
+++ b/tests/cli/test_agent_upgrade.py
@@ -1,0 +1,281 @@
+"""Tests for `clawctl agent upgrade` (issue #592).
+
+The upgrade subcommand is forward-only and max-only — the manifest's
+max-compatible entry is always the target. Every test patches
+`run_installation` and the drift helper so we exercise the CLI logic
+without touching SSH or ansible-runner. Where state mutation is part of
+the contract, the test reads `hosts.json` back to confirm.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+
+runner = CliRunner()
+
+
+def _write_host(
+    config_dir: Path,
+    agent_type: str,
+    installed_version: str,
+    *,
+    agent_name: str = "test-agent",
+    hostname: str = "192.168.1.100",
+) -> None:
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "keys" / hostname).mkdir(parents=True, exist_ok=True)
+    (config_dir / "keys" / hostname / "xclm_ed25519").write_text("k")
+    (config_dir / "keys" / hostname / "xclm_ed25519").chmod(0o600)
+    (config_dir / "keys" / hostname / "xclm_ed25519.pub").write_text(
+        "ssh-ed25519 AAAA"
+    )
+    hosts = [
+        {
+            "hostname": hostname,
+            "key_id": hostname,
+            "port": 22,
+            "user": "xclm",
+            "auth_method": "key",
+            "alias": "h1",
+            "hardware": {
+                "architecture": "x86_64",
+                "processor_cores": 4,
+                "memtotal_mb": 8192,
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "gpu": {"present": False},
+            },
+            "metadata": {
+                "added_at": "2026-06-01T00:00:00Z",
+                "last_seen": "2026-06-01T00:00:00Z",
+                "tags": [],
+            },
+            "agents": {
+                agent_name: {
+                    "type": agent_type,
+                    "agent_name": agent_name,
+                    "version": installed_version,
+                    "installed_at": "2026-06-01T00:00:00Z",
+                    "status": "installed",
+                    "onboarding": {"state": "ready", "stages": {}},
+                    "config": {},
+                }
+            },
+        }
+    ]
+    (config_dir / "hosts.json").write_text(json.dumps(hosts, indent=2))
+
+
+def _read_version(config_dir: Path, agent_name: str = "test-agent") -> str:
+    data = json.loads((config_dir / "hosts.json").read_text())
+    return data[0]["agents"][agent_name]["version"]
+
+
+@pytest.fixture
+def _patch_drift_clean():
+    """Patch the drift helper to return no changed files."""
+    with patch(
+        "clawrium.cli.clawctl.agent.upgrade._drift_files", return_value=[]
+    ) as m:
+        yield m
+
+
+def test_upgrade_no_op_when_already_at_max(isolated_config: Path):
+    """Already at manifest max → exit 0, no install, no version mutation."""
+    _write_host(isolated_config, "openclaw", "2026.5.28")
+    with patch("clawrium.core.install.run_installation") as mock_install:
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+    assert result.exit_code == 0, result.output
+    assert "already at latest" in result.output.lower()
+    mock_install.assert_not_called()
+    assert _read_version(isolated_config) == "2026.5.28"
+
+
+def test_upgrade_nochange_zeroclaw_exits_zero(isolated_config: Path):
+    """Zeroclaw manifest max is unchanged → upgrade is a no-op."""
+    _write_host(isolated_config, "zeroclaw", "0.7.5")
+    with patch("clawrium.core.install.run_installation") as mock_install:
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+    assert result.exit_code == 0, result.output
+    assert "already at latest" in result.output.lower()
+    mock_install.assert_not_called()
+    assert _read_version(isolated_config) == "0.7.5"
+
+
+def test_upgrade_rejects_drift(isolated_config: Path):
+    """Drift detected → non-zero exit; install not called; version unchanged."""
+    _write_host(isolated_config, "openclaw", "2026.4.2")
+    with patch(
+        "clawrium.cli.clawctl.agent.upgrade._drift_files",
+        return_value=["~/.openclaw/config.yaml"],
+    ), patch("clawrium.core.install.run_installation") as mock_install:
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+    assert result.exit_code != 0, result.output
+    assert "drift" in result.output.lower()
+    assert "~/.openclaw/config.yaml" in result.output
+    mock_install.assert_not_called()
+    assert _read_version(isolated_config) == "2026.4.2"
+
+
+def test_upgrade_rejects_downgrade_attempt(
+    isolated_config: Path, _patch_drift_clean
+):
+    """Installed > manifest max → hard reject."""
+    _write_host(isolated_config, "openclaw", "9999.0.0")
+    with patch("clawrium.core.install.run_installation") as mock_install:
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+    assert result.exit_code != 0, result.output
+    assert "downgrade" in result.output.lower()
+    mock_install.assert_not_called()
+    assert _read_version(isolated_config) == "9999.0.0"
+
+
+def test_upgrade_happy_path_openclaw(isolated_config: Path, _patch_drift_clean):
+    """Happy path: force=True is forwarded; hosts.json reflects new version."""
+    _write_host(isolated_config, "openclaw", "2026.4.2")
+
+    def _fake_install(claw_name, hostname, name=None, **kwargs):
+        # Simulate the real write at install.py:562.
+        path = isolated_config / "hosts.json"
+        data = json.loads(path.read_text())
+        data[0]["agents"]["test-agent"]["version"] = "2026.5.28"
+        path.write_text(json.dumps(data, indent=2))
+        return {
+            "success": True,
+            "agent": "openclaw",
+            "version": "2026.5.28",
+            "host": hostname,
+            "playbooks_run": [],
+            "error": None,
+        }
+
+    with patch(
+        "clawrium.core.install.run_installation", side_effect=_fake_install
+    ) as mock_install:
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+    assert result.exit_code == 0, result.output
+    mock_install.assert_called_once()
+    _, kwargs = mock_install.call_args
+    # `run_installation` is called positionally too — normalize.
+    call_kwargs = {**kwargs}
+    if mock_install.call_args.args:
+        # First positional is claw_name
+        call_kwargs.setdefault("claw_name", mock_install.call_args.args[0])
+    assert call_kwargs.get("force") is True
+    assert _read_version(isolated_config) == "2026.5.28"
+
+
+def test_upgrade_happy_path_hermes(isolated_config: Path, _patch_drift_clean):
+    """Hermes happy path: forwards force=True; version persisted."""
+    _write_host(isolated_config, "hermes", "2026.5.7")
+
+    def _fake_install(*args, **kwargs):
+        path = isolated_config / "hosts.json"
+        data = json.loads(path.read_text())
+        data[0]["agents"]["test-agent"]["version"] = "2026.5.29.2"
+        path.write_text(json.dumps(data, indent=2))
+        return {
+            "success": True,
+            "agent": "hermes",
+            "version": "2026.5.29.2",
+            "host": args[1] if len(args) > 1 else kwargs.get("hostname", ""),
+            "playbooks_run": [],
+            "error": None,
+        }
+
+    with patch(
+        "clawrium.core.install.run_installation", side_effect=_fake_install
+    ) as mock_install:
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+    assert result.exit_code == 0, result.output
+    mock_install.assert_called_once()
+    assert _read_version(isolated_config) == "2026.5.29.2"
+
+
+def test_upgrade_json_output_mode(isolated_config: Path, _patch_drift_clean):
+    """`-o json --yes` emits a parseable payload with expected keys."""
+    _write_host(isolated_config, "openclaw", "2026.4.2")
+
+    def _fake_install(*args, **kwargs):
+        return {
+            "success": True,
+            "agent": "openclaw",
+            "version": "2026.5.28",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+        }
+
+    with patch("clawrium.core.install.run_installation", side_effect=_fake_install):
+        result = runner.invoke(
+            app,
+            ["agent", "upgrade", "test-agent", "-o", "json", "--yes"],
+            env=os.environ,
+        )
+    assert result.exit_code == 0, result.output
+    # The last line of output is the JSON payload.
+    payload = None
+    for line in reversed(result.output.strip().splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            payload = json.loads(line)
+            break
+    assert payload is not None, result.output
+    assert payload["agent"] == "test-agent"
+    assert payload["from_version"] == "2026.4.2"
+    assert payload["to_version"] == "2026.5.28"
+
+
+def test_upgrade_skip_drift_check_bypasses_preflight(isolated_config: Path):
+    """`--skip-drift-check` means the drift helper is never called."""
+    _write_host(isolated_config, "openclaw", "2026.4.2")
+
+    def _fake_install(*args, **kwargs):
+        return {
+            "success": True,
+            "agent": "openclaw",
+            "version": "2026.5.28",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+        }
+
+    with patch(
+        "clawrium.cli.clawctl.agent.upgrade._drift_files",
+        side_effect=AssertionError("drift helper must not be called"),
+    ), patch(
+        "clawrium.core.install.run_installation", side_effect=_fake_install
+    ) as mock_install:
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "upgrade",
+                "test-agent",
+                "--skip-drift-check",
+                "--yes",
+            ],
+            env=os.environ,
+        )
+    assert result.exit_code == 0, result.output
+    mock_install.assert_called_once()

--- a/tests/core/test_registry_latest_supported.py
+++ b/tests/core/test_registry_latest_supported.py
@@ -1,0 +1,35 @@
+"""Tests for `registry.latest_supported_version` (issue #592)."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawrium.core.registry import latest_supported_version
+
+
+@pytest.mark.parametrize(
+    "claw_name,os_,os_version,arch,expected",
+    [
+        ("openclaw", "ubuntu", "24.04", "x86_64", "2026.5.28"),
+        ("openclaw", "ubuntu", "22.04", "x86_64", "2026.5.28"),
+        ("hermes", "ubuntu", "24.04", "x86_64", "2026.5.29.2"),
+        ("hermes", "ubuntu", "22.04", "x86_64", "2026.5.29.2"),
+        ("hermes", "macos", "14.5", "arm64", "2026.5.29.2"),
+    ],
+)
+def test_latest_supported_per_host_filter(
+    claw_name, os_, os_version, arch, expected
+):
+    hardware = {"os": os_, "os_version": os_version, "architecture": arch}
+    assert latest_supported_version(claw_name, hardware) == expected
+
+
+def test_latest_supported_returns_none_when_no_platform_matches():
+    """openclaw is x86_64-only — aarch64 host returns None."""
+    hardware = {"os": "ubuntu", "os_version": "24.04", "architecture": "aarch64"}
+    assert latest_supported_version("openclaw", hardware) is None
+
+
+def test_latest_supported_returns_none_for_unknown_os():
+    hardware = {"os": "debian", "os_version": "12", "architecture": "x86_64"}
+    assert latest_supported_version("openclaw", hardware) is None

--- a/tests/test_gui_agent_detail_latest_version.py
+++ b/tests/test_gui_agent_detail_latest_version.py
@@ -1,0 +1,78 @@
+"""Tests for `latest_supported_version` on the agent-detail API (issue #592)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from clawrium.gui.server import app
+
+
+def _seed_hosts(
+    config_dir: Path,
+    *,
+    agent_type: str,
+    installed_version: str,
+    architecture: str = "x86_64",
+    os_: str = "ubuntu",
+    os_version: str = "24.04",
+) -> None:
+    hosts = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "box",
+            "port": 22,
+            "user": "xclm",
+            "hardware": {
+                "architecture": architecture,
+                "processor_cores": 4,
+                "memtotal_mb": 8192,
+                "os": os_,
+                "os_version": os_version,
+                "gpu": {"present": False},
+            },
+            "agents": {
+                "demo": {
+                    "type": agent_type,
+                    "agent_name": "demo",
+                    "name": "demo",
+                    "version": installed_version,
+                    "status": "installed",
+                    "onboarding": {"state": "ready", "stages": {}},
+                    "config": {},
+                }
+            },
+        }
+    ]
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "hosts.json").write_text(json.dumps(hosts))
+
+
+def test_agent_detail_includes_latest_supported_version(isolated_config: Path):
+    _seed_hosts(isolated_config, agent_type="openclaw", installed_version="2026.4.2")
+    with TestClient(app) as client:
+        resp = client.get("/api/fleet/agents/demo")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "latest_supported_version" in body
+    assert body["latest_supported_version"] == "2026.5.28"
+
+
+def test_agent_detail_latest_supported_version_is_none_for_unmatched_host(
+    isolated_config: Path,
+):
+    """openclaw has no aarch64 platform entry — field must be None, not omitted."""
+    _seed_hosts(
+        isolated_config,
+        agent_type="openclaw",
+        installed_version="2026.4.2",
+        architecture="aarch64",
+    )
+    with TestClient(app) as client:
+        resp = client.get("/api/fleet/agents/demo")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "latest_supported_version" in body
+    assert body["latest_supported_version"] is None

--- a/website/docs/reference/cli/agent.md
+++ b/website/docs/reference/cli/agent.md
@@ -538,7 +538,9 @@ Installed Agents (4):
 
 ### upgrade
 
-Upgrade an agent to a newer version.
+Upgrade an agent to the registry's max supported version for the host's
+hardware. Forward-only: there is no `--version` pin and no downgrade
+path — the manifest is the contract.
 
 ```bash
 clawctl agent upgrade <agent-name> [options]
@@ -548,42 +550,43 @@ clawctl agent upgrade <agent-name> [options]
 - `agent-name` - Name of the agent to upgrade
 
 **Options:**
-- `--version <version>` - Upgrade to specific version (default: latest)
-- `--restart` - Restart agent after upgrade (if it was running)
+- `--yes`, `-y` - Skip confirmation prompt
+- `--skip-drift-check` - Bypass the drift pre-flight gate (hidden; escape hatch)
+- `-o`, `--output <fmt>` - Output format: `table` (default) or `json`
 
 **Examples:**
 
 ```bash
-# Upgrade to latest version
+# Upgrade to the manifest's max supported version
 clawctl agent upgrade opc-work
 
-# Upgrade to specific version
-clawctl agent upgrade opc-work --version 2026.5.0
+# Non-interactive
+clawctl agent upgrade opc-work --yes
 
-# Upgrade and restart
-clawctl agent upgrade opc-work --restart
+# JSON output (implies --yes-equivalent: no confirmation prompt)
+clawctl agent upgrade opc-work -o json
 ```
 
-**Output:**
-```
-Agent: opc-work
-Current version: 2026.4.2
-Latest version: 2026.5.1
+**Pre-flight rejection cases:**
 
-Upgrading to v2026.5.1...
-✓ Downloaded package
-✓ Stopped agent
-✓ Installed new version
-✓ Started agent
-✓ Upgrade complete
+1. **Already at max** — exits 0 with `already at latest (<version>)`. No
+   work is performed.
+2. **Downgrade refused** — if the manifest's max is older than the
+   installed version (only possible if entries were removed from the
+   manifest), the command exits non-zero. Restore the manifest entries
+   or reinstall.
+3. **Drift refused** — if any rendered config file differs from the
+   on-host state, the command lists the changed files and exits
+   non-zero. Run `clawctl agent sync` first, or re-run with
+   `--skip-drift-check` to bypass.
+4. **Drift bypass** — `--skip-drift-check` proceeds without comparing
+   rendered vs. on-host files. The upgrade is force-installed in place.
 
-opc-work is now running v2026.5.1
-```
-
-**Note:**
-- Onboarding configuration is preserved during upgrades
-- Secrets and identity files are not affected
-- Agent is stopped during upgrade (use `--restart` to auto-start)
+**Notes:**
+- Onboarding configuration, secrets, and identity files are preserved.
+- For zeroclaw agents, the gateway bearer is rotated as part of the
+  canonical lifecycle (see AGENTS.md §"Gateway Token Lifecycle").
+  Remote `clawctl agent chat` sessions must reconnect after upgrade.
 
 ---
 


### PR DESCRIPTION
## Summary

- Implements `clawctl agent upgrade <name>` — forward-only, max-only promotion to the manifest's max-supported version for the host's hardware (no `--version` pin, no downgrade path).
- Bumps openclaw to **2026.5.28** and hermes to **v2026.5.29.2** in their registry manifests + install playbook defaults. Zeroclaw is unchanged (upstream stable is still 0.7.5).
- Adds a GUI "Upgrade available" badge on the agent-detail overview tab (CLI remains the only mutation path).

Closes #592.

## ATX Review Summary

**Final Review: blocking=false (0 blockers, 1 warning out-of-scope, 1 suggestion out-of-scope)**
**Total Cost: $6.41 | Total Duration: ~21m | Specialists invoked: 6 (iter-1), 1 (iter-2)**

| Review | Blocking | Blocking Issues | Status | Cost | Duration | Specialists |
|--------|----------|-----------------|--------|------|----------|-------------|
| 1 (`336f64e8`) | true | B1, B2, B3 | All Fixed | $3.59 | 14m15s | cli-typer, registry-manifest, gui-frontend, security, lifecycle-state-machine, test-coverage |
| 2 (`bdja9zpr7`) | false | — | Cleared | $2.82 | 7m24s | security (rating 3/5) |

> **Note**: Reviews invoked via the local `atx review request` CLI against the worktree, not via a GitHub-actions check. The JSON output was parsed and the actionable findings are documented in the iteration details below. No `atx-ci` workflow is wired to this repository — see Callouts.

<details>
<summary>Review 1 details (blocking=true — 3 blockers / 5 warnings / 6 suggestions)</summary>

**Blocking issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `openclaw/playbooks/install.yaml:103`, `install.py:712,831` | Playbook used `installer_checksum` (never resolved) while `install.py` injects `claw_sha256`. `default(omit)` silently dropped the checksum gate. | Fixed in commit `4432ddc` — variable renamed, `('sha256:' + claw_sha256) if claw_sha256 else omit` keeps the omit fallback explicit. |
| B2 | `upgrade.py:155-162`, `install.py:1069-1077` | `upgrade()` called `run_installation(force=True)` and nothing else. Zeroclaw install does NOT pair; the daemon mints a new bearer on restart while `hosts.json.gateway.auth` stays stale → every subsequent `clawctl agent chat` 401s. | Fixed in commit `4432ddc` — `_PAIRING_AGENT_TYPES = {"zeroclaw"}`; `lifecycle.restart_agent` is invoked unconditionally after `run_installation` for those types so the bearer rotates and `gateway_token_rotated` fires per AGENTS.md. Iter-2 follow-up in `e04becd` adds the return-value check (see Review 2). |
| B3 | `install.py:562`, `install.py:1206-1221` | `set_installing()` stamps `version=<new_target>` to `hosts.json` BEFORE Ansible runs. A failed playbook leaves `status="failed"` with the new version, so a retry would `installed==target` → no-op forever. | Fixed in commit `4432ddc` — `upgrade.py` detects `status=="failed"` and skips both the no-op and downgrade shortcuts so the retry actually re-runs `run_installation`. The deeper fix in `set_failed()` (version restore) is broader-blast-radius and deferred. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `registry.py:1042` | Docstring claimed "same matching rules as `check_compatibility`" but the helper skips memory/GPU checks. | Fixed in `4432ddc` — docstring rewritten to clarify the OS/arch-only filter scope; richer compatibility deferred to `check_compatibility` at install/upgrade time. |
| W2 | `overview-tab.tsx:156-159` | `version='?'` sentinel (never-started agents) tripped `parseInt('?', 10) || 0` → 0 → badge fired for every never-started agent. | Fixed in `4432ddc` — `version !== '?'` guard added; new vitest case covers it. |
| W3 | `gui/routes/fleet.py:213` | `h.get("hardware", {})` returns `None` for explicit-null hosts; `latest_supported_version(None.get(...))` raised, swallowed by bare `except Exception`. | Fixed in `4432ddc` — switched to `h.get("hardware") or {}`. |
| W4 | `render_diff.py:119` | SSH `WarningPolicy` accepts unknown host keys; MITM could feed an empty drift diff and trick the upgrade into thinking host is clean. | Out-of-scope. Pre-existing host-key policy spanning every SSH-based code path; fixing requires a fingerprint-store contract introduced at `clawctl host create`. Tracked as a hardening follow-up. |
| W5 | n/a (test coverage) | No tests for B3 trap, live-binary-vs-hosts.json drift, or corrupted version strings. | Partially addressed — B3 trap now covered by `test_upgrade_retries_after_previous_failed_install`. Live-binary drift coverage requires SSH-mocked tests against `run_installation`'s validate step and is deferred. |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Dead `return` after `emit_error()` in `upgrade.py:184`. | Deferred — pattern matches the existing CLI convention (sync.py, configure.py); `emit_error` is `NoReturn` but the trailing return defends against accidental change. |
| S2 | Rename `agent_name` kwarg or document it on `_drift_files`. | Deferred — same naming convention as `core/render_diff.py`. |
| S3 | Add a comment explaining single-installer-script rationale for the three new hermes entries sharing one sha256. | Deferred — pattern already explained at the existing `# Note:` block above the platforms array. |
| S4 | Move the `latest_supported_version` import to module level in `gui/routes/fleet.py`. | Deferred — keeps the cold-path agent_detail import out of the hot fleet-overview path. |
| S5 | Wrap the upgrade-command hint in `<code className="select-all">`. | Deferred — current `<span>` styling matches the rest of the overview-tab card. |
| S6 | Replace live-manifest-dependent test values with an in-memory fixture. | Deferred — the live-manifest coupling is intentional: it surfaces accidental manifest churn as a test diff. |

</details>

<details>
<summary>Review 2 details (blocking=false — security-reviewer rating 3/5)</summary>

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `upgrade.py:227-238` | `restart_agent` returns `{"success": False, "error": str}` on stop-fail / repair-fail branches without raising. The prior commit only caught `LifecycleError`, so a failed re-pair silently fell through to the "upgraded" success output — exactly the silent-stale-bearer trap AGENTS.md §"Gateway Token Lifecycle" calls out. | Fixed in commit `e04becd` — captured the return dict and surface `success=False` via `emit_error` with the upstream error string. New pytest case `test_upgrade_zeroclaw_surfaces_failed_restart_as_error` covers it. |
| W2 | `openclaw/manifest.yaml` (all entries) | All openclaw platform entries omit `sha256:`, so `claw_sha256` is always empty and `checksum: omit` always fires despite the B1 variable rename. | Out-of-scope. Deliberate trade-off: the openclaw installer URL `https://openclaw.ai/install-cli.sh` is unpinned upstream and the digest rotates without manifest bumps; pinning here would break every fresh install on the next upstream rebuild. Requires an upstream contract change (pinned per-version URL) before manifest-side pinning becomes safe. |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Pre-initialize `changed: list[str] = []` before the drift try block (decouples correctness from the implicit `emit_error` NoReturn contract). | Fixed in `e04becd`. |
| S2 | Emit `gateway_token_minted` (distinct event) when `old_clean` is empty, so first-mint can be distinguished from rotation without relaxing the suppress-on-same-token guard. | Out-of-scope — event vocabulary refactor that spans every lifecycle code path; broader than the upgrade verb. |

</details>

## Testing

### Test Results
- [x] All existing tests pass (`uv run pytest` → 3791 passed, 8 skipped).
- [x] Python linter passes (`uv run ruff check src tests` → clean).
- [x] New vitest tests pass (`npm test` → 254 passed across 25 files).
- [x] GUI ESLint passes (`npm run lint` → clean).
- [x] New tests added per plan §"Test strategy" + ATX iteration coverage:
  - `tests/cli/test_agent_upgrade.py` — 12 cases (no-op, drift reject, downgrade reject, openclaw + hermes happy paths, JSON output, --skip-drift-check, zeroclaw no-op, **B3 failed-status retry**, **B2 zeroclaw restart_agent invoked**, openclaw NOT calling restart_agent, **iter-2 failed-restart surfaces error**).
  - `tests/core/test_registry_latest_supported.py` — per-host filter + None-on-unmatched (7 cases).
  - `tests/test_gui_agent_detail_latest_version.py` — field surfaced + None for unmatched host (2 cases).
  - `gui/src/components/agent-detail/overview-tab.test.tsx` — 4 cases for the badge render gates (incl. **W2 `'?'` sentinel**).

### Manual Testing
None — install-on-real-host verification is tracked as subtasks #598 (openclaw) and #599 (hermes), out-of-scope for this PR.

### Security Checklist
- [x] No hardcoded secrets or credentials.
- [x] Input validation for user-provided data.
- [x] No SQL injection, XSS, or command injection risks introduced.
- [x] Dependencies are from trusted sources (no new deps).

## Callouts

- [DECISION] **Subtasks #598 and #599 are intentionally out-of-scope for this PR.** Post-merge manual install-verification on real Ubuntu hosts that cannot be exercised in this worktree.
- [DECISION] `latest_supported_version` is injected at the `/api/fleet/agents/{key}` route rather than `AgentViewModel`. The field is only consumed by agent-detail; adding it to the shared view model would force every other consumer to ferry an unused field.
- [DECISION] **W4 (SSH `WarningPolicy`) and W2 iter-2 (openclaw sha256) are deferred.** Both are pre-existing properties whose fixes require contract changes outside this PR's scope (fingerprint store for W4; pinned per-version installer URL upstream for openclaw W2). Recorded so a follow-up doesn't lose the context.
- [ENVIRONMENT] **ATX review ran via the local `atx review` CLI against the worktree**, not via a GitHub-actions check. No `atx-ci` workflow is wired to this repository — review summaries above are reproduced from the local JSON output (task IDs `336f64e8` and `bdja9zpr7`).
- [TODO-FOLLOWUP] Bearer-rotation coverage on a real zeroclaw upgrade. Cannot be exercised here because zeroclaw's manifest max is unchanged in this PR; to be filed when zeroclaw next bumps.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
