### PR TITLE
chore(release): v26.6.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ Currently available:
 
 - Repository: https://github.com/ric03uec/clawrium
 - Project Board: https://github.com/users/ric03uec/projects/1
-- Version: 26.6.0
+- Version: 26.6.1
 - Changelog: [`CHANGELOG.md`](CHANGELOG.md) (current unreleased) · [`docs/releases/`](docs/releases/) (per-release archive)
 
 ## Gateway Token Lifecycle (zeroclaw)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,49 +17,10 @@ release.
 
 ### BREAKING
 
-- **Provider state has a single source of truth.** An agent's provider is
-  now read from exactly one place — the top-level `providers` list on the
-  agent record (tier-1, written by `clawctl agent provider attach` and
-  `clawctl agent configure`). The vestigial `config.providers` field
-  (tier-3) has been removed from the code, and there is **no fallback** to
-  the materialized `config.provider` block (tier-2). If no provider is
-  attached, the render path fails fast with `AgentConfigError` instead of
-  silently resolving from another tier.
-  - **No migration.** This is a hard cutover. Legacy records whose provider
-    lives only in `config.provider` must be repaired by running
-    `clawctl agent provider attach <provider> --agent <name>`, which
-    populates the canonical top-level `providers` list.
-
 ### Added
-
-- Openclaw can now be installed and run on macOS hosts alongside
-  hermes (#604). `clawctl agent create --type openclaw --host <mac>`
-  provisions an agent user via `dscl`, installs the openclaw CLI under
-  `/Users/<agent>/.openclaw`, registers a launchd unit under
-  `/Library/LaunchDaemons/ai.clawrium.openclaw.<agent>.plist`, and runs
-  the gateway pairing handshake the same way the Linux path does.
-  Hermes and openclaw can coexist on the same macOS host with distinct
-  launchd labels (`ai.clawrium.hermes.<agent>` vs
-  `ai.clawrium.openclaw.<agent>`).
 
 ### Changed
 
-- `lifecycle.sync_agent` accepts a new `defer_state_transition`
-  keyword (default `False`) so OS-specific callers can own the
-  `state=READY` write. The macOS path now uses this to commit
-  `state=READY` only after the post-configure `launchctl restart`
-  succeeds — otherwise a failed restart would leave `hosts.json`
-  claiming an agent is ready while the daemon is down (#604).
-
 ### Fixed
-
-- Openclaw pairing now negotiates gateway protocol v3..v4, unblocking
-  fresh installs against the currently-pinned openclaw v2026.5.28
-  (`expectedProtocol=4`) on both Linux and macOS while remaining
-  backward compatible with hosts still running v2026.4.2-era daemons
-  (`expectedProtocol=3`). The pair script also surfaces a clear
-  `supports v3-v4, daemon expected vN` error when a future daemon
-  advertises an unsupported protocol, so the next operator hitting
-  the bump knows exactly what to update (#608).
 
 ### Documentation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,7 +54,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.6.0
+ + clawrium==26.6.1
 ```
 
 ### Run Without Installing
@@ -101,7 +101,7 @@ Check the version:
 clawctl --version
 ```
 ```
-clawctl 26.6.0
+clawctl 26.6.1
 ```
 
 ## Initialize Clawrium

--- a/docs/releases/26.6.1/CHANGELOG.md
+++ b/docs/releases/26.6.1/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Release 26.6.1
+
+Archived changelog for the **26.6.1** release. This is the frozen record of
+everything that shipped in this version; the working changelog for the next
+release lives at the repository root in [`CHANGELOG.md`](../../../CHANGELOG.md).
+
+Versions follow [SemVer](https://semver.org/), and the project tracks a
+calendar versioning convention: `YY.M.PATCH`.
+
+## [26.6.1]
+
+### BREAKING
+
+- **Provider state has a single source of truth.** An agent's provider is
+  now read from exactly one place — the top-level `providers` list on the
+  agent record (tier-1, written by `clawctl agent provider attach` and
+  `clawctl agent configure`). The vestigial `config.providers` field
+  (tier-3) has been removed from the code, and there is **no fallback** to
+  the materialized `config.provider` block (tier-2). If no provider is
+  attached, the render path fails fast with `AgentConfigError` instead of
+  silently resolving from another tier.
+  - **No migration.** This is a hard cutover. Legacy records whose provider
+    lives only in `config.provider` must be repaired by running
+    `clawctl agent provider attach <provider> --agent <name>`, which
+    populates the canonical top-level `providers` list.
+
+### Added
+
+- Openclaw can now be installed and run on macOS hosts alongside
+  hermes (#604). `clawctl agent create --type openclaw --host <mac>`
+  provisions an agent user via `dscl`, installs the openclaw CLI under
+  `/Users/<agent>/.openclaw`, registers a launchd unit under
+  `/Library/LaunchDaemons/ai.clawrium.openclaw.<agent>.plist`, and runs
+  the gateway pairing handshake the same way the Linux path does.
+  Hermes and openclaw can coexist on the same macOS host with distinct
+  launchd labels (`ai.clawrium.hermes.<agent>` vs
+  `ai.clawrium.openclaw.<agent>`).
+
+### Changed
+
+- `lifecycle.sync_agent` accepts a new `defer_state_transition`
+  keyword (default `False`) so OS-specific callers can own the
+  `state=READY` write. The macOS path now uses this to commit
+  `state=READY` only after the post-configure `launchctl restart`
+  succeeds — otherwise a failed restart would leave `hosts.json`
+  claiming an agent is ready while the daemon is down (#604).
+
+### Fixed
+
+- Openclaw pairing now negotiates gateway protocol v3..v4, unblocking
+  fresh installs against the currently-pinned openclaw v2026.5.28
+  (`expectedProtocol=4`) on both Linux and macOS while remaining
+  backward compatible with hosts still running v2026.4.2-era daemons
+  (`expectedProtocol=3`). The pair script also surfaces a clear
+  `supports v3-v4, daemon expected vN` error when a future daemon
+  advertises an unsupported protocol, so the next operator hitting
+  the bump knows exactly what to update (#608).
+
+### Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawrium"
-version = "26.6.0"
+version = "26.6.1"
 description = "CLI tool for managing AI assistant fleets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "clawrium"
-version = "26.6.0"
+version = "26.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -33,7 +33,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.6.0
+ + clawrium==26.6.1
 ```
 
 Verify installation:

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -62,7 +62,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.6.0
+ + clawrium==26.6.1
 ```
 
 ### Run Without Installing
@@ -109,7 +109,7 @@ Check the version:
 clawctl --version
 ```
 ```
-clawctl 26.6.0
+clawctl 26.6.1
 ```
 
 ## Initialize Clawrium

--- a/website/docs/scenarios/101.md
+++ b/website/docs/scenarios/101.md
@@ -43,7 +43,7 @@ Verify the installation:
 
 ```bash
 $ clawctl --version
-clawctl 26.6.0
+clawctl 26.6.1
 ```
 
 ## Step 2: Register the Host (first run — surface the manual setup)


### PR DESCRIPTION
## Summary
- Bump `clawrium` to v26.6.1
- Sync version mentions in AGENTS.md + website docs (installation, quickstart, scenarios/101)
- Archive root `CHANGELOG.md` to `docs/releases/26.6.1/CHANGELOG.md`; reset root to empty `[Unreleased]` template

## Release contents (from archived changelog)
- **BREAKING**: Provider state has a single source of truth (`config.providers` removed; legacy records need `clawctl agent provider attach`)
- **Added**: openclaw on macOS hosts (#604)
- **Changed**: `lifecycle.sync_agent` defer_state_transition for macOS path (#604)
- **Fixed**: openclaw pairing negotiates gateway protocol v3..v4 (#608)

## Testing
- [x] `make lint` passes
- [x] `make test` passes (254 tests)

Release housekeeping — manual review only (no ATX).