### PR TITLE
feat(cli): hermes multi-provider attach --role + detach-primary guard (#612)

### DIFF
--- a/.itx/612/00_PLAN.md
+++ b/.itx/612/00_PLAN.md
@@ -1,0 +1,62 @@
+# Issue #612 — CLI `--role` flag on provider attach + detach-primary guard
+
+Subtask 1 of 4 under parent #589 (hermes multi-provider end-to-end).
+
+## Scope (frozen)
+
+CLI surface only. **Hermes-only behaviors.** zeroclaw/openclaw
+singleton invariant stays untouched and its `single-provider invariant`
+phrase from `core/provider_attachments.validate()` remains pinned.
+
+## Changes
+
+- Add `--role` Typer option on `clawctl agent provider attach`.
+  - Required on hermes (`primary` for the first attachment, one of the
+    nine `AUXILIARY_SLOTS` for subsequent ones).
+  - Rejected on non-hermes with a clear remediation message.
+- Replace the unconditional singleton rejection at the old
+  `provider.py:106-118` with a `not supports_multi_provider(agent_type)`
+  gate, so the existing zeroclaw/openclaw `already has provider`
+  message keeps firing.
+- Read/write attachments through `provider_attachments.normalize()` /
+  `validate()`. No duplicated invariants in the CLI layer.
+- Hermes detach-primary guard: refuse `detach <primary-name>` when
+  any auxiliary attachments remain. Hint enumerates the exact
+  `clawctl agent provider detach` commands the operator must run
+  first. Promotion is explicitly out of scope.
+- `clawctl agent provider get`: for multi-provider agents, render
+  `NAME / ROLE / MODEL / AGENT` columns; for singleton agents, keep
+  the existing flat `NAME / AGENT` layout for back-compat.
+
+## Out of scope
+
+- Per-attachment API-key hydration (subtask 2).
+- Template rendering of `auxiliary.<role>` (subtask 3).
+- GUI parity (subtask 4).
+- `set-role` / promote-to-primary command.
+
+## Test surface
+
+`tests/cli/clawctl/provider/test_agent_attach_hermes_multi.py`
+covers:
+
+- Attach without `--role` rejected on hermes
+- Attach with `--role primary` succeeds
+- Aux attach after primary
+- Invalid `--role` value rejected
+- Duplicate-primary attach rejected (via `validate()`)
+- Same-name re-attach with mismatched role rejected
+- Idempotent re-attach with matching role
+- `get` table renders ROLE + MODEL columns
+- Detach-primary blocked while aux present
+- Detach-primary OK when alone
+- Aux-then-primary detach sequence
+- Non-hermes rejects `--role`
+- Non-hermes singleton invariant (verbatim `single-provider invariant`
+  phrase) preserved at the `validate()` level
+
+## Refs
+
+- `src/clawrium/cli/clawctl/agent/provider.py`
+- `src/clawrium/core/provider_attachments.py`
+- Parent: #589

--- a/.itx/612/01_EXECUTION.md
+++ b/.itx/612/01_EXECUTION.md
@@ -1,0 +1,33 @@
+# Issue #612 — execution log
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-06-04T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx:execute 612
+
+Orchestrator handoff notes (parent #589, stacked-PR pipeline):
+- Use the ATX CLI for reviews, NOT the MCP tool. Invoke:
+  `atx review --pr <pr-number> --json` and parse JSON for rating +
+  blockers. Persist session metadata to .itx/612/atx-session.json.
+- PR base: main (bottom of the stack).
+- Branch already created/checked out: issue-612-cli-role-flag.
+- Worktree: /home/devashish/workspace/ric03uec/clawrium-issue-612.
+```
+
+**Output**:
+- `src/clawrium/cli/clawctl/agent/provider.py` — `--role` flag,
+  multi-provider gating, normalize/validate round-trip,
+  detach-primary guard, type-aware `get` rendering.
+- `tests/cli/clawctl/provider/conftest.py` — `hermes_fleet_dir`
+  fixture that augments the seed hosts with a hermes agent.
+- `tests/cli/clawctl/provider/test_agent_attach_hermes_multi.py`
+  — 13 new tests covering the acceptance criteria.
+- `CHANGELOG.md` — `[Unreleased]` entry under Added.
+
+`make test-py` → 3866 passed, 8 skipped.
+`make lint-py` → All checks passed.

--- a/.itx/612/atx-session.json
+++ b/.itx/612/atx-session.json
@@ -1,0 +1,10 @@
+{
+  "session_id": "e17b9666-0483-4878-8739-e82938c49ee2",
+  "transport": "cli",
+  "commit_sha": "fae1aa0e2ec3ae6901f3a6efaed376dee957cda9",
+  "iteration": 1,
+  "last_rating": 3,
+  "last_blockers": ["B1", "B2", "B3", "B4"],
+  "started_at": "2026-06-04T22:34:00Z",
+  "updated_at": "2026-06-04T22:41:06Z"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ release.
 
 ### Added
 
+- `clawctl agent provider attach --role <role>` for hermes agents.
+  Required on hermes (`primary` for the first attachment, plus one of
+  nine upstream auxiliary slots — `vision`, `web_extract`,
+  `compression`, `session_search`, `skills_hub`, `approval`, `mcp`,
+  `title_generation`, `curator` — for any subsequent attachment).
+  Rejected on `zeroclaw`/`openclaw`. `clawctl agent provider get`
+  renders the additional `role` and `model` columns for hermes; the
+  legacy flat output is unchanged for singleton agents. `clawctl agent
+  provider detach <primary-name>` now refuses to remove the primary
+  attachment while auxiliary attachments remain — detach those first.
+  Singleton agents keep the `single-provider invariant` rejection
+  message verbatim. (#612, parent #589)
+
 ### Changed
 
 ### Fixed

--- a/src/clawrium/cli/clawctl/agent/provider.py
+++ b/src/clawrium/cli/clawctl/agent/provider.py
@@ -96,7 +96,11 @@ def _set_attachments(
     try:
         validate(attachments, agent_type)
     except AttachmentError as exc:
+        # ATX iter-1 B4: explicit early return after emit_error so the
+        # validation gate still keeps `update_host` from running even if
+        # tests (or future callers) patch `emit_error` to a no-op.
         emit_error(str(exc))
+        return False
 
     def updater(h: dict) -> dict:
         agents = h.get("agents", {})
@@ -137,7 +141,7 @@ def attach(
         "--role",
         help=(
             "Attachment role (hermes only). Required on hermes: 'primary' "
-            f"or one of {sorted(AUXILIARY_SLOTS)}. Rejected on non-hermes."
+            f"or one of {', '.join(sorted(AUXILIARY_SLOTS))}. Rejected on non-hermes."
         ),
     ),
 ) -> None:
@@ -167,13 +171,13 @@ def attach(
                 f"agent '{agent}' is a hermes agent; --role is required",
                 hint=(
                     "pass --role primary for the first attachment, "
-                    f"or one of {sorted(AUXILIARY_SLOTS)} for an auxiliary slot"
+                    f"or one of {', '.join(sorted(AUXILIARY_SLOTS))} for an auxiliary slot"
                 ),
             )
         if role not in VALID_ROLES:
             emit_error(
                 f"invalid --role {role!r}",
-                hint=f"expected one of {sorted(VALID_ROLES)}",
+                hint=f"expected one of {', '.join(sorted(VALID_ROLES))}",
             )
     else:
         if role is not None:

--- a/src/clawrium/cli/clawctl/agent/provider.py
+++ b/src/clawrium/cli/clawctl/agent/provider.py
@@ -1,11 +1,14 @@
 """`clawctl agent provider attach|detach|get` — Pattern A per-agent.
 
-Stores attached provider names in `agent.providers` (a list of provider
-names) on the agent record. The legacy `agent.config.providers` dict
-(per-provider configuration written by `clm agent configure --stage
-providers`) is left untouched — `attach`/`detach` add or remove the
-provider's *name* from the dedicated attachments list, mirroring how
-integrations track per-agent attachments (`agent.integrations`).
+Stores attached provider names in `agent.providers` on the agent record.
+The shape depends on agent type — see `core/provider_attachments.py`:
+
+- `hermes` (multi-provider) — list of `{name, role, model}` dicts.
+  `--role` is required at attach time; exactly one `primary` plus
+  optional auxiliary slots (#612 / parent #589).
+- `openclaw` / `zeroclaw` (singleton) — list of provider-name strings.
+  Second attach is rejected with the pinned `single-provider invariant`
+  message that callers + docs depend on (#426).
 
 The provider record itself lives in `~/.config/clawrium/providers.json`
 and is the source of truth for credentials, default model, etc.; the
@@ -13,6 +16,8 @@ agent record only tracks the *attachment*.
 """
 
 from __future__ import annotations
+
+from typing import Optional
 
 import typer
 
@@ -26,6 +31,15 @@ from clawrium.cli.output import (
     render_table,
 )
 from clawrium.core.hosts import update_host
+from clawrium.core.provider_attachments import (
+    AUXILIARY_SLOTS,
+    PRIMARY_ROLE,
+    VALID_ROLES,
+    AttachmentError,
+    normalize,
+    supports_multi_provider,
+    validate,
+)
 from clawrium.core.providers.storage import (
     ProvidersFileCorruptedError,
     get_provider,
@@ -56,19 +70,34 @@ def _safe_get_provider(name: str) -> dict:
     return record  # type: ignore[return-value]
 
 
-def _get_attached_providers(host: dict, agent_key: str) -> list[str]:
+def _agent_type(claw_record: dict) -> str:
+    return str(claw_record.get("type") or "")
+
+
+def _get_attachments(
+    host: dict, agent_key: str, agent_type: str
+) -> list:
+    """Read the normalized attachment list for an agent.
+
+    Returns list-of-dicts for hermes (per provider_attachments.normalize)
+    and list-of-strings for singleton agent types.
+    """
     agent_data = (host.get("agents", {}) or {}).get(agent_key, {})
     if not isinstance(agent_data, dict):
         return []
-    providers = agent_data.get("providers", [])
-    if not isinstance(providers, list):
-        return []
-    return list(providers)
+    raw = agent_data.get("providers", [])
+    return normalize(raw, agent_type)
 
 
-def _set_attached_providers(
-    hostname: str, agent_key: str, providers: list[str]
+def _set_attachments(
+    hostname: str, agent_key: str, agent_type: str, attachments: list
 ) -> bool:
+    """Validate then persist the attachment list onto the agent record."""
+    try:
+        validate(attachments, agent_type)
+    except AttachmentError as exc:
+        emit_error(str(exc))
+
     def updater(h: dict) -> dict:
         agents = h.get("agents", {})
         if agent_key not in agents:
@@ -76,50 +105,145 @@ def _set_attached_providers(
         agent_data = agents[agent_key]
         if not isinstance(agent_data, dict):
             return h
-        agent_data["providers"] = providers
+        agent_data["providers"] = attachments
         return h
 
     return update_host(hostname, updater)
+
+
+def _attachment_name(entry: object) -> Optional[str]:
+    if isinstance(entry, str):
+        return entry
+    if isinstance(entry, dict):
+        name = entry.get("name")
+        if isinstance(name, str):
+            return name
+    return None
+
+
+def _find_attachment(attachments: list, name: str) -> Optional[object]:
+    for entry in attachments:
+        if _attachment_name(entry) == name:
+            return entry
+    return None
 
 
 @provider_app.command("attach")
 def attach(
     name: str = typer.Argument(..., help="Provider name to attach."),
     agent: str = typer.Option(..., "--agent", help="Agent instance name."),
+    role: Optional[str] = typer.Option(
+        None,
+        "--role",
+        help=(
+            "Attachment role (hermes only). Required on hermes: 'primary' "
+            f"or one of {sorted(AUXILIARY_SLOTS)}. Rejected on non-hermes."
+        ),
+    ),
 ) -> None:
     """Attach a registered provider to an agent.
 
     The attachment is metadata only at this point — the provider config
     is materialized onto the remote agent on the next `clawctl agent
-    sync`. Single-provider invariant: detach the current provider
-    before attaching a different one. See #426.
+    sync`.
+
+    On hermes, `--role` is required: pass `--role primary` for the
+    primary attachment and one of the auxiliary slot names for any
+    subsequent attachment. On non-hermes (zeroclaw, openclaw) the
+    singleton invariant from #426 still applies — the second attach
+    is rejected with the pinned `single-provider invariant` message.
     """
-    _safe_get_provider(name)
-    host, _agent_type, _claw = safe_resolve_agent(agent)
+    provider_record = _safe_get_provider(name)
+    host, _agent_key_unused, claw = safe_resolve_agent(agent)
     hostname = host["hostname"]
     agent_key = resolve_agent_key(host, agent)
+    agent_type = _agent_type(claw)
+    multi = supports_multi_provider(agent_type)
 
-    current = _get_attached_providers(host, agent_key)
-    if name in current:
+    # Role flag validity is agent-type-scoped.
+    if multi:
+        if role is None:
+            emit_error(
+                f"agent '{agent}' is a hermes agent; --role is required",
+                hint=(
+                    "pass --role primary for the first attachment, "
+                    f"or one of {sorted(AUXILIARY_SLOTS)} for an auxiliary slot"
+                ),
+            )
+        if role not in VALID_ROLES:
+            emit_error(
+                f"invalid --role {role!r}",
+                hint=f"expected one of {sorted(VALID_ROLES)}",
+            )
+    else:
+        if role is not None:
+            emit_error(
+                f"--role is not supported on agent type {agent_type!r}",
+                hint="--role applies to hermes agents only",
+            )
+
+    current = _get_attachments(host, agent_key, agent_type)
+
+    # Idempotent re-attach by name. For hermes, role must match the
+    # already-attached entry's role — otherwise the operator's intent
+    # (rebinding to a different slot) is ambiguous and we make them
+    # detach first.
+    existing = _find_attachment(current, name)
+    if existing is not None:
+        if multi and isinstance(existing, dict):
+            existing_role = existing.get("role")
+            if role != existing_role:
+                emit_error(
+                    f"provider {name!r} already attached to agent {agent!r} "
+                    f"with role {existing_role!r}",
+                    hint=(
+                        f"detach first: clawctl agent provider detach {name} "
+                        f"--agent {agent}"
+                    ),
+                )
         typer.echo(f"agent/{agent}: provider {name!r} already attached")
         return
-    # Issue #426: single-provider invariant. Once an agent has a
-    # provider attached, refuse a second attachment with a clear
-    # remediation pointer. `sync` materializes the attachment into
-    # `config.provider`; multiple attachments would silently ambiguate
-    # which one wins at reconcile time.
-    if current:
-        emit_error(
-            f"agent '{agent}' already has provider {current[0]!r} attached",
-            hint=(
-                f"detach first: clawctl agent provider detach {current[0]} "
-                f"--agent {agent}"
-            ),
-        )
-    current.append(name)
-    if not _set_attached_providers(hostname, agent_key, current):
+
+    if not multi:
+        # Issue #426 singleton invariant. The verbatim phrase
+        # "single-provider invariant" comes from
+        # `provider_attachments.validate()` and is pinned by tests +
+        # docs; let `validate()` raise it via `_set_attachments` instead
+        # of duplicating the string here. Same UX as before via the
+        # `already has provider` hint.
+        if current:
+            other = _attachment_name(current[0]) or ""
+            emit_error(
+                f"agent '{agent}' already has provider {other!r} attached",
+                hint=(
+                    f"detach first: clawctl agent provider detach {other} "
+                    f"--agent {agent}"
+                ),
+            )
+        new_attachments = [*current, name]
+    else:
+        # Hermes multi-attach. Determine model from the provider record's
+        # default_model when available so the rendered hermes config has
+        # a model to point at; empty string is acceptable and lets the
+        # template fall back to `auto` per upstream.
+        model = ""
+        default_model = provider_record.get("default_model")
+        if isinstance(default_model, str):
+            model = default_model
+        new_attachments = [
+            *current,
+            {"name": name, "role": role, "model": model},
+        ]
+
+    if not _set_attachments(hostname, agent_key, agent_type, new_attachments):
         emit_error(f"failed to attach provider {name!r} to agent {agent!r}")
-    typer.echo(f"agent/{agent}: attached provider {name!r}")
+
+    if multi:
+        typer.echo(
+            f"agent/{agent}: attached provider {name!r} with role {role!r}"
+        )
+    else:
+        typer.echo(f"agent/{agent}: attached provider {name!r}")
 
 
 @provider_app.command("detach")
@@ -134,19 +258,50 @@ def detach(
     syncs. To switch providers, attach a replacement and run
     `clawctl agent sync`; the new provider will overwrite the old.
     See #426.
+
+    On hermes, detaching the primary while auxiliary attachments remain
+    is rejected — promotion is out of scope (#612). Detach the aux
+    attachments first.
     """
-    host, _agent_type, _claw = safe_resolve_agent(agent)
+    host, _agent_key_unused, claw = safe_resolve_agent(agent)
     hostname = host["hostname"]
     agent_key = resolve_agent_key(host, agent)
+    agent_type = _agent_type(claw)
+    multi = supports_multi_provider(agent_type)
 
-    current = _get_attached_providers(host, agent_key)
-    if name not in current:
+    current = _get_attachments(host, agent_key, agent_type)
+    target = _find_attachment(current, name)
+    if target is None:
         emit_error(
             f"provider {name!r} not attached to agent {agent!r}",
             hint=f"clawctl agent provider get --agent {agent}",
         )
-    current.remove(name)
-    if not _set_attached_providers(hostname, agent_key, current):
+
+    # Primary-detach guard on hermes: refuse when aux slots are filled.
+    if multi and isinstance(target, dict) and target.get("role") == PRIMARY_ROLE:
+        if len(current) > 1:
+            aux_names = [
+                _attachment_name(e) or ""
+                for e in current
+                if e is not target
+            ]
+            aux_hint = ", ".join(
+                f"clawctl agent provider detach {n} --agent {agent}"
+                for n in aux_names
+                if n
+            )
+            emit_error(
+                f"cannot detach primary provider {name!r} from agent "
+                f"{agent!r} while auxiliary attachments remain",
+                hint=(
+                    f"detach auxiliary attachments first: {aux_hint}"
+                    if aux_hint
+                    else "detach auxiliary attachments first"
+                ),
+            )
+
+    remaining = [e for e in current if e is not target]
+    if not _set_attachments(hostname, agent_key, agent_type, remaining):
         emit_error(f"failed to detach provider {name!r} from agent {agent!r}")
     # Issue #426 design decision: detach does NOT strip
     # `agent.config.provider`. The provider config persists across
@@ -163,12 +318,33 @@ def get(
     ),
     no_headers: bool = typer.Option(False, "--no-headers", help="Skip header row."),
 ) -> None:
-    """List providers attached to an agent."""
-    host, _agent_type, _claw = safe_resolve_agent(agent)
-    agent_key = resolve_agent_key(host, agent)
-    names = _get_attached_providers(host, agent_key)
+    """List providers attached to an agent.
 
-    rows = [{"kind": "provider", "name": n, "agent": agent} for n in names]
+    For multi-provider agent types (hermes) the table renders
+    `name`, `role`, `model` columns; for singleton agent types only
+    `name` is meaningful and the table stays flat for back-compat.
+    """
+    host, _agent_key_unused, claw = safe_resolve_agent(agent)
+    agent_key = resolve_agent_key(host, agent)
+    agent_type = _agent_type(claw)
+    multi = supports_multi_provider(agent_type)
+    attachments = _get_attachments(host, agent_key, agent_type)
+
+    rows: list[dict] = []
+    for entry in attachments:
+        if multi and isinstance(entry, dict):
+            rows.append(
+                {
+                    "kind": "provider",
+                    "name": entry.get("name", ""),
+                    "agent": agent,
+                    "role": entry.get("role", ""),
+                    "model": entry.get("model", ""),
+                }
+            )
+        else:
+            n = _attachment_name(entry) or ""
+            rows.append({"kind": "provider", "name": n, "agent": agent})
 
     if output is OutputFormat.json:
         typer.echo(dump_json(rows), nl=False)
@@ -180,6 +356,32 @@ def get(
         typer.echo(dump_name(rows), nl=False)
         return
 
-    headers = ["NAME", "AGENT"]
-    body = [[str(r["name"]), str(r["agent"])] for r in rows]
+    if multi:
+        headers = ["NAME", "ROLE", "MODEL", "AGENT"]
+        body = [
+            [str(r["name"]), str(r["role"]), str(r["model"]), str(r["agent"])]
+            for r in rows
+        ]
+    else:
+        headers = ["NAME", "AGENT"]
+        body = [[str(r["name"]), str(r["agent"])] for r in rows]
     typer.echo(render_table(headers, body, no_headers=no_headers), nl=False)
+
+
+# Used by tests + neighboring modules that previously imported the
+# original helpers. The shape they expected (list of strings) only
+# matched the singleton path; new callers should prefer
+# `_get_attachments` directly with an explicit agent_type.
+def _get_attached_providers(host: dict, agent_key: str) -> list[str]:
+    agent_data = (host.get("agents", {}) or {}).get(agent_key, {})
+    if not isinstance(agent_data, dict):
+        return []
+    providers = agent_data.get("providers", [])
+    if not isinstance(providers, list):
+        return []
+    out: list[str] = []
+    for entry in providers:
+        n = _attachment_name(entry)
+        if n is not None:
+            out.append(n)
+    return out

--- a/tests/cli/clawctl/provider/conftest.py
+++ b/tests/cli/clawctl/provider/conftest.py
@@ -1,0 +1,49 @@
+"""Provider-CLI test fixtures.
+
+Extends the clawctl `fleet_dir` fixture with a hermes agent so the
+multi-provider attach tests (#612) have a real hermes target without
+perturbing tests that count the default fleet (e.g.
+`test_get_name_format` asserts an exact single-agent listing).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@pytest.fixture
+def hermes_fleet_dir(fleet_dir: Path) -> Path:
+    """Augment the seeded hosts.json with a hermes agent (`sage-hermes`)."""
+    hosts_path = fleet_dir / "hosts.json"
+    hosts = json.loads(hosts_path.read_text())
+    hosts[0]["agents"]["sage-hermes"] = {
+        "type": "hermes",
+        "agent_name": "sage-hermes",
+        "version": "v2026.5.7",
+        "installed_at": _utcnow(),
+        "status": "installed",
+        "onboarding": {
+            "state": "ready",
+            "stages": {
+                "providers": {
+                    "status": "complete",
+                    "completed_at": _utcnow(),
+                },
+                "identity": {
+                    "status": "complete",
+                    "completed_at": _utcnow(),
+                },
+            },
+        },
+        "config": {},
+    }
+    hosts_path.write_text(json.dumps(hosts, indent=2))
+    return fleet_dir

--- a/tests/cli/clawctl/provider/test_agent_attach_hermes_multi.py
+++ b/tests/cli/clawctl/provider/test_agent_attach_hermes_multi.py
@@ -74,7 +74,7 @@ def test_hermes_attach_primary_succeeds(hermes_fleet_dir, stdin_not_tty) -> None
 def test_hermes_attach_aux_after_primary(hermes_fleet_dir, stdin_not_tty) -> None:
     _create_provider("anth")
     _create_provider("openrt", ptype="openrouter")
-    runner.invoke(
+    setup = runner.invoke(
         app,
         [
             "agent",
@@ -87,6 +87,7 @@ def test_hermes_attach_aux_after_primary(hermes_fleet_dir, stdin_not_tty) -> Non
             "primary",
         ],
     )
+    assert setup.exit_code == 0, setup.output
     result = runner.invoke(
         app,
         [
@@ -133,7 +134,7 @@ def test_hermes_attach_invalid_role(hermes_fleet_dir, stdin_not_tty) -> None:
 def test_hermes_attach_duplicate_primary_rejected(hermes_fleet_dir, stdin_not_tty) -> None:
     _create_provider("anth")
     _create_provider("openrt", ptype="openrouter")
-    runner.invoke(
+    setup = runner.invoke(
         app,
         [
             "agent",
@@ -146,8 +147,11 @@ def test_hermes_attach_duplicate_primary_rejected(hermes_fleet_dir, stdin_not_tt
             "primary",
         ],
     )
+    assert setup.exit_code == 0, setup.output
     # Attaching a second primary must fail (validate() enforces exactly
-    # one primary).
+    # one primary). Pin the verbatim phrase from
+    # `provider_attachments.validate()` — a refactor that re-routes the
+    # error through a different code path would silently regress UX.
     result = runner.invoke(
         app,
         [
@@ -162,6 +166,8 @@ def test_hermes_attach_duplicate_primary_rejected(hermes_fleet_dir, stdin_not_tt
         ],
     )
     assert result.exit_code != 0, result.output
+    assert "primary" in result.output
+    assert "requires exactly one" in result.output
 
 
 def test_hermes_attach_same_name_with_different_role_rejected(
@@ -260,7 +266,7 @@ def test_hermes_detach_primary_blocked_when_aux_present(
 ) -> None:
     _create_provider("anth")
     _create_provider("openrt", ptype="openrouter")
-    runner.invoke(
+    p_setup = runner.invoke(
         app,
         [
             "agent",
@@ -273,7 +279,8 @@ def test_hermes_detach_primary_blocked_when_aux_present(
             "primary",
         ],
     )
-    runner.invoke(
+    assert p_setup.exit_code == 0, p_setup.output
+    a_setup = runner.invoke(
         app,
         [
             "agent",
@@ -286,6 +293,7 @@ def test_hermes_detach_primary_blocked_when_aux_present(
             "vision",
         ],
     )
+    assert a_setup.exit_code == 0, a_setup.output
     result = runner.invoke(
         app,
         ["agent", "provider", "detach", "anth", "--agent", "sage-hermes"],
@@ -327,11 +335,12 @@ def test_hermes_detach_aux_then_primary(hermes_fleet_dir, stdin_not_tty) -> None
         ["anth", "--role", "primary"],
         ["openrt", "--role", "vision"],
     ):
-        runner.invoke(
+        setup = runner.invoke(
             app,
             ["agent", "provider", "attach", args[0], "--agent", "sage-hermes"]
             + args[1:],
         )
+        assert setup.exit_code == 0, setup.output
     # Detach aux first, then primary should succeed.
     aux = runner.invoke(
         app,
@@ -400,3 +409,127 @@ def test_non_hermes_singleton_invariant_preserved(
     # reference it.
     with pytest.raises(AttachmentError, match="single-provider invariant"):
         validate(["a", "b"], "openclaw")
+
+
+def test_non_hermes_get_table_omits_role_and_model_columns(
+    hermes_fleet_dir, stdin_not_tty
+) -> None:
+    """ATX iter-1 B3: pin the back-compat column layout on singleton
+    agent types. If the `multi` gate ever mis-fires for openclaw, the
+    table would silently grow ROLE/MODEL columns and break any tooling
+    that grepped the legacy two-column output.
+    """
+    _create_provider("anth")
+    setup = runner.invoke(
+        app,
+        ["agent", "provider", "attach", "anth", "--agent", "wise-hypatia"],
+    )
+    assert setup.exit_code == 0, setup.output
+
+    result = runner.invoke(
+        app, ["agent", "provider", "get", "--agent", "wise-hypatia"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "NAME" in result.output
+    assert "ROLE" not in result.output
+    assert "MODEL" not in result.output
+
+
+def test_hermes_attach_duplicate_aux_slot_rejected(
+    hermes_fleet_dir, stdin_not_tty
+) -> None:
+    """Both ATX iter-1 W7 + lifecycle suggestion: same aux slot filled
+    twice must error with the validate()-layer 'already filled' phrase
+    so the UX is testable independent of the CLI guard.
+    """
+    _create_provider("anth")
+    _create_provider("openrt", ptype="openrouter")
+    primary = runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "anth",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "primary",
+        ],
+    )
+    assert primary.exit_code == 0, primary.output
+    aux_a = runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "openrt",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "vision",
+        ],
+    )
+    assert aux_a.exit_code == 0, aux_a.output
+    # Reuse the same vision slot with a third provider.
+    _create_provider("oai", ptype="openai")
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "oai",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "vision",
+        ],
+    )
+    assert result.exit_code != 0, result.output
+    assert "vision" in result.output
+    assert "already filled" in result.output
+
+
+def test_set_attachments_validation_gate_blocks_persistence(
+    hermes_fleet_dir, monkeypatch
+) -> None:
+    """ATX iter-1 B4: even if `emit_error` is patched to a no-op (or
+    swallowed in tests), `_set_attachments` must NOT call
+    `update_host()` when `validate()` rejects the attachments. Pins
+    the early-return-after-emit-error contract.
+    """
+    from clawrium.cli.clawctl.agent import provider as provider_mod
+
+    captured: dict[str, object] = {"errors": [], "updates": []}
+
+    def fake_emit_error(message: str, **_: object) -> None:
+        captured["errors"].append(message)  # type: ignore[attr-defined]
+        # Intentionally do NOT raise — this is the test isolation
+        # behavior the gate must survive.
+
+    def fake_update_host(*args: object, **kwargs: object) -> bool:
+        captured["updates"].append((args, kwargs))  # type: ignore[attr-defined]
+        return True
+
+    monkeypatch.setattr(provider_mod, "emit_error", fake_emit_error)
+    monkeypatch.setattr(provider_mod, "update_host", fake_update_host)
+
+    # Two primaries on hermes: validate() raises AttachmentError. The
+    # function must surface the error AND return without persisting.
+    result = provider_mod._set_attachments(
+        "10.0.0.1",
+        "sage-hermes",
+        "hermes",
+        [
+            {"name": "a", "role": "primary", "model": ""},
+            {"name": "b", "role": "primary", "model": ""},
+        ],
+    )
+    assert result is False
+    assert captured["errors"], "emit_error must surface the validation failure"
+    assert not captured["updates"], (
+        "update_host must NOT be called when validate() rejects the "
+        "attachment list"
+    )

--- a/tests/cli/clawctl/provider/test_agent_attach_hermes_multi.py
+++ b/tests/cli/clawctl/provider/test_agent_attach_hermes_multi.py
@@ -1,0 +1,402 @@
+"""Issue #612 — hermes multi-provider attach/detach via clawctl.
+
+Covers the CLI surface added under parent #589:
+
+- `--role primary` required for the first attach on hermes
+- attach without `--role` rejected with a remediation hint
+- second `--role <aux>` attach succeeds and shows up in `get`
+- `get` table renders `name`, `role`, `model` columns
+- `detach` of primary is rejected while aux attachments remain
+- non-hermes still rejects the second attach with the verbatim
+  `single-provider invariant` phrase pinned from
+  `core/provider_attachments.validate()`
+"""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+
+runner = CliRunner()
+
+
+def _create_provider(name: str, ptype: str = "anthropic") -> None:
+    result = runner.invoke(
+        app,
+        [
+            "provider",
+            "registry",
+            "create",
+            name,
+            "--type",
+            ptype,
+            "--api-key",
+            "k",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_hermes_attach_without_role_is_rejected(hermes_fleet_dir, stdin_not_tty) -> None:
+    _create_provider("anth")
+    result = runner.invoke(
+        app, ["agent", "provider", "attach", "anth", "--agent", "sage-hermes"]
+    )
+    assert result.exit_code != 0, result.output
+    assert "--role is required" in result.output
+    # Hint must surface primary as the canonical first-attach role.
+    assert "primary" in result.output
+
+
+def test_hermes_attach_primary_succeeds(hermes_fleet_dir, stdin_not_tty) -> None:
+    _create_provider("anth")
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "anth",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "primary",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "attached" in result.output
+    assert "primary" in result.output
+
+
+def test_hermes_attach_aux_after_primary(hermes_fleet_dir, stdin_not_tty) -> None:
+    _create_provider("anth")
+    _create_provider("openrt", ptype="openrouter")
+    runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "anth",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "primary",
+        ],
+    )
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "openrt",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "vision",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    listed = runner.invoke(
+        app, ["agent", "provider", "get", "--agent", "sage-hermes", "-o", "json"]
+    )
+    data = json.loads(listed.output)
+    by_name = {p["name"]: p for p in data}
+    assert by_name["anth"]["role"] == "primary"
+    assert by_name["openrt"]["role"] == "vision"
+
+
+def test_hermes_attach_invalid_role(hermes_fleet_dir, stdin_not_tty) -> None:
+    _create_provider("anth")
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "anth",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "not-a-real-slot",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "invalid --role" in result.output
+
+
+def test_hermes_attach_duplicate_primary_rejected(hermes_fleet_dir, stdin_not_tty) -> None:
+    _create_provider("anth")
+    _create_provider("openrt", ptype="openrouter")
+    runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "anth",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "primary",
+        ],
+    )
+    # Attaching a second primary must fail (validate() enforces exactly
+    # one primary).
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "openrt",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "primary",
+        ],
+    )
+    assert result.exit_code != 0, result.output
+
+
+def test_hermes_attach_same_name_with_different_role_rejected(
+    hermes_fleet_dir, stdin_not_tty
+) -> None:
+    _create_provider("anth")
+    runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "anth",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "primary",
+        ],
+    )
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "anth",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "vision",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "already attached" in result.output
+
+
+def test_hermes_attach_idempotent_same_role(hermes_fleet_dir, stdin_not_tty) -> None:
+    _create_provider("anth")
+    runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "anth",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "primary",
+        ],
+    )
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "anth",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "primary",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "already attached" in result.output
+
+
+def test_hermes_get_table_renders_role_and_model_columns(
+    hermes_fleet_dir, stdin_not_tty
+) -> None:
+    _create_provider("anth")
+    runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "anth",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "primary",
+        ],
+    )
+    result = runner.invoke(
+        app, ["agent", "provider", "get", "--agent", "sage-hermes"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "ROLE" in result.output
+    assert "MODEL" in result.output
+
+
+def test_hermes_detach_primary_blocked_when_aux_present(
+    hermes_fleet_dir, stdin_not_tty
+) -> None:
+    _create_provider("anth")
+    _create_provider("openrt", ptype="openrouter")
+    runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "anth",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "primary",
+        ],
+    )
+    runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "openrt",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "vision",
+        ],
+    )
+    result = runner.invoke(
+        app,
+        ["agent", "provider", "detach", "anth", "--agent", "sage-hermes"],
+    )
+    assert result.exit_code != 0, result.output
+    assert "primary" in result.output
+    # Hint should mention detaching aux first.
+    assert "openrt" in result.output
+
+
+def test_hermes_detach_primary_succeeds_when_alone(
+    hermes_fleet_dir, stdin_not_tty
+) -> None:
+    _create_provider("anth")
+    runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "anth",
+            "--agent",
+            "sage-hermes",
+            "--role",
+            "primary",
+        ],
+    )
+    result = runner.invoke(
+        app,
+        ["agent", "provider", "detach", "anth", "--agent", "sage-hermes"],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_hermes_detach_aux_then_primary(hermes_fleet_dir, stdin_not_tty) -> None:
+    _create_provider("anth")
+    _create_provider("openrt", ptype="openrouter")
+    for args in (
+        ["anth", "--role", "primary"],
+        ["openrt", "--role", "vision"],
+    ):
+        runner.invoke(
+            app,
+            ["agent", "provider", "attach", args[0], "--agent", "sage-hermes"]
+            + args[1:],
+        )
+    # Detach aux first, then primary should succeed.
+    aux = runner.invoke(
+        app,
+        ["agent", "provider", "detach", "openrt", "--agent", "sage-hermes"],
+    )
+    assert aux.exit_code == 0
+    primary = runner.invoke(
+        app,
+        ["agent", "provider", "detach", "anth", "--agent", "sage-hermes"],
+    )
+    assert primary.exit_code == 0
+
+
+def test_non_hermes_rejects_role_flag(hermes_fleet_dir, stdin_not_tty) -> None:
+    _create_provider("anth")
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "anth",
+            "--agent",
+            "wise-hypatia",
+            "--role",
+            "primary",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--role" in result.output
+
+
+def test_non_hermes_singleton_invariant_preserved(
+    hermes_fleet_dir, stdin_not_tty
+) -> None:
+    """The verbatim `single-provider invariant` phrase from
+    provider_attachments.validate() is pinned by docs + tests; the
+    refactor must not regress the existing UX on zeroclaw/openclaw.
+
+    The UX on the second-attach path is delivered via the
+    `already has provider` clawctl-level error (the same message the
+    pre-#612 code emitted) — the verbatim phrase remains the one
+    `validate()` raises if attachments are ever forced past the CLI
+    guard (e.g., by hand-editing hosts.json).
+    """
+    from clawrium.core.provider_attachments import AttachmentError, validate
+    import pytest
+
+    _create_provider("anth")
+    _create_provider("openrt", ptype="openrouter")
+    first = runner.invoke(
+        app,
+        ["agent", "provider", "attach", "anth", "--agent", "wise-hypatia"],
+    )
+    assert first.exit_code == 0
+
+    second = runner.invoke(
+        app,
+        ["agent", "provider", "attach", "openrt", "--agent", "wise-hypatia"],
+    )
+    assert second.exit_code != 0
+    assert "already has provider" in second.output
+    assert "anth" in second.output
+
+    # And the validate()-level phrase is still wired up exactly as docs
+    # reference it.
+    with pytest.raises(AttachmentError, match="single-provider invariant"):
+        validate(["a", "b"], "openclaw")


### PR DESCRIPTION
## Summary

Wires the CLI surface for hermes multi-provider attach (subtask 1 of 4
under parent #589). Adds a `--role` flag to `clawctl agent provider
attach`, replaces the unconditional singleton rejection with a per-agent
gate, refuses detach-primary on hermes while aux attachments remain, and
makes `clawctl agent provider get` render `ROLE` + `MODEL` columns for
multi-provider agents.

Scope is **CLI only**. Templates, API-key hydration, and GUI parity are
deferred to subtasks 2–4. `zeroclaw`/`openclaw` keep the singleton
invariant — the `single-provider invariant` phrase from
`core/provider_attachments.validate()` is pinned by tests.

Stacked on top of `main`.

## Testing

- `make test-py` → 3869 passed, 8 skipped
- `make lint-py` → All checks passed
- 14 new tests in `tests/cli/clawctl/provider/test_agent_attach_hermes_multi.py`

## ATX Review Summary

**Iter-1 Review: blocking=true · Cost: $2.72 · Time: ~7m**
**Iter-2: not yet run.**

| Review | Specialist | Rating | Blocking Issues | Status |
|--------|-----------|--------|-----------------|--------|
| 1 | CLI / Typer UX | 3/5 | 0 | — |
| 1 | Test Coverage | 2/5 | B1, B2, B3, B4 | All fixed in `61483a4` |
| 1 | Security | 4/5 | 0 | W5 (TOCTOU) deferred — see Callouts |
| 1 | Lifecycle / State Machine | 3/5 | 0 | W6 (CLI-only guard) deferred — see Callouts |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Iter-1 Blocking Issues (Test Coverage 2/5)</summary>

**Blocking Issues — all resolved in commit `61483a4`:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/cli/clawctl/provider/test_agent_attach_hermes_multi.py:155-175` | `test_hermes_attach_duplicate_primary_rejected` pinned only `exit_code != 0`; the verbatim `requires exactly one` phrase from `validate()` was not asserted | Fixed — assertions now pin `'primary'` and `'requires exactly one'` in `result.output`, matching `test_non_hermes_singleton_invariant_preserved` |
| B2 | Same file, multiple tests | 4 setup `runner.invoke()` calls across `test_hermes_attach_aux_after_primary`, `test_hermes_detach_primary_blocked_when_aux_present`, `test_hermes_detach_aux_then_primary` did not assert exit codes — silent setup failures would false-green postconditions | Fixed — every setup invoke now asserts `exit_code == 0, result.output`; loop bodies capture and assert inline |
| B3 | `tests/cli/clawctl/provider/test_agent_attach.py` (missing) | No regression guard for the back-compat 2-column `get` table on singleton agents — a mis-fired `multi` gate would silently grow ROLE/MODEL columns | Fixed — added `test_non_hermes_get_table_omits_role_and_model_columns` asserting `'NAME' in output`, `'ROLE' not in output`, `'MODEL' not in output` |
| B4 | `src/clawrium/cli/clawctl/agent/provider.py:96-99` | `_set_attachments` had no `return False` after `emit_error`; if a test patches `emit_error` to no-op, invalid attachments would persist via `update_host()` | Fixed — added explicit `return False` after `emit_error` plus `test_set_attachments_validation_gate_blocks_persistence` which monkey-patches `emit_error` and `update_host` to prove `update_host` is never called when `validate()` rejects |

**Warnings — fixed in this PR:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1-W3 | `provider.py:139-140, 170, 176` | f-strings rendered `sorted(AUXILIARY_SLOTS)` / `sorted(VALID_ROLES)` as Python list repr in `--help` and error hints | Fixed — replaced with `', '.join(sorted(...))` |
| W7 (partial) | `test_agent_attach_hermes_multi.py` | No test for duplicate aux-slot attach (`--role vision` twice) | Fixed — added `test_hermes_attach_duplicate_aux_slot_rejected` pinning the `already filled` phrase |

**Warnings — deferred (see Callouts below):**

| # | File | Warning | Disposition |
|---|------|---------|-------------|
| W4 | `provider.py:92-111` | `_set_attachments` mixes `emit_error` (NoReturn) with `-> bool` return contract | Acknowledged — B4 fix added `return False` after `emit_error`, so the contract is now self-consistent for the validation path. Full callsite refactor is a follow-up. |
| W5 | `provider.py:185, 238` | TOCTOU race: `_get_attachments` reads outside the `fcntl.LOCK_EX` boundary of `update_host`; concurrent attaches can lose writes | **Out-of-scope** for subtask 1. Refactoring read-modify-write into the updater closure is an architectural change that should land alongside subtask 3 (template hydration) where the multi-provider write path matures. Tracked as follow-up. |
| W6 | `provider.py:281-301` | Detach-primary guard lives only at the CLI layer; a direct `update_host` bypass would corrupt state until next `sync_agent` | **Out-of-scope** for subtask 1. Moving the semantic check into `core/provider_attachments.py` is an architectural cleanup. `validate()` already provides a structural backstop at write time. Tracked as follow-up. |
| W7 (rest) | Same | Case-folding (`--role Primary`), empty `--role ''`, legacy `normalize()` migration branch | Deferred to a follow-up — covered indirectly by `VALID_ROLES` whitelist; full edge-case sweep is low priority. |

**Suggestions (S1-S5):** acknowledged, none addressed in this PR; all are low-priority code-hygiene items that fit better in subtasks 2-4.

</details>

## Callouts

- [DECISION] W5 (TOCTOU race on concurrent multi-provider attach) and
  W6 (CLI-only detach-primary guard) are not addressed in this PR.
  - Why: subtask 1's scope is "wire the CLI surface." Both warnings
    require architectural changes (moving read-modify-write into the
    `update_host` updater closure; pushing the semantic detach check
    into `core/provider_attachments.py`). `validate()` already
    provides a structural backstop on `_set_attachments` — corrupt
    state cannot reach disk through this PR's code paths. The race
    surfaces only when two `clawctl` processes attach to the same
    hermes agent simultaneously, which is not a realistic operator
    workflow today.
  - Reviewer: push back if you want W5/W6 in-PR. The fix for W5 is
    ~30 lines (move the check into the updater closure); W6 is ~15
    lines (add `validate_detach()` to the core module).

- [DECISION] `model` field on a new hermes attachment defaults to an
  empty string because the provider record carries no
  `default_model` field today.
  - Why: matches `provider_attachments.normalize()` semantics and
    avoids inventing a new provider-record field in a CLI-only subtask.
  - Reviewer: confirm — a `--model` flag is a one-line addition if you
    want it surfaced now.

- [DECISION] Singleton-invariant UX is delivered at the **clawctl**
  layer with the same `already has provider` message the pre-#612
  code emitted. The `single-provider invariant` phrase from
  `provider_attachments.validate()` is preserved verbatim and asserted
  via `pytest.raises(AttachmentError, match=…)` so docs that reference
  that exact wording stay valid.

- [DECISION] Provider tests use a new `hermes_fleet_dir` fixture in
  `tests/cli/clawctl/provider/conftest.py` instead of mutating the
  shared `fleet_dir` fixture, because `test_get_name_format` in
  `tests/cli/clawctl/agent/test_get_describe.py` asserts an exact
  single-agent listing and would have regressed.

- [DECISION] Iter-2 ATX review not yet run. User interrupted the
  iter-2 invocation; PR is being opened for review with iter-1
  blockers documented as resolved. The orchestrator polling loop or
  reviewer can trigger iter-2 explicitly if needed.

- [ENVIRONMENT] ATX **CLI** (not MCP) was used per orchestrator
  handoff notes. Session metadata persisted at
  `.itx/612/atx-session.json`.

- [TODO-FOLLOWUP] W5 (TOCTOU), W6 (detach guard at core layer),
  W4 (return-bool contract callsite refactor), W7 (case-folding +
  empty-role edge cases), S1-S5 (low-priority hygiene). None blocking;
  natural home is subtasks 2-4 of parent #589.

---

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
