### PR TITLE
feat(skills): add #411 Phase A local skill helpers

### DIFF
--- a/.itx/411/00_PLAN.md
+++ b/.itx/411/00_PLAN.md
@@ -233,7 +233,7 @@ introduced) unions bundled + overlay and tags origin.
   - `add` rollback: if `skills_state.add_skill` fails after the
     local dir is written, delete the dir before returning the
     error. Symmetric to the existing preflight → mutate → apply
-    pattern in `attach` (line 86–130 of the current file).
+    pattern in the current `attach` implementation.
   - `add` does NOT call `apply_state`. The CLI exits after the
     state file is mutated. Use `clawctl agent sync <agent>` to
     flush. (Same model as `clawctl agent configure`/`sync`.)
@@ -350,7 +350,8 @@ introduced) unions bundled + overlay and tags origin.
   - `load_agent_skill(agent, name, agent_type)` returns a native
     `Skill` for `hermes`, `openclaw`, and `zeroclaw`; raises
     `SkillNotFound` for missing; raises `SchemaValidationError` for
-    malformed native `SKILL.md` frontmatter.
+    malformed or schema-invalid native `SKILL.md` frontmatter; raises
+    `InvalidSkillRef` for invalid local names.
   - `list_agent_skills` returns sorted bare names; empty list if
     dir absent.
   - `skills_state` rejects any desired-state entry containing `/` and

--- a/.itx/411/00_PLAN.md
+++ b/.itx/411/00_PLAN.md
@@ -160,7 +160,10 @@ introduced) unions bundled + overlay and tags origin.
     materializes to the target native shape, and validates the native
     result. The important invariant is call-site placement: CLI/GUI add
     paths call it before persisting the per-agent skill; sync/apply does
-    not call it.
+    not call it. The returned `Skill.path` is set to the sentinel
+    `Path("__materialized__")` to signal the skill has no on-disk target
+    yet; Phase B callers must choose the per-agent target path before
+    persisting bytes.
   - `parse_skill_ref` is **unchanged**. Bare names continue to raise
     `MissingRegistryPrefix`. Agent-local lookups go through the new
     `load_agent_skill(agent, name, agent_type)` API; they never flow through

--- a/.itx/411/00_PLAN.md
+++ b/.itx/411/00_PLAN.md
@@ -140,10 +140,12 @@ introduced) unions bundled + overlay and tags origin.
     `_load_schema` and `_bare_name_hint`. **Do not change its
     signature.** Adding a sibling helper is cheaper than fanning out
     a return-type change through every existing caller.
-  - Rewrite `list_skills` to iterate `_catalog_roots()` and dedupe
-    on `<registry>/<name>`. Overlay wins on collision; emit a
-    `logger.warning` once per collision per process.
-  - Rewrite `load_skill` to try overlay first, then bundled.
+  - Add private overlay-aware catalog enumeration/lookup helpers that
+    dedupe on `<registry>/<name>`. Overlay wins on collision; emit a
+    `logger.warning` once per collision per process. Phase A must not
+    wire these helpers into public CLI/GUI paths; Phase B wires
+    `list_skills` and `load_skill` to them alongside the user-facing
+    semantic switch.
   - Add `load_agent_skill(agent: str, name: str, agent_type: str) -> Skill`
     and `list_agent_skills(agent: str) -> list[str]`, reading from
     `~/.config/clawrium/agents/<agent>/skills/<name>/`. Agent-local
@@ -152,11 +154,13 @@ introduced) unions bundled + overlay and tags origin.
     The returned `Skill.ref.registry` should be the concrete agent type
     (`hermes`, `openclaw`, or `zeroclaw`), not a synthetic `local`
     registry, so existing native schema validation can be reused.
-  - Add `materialize_skill_for_agent(skill: Skill, agent_type: str) -> tuple[dict, str]`
-    only if needed as a public wrapper around the current
-    `materialize_for_claw` logic. The important invariant is call-site
-    placement: CLI/GUI add paths call it before persisting the
-    per-agent skill; sync/apply does not call it.
+  - Add `materialize_skill_for_agent(skill: Skill, agent_type: str) -> Skill`
+    as an add-time wrapper around the current `materialize_for_claw`
+    logic. It validates the source skill, checks compatibility,
+    materializes to the target native shape, and validates the native
+    result. The important invariant is call-site placement: CLI/GUI add
+    paths call it before persisting the per-agent skill; sync/apply does
+    not call it.
   - `parse_skill_ref` is **unchanged**. Bare names continue to raise
     `MissingRegistryPrefix`. Agent-local lookups go through the new
     `load_agent_skill(agent, name, agent_type)` API; they never flow through
@@ -173,8 +177,10 @@ introduced) unions bundled + overlay and tags origin.
     (`"clawrium/tdd"`) are not valid desired state after this change.
     Document this in the file's module docstring.
   - `read_state` / `write_state` / `add_skill` / `remove_skill`
-    validate names with the existing slug regex and reject any value
-    containing `/`.
+    validate names with the existing `_NAME_RE` slug regex
+    (`^[a-z0-9][a-z0-9_-]*$`). Reject values such as `/`, `..`, empty
+    strings, uppercase names, spaces, and other non-slug forms before
+    any directory creation or state mutation.
   - Add an explicit migration or one-time error strategy for old
     `skills.json` files containing registry refs. Preferred behavior:
     `clawctl agent skill add <agent> --from-template clawrium/tdd`
@@ -204,11 +210,16 @@ introduced) unions bundled + overlay and tags origin.
     1. `--from-template <registry>/<name>` — copy bytes from
        bundled-or-overlay catalog, materialized for the target
        agent's type, into the agent's local dir.
-    2. Positional `PATH` — file (a single `SKILL.md`) or directory
-       (a full skill tree). Validate the input shape, materialize it
-       for the target agent type if it is a normalized `clawrium`
-       shape, then persist the target-agent-native `SKILL.md` into the
-       agent's local dir.
+     2. Positional `PATH` — file (a single `SKILL.md`) or directory
+        (a full skill tree). Validate the input shape, materialize it
+        for the target agent type if it is a normalized `clawrium`
+        shape, then persist the target-agent-native `SKILL.md` into the
+        agent's local dir.
+        - Name derivation rule: if `--name` is omitted, derive the
+          persisted name from validated `SKILL.md` frontmatter `name`,
+          not from `Path(input).name`. Reject invalid or missing
+          frontmatter names with `InvalidSkillRef` before creating any
+          directory. `--name`, when provided, must also pass `_NAME_RE`.
     3. No path and no template — open `$EDITOR` (or `EDITOR` env
        var; fall back to `vi`) on a stub `SKILL.md` in the target
        agent's native format, then persist on save.

--- a/.itx/411/01_SCAFFOLD.md
+++ b/.itx/411/01_SCAFFOLD.md
@@ -43,8 +43,9 @@ desired-state semantics or any CLI/GUI surface.
     `_schema/native/<agent_type>.schema.json`.
   - Add `list_agent_skills(agent: str) -> list[str]` returning
     sorted bare names; empty list if dir absent.
-  - Expose reusable add-time materialization helper if needed, but do
-    not leave materialization in the sync/apply path.
+  - Expose `materialize_skill_for_agent(skill, agent_type) -> Skill`
+    as the reusable add-time materialization helper, but do not leave
+    materialization in the sync/apply path.
   - **Do not change** `parse_skill_ref`. Agent-local lookups go
     through `load_agent_skill(agent, name, agent_type)` directly; they never
     flow through `parse_skill_ref`.
@@ -59,19 +60,27 @@ desired-state semantics or any CLI/GUI surface.
     the new CLI and the semantic switch together.
 
 - Tests:
-  - Catalog union and overlay precedence.
+  - Private catalog union and overlay precedence helpers, without
+    changing public `list_skills` / `load_skill` behavior yet.
   - Agent-native schema validation for hermes/openclaw/zeroclaw sample
     `SKILL.md` files.
   - Add-time materialization helper converts `clawrium/tdd` into valid
     native frontmatter for each supported agent type.
+  - `load_agent_skill` failure paths: missing local skill raises
+    `SkillNotFound`; malformed `SKILL.md` frontmatter raises
+    `SchemaValidationError`.
 
 **Exit criteria**
 - `make test` and `make lint` green.
-- Catalog union path covered for: bundled-only, overlay-only,
+- Private catalog union path covered for: bundled-only, overlay-only,
   both-present (overlay wins + warning), neither (existing
-  `SkillNotFound` raised — error class unchanged).
+  `SkillNotFound` raised — error class unchanged). Public
+  `list_skills` / `load_skill` remain bundled-only until B.
 - Materialization helper covered for `hermes`, `openclaw`, and
   `zeroclaw`; each result validates against that agent's native schema.
+- Byte-preservation boundary is documented for B: sync/apply must stage
+  already-native local `SKILL.md` bytes unchanged when B switches the
+  desired-state source to per-agent local skills.
 - **No public CLI or GUI behavior change yet** — existing
   `clawctl agent skill attach/detach/get` flows continue to work.
 
@@ -102,7 +111,10 @@ add top-level `clawctl skill add`, and update docs.
     (`"<registry>/<name>"`) are invalid desired state. Document this
     in the module docstring.
   - `read_state` / `write_state` / `add_skill` / `remove_skill`
-    validate safe bare names and reject any value containing `/`.
+    validate safe bare names with `_NAME_RE`
+    (`^[a-z0-9][a-z0-9_-]*$`) and reject `/`, `..`, uppercase, spaces,
+    empty strings, and all non-slug forms before any directory creation
+    or state mutation.
   - Old state files containing registry refs fail with a clear
     operator message to re-add those skills from template. Do not
     silently copy templates during sync.
@@ -136,6 +148,10 @@ add top-level `clawctl skill add`, and update docs.
     - Positional `PATH` — file (a single `SKILL.md`) or directory
       (full skill tree). Validate the input, materialize it for the
       target agent type if needed, then persist native `SKILL.md`.
+      If `--name` is omitted, derive the persisted name from validated
+      `SKILL.md` frontmatter `name`, not from `Path(input).name`.
+      Reject invalid/missing frontmatter names before creating any
+      directory. `--name`, when provided, must also pass `_NAME_RE`.
     - Neither — open `$EDITOR` (or `EDITOR` env var; fall back to
       `vi`) on a stub native `SKILL.md`, persist on save.
   - `add` resolves the agent first to determine `agent_type`. It

--- a/.itx/411/01_SCAFFOLD.md
+++ b/.itx/411/01_SCAFFOLD.md
@@ -32,10 +32,13 @@ desired-state semantics or any CLI/GUI surface.
     by `_load_schema` and `_bare_name_hint`. **Do not change its
     signature** — that would fan out to schema resolution and the
     bare-name hint path with no benefit.
-  - Rewrite `list_skills` to iterate `_catalog_roots()` and dedupe
-    on `<registry>/<name>`. Overlay wins on collision; emit a
-    `logger.warning` (once per `(registry, name)` per process).
-  - Rewrite `load_skill` to try overlay first, fall back to bundled.
+  - Add private overlay-aware helpers (for example,
+    `_list_skills_from_roots()` and `_find_catalog_skill_dir()`) that
+    iterate `_catalog_roots()` and dedupe on `<registry>/<name>`.
+    Overlay wins on collision; emit a `logger.warning` (once per
+    `(registry, name)` per process). Public `list_skills` and
+    `load_skill` stay bundled-only until B wires overlays alongside the
+    user-facing semantic switch.
   - Add `load_agent_skill(agent: str, name: str, agent_type: str) -> Skill`.
     Per-agent skills are already materialized for their target agent,
     so the returned `Skill.ref.registry` is the concrete agent type
@@ -67,8 +70,9 @@ desired-state semantics or any CLI/GUI surface.
   - Add-time materialization helper converts `clawrium/tdd` into valid
     native frontmatter for each supported agent type.
   - `load_agent_skill` failure paths: missing local skill raises
-    `SkillNotFound`; malformed `SKILL.md` frontmatter raises
-    `SchemaValidationError`.
+    `SkillNotFound`; malformed or schema-invalid `SKILL.md`
+    frontmatter raises `SchemaValidationError`; invalid local names
+    raise `InvalidSkillRef`.
 
 **Exit criteria**
 - `make test` and `make lint` green.

--- a/.itx/411/01_SCAFFOLD.md
+++ b/.itx/411/01_SCAFFOLD.md
@@ -82,9 +82,10 @@ desired-state semantics or any CLI/GUI surface.
   `list_skills` / `load_skill` remain bundled-only until B.
 - Materialization helper covered for `hermes`, `openclaw`, and
   `zeroclaw`; each result validates against that agent's native schema.
-- Byte-preservation boundary is documented for B: sync/apply must stage
-  already-native local `SKILL.md` bytes unchanged when B switches the
-  desired-state source to per-agent local skills.
+- Byte-preservation boundary is documented for B in this scaffold and
+  `.itx/411/00_PLAN.md`: sync/apply must stage already-native local
+  `SKILL.md` bytes unchanged when B switches the desired-state source
+  to per-agent local skills.
 - **No public CLI or GUI behavior change yet** — existing
   `clawctl agent skill attach/detach/get` flows continue to work.
 
@@ -94,6 +95,8 @@ desired-state semantics or any CLI/GUI surface.
 - Any CLI verb changes.
 - Any GUI route or frontend changes.
 - Docs (covered by B).
+- Wiring overlay helpers into `_bare_name_hint`; keep bare-name hints
+  bundled-only until B wires public overlay behavior.
 
 ---
 
@@ -167,8 +170,8 @@ add top-level `clawctl skill add`, and update docs.
     remove or rename the existing skill first.
   - `add` rollback: if `add_skill` fails after the local dir is
     written, delete the dir before returning the error. Symmetric
-    to the existing preflight → mutate → apply pattern at lines
-    97–121 of the pre-change file.
+    to the existing preflight → mutate → apply pattern in the
+    pre-change file.
   - `add` does **not** call `apply_state`. CLI exits after the
     state file is mutated. Use `clawctl agent sync <agent>` to
     flush.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ release.
 
 ### Fixed
 
+- `clawctl` skill-not-found guidance now references
+  `clawctl skill registry get` instead of the removed legacy
+  `clm skill list` command. (#411)
 - `clawctl agent sync` on hermes agents with multiple provider
   attachments now renders one `auxiliary.<role>:` block per non-primary
   attachment in `~/.hermes/config.yaml`, and emits each non-primary

--- a/src/clawrium/core/skills.py
+++ b/src/clawrium/core/skills.py
@@ -389,7 +389,8 @@ def load_skill(ref: SkillRef | str) -> Skill:
     skill_dir = root / ref.registry / ref.name
     if not skill_dir.is_dir():
         raise SkillNotFound(
-            f"Skill {ref} not found. Run `clm skill list` to see available skills."
+            f"Skill {ref} not found. Run `clawctl skill registry get` to see "
+            "available skills."
         )
 
     return _load_skill_from_dir(ref, skill_dir)
@@ -540,8 +541,10 @@ def check_agent_compatibility(skill: Skill, agent_type: str) -> None:
                 f"got {type(compat).__name__}."
             )
         # Default-true if the claw key is absent (a normalized skill is
-        # meant to run anywhere unless it opts out). Only an explicit
-        # `false` value fails closed.
+        # meant to run anywhere unless it opts out). `validate_skill` enforces
+        # the shipped schema's required compatibility keys before add-time
+        # materialization; this branch remains lenient for legacy direct callers.
+        # Only an explicit `false` value fails closed.
         flag = compat.get(agent_type, True)
         if not flag:
             raise IncompatibleSkillRegistry(

--- a/src/clawrium/core/skills.py
+++ b/src/clawrium/core/skills.py
@@ -26,6 +26,8 @@ from typing import Any, Iterable
 
 import yaml
 
+from clawrium.core.config import get_config_dir
+
 logger = logging.getLogger(__name__)
 
 
@@ -37,6 +39,8 @@ NATIVE_REGISTRIES: frozenset[str] = frozenset({"openclaw", "hermes", "zeroclaw"}
 
 _NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 """Slug pattern for `<name>` in `<registry>/<name>` and for directory names."""
+
+_CATALOG_OVERLAY_COLLISIONS_WARNED: set[str] = set()
 
 _EXTERNAL_PREFIXES = (
     "http://",
@@ -141,6 +145,41 @@ def _catalog_root() -> Path:
         f"{bundled} and dev {dev}). "
         "Reinstall with: `uv tool install --force clawrium`."
     )
+
+
+def _overlay_root() -> Path:
+    """Return the user-writable skill overlay root.
+
+    The directory may not exist yet; callers decide whether absence is
+    meaningful for their operation.
+    """
+    return get_config_dir() / "skills"
+
+
+def _catalog_roots() -> list[tuple[str, Path]]:
+    """Return available catalog roots in precedence application order.
+
+    Bundled skills are listed first and the user overlay second so callers
+    that fold by ref can let the overlay win collisions. If neither root is
+    available, preserve the existing `_catalog_root()` `SkillNotFound`
+    failure mode.
+    """
+    roots: list[tuple[str, Path]] = []
+    catalog_error: SkillNotFound | None = None
+    try:
+        roots.append(("bundled", _catalog_root()))
+    except SkillNotFound as error:
+        catalog_error = error
+
+    overlay = _overlay_root()
+    if overlay.is_dir():
+        roots.append(("overlay", overlay))
+
+    if not roots:
+        if catalog_error is not None:
+            raise catalog_error
+        raise SkillNotFound("skills catalog not found.")
+    return roots
 
 
 def parse_skill_ref(raw: str) -> SkillRef:
@@ -252,9 +291,9 @@ def list_skills(registry: str | None = None) -> list[SkillRef]:
             f"Unknown registry {registry!r}. Allowed: {', '.join(REGISTRIES)}."
         )
 
-    root = _catalog_root()
     registries: Iterable[str] = (registry,) if registry else REGISTRIES
 
+    root = _catalog_root()
     refs: list[SkillRef] = []
     for reg in registries:
         reg_dir = root / reg
@@ -272,6 +311,52 @@ def list_skills(registry: str | None = None) -> list[SkillRef]:
         for name in sorted(names):
             refs.append(SkillRef(registry=reg, name=name))
     return refs
+
+
+def _list_skills_from_roots(registry: str | None = None) -> list[SkillRef]:
+    """Enumerate bundled plus overlay roots, with overlay collisions winning.
+
+    Kept private in Phase A so public CLI/GUI behavior does not change
+    before the issue #411 semantic switch wires overlays intentionally.
+    """
+    if registry is not None and registry not in REGISTRIES:
+        raise InvalidSkillRef(
+            f"Unknown registry {registry!r}. Allowed: {', '.join(REGISTRIES)}."
+        )
+
+    registries: Iterable[str] = (registry,) if registry else REGISTRIES
+    refs_by_key: dict[tuple[str, str], SkillRef] = {}
+    paths_by_key: dict[tuple[str, str], Path] = {}
+    for source, root in _catalog_roots():
+        for reg in registries:
+            reg_dir = root / reg
+            if not reg_dir.is_dir():
+                continue
+            for entry in reg_dir.iterdir():
+                if not entry.is_dir():
+                    continue
+                if not _NAME_RE.match(entry.name):
+                    continue
+                if not _has_skill_files(entry, reg):
+                    continue
+                key = (reg, entry.name)
+                if key in refs_by_key and source == "overlay":
+                    collision_key = f"{reg}/{entry.name}"
+                    if collision_key not in _CATALOG_OVERLAY_COLLISIONS_WARNED:
+                        logger.warning(
+                            "User skill overlay %s shadows bundled skill %s at %s",
+                            entry,
+                            collision_key,
+                            paths_by_key[key],
+                        )
+                        _CATALOG_OVERLAY_COLLISIONS_WARNED.add(collision_key)
+                refs_by_key[key] = SkillRef(registry=reg, name=entry.name)
+                paths_by_key[key] = entry
+
+    registry_order = {reg: index for index, reg in enumerate(REGISTRIES)}
+    return sorted(
+        refs_by_key.values(), key=lambda ref: (registry_order[ref.registry], ref.name)
+    )
 
 
 def _has_skill_files(skill_dir: Path, registry: str) -> bool:
@@ -307,6 +392,22 @@ def load_skill(ref: SkillRef | str) -> Skill:
             f"Skill {ref} not found. Run `clm skill list` to see available skills."
         )
 
+    return _load_skill_from_dir(ref, skill_dir)
+
+
+def _find_catalog_skill_dir(ref: SkillRef) -> Path | None:
+    """Return overlay-first directory for a catalog ref, if present."""
+    roots = list(reversed(_catalog_roots()))
+    for _source, root in roots:
+        skill_dir = root / ref.registry / ref.name
+        if skill_dir.is_dir():
+            return skill_dir
+    return None
+
+
+def _load_skill_from_dir(ref: SkillRef, skill_dir: Path) -> Skill:
+    """Load ``ref`` from a concrete directory without applying catalog lookup."""
+
     skill_md = skill_dir / "SKILL.md"
     if not skill_md.is_file():
         raise SkillNotFound(f"Skill {ref} is missing SKILL.md at {skill_md}.")
@@ -336,6 +437,51 @@ def load_skill(ref: SkillRef | str) -> Skill:
         body=body,
         skill_md_frontmatter=frontmatter,
     )
+
+
+def list_agent_skills(agent: str) -> list[str]:
+    """List local, already-materialized skill names for ``agent``."""
+    from clawrium.core.skills_state import agent_skills_dir
+
+    root = agent_skills_dir(agent)
+    if not root.is_dir():
+        return []
+    names: list[str] = []
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        if not _NAME_RE.match(entry.name):
+            continue
+        if (entry / "SKILL.md").is_file():
+            names.append(entry.name)
+    return sorted(names)
+
+
+def load_agent_skill(agent: str, name: str, agent_type: str) -> Skill:
+    """Load an already-materialized local skill for a specific agent.
+
+    Per-agent skills are stored in the target agent's native format, so
+    the returned ref uses the concrete native registry rather than a
+    synthetic `local` registry.
+    """
+    if agent_type not in NATIVE_REGISTRIES:
+        raise IncompatibleSkillRegistry(
+            f"Unknown agent type {agent_type!r}. "
+            f"Supported: {', '.join(sorted(NATIVE_REGISTRIES))}."
+        )
+    if not isinstance(name, str) or not _NAME_RE.match(name):
+        raise InvalidSkillRef(
+            f"Invalid skill name {name!r}. Names must match ^[a-z0-9][a-z0-9_-]*$."
+        )
+
+    from clawrium.core.skills_state import agent_skills_dir
+
+    skill_dir = agent_skills_dir(agent) / name
+    if not skill_dir.is_dir():
+        raise SkillNotFound(f"Local skill {name!r} not found for agent {agent!r}.")
+    skill = _load_skill_from_dir(SkillRef(agent_type, name), skill_dir)
+    validate_skill(skill)
+    return skill
 
 
 def validate_skill(skill: Skill) -> None:
@@ -371,14 +517,11 @@ def check_agent_compatibility(skill: Skill, agent_type: str) -> None:
     Compatibility rules (locked in `.itx/364/00_PLAN.md`):
 
     - ``clawrium/<name>``: read the ``compatibility`` map in `_meta.yaml`.
-      **Fail-closed**: missing key OR explicit ``false`` raises
-      ``IncompatibleSkillRegistry``. The catalog author must list each
-      claw they intend to support — silent "absent means anywhere" was
-      rejected during planning because it makes drift hard to debug
-      ("why did install succeed but the skill never run?"). The
-      `clawrium.schema.json` also requires the map (and all three claw
-      entries inside it), so a missing key represents a malformed skill.
-      Unknown agent types fail closed too.
+      A missing claw key defaults to compatible; only an explicit ``false``
+      raises ``IncompatibleSkillRegistry``. Callers that need schema-level
+      guarantees must run ``validate_skill`` before this helper; the public
+      add-time materialization helper does that before checking compatibility.
+      Unknown agent types fail closed.
     - ``<claw>/<name>`` (native): must match ``agent_type`` exactly.
       Cross-claw native installs are a hard error because the SKILL.md
       is already in a per-claw frontmatter shape.
@@ -398,7 +541,7 @@ def check_agent_compatibility(skill: Skill, agent_type: str) -> None:
             )
         # Default-true if the claw key is absent (a normalized skill is
         # meant to run anywhere unless it opts out). Only an explicit
-        # `false` value fails closed. Mirrors the docstring contract.
+        # `false` value fails closed.
         flag = compat.get(agent_type, True)
         if not flag:
             raise IncompatibleSkillRegistry(
@@ -472,6 +615,28 @@ def materialize_for_claw(skill: Skill, claw: str) -> tuple[dict[str, Any], str]:
                 frontmatter[key] = value
 
     return frontmatter, skill.body
+
+
+def materialize_skill_for_agent(skill: Skill, agent_type: str) -> Skill:
+    """Materialize ``skill`` into ``agent_type``'s native skill shape.
+
+    This is the reusable add-time conversion helper for issue #411. It
+    validates compatibility, converts to native frontmatter/body, then
+    validates the native shape before returning an in-memory ``Skill``.
+    It intentionally does not write to disk.
+    """
+    validate_skill(skill)
+    check_agent_compatibility(skill, agent_type)
+    frontmatter, body = materialize_for_claw(skill, agent_type)
+    native_skill = Skill(
+        ref=SkillRef(agent_type, skill.ref.name),
+        path=skill.path,
+        metadata=dict(frontmatter),
+        body=body,
+        skill_md_frontmatter=dict(frontmatter),
+    )
+    validate_skill(native_skill)
+    return native_skill
 
 
 def _split_frontmatter(text: str) -> tuple[str, dict[str, Any]]:
@@ -595,10 +760,13 @@ __all__ = [
     "parse_skill_ref",
     "list_skills",
     "load_skill",
+    "list_agent_skills",
+    "load_agent_skill",
     "validate_skill",
     "check_agent_compatibility",
     "clear_schema_cache",
     "materialize_for_claw",
+    "materialize_skill_for_agent",
 ]
 # Note: `scripts/validate_skills.py` imports a handful of underscored
 # helpers from this module by explicit name (`_NAME_RE`, `_load_schema`,

--- a/src/clawrium/core/skills.py
+++ b/src/clawrium/core/skills.py
@@ -398,10 +398,13 @@ def load_skill(ref: SkillRef | str) -> Skill:
 
 def _find_catalog_skill_dir(ref: SkillRef) -> Path | None:
     """Return overlay-first directory for a catalog ref, if present."""
-    roots = list(reversed(_catalog_roots()))
+    try:
+        roots = list(reversed(_catalog_roots()))
+    except SkillNotFound:
+        return None
     for _source, root in roots:
         skill_dir = root / ref.registry / ref.name
-        if skill_dir.is_dir():
+        if skill_dir.is_dir() and _has_skill_files(skill_dir, ref.registry):
             return skill_dir
     return None
 
@@ -466,7 +469,7 @@ def load_agent_skill(agent: str, name: str, agent_type: str) -> Skill:
     synthetic `local` registry.
     """
     if agent_type not in NATIVE_REGISTRIES:
-        raise IncompatibleSkillRegistry(
+        raise InvalidSkillRef(
             f"Unknown agent type {agent_type!r}. "
             f"Supported: {', '.join(sorted(NATIVE_REGISTRIES))}."
         )
@@ -633,7 +636,9 @@ def materialize_skill_for_agent(skill: Skill, agent_type: str) -> Skill:
     frontmatter, body = materialize_for_claw(skill, agent_type)
     native_skill = Skill(
         ref=SkillRef(agent_type, skill.ref.name),
-        path=skill.path,
+        # Materialized skills are not on disk yet. Phase B add/edit callers
+        # must choose the per-agent target dir before persisting bytes.
+        path=Path("__materialized__"),
         metadata=dict(frontmatter),
         body=body,
         skill_md_frontmatter=dict(frontmatter),

--- a/src/clawrium/core/skills_state.py
+++ b/src/clawrium/core/skills_state.py
@@ -39,6 +39,7 @@ from clawrium.core.skills import (
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "agent_skills_dir",
     "state_file_path",
     "read_state",
     "write_state",
@@ -73,6 +74,16 @@ def state_file_path(agent_name: str) -> Path:
     """
     _validate_agent_name(agent_name)
     return get_config_dir() / "agents" / agent_name / "skills.json"
+
+
+def agent_skills_dir(agent_name: str) -> Path:
+    """Return the local directory containing ``agent_name``'s skill files.
+
+    Phase A only exposes the path helper; the desired-state file continues
+    to store registry refs until the issue #411 semantic switch lands.
+    """
+    _validate_agent_name(agent_name)
+    return get_config_dir() / "agents" / agent_name / "skills"
 
 
 def read_state(agent_name: str) -> list[str]:

--- a/tests/test_core_skills.py
+++ b/tests/test_core_skills.py
@@ -167,15 +167,56 @@ def test_list_skills_empty_native_registries():
         assert refs == [], f"{native} should be empty, got {refs}"
 
 
+def test_catalog_roots_returns_bundled_only(monkeypatch, tmp_path):
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+
+    assert skills._catalog_roots() == [("bundled", tmp_path)]
+
+
+def test_catalog_roots_returns_bundled_then_overlay(monkeypatch, tmp_path):
+    bundled = tmp_path / "bundled"
+    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    bundled.mkdir()
+    overlay.mkdir(parents=True)
+    monkeypatch.setattr(skills, "_catalog_root", lambda: bundled)
+
+    assert skills._catalog_roots() == [("bundled", bundled), ("overlay", overlay)]
+
+
+def test_catalog_roots_returns_overlay_only(monkeypatch, tmp_path):
+    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    overlay.mkdir(parents=True)
+
+    def missing_catalog():
+        raise SkillNotFound("missing bundled catalog")
+
+    monkeypatch.setattr(skills, "_catalog_root", missing_catalog)
+
+    assert skills._catalog_roots() == [("overlay", overlay)]
+
+
+def test_catalog_roots_raises_when_neither_root_exists(monkeypatch):
+    def missing_catalog():
+        raise SkillNotFound("missing bundled catalog")
+
+    monkeypatch.setattr(skills, "_catalog_root", missing_catalog)
+
+    with pytest.raises(SkillNotFound, match="missing bundled catalog"):
+        skills._catalog_roots()
+
+
 def test_public_list_skills_ignores_overlay_until_wired(monkeypatch, tmp_path):
     bundled = tmp_path / "bundled"
     overlay = tmp_path / "xdg" / "clawrium" / "skills"
     bundled.mkdir()
     _copy_schemas(bundled)
+    _build_fake_native_skill(bundled, registry="hermes", name="bundled-skill")
     _build_fake_native_skill(overlay, registry="hermes", name="overlay-only")
     monkeypatch.setattr(skills, "_catalog_root", lambda: bundled)
 
-    assert SkillRef("hermes", "overlay-only") not in list_skills(registry="hermes")
+    refs = list_skills(registry="hermes")
+    assert SkillRef("hermes", "bundled-skill") in refs
+    assert SkillRef("hermes", "overlay-only") not in refs
 
 
 def test_public_load_skill_ignores_overlay_until_wired(monkeypatch, tmp_path):
@@ -183,9 +224,13 @@ def test_public_load_skill_ignores_overlay_until_wired(monkeypatch, tmp_path):
     overlay = tmp_path / "xdg" / "clawrium" / "skills"
     bundled.mkdir()
     _copy_schemas(bundled)
+    _build_fake_native_skill(bundled, registry="hermes", name="bundled-skill")
     _build_fake_native_skill(overlay, registry="hermes", name="overlay-only")
     monkeypatch.setattr(skills, "_catalog_root", lambda: bundled)
 
+    assert load_skill("hermes/bundled-skill").ref == SkillRef(
+        "hermes", "bundled-skill"
+    )
     with pytest.raises(SkillNotFound):
         load_skill("hermes/overlay-only")
 
@@ -256,10 +301,46 @@ def test_find_catalog_skill_dir_returns_bundled_when_no_overlay(monkeypatch, tmp
 
 
 def test_find_catalog_skill_dir_returns_none_for_missing(monkeypatch, tmp_path):
-    _copy_schemas(tmp_path)
     monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
 
     assert skills._find_catalog_skill_dir(SkillRef("hermes", "missing")) is None
+
+
+def test_find_catalog_skill_dir_returns_overlay_when_bundled_absent(
+    monkeypatch, tmp_path
+):
+    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    _build_fake_native_skill(overlay, registry="hermes", name="sample")
+
+    def missing_catalog():
+        raise SkillNotFound("missing bundled catalog")
+
+    monkeypatch.setattr(skills, "_catalog_root", missing_catalog)
+
+    assert skills._find_catalog_skill_dir(SkillRef("hermes", "sample")) == (
+        overlay / "hermes" / "sample"
+    )
+
+
+def test_find_catalog_skill_dir_ignores_stub_overlay(monkeypatch, tmp_path):
+    bundled = tmp_path / "bundled"
+    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    _build_fake_native_skill(bundled, registry="hermes", name="sample")
+    (overlay / "hermes" / "sample").mkdir(parents=True)
+    monkeypatch.setattr(skills, "_catalog_root", lambda: bundled)
+
+    assert skills._find_catalog_skill_dir(SkillRef("hermes", "sample")) == (
+        bundled / "hermes" / "sample"
+    )
+
+
+def test_find_catalog_skill_dir_returns_none_when_no_roots(monkeypatch):
+    def missing_catalog():
+        raise SkillNotFound("missing bundled catalog")
+
+    monkeypatch.setattr(skills, "_catalog_root", missing_catalog)
+
+    assert skills._find_catalog_skill_dir(SkillRef("hermes", "sample")) is None
 
 
 # ------------------------------ load_skill ----------------------------------
@@ -345,7 +426,7 @@ def test_load_agent_skill_rejects_schema_invalid_frontmatter(tmp_path, agent_typ
 
 
 def test_load_agent_skill_rejects_unknown_agent_type():
-    with pytest.raises(IncompatibleSkillRegistry, match="Unknown agent type"):
+    with pytest.raises(InvalidSkillRef, match="Unknown agent type"):
         load_agent_skill("hermes-tdd", "local", "not-a-claw")
 
 
@@ -364,6 +445,8 @@ def test_materialize_skill_for_agent_returns_valid_native_skill(agent_type):
     native_skill = materialize_skill_for_agent(skill, agent_type)
 
     assert native_skill.ref == SkillRef(agent_type, "tdd")
+    assert native_skill.path == Path("__materialized__")
+    assert native_skill.path != skill.path
     assert native_skill.metadata["name"] == "tdd"
     assert native_skill.body.strip().startswith("# TDD")
     validate_skill(native_skill)

--- a/tests/test_core_skills.py
+++ b/tests/test_core_skills.py
@@ -22,13 +22,18 @@ from clawrium.core import skills
 from clawrium.core.skills import (
     ExternalSourceBlocked,
     InvalidSkillRef,
+    IncompatibleSkillRegistry,
     MissingRegistryPrefix,
+    NATIVE_REGISTRIES,
     REGISTRIES,
     SchemaValidationError,
     SkillNotFound,
     SkillRef,
+    list_agent_skills,
     list_skills,
+    load_agent_skill,
     load_skill,
+    materialize_skill_for_agent,
     parse_skill_ref,
     validate_skill,
 )
@@ -44,7 +49,7 @@ def test_parse_skill_ref_happy_path():
 
 
 @pytest.fixture(autouse=True)
-def _reset_schema_cache():
+def _reset_schema_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Schema cache is module-level. Tests that build a fake catalog
     in tmp_path poison the cache for whichever test runs next; clear
     it on every setup and teardown to keep tests independent.
@@ -53,9 +58,12 @@ def _reset_schema_cache():
     the private `_SCHEMA_CACHE` name — keeps the fixture working if the
     cache implementation ever changes (e.g. swaps to functools.lru_cache).
     """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
     skills.clear_schema_cache()
+    skills._CATALOG_OVERLAY_COLLISIONS_WARNED.clear()
     yield
     skills.clear_schema_cache()
+    skills._CATALOG_OVERLAY_COLLISIONS_WARNED.clear()
 
 
 @pytest.mark.parametrize("raw", ["", "   ", "\t\n"])
@@ -159,6 +167,62 @@ def test_list_skills_empty_native_registries():
         assert refs == [], f"{native} should be empty, got {refs}"
 
 
+def test_list_skills_includes_overlay_only(monkeypatch, tmp_path):
+    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    _build_fake_native_skill(overlay, registry="hermes", name="overlay-skill")
+
+    def missing_catalog():
+        raise SkillNotFound("missing bundled catalog")
+
+    monkeypatch.setattr(skills, "_catalog_root", missing_catalog)
+
+    assert skills._list_skills_from_roots(registry="hermes") == [
+        SkillRef("hermes", "overlay-skill")
+    ]
+
+
+def test_list_skills_raises_when_no_catalog_roots(monkeypatch):
+    def missing_catalog():
+        raise SkillNotFound("missing bundled catalog")
+
+    monkeypatch.setattr(skills, "_catalog_root", missing_catalog)
+
+    with pytest.raises(SkillNotFound, match="missing bundled catalog"):
+        skills._list_skills_from_roots()
+
+
+def test_overlay_shadows_bundled_skill_once(monkeypatch, tmp_path, caplog):
+    bundled = tmp_path / "bundled"
+    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    _build_fake_native_skill(
+        bundled,
+        registry="hermes",
+        name="sample",
+        frontmatter={"name": "sample", "description": "bundled"},
+    )
+    _build_fake_native_skill(
+        overlay,
+        registry="hermes",
+        name="sample",
+        frontmatter={"name": "sample", "description": "overlay"},
+    )
+    monkeypatch.setattr(skills, "_catalog_root", lambda: bundled)
+
+    with caplog.at_level("WARNING"):
+        assert skills._list_skills_from_roots(registry="hermes") == [
+            SkillRef("hermes", "sample")
+        ]
+        assert skills._list_skills_from_roots(registry="hermes") == [
+            SkillRef("hermes", "sample")
+        ]
+
+    warnings = [record for record in caplog.records if "shadows bundled" in record.message]
+    assert len(warnings) == 1
+    assert skills._find_catalog_skill_dir(SkillRef("hermes", "sample")) == (
+        overlay / "hermes" / "sample"
+    )
+
+
 # ------------------------------ load_skill ----------------------------------
 
 
@@ -182,12 +246,76 @@ def test_load_skill_via_string_runs_parse_first():
         load_skill("https://example.com/foo")
 
 
+def test_list_agent_skills_returns_sorted_valid_local_names(tmp_path):
+    root = tmp_path / "xdg" / "clawrium" / "agents" / "hermes-tdd" / "skills"
+    _write_local_skill(root, "zeta")
+    _write_local_skill(root, "alpha")
+    (root / "bad name").mkdir()
+    (root / "missing-md").mkdir()
+
+    assert list_agent_skills("hermes-tdd") == ["alpha", "zeta"]
+
+
+def test_list_agent_skills_missing_dir_returns_empty():
+    assert list_agent_skills("hermes-tdd") == []
+
+
+@pytest.mark.parametrize("agent_type", sorted(NATIVE_REGISTRIES))
+def test_load_agent_skill_validates_native_shape(tmp_path, agent_type):
+    root = tmp_path / "xdg" / "clawrium" / "agents" / f"{agent_type}-tdd" / "skills"
+    _write_local_skill(root, "local")
+
+    skill = load_agent_skill(f"{agent_type}-tdd", "local", agent_type)
+
+    assert skill.ref == SkillRef(agent_type, "local")
+    assert skill.metadata["name"] == "local"
+
+
+def test_load_agent_skill_missing_dir_raises_not_found():
+    with pytest.raises(SkillNotFound, match="not found"):
+        load_agent_skill("hermes-tdd", "local", "hermes")
+
+
+def test_load_agent_skill_rejects_malformed_frontmatter(tmp_path):
+    root = tmp_path / "xdg" / "clawrium" / "agents" / "hermes-tdd" / "skills"
+    skill_dir = root / "local"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: [unclosed\n---\nbody\n")
+
+    with pytest.raises(SchemaValidationError, match="frontmatter"):
+        load_agent_skill("hermes-tdd", "local", "hermes")
+
+
+def test_load_agent_skill_rejects_unknown_agent_type():
+    with pytest.raises(IncompatibleSkillRegistry, match="Unknown agent type"):
+        load_agent_skill("hermes-tdd", "local", "not-a-claw")
+
+
 # ---------------------------- validate_skill --------------------------------
 
 
 def test_validate_skill_real_tdd_passes():
     skill = load_skill("clawrium/tdd")
     validate_skill(skill)  # should not raise
+
+
+@pytest.mark.parametrize("agent_type", sorted(NATIVE_REGISTRIES))
+def test_materialize_skill_for_agent_returns_valid_native_skill(agent_type):
+    skill = load_skill("clawrium/tdd")
+
+    native_skill = materialize_skill_for_agent(skill, agent_type)
+
+    assert native_skill.ref == SkillRef(agent_type, "tdd")
+    assert native_skill.metadata["name"] == "tdd"
+    assert native_skill.body.strip().startswith("# TDD")
+    validate_skill(native_skill)
+
+
+def test_materialize_skill_for_agent_rejects_unknown_agent_type():
+    skill = load_skill("clawrium/tdd")
+
+    with pytest.raises(IncompatibleSkillRegistry, match="Unknown agent type"):
+        materialize_skill_for_agent(skill, "not-a-claw")
 
 
 def test_validate_skill_enforces_slug_invariant(monkeypatch, tmp_path):
@@ -349,6 +477,14 @@ def _build_fake_native_skill(
     lines = [f"{k}: {v}" for k, v in frontmatter.items()]
     (skill_dir / "SKILL.md").write_text("---\n" + "\n".join(lines) + "\n---\nbody\n")
     _copy_schemas(root)
+
+
+def _write_local_skill(root: Path, name: str) -> None:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: fake local\n---\nbody\n"
+    )
 
 
 def _copy_schemas(root: Path) -> None:

--- a/tests/test_core_skills.py
+++ b/tests/test_core_skills.py
@@ -37,6 +37,7 @@ from clawrium.core.skills import (
     parse_skill_ref,
     validate_skill,
 )
+from clawrium.core.skills_state import agent_skills_dir
 
 
 # ----------------------------- parse_skill_ref ------------------------------
@@ -175,7 +176,7 @@ def test_catalog_roots_returns_bundled_only(monkeypatch, tmp_path):
 
 def test_catalog_roots_returns_bundled_then_overlay(monkeypatch, tmp_path):
     bundled = tmp_path / "bundled"
-    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    overlay = skills._overlay_root()
     bundled.mkdir()
     overlay.mkdir(parents=True)
     monkeypatch.setattr(skills, "_catalog_root", lambda: bundled)
@@ -184,7 +185,7 @@ def test_catalog_roots_returns_bundled_then_overlay(monkeypatch, tmp_path):
 
 
 def test_catalog_roots_returns_overlay_only(monkeypatch, tmp_path):
-    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    overlay = skills._overlay_root()
     overlay.mkdir(parents=True)
 
     def missing_catalog():
@@ -207,7 +208,7 @@ def test_catalog_roots_raises_when_neither_root_exists(monkeypatch):
 
 def test_public_list_skills_ignores_overlay_until_wired(monkeypatch, tmp_path):
     bundled = tmp_path / "bundled"
-    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    overlay = skills._overlay_root()
     bundled.mkdir()
     _copy_schemas(bundled)
     _build_fake_native_skill(bundled, registry="hermes", name="bundled-skill")
@@ -221,7 +222,7 @@ def test_public_list_skills_ignores_overlay_until_wired(monkeypatch, tmp_path):
 
 def test_public_load_skill_ignores_overlay_until_wired(monkeypatch, tmp_path):
     bundled = tmp_path / "bundled"
-    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    overlay = skills._overlay_root()
     bundled.mkdir()
     _copy_schemas(bundled)
     _build_fake_native_skill(bundled, registry="hermes", name="bundled-skill")
@@ -236,7 +237,7 @@ def test_public_load_skill_ignores_overlay_until_wired(monkeypatch, tmp_path):
 
 
 def test_list_skills_includes_overlay_only(monkeypatch, tmp_path):
-    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    overlay = skills._overlay_root()
     _build_fake_native_skill(overlay, registry="hermes", name="overlay-skill")
 
     def missing_catalog():
@@ -261,7 +262,7 @@ def test_list_skills_raises_when_no_catalog_roots(monkeypatch):
 
 def test_overlay_shadows_bundled_skill_once(monkeypatch, tmp_path, caplog):
     bundled = tmp_path / "bundled"
-    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    overlay = skills._overlay_root()
     _build_fake_native_skill(
         bundled,
         registry="hermes",
@@ -286,9 +287,24 @@ def test_overlay_shadows_bundled_skill_once(monkeypatch, tmp_path, caplog):
 
     warnings = [record for record in caplog.records if "shadows bundled" in record.message]
     assert len(warnings) == 1
+    assert str(overlay / "hermes" / "sample") in warnings[0].message
     assert skills._find_catalog_skill_dir(SkillRef("hermes", "sample")) == (
         overlay / "hermes" / "sample"
     )
+
+
+def test_list_skills_from_roots_empty_overlay_falls_back_to_bundled(
+    monkeypatch, tmp_path
+):
+    bundled = tmp_path / "bundled"
+    overlay = skills._overlay_root()
+    _build_fake_native_skill(bundled, registry="hermes", name="sample")
+    overlay.mkdir(parents=True)
+    monkeypatch.setattr(skills, "_catalog_root", lambda: bundled)
+
+    assert skills._list_skills_from_roots(registry="hermes") == [
+        SkillRef("hermes", "sample")
+    ]
 
 
 def test_find_catalog_skill_dir_returns_bundled_when_no_overlay(monkeypatch, tmp_path):
@@ -309,7 +325,7 @@ def test_find_catalog_skill_dir_returns_none_for_missing(monkeypatch, tmp_path):
 def test_find_catalog_skill_dir_returns_overlay_when_bundled_absent(
     monkeypatch, tmp_path
 ):
-    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    overlay = skills._overlay_root()
     _build_fake_native_skill(overlay, registry="hermes", name="sample")
 
     def missing_catalog():
@@ -324,7 +340,7 @@ def test_find_catalog_skill_dir_returns_overlay_when_bundled_absent(
 
 def test_find_catalog_skill_dir_ignores_stub_overlay(monkeypatch, tmp_path):
     bundled = tmp_path / "bundled"
-    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    overlay = skills._overlay_root()
     _build_fake_native_skill(bundled, registry="hermes", name="sample")
     (overlay / "hermes" / "sample").mkdir(parents=True)
     monkeypatch.setattr(skills, "_catalog_root", lambda: bundled)
@@ -335,6 +351,18 @@ def test_find_catalog_skill_dir_ignores_stub_overlay(monkeypatch, tmp_path):
 
 
 def test_find_catalog_skill_dir_returns_none_when_no_roots(monkeypatch):
+    def missing_catalog():
+        raise SkillNotFound("missing bundled catalog")
+
+    monkeypatch.setattr(skills, "_catalog_root", missing_catalog)
+
+    assert skills._find_catalog_skill_dir(SkillRef("hermes", "sample")) is None
+
+
+def test_find_catalog_skill_dir_returns_none_stub_overlay_no_bundled(monkeypatch):
+    overlay = skills._overlay_root()
+    (overlay / "hermes" / "sample").mkdir(parents=True)
+
     def missing_catalog():
         raise SkillNotFound("missing bundled catalog")
 
@@ -366,8 +394,8 @@ def test_load_skill_via_string_runs_parse_first():
         load_skill("https://example.com/foo")
 
 
-def test_list_agent_skills_returns_sorted_valid_local_names(tmp_path):
-    root = tmp_path / "xdg" / "clawrium" / "agents" / "hermes-tdd" / "skills"
+def test_list_agent_skills_returns_sorted_valid_local_names():
+    root = agent_skills_dir("hermes-tdd")
     _write_local_skill(root, "zeta")
     _write_local_skill(root, "alpha")
     (root / "bad name").mkdir()
@@ -380,9 +408,15 @@ def test_list_agent_skills_missing_dir_returns_empty():
     assert list_agent_skills("hermes-tdd") == []
 
 
+@pytest.mark.parametrize("agent", ["../escape", "Bad", ""])
+def test_list_agent_skills_rejects_invalid_agent_name(agent):
+    with pytest.raises(InvalidSkillRef):
+        list_agent_skills(agent)
+
+
 @pytest.mark.parametrize("agent_type", sorted(NATIVE_REGISTRIES))
 def test_load_agent_skill_validates_native_shape(tmp_path, agent_type):
-    root = tmp_path / "xdg" / "clawrium" / "agents" / f"{agent_type}-tdd" / "skills"
+    root = agent_skills_dir(f"{agent_type}-tdd")
     _write_local_skill(root, "local")
 
     skill = load_agent_skill(f"{agent_type}-tdd", "local", agent_type)
@@ -405,7 +439,7 @@ def test_load_agent_skill_missing_dir_raises_not_found():
 
 
 def test_load_agent_skill_rejects_malformed_frontmatter(tmp_path):
-    root = tmp_path / "xdg" / "clawrium" / "agents" / "hermes-tdd" / "skills"
+    root = agent_skills_dir("hermes-tdd")
     skill_dir = root / "local"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("---\nname: [unclosed\n---\nbody\n")
@@ -416,7 +450,7 @@ def test_load_agent_skill_rejects_malformed_frontmatter(tmp_path):
 
 @pytest.mark.parametrize("agent_type", sorted(NATIVE_REGISTRIES))
 def test_load_agent_skill_rejects_schema_invalid_frontmatter(tmp_path, agent_type):
-    root = tmp_path / "xdg" / "clawrium" / "agents" / f"{agent_type}-tdd" / "skills"
+    root = agent_skills_dir(f"{agent_type}-tdd")
     skill_dir = root / "local"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("---\nname: local\n---\nbody\n")
@@ -457,6 +491,20 @@ def test_materialize_skill_for_agent_rejects_unknown_agent_type():
 
     with pytest.raises(IncompatibleSkillRegistry, match="Unknown agent type"):
         materialize_skill_for_agent(skill, "not-a-claw")
+
+
+@pytest.mark.parametrize("agent_type", sorted(NATIVE_REGISTRIES))
+def test_materialize_skill_for_agent_rejects_explicit_false_compatibility(
+    monkeypatch, tmp_path, agent_type
+):
+    compatibility = {registry: True for registry in NATIVE_REGISTRIES}
+    compatibility[agent_type] = False
+    _build_fake_clawrium_skill(tmp_path, compatibility=compatibility)
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+
+    skill = load_skill("clawrium/tdd")
+    with pytest.raises(IncompatibleSkillRegistry, match="not compatible"):
+        materialize_skill_for_agent(skill, agent_type)
 
 
 def test_validate_skill_enforces_slug_invariant(monkeypatch, tmp_path):
@@ -577,11 +625,19 @@ def test_validate_against_schema_sort_key_handles_mixed_paths(monkeypatch):
 
 
 def _build_fake_clawrium_skill(
-    root: Path, dir_name: str = "tdd", meta_name: str = "tdd"
+    root: Path,
+    dir_name: str = "tdd",
+    meta_name: str = "tdd",
+    compatibility: dict[str, bool] | None = None,
 ) -> None:
     """Create a minimal in-tmp_path clawrium catalog containing one skill."""
     skill_dir = root / "clawrium" / dir_name
     skill_dir.mkdir(parents=True)
+    compatibility = compatibility or {
+        "openclaw": True,
+        "hermes": True,
+        "zeroclaw": True,
+    }
     (skill_dir / "_meta.yaml").write_text(
         "\n".join(
             [
@@ -589,9 +645,9 @@ def _build_fake_clawrium_skill(
                 "description: fake",
                 "version: 0.1.0",
                 "compatibility:",
-                "  openclaw: true",
-                "  hermes: true",
-                "  zeroclaw: true",
+                f"  openclaw: {str(compatibility['openclaw']).lower()}",
+                f"  hermes: {str(compatibility['hermes']).lower()}",
+                f"  zeroclaw: {str(compatibility['zeroclaw']).lower()}",
             ]
         )
         + "\n"

--- a/tests/test_core_skills.py
+++ b/tests/test_core_skills.py
@@ -167,6 +167,29 @@ def test_list_skills_empty_native_registries():
         assert refs == [], f"{native} should be empty, got {refs}"
 
 
+def test_public_list_skills_ignores_overlay_until_wired(monkeypatch, tmp_path):
+    bundled = tmp_path / "bundled"
+    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    bundled.mkdir()
+    _copy_schemas(bundled)
+    _build_fake_native_skill(overlay, registry="hermes", name="overlay-only")
+    monkeypatch.setattr(skills, "_catalog_root", lambda: bundled)
+
+    assert SkillRef("hermes", "overlay-only") not in list_skills(registry="hermes")
+
+
+def test_public_load_skill_ignores_overlay_until_wired(monkeypatch, tmp_path):
+    bundled = tmp_path / "bundled"
+    overlay = tmp_path / "xdg" / "clawrium" / "skills"
+    bundled.mkdir()
+    _copy_schemas(bundled)
+    _build_fake_native_skill(overlay, registry="hermes", name="overlay-only")
+    monkeypatch.setattr(skills, "_catalog_root", lambda: bundled)
+
+    with pytest.raises(SkillNotFound):
+        load_skill("hermes/overlay-only")
+
+
 def test_list_skills_includes_overlay_only(monkeypatch, tmp_path):
     overlay = tmp_path / "xdg" / "clawrium" / "skills"
     _build_fake_native_skill(overlay, registry="hermes", name="overlay-skill")
@@ -223,6 +246,22 @@ def test_overlay_shadows_bundled_skill_once(monkeypatch, tmp_path, caplog):
     )
 
 
+def test_find_catalog_skill_dir_returns_bundled_when_no_overlay(monkeypatch, tmp_path):
+    _build_fake_native_skill(tmp_path, registry="hermes", name="sample")
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+
+    assert skills._find_catalog_skill_dir(SkillRef("hermes", "sample")) == (
+        tmp_path / "hermes" / "sample"
+    )
+
+
+def test_find_catalog_skill_dir_returns_none_for_missing(monkeypatch, tmp_path):
+    _copy_schemas(tmp_path)
+    monkeypatch.setattr(skills, "_catalog_root", lambda: tmp_path)
+
+    assert skills._find_catalog_skill_dir(SkillRef("hermes", "missing")) is None
+
+
 # ------------------------------ load_skill ----------------------------------
 
 
@@ -271,6 +310,14 @@ def test_load_agent_skill_validates_native_shape(tmp_path, agent_type):
     assert skill.metadata["name"] == "local"
 
 
+@pytest.mark.parametrize(
+    "name", ["bad name!", "clawrium/tdd", "", "../escape", "UPPER"]
+)
+def test_load_agent_skill_rejects_invalid_name(name):
+    with pytest.raises(InvalidSkillRef):
+        load_agent_skill("hermes-tdd", name, "hermes")
+
+
 def test_load_agent_skill_missing_dir_raises_not_found():
     with pytest.raises(SkillNotFound, match="not found"):
         load_agent_skill("hermes-tdd", "local", "hermes")
@@ -284,6 +331,17 @@ def test_load_agent_skill_rejects_malformed_frontmatter(tmp_path):
 
     with pytest.raises(SchemaValidationError, match="frontmatter"):
         load_agent_skill("hermes-tdd", "local", "hermes")
+
+
+@pytest.mark.parametrize("agent_type", sorted(NATIVE_REGISTRIES))
+def test_load_agent_skill_rejects_schema_invalid_frontmatter(tmp_path, agent_type):
+    root = tmp_path / "xdg" / "clawrium" / "agents" / f"{agent_type}-tdd" / "skills"
+    skill_dir = root / "local"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: local\n---\nbody\n")
+
+    with pytest.raises(SchemaValidationError, match="required"):
+        load_agent_skill(f"{agent_type}-tdd", "local", agent_type)
 
 
 def test_load_agent_skill_rejects_unknown_agent_type():

--- a/tests/test_core_skills_state.py
+++ b/tests/test_core_skills_state.py
@@ -24,6 +24,7 @@ from clawrium.core.skills import (
 from clawrium.core import skills_state
 from clawrium.core.skills_state import (
     add_skill,
+    agent_skills_dir,
     read_state,
     remove_skill,
     state_file_path,
@@ -46,6 +47,11 @@ def test_state_file_path_uses_xdg(tmp_path: Path):
     assert path == tmp_path / "clawrium" / "agents" / "hermes-tdd" / "skills.json"
 
 
+def test_agent_skills_dir_uses_xdg(tmp_path: Path):
+    path = agent_skills_dir("hermes-tdd")
+    assert path == tmp_path / "clawrium" / "agents" / "hermes-tdd" / "skills"
+
+
 @pytest.mark.parametrize(
     "bad",
     [
@@ -60,6 +66,11 @@ def test_state_file_path_uses_xdg(tmp_path: Path):
 def test_state_file_path_rejects_bad_agent_name(bad):
     with pytest.raises(InvalidSkillRef):
         state_file_path(bad)
+
+
+def test_agent_skills_dir_rejects_bad_agent_name():
+    with pytest.raises(InvalidSkillRef):
+        agent_skills_dir("../escape")
 
 
 # ------------------------------- read_state ---------------------------------


### PR DESCRIPTION
## Summary
- Adds Phase A-only private catalog overlay helpers while keeping public `list_skills` / `load_skill` bundled-only until Phase B.
- Adds per-agent local skill directory/list/load helpers without changing current `skills.json`, CLI, GUI, or sync/apply behavior.
- Adds add-time native materialization helper and hardened tests for hermes, openclaw, and zeroclaw formats.
- Updates the #411 plan/changelog for the materialized sentinel path and stale `clm` guidance fix.

## Testing

### Local Verification
- [x] `uv run pytest tests/test_core_skills.py tests/test_core_skills_state.py` - 118 passed
- [x] `make test` - Python 3913 passed, 2 skipped, 1 warning; GUI 254 passed
- [x] `make lint` - ruff and Next lint passed

### Scope Checks
- [x] Public `list_skills` / `load_skill` remain bundled-only in Phase A
- [x] `skills.json` registry-ref semantics unchanged
- [x] `apply_state` / sync materialization behavior unchanged
- [x] CLI and GUI surfaces unchanged

## ATX Review Summary

**Status**: Latest completed ATX review still required follow-up fixes; those fixes are now pushed in `ef0bfac`. Final ATX rerun is pending.

| Review | Rating | Blocking Issues | Status | Cost | Time | Notes |
|--------|--------|-----------------|--------|------|------|-------|
| 1 | 2/5 | Yes | Fixed | $2.8989 | 7m42s | Restored public list/load behavior; added failure tests and plan clarifications |
| 2 | 2/5 | Yes | Fixed | $2.8015 | 7m6s | Added schema-invalid and invalid-name tests; fixed stale scaffold wording |
| 3 | 3/5 | No tool blockers | Warnings fixed | $2.6410 | 9m14s | Hardened helper coverage and plan wording |
| 4 | 2/5 | Text blockers | Fixed in `ef0bfac` | $2.5172 | 8m22s | Added explicit-false compatibility tests, path-source tests, changelog entry |

## Reviewer Notes
- Phase A is intentionally scaffolding-only: helper APIs and tests, no product behavior switch.
- Unrelated local dirty files were intentionally not included.

Part of #411