### PR TITLE
fix(provider): single source of truth for provider state

### DIFF
--- a/.claude/skills/itx-release/SKILL.md
+++ b/.claude/skills/itx-release/SKILL.md
@@ -26,6 +26,8 @@ Hard-coded list. The skill will edit exactly these and warn if it finds version-
 | `website/docs/installation.md` | `clawrium==<NEW>` and `clm, version <NEW>`. Mirror of `docs/installation.md`; body must stay identical (only the Docusaurus frontmatter and mirror-warning comment at the top differ). |
 | `website/docs/guides/quickstart.md` | `clawrium==<NEW>` |
 | `website/docs/scenarios/101.md` | `clm <NEW>` |
+| `CHANGELOG.md` (root) | Archive the current contents to `docs/releases/<NEW>/CHANGELOG.md`, then reset this file to the empty `[Unreleased]` template. See Phase 1 step 6a. |
+| `docs/releases/<NEW>/CHANGELOG.md` | New per-release archive folder created from the root changelog at cut time. See Phase 1 step 6a. |
 
 Do NOT touch:
 - `docs/agent-support/hermes.md` — that's the hermes upstream agent version, not clawrium.
@@ -70,6 +72,28 @@ Do NOT touch:
 
 6. **Apply edits** to every file in the known set. Use the Edit tool — exact string matches only, no regex sweeps. After each edit, the file's *previous* version string (e.g. `26.5.1`) must no longer appear in that file (verify with grep).
 
+6a. **Archive + reset the changelog**. The root `CHANGELOG.md` is the working
+    log for the just-finished release. Freeze it into a per-version archive,
+    then reset the root to an empty template for the next cycle:
+    ```bash
+    mkdir -p docs/releases/<NEW>
+    cp CHANGELOG.md docs/releases/<NEW>/CHANGELOG.md
+    ```
+    Then edit `docs/releases/<NEW>/CHANGELOG.md`:
+    - Replace the top-of-file "working changelog" preamble with a release-specific
+      header (title `# Release <NEW>`, a note that it is the frozen archive, and a
+      back-link to the root `CHANGELOG.md`).
+    - Rename the `## [Unreleased]` heading to `## [<NEW>]`.
+    - Confirm no `Unreleased` references remain: `grep -ni unreleased docs/releases/<NEW>/CHANGELOG.md`.
+
+    Then reset the root `CHANGELOG.md` to the empty template — keep the
+    `# Changelog` preamble and the `docs/releases/` archive note, drop all
+    shipped entries, and leave a bare `## [Unreleased]` with empty
+    `### BREAKING` / `### Added` / `### Changed` / `### Fixed` /
+    `### Documentation` subsections. Use the existing archived release as the
+    structural reference (see `docs/releases/26.6.0/CHANGELOG.md`, the first
+    one created under this convention).
+
 7. **Stale-mention scan** (warn, don't auto-fix):
    ```bash
    git grep -nE 'clawrium[^a-z]+(==|version )[0-9]+\.[0-9]+\.[0-9]+' \
@@ -80,7 +104,7 @@ Do NOT touch:
 
 8. **Diff-scope guard** (this is the safety net for the "no ATX on release PRs" carve-out — release PRs skip automated review, so the skill must hard-fail if non-mechanical files crept in):
    ```bash
-   KNOWN_SET='^(pyproject\.toml|uv\.lock|AGENTS\.md|docs/installation\.md|website/docs/installation\.md|website/docs/guides/quickstart\.md|website/docs/scenarios/101\.md|CONTRIBUTING\.md|\.claude/skills/itx-release/SKILL\.md|tests/test_demo_assets\.py)$'
+   KNOWN_SET='^(pyproject\.toml|uv\.lock|AGENTS\.md|CHANGELOG\.md|docs/installation\.md|docs/releases/.*|website/docs/installation\.md|website/docs/guides/quickstart\.md|website/docs/scenarios/101\.md|CONTRIBUTING\.md|\.claude/skills/itx-release/SKILL\.md|tests/test_demo_assets\.py)$'
    UNEXPECTED=$(git diff --name-only main...HEAD | grep -vE "$KNOWN_SET" || true)
    if [ -n "$UNEXPECTED" ]; then
      echo "BLOCKED: release branch touches files outside the known set:"
@@ -98,7 +122,7 @@ Do NOT touch:
 
 10. **Commit + push**:
     ```bash
-    git add pyproject.toml uv.lock AGENTS.md docs/installation.md website/docs/
+    git add pyproject.toml uv.lock AGENTS.md CHANGELOG.md docs/releases/ docs/installation.md website/docs/
     git commit -m "chore(release): bump to v<NEW> + sync doc versions"
     git push -u origin release/v<NEW>
     ```

--- a/.itx/provider-single-source/00_PLAN.md
+++ b/.itx/provider-single-source/00_PLAN.md
@@ -1,0 +1,210 @@
+# Provider Single-Source-of-Truth — Implementation Plan
+
+> No open GitHub issue tracks this bug; slug `provider-single-source`.
+> The BREAKING entry for this change is already written in the root
+> `CHANGELOG.md` under `## [Unreleased]`.
+
+## Overview
+
+Provider state is read inconsistently across the codebase. The render /
+drift / upgrade path (`build_render_inputs`) reads provider attachments
+from exactly **one** place — the tier-1 top-level `providers` list — and
+fails fast when it is empty. The display path (`_first_provider`, used by
+`clawctl agent get` / `describe`) is more tolerant: it falls back through
+**three** tiers (tier-1 `providers` list → tier-2 `config.provider.name`
+→ tier-3 vestigial `config.providers` plural).
+
+This asymmetry is the bug: an agent whose provider lives only in tier-2
+(the common state for agents onboarded via a sync-only flow, e.g. `vand`
+and `doppio` before back-fill) **shows a provider in `agent get` but
+fails render/drift/upgrade** with a false-positive
+`AgentConfigError: agent '<name>' has no provider attached`.
+
+The fix: make tier-1 (`providers` list) the **single source of truth** for
+reading provider state. Collapse `_first_provider` to read tier-1 only and
+return `None` (no fallback) when it is empty or malformed. This makes the
+display path agree with the render path. `build_render_inputs` already
+behaves correctly and needs **no change**.
+
+### Outcome
+
+- Exactly one place provider state is read from: tier-1 `providers` list.
+- `_first_provider` and `build_render_inputs` agree on whether a provider
+  is attached for every agent record.
+- No silent fallback: a record with provider only in tier-2/tier-3 now
+  reads as "no provider" everywhere (consistent), so the operator gets a
+  clear, uniform signal to run `clawctl agent provider attach`.
+- The vestigial tier-3 (`config.providers` plural) handling is removed
+  from the code entirely.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `src/clawrium/cli/clawctl/agent/_shared.py` | Collapse `_first_provider` (lines 111-178) to tier-1 only; delete tier-2 (155-160) and tier-3 (162-177) blocks; rewrite docstring. |
+| `tests/cli/clawctl/agent/test_get_describe.py` | Remove/invert the tier-2 and tier-3 fallback cases; add explicit "tier-2-only record reads as None" regression test. |
+
+## Files to Create
+
+None.
+
+## Steps
+
+1. **Collapse `_first_provider` to tier-1 only** in
+   `src/clawrium/cli/clawctl/agent/_shared.py:111-178`. New body keeps the
+   `_accept` helper (PROVIDER_NAME_PATTERN validation) and the tier-1 read,
+   then returns `None`:
+
+   ```python
+   def _first_provider(claw_record: dict) -> Optional[str]:
+       """Surface the attached provider name for the describe/get row.
+
+       Provider state is read from a SINGLE source of truth: the tier-1
+       top-level ``claw_record["providers"]`` attach list (Pattern A;
+       #426/#509). This is the same list `build_render_inputs` reads, so
+       the display path and the render/drift/upgrade path always agree.
+
+       There is NO fallback to `config.provider` (the materialized render
+       payload) or to the vestigial `config.providers` plural key. A record
+       with no tier-1 attachment reads as "no provider" everywhere; the
+       operator recovers with `clawctl agent provider attach`.
+
+       Accepts both `["name"]` (string entries) and `[{"name": "..."}]`
+       (dict entries) shapes. String entries are validated against
+       PROVIDER_NAME_PATTERN; mismatches return None.
+       """
+       from clawrium.core.providers.storage import PROVIDER_NAME_PATTERN
+
+       def _accept(value: object) -> Optional[str]:
+           if isinstance(value, str) and value and PROVIDER_NAME_PATTERN.match(value):
+               return value
+           return None
+
+       attached = claw_record.get("providers")
+       if isinstance(attached, list) and attached:
+           first = attached[0]
+           accepted = _accept(first)
+           if accepted:
+               return accepted
+           if isinstance(first, dict):
+               return _accept(first.get("name"))
+       return None
+   ```
+
+   This deletes the tier-2 block (old lines 155-160) and the tier-3
+   vestigial-plural block (old lines 162-177).
+
+2. **Leave `build_render_inputs` (`src/clawrium/core/render.py:243-250`)
+   unchanged.** It already reads tier-1 only and raises `AgentConfigError`
+   when empty — this is exactly the single-source / fail-fast behavior we
+   want. The fix is to bring the *display* reader in line with it, not the
+   other way around.
+
+3. **Do NOT remove the tier-2/tier-3 writes in `lifecycle.py`.** See
+   Risk R1: `config["provider"]` (and hermes `config["providers"]`) at
+   `lifecycle.py:1480` / `:1496` are the **render payload** consumed by
+   `configure_agent` / the Ansible templates — not an independent read
+   source. They are *derived from* tier-1 (`_build_overlay` reads the
+   tier-1 attachments). Removing them would break remote rendering. The
+   USER decision "stop writing tier-2" is satisfied by stopping the use of
+   tier-2 as a **READ source** (step 1); the writes that remain are render
+   inputs, not a competing source of truth.
+
+4. **Sweep for other tier-2/tier-3 *readers*.** `grep -rn
+   "config\\[.provider" "config.get(.provider" "config\\[.providers"` in
+   `src/` (excluding the lifecycle render-payload writes). Confirm no other
+   code reads provider identity from `config.provider`/`config.providers`.
+   Known tier-1 readers (`provider.py:63/79`, `lifecycle.py` overlay
+   builder, `configure.py:100` writer) are already correct.
+
+5. **Rewrite the tests** (see Test Strategy), then run `make lint` and
+   `make test`.
+
+## Test Strategy
+
+### Unit (`tests/cli/clawctl/agent/test_get_describe.py`)
+
+| Existing test | Action |
+|---|---|
+| `test_first_provider_prefers_attach_list_string` | KEEP (tier-1 string entry resolves; stale tier-2 ignored — now ignored by design). |
+| `test_first_provider_prefers_attach_list_dict_entry` | KEEP (tier-1 dict entry resolves). |
+| `..._falls_back_to_materialized_config_provider` | INVERT → rename to `..._ignores_materialized_config_provider`; assert returns `None` when provider lives only in tier-2. |
+| `..._skips_empty_attach_list_then_uses_materialization` | INVERT → empty tier-1 + populated tier-2 now returns `None`. |
+| `..._returns_none_when_nothing_present` | KEEP. |
+| `..._vestigial_plural_path_still_resolves` | INVERT → rename to `..._ignores_vestigial_plural_path`; assert `None`. |
+| `..._dict_entry_without_name_falls_through_to_materialization` | REWRITE → tier-1 dict entry without `name` now returns `None` (no tier-2 fallback). |
+| `..._empty_string_attach_entry_falls_through` | REWRITE → empty/invalid tier-1 string entry returns `None`. |
+| `..._never_synced_agent_shape` | KEEP (already expects `None`). |
+
+Add one new regression test:
+`test_first_provider_tier2_only_record_reads_as_none` — builds a record
+shaped exactly like `vand`/`doppio` before back-fill (`providers` absent,
+`config.provider = {"name": "esper-bedrock", ...}`) and asserts
+`_first_provider(...) is None`, documenting the display/render agreement.
+
+### End-to-end manual (against host `clawdmin`, 192.168.20.44)
+
+Run all clawctl via `uv run clawctl ...`.
+
+1. `uv run clawctl agent get` — confirm `doppio` (tier-1 back-filled)
+   still shows its provider; STATUS unaffected.
+2. `uv run clawctl agent sync doppio --diff` — confirm the render path
+   still resolves the provider (drift diff renders, no `AgentConfigError`).
+3. Construct/inspect a tier-2-only record (or temporarily clear `vand`'s
+   tier-1 in a scratch copy of hosts.json) and confirm `agent get` now
+   shows **no provider** for it — i.e. display and render agree that it
+   needs an attach. Restore afterward.
+4. Re-attach if needed: `uv run clawctl agent provider attach
+   esper-bedrock --agent vand` and confirm both paths see it again.
+
+## Risks
+
+- **R1 — "stop writing tier-2" could be misread as deleting the render
+  payload.** `config["provider"]`/`config["providers"]` at
+  `lifecycle.py:1480/1496` are the Ansible render inputs, derived from
+  tier-1; they are not a competing read source. DECISION: do not touch the
+  writes; only remove tier-2/tier-3 as **read** sources (the actual bug).
+  This fully satisfies the single-source-of-truth requirement because the
+  only thing reading provider *identity* after this change is tier-1.
+
+- **R2 — back-compat for legacy records with provider only in tier-2.**
+  After this change they read as "no provider" in `agent get` (previously
+  shown via fallback). This is intentional (hard cutover, no migration —
+  USER decision). Recovery is a single `clawctl agent provider attach`.
+  Documented as BREAKING in `CHANGELOG.md [Unreleased]`. The render path
+  already failed for these records, so `get`/render now simply agree.
+
+- **R3 — handwritten/third-party records using `config.providers`
+  plural.** These lose their last reader. Acceptable: the key was
+  explicitly vestigial; the BREAKING note instructs operators to attach.
+
+## Subtasks
+
+1. Collapse `_first_provider` to tier-1 only (`_shared.py`).
+2. Grep-sweep `src/` for other tier-2/tier-3 provider readers; remove any.
+3. Rewrite/invert the `_first_provider` unit tests + add the tier-2-only
+   regression test.
+4. `make lint && make test`.
+5. E2E re-validation against `clawdmin` (doppio render/drift path).
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: plan
+**Skill**: (none — direct request)
+**Timestamp**: 2026-06-02T16:04:41Z
+**Model**: claude-opus-4-8
+
+```prompt
+whats the fix for th eoriginal issue now
+...
+create a plan and outcomes and testing strategy first. put in a plan file acording to exising format
+```
+
+**Output**: `.itx/provider-single-source/00_PLAN.md` — implementation plan
+to collapse `_first_provider` to a single tier-1 source of truth (no
+fallback), aligning the display reader with the render reader, with a
+test rewrite matrix and an E2E re-validation strategy against the
+`clawdmin` host.
+
+</details>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,43 @@ Host preparation instructions live in [`docs/host-preparation.md`](docs/host-pre
 
 The website docs MUST follow `docs/host-preparation.md` exactly. Do not edit `website/docs/guides/host-setup.md` directly.
 
+## Changelog & Release Notes
+
+Clawrium tracks every change across every release. There are two layers:
+
+- **Root [`CHANGELOG.md`](CHANGELOG.md)** — the working log for the
+  **current, unreleased version only**. All new work is documented here as
+  it lands, under the `## [Unreleased]` heading.
+- **[`docs/releases/<version>/`](docs/releases/)** — one folder per shipped
+  release, each containing a frozen `CHANGELOG.md`. On every release cut the
+  `itx:release` skill archives the root changelog into a new
+  `docs/releases/<version>/CHANGELOG.md` and then resets the root file to an
+  empty `[Unreleased]` template. The per-version folder may also hold
+  detailed migration instructions for that release.
+
+`docs/releases/` is therefore the single place to read the full history of
+what changed in any release. Do not delete entries from it.
+
+### Update Rules
+
+Update the root `CHANGELOG.md` (under `## [Unreleased]`) as part of the same
+change that introduces the behavior — not as an afterthought:
+
+- **Every new feature** gets an entry under `### Added` with a short, plain
+  description of what it does (one or two lines, user-facing language).
+- **Every behavior change** goes under `### Changed`; **every notable bug
+  fix** goes under `### Fixed`, referencing the issue/PR number where one
+  exists (e.g. `#555`).
+- **Every breaking change** MUST be documented under `### BREAKING`. State
+  what breaks, why, and exactly what operators must do to recover (commands,
+  config edits). If there is no automated migration, say so explicitly and
+  give the manual steps. Breaking changes are non-negotiable to document —
+  an undocumented breaking change is a release blocker.
+- Documentation-only changes go under `### Documentation`.
+
+The `itx:release` skill handles archiving and resetting the changelog at cut
+time; contributors only ever edit the root file's `[Unreleased]` section.
+
 ## Hermes Skills
 
 When a Hermes agent (e.g. Maurice) is asked to work on this repository, it MUST load skills from `.hermes/skills/` and treat them as available alongside its built-in skills. Each skill follows the upstream Hermes skill format documented at https://hermes-agent.nousresearch.com/docs/developer-guide/creating-skills.
@@ -98,6 +135,7 @@ Currently available:
 - Repository: https://github.com/ric03uec/clawrium
 - Project Board: https://github.com/users/ric03uec/projects/1
 - Version: 26.6.0
+- Changelog: [`CHANGELOG.md`](CHANGELOG.md) (current unreleased) · [`docs/releases/`](docs/releases/) (per-release archive)
 
 ## Gateway Token Lifecycle (zeroclaw)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,152 +4,36 @@ All notable changes to Clawrium are documented in this file. Versions
 follow [SemVer](https://semver.org/), and the project tracks a calendar
 versioning convention: `YY.M.PATCH`.
 
-The breaking changes for the next release land under the **Unreleased**
-heading; on cut they become the new version's section.
+This file is the **working changelog for the current, unreleased version
+only**. Everything that has already shipped is archived per release under
+[`docs/releases/<version>/CHANGELOG.md`](docs/releases/). On each release
+cut, the contents below are moved into a new `docs/releases/<version>/`
+folder and this file is reset to the empty template you see here.
+
+See [docs/releases/](docs/releases/) for the changelog of every past
+release.
 
 ## [Unreleased]
 
 ### BREAKING
 
-This release renames the CLI binary and reshapes the entire command
-surface to follow kubectl-style verb grammar. There is **no `clm` alias**
-and **no deprecation period** — the move is a hard cutover, and existing
-installs require a `clawctl agent sync` pass to pick up the new template
-filenames.
-
-See the full BEFORE → AFTER table in
-[`.itx/435/00_PLAN.md` §5](.itx/435/00_PLAN.md) for every command remap.
-Highlights:
-
-- **Binary renamed `clm` → `clawctl`.** Both `uv tool install clawrium`
-  and `uvx --from clawrium clawctl --help` now expose the binary as
-  `clawctl`. The old `clm` script is no longer published.
-- **Verb grammar standardized.** Every top-level group exposes the same
-  kubectl-like verbs: `get` / `describe` / `create` / `delete` /
-  `edit`. Action verbs (`start`, `stop`, `restart`, `sync`, `configure`,
-  `logs`, `open`, `chat`, `attach`, `detach`) live where they map to
-  real lifecycle operations.
-- **`channel` extracted from `agent configure`.** Discord and Slack are
-  now first-class attachables managed under
-  `clawctl channel registry create` / `clawctl agent channel attach`
-  instead of being prompted-for inside the interactive `agent configure`
-  flow. Configure is now fully non-interactive.
-- **Templates carry their agent-type prefix.** The four templates below
-  were renamed; existing installs carry stale dropin files until the
-  next `clawctl agent sync` is run.
-  - `zeroclaw/clm-env.conf.j2` → `zeroclaw/zeroclaw-env.conf.j2`
-  - `zeroclaw/config.toml.j2` → `zeroclaw/zeroclaw-config.toml.j2`
-  - `hermes/config.yaml.j2` → `hermes/hermes-config.yaml.j2`
-  - `hermes/.env.j2` → `hermes/hermes.env.j2`
-  - Systemd drop-in destination renamed:
-    `/etc/systemd/system/zeroclaw-<n>.service.d/10-clm-env.conf` →
-    `/etc/systemd/system/zeroclaw-<n>.service.d/10-zeroclaw-env.conf`.
-- **`sync` semantics redefined.** `clawctl agent sync <name>` is now a
-  drift-to-zero flush — it re-renders configuration, restarts the
-  daemon if files changed, and waits for the agent to converge. The
-  default timeout is **2 minutes**; override with `--timeout <seconds>`.
-- **No migration tooling.** A clean reinstall is the expected upgrade
-  path. Existing hosts can be brought up with
-  `clawctl agent sync <name>` per agent — this also rotates the gateway
-  bearer (issue #437), so remote `clawctl agent chat` sessions will see
-  a clean 401 and must reconnect.
+- **Provider state has a single source of truth.** An agent's provider is
+  now read from exactly one place — the top-level `providers` list on the
+  agent record (tier-1, written by `clawctl agent provider attach` and
+  `clawctl agent configure`). The vestigial `config.providers` field
+  (tier-3) has been removed from the code, and there is **no fallback** to
+  the materialized `config.provider` block (tier-2). If no provider is
+  attached, the render path fails fast with `AgentConfigError` instead of
+  silently resolving from another tier.
+  - **No migration.** This is a hard cutover. Legacy records whose provider
+    lives only in `config.provider` must be repaired by running
+    `clawctl agent provider attach <provider> --agent <name>`, which
+    populates the canonical top-level `providers` list.
 
 ### Added
 
-- Top-level `channel` noun with `clawctl channel registry {create, get,
-  describe, edit, delete}` for Discord and Slack.
-- `clawctl service` group: `init`, `snapshot` (stub), `start` / `stop`
-  (stubs reserved for #N).
-- `clawctl completion <bash|zsh|fish>` emits shell completion scripts.
-- Output format contract: `-o table | json | yaml | wide | name` on
-  every `get`, plus `--no-headers` and `-l KEY=VALUE` label selectors.
-- Guard test `tests/platform/test_template_naming.py` prevents future
-  templates from regressing the `clm-` prefix.
-
 ### Changed
-
-- All `get` verbs render kubectl-style padded columns with `NAME` /
-  `TYPE` / `STATUS` / `AGE` etc. AGE is humanized (e.g. `2m`, `4h`,
-  `9d`). Status vocabulary aligned: `Running` / `Stopped` / `Failed` /
-  `Pending`.
-- Action streaming output is line-oriented and can emit NDJSON via
-  `-o json` for scripting.
-
-### Documentation
-
-- `README.md`, `AGENTS.md`, `docs/installation.md`, and the website
-  mirror at `website/docs/installation.md` reflect the new binary.
-- Every `clm`-rooted snippet under `docs/` and `website/docs/` has been
-  remapped per §5. The introducing-Clawrium blog post is preserved
-  verbatim for historical accuracy.
-- New blog post:
-  [`website/blog/2026-05-24-clawctl-kubectl-ux.md`](website/blog/2026-05-24-clawctl-kubectl-ux.md).
 
 ### Fixed
 
-- **#555 — silent on-host config wipe on every `clawctl agent
-  sync|configure|restart|skill attach|channel attach|integration
-  attach`.** Templates emitted provider, channel, and integration
-  blocks conditionally on `hosts.json.agents.<n>.config.*` being
-  populated; when those fields were null (the common state after the
-  attachment-list refactor), every sync silently dropped the
-  `OPENROUTER_API_KEY`, `DISCORD_*`, `SLACK_*`, and integration env
-  vars from `~/.hermes/.env` and `[channels.discord]` /
-  `[providers.models.*]` blocks from `~/.zeroclaw/config.toml` while
-  reporting `drift=0`.
-
-  **Regression window:** from the conditional-emit commit that
-  introduced the `config.channels` / `config.provider` reads through
-  the F1–F6 canonical render pipeline (PR #556, #557, #559) and
-  legacy read-path drop (PR #566, #567, #568 — this release).
-
-  **Affected agents:** anyone whose
-  `hosts.json.agents.<n>.config.provider` or
-  `hosts.json.agents.<n>.config.channels` was ever null (the default
-  state when the agent was last attached using the new
-  `clawctl channel registry create` / `clawctl agent channel attach`
-  flow without a prior legacy-stage write).
-
-  **Recovery:**
-
-  ```bash
-  # 1. Re-derive provider_id / channels[] / integrations[] from
-  #    onboarding + secrets.json + on-host .env grep. Idempotent.
-  clawctl admin migrate-agent <agent-name>
-
-  # 2. Confirm the agent's declared attachments resolve cleanly.
-  clawctl agent doctor <agent-name>
-
-  # 3. Dry-run the sync to see exactly what will land on the host.
-  clawctl agent sync <agent-name> --dry-run --diff
-
-  # 4. Apply.
-  clawctl agent sync <agent-name>
-  ```
-
-  After this release, `clawctl agent sync` reads from clawctl's own
-  stores (`providers.json` + `channels.json` + `integrations.json` +
-  `secrets.json` + `hosts.json.agents.<n>.{provider_id, channels[],
-  integrations[]}`), renders the full canonical bundle deterministically,
-  and refuses to remove a host-side secret without `--force` or an
-  explicit detach. There is no `drift=0` success path that depends on
-  clawctl's own incomplete model — drift is computed against what's
-  actually on the host.
-
-### Migration notes
-
-For each existing agent on each host:
-
-```bash
-# Reload the renamed templates (drift-to-zero flush). This also rotates
-# the gateway bearer for zeroclaw agents.
-clawctl agent sync <agent-name>
-```
-
-Remote `clawctl agent chat` sessions will see a one-time 401 after the
-sync; reconnecting picks up the fresh bearer transparently.
-
-**Anyone who ran `clawctl agent sync|configure|restart` against an
-agent during the regression window:** follow the recovery sequence
-above to re-derive lost attachments and re-render the on-host config
-from the canonical pipeline.
+### Documentation

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ make format     # Auto-format
 
 Issues are the source of truth. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
 
+## Changelog
+
+Changes for the current, unreleased version are tracked in [CHANGELOG.md](CHANGELOG.md). Every shipped release is archived under [`docs/releases/<version>/`](docs/releases/), which is the single place to read the full history of what changed in any release.
+
 ## License
 
 Apache 2.0

--- a/docs/releases/26.6.0/CHANGELOG.md
+++ b/docs/releases/26.6.0/CHANGELOG.md
@@ -1,0 +1,155 @@
+# Release 26.6.0
+
+Archived changelog for the **26.6.0** release. This is the frozen record of
+everything that shipped in this version; the working changelog for the next
+release lives at the repository root in [`CHANGELOG.md`](../../../CHANGELOG.md).
+
+Versions follow [SemVer](https://semver.org/), and the project tracks a
+calendar versioning convention: `YY.M.PATCH`.
+
+## [26.6.0]
+
+### BREAKING
+
+This release renames the CLI binary and reshapes the entire command
+surface to follow kubectl-style verb grammar. There is **no `clm` alias**
+and **no deprecation period** — the move is a hard cutover, and existing
+installs require a `clawctl agent sync` pass to pick up the new template
+filenames.
+
+See the full BEFORE → AFTER table in
+[`.itx/435/00_PLAN.md` §5](.itx/435/00_PLAN.md) for every command remap.
+Highlights:
+
+- **Binary renamed `clm` → `clawctl`.** Both `uv tool install clawrium`
+  and `uvx --from clawrium clawctl --help` now expose the binary as
+  `clawctl`. The old `clm` script is no longer published.
+- **Verb grammar standardized.** Every top-level group exposes the same
+  kubectl-like verbs: `get` / `describe` / `create` / `delete` /
+  `edit`. Action verbs (`start`, `stop`, `restart`, `sync`, `configure`,
+  `logs`, `open`, `chat`, `attach`, `detach`) live where they map to
+  real lifecycle operations.
+- **`channel` extracted from `agent configure`.** Discord and Slack are
+  now first-class attachables managed under
+  `clawctl channel registry create` / `clawctl agent channel attach`
+  instead of being prompted-for inside the interactive `agent configure`
+  flow. Configure is now fully non-interactive.
+- **Templates carry their agent-type prefix.** The four templates below
+  were renamed; existing installs carry stale dropin files until the
+  next `clawctl agent sync` is run.
+  - `zeroclaw/clm-env.conf.j2` → `zeroclaw/zeroclaw-env.conf.j2`
+  - `zeroclaw/config.toml.j2` → `zeroclaw/zeroclaw-config.toml.j2`
+  - `hermes/config.yaml.j2` → `hermes/hermes-config.yaml.j2`
+  - `hermes/.env.j2` → `hermes/hermes.env.j2`
+  - Systemd drop-in destination renamed:
+    `/etc/systemd/system/zeroclaw-<n>.service.d/10-clm-env.conf` →
+    `/etc/systemd/system/zeroclaw-<n>.service.d/10-zeroclaw-env.conf`.
+- **`sync` semantics redefined.** `clawctl agent sync <name>` is now a
+  drift-to-zero flush — it re-renders configuration, restarts the
+  daemon if files changed, and waits for the agent to converge. The
+  default timeout is **2 minutes**; override with `--timeout <seconds>`.
+- **No migration tooling.** A clean reinstall is the expected upgrade
+  path. Existing hosts can be brought up with
+  `clawctl agent sync <name>` per agent — this also rotates the gateway
+  bearer (issue #437), so remote `clawctl agent chat` sessions will see
+  a clean 401 and must reconnect.
+
+### Added
+
+- Top-level `channel` noun with `clawctl channel registry {create, get,
+  describe, edit, delete}` for Discord and Slack.
+- `clawctl service` group: `init`, `snapshot` (stub), `start` / `stop`
+  (stubs reserved for #N).
+- `clawctl completion <bash|zsh|fish>` emits shell completion scripts.
+- Output format contract: `-o table | json | yaml | wide | name` on
+  every `get`, plus `--no-headers` and `-l KEY=VALUE` label selectors.
+- Guard test `tests/platform/test_template_naming.py` prevents future
+  templates from regressing the `clm-` prefix.
+
+### Changed
+
+- All `get` verbs render kubectl-style padded columns with `NAME` /
+  `TYPE` / `STATUS` / `AGE` etc. AGE is humanized (e.g. `2m`, `4h`,
+  `9d`). Status vocabulary aligned: `Running` / `Stopped` / `Failed` /
+  `Pending`.
+- Action streaming output is line-oriented and can emit NDJSON via
+  `-o json` for scripting.
+
+### Documentation
+
+- `README.md`, `AGENTS.md`, `docs/installation.md`, and the website
+  mirror at `website/docs/installation.md` reflect the new binary.
+- Every `clm`-rooted snippet under `docs/` and `website/docs/` has been
+  remapped per §5. The introducing-Clawrium blog post is preserved
+  verbatim for historical accuracy.
+- New blog post:
+  [`website/blog/2026-05-24-clawctl-kubectl-ux.md`](website/blog/2026-05-24-clawctl-kubectl-ux.md).
+
+### Fixed
+
+- **#555 — silent on-host config wipe on every `clawctl agent
+  sync|configure|restart|skill attach|channel attach|integration
+  attach`.** Templates emitted provider, channel, and integration
+  blocks conditionally on `hosts.json.agents.<n>.config.*` being
+  populated; when those fields were null (the common state after the
+  attachment-list refactor), every sync silently dropped the
+  `OPENROUTER_API_KEY`, `DISCORD_*`, `SLACK_*`, and integration env
+  vars from `~/.hermes/.env` and `[channels.discord]` /
+  `[providers.models.*]` blocks from `~/.zeroclaw/config.toml` while
+  reporting `drift=0`.
+
+  **Regression window:** from the conditional-emit commit that
+  introduced the `config.channels` / `config.provider` reads through
+  the F1–F6 canonical render pipeline (PR #556, #557, #559) and
+  legacy read-path drop (PR #566, #567, #568 — this release).
+
+  **Affected agents:** anyone whose
+  `hosts.json.agents.<n>.config.provider` or
+  `hosts.json.agents.<n>.config.channels` was ever null (the default
+  state when the agent was last attached using the new
+  `clawctl channel registry create` / `clawctl agent channel attach`
+  flow without a prior legacy-stage write).
+
+  **Recovery:**
+
+  ```bash
+  # 1. Re-derive provider_id / channels[] / integrations[] from
+  #    onboarding + secrets.json + on-host .env grep. Idempotent.
+  clawctl admin migrate-agent <agent-name>
+
+  # 2. Confirm the agent's declared attachments resolve cleanly.
+  clawctl agent doctor <agent-name>
+
+  # 3. Dry-run the sync to see exactly what will land on the host.
+  clawctl agent sync <agent-name> --dry-run --diff
+
+  # 4. Apply.
+  clawctl agent sync <agent-name>
+  ```
+
+  After this release, `clawctl agent sync` reads from clawctl's own
+  stores (`providers.json` + `channels.json` + `integrations.json` +
+  `secrets.json` + `hosts.json.agents.<n>.{provider_id, channels[],
+  integrations[]}`), renders the full canonical bundle deterministically,
+  and refuses to remove a host-side secret without `--force` or an
+  explicit detach. There is no `drift=0` success path that depends on
+  clawctl's own incomplete model — drift is computed against what's
+  actually on the host.
+
+### Migration notes
+
+For each existing agent on each host:
+
+```bash
+# Reload the renamed templates (drift-to-zero flush). This also rotates
+# the gateway bearer for zeroclaw agents.
+clawctl agent sync <agent-name>
+```
+
+Remote `clawctl agent chat` sessions will see a one-time 401 after the
+sync; reconnecting picks up the fresh bearer transparently.
+
+**Anyone who ran `clawctl agent sync|configure|restart` against an
+agent during the regression window:** follow the recovery sequence
+above to re-derive lost attachments and re-render the on-host config
+from the canonical pipeline.

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -731,11 +731,15 @@ def _sync_channel_config(
     # Merge channels into existing config
     existing_config = agent.get("config", {})
 
-    # Guard against overwriting provider config if not present (B4)
-    # If provider stage was completed, config should have provider key
-    if not existing_config.get("provider"):
+    # Guard against configuring channels before a provider is attached (B4).
+    # Tier-1 `providers` (the attachment list) is the single source of truth for
+    # whether a provider is attached — the same list build_render_inputs and
+    # _first_provider read. Do not fall back to the tier-2 `config.provider`
+    # render payload here (it materializes only after a successful sync).
+    if not (agent.get("providers") or []):
         raise RuntimeError(
-            "Provider not configured. Run 'clm agent configure <agent> --stage providers' first."
+            f"Provider not configured. Run "
+            f"'clawctl agent provider attach <provider> --agent {agent_name}' first."
         )
 
     existing_config["channels"] = channels_config

--- a/src/clawrium/cli/clawctl/agent/_shared.py
+++ b/src/clawrium/cli/clawctl/agent/_shared.py
@@ -109,29 +109,26 @@ def agent_to_row(
 
 
 def _first_provider(claw_record: dict) -> Optional[str]:
-    """Surface the first attached provider name for the describe/get row.
+    """Surface the attached provider name for the describe/get row.
 
-    Read order (falsy/malformed at any tier falls through to the next):
-    1. `claw_record["providers"]` — the new attach list (Pattern A; #426/#509).
-       Single-provider invariant is enforced at attach time, so index 0 is
-       the canonical name. Accepts both `["name"]` (string entries) and
-       `[{"name": "..."}]` (dict entries) shapes.
-    2. `claw_record["config"]["provider"]["name"]` — the materialization
-       layer written by `sync_agent` (lifecycle.py:945-992) on every
-       successful sync/configure with a provider attached. Absent on
-       fresh `clawctl agent create` records (config={}) and on agents
-       whose last configure call failed.
-    3. `claw_record["config"]["providers"]` — vestigial plural-key path
-       kept for any handwritten or third-party record that uses it.
-       Accepts dict (`{name: {...}}`) and list (`[name, ...]` /
-       `[{"name": "..."}, ...]`) shapes. Terminal tier — anything
-       malformed here returns None (no further fallback).
+    Single source of truth: `claw_record["providers"]` — the attach list
+    (Pattern A; #426/#509). The single-provider invariant is enforced at
+    attach time, so index 0 is the canonical name. Accepts both
+    `["name"]` (string entries) and `[{"name": "..."}]` (dict entries)
+    shapes.
 
-    String entries are validated against `PROVIDER_NAME_PATTERN` (the
-    same pattern enforced at write time by `validate_provider_name`).
-    Mismatches fall through rather than render — this closes the
-    write-time/read-time validation asymmetry against handwritten
-    records that contain markup or other non-conforming characters.
+    There is intentionally NO fallback to `config["provider"]` (the
+    materialized render payload written by sync) or to the vestigial
+    `config["providers"]` plural key. Provider state is read from exactly
+    one place; if nothing is attached this returns None, matching
+    `build_render_inputs` (render.py), which raises when the same tier-1
+    list is empty. This alignment closes the historical asymmetry where an
+    agent with a provider only in `config.provider` rendered in `agent get`
+    but failed the render/drift/upgrade path.
+
+    String entries are validated against `PROVIDER_NAME_PATTERN` (the same
+    pattern enforced at write time by `validate_provider_name`); a
+    non-conforming entry returns None rather than rendering markup.
     """
     from clawrium.core.providers.storage import PROVIDER_NAME_PATTERN
 
@@ -148,31 +145,6 @@ def _first_provider(claw_record: dict) -> Optional[str]:
         if accepted:
             return accepted
         if isinstance(first, dict):
-            accepted = _accept(first.get("name"))
-            if accepted:
-                return accepted
+            return _accept(first.get("name"))
 
-    config = claw_record.get("config", {}) or {}
-    materialized = config.get("provider")
-    if isinstance(materialized, dict):
-        accepted = _accept(materialized.get("name"))
-        if accepted:
-            return accepted
-
-    providers = config.get("providers") or {}
-    if isinstance(providers, dict) and providers:
-        # Dict key path: validate the key the same way as other tiers
-        # so e.g. `{"[bold]x[/]": {...}}` doesn't render markup.
-        accepted = _accept(next(iter(providers.keys())))
-        if accepted:
-            return accepted
-    elif isinstance(providers, list) and providers:
-        first = providers[0]
-        accepted = _accept(first)
-        if accepted:
-            return accepted
-        if isinstance(first, dict):
-            accepted = _accept(first.get("name"))
-            if accepted:
-                return accepted
     return None

--- a/src/clawrium/cli/tui/data.py
+++ b/src/clawrium/cli/tui/data.py
@@ -20,6 +20,29 @@ logger = logging.getLogger(__name__)
 
 AGENT_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
 
+# Provider names share the agent-key grammar (lowercase, digits, _-).
+_PROVIDER_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+
+
+def _resolve_provider_name(claw_record: dict) -> str | None:
+    """Resolve the attached provider name from tier-1 only.
+
+    The top-level ``providers`` attachment list is the single source of truth
+    for which provider is attached — the same list ``build_render_inputs`` and
+    ``_first_provider`` read. The tier-2 ``config.provider`` render payload is
+    intentionally NOT consulted here; it is read separately for display-only
+    enrichment (default_model / type) that tier-1 does not carry.
+    """
+    attached = claw_record.get("providers")
+    if not isinstance(attached, list) or not attached:
+        return None
+    first = attached[0]
+    if isinstance(first, dict):
+        first = first.get("name")
+    if isinstance(first, str) and first and _PROVIDER_NAME_PATTERN.match(first):
+        return first
+    return None
+
 
 class AgentViewModel(TypedDict):
     agent_key: str
@@ -150,8 +173,14 @@ def get_fleet_data_local(
                 provider_cfg = config.get("provider")
                 if isinstance(provider_cfg, dict):
                     model = provider_cfg.get("default_model", "-")
-                    provider_name = provider_cfg.get("name") or provider_cfg.get("type")
                     provider_type = provider_cfg.get("type")
+                # Tier-1 attachment list is canonical for the provider name;
+                # fall back to the tier-2 render payload only for display.
+                provider_name = _resolve_provider_name(claw_record)
+                if provider_name is None and isinstance(provider_cfg, dict):
+                    provider_name = provider_cfg.get("name") or provider_cfg.get(
+                        "type"
+                    )
                 gateway_cfg = config.get("gateway")
                 if isinstance(gateway_cfg, dict):
                     port_val = gateway_cfg.get("port")
@@ -276,8 +305,14 @@ def get_fleet_data(
                 provider_cfg = config.get("provider")
                 if isinstance(provider_cfg, dict):
                     model = provider_cfg.get("default_model", "-")
-                    provider_name = provider_cfg.get("name") or provider_cfg.get("type")
                     provider_type = provider_cfg.get("type")
+                # Tier-1 attachment list is canonical for the provider name;
+                # fall back to the tier-2 render payload only for display.
+                provider_name = _resolve_provider_name(claw_record)
+                if provider_name is None and isinstance(provider_cfg, dict):
+                    provider_name = provider_cfg.get("name") or provider_cfg.get(
+                        "type"
+                    )
                 gateway_cfg = config.get("gateway")
                 if isinstance(gateway_cfg, dict):
                     port_val = gateway_cfg.get("port")
@@ -424,8 +459,12 @@ def get_agent_detail(agent_key: str, host_identifier: str) -> AgentViewModel | N
             provider_cfg = config.get("provider")
             if isinstance(provider_cfg, dict):
                 model = provider_cfg.get("default_model", "-")
-                provider_name = provider_cfg.get("name") or provider_cfg.get("type")
                 provider_type = provider_cfg.get("type")
+            # Tier-1 attachment list is canonical for the provider name;
+            # fall back to the tier-2 render payload only for display.
+            provider_name = _resolve_provider_name(claw_record)
+            if provider_name is None and isinstance(provider_cfg, dict):
+                provider_name = provider_cfg.get("name") or provider_cfg.get("type")
             gateway_cfg = config.get("gateway")
             if isinstance(gateway_cfg, dict):
                 port_val = gateway_cfg.get("port")

--- a/tests/cli/clawctl/agent/test_get_describe.py
+++ b/tests/cli/clawctl/agent/test_get_describe.py
@@ -103,12 +103,16 @@ def test_describe_json(fleet_dir) -> None:
 
 
 # ---------------------------------------------------------------------------
-# _first_provider read-order coverage
+# _first_provider read coverage
 #
-# Resolution order (see _shared.py:_first_provider docstring):
-#   1. claw_record["providers"]                       # attach list (new)
-#   2. claw_record["config"]["provider"]["name"]      # materialization layer
-#   3. claw_record["config"]["providers"]             # vestigial plural
+# Single source of truth: provider state is read from EXACTLY one place —
+# tier-1 `claw_record["providers"]` (the attach list). There is no fallback
+# to the tier-2 `config.provider` materialization or the vestigial tier-3
+# `config.providers` plural. This aligns the display reader with
+# build_render_inputs (render.py), which raises when the same tier-1 list is
+# empty. An agent whose provider lives only in `config.provider` reads as
+# "no provider attached" and must be fixed with `clawctl agent provider
+# attach <provider> --agent <name>`.
 # ---------------------------------------------------------------------------
 
 
@@ -125,21 +129,21 @@ def test_first_provider_prefers_attach_list_dict_entry():
     assert _first_provider(record) == "clawrium-glm51"
 
 
-def test_first_provider_falls_back_to_materialized_config_provider():
-    # Covers every pre-Pattern-A install on disk: config.provider is the
-    # singular dict written by sync_agent / configure_agent. Without this
-    # fallback, `clawctl agent describe` showed `Provider: -` for every
-    # legacy agent.
+def test_first_provider_ignores_materialized_config_provider():
+    # tier-2 `config.provider` is the singular dict written by
+    # sync_agent / configure_agent as the Ansible render payload. It is
+    # NOT a read source: with no tier-1 attach list, _first_provider
+    # returns None regardless of config.provider.
     record = {"config": {"provider": {"name": "clawrium-glm51"}}}
-    assert _first_provider(record) == "clawrium-glm51"
+    assert _first_provider(record) is None
 
 
-def test_first_provider_skips_empty_attach_list_then_uses_materialization():
+def test_first_provider_empty_attach_list_does_not_use_materialization():
     record = {
         "providers": [],
         "config": {"provider": {"name": "clawrium-glm51"}},
     }
-    assert _first_provider(record) == "clawrium-glm51"
+    assert _first_provider(record) is None
 
 
 def test_first_provider_returns_none_when_nothing_present():
@@ -148,31 +152,50 @@ def test_first_provider_returns_none_when_nothing_present():
     assert _first_provider({"config": {"provider": {}}}) is None
 
 
-def test_first_provider_vestigial_plural_path_still_resolves():
+def test_first_provider_ignores_vestigial_plural_path():
+    # tier-3 `config.providers` (plural) was a vestigial reader. It is no
+    # longer consulted; only the tier-1 attach list resolves.
     record = {"config": {"providers": {"legacy-name": {"type": "ollama"}}}}
-    assert _first_provider(record) == "legacy-name"
+    assert _first_provider(record) is None
 
 
-def test_first_provider_dict_entry_without_name_falls_through_to_materialization():
-    # ATX W1: a dict attach-list entry that's missing the `name` key
-    # must NOT short-circuit the function with None. It must fall
-    # through to the config.provider.name materialization tier so a
-    # malformed attach record doesn't silently swallow the real value.
+def test_first_provider_dict_entry_without_name_returns_none():
+    # A dict attach-list entry missing the `name` key has no resolvable
+    # tier-1 provider; with no fallback this reads as None.
     record = {
         "providers": [{"type": "openrouter"}],  # no `name`
         "config": {"provider": {"name": "clawrium-glm51"}},
     }
-    assert _first_provider(record) == "clawrium-glm51"
+    assert _first_provider(record) is None
 
 
-def test_first_provider_empty_string_attach_entry_falls_through():
-    # Defence-in-depth: empty string in attach list should not render
-    # as the provider name; fall through to materialization.
+def test_first_provider_empty_string_attach_entry_returns_none():
+    # An empty string in the attach list is not a valid provider name and
+    # does not fall through to any other tier.
     record = {
         "providers": [""],
         "config": {"provider": {"name": "clawrium-glm51"}},
     }
-    assert _first_provider(record) == "clawrium-glm51"
+    assert _first_provider(record) is None
+
+
+def test_first_provider_tier2_only_record_reads_as_none():
+    # Regression for the provider-tier reader asymmetry bug: a record
+    # shaped like vand/doppio before tier-1 back-fill — no top-level
+    # `providers`, provider only in `config.provider` — must read as
+    # None so the display agrees with the render/drift path that raises
+    # AgentConfigError for the same shape.
+    record = {
+        "config": {
+            "provider": {
+                "name": "esper-bedrock",
+                "type": "bedrock",
+                "endpoint": "",
+                "default_model": "zai.glm-5",
+            }
+        }
+    }
+    assert _first_provider(record) is None
 
 
 def test_first_provider_never_synced_agent_shape():
@@ -298,133 +321,90 @@ def test_describe_provider_line_renders_attach_list_name(fleet_dir) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Tier-3 vestigial-list path safety (W-A iter-2)
+# Tier-3 vestigial path is no longer read (single-source consolidation)
 # ---------------------------------------------------------------------------
 
 
 def test_first_provider_tier3_list_dict_without_name_returns_none():
-    # W-A: tier-3 list-of-dicts with a nameless entry. Used to fall
-    # through `return first.get("name")` returning None; now explicit.
     record = {"config": {"providers": [{"type": "ollama"}]}}
     assert _first_provider(record) is None
 
 
-def test_first_provider_tier3_list_none_entry_does_not_render_None_string():
-    # W-A: `return str(first)` would have produced the literal string
-    # "None" in the PROVIDER column. Must return None instead.
+def test_first_provider_tier3_list_none_entry_returns_none():
     record = {"config": {"providers": [None]}}
     assert _first_provider(record) is None
 
 
-def test_first_provider_tier3_list_int_entry_does_not_coerce():
-    # W-A: integer entry should not render as "42" in the PROVIDER
-    # column.
+def test_first_provider_tier3_list_int_entry_returns_none():
     record = {"config": {"providers": [42]}}
     assert _first_provider(record) is None
 
 
 # ---------------------------------------------------------------------------
-# Type-safety on tier-1 dict `name` value (W-C iter-2)
+# Type-safety on tier-1 dict `name` value
 # ---------------------------------------------------------------------------
 
 
-def test_first_provider_dict_name_value_is_non_string_falls_through():
-    # W-C: a dict attach-list entry whose `name` is itself a dict
-    # would have rendered as a Python repr in the PROVIDER column.
-    # Now falls through to the materialization tier.
+def test_first_provider_dict_name_value_is_non_string_returns_none():
+    # A dict attach-list entry whose `name` is itself a dict is not a
+    # valid provider name; with no fallback this reads as None.
     record = {
         "providers": [{"name": {"nested": "bad"}}],
         "config": {"provider": {"name": "clawrium-glm51"}},
     }
-    assert _first_provider(record) == "clawrium-glm51"
+    assert _first_provider(record) is None
 
 
 # ---------------------------------------------------------------------------
-# Format validation on string entries (W-D iter-2 — defense-in-depth)
+# Format validation on tier-1 string entries (defense-in-depth)
 # ---------------------------------------------------------------------------
 
 
-def test_first_provider_string_attach_with_markup_falls_through():
-    # W-D: a handwritten attach entry containing Rich/markdown markup
-    # (`[bold]x[/]`) does not match PROVIDER_NAME_PATTERN at write
-    # time but historically passed the read-time check. Now read-time
-    # also validates the pattern, falling through to the materialized
-    # value so a malformed attach record cannot inject characters
-    # into the PROVIDER column.
+def test_first_provider_string_attach_with_markup_returns_none():
+    # A tier-1 attach entry containing Rich/markdown markup (`[bold]x[/]`)
+    # does not match PROVIDER_NAME_PATTERN; with no fallback it reads as
+    # None so a malformed attach record cannot inject characters into the
+    # PROVIDER column.
     record = {
         "providers": ["[bold]atk[/]"],
         "config": {"provider": {"name": "clawrium-glm51"}},
     }
-    assert _first_provider(record) == "clawrium-glm51"
+    assert _first_provider(record) is None
 
 
-def test_first_provider_string_attach_with_invalid_chars_falls_through():
-    # W-D: pattern rejects names with `/`, `:`, etc. — falls through.
+def test_first_provider_string_attach_with_invalid_chars_returns_none():
+    # Pattern rejects names with `/`, `:`, etc.
     record = {
         "providers": ["evil/path"],
         "config": {"provider": {"name": "clawrium-glm51"}},
     }
-    assert _first_provider(record) == "clawrium-glm51"
+    assert _first_provider(record) is None
 
 
 # ---------------------------------------------------------------------------
-# Iter-3 cleanups (W-N-3, W-N-4, W-N-5)
+# Tier-1 pattern boundary coverage
 # ---------------------------------------------------------------------------
-
-
-def test_first_provider_tier3_list_dict_without_name_falls_through_to_tier2():
-    # W-N-3 (iter-3): the existing "returns None" test was
-    # non-discriminating (old code returned None for the same input).
-    # This variant proves the dict-without-name in tier-3 list does
-    # not short-circuit before tier-2 would otherwise resolve.
-    record = {
-        "config": {
-            "providers": [{"type": "ollama"}],  # tier-3 dict, no name
-            "provider": {"name": "tier2-fallback-name"},  # tier-2 wins
-        },
-    }
-    # In _first_provider's iteration order, tier-2 is checked BEFORE
-    # tier-3, so this actually exercises tier-2 winning. The point of
-    # this test is that adding a malformed tier-3 entry doesn't break
-    # the tier-2 read — i.e. _first_provider is robust to having
-    # garbage in tiers it doesn't reach.
-    assert _first_provider(record) == "tier2-fallback-name"
-
-
-def test_first_provider_tier3_list_string_happy_path():
-    # W-N-4: tier-3 list with a valid string entry. The post-W-A
-    # rewrite uses `_accept` here; without a happy-path test, a
-    # silent rejection (e.g. if PROVIDER_NAME_PATTERN were tightened)
-    # would go uncaught.
-    record = {"config": {"providers": ["valid-provider"]}}
-    assert _first_provider(record) == "valid-provider"
-
-
-def test_first_provider_tier3_list_dict_with_name_happy_path():
-    # W-N-4: tier-3 list with a valid dict-with-name entry.
-    record = {"config": {"providers": [{"name": "valid-provider"}]}}
-    assert _first_provider(record) == "valid-provider"
 
 
 def test_first_provider_accept_64_char_name_is_valid():
-    # W-N-5: PROVIDER_NAME_PATTERN's `{0,63}` quantifier allows up to
-    # 64 chars total (1 leading letter + 63 trailing). Exercise the
-    # boundary so a future tightening (e.g. `{0,62}`) would be
-    # caught by test failure rather than silent rejection at runtime.
+    # PROVIDER_NAME_PATTERN's `{0,63}` quantifier allows up to 64 chars
+    # total (1 leading letter + 63 trailing). Exercise the boundary so a
+    # future tightening (e.g. `{0,62}`) would be caught by test failure
+    # rather than silent rejection at runtime.
     name_64 = "a" + "x" * 63
     assert len(name_64) == 64
     assert _first_provider({"providers": [name_64]}) == name_64
 
 
-def test_first_provider_accept_65_char_name_falls_through():
-    # W-N-5: one character over the limit must fall through.
+def test_first_provider_accept_65_char_name_returns_none():
+    # One character over the limit must read as None (no fallback).
     name_65 = "a" + "x" * 64
     assert len(name_65) == 65
     record = {
         "providers": [name_65],
         "config": {"provider": {"name": "clawrium-glm51"}},
     }
-    assert _first_provider(record) == "clawrium-glm51"
+    assert _first_provider(record) is None
 
 
 def test_describe_stage_empty_status_string_does_not_use_state_shim(

--- a/tests/test_cli_agent_configure.py
+++ b/tests/test_cli_agent_configure.py
@@ -31,8 +31,14 @@ def create_host_with_claw(
     claw_type: str = "openclaw",
     onboarding_state: str = "pending",
     config: dict | None = None,
+    providers: list | None = None,
 ) -> None:
-    """Create a test host with a claw installed."""
+    """Create a test host with a claw installed.
+
+    ``providers`` populates the tier-1 attachment list (the single source of
+    truth for whether a provider is attached). Pass it when a test exercises a
+    code path gated on provider attachment (e.g. channels configure).
+    """
     hosts_file = config_dir / "hosts.json"
     config_dir.mkdir(parents=True, exist_ok=True)
 
@@ -75,6 +81,10 @@ def create_host_with_claw(
     # Add config if provided
     if config:
         agent_data["config"] = config
+
+    # Tier-1 provider attachment list (single source of truth)
+    if providers is not None:
+        agent_data["providers"] = providers
 
     hosts_data = [
         {
@@ -900,11 +910,14 @@ class TestRunChannelsStageDiscord:
         from clawrium.cli.agent import _sync_channel_config
 
         create_test_keypair(isolated_config, "work")
-        # Create host with configured provider - agent stored under claw_type key
+        # Create host with configured provider - agent stored under claw_type key.
+        # Tier-1 `providers` is the single source of truth the channels-configure
+        # gate checks; a real agent has a provider attached before this stage.
         create_host_with_claw(
             isolated_config,
             onboarding_state="channels",
             config={"provider": {"name": "test-provider", "type": "openai"}},
+            providers=["test-provider"],
         )
 
         captured_calls = []


### PR DESCRIPTION
## Summary

- Collapse `_first_provider` (`clawctl/agent/_shared.py`) to read tier-1 `claw_record["providers"]` only — no fallback to tier-2 `config.provider` or vestigial tier-3 `config.providers`. Display path now agrees with `build_render_inputs` (render.py).
- `_sync_channel_config` guard switched from `config.provider` to the tier-1 attach list; error message points to `clawctl agent provider attach`.
- `tui/data.py` introduces `_resolve_provider_name` (tier-1 canonical, tier-2 display-only fallback).
- Tests inverted in `test_get_describe.py` (tier-2/tier-3 reads now return None) plus new `_tier2_only_record_reads_as_none` regression.
- Root `CHANGELOG.md` reset to working-template format; `26.6.0` archived under `docs/releases/26.6.0/`. `AGENTS.md` and `itx-release` skill document the new changelog/archive workflow.

No open issue tracks this — implementation plan at `.itx/provider-single-source/00_PLAN.md`.

## BREAKING

Legacy records whose provider lives only in `config.provider` (tier-2) now read as "no provider" everywhere. Recovery is a single `clawctl agent provider attach <provider> --agent <name>`. Documented in `CHANGELOG.md [Unreleased] → BREAKING`.

## Testing

- `make lint` — clean (ruff + next lint)
- `make test` — 3793 passed, 2 skipped (Python) + 254 passed (GUI)
- E2E re-validation against `clawdmin` (per plan §Test Strategy) — pending operator step

## ATX Review Summary

**Final Review: Rating 2/5**
**Total Cost: \$3.37 | Total Time: 8m 3s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1, B2 | All Out-of-scope | \$3.37 | 8m 3s | leader, cli-typer, docs-site, security, test-coverage |

> **Note**: Both blocking issues are pre-existing code in `agent.py` unrelated to the provider single-source-of-truth change. The core change (cli-typer-reviewer rating: **4/5**) is clean and production-ready. Composite 2/5 reflects pre-existing technical debt surfaced by the reviewer fleet across the touched files.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Per-specialist ratings:**

| Specialist | Rating | Notes |
|---|---|---|
| cli-typer-reviewer | 4/5 | Core provider change is clean and production-ready |
| docs-site-reviewer | 2/5 | Pre-existing `clm` references in SKILL.md table |
| security-reviewer | 2/5 | `_run_edit_config` `on_event` regression (pre-existing) |
| test-coverage | 2/5 | Configure-path `gateway_token_rotated` coverage gap (pre-existing) |

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `src/clawrium/cli/agent.py:1863` | `_run_edit_config` calls `restart_agent` without `on_event`, swallowing the `gateway_token_rotated` notice (AGENTS.md §437). | Out-of-scope — pre-existing code, not touched by this patch. Tracked as follow-up. |
| B2 | `tests/test_cli_agent_configure.py` (missing) | No tests for `_print_configure_warnings(stage='gateway_token_rotated', ...)` on configure path. | Out-of-scope — pre-existing coverage gap unrelated to provider single-source change. Tracked as follow-up. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `.claude/skills/itx-release/SKILL.md:25-28` | Table still references `clm` command strings — will stamp wrong entrypoint on next release cut. | Acknowledged — release-skill scope, follow-up. |
| W2 | `.claude/skills/itx-release/SKILL.md:6` | Duplicate `name: itx:release` body line renders as visible markdown. | Acknowledged — follow-up. |
| W3 | `src/clawrium/cli/agent.py:1795-1798` | `_resolve_editor` does not `shlex.split` VISUAL/EDITOR — breaks on `vim -R`. | Out-of-scope — pre-existing. |
| W4 | `AGENTS.md:127`, `README.md:47` | Agent-type lists disagree (IronClaw vs nemoclaw, hermes missing from Key Concepts). | Out-of-scope — pre-existing docs drift. |
| W5 | `tests/test_tui/test_tui_data.py` (missing) | Tier-2 display fallback in `tui/data.py::_resolve_provider_name` unpinned by tests. | Acknowledged — follow-up. |
| W6 | `tests/test_cli_agent_configure.py` (missing) | `AmbiguousAgentNameError` configure branch untested. | Out-of-scope — pre-existing. |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | `agent.py:739`: `if not (agent.get("providers") or [])` → `if not agent.get("providers")` (identical semantics). | Deferred — micro-cleanup follow-up. |
| S2 | Error message f-string across two lines — single line for readability. | Deferred. |
| S3 | Inline comment on openclaw fixture explaining why `providers` (tier-1) is intentionally absent. | Deferred. |
| S4 | Strict `dev.output.strip() == ''` assertion in `test_get_selector_filters_via_host_labels`. | Deferred. |
| S5 | `assert_called_once()` → `assert_called_once_with(...)` on `--yes` path. | Deferred. |
| S6 | `old_token_prefix`/`new_token_prefix` in `gateway_token_rotated` event payload exposes 8 chars of bearer. | Out-of-scope — pre-existing payload shape. |
| S7 | 24 remaining `clm` references in `agent.py`; this diff fixes 1. | Out-of-scope — separate cleanup pass. |

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>