### PR TITLE
docs(hermes): document multi-provider attachments (--role, 9 aux slots)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,3 +84,15 @@ release.
   to dev-only fails CI. (#620)
 
 ### Documentation
+
+- Documented the hermes multi-provider attachment model in the
+  Hermes Support Matrix (`docs/agent-support/hermes.md` and its
+  website mirror): the 1 `primary` + 9 auxiliary slot enumeration,
+  the `clawctl agent provider attach --role <role>` workflow, the
+  per-slot single-provider invariant, the primary-detached-last
+  invariant, and the rendered `auxiliary.<role>:` shape. The macOS
+  install walkthrough (`docs/installation.md` + website mirror)
+  now shows `--role` in the `provider attach` example and links to
+  the new section. Closes documentation drift identified after
+  #612 / #621 / #622 landed multi-provider support in the CLI
+  without updating user-facing docs.

--- a/docs/agent-support/hermes.md
+++ b/docs/agent-support/hermes.md
@@ -60,7 +60,7 @@ Hermes supports three channels managed by clawctl: a loopback OpenAI-compatible 
 | Feature | Status | Notes |
 |---------|:------:|-------|
 | **Local API server** | ✅ | `API_SERVER_ENABLED=1` + `API_SERVER_KEY` in `~/.hermes/.env`, bound to `127.0.0.1:8642` |
-| **Multi-provider** | ✅ | openrouter, anthropic, openai, ollama / custom |
+| **Multi-provider** | ✅ | Up to **10 attachments per agent**: 1 `primary` slot + 9 upstream auxiliary slots (`vision`, `web_extract`, `compression`, `session_search`, `skills_hub`, `approval`, `mcp`, `title_generation`, `curator`). One provider per slot. See [Multi-provider attachments](#multi-provider-attachments). |
 | **Memory (Markdown backend)** | ✅ | Two-file model: `MEMORY.md` (≤ 2200 chars), `USER.md` (≤ 1375 chars). See [memory.md](memory.md). |
 | **Pluggable memory backends** (Holographic / Honcho / Hindsight / Mem0 / Byterover / OpenViking) | 📋 | Deferred. clawctl's `memory` CLI sees only the default markdown backend in this iteration. |
 | **Secrets management** | ✅ | `HERMES_API_SERVER_KEY` persisted in `~/.config/clawrium/secrets.json` (NOT `hosts.json`) under the canonical instance key `<key_id>:hermes:<agent-name>` (single-colon, 3 components). `key_id` is the immutable host identifier set when the host was first registered via `clawctl host create`. It does not change when the host's `hostname` is updated (issue #448). `secrets.json` is chmod 0600 on creation. Per-agent secrets are isolated by instance key. |
@@ -149,6 +149,68 @@ Hermes deep-merges `config.yaml` with its built-in defaults at load time, so onl
 | `bedrock` | `bedrock` | (omitted; hermes uses boto3 credential chain) | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + `AWS_DEFAULT_REGION` |
 
 After `.env` write, the restart handler enables and starts the systemd unit. The configure playbook probes `http://127.0.0.1:8642/health` with `retries: 20, delay: 3` (≈60s max). `/health` is unauthenticated; `/v1/*` requires the bearer header.
+
+### Multi-provider attachments
+
+Hermes is the only agent type in clawrium that accepts more than one provider attachment. Each hermes agent supports **up to 10 attachments**:
+
+| Slot | Role | Purpose |
+|------|------|---------|
+| 1 | `primary` | The main inference model. Required — the first attachment on a hermes agent **must** use `--role primary`. |
+| 2 | `vision` | Image / multimodal input handling. |
+| 3 | `web_extract` | Extracting structured content from fetched web pages. |
+| 4 | `compression` | Summarising / compressing long context windows. |
+| 5 | `session_search` | Semantic search across past sessions. |
+| 6 | `skills_hub` | Skill discovery and routing. |
+| 7 | `approval` | Action / tool-call approval gating. |
+| 8 | `mcp` | MCP server routing. |
+| 9 | `title_generation` | Generating session / transcript titles. |
+| 10 | `curator` | Memory curation / pruning. |
+
+The slot list comes from upstream `NousResearch/hermes-agent` (`hermes_cli/config.py`) and is mirrored in `src/clawrium/core/provider_attachments.py:AUXILIARY_SLOTS`. `zeroclaw`, `openclaw`, and `nemoclaw` reject `--role` and continue to enforce the single-provider invariant.
+
+#### Attach a primary and an auxiliary
+
+```bash
+# 1. Register the providers (one-time, fleet-wide)
+clawctl provider registry create my-openrouter --type openrouter --api-key <...>
+clawctl provider registry create my-anthropic-haiku --type anthropic --api-key <...>
+
+# 2. Attach them to the agent with explicit roles
+clawctl agent provider attach my-openrouter      --agent <agent-name> --role primary
+clawctl agent provider attach my-anthropic-haiku --agent <agent-name> --role title_generation
+
+# 3. Materialise on the agent host
+clawctl agent sync <agent-name>
+```
+
+#### Invariants
+
+- **`--role` is required on hermes.** Omitting it returns: _"agent '<name>' is a hermes agent; --role is required"_.
+- **One provider per slot.** Re-attaching a different provider to a slot that is already filled is rejected; detach the existing one first.
+- **Primary is required and detached last.** `clawctl agent provider detach <primary-name>` refuses to remove the primary attachment while any auxiliary attachments remain — detach the auxiliaries first. An agent with zero attachments fails to render (`agent '<name>' has no provider attached`).
+- **Same-type collisions fail loudly.** Two attachments of the same provider type (e.g. two `bedrock` slots) with mismatched credentials are rejected at render time rather than silently overwriting the `.env`.
+
+#### Rendered output for multi-provider
+
+With two attachments on an openrouter primary, `~/.hermes/config.yaml` renders as:
+
+```yaml
+model:
+  provider: "openrouter"
+  base_url: "https://openrouter.ai/api/v1"
+  default: "<primary-model>"
+auxiliary:
+  title_generation:
+    provider: "anthropic"
+    model: "claude-haiku-4-5-20251001"
+```
+
+`~/.hermes/.env` carries the bearer key for every cloud-provider attachment (the AWS triple for bedrock). The `ollama` / `custom` provider type does not emit an auxiliary block by itself — local primary models are not paired with a remote aux pin by default; explicit auxiliary attachments are still honoured.
+
+When no auxiliary is attached, the renderer falls back to the upstream per-primary-type default for `title_generation` (e.g. `anthropic/claude-haiku-4.5` for openrouter primaries). The fallback is hermes' own behaviour, not a clawctl invention.
+
+`clawctl agent provider get <agent-name>` renders the `role` and `model` columns for hermes; the legacy flat output is preserved for single-provider agent types.
 
 ### 3. Use the local OpenAI-compatible API
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -186,11 +186,18 @@ macOS user (`/Users/<agent_name>/`), and runs the upstream installer:
 Configure, start, chat — same commands as Linux:
 
 ```bash
-clawctl agent provider attach <provider> --agent <name>
+# On hermes, --role is required (use `primary` for the first attachment;
+# auxiliary slots: vision, web_extract, compression, session_search,
+# skills_hub, approval, mcp, title_generation, curator). On openclaw,
+# omit --role — only one provider per agent is permitted.
+clawctl agent provider attach <provider> --agent <name> [--role primary]
 clawctl agent configure <name> --stage providers --provider <provider>
 clawctl agent start <name>
 clawctl agent chat <name>
 ```
+
+For the full hermes multi-provider model (1 primary + up to 9 auxiliary
+slots), see [Hermes Support Matrix → Multi-provider attachments](agent-support/hermes.md#multi-provider-attachments).
 
 ### Lifecycle differences
 

--- a/website/docs/agent-support/hermes.md
+++ b/website/docs/agent-support/hermes.md
@@ -60,7 +60,7 @@ Hermes supports three channels managed by clawctl: a loopback OpenAI-compatible 
 | Feature | Status | Notes |
 |---------|:------:|-------|
 | **Local API server** | ✅ | `API_SERVER_ENABLED=1` + `API_SERVER_KEY` in `~/.hermes/.env`, bound to `127.0.0.1:8642` |
-| **Multi-provider** | ✅ | openrouter, anthropic, openai, ollama / custom |
+| **Multi-provider** | ✅ | Up to **10 attachments per agent**: 1 `primary` slot + 9 upstream auxiliary slots (`vision`, `web_extract`, `compression`, `session_search`, `skills_hub`, `approval`, `mcp`, `title_generation`, `curator`). One provider per slot. See [Multi-provider attachments](#multi-provider-attachments). |
 | **Memory (Markdown backend)** | ✅ | Two-file model: `MEMORY.md` (≤ 2200 chars), `USER.md` (≤ 1375 chars). See [Memory model on GitHub](https://github.com/ric03uec/clawrium/blob/main/docs/agent-support/memory.md). |
 | **Pluggable memory backends** (Holographic / Honcho / Hindsight / Mem0 / Byterover / OpenViking) | 📋 | Deferred. clawctl's `memory` CLI sees only the default markdown backend in this iteration. |
 | **Secrets management** | ✅ | `HERMES_API_SERVER_KEY` persisted in `~/.config/clawrium/secrets.json` (NOT `hosts.json`) under the canonical instance key `<host>:hermes:<agent-name>` (single-colon, 3 components). `secrets.json` is chmod 0600 on creation. Per-agent secrets are isolated by instance key. |
@@ -149,6 +149,68 @@ Hermes deep-merges `config.yaml` with its built-in defaults at load time, so onl
 | `bedrock` | `bedrock` | (omitted; hermes uses boto3 credential chain) | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + `AWS_DEFAULT_REGION` |
 
 After `.env` write, the restart handler enables and starts the systemd unit. The configure playbook probes `http://127.0.0.1:8642/health` with `retries: 20, delay: 3` (≈60s max). `/health` is unauthenticated; `/v1/*` requires the bearer header.
+
+### Multi-provider attachments
+
+Hermes is the only agent type in clawrium that accepts more than one provider attachment. Each hermes agent supports **up to 10 attachments**:
+
+| Slot | Role | Purpose |
+|------|------|---------|
+| 1 | `primary` | The main inference model. Required — the first attachment on a hermes agent **must** use `--role primary`. |
+| 2 | `vision` | Image / multimodal input handling. |
+| 3 | `web_extract` | Extracting structured content from fetched web pages. |
+| 4 | `compression` | Summarising / compressing long context windows. |
+| 5 | `session_search` | Semantic search across past sessions. |
+| 6 | `skills_hub` | Skill discovery and routing. |
+| 7 | `approval` | Action / tool-call approval gating. |
+| 8 | `mcp` | MCP server routing. |
+| 9 | `title_generation` | Generating session / transcript titles. |
+| 10 | `curator` | Memory curation / pruning. |
+
+The slot list comes from upstream `NousResearch/hermes-agent` (`hermes_cli/config.py`) and is mirrored in `src/clawrium/core/provider_attachments.py:AUXILIARY_SLOTS`. `zeroclaw`, `openclaw`, and `nemoclaw` reject `--role` and continue to enforce the single-provider invariant.
+
+#### Attach a primary and an auxiliary
+
+```bash
+# 1. Register the providers (one-time, fleet-wide)
+clawctl provider registry create my-openrouter --type openrouter --api-key <...>
+clawctl provider registry create my-anthropic-haiku --type anthropic --api-key <...>
+
+# 2. Attach them to the agent with explicit roles
+clawctl agent provider attach my-openrouter      --agent <agent-name> --role primary
+clawctl agent provider attach my-anthropic-haiku --agent <agent-name> --role title_generation
+
+# 3. Materialise on the agent host
+clawctl agent sync <agent-name>
+```
+
+#### Invariants
+
+- **`--role` is required on hermes.** Omitting it returns: _"agent '<name>' is a hermes agent; --role is required"_.
+- **One provider per slot.** Re-attaching a different provider to a slot that is already filled is rejected; detach the existing one first.
+- **Primary is required and detached last.** `clawctl agent provider detach <primary-name>` refuses to remove the primary attachment while any auxiliary attachments remain — detach the auxiliaries first. An agent with zero attachments fails to render (`agent '<name>' has no provider attached`).
+- **Same-type collisions fail loudly.** Two attachments of the same provider type (e.g. two `bedrock` slots) with mismatched credentials are rejected at render time rather than silently overwriting the `.env`.
+
+#### Rendered output for multi-provider
+
+With two attachments on an openrouter primary, `~/.hermes/config.yaml` renders as:
+
+```yaml
+model:
+  provider: "openrouter"
+  base_url: "https://openrouter.ai/api/v1"
+  default: "<primary-model>"
+auxiliary:
+  title_generation:
+    provider: "anthropic"
+    model: "claude-haiku-4-5-20251001"
+```
+
+`~/.hermes/.env` carries the bearer key for every cloud-provider attachment (the AWS triple for bedrock). The `ollama` / `custom` provider type does not emit an auxiliary block by itself — local primary models are not paired with a remote aux pin by default; explicit auxiliary attachments are still honoured.
+
+When no auxiliary is attached, the renderer falls back to the upstream per-primary-type default for `title_generation` (e.g. `anthropic/claude-haiku-4.5` for openrouter primaries). The fallback is hermes' own behaviour, not a clawctl invention.
+
+`clawctl agent provider get <agent-name>` renders the `role` and `model` columns for hermes; the legacy flat output is preserved for single-provider agent types.
 
 ### 3. Use the local OpenAI-compatible API
 

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -194,11 +194,18 @@ macOS user (`/Users/<agent_name>/`), and runs the upstream installer:
 Configure, start, chat — same commands as Linux:
 
 ```bash
-clawctl agent provider attach <provider> --agent <name>
+# On hermes, --role is required (use `primary` for the first attachment;
+# auxiliary slots: vision, web_extract, compression, session_search,
+# skills_hub, approval, mcp, title_generation, curator). On openclaw,
+# omit --role — only one provider per agent is permitted.
+clawctl agent provider attach <provider> --agent <name> [--role primary]
 clawctl agent configure <name> --stage providers --provider <provider>
 clawctl agent start <name>
 clawctl agent chat <name>
 ```
+
+For the full hermes multi-provider model (1 primary + up to 9 auxiliary
+slots), see [Hermes Support Matrix → Multi-provider attachments](agent-support/hermes.md#multi-provider-attachments).
 
 ### Lifecycle differences
 


### PR DESCRIPTION
## Summary

- Documents the hermes multi-provider attachment model that landed via #612, #621, and #622 but was never reflected in user-facing docs.
- Adds a new "Multi-provider attachments" section to the Hermes Support Matrix that enumerates the 1 `primary` + 9 upstream auxiliary slots (`vision`, `web_extract`, `compression`, `session_search`, `skills_hub`, `approval`, `mcp`, `title_generation`, `curator`), the `clawctl agent provider attach --role` workflow, the per-slot single-provider invariant, the primary-detached-last invariant, and the rendered `auxiliary.<role>:` shape.
- Updates the macOS install walkthrough to show `--role` in the `provider attach` example and cross-link the new section.
- Logs the change under `### Documentation` in the unreleased `CHANGELOG.md`.

Docs-only PR — no source code touched.

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — N/A, no code changed
- [x] Linter passes (`make lint`) — N/A, docs-only
- [x] New tests added for new functionality — N/A, docs-only

### Test Coverage
- Files changed: `CHANGELOG.md`, `docs/agent-support/hermes.md`, `docs/installation.md`, `website/docs/agent-support/hermes.md`, `website/docs/installation.md`
- New tests: N/A (docs-only)
- Coverage impact: unchanged

### Manual Testing
- Verified the new `#multi-provider-attachments` anchor matches GitHub / Docusaurus slug derivation from the H3 heading.
- Verified `diff docs/installation.md website/docs/installation.md` shows only the Docusaurus frontmatter + mirror-warning HTML comment as the delta (per the AGENTS.md mirror rule).
- Cross-checked the slot enumeration against `src/clawrium/core/provider_attachments.py:AUXILIARY_SLOTS` (lines 39–49).
- Cross-checked the rendered `auxiliary.<role>:` block against `src/clawrium/platform/registry/hermes/templates/hermes-config.canonical.yaml.j2`.
- Cross-checked the CLI invariants (`--role` required on hermes, rejected on others; primary-detached-last; same-type collisions) against `src/clawrium/cli/clawctl/agent/provider.py` and `src/clawrium/core/render.py`.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — N/A
- [x] No SQL injection, XSS, or command injection risks — N/A
- [x] Dependencies are from trusted sources — N/A

## Reviewer Notes

The error strings in `docs/operations/sync.md:46-47,91` were intentionally left untouched — they are verbatim quotes of the CLI error emitted from `src/clawrium/core/render.py:289-290`, which does **not** mention `--role` (the generic message covers all agent types; the `--role required` follow-up surfaces only after attach, not at render time).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)