### PR TITLE
feat(lifecycle): per-attachment provider credential hydration into ansible_vars (#613)

### DIFF
--- a/.itx/613/atx-session.json
+++ b/.itx/613/atx-session.json
@@ -1,10 +1,10 @@
 {
   "session_id": "f9ec9bac-098b-41f5-9600-4d4506201ffb",
   "transport": "cli",
-  "commit_sha": "aafa69c99ecafe34f2a08cd45af803d9a50a089d",
-  "iteration": 1,
-  "last_rating": 2,
-  "last_blockers": ["B1","B2","B3","B4","B5","B6"],
+  "commit_sha": "68da338a2418eecaded4741459d09ea144c9a181",
+  "iteration": 2,
+  "last_rating": 3,
+  "last_blockers": ["B1'"],
   "started_at": "2026-06-05T07:18:51Z",
-  "updated_at": "2026-06-05T07:30:00Z"
+  "updated_at": "2026-06-05T07:50:00Z"
 }

--- a/.itx/613/atx-session.json
+++ b/.itx/613/atx-session.json
@@ -1,10 +1,11 @@
 {
   "session_id": "f9ec9bac-098b-41f5-9600-4d4506201ffb",
   "transport": "cli",
-  "commit_sha": "68da338a2418eecaded4741459d09ea144c9a181",
-  "iteration": 2,
+  "commit_sha": "48f6bb714dfdada77eb2a02ff932051de1f36c74",
+  "iteration": 3,
   "last_rating": 3,
-  "last_blockers": ["B1'"],
+  "last_blockers": [],
   "started_at": "2026-06-05T07:18:51Z",
-  "updated_at": "2026-06-05T07:50:00Z"
+  "updated_at": "2026-06-05T08:00:00Z",
+  "notes": "Iter-3 returned 1 blocker (B1: missing W2 test coverage) + 4 warnings (W-new-1..4). All addressed in commit 48f6bb7 without a 4th ATX iteration (skill ceiling = 3). PR opens with full Callouts; no [ITX-STUCK] marker since all named issues addressed."
 }

--- a/.itx/613/atx-session.json
+++ b/.itx/613/atx-session.json
@@ -1,0 +1,10 @@
+{
+  "session_id": "f9ec9bac-098b-41f5-9600-4d4506201ffb",
+  "transport": "cli",
+  "commit_sha": "aafa69c99ecafe34f2a08cd45af803d9a50a089d",
+  "iteration": 1,
+  "last_rating": 2,
+  "last_blockers": ["B1","B2","B3","B4","B5","B6"],
+  "started_at": "2026-06-05T07:18:51Z",
+  "updated_at": "2026-06-05T07:30:00Z"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ release.
   attachment while auxiliary attachments remain — detach those first.
   Singleton agents keep the `single-provider invariant` rejection
   message verbatim. (#612, parent #589)
+- `configure_agent` now hydrates per-attachment provider credentials
+  into `ansible_vars` for hermes: `provider_api_keys` (dict keyed by
+  provider name) carries API keys for non-bedrock attachments, and
+  `provider_aws_credentials` (dict of `{access_key, secret_key,
+  region}` keyed by provider name) carries AWS creds for bedrock
+  attachments. The legacy singleton `provider_api_key` /
+  `aws_access_key` / `aws_secret_key` vars continue to reflect the
+  primary attachment for back-compat with un-migrated canonical
+  templates. Zeroclaw/openclaw `ansible_vars` are unchanged. (#613,
+  parent #589)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ release.
   primary attachment for back-compat with un-migrated canonical
   templates. Zeroclaw/openclaw `ansible_vars` are unchanged. (#613,
   parent #589)
+- Hermes manifest now lists `AWS_ACCESS_KEY_ID` and
+  `AWS_SECRET_ACCESS_KEY` under `secrets.optional` so the configure
+  wizard surfaces them for bedrock attachments. (#613)
 
 ### Changed
 

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -124,6 +124,45 @@ def _resolve_agent_type(agent_type: str) -> str:
     return ALIAS_TO_CANONICAL.get(agent_type, agent_type)
 
 
+def _build_provider_overlay(provider_name: str) -> dict:
+    """Build a config.provider(s) overlay dict from a registered provider.
+
+    Extracted to module scope (ATX iter-2 B1' on #613) so the per-field
+    copy contract — including the bedrock `region` propagation added in
+    iter-1 B1 — is unit-testable without standing up the full
+    `sync_agent` flow. Used by the `_build_overlay` closure inside
+    `sync_agent`; see comments there for the upstream wiring contract.
+    """
+    provider_record = _provider_storage.get_provider(provider_name)
+    if provider_record is None:
+        raise LifecycleError(
+            f"attached provider '{provider_name}' not registered. "
+            f"Run 'clawctl provider registry get' to list available providers."
+        )
+    overlay = {
+        "name": provider_record.get("name", ""),
+        "type": provider_record.get("type", "ollama"),
+        "endpoint": provider_record.get("endpoint", ""),
+        "default_model": provider_record.get("default_model", ""),
+    }
+    # `is not None` instead of truthy: max_tokens=0 / context_window=0
+    # are meaningful (no-limit signals on some APIs); a falsy check
+    # would silently drop them. ATX iter-1 S1 on #612.
+    if provider_record.get("context_window") is not None:
+        overlay["context_window"] = provider_record["context_window"]
+    if provider_record.get("max_tokens") is not None:
+        overlay["max_tokens"] = provider_record["max_tokens"]
+    # ATX iter-1 B1 (#613): propagate bedrock region from the provider
+    # record so the hermes auxiliary-slot AWS_DEFAULT_REGION/templates
+    # render the correct region. Without this the per-attachment
+    # credential dict at configure-time always sees an empty string,
+    # forcing fall-back to us-east-1 even when the operator registered
+    # the provider in a different region.
+    if provider_record.get("region") is not None:
+        overlay["region"] = provider_record["region"]
+    return overlay
+
+
 def _get_lifecycle_playbook_path(claw_name: str, operation: str) -> Path:
     canonical_name = _resolve_agent_type(claw_name)
     return (
@@ -1240,34 +1279,7 @@ def sync_agent(
     provider_name_for_state: str | None = None
 
     def _build_overlay(provider_name: str) -> dict:
-        provider_record = _provider_storage.get_provider(provider_name)
-        if provider_record is None:
-            raise LifecycleError(
-                f"attached provider '{provider_name}' not registered. "
-                f"Run 'clawctl provider registry get' to list available providers."
-            )
-        overlay = {
-            "name": provider_record.get("name", ""),
-            "type": provider_record.get("type", "ollama"),
-            "endpoint": provider_record.get("endpoint", ""),
-            "default_model": provider_record.get("default_model", ""),
-        }
-        # `is not None` instead of truthy: max_tokens=0 / context_window=0
-        # are meaningful (no-limit signals on some APIs); a falsy check
-        # would silently drop them. ATX iter-1 S1.
-        if provider_record.get("context_window") is not None:
-            overlay["context_window"] = provider_record["context_window"]
-        if provider_record.get("max_tokens") is not None:
-            overlay["max_tokens"] = provider_record["max_tokens"]
-        # ATX iter-1 B1 (#613): propagate bedrock region from the provider
-        # record so the hermes auxiliary-slot AWS_DEFAULT_REGION/templates
-        # render the correct region. Without this the per-attachment
-        # credential dict at configure-time always sees an empty string,
-        # forcing fall-back to us-east-1 even when the operator registered
-        # the provider in a different region.
-        if provider_record.get("region"):
-            overlay["region"] = provider_record["region"]
-        return overlay
+        return _build_provider_overlay(provider_name)
 
     if attachments and _pa.supports_multi_provider(agent_type):
         # Hermes path: build a config.providers list (one overlay per
@@ -1303,6 +1315,14 @@ def sync_agent(
                 provider_overlay = {
                     k: v for k, v in overlay.items() if k not in ("role",)
                 }
+                # ATX iter-2 W2 (#613): the legacy hermes-config.yaml.j2
+                # template reads `config.provider.default_model`, not
+                # `model`. Reflect the per-attachment model override here
+                # so an operator-provided override (`attach --model X`)
+                # actually lands in the rendered config instead of being
+                # silently dropped back to the registry default.
+                if attachment_model:
+                    provider_overlay["default_model"] = attachment_model
                 provider_name_for_state = entry["name"]
     elif attachments:
         # Singleton path (zeroclaw/openclaw). normalize() guarantees
@@ -2094,9 +2114,12 @@ def configure_agent(
             try:
                 _validate_name(ov_name)
             except _IPNE as exc:
+                # ATX iter-2 W5 (#613): %r on both name and exception so a
+                # CR/LF or escape-sequence payload can't spoof additional
+                # log lines via the formatter.
                 logger.warning(
                     "Skipping per-attachment credential hydration for invalid "
-                    "provider name %r: %s",
+                    "provider name %r: %r",
                     ov_name,
                     exc,
                 )

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -130,8 +130,8 @@ def _build_provider_overlay(provider_name: str) -> dict:
     Extracted to module scope (ATX iter-2 B1' on #613) so the per-field
     copy contract — including the bedrock `region` propagation added in
     iter-1 B1 — is unit-testable without standing up the full
-    `sync_agent` flow. Used by the `_build_overlay` closure inside
-    `sync_agent`; see comments there for the upstream wiring contract.
+    `sync_agent` flow. Called directly from `sync_agent` for both the
+    multi-provider (hermes) and singleton (zeroclaw/openclaw) paths.
     """
     provider_record = _provider_storage.get_provider(provider_name)
     if provider_record is None:
@@ -158,7 +158,11 @@ def _build_provider_overlay(provider_name: str) -> dict:
     # credential dict at configure-time always sees an empty string,
     # forcing fall-back to us-east-1 even when the operator registered
     # the provider in a different region.
-    if provider_record.get("region") is not None:
+    # Truthy guard (not `is not None`) so an empty-string region from a
+    # hand-edited record falls back to the template default rather than
+    # silently overriding it with "". A bedrock region is never validly
+    # the empty string. ATX iter-3 W-new-2 on #613.
+    if provider_record.get("region"):
         overlay["region"] = provider_record["region"]
     return overlay
 
@@ -1278,9 +1282,6 @@ def sync_agent(
     provider_overlays: list[dict] | None = None
     provider_name_for_state: str | None = None
 
-    def _build_overlay(provider_name: str) -> dict:
-        return _build_provider_overlay(provider_name)
-
     if attachments and _pa.supports_multi_provider(agent_type):
         # Hermes path: build a config.providers list (one overlay per
         # attachment, carrying role + per-attachment model) and also
@@ -1301,7 +1302,7 @@ def sync_agent(
                     f"after normalization: {entry!r}. Inspect with "
                     f"'clawctl agent provider get --agent {agent_key}'."
                 )
-            overlay = _build_overlay(entry["name"])
+            overlay = _build_provider_overlay(entry["name"])
             overlay["role"] = entry.get("role", "")
             # Per-attachment model override; falls back to provider's
             # default_model when the attachment didn't specify one.
@@ -1315,14 +1316,17 @@ def sync_agent(
                 provider_overlay = {
                     k: v for k, v in overlay.items() if k not in ("role",)
                 }
-                # ATX iter-2 W2 (#613): the legacy hermes-config.yaml.j2
-                # template reads `config.provider.default_model`, not
-                # `model`. Reflect the per-attachment model override here
-                # so an operator-provided override (`attach --model X`)
-                # actually lands in the rendered config instead of being
-                # silently dropped back to the registry default.
-                if attachment_model:
-                    provider_overlay["default_model"] = attachment_model
+                # ATX iter-2 W2 + iter-3 W-new-4 (#613): the legacy
+                # hermes-config.yaml.j2 template reads
+                # `config.provider.default_model`, not `model`. Reflect
+                # the per-attachment override here so an operator-provided
+                # `attach --model X` actually lands in the rendered
+                # config instead of being silently dropped to the
+                # registry default. Guard on the raw `entry["model"]`
+                # (not the post-fallback `attachment_model`) so the
+                # no-override path remains a true no-op.
+                if entry.get("model"):
+                    provider_overlay["default_model"] = entry["model"]
                 provider_name_for_state = entry["name"]
     elif attachments:
         # Singleton path (zeroclaw/openclaw). normalize() guarantees
@@ -1332,7 +1336,7 @@ def sync_agent(
             raise LifecycleError(
                 f"agent '{agent_key}' provider attachment shape unexpected"
             )
-        provider_overlay = _build_overlay(provider_name)
+        provider_overlay = _build_provider_overlay(provider_name)
         provider_name_for_state = provider_name
 
     onboarding = claw_record.get("onboarding", {})

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -1485,14 +1485,8 @@ def sync_agent(
         # render `auxiliary.<slot>` in hermes-config.yaml.j2 (Phase 3).
         # `config.provider` stays populated above from the primary so
         # existing readers continue to function unchanged in Phase 1.
-        #
-        # TODO(#501 Phase 3): when hermes-config.yaml.j2 renders
-        # `auxiliary.<slot>` per non-primary attachment, configure_agent
-        # must also hydrate per-attachment API keys into ansible_vars.
-        # Today only the primary's `provider_api_key` is loaded
-        # (lifecycle.py configure path), so every auxiliary slot would
-        # render with an empty key. Block the Phase 3 template work on
-        # this hydration to avoid a silent misconfigure at first use.
+        # Issue #613 (subtask 2 of #589): per-attachment API-key
+        # hydration into ansible_vars now lives in configure_agent.
         existing_config = dict(existing_config)
         existing_config["providers"] = provider_overlays
 
@@ -2058,6 +2052,45 @@ def configure_agent(
             if provider_api_key:
                 emit("configure", "Loaded provider API key from secrets")
 
+    # Issue #613 (subtask 2 of #589): per-attachment credential hydration
+    # for hermes multi-provider. Templates (subtask 3) iterate these to
+    # render `auxiliary.<slot>` blocks with each attachment's own key.
+    # The singleton `provider_api_key` / `aws_access_key` / `aws_secret_key`
+    # above stays in place — the primary's credentials must still populate
+    # the legacy scalars so un-migrated canonical-pipeline templates keep
+    # working (back-compat invariant in the acceptance criteria).
+    provider_api_keys: dict[str, str] = {}
+    provider_aws_credentials: dict[str, dict[str, str]] = {}
+    if _pa.supports_multi_provider(resolved_type) and isinstance(
+        config_data.get("providers"), list
+    ):
+        for overlay in config_data["providers"]:
+            if not isinstance(overlay, dict):
+                continue
+            ov_name = overlay.get("name")
+            if not isinstance(ov_name, str) or not ov_name:
+                continue
+            ov_type = overlay.get("type", "")
+            if ov_type == "bedrock":
+                ak, sk = get_provider_aws_credentials(ov_name)
+                if ak and sk:
+                    provider_aws_credentials[ov_name] = {
+                        "access_key": ak,
+                        "secret_key": sk,
+                        "region": overlay.get("region", "") or "",
+                    }
+            else:
+                key = get_provider_api_key(ov_name) or ""
+                if key:
+                    provider_api_keys[ov_name] = key
+        if provider_api_keys or provider_aws_credentials:
+            emit(
+                "configure",
+                f"Loaded per-attachment credentials for "
+                f"{len(provider_api_keys)} API + "
+                f"{len(provider_aws_credentials)} AWS providers",
+            )
+
     # Load channel secrets (Discord bot token)
     discord_bot_token = ""
     try:
@@ -2251,6 +2284,8 @@ def configure_agent(
         "provider_api_key": provider_api_key,
         "aws_access_key": aws_access_key,
         "aws_secret_key": aws_secret_key,
+        "provider_api_keys": provider_api_keys,
+        "provider_aws_credentials": provider_aws_credentials,
         "discord_bot_token": discord_bot_token,
         "slack_bot_token": slack_bot_token,
         "slack_app_token": slack_app_token,

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -1259,6 +1259,14 @@ def sync_agent(
             overlay["context_window"] = provider_record["context_window"]
         if provider_record.get("max_tokens") is not None:
             overlay["max_tokens"] = provider_record["max_tokens"]
+        # ATX iter-1 B1 (#613): propagate bedrock region from the provider
+        # record so the hermes auxiliary-slot AWS_DEFAULT_REGION/templates
+        # render the correct region. Without this the per-attachment
+        # credential dict at configure-time always sees an empty string,
+        # forcing fall-back to us-east-1 even when the operator registered
+        # the provider in a different region.
+        if provider_record.get("region"):
+            overlay["region"] = provider_record["region"]
         return overlay
 
     if attachments and _pa.supports_multi_provider(agent_type):
@@ -2064,11 +2072,34 @@ def configure_agent(
     if _pa.supports_multi_provider(resolved_type) and isinstance(
         config_data.get("providers"), list
     ):
+        from clawrium.core.providers import (
+            InvalidProviderNameError as _IPNE,
+            validate_provider_name as _validate_name,
+        )
+
         for overlay in config_data["providers"]:
             if not isinstance(overlay, dict):
                 continue
             ov_name = overlay.get("name")
             if not isinstance(ov_name, str) or not ov_name:
+                continue
+            # ATX iter-1 B2 (#613): defensive name validation. Provider
+            # records are validated at write time by the CLI, but a
+            # hand-edited hosts.json or future programmatic caller could
+            # bypass that. Section-injection / Jinja-marker names would
+            # otherwise flow into ansible_vars dict keys and downstream
+            # template renders. Skip the entry rather than fail the whole
+            # configure — other attachments may still be hydratable, and
+            # the silent gap is preferable to a hard configure failure.
+            try:
+                _validate_name(ov_name)
+            except _IPNE as exc:
+                logger.warning(
+                    "Skipping per-attachment credential hydration for invalid "
+                    "provider name %r: %s",
+                    ov_name,
+                    exc,
+                )
                 continue
             ov_type = overlay.get("type", "")
             if ov_type == "bedrock":
@@ -2079,10 +2110,27 @@ def configure_agent(
                         "secret_key": sk,
                         "region": overlay.get("region", "") or "",
                     }
+                else:
+                    # ATX iter-1 W1 (#613): surface the gap so operators
+                    # know which provider needs `clawctl provider set-aws-
+                    # credentials` before configure will produce a working
+                    # render.
+                    logger.warning(
+                        "No AWS credentials found in secrets for bedrock "
+                        "provider %r; auxiliary slot will render with empty "
+                        "credentials",
+                        ov_name,
+                    )
             else:
                 key = get_provider_api_key(ov_name) or ""
                 if key:
                     provider_api_keys[ov_name] = key
+                else:
+                    logger.warning(
+                        "No API key found in secrets for provider %r; "
+                        "auxiliary slot will render with empty credential",
+                        ov_name,
+                    )
         if provider_api_keys or provider_aws_credentials:
             emit(
                 "configure",

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -39,6 +39,10 @@ secrets:
       description: "Anthropic API key"
     - key: OPENAI_API_KEY
       description: "OpenAI API key"
+    - key: AWS_ACCESS_KEY_ID
+      description: "AWS access key ID for Bedrock provider"
+    - key: AWS_SECRET_ACCESS_KEY
+      description: "AWS secret access key for Bedrock provider"
     # Atlassian credentials are NOT listed here: they live in the per-integration
     # credential store (managed via `clawctl integration credentials`) and a single
     # hermes agent may have multiple atlassian integrations (team-a, team-b)

--- a/src/clawrium/platform/registry/hermes/templates/hermes-config.yaml.j2
+++ b/src/clawrium/platform/registry/hermes/templates/hermes-config.yaml.j2
@@ -67,7 +67,11 @@ model:
 {% if model_id %}  default: "{{ model_id }}"
 {% endif %}
 bedrock:
-  region: "{{ provider.region | default('us-east-1') }}"
+{# yaml_quote on region so a hand-edited or registry-provided region value
+   containing `"` or `\` cannot break out of the YAML scalar (ATX iter-2 W1
+   on #613 — the upstream `_build_overlay` change now reliably propagates
+   provider_record["region"] into this scalar). #}
+  region: {{ yaml_quote(provider.region | default('us-east-1')) }}
 auxiliary:
   title_generation:
 {# Plain bedrock model ID (no `us.` / `eu.` / `ap.` cross-region inference

--- a/tests/cli/clawctl/agent/test_sync_hermes_multi_provider.py
+++ b/tests/cli/clawctl/agent/test_sync_hermes_multi_provider.py
@@ -131,6 +131,72 @@ def test_hermes_legacy_list_of_strings_migrates_to_primary():
     assert providers[0]["role"] == "primary"
 
 
+def test_hermes_primary_model_override_lands_in_default_model():
+    """ATX iter-3 B1 (#613): when the primary attachment carries an
+    explicit `--model` override, the rendered `config.provider.default_model`
+    must reflect the override so the legacy hermes-config.yaml.j2 template
+    (which reads default_model, not model) renders the operator's intent.
+    """
+    host = _hermes_host(
+        attachments=[{"name": "anth", "role": "primary", "model": "claude-opus-4-5"}]
+    )
+
+    captured: dict = {}
+
+    def fake_configure(hostname, claw_name, config_data, **kwargs):
+        captured["config_data"] = config_data
+        return (True, None)
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch(
+            "clawrium.core.providers.storage.get_provider",
+            return_value=_provider_record("anth", "anthropic"),
+        ),
+        patch("clawrium.core.onboarding.complete_stage", return_value=True),
+        patch("clawrium.core.onboarding.transition_state", return_value=True),
+        patch("clawrium.core.onboarding.can_skip_stage", return_value=True),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "hermes")
+
+    assert result["success"] is True
+    cfg = captured["config_data"]
+    assert cfg["provider"]["default_model"] == "claude-opus-4-5"
+
+
+def test_hermes_primary_no_model_override_keeps_registry_default():
+    """ATX iter-3 B1 inverse (#613): primary attachment with no model
+    override falls back to the registry's `default_model`. Pins the
+    no-op-on-no-override behavior of the W2 fix guard."""
+    host = _hermes_host(
+        attachments=[{"name": "anth", "role": "primary", "model": ""}]
+    )
+
+    captured: dict = {}
+
+    def fake_configure(hostname, claw_name, config_data, **kwargs):
+        captured["config_data"] = config_data
+        return (True, None)
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch(
+            "clawrium.core.providers.storage.get_provider",
+            return_value=_provider_record("anth", "anthropic"),
+        ),
+        patch("clawrium.core.onboarding.complete_stage", return_value=True),
+        patch("clawrium.core.onboarding.transition_state", return_value=True),
+        patch("clawrium.core.onboarding.can_skip_stage", return_value=True),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "hermes")
+
+    assert result["success"] is True
+    cfg = captured["config_data"]
+    assert cfg["provider"]["default_model"] == "anthropic-default-model"
+
+
 def test_hermes_attachment_model_falls_back_to_provider_default():
     """When the attachment has no `model` override, the rendered
     overlay carries the provider's `default_model`."""

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -14,6 +14,7 @@ import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 import yaml
 from jinja2 import Environment, FileSystemLoader
 
@@ -3570,6 +3571,37 @@ class TestBuildProviderOverlayRegion:
         ):
             overlay = _build_provider_overlay("bd-aux")
         assert overlay["region"] == "eu-central-1"
+
+    def test_empty_string_region_falls_back_to_template_default(self):
+        # ATX iter-3 W-new-2 (#613): a hand-edited provider record with
+        # `region: ""` must fall back to the template default rather than
+        # silently shadowing it with an empty scalar.
+        from clawrium.core.lifecycle import _build_provider_overlay
+
+        record = {
+            "name": "bd-aux",
+            "type": "bedrock",
+            "endpoint": "",
+            "default_model": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "region": "",
+        }
+        with patch(
+            "clawrium.core.providers.storage.get_provider", return_value=record
+        ):
+            overlay = _build_provider_overlay("bd-aux")
+        assert "region" not in overlay
+
+    def test_unregistered_provider_raises_lifecycle_error(self):
+        # ATX iter-3 W-new-1 (#613): the unregistered-provider error
+        # path is the primary motivation for extracting this helper —
+        # pin it directly.
+        from clawrium.core.lifecycle import LifecycleError, _build_provider_overlay
+
+        with patch(
+            "clawrium.core.providers.storage.get_provider", return_value=None
+        ):
+            with pytest.raises(LifecycleError, match="not registered"):
+                _build_provider_overlay("ghost")
 
     def test_missing_region_field_omitted_from_overlay(self):
         # Non-bedrock providers (or bedrock records pre-region) must not

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -3231,3 +3231,170 @@ class TestConfigYamlMCPServers:
             "CONFLUENCE_USERNAME",
             "CONFLUENCE_API_TOKEN",
         }
+
+
+class TestHermesMultiProviderHydration:
+    """Issue #613: configure_agent hydrates per-attachment API keys into
+    `provider_api_keys` and AWS creds into `provider_aws_credentials` for
+    hermes, while keeping the legacy singleton vars populated for back-compat.
+    """
+
+    def _host(self) -> dict:
+        return {
+            "hostname": "test-host",
+            "key_id": "test",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {
+                        "api_server": {
+                            "enabled": True,
+                            "host": "127.0.0.1",
+                            "port": 8642,
+                        }
+                    },
+                }
+            },
+        }
+
+    def _config_data(self) -> dict:
+        # `config.provider` reflects the primary (preserved by lifecycle's
+        # overlay branch for back-compat). `config.providers` is the new
+        # multi-attachment list the hermes path emits.
+        return {
+            "gateway": {"host": "127.0.0.1", "port": 8642},
+            "provider": {
+                "name": "ant-primary",
+                "type": "anthropic",
+                "default_model": "claude-3",
+            },
+            "providers": [
+                {
+                    "name": "ant-primary",
+                    "type": "anthropic",
+                    "default_model": "claude-3",
+                    "role": "primary",
+                    "model": "claude-3",
+                },
+                {
+                    "name": "or-aux",
+                    "type": "openrouter",
+                    "default_model": "auto",
+                    "role": "vision",
+                    "model": "auto",
+                },
+                {
+                    "name": "bd-aux",
+                    "type": "bedrock",
+                    "default_model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                    "role": "compression",
+                    "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                    "region": "us-west-2",
+                },
+            ],
+        }
+
+    def _api_server_secrets(self) -> dict:
+        return {
+            "HERMES_API_SERVER_KEY": {
+                "key": "HERMES_API_SERVER_KEY",
+                "value": "a" * 64,
+                "created_at": "2026-06-04T00:00:00+00:00",
+                "updated_at": "2026-06-04T00:00:00+00:00",
+                "description": "",
+            }
+        }
+
+    def _run(self, tmp_path: Path, config_data: dict, agent_type: str = "hermes"):
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        captured = {}
+
+        def fake_run(**kwargs):
+            captured["inventory"] = kwargs["inventory"]
+            mock = MagicMock()
+            mock.status = "successful"
+            mock.events = []
+            return mock
+
+        api_keys = {"ant-primary": "sk-ant-123", "or-aux": "sk-or-456"}
+        aws_creds = {
+            "bd-aux": ("AKIAEXAMPLE", "wJalrEXAMPLE"),
+        }
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=self._host()),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ),
+            patch("clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run),
+            patch("clawrium.core.lifecycle.update_host", return_value=True),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                return_value=self._api_server_secrets(),
+            ),
+            patch(
+                "clawrium.core.providers.get_provider_api_key",
+                side_effect=lambda name: api_keys.get(name),
+            ),
+            patch(
+                "clawrium.core.providers.get_provider_aws_credentials",
+                side_effect=lambda name: aws_creds.get(name, (None, None)),
+            ),
+        ):
+            success, error = configure_agent(
+                "test-host", agent_type, config_data, agent_name="hermes-test"
+            )
+
+        return success, error, captured
+
+    def test_multi_provider_keys_hydrated_for_hermes(self, tmp_path: Path):
+        success, error, captured = self._run(tmp_path, self._config_data())
+        assert success is True, error
+
+        ansible_vars = captured["inventory"]["all"]["vars"]
+        # Multi-provider dicts present and correctly partitioned by type.
+        assert ansible_vars["provider_api_keys"] == {
+            "ant-primary": "sk-ant-123",
+            "or-aux": "sk-or-456",
+        }
+        assert ansible_vars["provider_aws_credentials"] == {
+            "bd-aux": {
+                "access_key": "AKIAEXAMPLE",
+                "secret_key": "wJalrEXAMPLE",
+                "region": "us-west-2",
+            }
+        }
+        # Back-compat: primary's key also lives in the legacy scalar so
+        # un-migrated canonical templates keep rendering.
+        assert ansible_vars["provider_api_key"] == "sk-ant-123"
+
+    def test_hermes_without_providers_list_emits_empty_multi_dicts(
+        self, tmp_path: Path
+    ):
+        # A hermes agent whose config_data carries only the legacy
+        # singleton `provider` (no `providers` list) must produce empty
+        # multi-provider dicts and leave the legacy scalar populated.
+        config_data = {
+            "gateway": {"host": "127.0.0.1", "port": 8642},
+            "provider": {
+                "name": "ant-primary",
+                "type": "anthropic",
+                "default_model": "claude-3",
+            },
+        }
+        success, error, captured = self._run(tmp_path, config_data)
+        assert success is True, error
+
+        ansible_vars = captured["inventory"]["all"]["vars"]
+        assert ansible_vars["provider_api_key"] == "sk-ant-123"
+        assert ansible_vars["provider_api_keys"] == {}
+        assert ansible_vars["provider_aws_credentials"] == {}

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -3261,9 +3261,17 @@ class TestHermesMultiProviderHydration:
     def _config_data(self) -> dict:
         # `config.provider` reflects the primary (preserved by lifecycle's
         # overlay branch for back-compat). `config.providers` is the new
-        # multi-attachment list the hermes path emits.
+        # multi-attachment list the hermes path emits. ATX iter-1 B6 (#613):
+        # carry `api_server` here too — the live configure path requires it
+        # and the playbook guard enforces it; the test stub previously hid
+        # this dependency.
         return {
             "gateway": {"host": "127.0.0.1", "port": 8642},
+            "api_server": {
+                "enabled": True,
+                "host": "127.0.0.1",
+                "port": 8642,
+            },
             "provider": {
                 "name": "ant-primary",
                 "type": "anthropic",
@@ -3306,7 +3314,13 @@ class TestHermesMultiProviderHydration:
             }
         }
 
-    def _run(self, tmp_path: Path, config_data: dict, agent_type: str = "hermes"):
+    def _run(
+        self,
+        tmp_path: Path,
+        config_data: dict,
+        api_keys: dict[str, str] | None = None,
+        aws_creds: dict[str, tuple[str, str]] | None = None,
+    ):
         key_path = tmp_path / "key"
         key_path.write_text("k")
         playbook = tmp_path / "configure.yaml"
@@ -3321,11 +3335,17 @@ class TestHermesMultiProviderHydration:
             mock.events = []
             return mock
 
-        api_keys = {"ant-primary": "sk-ant-123", "or-aux": "sk-or-456"}
-        aws_creds = {
-            "bd-aux": ("AKIAEXAMPLE", "wJalrEXAMPLE"),
-        }
+        if api_keys is None:
+            api_keys = {"ant-primary": "sk-ant-123", "or-aux": "sk-or-456"}
+        if aws_creds is None:
+            aws_creds = {"bd-aux": ("AKIAEXAMPLE", "wJalrEXAMPLE")}
 
+        # ATX iter-1 W6 (#613): patch at the source module path because
+        # configure_agent does a deferred `from clawrium.core.providers
+        # import ...` — once the import lands in the function scope the
+        # name resolves against the source module, so this is the correct
+        # patch target. If a future refactor hoists the import to module
+        # scope, switch to `clawrium.core.lifecycle.get_provider_api_key`.
         with (
             patch("clawrium.core.lifecycle.get_host", return_value=self._host()),
             patch(
@@ -3351,7 +3371,7 @@ class TestHermesMultiProviderHydration:
             ),
         ):
             success, error = configure_agent(
-                "test-host", agent_type, config_data, agent_name="hermes-test"
+                "test-host", "hermes", config_data, agent_name="hermes-test"
             )
 
         return success, error, captured
@@ -3385,6 +3405,11 @@ class TestHermesMultiProviderHydration:
         # multi-provider dicts and leave the legacy scalar populated.
         config_data = {
             "gateway": {"host": "127.0.0.1", "port": 8642},
+            "api_server": {
+                "enabled": True,
+                "host": "127.0.0.1",
+                "port": 8642,
+            },
             "provider": {
                 "name": "ant-primary",
                 "type": "anthropic",
@@ -3398,3 +3423,233 @@ class TestHermesMultiProviderHydration:
         assert ansible_vars["provider_api_key"] == "sk-ant-123"
         assert ansible_vars["provider_api_keys"] == {}
         assert ansible_vars["provider_aws_credentials"] == {}
+
+    def test_hermes_empty_providers_list_emits_empty_multi_dicts(
+        self, tmp_path: Path
+    ):
+        # ATX iter-1 W4 (#613): `providers: []` satisfies the isinstance
+        # check and enters the loop with zero iterations — a distinct
+        # branch from "key absent". Pin it.
+        config_data = {
+            "gateway": {"host": "127.0.0.1", "port": 8642},
+            "api_server": {
+                "enabled": True,
+                "host": "127.0.0.1",
+                "port": 8642,
+            },
+            "provider": {
+                "name": "ant-primary",
+                "type": "anthropic",
+                "default_model": "claude-3",
+            },
+            "providers": [],
+        }
+        success, error, captured = self._run(tmp_path, config_data)
+        assert success is True, error
+        ansible_vars = captured["inventory"]["all"]["vars"]
+        assert ansible_vars["provider_api_keys"] == {}
+        assert ansible_vars["provider_aws_credentials"] == {}
+
+    def test_hermes_bedrock_primary_back_compat_aws_scalars(self, tmp_path: Path):
+        # ATX iter-1 B4 (#613): a bedrock primary must continue to populate
+        # the legacy `aws_access_key` / `aws_secret_key` scalars (the AC#2
+        # back-compat invariant for canonical-pipeline templates).
+        config_data = {
+            "gateway": {"host": "127.0.0.1", "port": 8642},
+            "api_server": {
+                "enabled": True,
+                "host": "127.0.0.1",
+                "port": 8642,
+            },
+            "provider": {
+                "name": "bd-primary",
+                "type": "bedrock",
+                "default_model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                "region": "us-west-2",
+            },
+            "providers": [
+                {
+                    "name": "bd-primary",
+                    "type": "bedrock",
+                    "default_model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                    "role": "primary",
+                    "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                    "region": "us-west-2",
+                }
+            ],
+        }
+        success, error, captured = self._run(
+            tmp_path,
+            config_data,
+            api_keys={},
+            aws_creds={"bd-primary": ("AKIAPRIMARY", "wJalrPRIMARY")},
+        )
+        assert success is True, error
+        ansible_vars = captured["inventory"]["all"]["vars"]
+        # Legacy scalars populated for back-compat.
+        assert ansible_vars["aws_access_key"] == "AKIAPRIMARY"
+        assert ansible_vars["aws_secret_key"] == "wJalrPRIMARY"
+        # Bedrock primary also flows into the multi-provider dict.
+        assert ansible_vars["provider_aws_credentials"] == {
+            "bd-primary": {
+                "access_key": "AKIAPRIMARY",
+                "secret_key": "wJalrPRIMARY",
+                "region": "us-west-2",
+            }
+        }
+        # No API-key path used.
+        assert ansible_vars["provider_api_key"] == ""
+        assert ansible_vars["provider_api_keys"] == {}
+
+    def test_hermes_invalid_provider_name_skipped_not_fatal(self, tmp_path: Path):
+        # ATX iter-1 B2 (#613): a malformed provider name in `providers`
+        # must be skipped (logged) rather than poisoning ansible_vars
+        # dict keys with section-injection / Jinja-marker payloads.
+        bad_name = "bad\nname[SECTION]"
+        config_data = {
+            "gateway": {"host": "127.0.0.1", "port": 8642},
+            "api_server": {
+                "enabled": True,
+                "host": "127.0.0.1",
+                "port": 8642,
+            },
+            "provider": {
+                "name": "ant-primary",
+                "type": "anthropic",
+                "default_model": "claude-3",
+            },
+            "providers": [
+                {
+                    "name": "ant-primary",
+                    "type": "anthropic",
+                    "default_model": "claude-3",
+                    "role": "primary",
+                    "model": "claude-3",
+                },
+                {
+                    "name": bad_name,
+                    "type": "openrouter",
+                    "default_model": "auto",
+                    "role": "vision",
+                    "model": "auto",
+                },
+            ],
+        }
+        success, error, captured = self._run(
+            tmp_path,
+            config_data,
+            api_keys={"ant-primary": "sk-ant-123", bad_name: "sk-bad-should-not-leak"},
+        )
+        assert success is True, error
+        ansible_vars = captured["inventory"]["all"]["vars"]
+        # Bad name never reaches the dict; good name does.
+        assert bad_name not in ansible_vars["provider_api_keys"]
+        assert ansible_vars["provider_api_keys"] == {"ant-primary": "sk-ant-123"}
+
+
+class TestRegionPropagationThroughConfigureAgent:
+    """ATX iter-1 B1 (#613): the bedrock `region` carried on a
+    `config.providers[i]` overlay must flow into
+    `ansible_vars["provider_aws_credentials"][name]["region"]`. The
+    upstream `_build_overlay` change (lifecycle.py ~1249) lands the
+    region on the overlay; this test pins the downstream propagation
+    so the contract stays honored if either side regresses.
+
+    A full `sync_agent` → `_build_overlay` integration test is deferred:
+    `_build_overlay` is a closure inside `sync_agent` and the surrounding
+    setup (onboarding state machine, provider attachment normalization,
+    Ansible mocking) is disproportionate to the one-line copy under test.
+    See the Callouts section of the PR for the deferred follow-up.
+    """
+
+    def test_bedrock_overlay_region_flows_into_ansible_vars(self, tmp_path: Path):
+        config_data = {
+            "gateway": {"host": "127.0.0.1", "port": 8642},
+            "api_server": {"enabled": True, "host": "127.0.0.1", "port": 8642},
+            "provider": {
+                "name": "bd-primary",
+                "type": "bedrock",
+                "default_model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                "region": "eu-central-1",
+            },
+            "providers": [
+                {
+                    "name": "bd-primary",
+                    "type": "bedrock",
+                    "default_model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                    "role": "primary",
+                    "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                    "region": "eu-central-1",
+                }
+            ],
+        }
+        host = {
+            "hostname": "h",
+            "key_id": "h",
+            "agents": {
+                "hermes-test": {
+                    "type": "hermes",
+                    "agent_name": "hermes-test",
+                    "config": {
+                        "api_server": {
+                            "enabled": True,
+                            "host": "127.0.0.1",
+                            "port": 8642,
+                        }
+                    },
+                }
+            },
+        }
+        key_path = tmp_path / "key"
+        key_path.write_text("k")
+        playbook = tmp_path / "configure.yaml"
+        playbook.write_text("---\n")
+
+        captured = {}
+
+        def fake_run(**kwargs):
+            captured["inventory"] = kwargs["inventory"]
+            mock = MagicMock()
+            mock.status = "successful"
+            mock.events = []
+            return mock
+
+        api_server_secrets = {
+            "HERMES_API_SERVER_KEY": {
+                "key": "HERMES_API_SERVER_KEY",
+                "value": "a" * 64,
+                "created_at": "2026-06-04T00:00:00+00:00",
+                "updated_at": "2026-06-04T00:00:00+00:00",
+                "description": "",
+            }
+        }
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key", return_value=key_path
+            ),
+            patch("clawrium.core.lifecycle.ansible_runner.run", side_effect=fake_run),
+            patch("clawrium.core.lifecycle.update_host", return_value=True),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                return_value=api_server_secrets,
+            ),
+            patch(
+                "clawrium.core.providers.get_provider_aws_credentials",
+                return_value=("AKIAEU", "wJalrEU"),
+            ),
+        ):
+            from clawrium.core.lifecycle import configure_agent as _ca
+
+            success, error = _ca(
+                "h", "hermes", config_data, agent_name="hermes-test"
+            )
+
+        assert success is True, error
+        creds = captured["inventory"]["all"]["vars"]["provider_aws_credentials"]
+        assert creds["bd-primary"]["region"] == "eu-central-1"

--- a/tests/test_hermes_configure.py
+++ b/tests/test_hermes_configure.py
@@ -3547,6 +3547,49 @@ class TestHermesMultiProviderHydration:
         assert ansible_vars["provider_api_keys"] == {"ant-primary": "sk-ant-123"}
 
 
+class TestBuildProviderOverlayRegion:
+    """ATX iter-2 B1' (#613): `_build_provider_overlay` must copy the
+    bedrock `region` from the provider record into the overlay dict.
+    The previous configure_agent-level test only proved the downstream
+    propagation; reverting the iter-1 B1 line in `_build_provider_overlay`
+    would not have failed it. This test exercises the fix site directly.
+    """
+
+    def test_bedrock_region_copied_from_provider_record(self):
+        from clawrium.core.lifecycle import _build_provider_overlay
+
+        record = {
+            "name": "bd-aux",
+            "type": "bedrock",
+            "endpoint": "",
+            "default_model": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "region": "eu-central-1",
+        }
+        with patch(
+            "clawrium.core.providers.storage.get_provider", return_value=record
+        ):
+            overlay = _build_provider_overlay("bd-aux")
+        assert overlay["region"] == "eu-central-1"
+
+    def test_missing_region_field_omitted_from_overlay(self):
+        # Non-bedrock providers (or bedrock records pre-region) must not
+        # leak a spurious `region` key — downstream templates default the
+        # field, and an empty-string key would mask the default.
+        from clawrium.core.lifecycle import _build_provider_overlay
+
+        record = {
+            "name": "ant",
+            "type": "anthropic",
+            "endpoint": "",
+            "default_model": "claude-3",
+        }
+        with patch(
+            "clawrium.core.providers.storage.get_provider", return_value=record
+        ):
+            overlay = _build_provider_overlay("ant")
+        assert "region" not in overlay
+
+
 class TestRegionPropagationThroughConfigureAgent:
     """ATX iter-1 B1 (#613): the bedrock `region` carried on a
     `config.providers[i]` overlay must flow into


### PR DESCRIPTION
## Summary

Subtask 2 of 4 for parent #589. Hydrates per-attachment provider credentials into `ansible_vars` for hermes so subtask 3's template work can render `auxiliary.<slot>` blocks with real keys.

- `configure_agent` now emits two new ansible_vars when the resolved agent type supports multi-provider (hermes) and `config_data["providers"]` is present:
  - `provider_api_keys: dict[str, str]` — API keys for non-bedrock attachments, keyed by provider name (two attachments of the same type stay distinct).
  - `provider_aws_credentials: dict[str, {access_key, secret_key, region}]` — AWS creds for bedrock attachments, keyed by provider name.
- Legacy singleton `provider_api_key` / `aws_access_key` / `aws_secret_key` continue to reflect the primary attachment so canonical-pipeline templates that haven't migrated keep rendering.
- `_build_provider_overlay` extracted to module scope so the per-field copy contract (including the new bedrock `region` propagation) is directly unit-testable.
- TODO marker at `lifecycle.py:1488-1494` removed; subtask 3 (#614) is unblocked.

Stacked on top of `issue-612-cli-role-flag` (#616).

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — 3881 passed
- [x] Linter passes (`make lint`) — ruff + ESLint clean
- [x] New tests added for new functionality

### Test Coverage
- `tests/test_hermes_configure.py` — `TestHermesMultiProviderHydration` (4 cases) + `TestBuildProviderOverlayRegion` (4 cases) + `TestRegionPropagationThroughConfigureAgent` (1 case)
- `tests/cli/clawctl/agent/test_sync_hermes_multi_provider.py` — primary `default_model` override + no-override fallback (2 cases)

### Manual Testing
Not performed — verification against a real hermes host is gated on subtask 3 (#614) actually consuming the new vars in templates.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — `validate_provider_name` guard in per-attachment hydration; YAML scalar injection on bedrock `region` closed via `yaml_quote` macro
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources

## ATX Review Summary

**Final Review: Rating 3/5 — all named blockers + warnings resolved past the iteration ceiling**
**Total Cost: $9.80 | Total Time: ~28m**

| Review | Rating | Blocking Issues | Status | Cost | Time |
|--------|--------|-----------------|--------|------|------|
| 1 | 2/5 | B1, B2, B3, B4, B5, B6 | B3 Callout; rest fixed in aafa69c | $3.13 | 8m30s |
| 2 | 3/5 | B1' | Fixed in 68da338 | $3.76 | 10m6s |
| 3 | 3/5 | B1 (+4 W-new) | All fixed in 48f6bb7 (no iter-4 ATX run) | $2.91 | ~9m |

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

| # | Status | Issue |
|---|--------|-------|
| B1 | Fixed | `_build_provider_overlay` propagates `region` from provider record |
| B2 | Fixed | `validate_provider_name` guard in per-attachment hydration loop |
| B3 | Out-of-scope (Callout) | Direct zeroclaw `configure_agent` regression requires pairing-state mocks unrelated to #613 |
| B4 | Fixed | Bedrock-primary back-compat AWS scalars now pinned by test |
| B5 | Fixed | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` added to hermes manifest `secrets.optional` |
| B6 | Fixed | Test `_config_data()` carries `api_server` explicitly |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

| # | Status | Issue |
|---|--------|-------|
| B1' | Fixed | `_build_provider_overlay` extracted to module level; direct unit tests |
| W1 | Fixed | `yaml_quote` on bedrock region scalar in `hermes-config.yaml.j2` |
| W2 | Fixed | Primary's `default_model` reflects per-attachment `--model` override |
| W3 | Acknowledged (Callout) | Manifest `secrets.optional` AWS entries are display-only |
| W4 | Acknowledged (Callout) | `_build_provider_overlay` already raises `LifecycleError` on missing record |
| W5 | Fixed | `%r` on `validate_provider_name` warning |

</details>

<details>
<summary>Review 3 Details (Rating 3/5)</summary>

| # | Status | Issue |
|---|--------|-------|
| B1 | Fixed | New `sync_agent` tests pin primary `default_model` override + no-override fallback |
| W-new-1 | Fixed | `_build_provider_overlay` LifecycleError path covered by new unit test |
| W-new-2 | Fixed | Truthy guard on region (empty-string falls back to template default) + test |
| W-new-3 | Fixed | Closure shim removed; `_build_provider_overlay` called directly |
| W-new-4 | Fixed | Guard switched to `entry.get("model")` so no-override path is a true no-op |

Iter-4 ATX run was not started — every named iter-3 issue is addressed in commit 48f6bb7 and the iteration ceiling is 3.

</details>

## Callouts

- [DECISION] **B3 (iter-1): direct zeroclaw/openclaw regression test deferred.**
  - Why: The multi-provider hydration block is gated on `_pa.supports_multi_provider(resolved_type)`; non-hermes agents cannot reach the new code at runtime. A direct `configure_agent("zeroclaw", ...)` unit test requires mocking the pairing-state handshake, which is orthogonal to #613. The existing 3881-test suite against the singleton path covers the behavior we care about.
  - Reviewer: confirm or push back.

- [DECISION] **W3 (iter-2): manifest AWS entries are display-only.**
  - Why: `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` surface in `clawctl registry describe` so operators see them; actual credential storage flows through `clawctl provider set-aws-credentials`. Tightening the description text is a follow-up on the manifest schema.

- [DECISION] **W4 (iter-2): `validate_provider_name` not added to `sync_agent` pre-`_build_provider_overlay`.**
  - Why: `_build_provider_overlay` already raises `LifecycleError` on an unregistered name. The configure-time guard is the relevant injection surface for ansible_vars; layering at sync_agent would be additive defense-in-depth, not a correctness fix.

- [ENVIRONMENT] ATX iter-3 returned 1 blocker (B1: missing W2 test coverage) + 4 warnings. All named issues are resolved in commit 48f6bb7 without a 4th ATX iteration (skill ceiling = 3). Final ATX rating on record is 3/5; the iter-3 specialist notes confirmed B1', W1, W3-W5 clean.

- [TODO-FOLLOWUP] Subtask 3 (#614) templates iterate `provider_api_keys` and `provider_aws_credentials` to render `auxiliary.<slot>` blocks. Until that lands, the new ansible_vars are populated but unread.
  - Tracking: #614 (parent #589).

- [TODO-FOLLOWUP] Pre-existing `model_id` quoting gap in `hermes-config.yaml.j2` (6 lines without `yaml_quote`) flagged by ATX iter-3 as out of scope for #613. Worth a separate follow-up issue.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
