### PR TITLE
docs(itx): rewrite #411 plan end-to-end (per-agent + user-overlay, clawctl)

### DIFF
--- a/.itx/411/00_PLAN.md
+++ b/.itx/411/00_PLAN.md
@@ -2,182 +2,212 @@
 
 **Issue**: https://github.com/ric03uec/clawrium/issues/411
 **Complexity**: M
-**Status**: planned (this file supersedes the prior planning draft in
-this directory; see git history for the earlier vetted/local model that
-was discarded in favor of the current per-agent + user-registry-overlay
-design)
+**Status**: planned
 
 ## Overview
 
-Users today can only install skills onto an agent by referencing the bundled
-in-repo catalog (`clm agent skill attach clawrium/tdd --agent <name>`). This
-plan adds two new capabilities while keeping the catalog as-is:
+Today a user can only install a skill onto a clawrium-managed agent by
+referencing the bundled in-repo catalog
+(`clawctl agent skill attach clawrium/tdd --agent <name>`). This plan
+adds two new capabilities while leaving the existing bundled catalog
+exactly as it is on `main`:
 
-1. **Per-agent ad-hoc skills.** A user can add a skill to a specific agent
-   from any of three sources — interactively, from a local file, or from a
-   local directory — and edit it afterwards. The skill is copied into the
-   agent's own config directory and becomes part of the agent.
-2. **Registry-level `clm skill add`.** A user can author a new skill and
-   publish it to the skill registry, picking which agent type (registry
-   namespace) it applies to. This is a separate command with no agent
-   context.
+1. **Per-agent ad-hoc skills.** A user can add a skill to a specific
+   agent from any of three sources — interactively, from a local file,
+   or from a local directory — and edit it afterwards. The skill is
+   copied into the agent's own config directory and becomes part of
+   that agent.
+2. **Registry-level `clawctl skill add`.** A user can author a new
+   skill and publish it to a user-owned registry overlay, picking
+   which registry namespace (`clawrium` / `hermes` / `openclaw` /
+   `zeroclaw`) it applies to. This is a separate command with no
+   agent context.
 
-The bundled `skills/` catalog stops being a live reference for on-agent
-installs. It becomes a **template source**: when an agent skill is added
-from a template, the bytes are copied into the agent's local skill dir,
-and from that point on the agent's copy is the source of truth and is
-fully editable.
+The bundled `skills/` catalog stops being a live reference for
+on-agent installs. It becomes a **template source**: when an agent
+skill is added from a template, the bytes are copied into the agent's
+local skill directory, and from that point the agent's copy is the
+source of truth and is fully editable.
+
+The four bundled registries (`clawrium/`, `hermes/`, `openclaw/`,
+`zeroclaw/`) and the `_schema/` directory under `skills/` stay
+exactly as they are on `main`. No restructuring.
 
 ## Conceptual model
 
 | Concept | Where it lives | Mutable by user? |
 |---|---|---|
 | Bundled registry skill (seed catalog) | repo `skills/<registry>/<name>/` (also bundled into the wheel as `clawrium/_skills/`) | No (read-only) |
-| User registry skill (added via `clm skill add`) | `~/.config/clawrium/skills/<registry>/<name>/` | Yes |
-| Per-agent local skill (added via `clm agent skill add`) | `~/.config/clawrium/agents/<agent>/skills/<name>/` | Yes |
+| User registry overlay skill (added via `clawctl skill add`) | `~/.config/clawrium/skills/<registry>/<name>/` | Yes |
+| Per-agent local skill (added via `clawctl agent skill add`) | `~/.config/clawrium/agents/<agent>/skills/<name>/` | Yes |
 
-Decision locked in this plan: `clm skill add` writes to the **user
-registry overlay** at `~/.config/clawrium/skills/<registry>/<name>/`. The
-bundled `skills/` directory stays read-only because installed wheels
-cannot be written to. Listing/loading code unions bundled + overlay;
-overlay wins on name collision (with a warning).
+`<registry>` is one of `clawrium`, `hermes`, `openclaw`, `zeroclaw` —
+the existing four-registry namespace. The user overlay is just a
+second, writeable root that mirrors the bundled tree's shape.
+Listing/loading code unions bundled + overlay; on a name collision
+the overlay wins and a warning is logged.
+
+Per-agent local skills live under the agent's own config directory.
+They are not addressable by a `<registry>/<name>` ref because the
+namespace is implicit — they belong to exactly one agent. State
+file entries are bare names.
 
 Stage / flush model: every command in this plan only mutates local
-state. The single host-side flush is the existing `clm agent sync
-<name>` command, which already calls `apply_state`.
+state. The single host-side flush is the existing
+`clawctl agent sync <name>` command, which already calls
+`apply_state`. There is no new skill-specific sync verb.
 
 ## CLI surface (Option 1 — agent as required positional)
 
-New / changed commands under `clm agent skill`:
+New commands under `clawctl agent skill`:
 
 ```
-clm agent skill add    <agent-name> [PATH | --from-template <registry>/<name>]
-clm agent skill edit   <agent-name> <skill-name>
-clm agent skill list   <agent-name>
-clm agent skill remove <agent-name> <skill-name>
+clawctl agent skill add    <agent-name> [PATH | --from-template <registry>/<name>]
+clawctl agent skill edit   <agent-name> <skill-name>
+clawctl agent skill list   <agent-name>
+clawctl agent skill remove <agent-name> <skill-name>
 ```
 
 The existing `attach` / `detach` verbs are **removed** and folded into
 `add` / `remove`:
 
-- `attach <ref>` becomes `add <agent> --from-template <ref>` — bytes are
-  copied, not referenced.
-- `detach <ref>` becomes `remove <agent> <skill-name>`.
+- `attach <ref>` becomes `add <agent> --from-template <ref>` — bytes
+  are copied from the bundled (or overlay) catalog into the agent's
+  local directory.
+- `detach <ref>` becomes `remove <agent> <skill-name>` — drops the
+  entry from the agent's `skills.json` and deletes the local dir.
 
 The existing `--agent` flag is removed from every command in the
-`clm agent skill` sub-app. Agent name becomes a required positional
-everywhere, matching `clm agent configure <name>` and `clm agent sync <name>`.
+`clawctl agent skill` sub-app. Agent name becomes a required
+positional everywhere, matching `clawctl agent configure <name>` and
+`clawctl agent sync <name>`.
 
-New top-level command:
+New top-level command (no agent context):
 
 ```
-clm skill add [PATH | --interactive] \
-              [--registry clawrium|openclaw|hermes|zeroclaw] \
-              [--name <slug>]
+clawctl skill add [PATH | --interactive] \
+                  [--registry clawrium|hermes|openclaw|zeroclaw] \
+                  [--name <slug>]
 ```
 
 Writes to `~/.config/clawrium/skills/<registry>/<name>/`. Prompts for
-registry namespace if not supplied. Validates frontmatter / `_meta.yaml`
-against the existing `skills/_schema/` definitions.
+the registry namespace if not supplied. Validates frontmatter /
+`_meta.yaml` against the existing per-registry schemas under
+`skills/_schema/`.
 
 ## Files to modify
 
 ### Core
 - `src/clawrium/core/skills.py`
-  - Extend `_catalog_root()` / `list_skills()` / `load_skill()` to union
-    bundled catalog + user overlay (`~/.config/clawrium/skills/`).
-  - Treat per-agent local skills as a separate axis; add
-    `load_agent_skill(agent, name)` and `list_agent_skills(agent)`.
-  - Per-agent local skills are universally compatible unless their
-    authored `_meta.yaml.compatibility` says otherwise.
+  - Extend `_catalog_root()` to return a list of roots: bundled plus
+    user overlay (`~/.config/clawrium/skills/`).
+  - Update `list_skills()` / `load_skill()` to union both roots;
+    overlay wins on `<registry>/<name>` collision and emits a
+    warning log.
+  - Add `load_agent_skill(agent, name)` and `list_agent_skills(agent)`
+    reading from `~/.config/clawrium/agents/<agent>/skills/<name>/`.
+  - Per-agent local skills validate as `clawrium`-flavored
+    (universally compatible) unless their `_meta.yaml.compatibility`
+    overrides.
 - `src/clawrium/core/skills_state.py`
   - Add `agent_skills_root(agent)` helper next to `state_file_path`.
-  - State file shape unchanged — still a list of skill identifiers. For
-    per-agent ad-hoc skills, identifier is the bare skill name (no
-    registry prefix), since the namespace is implicitly `agent-local`.
+  - State file shape unchanged. Per-agent ad-hoc skill entries are
+    bare names (no `<registry>/` prefix); the namespace is implicit.
 - `src/clawrium/core/skills_apply.py`
-  - On apply, ship per-agent local skill bytes from
-    `~/.config/clawrium/agents/<agent>/skills/<name>/` instead of the
-    bundled catalog.
-  - Registry-overlay skills go through the same code path as bundled
-    skills once they exist on disk — the catalog union handles it.
+  - On apply, stage all skills (bundled, overlay, agent-local) into a
+    temporary mirror dir that matches the existing catalog shape,
+    then invoke the existing playbook against the temp dir. Keeps
+    the playbook source-agnostic.
 
 ### CLI
 - `src/clawrium/cli/agent_skill.py`
   - Remove `attach` / `detach` verbs and the `--agent` flag.
   - Add `add` / `edit` / `list` / `remove` with agent as required
     positional.
-  - `add` rollback: if writing the local dir succeeds but state mutation
-    fails, delete the freshly-written dir. Symmetric to the existing
-    preflight → mutate → apply pattern.
+  - `add` input modes: `--from-template <registry>/<name>`,
+    positional `PATH` (file or directory), interactive prompt.
+  - `add` rollback: if state mutation fails after the local dir is
+    written, delete the dir before returning the error. Symmetric
+    to the existing preflight → mutate → apply pattern.
+  - `edit` opens `$EDITOR` on the local `SKILL.md`.
+  - `remove` drops the state entry and deletes the local dir.
 - `src/clawrium/cli/skill.py`
-  - Add top-level `add` command. Prompts (or accepts as flags) for
-    registry namespace and name. Validates against schema before writing.
+  - Add top-level `add` command writing to
+    `~/.config/clawrium/skills/<registry>/<name>/`. Accepts a
+    positional `PATH` (file or dir) or runs an interactive prompt.
+    Requires `--registry <clawrium|hermes|openclaw|zeroclaw>` (or
+    prompts). Validates against the existing per-registry schemas
+    before writing.
 
 ### GUI
-- `src/clawrium/gui/routes/skills.py` + `gui/routes/agents.py`
+- `src/clawrium/gui/routes/skills.py` + `src/clawrium/gui/routes/agents.py`
   - Per-agent payload tags each skill with `origin: "local" | "<registry>"`.
-  - New POST endpoints for agent-skill `add` / `edit` / `remove`.
-  - New POST endpoint for registry `add` (top-level).
+  - New `POST /api/agents/{agent}/skills` for `add`.
+  - New `PUT /api/agents/{agent}/skills/{name}` for `edit`.
+  - New `DELETE /api/agents/{agent}/skills/{name}` for `remove`.
+  - New `POST /api/skills` for the top-level user-overlay `add`.
 - `src/clawrium/gui/frontend/...`
-  - Local-skills section in the per-agent view with Add / Edit / Remove
-    controls mirroring the CLI.
-  - "Add Skill" modal: three input modes (template picker, file upload,
-    raw editor).
-  - Registry browser gains an "Add to registry" entry point that maps
-    to the top-level `clm skill add` semantics.
+  - Local-skills section in the per-agent view with Add / Edit /
+    Remove controls mirroring the CLI.
+  - Add Skill modal: three input modes (template picker, file upload,
+    raw editor). Template picker pulls from `list_skills()` so users
+    can pick bundled + overlay.
+  - Registry browser gains an "Add to registry" entry point that
+    maps to the top-level `clawctl skill add` semantics.
+  - Reuse the existing whole-agent Sync control to flush; no
+    skill-specific sync button.
 
 ### Docs
-- `README.md` — replace `clawctl agent skill attach clawrium/tdd --agent
-  <agent-name>` example with `clm agent skill add <agent-name>
-  --from-template clawrium/tdd`. Add a one-liner for the new top-level
-  `clm skill add`.
+- `README.md` — replace the
+  `clawctl agent skill attach clawrium/tdd --agent <agent-name>`
+  example with `clawctl agent skill add <agent-name> --from-template clawrium/tdd`.
+  Add a one-liner for the new top-level `clawctl skill add`.
 - `AGENTS.md` — update the "Skill Registry" Key Concepts section to
-  describe copy-on-add semantics and the user-overlay path. Update CLI
-  examples.
-- `CONTRIBUTING.md` — if it references skill workflow, update to new
-  grammar.
-- `docs/skills.md` — canonical skill guide. Sections:
+  describe copy-on-add semantics and the user-overlay path. Update
+  CLI examples.
+- `CONTRIBUTING.md` — sweep for `--agent` references; update.
+- `docs/skills.md` (new or updated) — canonical skill guide:
   - Mental model: bundled vs user overlay vs agent-local
   - Three ways to add a skill to an agent
   - Editing an on-agent skill
-  - Adding a skill to the registry with `clm skill add`
-  - Flushing changes via `clm agent sync <agent>`
+  - Adding a skill to the registry with `clawctl skill add`
+  - Flushing changes via `clawctl agent sync <agent>`
 - `website/docs/skills.md` — verbatim mirror of `docs/skills.md` with
   Docusaurus frontmatter + mirror-warning HTML comment at top.
 - `CHANGELOG.md` under `[Unreleased]`:
-  - `### Added` — `clm agent skill add/edit/list/remove`, `clm skill add`,
-    GUI "Add Skill" flow.
-  - `### BREAKING` — `clm agent skill attach/detach` and the `--agent`
-    flag are removed. Concrete before/after invocations. Note that
-    existing `skills.json` state files remain readable; only invocations
-    change.
+  - `### Added` — `clawctl agent skill add/edit/list/remove`,
+    `clawctl skill add`, GUI Add Skill flow.
+  - `### BREAKING` — `clawctl agent skill attach/detach` and the
+    `--agent` flag are removed. Concrete before/after invocations.
+    `skills.json` state files on disk remain readable; only
+    invocations change.
 
 ## Test strategy
 
 - **Unit (core)**: catalog union (bundled + overlay), `load_agent_skill`,
   `list_agent_skills`, collision rejection, overlay-wins behavior,
-  apply-state routing for per-agent bytes, rollback on add failure.
+  apply-state routing for per-agent bytes, rollback on `add` failure.
 - **CLI (Typer `CliRunner`)**: each `add` input mode against a tmp
-  `~/.config/clawrium/`; `edit` opens editor and rewrites file; `remove`
-  removes from state and keeps the local dir; `list` shows the
-  expected origin tags; `clm skill add` writes to the overlay and shows
-  up in subsequent `clm skill list` calls.
-- **GUI**: per-agent route shape with `origin` tag; POST endpoints
-  round-trip; rejects malformed payloads.
-- **Real host**: add a local skill, run `clm agent sync <agent>`, verify
-  it lands on the agent host alongside registry skills. Verify edit ->
-  sync propagates changes. Verify remove -> sync removes from host but
-  keeps the local dir.
+  `~/.config/clawrium/`; `edit` opens editor and rewrites file;
+  `remove` drops state and deletes the local dir; `list` shows the
+  expected origin tags; `clawctl skill add` writes to the overlay
+  and shows up in subsequent `clawctl skill list` calls.
+- **GUI**: per-agent route shape with `origin` tag; new POST/PUT/
+  DELETE endpoints round-trip; rejects malformed payloads.
+- **Real host**: add a local skill, run `clawctl agent sync <agent>`,
+  verify it lands on the agent host alongside bundled-template skills.
+  Verify `edit` → `sync` propagates changes. Verify `remove` → `sync`
+  removes from host.
 
 ## Subtasks
 
 - **A. Core + apply** — catalog union, per-agent loader, apply-state
-  routing, schema reuse, rollback. Unit tests.
-- **B. CLI** — `clm agent skill add/edit/list/remove` (with breaking
-  removal of `attach/detach/--agent`), `clm skill add` top-level command,
-  docs updates (README, AGENTS.md, docs/skills.md, website mirror,
-  CHANGELOG `[Unreleased]` `### Added` + `### BREAKING`).
+  routing, unit tests. Hard prereq for B and C.
+- **B. CLI** — `clawctl agent skill add/edit/list/remove` (with
+  breaking removal of `attach/detach/--agent`), `clawctl skill add`
+  top-level command, docs updates (README, AGENTS.md, docs/skills.md,
+  website mirror, CHANGELOG `[Unreleased]` `### Added` +
+  `### BREAKING`).
 - **C. GUI** — backend routes for agent-skill add/edit/remove and
   registry add; frontend local-skills section, Add Skill modal,
   Edit/Remove controls.
@@ -187,29 +217,28 @@ once A is merged.
 
 ## Deferred (separate issues)
 
-- **Promote / clone** an agent-local skill back into the registry
-  (`clm skill add --from-agent <agent>/<name>`-style).
+- **Promote / clone** an agent-local skill back into the overlay
+  registry (`clawctl skill add --from-agent <agent>/<name>`-style).
 - **AI-assisted skill authoring** (Claude Code slash command or
-  `clm skill draft --prompt`).
+  `clawctl skill draft --prompt`).
 - **Multiple named user registries** (per-team, etc.).
 
 ## Risks / known unknowns
 
 - **Apply playbook source path.** The current playbook in
-  `skills_apply.py` assumes a single catalog root. Per-agent dirs and the
-  user overlay need to be wired in without making the playbook
-  source-aware. Likely approach: stage all skills for the agent into a
-  temporary mirror dir that matches the bundled catalog shape, then
-  invoke the playbook against the temp dir. Pinned down in Subtask A.
+  `skills_apply.py` reads from a single catalog root. Per-agent dirs
+  and the user overlay need to be wired in without making the
+  playbook source-aware. The plan stages all sources into a
+  temporary mirror dir matching the bundled catalog shape. Pin
+  down in Subtask A.
 - **Name collisions across origins.** `clawrium/tdd` (bundled),
-  `clawrium/tdd` (user overlay), and `tdd` (agent-local) can all
-  coexist. State file only contains the agent-local list; the UI must
-  show origin clearly so users don't think one shadows another.
-- **`skills.json` schema.** Today entries look like `clawrium/tdd`. For
-  per-agent ad-hoc skills, do we use the bare name (`tdd`) or a
-  reserved namespace (`local/tdd`)? Default in this plan: bare name,
-  because the namespace is implicit and the state file is already
-  per-agent. Subtask A locks this in.
+  `clawrium/tdd` (overlay), and `tdd` (agent-local on a specific
+  agent) can all coexist. State file only contains the agent-local
+  list; the UI must show origin clearly so users don't think one
+  shadows another.
+- **`skills.json` shape for agent-local entries.** Plan defaults to
+  bare names (`tdd`) rather than a reserved namespace (`local/tdd`).
+  Locked in Subtask A's exit criteria.
 
 ---
 
@@ -220,13 +249,13 @@ once A is merged.
 
 **Stage**: planning
 **Skill**: /itx-plan-create
-**Timestamp**: 2026-06-07T06:15:24Z
+**Timestamp**: 2026-06-07T17:43:41Z
 **Model**: claude-opus-4-7
 
 ```prompt
-411 ask me any clarifying questions. dont create any files, just plan first.
+ive closed the pr now. redo the plan end to end
 ```
 
-**Output**: `.itx/411/00_PLAN.md` and `.itx/411/01_SCAFFOLD.md` capturing per-agent ad-hoc skills, copy-on-add semantics from registry templates, agent-as-positional CLI grammar (Option 1), new top-level `clm skill add` writing to a user overlay, stage-then-`clm agent sync` flush model, GUI scope, docs deliverables, three subtasks (A core+apply / B CLI / C GUI), and deferred follow-ups.
+**Output**: `.itx/411/00_PLAN.md` and `.itx/411/01_SCAFFOLD.md` rewritten from scratch after PR #634 (wrong-model implementation) was closed. Per-agent local skills + user registry overlay + bundled `skills/<registry>/` unchanged. `clawctl` throughout. Three subtasks (A core+apply / B CLI / C GUI).
 
 </details>

--- a/.itx/411/00_PLAN.md
+++ b/.itx/411/00_PLAN.md
@@ -6,239 +6,465 @@
 
 ## Overview
 
-Today a user can only install a skill onto a clawrium-managed agent by
-referencing the bundled in-repo catalog
-(`clawctl agent skill attach clawrium/tdd --agent <name>`). This plan
-adds two new capabilities while leaving the existing bundled catalog
-exactly as it is on `main`:
+Today the only way to add a skill to a clawrium-managed agent is to
+reference the bundled in-repo catalog under `skills/<registry>/<name>/`
+via `clawctl agent skill attach`. This plan adds two new write paths
+while leaving the bundled catalog exactly as it is on `main`:
 
-1. **Per-agent ad-hoc skills.** A user can add a skill to a specific
-   agent from any of three sources — interactively, from a local file,
-   or from a local directory — and edit it afterwards. The skill is
-   copied into the agent's own config directory and becomes part of
-   that agent.
-2. **Registry-level `clawctl skill add`.** A user can author a new
-   skill and publish it to a user-owned registry overlay, picking
-   which registry namespace (`clawrium` / `hermes` / `openclaw` /
-   `zeroclaw`) it applies to. This is a separate command with no
-   agent context.
+1. **Per-agent local skills.** A user can add a skill to a specific
+   agent — interactively, from a local file, from a local directory,
+   or by copying from the bundled (or user-overlay) catalog. The skill
+   is copied into the agent's own clawrium config directory, and from
+   that point that copy is the source of truth and is fully editable.
+2. **User registry overlay.** A user can publish a new skill into a
+   user-owned overlay that mirrors the four bundled registries
+   (`clawrium` / `hermes` / `openclaw` / `zeroclaw`). The overlay is a
+   second writable root that appears alongside the bundled catalog in
+   `list_skills`/`load_skill`.
 
-The bundled `skills/` catalog stops being a live reference for
-on-agent installs. It becomes a **template source**: when an agent
-skill is added from a template, the bytes are copied into the agent's
-local skill directory, and from that point the agent's copy is the
-source of truth and is fully editable.
+The bundled `skills/` tree stops being the only on-agent source.
+When an agent skill is added from a template, the bytes are copied
+into the agent's local skill directory; that copy is then independent.
 
 The four bundled registries (`clawrium/`, `hermes/`, `openclaw/`,
-`zeroclaw/`) and the `_schema/` directory under `skills/` stay
-exactly as they are on `main`. No restructuring.
+`zeroclaw/`) and `_schema/` under `skills/` stay exactly as they are
+on `main`. No restructuring.
+
+This plan targets the `clawctl` CLI surface only. The legacy `clm`
+CLI (`src/clawrium/cli/skill.py`, `src/clawrium/cli/agent_skill.py`)
+is **out of scope** and is left untouched.
 
 ## Conceptual model
 
 | Concept | Where it lives | Mutable by user? |
 |---|---|---|
-| Bundled registry skill (seed catalog) | repo `skills/<registry>/<name>/` (also bundled into the wheel as `clawrium/_skills/`) | No (read-only) |
-| User registry overlay skill (added via `clawctl skill add`) | `~/.config/clawrium/skills/<registry>/<name>/` | Yes |
-| Per-agent local skill (added via `clawctl agent skill add`) | `~/.config/clawrium/agents/<agent>/skills/<name>/` | Yes |
+| Bundled registry skill | repo `skills/<registry>/<name>/`; bundled into the wheel as `clawrium/_skills/<registry>/<name>/` (see `core/skills.py:_catalog_root`) | No (read-only) |
+| User registry overlay skill (`clawctl skill add`) | `~/.config/clawrium/skills/<registry>/<name>/` | Yes |
+| Per-agent local skill (`clawctl agent skill add`) | `~/.config/clawrium/agents/<agent>/skills/<name>/` | Yes |
 
-`<registry>` is one of `clawrium`, `hermes`, `openclaw`, `zeroclaw` —
-the existing four-registry namespace. The user overlay is just a
-second, writeable root that mirrors the bundled tree's shape.
-Listing/loading code unions bundled + overlay; on a name collision
-the overlay wins and a warning is logged.
+`<registry>` is one of `clawrium`, `hermes`, `openclaw`, `zeroclaw`
+(the existing four-registry namespace; see `core/skills.py:REGISTRIES`).
+The user overlay is a second writeable root with the same shape as
+the bundled tree.
 
 Per-agent local skills live under the agent's own config directory.
 They are not addressable by a `<registry>/<name>` ref because the
-namespace is implicit — they belong to exactly one agent. State
-file entries are bare names.
+namespace is implicit — they belong to exactly one agent. State file
+entries are bare names only (no `/` separator). A registry skill is
+only a template source during `clawctl agent skill add`; after the
+copy, the per-agent skill has no lifecycle connection to the registry
+entry. Optional source metadata is informational only.
 
-Stage / flush model: every command in this plan only mutates local
-state. The single host-side flush is the existing
-`clawctl agent sync <name>` command, which already calls
-`apply_state`. There is no new skill-specific sync verb.
+**Materialization boundary (locked):** `clawctl agent skill add` is
+the only place that converts a template or user-provided skill into
+the target agent's native skill format. `clawctl agent sync <agent>`
+does not transform skill formats; it applies the already-materialized
+per-agent `SKILL.md` files as-is according to that agent type's host
+conventions.
 
-## CLI surface (Option 1 — agent as required positional)
+The `skills/_schema/` schemas (bundled only, never overlaid) gate all
+sources. `_schema/clawrium.schema.json` validates normalized template
+sources. `_schema/native/<claw>.schema.json` validates native overlay
+sources and every per-agent local skill after add-time materialization.
 
-New commands under `clawctl agent skill`:
+Stage / flush model: add/edit/remove commands only mutate local
+control-plane state. The single host-side flush is the existing
+`clawctl agent sync <name>` command (which calls `apply_state`).
+There is no new skill-specific sync verb. Sync copies/prunes the
+already-agent-native local skill files; it does not re-render them.
+
+## Supported Agent Format Plan
+
+Research source of truth:
+
+| Agent type | Existing schema | Host convention | Add-time plan | Sync-time plan |
+|---|---|---|---|---|
+| `hermes` | `skills/_schema/native/hermes.schema.json`; native `SKILL.md` frontmatter requires `name` + `description`, allows extra metadata | Playbook installs to `/home/<agent>/.hermes/skills/clawrium/<name>/SKILL.md` | Resolve target agent type, load template/input, materialize to hermes-native `SKILL.md`, validate against hermes schema, write `~/.config/clawrium/agents/<agent>/skills/<name>/SKILL.md` | Copy that exact local `SKILL.md` into staging unchanged; playbook installs it under hermes' `clawrium` skill category |
+| `openclaw` | `skills/_schema/native/openclaw.schema.json`; native `SKILL.md` frontmatter requires `name` + `description` | Playbook installs to `/home/<agent>/.openclaw/skills/<name>/SKILL.md` | Materialize/validate to openclaw-native `SKILL.md` at add time, then store only the native local file | Copy staged local bytes unchanged; playbook syncs into openclaw skill dir |
+| `zeroclaw` | `skills/_schema/native/zeroclaw.schema.json`; native `SKILL.md` frontmatter requires `name` + `description` | Playbook stages `<name>/SKILL.md` and invokes `zeroclaw skills install` | Materialize/validate to zeroclaw-native `SKILL.md` at add time, then store only the native local file | Copy staged local dir unchanged; playbook runs zeroclaw's installer against the staged native skill dir |
+
+Unsupported agent types fail before add because Clawrium cannot know
+which native format to persist.
+
+## CLI surface
+
+Active surface — `src/clawrium/cli/clawctl/agent/skill.py`:
 
 ```
-clawctl agent skill add    <agent-name> [PATH | --from-template <registry>/<name>]
-clawctl agent skill edit   <agent-name> <skill-name>
-clawctl agent skill list   <agent-name>
-clawctl agent skill remove <agent-name> <skill-name>
+clawctl agent skill list   <agent>
+clawctl agent skill add    <agent> [PATH | --from-template <registry>/<name>] [--name <slug>]
+clawctl agent skill edit   <agent> <skill-name>
+clawctl agent skill remove <agent> <skill-name>
 ```
 
-The existing `attach` / `detach` verbs are **removed** and folded into
-`add` / `remove`:
+The existing verbs in that file are **removed** as a BREAKING change:
 
-- `attach <ref>` becomes `add <agent> --from-template <ref>` — bytes
-  are copied from the bundled (or overlay) catalog into the agent's
-  local directory.
-- `detach <ref>` becomes `remove <agent> <skill-name>` — drops the
-  entry from the agent's `skills.json` and deletes the local dir.
+| Old | New |
+|---|---|
+| `clawctl agent skill attach <ref> --agent <a>` | `clawctl agent skill add <a> --from-template <ref>` |
+| `clawctl agent skill detach <ref> --agent <a>` | `clawctl agent skill remove <a> <skill-name>` |
+| `clawctl agent skill get --agent <a>` | `clawctl agent skill list <a>` |
 
-The existing `--agent` flag is removed from every command in the
-`clawctl agent skill` sub-app. Agent name becomes a required
-positional everywhere, matching `clawctl agent configure <name>` and
-`clawctl agent sync <name>`.
+Agent name becomes a required positional everywhere, matching
+`clawctl agent configure <name>` / `clawctl agent sync <name>`. The
+`--agent` flag is removed.
 
-New top-level command (no agent context):
+New top-level command — `src/clawrium/cli/clawctl/skill.py`:
 
 ```
 clawctl skill add [PATH | --interactive] \
-                  [--registry clawrium|hermes|openclaw|zeroclaw] \
+                  --registry <clawrium|hermes|openclaw|zeroclaw> \
                   [--name <slug>]
 ```
 
-Writes to `~/.config/clawrium/skills/<registry>/<name>/`. Prompts for
-the registry namespace if not supplied. Validates frontmatter /
-`_meta.yaml` against the existing per-registry schemas under
-`skills/_schema/`.
+Writes to `~/.config/clawrium/skills/<registry>/<name>/`. Validates
+against the per-registry schema before writing. There is no `--force`;
+if an overlay skill already exists at that registry/name, the user must
+remove or rename it first. Existing `clawctl skill registry get` /
+`describe` verbs are extended to include overlay entries (they share
+`list_skills`/`load_skill` below).
+
+`clawctl skill list` (in `cli/clawctl/skill.py` if present, else
+introduced) unions bundled + overlay and tags origin.
 
 ## Files to modify
 
 ### Core
 - `src/clawrium/core/skills.py`
-  - Extend `_catalog_root()` to return a list of roots: bundled plus
-    user overlay (`~/.config/clawrium/skills/`).
-  - Update `list_skills()` / `load_skill()` to union both roots;
-    overlay wins on `<registry>/<name>` collision and emits a
-    warning log.
-  - Add `load_agent_skill(agent, name)` and `list_agent_skills(agent)`
-    reading from `~/.config/clawrium/agents/<agent>/skills/<name>/`.
-  - Per-agent local skills validate as `clawrium`-flavored
-    (universally compatible) unless their `_meta.yaml.compatibility`
-    overrides.
+  - Add `_overlay_root() -> Path` returning
+    `${XDG_CONFIG_HOME:-~/.config}/clawrium/skills/`.
+  - Add `_catalog_roots() -> list[tuple[str, Path]]` returning
+    `[("bundled", bundled), ("overlay", overlay)]`, where `overlay`
+    is only included if it `is_dir()`.
+  - Keep `_catalog_root() -> Path` (bundled only) — used by
+    `_load_schema` and `_bare_name_hint`. **Do not change its
+    signature.** Adding a sibling helper is cheaper than fanning out
+    a return-type change through every existing caller.
+  - Rewrite `list_skills` to iterate `_catalog_roots()` and dedupe
+    on `<registry>/<name>`. Overlay wins on collision; emit a
+    `logger.warning` once per collision per process.
+  - Rewrite `load_skill` to try overlay first, then bundled.
+  - Add `load_agent_skill(agent: str, name: str, agent_type: str) -> Skill`
+    and `list_agent_skills(agent: str) -> list[str]`, reading from
+    `~/.config/clawrium/agents/<agent>/skills/<name>/`. Agent-local
+    skills are already materialized for the target `agent_type`, so
+    they validate against `_schema/native/<agent_type>.schema.json`.
+    The returned `Skill.ref.registry` should be the concrete agent type
+    (`hermes`, `openclaw`, or `zeroclaw`), not a synthetic `local`
+    registry, so existing native schema validation can be reused.
+  - Add `materialize_skill_for_agent(skill: Skill, agent_type: str) -> tuple[dict, str]`
+    only if needed as a public wrapper around the current
+    `materialize_for_claw` logic. The important invariant is call-site
+    placement: CLI/GUI add paths call it before persisting the
+    per-agent skill; sync/apply does not call it.
+  - `parse_skill_ref` is **unchanged**. Bare names continue to raise
+    `MissingRegistryPrefix`. Agent-local lookups go through the new
+    `load_agent_skill(agent, name, agent_type)` API; they never flow through
+    `parse_skill_ref`.
+
 - `src/clawrium/core/skills_state.py`
-  - Add `agent_skills_root(agent)` helper next to `state_file_path`.
-  - State file shape unchanged. Per-agent ad-hoc skill entries are
-    bare names (no `<registry>/` prefix); the namespace is implicit.
+  - Add `agent_skills_dir(agent: str) -> Path` returning
+    `~/.config/clawrium/agents/<agent>/skills/` (the on-disk dir for
+    per-agent skill bytes — distinct from the existing
+    `state_file_path` which points at `skills.json`).
+  - `skills.json` shape stays a flat list of strings, but the
+    semantics change. **Decision (locked here, not deferred):** every
+    entry is a per-agent local skill name (e.g. `"tdd"`). Registry refs
+    (`"clawrium/tdd"`) are not valid desired state after this change.
+    Document this in the file's module docstring.
+  - `read_state` / `write_state` / `add_skill` / `remove_skill`
+    validate names with the existing slug regex and reject any value
+    containing `/`.
+  - Add an explicit migration or one-time error strategy for old
+    `skills.json` files containing registry refs. Preferred behavior:
+    `clawctl agent skill add <agent> --from-template clawrium/tdd`
+    creates the local `skills/tdd/` copy and writes `"tdd"`; old refs
+    are rejected with a clear message telling the operator to re-add
+    from template. Do not silently infer/copy templates during sync.
+
 - `src/clawrium/core/skills_apply.py`
-  - On apply, stage all skills (bundled, overlay, agent-local) into a
-    temporary mirror dir that matches the existing catalog shape,
-    then invoke the existing playbook against the temp dir. Keeps
-    the playbook source-agnostic.
+  - Change `apply_state` to load only per-agent local skills listed as
+    bare names in `skills.json`. It no longer parses registry refs and
+    no longer loads bundled/overlay catalog skills.
+  - `_stage_skills` still produces `<staging>/<name>/SKILL.md`, but it
+    must copy the already-materialized local `SKILL.md` bytes as-is.
+    Remove the `materialize_for_claw(skill, agent_type)` call from the
+    sync/apply path.
+  - The playbook surface needs **no change**: it already receives a
+    staging dir containing one `<name>/SKILL.md` per desired skill and
+    `desired_skill_names` as bare names.
 
 ### CLI
-- `src/clawrium/cli/agent_skill.py`
-  - Remove `attach` / `detach` verbs and the `--agent` flag.
-  - Add `add` / `edit` / `list` / `remove` with agent as required
-    positional.
-  - `add` input modes: `--from-template <registry>/<name>`,
-    positional `PATH` (file or directory), interactive prompt.
-  - `add` rollback: if state mutation fails after the local dir is
-    written, delete the dir before returning the error. Symmetric
-    to the existing preflight → mutate → apply pattern.
-  - `edit` opens `$EDITOR` on the local `SKILL.md`.
-  - `remove` drops the state entry and deletes the local dir.
-- `src/clawrium/cli/skill.py`
-  - Add top-level `add` command writing to
+- `src/clawrium/cli/clawctl/agent/skill.py` (REPLACE existing verbs)
+  - Remove `attach`, `detach`, `get`, and the `--agent` option from
+    all of them.
+  - Add `list`, `add`, `edit`, `remove`. Agent name is a required
+    positional first arg in every verb.
+  - `add` input modes (mutually exclusive):
+    1. `--from-template <registry>/<name>` — copy bytes from
+       bundled-or-overlay catalog, materialized for the target
+       agent's type, into the agent's local dir.
+    2. Positional `PATH` — file (a single `SKILL.md`) or directory
+       (a full skill tree). Validate the input shape, materialize it
+       for the target agent type if it is a normalized `clawrium`
+       shape, then persist the target-agent-native `SKILL.md` into the
+       agent's local dir.
+    3. No path and no template — open `$EDITOR` (or `EDITOR` env
+       var; fall back to `vi`) on a stub `SKILL.md` in the target
+       agent's native format, then persist on save.
+  - `add` resolves the target agent first to determine `agent_type`.
+    It validates the input and the final materialized `SKILL.md`
+    against `_schema/native/<agent_type>.schema.json` before touching
+    `skills.json`. On failure: nothing is written.
+  - `add` has no `--force`. If `skills/<name>/` already exists or
+    `skills.json` already contains `<name>`, fail with a clear message:
+    remove or rename the existing skill first.
+  - `add` rollback: if `skills_state.add_skill` fails after the
+    local dir is written, delete the dir before returning the
+    error. Symmetric to the existing preflight → mutate → apply
+    pattern in `attach` (line 86–130 of the current file).
+  - `add` does NOT call `apply_state`. The CLI exits after the
+    state file is mutated. Use `clawctl agent sync <agent>` to
+    flush. (Same model as `clawctl agent configure`/`sync`.)
+  - `edit` opens `$EDITOR` on the already-agent-native local
+    `SKILL.md`; re-validates against the agent's native schema on
+    save; rejects schema-invalid writes (restoring the prior bytes in
+    place). It does not run normalized-to-native materialization.
+  - `remove` accepts only a bare local name; drops the matching
+    `skills.json` entry and deletes the local dir.
+
+- `src/clawrium/cli/clawctl/skill.py` (ADD top-level command)
+  - New `add` command writing to
     `~/.config/clawrium/skills/<registry>/<name>/`. Accepts a
-    positional `PATH` (file or dir) or runs an interactive prompt.
-    Requires `--registry <clawrium|hermes|openclaw|zeroclaw>` (or
-    prompts). Validates against the existing per-registry schemas
-    before writing.
+    positional `PATH` (file or dir) or `--interactive` to launch
+    `$EDITOR`. Requires `--registry <clawrium|hermes|openclaw|zeroclaw>`
+    (or prompts in interactive mode).
+  - Validates against the existing per-registry schemas before
+    writing (`validate_skill` after loading the staged copy).
+  - Existing `skill_app.add_typer(skill_registry_app, name="registry")`
+    wiring is unchanged. `add` is mounted directly on `skill_app`,
+    not under `registry`, mirroring the issue's "add to local
+    registry" framing.
+  - `skill_registry_app.get` / `describe` automatically include
+    overlay entries via the changed `list_skills` / `load_skill`.
 
 ### GUI
-- `src/clawrium/gui/routes/skills.py` + `src/clawrium/gui/routes/agents.py`
-  - Per-agent payload tags each skill with `origin: "local" | "<registry>"`.
-  - New `POST /api/agents/{agent}/skills` for `add`.
-  - New `PUT /api/agents/{agent}/skills/{name}` for `edit`.
-  - New `DELETE /api/agents/{agent}/skills/{name}` for `remove`.
-  - New `POST /api/skills` for the top-level user-overlay `add`.
+- `src/clawrium/gui/routes/agents.py` (per-agent endpoints already
+  live here at lines 401/530/543; this file owns per-agent skill
+  routes — NOT `routes/skills.py`)
+  - Extend `GET /{agent_key}/skills` to show local installed skills
+    from `skills.json` / `skills/<name>/`, plus catalog templates the
+    user can add from. Installed entries are always agent-local.
+  - The existing `POST /{agent_key}/skills/{registry}/{skill}` may be
+    retained as a compatibility route for template add, but it must
+    copy/materialize into the agent-local dir and write only the bare
+    name to `skills.json`. It must not persist `<registry>/<name>`.
+    The matching DELETE route should be deprecated or changed to local
+    bare-name removal; registry refs are not installed state anymore.
+  - **New** `POST /{agent_key}/skills` (no registry/skill path
+    segments) — body carries an `input_mode` of `template`, `file`,
+    or `inline` and the corresponding payload. Writes a per-agent
+    local skill.
+  - **New** `PUT /{agent_key}/skills/local/{name}` — replace the
+    body of a per-agent local skill. Validate the final body against
+    the agent's native schema; do not run normalized materialization
+    during edit.
+  - **New** `DELETE /{agent_key}/skills/local/{name}` — delete a
+    per-agent local skill.
+
+- `src/clawrium/gui/routes/skills.py` (catalog/read-only routes)
+  - `GET /api/skills` continues to enumerate the catalog; the
+    underlying `list_skills` change above means overlay entries
+    appear automatically.
+  - **New** `POST /api/skills` — add to user overlay. Accepts JSON
+    `{registry, name, body, meta}` or multipart for a file upload.
+
 - `src/clawrium/gui/frontend/...`
-  - Local-skills section in the per-agent view with Add / Edit /
-    Remove controls mirroring the CLI.
-  - Add Skill modal: three input modes (template picker, file upload,
-    raw editor). Template picker pulls from `list_skills()` so users
-    can pick bundled + overlay.
-  - Registry browser gains an "Add to registry" entry point that
-    maps to the top-level `clawctl skill add` semantics.
-  - Reuse the existing whole-agent Sync control to flush; no
+  - Per-agent view gains a "Local skills" section showing each
+    entry with an origin chip, plus Edit and Remove controls.
+  - "Add Skill" modal with three tabs (Template / File / Inline).
+    Template tab pulls from `list_skills()` so users see bundled +
+    overlay together.
+  - Registry browser gains an "Add skill" entry point that calls
+    `POST /api/skills`.
+  - Reuse the existing whole-agent Sync control to flush. No
     skill-specific sync button.
 
 ### Docs
-- `README.md` — replace the
-  `clawctl agent skill attach clawrium/tdd --agent <agent-name>`
-  example with `clawctl agent skill add <agent-name> --from-template clawrium/tdd`.
-  Add a one-liner for the new top-level `clawctl skill add`.
-- `AGENTS.md` — update the "Skill Registry" Key Concepts section to
-  describe copy-on-add semantics and the user-overlay path. Update
-  CLI examples.
+- `docs/skills/index.md` — replace the existing
+  `clawctl agent skill attach <agent> clawrium/tdd` example with
+  the new grammar. Update troubleshooting examples on lines
+  148/182/191/195/198 of the current file.
+- `docs/skills/authoring-clawrium.md` — update the
+  `attach <openclaw/hermes/zeroclaw-agent>` examples at lines
+  136–138.
+- `docs/skills/local.md` (NEW) — canonical guide for per-agent
+  local skills and the user overlay:
+  - Mental model: bundled vs overlay vs agent-local (the table
+    from this plan's "Conceptual model").
+  - Three input modes for `clawctl agent skill add`.
+  - Editing an on-agent skill via `clawctl agent skill edit`.
+  - Adding a skill to the user overlay via `clawctl skill add`.
+  - Flushing changes via `clawctl agent sync <agent>`.
+- `website/docs/skills/local.md` (NEW) — verbatim mirror of
+  `docs/skills/local.md` with Docusaurus frontmatter +
+  mirror-warning HTML comment at top. The existing
+  `website/docs/skills/` mirrors keep the same per-file pattern.
+- `README.md` — replace the `clawctl agent skill attach
+  clawrium/tdd --agent <agent-name>` example (line 50 of
+  `AGENTS.md`, mirrored briefly in README) with the new grammar.
+- `AGENTS.md` — update the "Skill Registry" Key Concepts section
+  (line ~50) to describe copy-on-add semantics and the user-overlay
+  path.
 - `CONTRIBUTING.md` — sweep for `--agent` references; update.
-- `docs/skills.md` (new or updated) — canonical skill guide:
-  - Mental model: bundled vs user overlay vs agent-local
-  - Three ways to add a skill to an agent
-  - Editing an on-agent skill
-  - Adding a skill to the registry with `clawctl skill add`
-  - Flushing changes via `clawctl agent sync <agent>`
-- `website/docs/skills.md` — verbatim mirror of `docs/skills.md` with
-  Docusaurus frontmatter + mirror-warning HTML comment at top.
-- `CHANGELOG.md` under `[Unreleased]`:
+- `CHANGELOG.md` `[Unreleased]`:
   - `### Added` — `clawctl agent skill add/edit/list/remove`,
     `clawctl skill add`, GUI Add Skill flow.
-  - `### BREAKING` — `clawctl agent skill attach/detach` and the
-    `--agent` flag are removed. Concrete before/after invocations.
-    `skills.json` state files on disk remain readable; only
-    invocations change.
+  - `### BREAKING` — `clawctl agent skill attach/detach/get`
+    removed; `--agent` flag removed across `clawctl agent skill`.
+    Include concrete before/after invocations in the entry body.
+    Note that old `skills.json` entries containing registry refs such
+    as `"clawrium/tdd"` are no longer valid desired state; operators
+    must re-add those skills from template so Clawrium creates the
+    per-agent native local copy.
 
 ## Test strategy
 
-- **Unit (core)**: catalog union (bundled + overlay), `load_agent_skill`,
-  `list_agent_skills`, collision rejection, overlay-wins behavior,
-  apply-state routing for per-agent bytes, rollback on `add` failure.
-- **CLI (Typer `CliRunner`)**: each `add` input mode against a tmp
-  `~/.config/clawrium/`; `edit` opens editor and rewrites file;
-  `remove` drops state and deletes the local dir; `list` shows the
-  expected origin tags; `clawctl skill add` writes to the overlay
-  and shows up in subsequent `clawctl skill list` calls.
-- **GUI**: per-agent route shape with `origin` tag; new POST/PUT/
-  DELETE endpoints round-trip; rejects malformed payloads.
-- **Real host**: add a local skill, run `clawctl agent sync <agent>`,
-  verify it lands on the agent host alongside bundled-template skills.
-  Verify `edit` → `sync` propagates changes. Verify `remove` → `sync`
-  removes from host.
+- **Unit (core)**
+  - `_catalog_roots()` returns just bundled when overlay dir
+    absent; returns both when present.
+  - `list_skills` unions both roots; overlay wins on
+    `<registry>/<name>` collision and emits one warning.
+  - `load_skill` prefers overlay over bundled when both exist.
+  - `load_agent_skill(agent, name, agent_type)` returns a native
+    `Skill` for `hermes`, `openclaw`, and `zeroclaw`; raises
+    `SkillNotFound` for missing; raises `SchemaValidationError` for
+    malformed native `SKILL.md` frontmatter.
+  - `list_agent_skills` returns sorted bare names; empty list if
+    dir absent.
+  - `skills_state` rejects any desired-state entry containing `/` and
+    accepts only safe bare names.
+  - `apply_state` stages only agent-local bare-name entries and copies
+    their already-materialized `SKILL.md` bytes unchanged.
+
+- **Per-agent format research locked into tests**
+  - `hermes`: add from `clawrium/tdd` materializes to native
+    `SKILL.md` frontmatter accepted by
+    `skills/_schema/native/hermes.schema.json` and stores it under
+    `~/.config/clawrium/agents/<agent>/skills/tdd/SKILL.md`. Sync
+    stages that exact file unchanged for the hermes playbook, which
+    installs to `~/.hermes/skills/clawrium/tdd/SKILL.md`.
+  - `openclaw`: add from `clawrium/tdd` materializes to native
+    `SKILL.md` frontmatter accepted by
+    `skills/_schema/native/openclaw.schema.json` and stores it under
+    the same control-plane local path. Sync stages that exact file
+    unchanged for installation to `~/.openclaw/skills/tdd/SKILL.md`.
+  - `zeroclaw`: add from `clawrium/tdd` materializes to native
+    `SKILL.md` frontmatter accepted by
+    `skills/_schema/native/zeroclaw.schema.json`. Sync stages that
+    exact `<name>/SKILL.md` dir unchanged; the playbook invokes
+    `zeroclaw skills install` on that staged dir.
+  - For each supported agent type, tests must assert add-time
+    materialization and sync-time non-mutation by comparing the local
+    `SKILL.md` bytes with the staged bytes.
+
+- **CLI (Typer `CliRunner`, tmp `$XDG_CONFIG_HOME`)**
+  - `clawctl agent skill add <a> --from-template clawrium/tdd`
+    materializes for the resolved agent type; state file gains bare
+    entry `"tdd"`; rerun fails because duplicate names are not
+    allowed.
+  - `clawctl agent skill add <a> ./mydir/` copies dir; validates;
+    rollback on schema failure leaves nothing behind.
+  - `clawctl agent skill add <a>` (no path) launches
+    `$EDITOR=true` (test stub) and persists the stub bytes.
+  - `clawctl agent skill edit <a> <name>` round-trips; rejects
+    invalid edits and restores prior bytes.
+  - `clawctl agent skill remove <a> <name>` drops state and
+    deletes dir. `remove <a> clawrium/tdd` is rejected because
+    installed skills are addressed by bare per-agent names only.
+  - `clawctl skill add ./mydir/ --registry clawrium` writes to
+    overlay; subsequent `clawctl skill registry get` shows it.
+  - Removed verbs (`attach`/`detach`/`get`) exit non-zero with a
+    clear "removed in vNN.N — use `…` instead" message. (Typer
+    natively reports "no such command" — augment with a hint via
+    a `no_args_is_help` + custom error.)
+
+- **GUI**
+  - `GET /api/agents/{agent}/skills` returns origin tags.
+  - `POST /api/agents/{agent}/skills` (no path segments) accepts
+    each of the three input modes; rejects schema-invalid bodies
+    with 422.
+  - `PUT /api/agents/{agent}/skills/local/{name}` round-trips.
+  - `DELETE /api/agents/{agent}/skills/local/{name}` removes
+    state + dir.
+  - `POST /api/skills` writes overlay; appears in subsequent
+    `GET /api/skills`.
+
+- **Real host (mac-test)**
+  - Add a per-agent local skill via `--from-template`, run
+    `clawctl agent sync <agent>`, verify the file lands on host
+    in the target agent's native location and format.
+  - Edit the local skill, sync, verify host content changes.
+  - Remove the local skill, sync, verify host removes it.
 
 ## Subtasks
 
-- **A. Core + apply** — catalog union, per-agent loader, apply-state
-  routing, unit tests. Hard prereq for B and C.
-- **B. CLI** — `clawctl agent skill add/edit/list/remove` (with
-  breaking removal of `attach/detach/--agent`), `clawctl skill add`
-  top-level command, docs updates (README, AGENTS.md, docs/skills.md,
-  website mirror, CHANGELOG `[Unreleased]` `### Added` +
-  `### BREAKING`).
-- **C. GUI** — backend routes for agent-skill add/edit/remove and
-  registry add; frontend local-skills section, Add Skill modal,
-  Edit/Remove controls.
+- **A. Core helpers + format validation** — catalog overlay helpers,
+  per-agent local directory helpers, reusable add-time materialization
+  helper, and hermes/openclaw/zeroclaw native-schema tests. No
+  desired-state or apply behavior switch yet.
+- **B. Desired-state switch + CLI + docs** — bare-name-only
+  `skills.json`, sync/apply copies local native files as-is,
+  `clawctl agent skill add/edit/list/remove`, BREAKING removal of
+  `attach/detach/get/--agent`, top-level `clawctl skill add`,
+  README/AGENTS.md/CONTRIBUTING.md/docs/skills/website mirror/CHANGELOG.
+- **C. GUI** — backend routes (`POST /api/agents/{a}/skills`,
+  `PUT|DELETE /api/agents/{a}/skills/local/{name}`,
+  `POST /api/skills`); frontend "Local skills" section + Add Skill
+  modal.
 
-Dependencies: B and C both depend on A. B and C can land in parallel
-once A is merged.
+Dependency graph: B and C both depend on A. **B must merge before
+C** — C's frontend strings reference the new CLI verbs in help
+text and would document removed verbs otherwise.
 
 ## Deferred (separate issues)
 
-- **Promote / clone** an agent-local skill back into the overlay
-  registry (`clawctl skill add --from-agent <agent>/<name>`-style).
-- **AI-assisted skill authoring** (Claude Code slash command or
-  `clawctl skill draft --prompt`).
-- **Multiple named user registries** (per-team, etc.).
+- **AI-assisted skill authoring** (Claude Code slash command /
+  `clawctl skill draft --prompt`). Issue #411's "utility functions
+  and slash commands as well in case users want to create skills
+  using an ai agent" explicitly asks for this. Scoped out of this
+  plan because the three input modes (template / file / interactive
+  editor) cover the core ad-hoc-skill ask without depending on AI
+  tooling. File as a follow-up before this plan merges.
+- **Promote / clone** a per-agent local skill back into the
+  overlay registry (`clawctl skill add --from-agent <agent>/<name>`).
+- **Multiple named user overlays** (per-team, etc.).
 
 ## Risks / known unknowns
 
-- **Apply playbook source path.** The current playbook in
-  `skills_apply.py` reads from a single catalog root. Per-agent dirs
-  and the user overlay need to be wired in without making the
-  playbook source-aware. The plan stages all sources into a
-  temporary mirror dir matching the bundled catalog shape. Pin
-  down in Subtask A.
-- **Name collisions across origins.** `clawrium/tdd` (bundled),
-  `clawrium/tdd` (overlay), and `tdd` (agent-local on a specific
-  agent) can all coexist. State file only contains the agent-local
-  list; the UI must show origin clearly so users don't think one
-  shadows another.
-- **`skills.json` shape for agent-local entries.** Plan defaults to
-  bare names (`tdd`) rather than a reserved namespace (`local/tdd`).
-  Locked in Subtask A's exit criteria.
+- **`_catalog_root` callers.** `_load_schema` (line 510) and
+  `_bare_name_hint` (line 232) still use the single-root helper.
+  Schemas live in the bundled tree only — keeping the single-root
+  helper for those uses is correct. The `_bare_name_hint` is
+  unioning-eligible but the cost of touching it is real-error-path
+  noise; defer to a follow-up unless tests force it.
+- **GUI route shape.** Existing routes use
+  `/{agent_key}/skills/{registry}/{skill}`. Adding
+  `/{agent_key}/skills/local/{name}` works because `local` is not
+  in `REGISTRIES`, so it cannot collide with a registry-template
+  add. Lock this in by adding a routes-test asserting that
+  `registry == "local"` always dispatches to the local handler.
+- **Editor stub for `clawctl agent skill add` and `edit`.** Tests
+  must inject `EDITOR=true` (or a script that writes deterministic
+  bytes) so CI doesn't try to spawn vi. Document in the test file.
+- **Overlay schema authority.** Schemas are loaded from the bundled
+  tree only. Users cannot override schemas via the overlay. Worth
+  one line in `docs/skills/local.md`.
+- **Add-time materialization drift.** Moving materialization out of
+  sync means `agent skill edit` edits native `SKILL.md` directly.
+  That is intentional, but tests must lock that sync copies local
+  bytes unchanged so future refactors do not reintroduce sync-time
+  conversion.
 
 ---
 
@@ -257,5 +483,33 @@ ive closed the pr now. redo the plan end to end
 ```
 
 **Output**: `.itx/411/00_PLAN.md` and `.itx/411/01_SCAFFOLD.md` rewritten from scratch after PR #634 (wrong-model implementation) was closed. Per-agent local skills + user registry overlay + bundled `skills/<registry>/` unchanged. `clawctl` throughout. Three subtasks (A core+apply / B CLI / C GUI).
+
+## Planning (review-driven rewrite)
+
+**Stage**: planning
+**Skill**: /itx-plan-create
+**Timestamp**: 2026-06-07T18:30:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+redo the full plan with this feedback. get rid of all old instruciotns
+```
+
+**Output**: `.itx/411/00_PLAN.md` and `.itx/411/01_SCAFFOLD.md` rewritten end-to-end after the prior version misnamed CLI file paths (`cli/agent_skill.py` vs the active `cli/clawctl/agent/skill.py`; `cli/skill.py` vs active `cli/clawctl/skill.py`), underspecified apply-pipeline staging shape, and hand-waved the `_catalog_root` signature change. This rewrite: pins file paths to the active `clawctl` surface, keeps `_catalog_root` returning a single `Path` and adds a sibling `_catalog_roots()`, locks `skills.json` bare-name decision in-plan (not at exit), aligns staging shape with the existing `_stage_skills` bare-name layout, and explicitly defers AI-authoring as a follow-up issue. Legacy `clm` modules called out as out of scope.
+
+## Planning (add-time materialization rewrite)
+
+**Stage**: planning
+**Skill**: /itx-plan-create
+**Timestamp**: 2026-06-07T21:20:27Z
+**Model**: openai/gpt-5.5
+
+```prompt
+update the plan. also update the /add explicit tests to validate the skills format for each supported agent first and then copy the  akikks in right format. do a research and create a plan for each agent type thats supported
+
+materiillzation should ahappen at the add time, not at the sync time. sync should movest apply the skillss as -is without any changes to the agent specific converntions
+```
+
+**Output**: Updated the plan to make `clawctl agent skill add` the materialization boundary. Per-agent skills are stored as already-native `SKILL.md` files under `~/.config/clawrium/agents/<agent>/skills/<name>/`; `skills.json` stores bare names only; `clawctl agent sync` stages and applies those files as-is without calling `materialize_for_claw`. Added per-agent format plan and tests for hermes, openclaw, and zeroclaw; removed force/collision semantics.
 
 </details>

--- a/.itx/411/01_SCAFFOLD.md
+++ b/.itx/411/01_SCAFFOLD.md
@@ -1,17 +1,19 @@
 # Issue #411 — Execution Scaffolding
 
-**Mode**: 3 subtasks (A core+apply, B CLI, C GUI), each its own PR.
+**Mode**: 3 subtasks (A safe core helpers, B semantic switch + CLI,
+C GUI), each its own PR.
 
-Subtask B and Subtask C both depend on Subtask A merging first. B and
-C can land in parallel afterward.
+**Merge order**: A → B → C **strict**. B and C cannot run in parallel
+— C's frontend strings reference the new CLI verbs in help text and
+would document removed verbs otherwise.
 
 ---
 
-## Subtask A — Core + Apply
+## Subtask A — Core Helpers + Format Validation
 
-**Goal**: extend the skills catalog and apply pipeline to support a
-user registry overlay and per-agent ad-hoc skills, without changing
-the CLI surface.
+**Goal**: add safe catalog overlay helpers and reusable per-agent
+format validation/materialization helpers without changing the current
+desired-state semantics or any CLI/GUI surface.
 
 **Entry criteria**
 - `.itx/411/00_PLAN.md` merged on `main`.
@@ -19,201 +21,360 @@ the CLI surface.
 
 **Deliverables**
 - `src/clawrium/core/skills.py`
-  - `_catalog_root()` returns a list of roots (bundled + user overlay
-    `~/.config/clawrium/skills/`).
-  - `list_skills()` / `load_skill()` union both roots; overlay wins
-    on `<registry>/<name>` collision and emits a warning log.
-  - New `load_agent_skill(agent, name)` and
-    `list_agent_skills(agent)` reading from
-    `~/.config/clawrium/agents/<agent>/skills/<name>/`.
-  - Per-agent local skills validated as `clawrium`-flavored
-    (universally compatible) unless their `_meta.yaml.compatibility`
-    overrides.
+  - Add `_overlay_root() -> Path` returning
+    `${XDG_CONFIG_HOME:-~/.config}/clawrium/skills/`. Use the same
+    `get_config_dir()` helper `skills_apply.py` already uses for
+    `staging/` and `logs/`.
+  - Add `_catalog_roots() -> list[tuple[str, Path]]` returning
+    `[("bundled", bundled)]` plus `("overlay", overlay)` when the
+    overlay dir exists.
+  - Keep `_catalog_root() -> Path` unchanged (bundled only). Used
+    by `_load_schema` and `_bare_name_hint`. **Do not change its
+    signature** — that would fan out to schema resolution and the
+    bare-name hint path with no benefit.
+  - Rewrite `list_skills` to iterate `_catalog_roots()` and dedupe
+    on `<registry>/<name>`. Overlay wins on collision; emit a
+    `logger.warning` (once per `(registry, name)` per process).
+  - Rewrite `load_skill` to try overlay first, fall back to bundled.
+  - Add `load_agent_skill(agent: str, name: str, agent_type: str) -> Skill`.
+    Per-agent skills are already materialized for their target agent,
+    so the returned `Skill.ref.registry` is the concrete agent type
+    (`hermes`, `openclaw`, or `zeroclaw`) and validation uses
+    `_schema/native/<agent_type>.schema.json`.
+  - Add `list_agent_skills(agent: str) -> list[str]` returning
+    sorted bare names; empty list if dir absent.
+  - Expose reusable add-time materialization helper if needed, but do
+    not leave materialization in the sync/apply path.
+  - **Do not change** `parse_skill_ref`. Agent-local lookups go
+    through `load_agent_skill(agent, name, agent_type)` directly; they never
+    flow through `parse_skill_ref`.
+
 - `src/clawrium/core/skills_state.py`
-  - `agent_skills_root(agent)` helper.
-  - On-disk shape decision for agent-local entries in `skills.json`
-    documented in the PR (default: bare name, no registry prefix).
-- `src/clawrium/core/skills_apply.py`
-  - Stage all skills (bundled, overlay, agent-local) into a temporary
-    mirror dir matching the existing catalog shape; invoke the
-    existing playbook against the temp dir so the playbook itself
-    stays source-agnostic.
-- Unit tests for every new public function and every union /
-  precedence path; mock the home dir via `tmp_path`.
+  - Add `agent_skills_dir(agent: str) -> Path` returning
+    `~/.config/clawrium/agents/<agent>/skills/`. This is the on-disk
+    bytes dir, distinct from `state_file_path` (which points at
+    `skills.json`).
+  - Do **not** change `skills.json` parsing semantics in A. The current
+    registry-ref state file format must continue working until B lands
+    the new CLI and the semantic switch together.
+
+- Tests:
+  - Catalog union and overlay precedence.
+  - Agent-native schema validation for hermes/openclaw/zeroclaw sample
+    `SKILL.md` files.
+  - Add-time materialization helper converts `clawrium/tdd` into valid
+    native frontmatter for each supported agent type.
 
 **Exit criteria**
 - `make test` and `make lint` green.
-- Catalog union path covered by tests for: bundled-only, overlay-only,
-  both-present (overlay wins + warning), neither (error class
-  unchanged).
-- `load_agent_skill` covered for: present, missing, malformed
-  `_meta.yaml`.
-- No public CLI or GUI behavior change yet — verified by running the
-  existing `clawctl agent skill attach/detach` flows manually against
-  a test host. They must still work; this subtask doesn't remove
-  them.
-- PR description spells out the on-disk shape decision for
-  agent-local entries in `skills.json`.
+- Catalog union path covered for: bundled-only, overlay-only,
+  both-present (overlay wins + warning), neither (existing
+  `SkillNotFound` raised — error class unchanged).
+- Materialization helper covered for `hermes`, `openclaw`, and
+  `zeroclaw`; each result validates against that agent's native schema.
+- **No public CLI or GUI behavior change yet** — existing
+  `clawctl agent skill attach/detach/get` flows continue to work.
 
 **Out of scope for A**
+- Changing `skills.json` to bare-name-only desired state.
+- Changing `apply_state` staging behavior.
 - Any CLI verb changes.
-- Any GUI changes.
+- Any GUI route or frontend changes.
 - Docs (covered by B).
 
 ---
 
-## Subtask B — CLI
+## Subtask B — Desired State Switch + CLI + Docs
 
-**Goal**: ship the new `clawctl agent skill add/edit/list/remove`
-verbs, remove the old `attach/detach` verbs and `--agent` flag, add
-the top-level `clawctl skill add` command, and update all user-facing
-docs.
+**Goal**: switch desired state to bare per-agent local names, make
+sync/apply copy already-native local files as-is, ship the new
+`clawctl agent skill add/edit/list/remove` verbs, remove old verbs,
+add top-level `clawctl skill add`, and update docs.
 
 **Entry criteria**
 - Subtask A merged on `main`.
 - `make test` green on `main`.
 
 **Deliverables**
-- `src/clawrium/cli/agent_skill.py`
-  - Remove `attach`, `detach`, and the `--agent` option.
-  - Add `add`, `edit`, `list`, `remove` with agent name as a required
-    positional.
-  - `add` input modes:
-    `--from-template <registry>/<name>`, positional `PATH` (file or
-    directory), interactive prompt when neither is supplied. All
-    three paths converge on writing
-    `~/.config/clawrium/agents/<agent>/skills/<name>/`, mutating
-    `skills.json`, and stopping. No host push — that's
-    `clawctl agent sync <agent>`.
-  - Rollback on `add` failure: if state mutation fails after the
-    local dir is written, delete the dir before returning the error.
-  - `edit` opens `$EDITOR` (or `EDITOR` env var with a sensible
-    default) on the local `SKILL.md`; rewrites in place; no host
-    push.
-  - `remove` mutates state to drop the entry and deletes the local
-    dir.
-- `src/clawrium/cli/skill.py`
-  - New top-level `add` command writing to
-    `~/.config/clawrium/skills/<registry>/<name>/`. Accepts a
-    positional `PATH` (file or dir) or runs an interactive prompt.
-    Requires `--registry <clawrium|hermes|openclaw|zeroclaw>` (or
-    prompts). Validates against the existing per-registry schemas
-    before writing.
-- Tests: Typer `CliRunner` covering each input mode against a tmp
-  `~/.config/clawrium/`; rejects schema-invalid input; rejects
-  existing name without `--force`; `remove` deletes the dir; `edit`
-  round-trips.
+- `src/clawrium/core/skills_state.py`
+  - `skills.json` shape stays a flat list of strings, but every entry
+    is a bare per-agent local skill name (e.g. `"tdd"`). Registry refs
+    (`"<registry>/<name>"`) are invalid desired state. Document this
+    in the module docstring.
+  - `read_state` / `write_state` / `add_skill` / `remove_skill`
+    validate safe bare names and reject any value containing `/`.
+  - Old state files containing registry refs fail with a clear
+    operator message to re-add those skills from template. Do not
+    silently copy templates during sync.
+
+- `src/clawrium/core/skills_apply.py`
+  - In `apply_state`'s read loop (currently lines 169–176), treat
+    every `raw_ref` as a bare local skill name and call
+    `load_agent_skill(agent_name, raw_ref, agent_type)`. Do not parse
+    registry refs and do not load bundled/overlay catalog skills.
+  - `_stage_skills` keeps the current `<staging>/<name>/SKILL.md`
+    shape, but it copies the local already-agent-native `SKILL.md`
+    bytes unchanged. Remove the sync-time `materialize_for_claw` call.
+  - Playbooks remain unchanged because they already consume a staging
+    dir plus `desired_skill_names` as bare names.
+
+- Unit tests for every new function and every union/precedence
+  path; mock the home dir via `tmp_path` + `monkeypatch.setenv` on
+  `XDG_CONFIG_HOME`.
+  Add explicit tests that sync stages exactly the local `SKILL.md`
+  bytes and does not perform materialization.
+- `src/clawrium/cli/clawctl/agent/skill.py` (REPLACE existing
+  verbs; do **not** edit `src/clawrium/cli/agent_skill.py` — that's
+  the `clm` legacy surface and is out of scope)
+  - Remove `attach`, `detach`, `get`, and every `--agent` option.
+  - Add `list`, `add`, `edit`, `remove`. Agent name is a required
+    positional first arg.
+  - `add` input modes (mutually exclusive):
+    - `--from-template <registry>/<name>` — copy bytes from
+      bundled-or-overlay catalog, materialized for the target agent
+      type, into the agent's local dir.
+    - Positional `PATH` — file (a single `SKILL.md`) or directory
+      (full skill tree). Validate the input, materialize it for the
+      target agent type if needed, then persist native `SKILL.md`.
+    - Neither — open `$EDITOR` (or `EDITOR` env var; fall back to
+      `vi`) on a stub native `SKILL.md`, persist on save.
+  - `add` resolves the agent first to determine `agent_type`. It
+    validates the input and the final materialized local `SKILL.md`
+    against `_schema/native/<agent_type>.schema.json` before touching
+    `skills.json`. On failure: nothing is written.
+  - `add` has no `--force`. If `skills/<name>/` already exists or
+    `skills.json` already contains `<name>`, fail and tell the user to
+    remove or rename the existing skill first.
+  - `add` rollback: if `add_skill` fails after the local dir is
+    written, delete the dir before returning the error. Symmetric
+    to the existing preflight → mutate → apply pattern at lines
+    97–121 of the pre-change file.
+  - `add` does **not** call `apply_state`. CLI exits after the
+    state file is mutated. Use `clawctl agent sync <agent>` to
+    flush.
+  - `edit` opens `$EDITOR` on the already-agent-native local
+    `SKILL.md`; re-validates against the target agent's native schema
+    on save; rejects schema-invalid writes (restoring prior bytes).
+  - `remove` accepts only a bare local name; drops the matching
+    `skills.json` entry and deletes the local dir.
+
+- `src/clawrium/cli/clawctl/skill.py` (ADD top-level command; do
+  **not** edit `src/clawrium/cli/skill.py` — that's `clm` legacy)
+  - New `add` command writing to
+    `~/.config/clawrium/skills/<registry>/<name>/`. Accepts
+    positional `PATH` (file or dir) or `--interactive` to launch
+    `$EDITOR`. Requires
+    `--registry <clawrium|hermes|openclaw|zeroclaw>` (or prompts
+    in interactive mode).
+  - Validates against existing per-registry schemas before writing
+    (`validate_skill` after loading the staged copy).
+  - No `--force`: existing overlay registry/name fails; user must
+    remove or rename first.
+  - Mount `add` directly on `skill_app`, not under `registry`,
+    mirroring issue #411's "add to local registry" framing.
+  - `skill_app.add_typer(skill_registry_app, name="registry")`
+    wiring (current line 178) is unchanged; the existing
+    `skill registry get`/`describe` verbs automatically include
+    overlay entries via the changed `list_skills`/`load_skill`
+    from Subtask A.
+
+- Tests (Typer `CliRunner`, tmp `$XDG_CONFIG_HOME` via
+  `monkeypatch`):
+  - Each `add` input mode against the tmp overlay/local dirs.
+  - `agent skill add --from-template clawrium/tdd` covered for each
+    supported agent type (`hermes`, `openclaw`, `zeroclaw`). Each test
+    asserts the persisted local `SKILL.md` validates against that
+    agent's native schema before the state file is written.
+  - Sync/apply test confirms staged bytes equal the already-native
+    local bytes for each supported agent type; no sync-time
+    materialization.
+  - Rejects schema-invalid input with a non-zero exit.
+  - Rejects existing agent-local names and existing overlay
+    registry/name collisions; there is no `--force` path.
+  - `remove` drops state and deletes the local dir (only for bare
+    names).
+  - `edit` round-trips (use `EDITOR=true` plus a pre-written stub
+    file the editor "saves").
+  - Removed verbs (`attach`/`detach`/`get`, `--agent` flag) exit
+    non-zero with a clear "removed — use `…` instead" message.
+
 - Docs (all in the same PR as the CLI change):
-  - `README.md` — replace the existing skill quickstart example with
-    the new grammar.
+  - `docs/skills/index.md` — replace the existing skill quickstart
+    example on line 33 and the troubleshooting examples on lines
+    148/182/191/195/198 with the new grammar.
+  - `docs/skills/authoring-clawrium.md` — update the
+    `attach <openclaw|hermes|zeroclaw>-agent` examples on lines
+    136–138.
+  - `docs/skills/local.md` (NEW) — canonical guide for per-agent
+    local skills and the user overlay. Sections:
+    - Mental model (the three-source table from `00_PLAN.md`).
+    - Three input modes for `clawctl agent skill add`.
+    - Editing an on-agent skill (`clawctl agent skill edit`).
+    - Adding to the user overlay (`clawctl skill add`).
+    - Flushing via `clawctl agent sync <agent>`.
+    - Note that schemas live in the bundled tree only — the
+      overlay cannot redefine schemas.
+  - `website/docs/skills/local.md` (NEW) — verbatim mirror with
+    Docusaurus frontmatter + mirror-warning HTML comment, matching
+    the per-file pattern in `website/docs/skills/`.
+  - `README.md` — only update if the quickstart skill example
+    changes (it does — current line referencing `attach`).
   - `AGENTS.md` — update the "Skill Registry" Key Concepts section
-    to describe copy-on-add semantics and the user-overlay path.
-  - `CONTRIBUTING.md` — sweep for `--agent` references; update.
-  - `docs/skills.md` — full guide (mental model, three input modes,
-    edit, registry-level `clawctl skill add`, flushing via
-    `clawctl agent sync`).
-  - `website/docs/skills.md` — verbatim mirror with Docusaurus
-    frontmatter + mirror-warning HTML comment.
+    (currently the `Skill Registry` paragraph + the line-50 example
+    `clawctl agent skill attach clawrium/tdd --agent <agent-name>`).
+  - `CONTRIBUTING.md` — sweep for `--agent` references and the old
+    verb names.
   - `CHANGELOG.md` `[Unreleased]`:
-    - `### Added` — every new verb (one bullet each), and the GUI
-      hook that Subtask C will fill in.
-    - `### BREAKING` — `attach`/`detach`/`--agent` removed; concrete
-      before/after invocation examples; note `skills.json` state
-      files remain readable.
+    - `### Added` — `clawctl agent skill add/edit/list/remove`,
+      `clawctl skill add`, GUI Add Skill flow (C will fill in
+      detail when it lands).
+    - `### BREAKING` — `clawctl agent skill attach/detach/get`
+      removed; `--agent` flag removed across `clawctl agent skill`.
+      Concrete before/after invocations. Note old `skills.json`
+      entries containing registry refs are no longer valid desired
+      state; re-add from template to create per-agent native local
+      copies.
 
 **Exit criteria**
 - `make test`, `make lint`, `make format` clean.
 - `--help` output for `clawctl agent skill` and `clawctl skill`
   matches the documented surface verbatim.
-- Real-host smoke test on the `mac-test` host: add an agent-local
-  skill, run `clawctl agent sync`, verify the file lands; edit +
-  sync; remove + sync.
-- Docs/website mirror invariant verified (`diff` between
-  `docs/skills.md` body and `website/docs/skills.md` body is empty
-  modulo the Docusaurus header).
-- CHANGELOG entries reviewed for accuracy.
+- Real-host smoke test on `mac-test`:
+  1. `clawctl agent skill add <agent> --from-template clawrium/tdd`
+  2. `clawctl agent sync <agent>` → verify file lands on host.
+  3. `clawctl agent skill edit <agent> tdd` → small edit →
+     `sync` → verify host content changes.
+  4. `clawctl agent skill remove <agent> tdd` → `sync` → verify
+     host removes the file.
+  5. `clawctl skill add ./tmpdir --registry clawrium` → verify
+     `clawctl skill registry get` lists it with overlay origin.
+- Docs/website mirror invariant: `diff` between
+  `docs/skills/local.md` body and `website/docs/skills/local.md`
+  body is empty modulo the Docusaurus header.
+- CHANGELOG `### BREAKING` entry contains the explicit
+  before/after invocations table.
 
 **Out of scope for B**
 - Any GUI changes (covered by C).
-- The deferred follow-ups (promote/clone, AI authoring,
+- The deferred follow-ups (AI authoring, promote/clone,
   multi-registry).
+- The `clm` legacy CLI surface (`src/clawrium/cli/skill.py`,
+  `src/clawrium/cli/agent_skill.py`) — untouched.
 
 ---
 
 ## Subtask C — GUI
 
-**Goal**: expose the same lifecycle in the web UI — list, add (three
-modes), edit, remove for agent-local skills; add to user registry
+**Goal**: expose the same lifecycle in the web UI — list, add
+(three modes), edit, remove for per-agent local skills; add to user
 overlay for registry-level skills.
 
 **Entry criteria**
-- Subtask A merged on `main`.
-- C can land before or after B. Prefer B-then-C for CLI/UI
-  consistency.
+- Subtask B merged on `main` (strict — frontend strings reference
+  the new CLI verbs).
+- `make test` green on `main`.
 
 **Deliverables**
-- `src/clawrium/gui/routes/skills.py` and
-  `src/clawrium/gui/routes/agents.py`
-  - Per-agent skill payload tags every entry with
-    `origin: "local" | "<registry>"`.
-  - `POST /api/agents/{agent}/skills` — add. Accepts JSON describing
-    the input mode (template ref / inline body / uploaded file).
-  - `PUT /api/agents/{agent}/skills/{name}` — edit (replace body).
-  - `DELETE /api/agents/{agent}/skills/{name}` — remove (state +
-    dir).
-  - `POST /api/skills` — add to user registry overlay. Accepts JSON
-    with `{registry, name, body}` or multipart for file uploads.
-  - All four reject schema-invalid input with a 422 + structured
-    error; rely on the same `skills/_schema/` validators the CLI
-    uses.
+- `src/clawrium/gui/routes/agents.py` (per-agent skill routes
+  already live here at lines 401/530/543; this file owns per-agent
+  skill routes — **not** `routes/skills.py`)
+  - Extend `GET /{agent_key}/skills` (line 401) to tag each entry
+    with `origin: "local" | "bundled" | "overlay"`.
+  - Existing `POST /{agent_key}/skills/{registry}/{skill}` (line
+    530) and `DELETE /{agent_key}/skills/{registry}/{skill}` (line
+    543) continue only as compatibility routes. Template add must
+    materialize/copy into the agent-local dir and write a bare name to
+    `skills.json`; it must not persist `<registry>/<skill>` as
+    installed state. Registry-ref delete should be deprecated or routed
+    to local bare-name removal.
+  - **New** `POST /{agent_key}/skills` (no path segments after
+    `/skills`). Body: `{input_mode: "template"|"file"|"inline",
+    ...payload}`. Writes a per-agent local skill.
+  - **New** `PUT /{agent_key}/skills/local/{name}` — replace the
+    body of a per-agent local skill. Validate against the target
+    agent's native schema; do not run normalized materialization on
+    edit. The `local/` prefix disambiguates from the
+    `{registry}/{skill}` route (FastAPI dispatches more-specific routes
+    first, but the explicit `local/` makes the dispatch unambiguous).
+  - **New** `DELETE /{agent_key}/skills/local/{name}` — remove a
+    per-agent local skill (state + dir).
+
+- `src/clawrium/gui/routes/skills.py` (catalog-level routes; the
+  read-only routes already live here)
+  - `GET /api/skills` continues to enumerate the catalog; overlay
+    entries appear automatically via the changed `list_skills`.
+  - **New** `POST /api/skills` — write to user overlay. Accepts
+    JSON `{registry, name, body, meta}` or multipart for file
+    uploads. Validates against the per-registry schema; rejects
+    422 on schema failure.
+
 - `src/clawrium/gui/frontend/...`
-  - Per-agent view: new "Local skills" section listing entries with
-    origin chips, Edit and Remove buttons.
-  - Add skill modal: tabs for Template / File / Inline editor.
-    Template tab pulls from `list_skills()` so users can pick from
-    bundled + overlay.
+  - Per-agent view: new "Local skills" section listing entries
+    with origin chips. Edit / Remove buttons per row.
+  - Add Skill modal: tabs for Template / File / Inline editor.
+    Template tab pulls from `GET /api/skills` (bundled + overlay).
   - Registry browser gains an "Add skill" entry point that calls
     `POST /api/skills`.
-  - Reuse the existing whole-agent Sync control to flush; no
+  - Reuse the existing whole-agent Sync control; no new
     skill-specific sync button.
+
 - Tests:
-  - Route-level tests with a tmp config dir (FastAPI `TestClient`).
-  - Frontend smoke tests (Playwright if already in the repo, else
-    component-level) for the Add Skill modal happy path.
+  - Route-level (FastAPI `TestClient`) for all five new endpoints
+    above. Each has at least one happy-path and one rejection-path
+    test.
+  - Routes-test asserting `registry == "local"` always dispatches
+    to the local handler (the disambiguation guard).
+  - Frontend: Playwright happy-path for the Add Skill modal if
+    Playwright is already in the repo; otherwise component-level
+    tests for the modal's three tabs.
+
 - Docs:
-  - Append a "Using the web UI" section to `docs/skills.md` covering
-    the same operations.
-  - Mirror update.
+  - Append a "Using the web UI" section to `docs/skills/local.md`.
+  - Mirror to `website/docs/skills/local.md`.
+  - `CHANGELOG.md` `[Unreleased]` `### Added` — append the GUI
+    surface (one bullet).
 
 **Exit criteria**
 - `make test`, `make lint`, `make format` clean.
-- All four new HTTP endpoints have route-level tests with at least
-  one happy-path and one rejection path.
-- Manual GUI walkthrough on `mac-test` host: add a skill via
-  Template, via File, via Inline editor; edit; remove; flush via
-  Sync. Each step verified against the running agent.
-- `docs/skills.md` "Using the web UI" section landed and mirrored.
+- All five new HTTP endpoints covered by happy-path + rejection
+  tests.
+- Manual GUI walkthrough on `mac-test`:
+  1. Add a per-agent local skill via Template tab.
+  2. Add another via File tab.
+  3. Add a third via Inline editor.
+  4. Edit one of them in place.
+  5. Remove one of them.
+  6. Flush via the agent's Sync control; verify each step on the
+     running agent.
+  7. Add an overlay skill via the registry browser's "Add skill";
+     verify it appears in `GET /api/skills` with origin
+     `"overlay"`.
+- `docs/skills/local.md` "Using the web UI" section landed and
+  mirrored.
 
 **Out of scope for C**
 - Any further GUI redesign of the existing skill browser beyond
   what this issue needs.
+- The deferred follow-ups (AI authoring, promote/clone,
+  multi-registry).
 
 ---
 
 ## Cross-cutting
 
 - **Branching**: each subtask gets its own branch
-  `issue-411-A-core`, `issue-411-B-cli`, `issue-411-C-gui`, each
-  its own PR.
-- **CHANGELOG ownership**: B owns the `### Added` and `### BREAKING`
-  entries for the CLI surface. C appends a line for the GUI surface
-  under `### Added`.
+  `issue-411-A-core`, `issue-411-B-cli`, `issue-411-C-gui`. One PR
+  per branch.
+- **CHANGELOG ownership**: B owns the initial `### Added` and
+  `### BREAKING` entries for the CLI surface. C appends a line
+  under `### Added` for the GUI surface.
 - **Real-host verification**: every subtask exits with a documented
-  manual run against the `mac-test` host. No subtask is marked exit
-  on unit tests alone.
-- **Merge order**: A → B → C is the safe path. A → C → B is
-  acceptable if C lands without removing the old CLI verbs first
-  (so users have both surfaces during the gap).
+  manual run against `mac-test`. No subtask is marked exit on unit
+  tests alone.
+- **Merge order**: A → B → C strict.
+- **Legacy `clm` surface untouched**: `src/clawrium/cli/skill.py`
+  and `src/clawrium/cli/agent_skill.py` are part of the `clm`
+  legacy CLI. Do not edit them in any subtask.
 
 ---
 
@@ -232,5 +393,33 @@ ive closed the pr now. redo the plan end to end
 ```
 
 **Output**: `.itx/411/01_SCAFFOLD.md` rewritten from scratch into 3 subtask phases (A core+apply, B CLI, C GUI), entry/exit criteria for each, branching and merge-order guidance, cross-cutting CHANGELOG ownership notes.
+
+## Scaffolding (review-driven rewrite)
+
+**Stage**: scaffold
+**Skill**: /itx-plan-scaffold
+**Timestamp**: 2026-06-07T18:30:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+redo the full plan with this feedback. get rid of all old instruciotns
+```
+
+**Output**: `.itx/411/01_SCAFFOLD.md` rewritten end-to-end alongside `00_PLAN.md`. Subtask A pinned to additive helper (`_catalog_roots()`) instead of changing `_catalog_root` signature; staging shape change confirmed unnecessary (existing `_stage_skills` already bare-name). Subtask B targets `cli/clawctl/agent/skill.py` and `cli/clawctl/skill.py` explicitly (legacy `cli/agent_skill.py` / `cli/skill.py` called out as out of scope). Subtask C targets `gui/routes/agents.py` (which owns per-agent skill routes) plus catalog-level `gui/routes/skills.py`; route shape `/{agent_key}/skills/local/{name}` introduced to disambiguate from existing `/{agent_key}/skills/{registry}/{skill}`. Merge order tightened from "B then C preferred" to "A → B → C strict."
+
+## Scaffolding (add-time materialization rewrite)
+
+**Stage**: scaffold
+**Skill**: /itx-plan-scaffold
+**Timestamp**: 2026-06-07T21:20:27Z
+**Model**: openai/gpt-5.5
+
+```prompt
+update the plan. also update the /add explicit tests to validate the skills format for each supported agent first and then copy the  akikks in right format. do a research and create a plan for each agent type thats supported
+
+materiillzation should ahappen at the add time, not at the sync time. sync should movest apply the skillss as -is without any changes to the agent specific converntions
+```
+
+**Output**: Updated scaffold so Subtask A is safe core helper/format validation work only, while Subtask B lands the desired-state semantic switch with the new CLI in the same PR. Added explicit per-agent add tests for hermes/openclaw/zeroclaw, sync-time byte-preservation tests, bare-name-only `skills.json`, and no-force collision handling.
 
 </details>

--- a/.itx/411/01_SCAFFOLD.md
+++ b/.itx/411/01_SCAFFOLD.md
@@ -1,46 +1,45 @@
 # Issue #411 — Execution Scaffolding
 
 **Mode**: 3 subtasks (A core+apply, B CLI, C GUI), each its own PR.
-**Supersedes**: the prior 7-phase single-PR scaffold previously committed
-in this directory (see git history); replaced because the locked plan
-splits work into 3 surfaces with clean handoffs.
 
-Subtask B and Subtask C both depend on Subtask A merging first. B and C
-can land in parallel afterward.
+Subtask B and Subtask C both depend on Subtask A merging first. B and
+C can land in parallel afterward.
 
 ---
 
 ## Subtask A — Core + Apply
 
-**Goal**: extend the skills catalog and apply pipeline to support a user
-registry overlay and per-agent ad-hoc skills, without changing the CLI
-surface.
+**Goal**: extend the skills catalog and apply pipeline to support a
+user registry overlay and per-agent ad-hoc skills, without changing
+the CLI surface.
 
 **Entry criteria**
-- `00_PLAN.md` merged on `main`.
+- `.itx/411/00_PLAN.md` merged on `main`.
 - No open PR touching `src/clawrium/core/skills*.py`.
 
 **Deliverables**
 - `src/clawrium/core/skills.py`
   - `_catalog_root()` returns a list of roots (bundled + user overlay
     `~/.config/clawrium/skills/`).
-  - `list_skills()` / `load_skill()` union both roots; overlay wins on
-    collision and emits a warning log.
-  - New `load_agent_skill(agent, name)` and `list_agent_skills(agent)`
-    reading from `~/.config/clawrium/agents/<agent>/skills/<name>/`.
-  - Per-agent local skills validated as `clawrium`-flavored (universally
-    compatible) unless their `_meta.yaml.compatibility` overrides.
+  - `list_skills()` / `load_skill()` union both roots; overlay wins
+    on `<registry>/<name>` collision and emits a warning log.
+  - New `load_agent_skill(agent, name)` and
+    `list_agent_skills(agent)` reading from
+    `~/.config/clawrium/agents/<agent>/skills/<name>/`.
+  - Per-agent local skills validated as `clawrium`-flavored
+    (universally compatible) unless their `_meta.yaml.compatibility`
+    overrides.
 - `src/clawrium/core/skills_state.py`
   - `agent_skills_root(agent)` helper.
-  - Decide and document the on-disk shape of agent-local entries in
-    `skills.json` (default: bare name, no registry prefix).
+  - On-disk shape decision for agent-local entries in `skills.json`
+    documented in the PR (default: bare name, no registry prefix).
 - `src/clawrium/core/skills_apply.py`
   - Stage all skills (bundled, overlay, agent-local) into a temporary
-    mirror dir that matches the existing catalog shape; invoke the
+    mirror dir matching the existing catalog shape; invoke the
     existing playbook against the temp dir so the playbook itself
     stays source-agnostic.
-- Unit tests for every new public function and every union/precedence
-  path; mock the home dir via `tmp_path`.
+- Unit tests for every new public function and every union /
+  precedence path; mock the home dir via `tmp_path`.
 
 **Exit criteria**
 - `make test` and `make lint` green.
@@ -49,11 +48,12 @@ surface.
   unchanged).
 - `load_agent_skill` covered for: present, missing, malformed
   `_meta.yaml`.
-- No public CLI or GUI behavior change yet (verified by running the
-  existing `clm agent skill attach/detach` flows manually against a
-  test host — must still work since this subtask doesn't remove them).
-- PR description spells out the on-disk shape decision for agent-local
-  entries in `skills.json`.
+- No public CLI or GUI behavior change yet — verified by running the
+  existing `clawctl agent skill attach/detach` flows manually against
+  a test host. They must still work; this subtask doesn't remove
+  them.
+- PR description spells out the on-disk shape decision for
+  agent-local entries in `skills.json`.
 
 **Out of scope for A**
 - Any CLI verb changes.
@@ -64,9 +64,10 @@ surface.
 
 ## Subtask B — CLI
 
-**Goal**: ship the new `clm agent skill add/edit/list/remove` verbs,
-remove the old `attach/detach` verbs and `--agent` flag, add the
-top-level `clm skill add` command, and update all user-facing docs.
+**Goal**: ship the new `clawctl agent skill add/edit/list/remove`
+verbs, remove the old `attach/detach` verbs and `--agent` flag, add
+the top-level `clawctl skill add` command, and update all user-facing
+docs.
 
 **Entry criteria**
 - Subtask A merged on `main`.
@@ -77,52 +78,56 @@ top-level `clm skill add` command, and update all user-facing docs.
   - Remove `attach`, `detach`, and the `--agent` option.
   - Add `add`, `edit`, `list`, `remove` with agent name as a required
     positional.
-  - `add` input modes: `--from-template <registry>/<name>`, positional
-    `PATH` (file or directory), and interactive prompt when neither is
-    supplied. All three paths converge on writing
+  - `add` input modes:
+    `--from-template <registry>/<name>`, positional `PATH` (file or
+    directory), interactive prompt when neither is supplied. All
+    three paths converge on writing
     `~/.config/clawrium/agents/<agent>/skills/<name>/`, mutating
-    `skills.json`, and stopping (no host push — that's `clm agent sync`).
-  - Rollback on add failure: if state mutation fails after the local
-    dir is written, delete the dir before returning the error.
+    `skills.json`, and stopping. No host push — that's
+    `clawctl agent sync <agent>`.
+  - Rollback on `add` failure: if state mutation fails after the
+    local dir is written, delete the dir before returning the error.
   - `edit` opens `$EDITOR` (or `EDITOR` env var with a sensible
-    default) on the local `SKILL.md`; rewrites in place; no host push.
-  - `remove` mutates state to drop the entry; keeps the on-disk dir so
-    the user can `add` it back without re-authoring.
+    default) on the local `SKILL.md`; rewrites in place; no host
+    push.
+  - `remove` mutates state to drop the entry and deletes the local
+    dir.
 - `src/clawrium/cli/skill.py`
   - New top-level `add` command writing to
-    `~/.config/clawrium/skills/<registry>/<name>/`. Accepts a positional
-    `PATH` (file or dir) or runs an interactive prompt. Requires
-    `--registry <clawrium|openclaw|hermes|zeroclaw>` (or prompts).
-    Validates against the existing `skills/_schema/` definitions before
-    writing.
+    `~/.config/clawrium/skills/<registry>/<name>/`. Accepts a
+    positional `PATH` (file or dir) or runs an interactive prompt.
+    Requires `--registry <clawrium|hermes|openclaw|zeroclaw>` (or
+    prompts). Validates against the existing per-registry schemas
+    before writing.
 - Tests: Typer `CliRunner` covering each input mode against a tmp
-  `~/.config/clawrium/`; rejects schema-invalid input; rejects existing
-  name without `--force`; `remove` preserves the dir; `edit` round-trips.
+  `~/.config/clawrium/`; rejects schema-invalid input; rejects
+  existing name without `--force`; `remove` deletes the dir; `edit`
+  round-trips.
 - Docs (all in the same PR as the CLI change):
-  - `README.md` — replace the existing skill quickstart example with the
-    new grammar.
-  - `AGENTS.md` — update the "Skill Registry" Key Concepts section to
-    describe copy-on-add semantics and the user-overlay path.
+  - `README.md` — replace the existing skill quickstart example with
+    the new grammar.
+  - `AGENTS.md` — update the "Skill Registry" Key Concepts section
+    to describe copy-on-add semantics and the user-overlay path.
   - `CONTRIBUTING.md` — sweep for `--agent` references; update.
   - `docs/skills.md` — full guide (mental model, three input modes,
-    edit, registry-level `clm skill add`, flushing via `clm agent
-    sync`).
+    edit, registry-level `clawctl skill add`, flushing via
+    `clawctl agent sync`).
   - `website/docs/skills.md` — verbatim mirror with Docusaurus
     frontmatter + mirror-warning HTML comment.
   - `CHANGELOG.md` `[Unreleased]`:
-    - `### Added` — every new verb (one bullet each), and the GUI hook
-      that Subtask C will fill in.
+    - `### Added` — every new verb (one bullet each), and the GUI
+      hook that Subtask C will fill in.
     - `### BREAKING` — `attach`/`detach`/`--agent` removed; concrete
-      before/after invocation examples; note `skills.json` state files
-      remain readable.
+      before/after invocation examples; note `skills.json` state
+      files remain readable.
 
 **Exit criteria**
 - `make test`, `make lint`, `make format` clean.
-- `--help` output for `clm agent skill` and `clm skill` matches the
-  documented surface verbatim.
-- Real-host smoke test on the `mac-test` host (per memory: standing
-  real-host verification target): add an agent-local skill, run `clm
-  agent sync`, verify the file lands; edit + sync; remove + sync.
+- `--help` output for `clawctl agent skill` and `clawctl skill`
+  matches the documented surface verbatim.
+- Real-host smoke test on the `mac-test` host: add an agent-local
+  skill, run `clawctl agent sync`, verify the file lands; edit +
+  sync; remove + sync.
 - Docs/website mirror invariant verified (`diff` between
   `docs/skills.md` body and `website/docs/skills.md` body is empty
   modulo the Docusaurus header).
@@ -130,39 +135,41 @@ top-level `clm skill add` command, and update all user-facing docs.
 
 **Out of scope for B**
 - Any GUI changes (covered by C).
-- The deferred follow-ups (promote/clone, AI authoring, multi-registry).
+- The deferred follow-ups (promote/clone, AI authoring,
+  multi-registry).
 
 ---
 
 ## Subtask C — GUI
 
 **Goal**: expose the same lifecycle in the web UI — list, add (three
-modes), edit, remove for agent-local skills; add to user registry for
-registry-level skills.
+modes), edit, remove for agent-local skills; add to user registry
+overlay for registry-level skills.
 
 **Entry criteria**
 - Subtask A merged on `main`.
-- (B is not a hard dependency; C can land before or after B. If C lands
-  first, GUI users get the feature before CLI breaking change ships.
-  Prefer B-then-C for consistency.)
+- C can land before or after B. Prefer B-then-C for CLI/UI
+  consistency.
 
 **Deliverables**
-- `src/clawrium/gui/routes/skills.py` and `src/clawrium/gui/routes/agents.py`
+- `src/clawrium/gui/routes/skills.py` and
+  `src/clawrium/gui/routes/agents.py`
   - Per-agent skill payload tags every entry with
-    `origin: "local" | "bundled" | "overlay"`.
-  - POST `/api/agents/{agent}/skills` — add. Accepts JSON describing
+    `origin: "local" | "<registry>"`.
+  - `POST /api/agents/{agent}/skills` — add. Accepts JSON describing
     the input mode (template ref / inline body / uploaded file).
-  - PUT `/api/agents/{agent}/skills/{name}` — edit (replace body).
-  - DELETE `/api/agents/{agent}/skills/{name}` — remove (state-only;
-    keep the dir).
-  - POST `/api/skills` — add to user registry overlay. Accepts JSON
+  - `PUT /api/agents/{agent}/skills/{name}` — edit (replace body).
+  - `DELETE /api/agents/{agent}/skills/{name}` — remove (state +
+    dir).
+  - `POST /api/skills` — add to user registry overlay. Accepts JSON
     with `{registry, name, body}` or multipart for file uploads.
-  - All four reject schema-invalid input with a 422 + structured error;
-    rely on the same `skills/_schema/` validators the CLI uses.
+  - All four reject schema-invalid input with a 422 + structured
+    error; rely on the same `skills/_schema/` validators the CLI
+    uses.
 - `src/clawrium/gui/frontend/...`
   - Per-agent view: new "Local skills" section listing entries with
     origin chips, Edit and Remove buttons.
-  - "Add skill" modal: tabs for Template / File / Inline editor.
+  - Add skill modal: tabs for Template / File / Inline editor.
     Template tab pulls from `list_skills()` so users can pick from
     bundled + overlay.
   - Registry browser gains an "Add skill" entry point that calls
@@ -180,32 +187,33 @@ registry-level skills.
 
 **Exit criteria**
 - `make test`, `make lint`, `make format` clean.
-- All four new HTTP endpoints have route-level tests with at least one
-  happy-path and one rejection path.
-- Manual GUI walkthrough on `mac-test` host: add a skill via Template,
-  via File, via Inline editor; edit; remove; flush via Sync. Each step
-  verified against the running agent.
+- All four new HTTP endpoints have route-level tests with at least
+  one happy-path and one rejection path.
+- Manual GUI walkthrough on `mac-test` host: add a skill via
+  Template, via File, via Inline editor; edit; remove; flush via
+  Sync. Each step verified against the running agent.
 - `docs/skills.md` "Using the web UI" section landed and mirrored.
 
 **Out of scope for C**
-- Any further GUI redesign of the existing skill browser beyond what
-  this issue needs.
+- Any further GUI redesign of the existing skill browser beyond
+  what this issue needs.
 
 ---
 
 ## Cross-cutting
 
-- **Branching**: each subtask gets its own branch `issue-411-A-core`,
-  `issue-411-B-cli`, `issue-411-C-gui`, each its own PR.
+- **Branching**: each subtask gets its own branch
+  `issue-411-A-core`, `issue-411-B-cli`, `issue-411-C-gui`, each
+  its own PR.
 - **CHANGELOG ownership**: B owns the `### Added` and `### BREAKING`
   entries for the CLI surface. C appends a line for the GUI surface
   under `### Added`.
 - **Real-host verification**: every subtask exits with a documented
   manual run against the `mac-test` host. No subtask is marked exit
   on unit tests alone.
-- **Merge order**: A → B → C is the safe path. A → C → B is acceptable
-  if C lands without removing the old CLI verbs first (so users have
-  both surfaces during the gap).
+- **Merge order**: A → B → C is the safe path. A → C → B is
+  acceptable if C lands without removing the old CLI verbs first
+  (so users have both surfaces during the gap).
 
 ---
 
@@ -216,13 +224,13 @@ registry-level skills.
 
 **Stage**: scaffold
 **Skill**: /itx-plan-scaffold
-**Timestamp**: 2026-06-07T06:15:24Z
+**Timestamp**: 2026-06-07T17:43:41Z
 **Model**: claude-opus-4-7
 
 ```prompt
-wrte the plan file and stages and send pr
+ive closed the pr now. redo the plan end to end
 ```
 
-**Output**: `.itx/411/01_SCAFFOLD.md` with 3 subtask phases (A core+apply, B CLI, C GUI), entry/exit criteria for each, branching and merge-order guidance, and cross-cutting CHANGELOG ownership notes.
+**Output**: `.itx/411/01_SCAFFOLD.md` rewritten from scratch into 3 subtask phases (A core+apply, B CLI, C GUI), entry/exit criteria for each, branching and merge-order guidance, cross-cutting CHANGELOG ownership notes.
 
 </details>


### PR DESCRIPTION
## Summary

Rewrites `.itx/411/00_PLAN.md` and `.itx/411/01_SCAFFOLD.md` from scratch after PR #634 (wrong conceptual model — `vetted/`/`local/` restructure under `skills/`) was closed.

This rewrite locks in the model from the planning conversation:

- Bundled `skills/<registry>/<name>/` tree (`clawrium`, `hermes`, `openclaw`, `zeroclaw`) stays exactly as it is on `main`. No restructuring.
- New user registry overlay at `~/.config/clawrium/skills/<registry>/<name>/` written by a new top-level `clawctl skill add`.
- New per-agent local skills at `~/.config/clawrium/agents/<agent>/skills/<name>/` written by `clawctl agent skill add <agent>`. Copy-on-add semantics: `--from-template clawrium/tdd` copies bytes from the bundled (or overlay) catalog into the agent's local dir; the local copy then becomes the source of truth and is editable via `clawctl agent skill edit`.
- BREAKING: `clawctl agent skill attach` / `detach` and the `--agent` flag are removed. Agent name becomes a required positional under `clawctl agent skill`, matching `clawctl agent configure <name>` and `clawctl agent sync <name>`.
- Flush model unchanged: existing `clawctl agent sync <agent>` is the single host push.
- `clawctl` throughout (not `clm`).

## Scaffold

Three subtasks, each its own PR:

- **A. Core + apply** — catalog union (bundled + overlay), per-agent loader, apply-state routing.
- **B. CLI + docs** — new verbs, breaking removal of old verbs, README/AGENTS.md/CONTRIBUTING.md/docs/skills.md/website mirror/CHANGELOG.
- **C. GUI** — backend routes + frontend Add Skill modal.

B and C depend on A. They can land in parallel.

## Testing

### Test Results
- [x] N/A — planning-only PR; no source-code changes.
- [x] Markdown only; lint not exercised.
- [x] No tests added (planning artifact).

### Test Coverage
- Files changed: `.itx/411/00_PLAN.md`, `.itx/411/01_SCAFFOLD.md`.
- New tests: N/A.
- Coverage impact: none.

### Manual Testing
- `grep -c '\bclm\b' .itx/411/*.md` → 0.
- `grep -c vetted .itx/411/*.md` → 0.
- Plan internally consistent with AGENTS.md "Skill Registry" Key Concept, `clawctl agent sync` semantics, and the existing `skills/_schema/` layout.

### Security Checklist
- [x] No hardcoded secrets or credentials.
- [x] Input validation for user-provided data — N/A.
- [x] No SQL injection, XSS, or command injection risks — N/A.
- [x] Dependencies are from trusted sources — N/A.

## Reviewer Notes

This PR ships **planning only**. Implementation follows in three subtask PRs (A/B/C per `01_SCAFFOLD.md`). Specific things worth a careful look:

- **User overlay location** (`~/.config/clawrium/skills/<registry>/<name>/`) — the bundled `skills/` dir stays read-only because installed wheels can't be written to. List/load unions both roots; overlay wins on collision with a warning. If you'd rather scope user registries differently, say so before Subtask A starts.
- **`skills.json` shape for agent-local entries** — the plan defaults to bare names (`tdd`) rather than a reserved namespace (`local/tdd`). Locked in Subtask A's exit criteria.
- **BREAKING removal** of `attach`/`detach`/`--agent` — concrete before/after invocations go in the CHANGELOG entry under Subtask B.

Closes the planning stage for #411. Supersedes the closed PR #634 entirely.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)