### PR TITLE
feat(skills): add #411 Phase B agent-local skill lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,8 @@ clawctl agent exec <agent-name> -- --version
 # Install a skill onto the agent (catalog: skills/)
 clawctl skill registry get
 clawctl skill registry describe clawrium/tdd       # Inspect a skill before installing
-clawctl agent skill attach clawrium/tdd --agent <agent-name>
+clawctl agent skill add <agent-name> --from-template clawrium/tdd
+clawctl agent sync <agent-name>
 
 # Check fleet status
 clawctl agent get
@@ -128,7 +129,7 @@ Currently available:
 - **Agent Type**: The specific AI assistant implementation (e.g., zeroclaw, nemoclaw, openclaw)
 - **Agent Name**: The unique identifier for an installed agent instance
 - **Agent Registry**: Platform-defined agent types with versions, dependencies, and templates
-- **Skill Registry**: A namespace under `skills/` from which skills can be installed onto an agent (`clawrium`, `openclaw`, `hermes`, `zeroclaw`). Skills are referenced as `<skill-registry>/<name>` (e.g. `clawrium/tdd`). Distinct from the Agent Registry.
+- **Skill Registry**: A namespace under bundled `skills/` and the user overlay at `~/.config/clawrium/skills/` from which skill templates can be copied onto an agent (`clawrium`, `openclaw`, `hermes`, `zeroclaw`). Catalog templates are referenced as `<skill-registry>/<name>` (e.g. `clawrium/tdd`); once copied onto an agent, the local desired state stores the bare skill name (e.g. `tdd`). Distinct from the Agent Registry.
 
 ## Resources
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ release.
 
 ### BREAKING
 
+- Skills desired state now stores **agent-local skill names** instead of
+  registry refs. `~/.config/clawrium/agents/<agent>/skills.json` entries
+  such as `"clawrium/tdd"` are no longer valid; re-add those templates with
+  `clawctl agent skill add <agent> --from-template clawrium/tdd` to create the
+  local `skills/tdd/SKILL.md` copy, then run `clawctl agent sync <agent>`.
+  The old `clawctl agent skill attach|detach|get --agent ...` surface has
+  been removed in favor of `add|remove|list <agent>`. There is no automated
+  migration because registry refs are now template sources only. (#411)
 - hermes: legacy ansible-side templates
   `src/clawrium/platform/registry/hermes/templates/hermes-config.yaml.j2`
   and `hermes.env.j2` have been **removed**. The configure playbook no
@@ -36,6 +44,15 @@ release.
 
 ### Added
 
+- `clawctl agent skill add <agent> --from-template <registry>/<name>` copies a
+  catalog template into the agent-local control-plane skill directory in that
+  agent's native format. `clawctl agent skill add <agent> <path>`, `edit`,
+  `remove`, and `list` manage those local skill files without touching the
+  host until `clawctl agent sync <agent>` is run. (#411)
+- `clawctl skill add <path> --registry <registry>` adds a user overlay skill
+  under `~/.config/clawrium/skills/<registry>/<name>/`; `clawctl skill
+  registry get/describe` now includes overlay entries with overlay copies
+  taking precedence over bundled catalog entries of the same ref. (#411)
 - `clawctl agent provider attach --role <role>` for hermes agents.
   Required on hermes (`primary` for the first attachment, plus one of
   nine upstream auxiliary slots — `vision`, `web_extract`,

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ clawctl agent configure my-assistant
 clawctl agent start my-assistant
 # → Agent 'my-assistant' started
 
+# Copy a catalog skill into the agent's local state and sync it
+clawctl agent skill add my-assistant --from-template clawrium/tdd
+clawctl agent sync my-assistant
+
 # Check fleet status
 clawctl agent get
 # NAME           TYPE       HOST       PROVIDER    STATUS    AGE

--- a/docs/skills/authoring-clawrium.md
+++ b/docs/skills/authoring-clawrium.md
@@ -2,8 +2,9 @@
 
 Use the `clawrium/` registry when the same behaviour should be available
 on every kind of claw (openclaw, hermes, zeroclaw). The skill is
-authored once in a normalized `_meta.yaml` shape; the per-claw apply
-playbooks materialize the right native frontmatter at install time.
+authored once in a normalized `_meta.yaml` shape; `clawctl agent skill
+add` materializes the right native frontmatter when it copies the
+template into an agent-local skill.
 
 This guide walks through adding a new `clawrium/<name>/` skill end to
 end. The CI validator (`scripts/validate_skills.py`) is the contract —
@@ -13,7 +14,7 @@ if your skill passes validation locally, it will pass in CI.
 
 The `<name>` is a lowercase slug (hyphens and underscores both
 allowed). Slug rule (enforced by the validator and by
-`parse_skill_ref`):
+catalog references and local agent skill names):
 
 ```
 ^[a-z0-9][a-z0-9_-]*$
@@ -133,9 +134,13 @@ every claw it claims compatibility with. From a checkout pointing at
 your dev fleet:
 
 ```bash
-clawctl agent skill attach <openclaw-agent> clawrium/<name>
-clawctl agent skill attach <hermes-agent>   clawrium/<name>
-clawctl agent skill attach <zeroclaw-agent> clawrium/<name>
+clawctl agent skill add <openclaw-agent> --from-template clawrium/<name>
+clawctl agent skill add <hermes-agent>   --from-template clawrium/<name>
+clawctl agent skill add <zeroclaw-agent> --from-template clawrium/<name>
+
+clawctl agent sync <openclaw-agent>
+clawctl agent sync <hermes-agent>
+clawctl agent sync <zeroclaw-agent>
 ```
 
 Confirm each agent's native `skills list` shows the new skill.

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -10,15 +10,17 @@
 -->
 
 Clawrium ships a curated catalog of **skills** that any agent in your
-fleet can install with one command. A skill is a directory of
+fleet can copy into local state and sync to its host. A skill is a directory of
 behaviour-shaping prompts and metadata that the underlying claw
 discovers at runtime — Test-Driven Development discipline, code-review
 guardrails, security-audit playbooks, and so on.
 
-Skills are sourced **only** from the in-repo `skills/` tree. There is no
-URL install, no arbitrary path install, no third-party registry. The
-catalog is the source of truth, and CI gates every change against a
-dual-schema validator (see [Authoring guides](#authoring) below).
+Bundled catalog skills live in the in-repo `skills/` tree. Operators can
+also add user-overlay catalog entries under
+`~/.config/clawrium/skills/<registry>/<name>/` with `clawctl skill add`.
+Both sources use the same registry names and schema validation; the user
+overlay wins if it defines the same `<registry>/<name>` as the bundled
+catalog.
 
 ## Quick start
 
@@ -29,14 +31,20 @@ clawctl skill registry get
 # Inspect a skill before installing
 clawctl skill registry describe clawrium/tdd
 
-# Install onto an agent
-clawctl agent skill attach my-agent clawrium/tdd
+# Copy the template into an agent-local skill
+clawctl agent skill add my-agent --from-template clawrium/tdd
+
+# Apply local skill state to the host
+clawctl agent sync my-agent
 
 # List skills installed on an agent
-clawctl agent skill get --agent my-agent
+clawctl agent skill list my-agent
 
 # Remove a skill
-clawctl agent skill detach my-agent clawrium/tdd
+clawctl agent skill remove my-agent tdd
+
+# Add a user-overlay catalog entry
+clawctl skill add ./my-hermes-skill --registry hermes
 ```
 
 The GUI mirrors the same surface under `Agents → <agent> → Skills`
@@ -55,18 +63,21 @@ its descriptor is validated against.
 | `hermes`   | only `hermes` agents    | `_schema/native/hermes.schema.json`   |
 | `zeroclaw` | only `zeroclaw` agents  | `_schema/native/zeroclaw.schema.json` |
 
-Skills are referenced everywhere as `<registry>/<name>` — CLI args, GUI
-URLs, and desired-state files. Bare names (`tdd`) are rejected with a
-hint that suggests the matching `<registry>/<name>`.
+Catalog templates are referenced as `<registry>/<name>` when browsing or
+copying from the catalog. Once a template is added to an agent, it is an
+agent-local skill named by its bare slug (`tdd`). The local desired-state
+file at `~/.config/clawrium/agents/<agent>/skills.json` stores only bare
+agent-local names, not registry refs.
 
 ### When to use `clawrium/`
 
 Use the `clawrium/` registry when the skill is behaviour you want
 available on **every** kind of claw. The normalized `_meta.yaml` shape
-is materialized into each native frontmatter format on install — a
-single source file ends up on disk as openclaw-shaped SKILL.md on an
-openclaw agent, hermes-shaped on a hermes agent, and zeroclaw-shaped
-(via `zeroclaw skills install`) on a zeroclaw agent.
+is materialized into each native frontmatter format at `clawctl agent
+skill add` time — a single source template becomes an openclaw-shaped
+local SKILL.md for an openclaw agent, hermes-shaped for a hermes agent,
+and zeroclaw-shaped for a zeroclaw agent. `clawctl agent sync` later
+copies that already-native local file to the host unchanged.
 
 ### When to use a native registry
 
@@ -76,6 +87,33 @@ keys, openclaw allowed-tools lists). Native skills are installable
 **only** on agents of the matching type. Attempting to install a
 `hermes/<name>` skill on an openclaw agent fails with
 `IncompatibleSkillRegistry`.
+
+## Agent-Local Skills
+
+Agent-local skills live on the control machine under:
+
+```text
+~/.config/clawrium/agents/<agent>/skills/<name>/SKILL.md
+~/.config/clawrium/agents/<agent>/skills.json
+```
+
+`skills.json` is a flat list of local names, for example:
+
+```json
+{"skills": ["tdd", "incident-review"]}
+```
+
+Registry refs such as `"clawrium/tdd"` are not valid desired state. To
+recover an old state file, remove the registry ref and re-add the skill
+from its template:
+
+```bash
+clawctl agent skill add <agent> --from-template clawrium/tdd
+clawctl agent sync <agent>
+```
+
+See [Local agent skills](local.md) for path installs, editing, sync
+semantics, and the no-collision rule.
 
 ## Authoring
 
@@ -123,10 +161,10 @@ on the remote host:
 sudo -u tdd-hermes ls /home/tdd-hermes/.hermes/skills/clawrium/tdd/
 ```
 
-Re-running `clawctl agent skill attach` is the recovery for drift. There
-is no separate `reconcile` command — the local desired-state file at
-`~/.config/clawrium/agents/<agent>/skills.json` is truth, and every
-install/remove re-applies it end-to-end.
+`clawctl agent sync <agent>` is the recovery for drift. It reads the
+local desired-state file at
+`~/.config/clawrium/agents/<agent>/skills.json`, stages each listed
+agent-local `SKILL.md` byte-for-byte, and applies that state to the host.
 
 ## Ownership boundaries
 
@@ -145,7 +183,13 @@ to recognize, check that its marker is intact.
 
 ## Troubleshooting
 
-### `clawctl agent skill attach` reports success but the file isn't where I expect
+### `clawctl agent skill add` succeeds but the host file is missing
+
+`clawctl agent skill add` only writes the control-plane copy under
+`~/.config/clawrium/agents/<agent>/skills/<name>/`. Run
+`clawctl agent sync <agent>` to push that local state to the host.
+
+### `clawctl agent sync` reports success but the file isn't where I expect
 
 The `~` in the on-host paths is the **agent user's** home, not yours.
 A common source of confusion when verifying via SSH as the management
@@ -178,24 +222,28 @@ playbook, exercise the full round-trip against a real agent before
 opening a PR:
 
 ```bash
-# 1. Install — should report success
-clawctl agent skill attach <agent> clawrium/<name>
+# 1. Add from a template — should create the local control-plane copy
+clawctl agent skill add <agent> --from-template clawrium/<name>
 
 # 2. List — should show it
-clawctl agent skill get --agent <agent>
+clawctl agent skill list <agent>
 
-# 3. Verify on host (substitute the agent's unix user)
+# 3. Sync — should push the local skill to the host
+clawctl agent sync <agent>
+
+# 4. Verify on host (substitute the agent's unix user)
 ssh <host> "sudo -u <agent-user> ls -la /home/<agent-user>/<claw-skill-path>"
 
-# 4. Idempotent re-install — should report "already in desired state"
-clawctl agent skill attach <agent> clawrium/<name>
+# 5. Duplicate add — should fail and tell you to remove/rename first
+clawctl agent skill add <agent> --from-template clawrium/<name>
 
-# 5. Drift recovery — delete on host, re-install reconverges
+# 6. Drift recovery — delete on host, sync reconverges
 ssh <host> "sudo -u <agent-user> rm -rf /home/<agent-user>/<claw-skill-path>"
-clawctl agent skill attach <agent> clawrium/<name>
+clawctl agent sync <agent>
 
-# 6. Remove — should clean up and report success
-clawctl agent skill detach <agent> clawrium/<name>
+# 7. Remove locally, then sync the removal
+clawctl agent skill remove <agent> <name>
+clawctl agent sync <agent>
 ```
 
 ### Local validator exit code

--- a/docs/skills/local.md
+++ b/docs/skills/local.md
@@ -1,0 +1,114 @@
+# Local Agent Skills
+
+Local agent skills are the editable, per-agent copies that Clawrium
+actually syncs to hosts. Catalog skills are templates; adding one to an
+agent copies and materializes it into that agent's native format.
+
+## Control-Plane Layout
+
+```text
+~/.config/clawrium/agents/<agent>/skills/<name>/SKILL.md
+~/.config/clawrium/agents/<agent>/skills.json
+```
+
+`skills.json` stores only bare local names:
+
+```json
+{"skills": ["tdd", "incident-review"]}
+```
+
+Registry refs such as `"clawrium/tdd"` are invalid in `skills.json`.
+Re-add old registry refs from their template instead:
+
+```bash
+clawctl agent skill add <agent> --from-template clawrium/tdd
+clawctl agent sync <agent>
+```
+
+## Add From A Catalog Template
+
+```bash
+clawctl agent skill add my-agent --from-template clawrium/tdd
+```
+
+This command resolves `my-agent`'s type, loads `clawrium/tdd`, converts it
+to the target native format, validates the final native frontmatter, and
+writes:
+
+```text
+~/.config/clawrium/agents/my-agent/skills/tdd/SKILL.md
+```
+
+The copied skill has no lifecycle link to the catalog template. Editing
+the catalog later does not mutate the agent-local copy.
+
+## Add From A Path
+
+```bash
+clawctl agent skill add my-agent ./skills/hermes/my-skill
+clawctl agent skill add my-agent ./SKILL.md --name incident-review
+```
+
+Path input can be either:
+
+- A normalized `clawrium/`-style directory with `_meta.yaml` and
+  `SKILL.md`. Clawrium materializes it for the target agent type.
+- A native `SKILL.md` file or directory. Clawrium validates it against
+  the target agent type's native schema and copies the bytes into the
+  local skill directory.
+
+If `--name` is omitted, Clawrium derives the local name from the validated
+frontmatter `name:` field, not from the input path.
+
+## Apply To Host
+
+`add`, `edit`, and `remove` mutate local control-plane state only. Push
+the state to the host explicitly:
+
+```bash
+clawctl agent sync my-agent
+```
+
+Sync does not convert formats. It reads the bare names in `skills.json`,
+copies each already-agent-native local `SKILL.md` into staging unchanged,
+and runs the agent type's apply playbook.
+
+## Edit And Remove
+
+```bash
+clawctl agent skill list my-agent
+clawctl agent skill edit my-agent tdd
+clawctl agent skill remove my-agent tdd
+clawctl agent sync my-agent
+```
+
+`edit` opens the local native `SKILL.md`, validates it against the
+agent's native schema, and restores the prior bytes if validation fails.
+
+## No Force Overwrites
+
+Skill names are unique per agent. If
+`~/.config/clawrium/agents/<agent>/skills/<name>/` exists or `skills.json`
+already contains `<name>`, `add` fails. There is no `--force`; remove or
+rename the existing skill first.
+
+## User Overlay Catalog
+
+Use `clawctl skill add` when you want a reusable template available to
+multiple agents:
+
+```bash
+clawctl skill add ./my-hermes-skill --registry hermes
+clawctl skill registry get
+clawctl agent skill add my-hermes-agent --from-template hermes/my-hermes-skill
+```
+
+Overlay entries are stored under:
+
+```text
+~/.config/clawrium/skills/<registry>/<name>/
+```
+
+They appear in `clawctl skill registry get` and `describe` alongside the
+bundled catalog. If an overlay entry has the same `<registry>/<name>` as
+a bundled skill, the overlay wins.

--- a/src/clawrium/cli/agent_skill.py
+++ b/src/clawrium/cli/agent_skill.py
@@ -27,8 +27,10 @@ is restored so the user-visible state file matches what the host has.
 from __future__ import annotations
 
 import logging
+import shutil
 
 import typer
+import yaml
 from rich.console import Console
 from rich.markup import escape
 from rich.table import Table
@@ -45,6 +47,7 @@ from clawrium.core.skills import (
     SkillNotFound,
     check_agent_compatibility,
     load_skill,
+    materialize_skill_for_agent,
     parse_skill_ref,
     validate_skill,
 )
@@ -56,6 +59,7 @@ from clawrium.core.skills_apply import (
 )
 from clawrium.core.skills_state import (
     add_skill,
+    agent_skills_dir,
     read_state,
     remove_skill,
     write_state,
@@ -124,6 +128,41 @@ def _resolve_agent_type(agent_name: str) -> str:
     return agent_type
 
 
+def _render_skill_md(skill) -> str:
+    frontmatter = yaml.safe_dump(
+        skill.skill_md_frontmatter,
+        sort_keys=False,
+        allow_unicode=False,
+    ).strip()
+    body = skill.body.rstrip()
+    return f"---\n{frontmatter}\n---\n\n{body}\n"
+
+
+def _write_local_skill(agent_name: str, skill_name: str, skill) -> tuple[bool, object]:
+    target = agent_skills_dir(agent_name) / skill_name
+    existed = target.exists()
+    target.mkdir(parents=True, exist_ok=True)
+    skill_file = target / "SKILL.md"
+    prior_bytes = skill_file.read_bytes() if skill_file.exists() else None
+    skill_file.write_text(_render_skill_md(skill), encoding="utf-8")
+    return existed, prior_bytes
+
+
+def _restore_local_skill(agent_name: str, skill_name: str, existed: bool, prior_bytes) -> None:
+    target = agent_skills_dir(agent_name) / skill_name
+    if not existed:
+        shutil.rmtree(target, ignore_errors=True)
+        return
+    target.mkdir(parents=True, exist_ok=True)
+    if prior_bytes is None:
+        try:
+            (target / "SKILL.md").unlink()
+        except FileNotFoundError:
+            pass
+        return
+    (target / "SKILL.md").write_bytes(prior_bytes)
+
+
 @agent_skill_app.command(name="list")
 def list_command(
     agent_name: str = typer.Argument(
@@ -151,14 +190,11 @@ def list_command(
         return
 
     table = Table(title=f"Skills on {escape(agent_name)}")
-    table.add_column("Ref", style="cyan", no_wrap=True)
-    table.add_column("Registry", style="green")
+    table.add_column("Name", style="cyan", no_wrap=True)
+    table.add_column("Scope", style="green")
     table.add_column("Name")
-    for ref_str in refs:
-        # Already-validated on write — but parse again so the table is
-        # consistent if a future change ever loosens the writer.
-        ref = parse_skill_ref(ref_str)
-        table.add_row(escape(ref_str), escape(ref.registry), escape(ref.name))
+    for name in refs:
+        table.add_row(escape(name), "local", escape(name))
     console.print(table)
 
 
@@ -184,10 +220,11 @@ def install(
     try:
         # Preflight — no state mutation yet.
         ref = parse_skill_ref(skill_ref)
+        agent_type = _resolve_agent_type(agent_name)
         skill = load_skill(ref)
         validate_skill(skill)
-        agent_type = _resolve_agent_type(agent_name)
         check_agent_compatibility(skill, agent_type)
+        local_skill = materialize_skill_for_agent(skill, agent_type)
     except _USER_FACING_ERRORS as error:
         _exit_with_error(error)
         return
@@ -198,9 +235,13 @@ def install(
     # it isn't.
     try:
         prior_state = read_state(agent_name)
-        _new_state, added = add_skill(agent_name, ref)
+        existed, prior_bytes = _write_local_skill(agent_name, ref.name, local_skill)
+        _new_state, added = add_skill(agent_name, ref.name)
     except _USER_FACING_ERRORS as error:
         _exit_with_error(error)
+        return
+    except Exception as error:
+        _exit_with_error(SkillError(str(error)))
         return
 
     try:
@@ -209,6 +250,7 @@ def install(
         # Roll back the state mutation; the host did not converge.
         try:
             write_state(agent_name, prior_state)
+            _restore_local_skill(agent_name, ref.name, existed, prior_bytes)
         except Exception as rollback_error:
             # Hard rollback failure is rare (the state file just got
             # written successfully one statement above) but it leaves
@@ -240,8 +282,7 @@ def install(
         console.print(
             f"[yellow]{escape(skill_ref)}[/yellow] was already in desired "
             f"state; reconciled host. Skills now installed: "
-            f"{', '.join(escape(r) for r in result.applied_skills) or '(none)'}."
-        )
+            f"{', '.join(escape(r) for r in result.applied_skills) or '(none)'}.")
 
 
 @agent_skill_app.command()
@@ -270,7 +311,14 @@ def remove(
         # SKILL.md may still exist and need pruning).
         ref = parse_skill_ref(skill_ref)
         prior_state = read_state(agent_name)
-        _new_state, removed = remove_skill(agent_name, ref)
+        target = agent_skills_dir(agent_name) / ref.name
+        existed = target.exists()
+        backup = target.with_name(f".{target.name}.clm-remove-backup")
+        if backup.exists():
+            shutil.rmtree(backup, ignore_errors=True)
+        if existed:
+            target.rename(backup)
+        _new_state, removed = remove_skill(agent_name, ref.name)
     except _USER_FACING_ERRORS as error:
         _exit_with_error(error)
         return
@@ -280,6 +328,8 @@ def remove(
     except _USER_FACING_ERRORS as error:
         try:
             write_state(agent_name, prior_state)
+            if existed and backup.exists() and not target.exists():
+                backup.rename(target)
         except Exception as rollback_error:
             logger.warning(
                 "Rollback of %s state failed: %s",
@@ -293,6 +343,9 @@ def remove(
             )
         _exit_with_error(error)
         return
+
+    if backup.exists():
+        shutil.rmtree(backup, ignore_errors=True)
 
     if removed:
         console.print(

--- a/src/clawrium/cli/agent_skill.py
+++ b/src/clawrium/cli/agent_skill.py
@@ -42,17 +42,15 @@ from clawrium.core.skills import (
     InvalidSkillRef,
     MissingRegistryPrefix,
     SchemaValidationError,
-    SOURCE_REF_FIELD,
-    Skill,
     SkillError,
     SkillNotFound,
-    SkillRef,
     check_agent_compatibility,
     load_skill,
     materialize_skill_for_agent,
     parse_skill_ref,
     render_skill_md,
     validate_skill,
+    with_source_ref,
 )
 from clawrium.core.skills_apply import (
     AgentNotFoundError,
@@ -131,23 +129,7 @@ def _resolve_agent_type(agent_name: str) -> str:
     return agent_type
 
 
-def _with_source_ref(skill: Skill, source_ref: str) -> Skill:
-    frontmatter = dict(skill.skill_md_frontmatter)
-    metadata = dict(skill.metadata)
-    frontmatter[SOURCE_REF_FIELD] = source_ref
-    metadata[SOURCE_REF_FIELD] = source_ref
-    sourced = Skill(
-        ref=SkillRef(skill.ref.registry, skill.ref.name),
-        path=skill.path,
-        metadata=metadata,
-        body=skill.body,
-        skill_md_frontmatter=frontmatter,
-    )
-    validate_skill(sourced)
-    return sourced
-
-
-def _write_local_skill(agent_name: str, skill_name: str, skill: Skill) -> tuple[bool, object]:
+def _write_local_skill(agent_name: str, skill_name: str, skill) -> tuple[bool, object]:
     target = agent_skills_dir(agent_name) / skill_name
     existed = target.exists()
     target.mkdir(parents=True, exist_ok=True)
@@ -234,7 +216,7 @@ def install(
         validate_skill(skill)
         check_agent_compatibility(skill, agent_type)
         local_skill = materialize_skill_for_agent(skill, agent_type)
-        local_skill = _with_source_ref(local_skill, str(ref))
+        local_skill = with_source_ref(local_skill, str(ref))
     except _USER_FACING_ERRORS as error:
         _exit_with_error(error)
         return

--- a/src/clawrium/cli/agent_skill.py
+++ b/src/clawrium/cli/agent_skill.py
@@ -30,7 +30,6 @@ import logging
 import shutil
 
 import typer
-import yaml
 from rich.console import Console
 from rich.markup import escape
 from rich.table import Table
@@ -43,12 +42,16 @@ from clawrium.core.skills import (
     InvalidSkillRef,
     MissingRegistryPrefix,
     SchemaValidationError,
+    SOURCE_REF_FIELD,
+    Skill,
     SkillError,
     SkillNotFound,
+    SkillRef,
     check_agent_compatibility,
     load_skill,
     materialize_skill_for_agent,
     parse_skill_ref,
+    render_skill_md,
     validate_skill,
 )
 from clawrium.core.skills_apply import (
@@ -128,23 +131,29 @@ def _resolve_agent_type(agent_name: str) -> str:
     return agent_type
 
 
-def _render_skill_md(skill) -> str:
-    frontmatter = yaml.safe_dump(
-        skill.skill_md_frontmatter,
-        sort_keys=False,
-        allow_unicode=False,
-    ).strip()
-    body = skill.body.rstrip()
-    return f"---\n{frontmatter}\n---\n\n{body}\n"
+def _with_source_ref(skill: Skill, source_ref: str) -> Skill:
+    frontmatter = dict(skill.skill_md_frontmatter)
+    metadata = dict(skill.metadata)
+    frontmatter[SOURCE_REF_FIELD] = source_ref
+    metadata[SOURCE_REF_FIELD] = source_ref
+    sourced = Skill(
+        ref=SkillRef(skill.ref.registry, skill.ref.name),
+        path=skill.path,
+        metadata=metadata,
+        body=skill.body,
+        skill_md_frontmatter=frontmatter,
+    )
+    validate_skill(sourced)
+    return sourced
 
 
-def _write_local_skill(agent_name: str, skill_name: str, skill) -> tuple[bool, object]:
+def _write_local_skill(agent_name: str, skill_name: str, skill: Skill) -> tuple[bool, object]:
     target = agent_skills_dir(agent_name) / skill_name
     existed = target.exists()
     target.mkdir(parents=True, exist_ok=True)
     skill_file = target / "SKILL.md"
     prior_bytes = skill_file.read_bytes() if skill_file.exists() else None
-    skill_file.write_text(_render_skill_md(skill), encoding="utf-8")
+    skill_file.write_text(render_skill_md(skill), encoding="utf-8")
     return existed, prior_bytes
 
 
@@ -225,6 +234,7 @@ def install(
         validate_skill(skill)
         check_agent_compatibility(skill, agent_type)
         local_skill = materialize_skill_for_agent(skill, agent_type)
+        local_skill = _with_source_ref(local_skill, str(ref))
     except _USER_FACING_ERRORS as error:
         _exit_with_error(error)
         return

--- a/src/clawrium/cli/clawctl/agent/skill.py
+++ b/src/clawrium/cli/clawctl/agent/skill.py
@@ -10,13 +10,13 @@ later copies those local bytes to the host without transforming them.
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
 
 import typer
-import yaml
 
 from clawrium.cli.clawctl._common import OutputFormat
 from clawrium.cli.clawctl.agent._shared import safe_resolve_agent
@@ -31,6 +31,7 @@ from clawrium.core.skills import (
     IncompatibleSkillRegistry,
     InvalidSkillRef,
     MissingRegistryPrefix,
+    SOURCE_REF_FIELD,
     SchemaValidationError,
     Skill,
     SkillError,
@@ -43,6 +44,7 @@ from clawrium.core.skills import (
     load_skill,
     materialize_skill_for_agent,
     parse_skill_ref,
+    render_skill_md,
     validate_skill,
 )
 from clawrium.core.skills_state import (
@@ -85,14 +87,6 @@ def _validate_local_name(name: str) -> str:
     return name
 
 
-def _render_skill_md(skill: Skill) -> str:
-    frontmatter = yaml.safe_dump(
-        dict(skill.skill_md_frontmatter), sort_keys=False, allow_unicode=False
-    ).strip()
-    body = skill.body or ""
-    return f"---\n{frontmatter}\n---\n{body}"
-
-
 def _persist_local_skill(agent: str, name: str, skill: Skill) -> None:
     target_dir = agent_skills_dir(agent) / name
     if target_dir.exists():
@@ -106,10 +100,15 @@ def _persist_local_skill(agent: str, name: str, skill: Skill) -> None:
             "Remove or rename the existing skill first."
         )
 
-    target_dir.mkdir(parents=True, exist_ok=False)
     try:
-        (target_dir / "SKILL.md").write_text(_render_skill_md(skill))
+        target_dir.mkdir(parents=True, exist_ok=False)
+        (target_dir / "SKILL.md").write_text(render_skill_md(skill), encoding="utf-8")
         add_skill(agent, name)
+    except FileExistsError as error:
+        raise InvalidSkillRef(
+            f"Local skill {name!r} already exists for agent {agent!r}. "
+            "Remove or rename the existing skill first."
+        ) from error
     except Exception:
         shutil.rmtree(target_dir, ignore_errors=True)
         raise
@@ -131,6 +130,22 @@ def _with_name(skill: Skill, name: str) -> Skill:
     )
     validate_skill(renamed)
     return renamed
+
+
+def _with_source_ref(skill: Skill, source_ref: str) -> Skill:
+    frontmatter = dict(skill.skill_md_frontmatter)
+    metadata = dict(skill.metadata)
+    frontmatter[SOURCE_REF_FIELD] = source_ref
+    metadata[SOURCE_REF_FIELD] = source_ref
+    sourced = Skill(
+        ref=skill.ref,
+        path=skill.path,
+        metadata=metadata,
+        body=skill.body,
+        skill_md_frontmatter=frontmatter,
+    )
+    validate_skill(sourced)
+    return sourced
 
 
 def _name_from_skill(skill: Skill, explicit_name: Optional[str]) -> str:
@@ -183,8 +198,10 @@ def _resolve_add_input(
     if path is not None and from_template is not None:
         raise InvalidSkillRef("Pass either PATH or --from-template, not both.")
     if from_template is not None:
-        source = load_skill(parse_skill_ref(from_template))
+        source_ref = parse_skill_ref(from_template)
+        source = load_skill(source_ref)
         skill = materialize_skill_for_agent(source, agent_type)
+        skill = _with_source_ref(skill, str(source_ref))
     elif path is not None:
         skill = _materialize_path_for_agent(path, agent_type)
     else:
@@ -198,7 +215,7 @@ def _resolve_add_input(
 
 def _editor_command(explicit: Optional[str]) -> list[str]:
     raw = explicit or os.environ.get("VISUAL") or os.environ.get("EDITOR") or "vi"
-    return raw.split()
+    return shlex.split(raw)
 
 
 def _run_editor(path: Path, editor: Optional[str]) -> int:

--- a/src/clawrium/cli/clawctl/agent/skill.py
+++ b/src/clawrium/cli/clawctl/agent/skill.py
@@ -31,7 +31,6 @@ from clawrium.core.skills import (
     IncompatibleSkillRegistry,
     InvalidSkillRef,
     MissingRegistryPrefix,
-    SOURCE_REF_FIELD,
     SchemaValidationError,
     Skill,
     SkillError,
@@ -46,6 +45,7 @@ from clawrium.core.skills import (
     parse_skill_ref,
     render_skill_md,
     validate_skill,
+    with_source_ref,
 )
 from clawrium.core.skills_state import (
     add_skill,
@@ -132,22 +132,6 @@ def _with_name(skill: Skill, name: str) -> Skill:
     return renamed
 
 
-def _with_source_ref(skill: Skill, source_ref: str) -> Skill:
-    frontmatter = dict(skill.skill_md_frontmatter)
-    metadata = dict(skill.metadata)
-    frontmatter[SOURCE_REF_FIELD] = source_ref
-    metadata[SOURCE_REF_FIELD] = source_ref
-    sourced = Skill(
-        ref=skill.ref,
-        path=skill.path,
-        metadata=metadata,
-        body=skill.body,
-        skill_md_frontmatter=frontmatter,
-    )
-    validate_skill(sourced)
-    return sourced
-
-
 def _name_from_skill(skill: Skill, explicit_name: Optional[str]) -> str:
     if explicit_name is not None:
         return _validate_local_name(explicit_name)
@@ -201,7 +185,7 @@ def _resolve_add_input(
         source_ref = parse_skill_ref(from_template)
         source = load_skill(source_ref)
         skill = materialize_skill_for_agent(source, agent_type)
-        skill = _with_source_ref(skill, str(source_ref))
+        skill = with_source_ref(skill, str(source_ref))
     elif path is not None:
         skill = _materialize_path_for_agent(path, agent_type)
     else:

--- a/src/clawrium/cli/clawctl/agent/skill.py
+++ b/src/clawrium/cli/clawctl/agent/skill.py
@@ -1,26 +1,22 @@
-"""`clawctl agent skill attach|detach|get` — Pattern A per-agent.
+"""`clawctl agent skill` — per-agent local skill lifecycle.
 
-Skills are stored differently from providers/channels/integrations:
-the desired-state lives in
-`~/.config/clawrium/agents/<agent>/skills.json` (see
-`clawrium.core.skills_state`), and an Ansible playbook reconciles
-on-host content via `clawrium.core.skills_apply.apply_state`.
-
-This module wraps that machinery with the Pattern A vocabulary:
-
-- `attach <ref> --agent N` ≡ legacy `clm agent skill install`
-- `detach <ref> --agent N` ≡ legacy `clm agent skill remove`
-- `get --agent N` ≡ legacy `clm agent skill list`
-
-The preflight → mutate → apply pattern from `cli/agent_skill.py` is
-preserved verbatim so behaviour is unchanged.
+Issue #411 changes skills from registry-ref desired state to local,
+agent-native skill files. Registry skills are templates only: `add`
+materializes/copies them into
+`~/.config/clawrium/agents/<agent>/skills/<name>/SKILL.md`; `sync`
+later copies those local bytes to the host without transforming them.
 """
 
 from __future__ import annotations
 
-import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
 
 import typer
+import yaml
 
 from clawrium.cli.clawctl._common import OutputFormat
 from clawrium.cli.clawctl.agent._shared import safe_resolve_agent
@@ -32,34 +28,36 @@ from clawrium.cli.output import (
     render_table,
 )
 from clawrium.core.skills import (
-    ExternalSourceBlocked,
     IncompatibleSkillRegistry,
     InvalidSkillRef,
     MissingRegistryPrefix,
     SchemaValidationError,
+    Skill,
     SkillError,
     SkillNotFound,
-    check_agent_compatibility,
+    SkillRef,
+    _NAME_RE,
+    _load_skill_from_dir,
+    _split_frontmatter,
+    load_agent_skill,
     load_skill,
+    materialize_skill_for_agent,
     parse_skill_ref,
     validate_skill,
 )
-from clawrium.core.skills_apply import (
-    AgentNotFoundError,
-    SkillApplyError,
-    SkillApplyNotSupported,
-    apply_state,
+from clawrium.core.skills_state import (
+    add_skill,
+    agent_skills_dir,
+    read_state,
+    remove_skill,
 )
-from clawrium.core.skills_state import add_skill, read_state, remove_skill, write_state
 
 __all__ = ["skill_app"]
-
-logger = logging.getLogger(__name__)
 
 
 skill_app = typer.Typer(
     name="skill",
-    help="Manage skill attachments on an agent.",
+    help="Manage local skills on an agent.",
     no_args_is_help=True,
     rich_markup_mode=None,
     add_completion=False,
@@ -67,134 +65,171 @@ skill_app = typer.Typer(
 
 
 _USER_FACING_ERRORS: tuple[type[SkillError], ...] = (
-    AgentNotFoundError,
-    ExternalSourceBlocked,
     IncompatibleSkillRegistry,
     InvalidSkillRef,
     MissingRegistryPrefix,
     SchemaValidationError,
-    SkillApplyError,
-    SkillApplyNotSupported,
     SkillNotFound,
 )
 
 
-def _exit_with_error(error: SkillError) -> None:
+def _exit_with_error(error: Exception) -> None:
     emit_error(str(error))
 
 
-@skill_app.command("attach")
-def attach(
-    skill_ref: str = typer.Argument(
-        ..., metavar="REGISTRY/NAME", help="Skill ref (e.g. `clawrium/tdd`)."
-    ),
-    agent: str = typer.Option(..., "--agent", help="Agent instance name."),
-) -> None:
-    """Attach a skill to an agent (installs on host via Ansible)."""
-    # Resolve agent up front so a non-existent agent fails before
-    # `add_skill` mutates the desired-state file.
-    _host, agent_type, _claw = safe_resolve_agent(agent)
-    try:
-        ref = parse_skill_ref(skill_ref)
-        skill = load_skill(ref)
-        validate_skill(skill)
-        check_agent_compatibility(skill, agent_type)
-    except _USER_FACING_ERRORS as exc:
-        _exit_with_error(exc)
-        return
+def _validate_local_name(name: str) -> str:
+    if not isinstance(name, str) or not _NAME_RE.fullmatch(name):
+        raise InvalidSkillRef(
+            f"Invalid skill name {name!r}. Names must match ^[a-z0-9][a-z0-9_-]*$."
+        )
+    return name
 
-    try:
-        prior_state = read_state(agent)
-        _new_state, added = add_skill(agent, ref)
-    except _USER_FACING_ERRORS as exc:
-        _exit_with_error(exc)
-        return
 
-    try:
-        result = apply_state(agent)
-    except _USER_FACING_ERRORS as exc:
-        try:
-            write_state(agent, prior_state)
-        except Exception as rollback_exc:
-            logger.warning("Rollback of %s state failed: %s", agent, rollback_exc)
-        _exit_with_error(exc)
-        return
+def _render_skill_md(skill: Skill) -> str:
+    frontmatter = yaml.safe_dump(
+        dict(skill.skill_md_frontmatter), sort_keys=False, allow_unicode=False
+    ).strip()
+    body = skill.body or ""
+    return f"---\n{frontmatter}\n---\n{body}"
 
-    if added:
-        typer.echo(f"agent/{agent}: attached skill {skill_ref!r}")
-    else:
-        applied = ", ".join(result.applied_skills) or "(none)"
-        typer.echo(
-            f"agent/{agent}: skill {skill_ref!r} already attached; "
-            f"reconciled host (skills now: {applied})"
+
+def _persist_local_skill(agent: str, name: str, skill: Skill) -> None:
+    target_dir = agent_skills_dir(agent) / name
+    if target_dir.exists():
+        raise InvalidSkillRef(
+            f"Local skill {name!r} already exists for agent {agent!r}. "
+            "Remove or rename the existing skill first."
+        )
+    if name in read_state(agent):
+        raise InvalidSkillRef(
+            f"Local skill {name!r} is already in desired state for agent {agent!r}. "
+            "Remove or rename the existing skill first."
         )
 
-
-@skill_app.command("detach")
-def detach(
-    skill_ref: str = typer.Argument(..., metavar="REGISTRY/NAME", help="Skill ref."),
-    agent: str = typer.Option(..., "--agent", help="Agent instance name."),
-) -> None:
-    """Detach a skill from an agent (uninstalls on host via Ansible)."""
-    _host, _agent_type, _claw = safe_resolve_agent(agent)
+    target_dir.mkdir(parents=True, exist_ok=False)
     try:
-        ref = parse_skill_ref(skill_ref)
-        prior_state = read_state(agent)
-        _new_state, removed = remove_skill(agent, ref)
-    except _USER_FACING_ERRORS as exc:
-        _exit_with_error(exc)
-        return
+        (target_dir / "SKILL.md").write_text(_render_skill_md(skill))
+        add_skill(agent, name)
+    except Exception:
+        shutil.rmtree(target_dir, ignore_errors=True)
+        raise
 
-    try:
-        _result = apply_state(agent)
-    except _USER_FACING_ERRORS as exc:
-        try:
-            write_state(agent, prior_state)
-        except Exception as rollback_exc:
-            logger.warning("Rollback of %s state failed: %s", agent, rollback_exc)
-        _exit_with_error(exc)
-        return
 
-    if removed:
-        typer.echo(f"agent/{agent}: detached skill {skill_ref!r}")
+def _with_name(skill: Skill, name: str) -> Skill:
+    if skill.ref.name == name and skill.skill_md_frontmatter.get("name") == name:
+        return skill
+    frontmatter = dict(skill.skill_md_frontmatter)
+    metadata = dict(skill.metadata)
+    frontmatter["name"] = name
+    metadata["name"] = name
+    renamed = Skill(
+        ref=SkillRef(skill.ref.registry, name),
+        path=skill.path,
+        metadata=metadata,
+        body=skill.body,
+        skill_md_frontmatter=frontmatter,
+    )
+    validate_skill(renamed)
+    return renamed
+
+
+def _name_from_skill(skill: Skill, explicit_name: Optional[str]) -> str:
+    if explicit_name is not None:
+        return _validate_local_name(explicit_name)
+    raw = skill.skill_md_frontmatter.get("name") or skill.metadata.get("name")
+    if not isinstance(raw, str):
+        raise InvalidSkillRef("SKILL.md frontmatter must include a string `name` field.")
+    return _validate_local_name(raw)
+
+
+def _load_native_path(path: Path, agent_type: str) -> Skill:
+    if path.is_dir():
+        skill_dir = path
+        skill_md = skill_dir / "SKILL.md"
     else:
-        typer.echo(
-            f"agent/{agent}: skill {skill_ref!r} was not in desired state; "
-            "host reconciled anyway"
-        )
+        skill_dir = path.parent
+        skill_md = path
+    if not skill_md.is_file():
+        raise SkillNotFound(f"Skill path {path} is missing SKILL.md.")
+    body, frontmatter = _split_frontmatter(skill_md.read_text())
+    name = frontmatter.get("name")
+    if not isinstance(name, str):
+        raise InvalidSkillRef("SKILL.md frontmatter must include a string `name` field.")
+    skill = Skill(
+        ref=SkillRef(agent_type, _validate_local_name(name)),
+        path=skill_dir,
+        metadata=dict(frontmatter),
+        body=body,
+        skill_md_frontmatter=dict(frontmatter),
+    )
+    validate_skill(skill)
+    return skill
 
 
-@skill_app.command("get")
-def get(
-    agent: str = typer.Option(..., "--agent", help="Agent instance name."),
+def _materialize_path_for_agent(path: Path, agent_type: str) -> Skill:
+    if path.is_dir() and (path / "_meta.yaml").is_file():
+        source = _load_skill_from_dir(SkillRef("clawrium", path.name), path)
+        return materialize_skill_for_agent(source, agent_type)
+    return _load_native_path(path, agent_type)
+
+
+def _resolve_add_input(
+    *,
+    agent_type: str,
+    path: Optional[Path],
+    from_template: Optional[str],
+    name: Optional[str],
+) -> tuple[str, Skill]:
+    if path is not None and from_template is not None:
+        raise InvalidSkillRef("Pass either PATH or --from-template, not both.")
+    if from_template is not None:
+        source = load_skill(parse_skill_ref(from_template))
+        skill = materialize_skill_for_agent(source, agent_type)
+    elif path is not None:
+        skill = _materialize_path_for_agent(path, agent_type)
+    else:
+        raise InvalidSkillRef("Pass PATH or --from-template. Interactive authoring is not implemented yet.")
+
+    local_name = _name_from_skill(skill, name)
+    skill = _with_name(skill, local_name)
+    validate_skill(skill)
+    return local_name, skill
+
+
+def _editor_command(explicit: Optional[str]) -> list[str]:
+    raw = explicit or os.environ.get("VISUAL") or os.environ.get("EDITOR") or "vi"
+    return raw.split()
+
+
+def _run_editor(path: Path, editor: Optional[str]) -> int:
+    return subprocess.run([*_editor_command(editor), str(path)], check=False).returncode
+
+
+@skill_app.command("list")
+def list_agent_skill(
+    agent: str = typer.Argument(..., help="Agent instance name."),
     output: OutputFormat = typer.Option(
         OutputFormat.table, "--output", "-o", help="Output format."
     ),
     no_headers: bool = typer.Option(False, "--no-headers", help="Skip header row."),
 ) -> None:
-    """List skills currently attached to an agent (desired state)."""
-    safe_resolve_agent(agent)  # validates agent exists
+    """List local skills in an agent's desired state."""
+    safe_resolve_agent(agent)
     try:
-        refs = read_state(agent)
+        names = read_state(agent)
     except _USER_FACING_ERRORS as exc:
         _exit_with_error(exc)
         return
 
-    rows = []
-    for ref_str in refs:
-        try:
-            ref = parse_skill_ref(ref_str)
-            registry = ref.registry
-        except _USER_FACING_ERRORS:
-            registry = ""
-        rows.append(
-            {
-                "kind": "skill",
-                "name": ref_str,
-                "registry": registry,
-                "agent": agent,
-            }
-        )
+    rows = [
+        {
+            "kind": "skill",
+            "name": name,
+            "agent": agent,
+            "path": str(agent_skills_dir(agent) / name / "SKILL.md"),
+        }
+        for name in names
+    ]
 
     if output is OutputFormat.json:
         typer.echo(dump_json(rows), nl=False)
@@ -206,6 +241,121 @@ def get(
         typer.echo(dump_name(rows), nl=False)
         return
 
-    headers = ["NAME", "REGISTRY", "AGENT"]
-    body = [[str(r["name"]), str(r["registry"] or "-"), str(r["agent"])] for r in rows]
+    headers = ["NAME", "AGENT", "PATH"]
+    body = [[str(r["name"]), str(r["agent"]), str(r["path"])] for r in rows]
     typer.echo(render_table(headers, body, no_headers=no_headers), nl=False)
+
+
+@skill_app.command("add")
+def add(
+    agent: str = typer.Argument(..., help="Agent instance name."),
+    path: Optional[Path] = typer.Argument(
+        None, metavar="PATH", help="Path to SKILL.md or skill directory."
+    ),
+    from_template: Optional[str] = typer.Option(
+        None,
+        "--from-template",
+        help="Registry template ref to copy, e.g. clawrium/tdd.",
+    ),
+    name: Optional[str] = typer.Option(None, "--name", help="Override local skill name."),
+) -> None:
+    """Add a local, agent-native skill without syncing the host."""
+    _host, agent_type, _claw = safe_resolve_agent(agent)
+    try:
+        local_name, skill = _resolve_add_input(
+            agent_type=agent_type, path=path, from_template=from_template, name=name
+        )
+        _persist_local_skill(agent, local_name, skill)
+    except _USER_FACING_ERRORS as exc:
+        _exit_with_error(exc)
+        return
+
+    typer.echo(
+        f"agent/{agent}: added local skill {local_name!r}; run `clawctl agent sync {agent}` to apply"
+    )
+
+
+@skill_app.command("edit")
+def edit(
+    agent: str = typer.Argument(..., help="Agent instance name."),
+    name: str = typer.Argument(..., help="Local skill name."),
+    editor: Optional[str] = typer.Option(None, "--editor", help="Editor command."),
+) -> None:
+    """Edit a local skill and validate the native result."""
+    _host, agent_type, _claw = safe_resolve_agent(agent)
+    try:
+        local_name = _validate_local_name(name)
+        skill_dir = agent_skills_dir(agent) / local_name
+        skill_md = skill_dir / "SKILL.md"
+        before = skill_md.read_text()
+    except (OSError, _USER_FACING_ERRORS) as exc:
+        _exit_with_error(exc)
+        return
+
+    code = _run_editor(skill_md, editor)
+    if code != 0:
+        emit_error(f"editor exited with status {code}")
+
+    try:
+        load_agent_skill(agent, local_name, agent_type)
+    except _USER_FACING_ERRORS as exc:
+        skill_md.write_text(before)
+        _exit_with_error(exc)
+        return
+    typer.echo(f"agent/{agent}: updated local skill {local_name!r}")
+
+
+@skill_app.command("remove")
+def remove(
+    agent: str = typer.Argument(..., help="Agent instance name."),
+    name: str = typer.Argument(..., help="Local skill name."),
+) -> None:
+    """Remove a local skill from desired state and disk."""
+    safe_resolve_agent(agent)
+    try:
+        local_name = _validate_local_name(name)
+        _new_state, removed = remove_skill(agent, local_name)
+        shutil.rmtree(agent_skills_dir(agent) / local_name, ignore_errors=True)
+    except _USER_FACING_ERRORS as exc:
+        _exit_with_error(exc)
+        return
+    if removed:
+        typer.echo(f"agent/{agent}: removed local skill {local_name!r}")
+    else:
+        typer.echo(f"agent/{agent}: local skill {local_name!r} was not present")
+
+
+def _removed_verb(old: str, replacement: str) -> None:
+    emit_error(
+        f"`clawctl agent skill {old}` was removed.",
+        hint=f"Use `{replacement}`.",
+    )
+
+
+@skill_app.command("attach", hidden=True)
+def attach(
+    skill_ref: str = typer.Argument(None),
+    agent: Optional[str] = typer.Option(None, "--agent"),
+) -> None:
+    """Removed compatibility shim."""
+    _removed_verb(
+        "attach",
+        "clawctl agent skill add <agent> --from-template <registry>/<name>",
+    )
+
+
+@skill_app.command("detach", hidden=True)
+def detach(
+    skill_ref: str = typer.Argument(None),
+    agent: Optional[str] = typer.Option(None, "--agent"),
+) -> None:
+    """Removed compatibility shim."""
+    _removed_verb("detach", "clawctl agent skill remove <agent> <skill-name>")
+
+
+@skill_app.command("get", hidden=True)
+def get(
+    agent: Optional[str] = typer.Option(None, "--agent"),
+) -> None:
+    """Removed compatibility shim."""
+    _removed_verb("get", "clawctl agent skill list <agent>")

--- a/src/clawrium/cli/clawctl/skill.py
+++ b/src/clawrium/cli/clawctl/skill.py
@@ -1,18 +1,13 @@
-"""`clawctl skill` — Pattern A attachable (READ-ONLY registry; #509).
-
-Skills are repo-bundled — the catalog ships inside the wheel. `skill
-registry` exposes `get` and `describe` only; there is no `create`
-verb. Per-agent `attach/detach/get` lives under
-`clawctl agent skill`.
-
-Storage layer is `clawrium.core.skills` (untouched per plan §2).
-"""
+"""`clawctl skill` — skill registry and user overlay management."""
 
 from __future__ import annotations
 
+import shutil
+from pathlib import Path
 from typing import Optional
 
 import typer
+import yaml
 
 from clawrium.cli.clawctl._common import OutputFormat, parse_kv_labels
 from clawrium.cli.output import (
@@ -25,9 +20,16 @@ from clawrium.cli.output import (
 from clawrium.core.skills import (
     InvalidSkillRef,
     MissingRegistryPrefix,
+    REGISTRIES,
     SchemaValidationError,
+    Skill,
     SkillError,
     SkillNotFound,
+    SkillRef,
+    _NAME_RE,
+    _load_skill_from_dir,
+    _overlay_root,
+    _split_frontmatter,
     list_skills,
     load_skill,
     parse_skill_ref,
@@ -39,7 +41,7 @@ __all__ = ["skill_app"]
 
 skill_app = typer.Typer(
     name="skill",
-    help="Skills catalog (Pattern A attachable, read-only).",
+    help="Skills catalog and user overlay management.",
     no_args_is_help=True,
     rich_markup_mode=None,
     add_completion=False,
@@ -67,6 +69,124 @@ def _skill_description(ref) -> str:
         return ""
     meta = skill.metadata or {}
     return str(meta.get("description") or "")
+
+
+def _validate_name(name: str) -> str:
+    if not isinstance(name, str) or not _NAME_RE.fullmatch(name):
+        raise InvalidSkillRef(
+            f"Invalid skill name {name!r}. Names must match ^[a-z0-9][a-z0-9_-]*$."
+        )
+    return name
+
+
+def _render_skill_md(skill: Skill) -> str:
+    frontmatter = yaml.safe_dump(
+        dict(skill.skill_md_frontmatter), sort_keys=False, allow_unicode=False
+    ).strip()
+    return f"---\n{frontmatter}\n---\n{skill.body or ''}"
+
+
+def _load_native_path(path: Path, registry: str) -> Skill:
+    if path.is_dir():
+        skill_dir = path
+        skill_md = skill_dir / "SKILL.md"
+    else:
+        skill_dir = path.parent
+        skill_md = path
+    if not skill_md.is_file():
+        raise SkillNotFound(f"Skill path {path} is missing SKILL.md.")
+    body, frontmatter = _split_frontmatter(skill_md.read_text())
+    name = frontmatter.get("name")
+    if not isinstance(name, str):
+        raise InvalidSkillRef("SKILL.md frontmatter must include a string `name` field.")
+    skill = Skill(
+        ref=SkillRef(registry, _validate_name(name)),
+        path=skill_dir,
+        metadata=dict(frontmatter),
+        body=body,
+        skill_md_frontmatter=dict(frontmatter),
+    )
+    validate_skill(skill)
+    return skill
+
+
+def _rename_skill(skill: Skill, name: str) -> Skill:
+    if skill.ref.name == name and skill.metadata.get("name") == name:
+        return skill
+    metadata = dict(skill.metadata)
+    frontmatter = dict(skill.skill_md_frontmatter)
+    metadata["name"] = name
+    if frontmatter:
+        frontmatter["name"] = name
+    renamed = Skill(
+        ref=SkillRef(skill.ref.registry, name),
+        path=skill.path,
+        metadata=metadata,
+        body=skill.body,
+        skill_md_frontmatter=frontmatter,
+    )
+    validate_skill(renamed)
+    return renamed
+
+
+def _load_overlay_input(path: Path, registry: str, name: Optional[str]) -> tuple[str, Skill]:
+    if registry not in REGISTRIES:
+        raise InvalidSkillRef(
+            f"Unknown registry {registry!r}. Allowed: {', '.join(REGISTRIES)}."
+        )
+    if registry == "clawrium":
+        if not path.is_dir():
+            raise InvalidSkillRef("clawrium registry skills must be provided as a directory.")
+        skill = _load_skill_from_dir(SkillRef("clawrium", path.name), path)
+        validate_skill(skill)
+    else:
+        skill = _load_native_path(path, registry)
+    local_name = _validate_name(name) if name is not None else skill.ref.name
+    skill = _rename_skill(skill, local_name)
+    return local_name, skill
+
+
+def _write_overlay_skill(registry: str, name: str, skill: Skill) -> None:
+    target_dir = _overlay_root() / registry / name
+    if target_dir.exists():
+        raise InvalidSkillRef(
+            f"Skill {registry}/{name} already exists in the user overlay. "
+            "Remove or rename it before adding a replacement."
+        )
+    target_dir.mkdir(parents=True, exist_ok=False)
+    try:
+        (target_dir / "SKILL.md").write_text(_render_skill_md(skill))
+        if registry == "clawrium":
+            (target_dir / "_meta.yaml").write_text(
+                yaml.safe_dump(dict(skill.metadata), sort_keys=False, allow_unicode=False)
+            )
+    except Exception:
+        shutil.rmtree(target_dir, ignore_errors=True)
+        raise
+
+
+@skill_app.command("add")
+def add(
+    path: Optional[Path] = typer.Argument(
+        None, metavar="PATH", help="Path to SKILL.md or skill directory."
+    ),
+    registry: str = typer.Option(..., "--registry", help="Target skill registry."),
+    name: Optional[str] = typer.Option(None, "--name", help="Override skill name."),
+    interactive: bool = typer.Option(
+        False, "--interactive", help="Open an editor for a new skill stub."
+    ),
+) -> None:
+    """Add a skill to the user overlay catalog."""
+    if interactive:
+        emit_error("interactive skill authoring is not implemented yet")
+    if path is None:
+        emit_error("PATH is required unless --interactive is implemented")
+    try:
+        local_name, skill = _load_overlay_input(path, registry, name)
+        _write_overlay_skill(registry, local_name, skill)
+    except (InvalidSkillRef, SchemaValidationError, SkillNotFound) as exc:
+        emit_error(str(exc))
+    typer.echo(f"skill/{registry}/{local_name}: added to user overlay")
 
 
 @skill_registry_app.command("get")

--- a/src/clawrium/cli/clawctl/skill.py
+++ b/src/clawrium/cli/clawctl/skill.py
@@ -147,14 +147,19 @@ def _write_overlay_skill(registry: str, name: str, skill: Skill) -> None:
             f"Skill {registry}/{name} already exists in the user overlay. "
             "Remove or rename it before adding a replacement."
         )
-    target_dir.mkdir(parents=True, exist_ok=False)
     try:
+        target_dir.mkdir(parents=True, exist_ok=False)
         (target_dir / "SKILL.md").write_text(render_skill_md(skill), encoding="utf-8")
         if registry == "clawrium":
             (target_dir / "_meta.yaml").write_text(
                 yaml.safe_dump(dict(skill.metadata), sort_keys=False, allow_unicode=True),
                 encoding="utf-8",
             )
+    except FileExistsError as error:
+        raise InvalidSkillRef(
+            f"Skill {registry}/{name} already exists in the user overlay. "
+            "Remove or rename it before adding a replacement."
+        ) from error
     except Exception:
         shutil.rmtree(target_dir, ignore_errors=True)
         raise

--- a/src/clawrium/cli/clawctl/skill.py
+++ b/src/clawrium/cli/clawctl/skill.py
@@ -33,6 +33,7 @@ from clawrium.core.skills import (
     list_skills,
     load_skill,
     parse_skill_ref,
+    render_skill_md,
     validate_skill,
 )
 
@@ -77,13 +78,6 @@ def _validate_name(name: str) -> str:
             f"Invalid skill name {name!r}. Names must match ^[a-z0-9][a-z0-9_-]*$."
         )
     return name
-
-
-def _render_skill_md(skill: Skill) -> str:
-    frontmatter = yaml.safe_dump(
-        dict(skill.skill_md_frontmatter), sort_keys=False, allow_unicode=False
-    ).strip()
-    return f"---\n{frontmatter}\n---\n{skill.body or ''}"
 
 
 def _load_native_path(path: Path, registry: str) -> Skill:
@@ -155,10 +149,11 @@ def _write_overlay_skill(registry: str, name: str, skill: Skill) -> None:
         )
     target_dir.mkdir(parents=True, exist_ok=False)
     try:
-        (target_dir / "SKILL.md").write_text(_render_skill_md(skill))
+        (target_dir / "SKILL.md").write_text(render_skill_md(skill), encoding="utf-8")
         if registry == "clawrium":
             (target_dir / "_meta.yaml").write_text(
-                yaml.safe_dump(dict(skill.metadata), sort_keys=False, allow_unicode=False)
+                yaml.safe_dump(dict(skill.metadata), sort_keys=False, allow_unicode=True),
+                encoding="utf-8",
             )
     except Exception:
         shutil.rmtree(target_dir, ignore_errors=True)
@@ -180,7 +175,7 @@ def add(
     if interactive:
         emit_error("interactive skill authoring is not implemented yet")
     if path is None:
-        emit_error("PATH is required unless --interactive is implemented")
+        emit_error("PATH is required; --interactive skill authoring is not implemented yet")
     try:
         local_name, skill = _load_overlay_input(path, registry, name)
         _write_overlay_skill(registry, local_name, skill)

--- a/src/clawrium/core/skills.py
+++ b/src/clawrium/core/skills.py
@@ -645,6 +645,23 @@ def render_skill_md(skill: Skill) -> str:
     return f"---\n{frontmatter}\n---\n"
 
 
+def with_source_ref(skill: Skill, source_ref: str) -> Skill:
+    """Return ``skill`` with informational catalog-source metadata attached."""
+    frontmatter = dict(skill.skill_md_frontmatter)
+    metadata = dict(skill.metadata)
+    frontmatter[SOURCE_REF_FIELD] = source_ref
+    metadata[SOURCE_REF_FIELD] = source_ref
+    sourced = Skill(
+        ref=SkillRef(skill.ref.registry, skill.ref.name),
+        path=skill.path,
+        metadata=metadata,
+        body=skill.body,
+        skill_md_frontmatter=frontmatter,
+    )
+    validate_skill(sourced)
+    return sourced
+
+
 def _split_frontmatter(text: str) -> tuple[str, dict[str, Any]]:
     """Split a SKILL.md into (body, frontmatter dict).
 
@@ -775,6 +792,7 @@ __all__ = [
     "materialize_skill_for_agent",
     "render_skill_md",
     "SOURCE_REF_FIELD",
+    "with_source_ref",
 ]
 # Note: `scripts/validate_skills.py` imports a handful of underscored
 # helpers from this module by explicit name (`_NAME_RE`, `_load_schema`,

--- a/src/clawrium/core/skills.py
+++ b/src/clawrium/core/skills.py
@@ -291,26 +291,7 @@ def list_skills(registry: str | None = None) -> list[SkillRef]:
             f"Unknown registry {registry!r}. Allowed: {', '.join(REGISTRIES)}."
         )
 
-    registries: Iterable[str] = (registry,) if registry else REGISTRIES
-
-    root = _catalog_root()
-    refs: list[SkillRef] = []
-    for reg in registries:
-        reg_dir = root / reg
-        if not reg_dir.is_dir():
-            continue
-        names: list[str] = []
-        for entry in reg_dir.iterdir():
-            if not entry.is_dir():
-                continue
-            if not _NAME_RE.match(entry.name):
-                continue
-            if not _has_skill_files(entry, reg):
-                continue
-            names.append(entry.name)
-        for name in sorted(names):
-            refs.append(SkillRef(registry=reg, name=name))
-    return refs
+    return _list_skills_from_roots(registry=registry)
 
 
 def _list_skills_from_roots(registry: str | None = None) -> list[SkillRef]:
@@ -385,9 +366,8 @@ def load_skill(ref: SkillRef | str) -> Skill:
     if isinstance(ref, str):
         ref = parse_skill_ref(ref)
 
-    root = _catalog_root()
-    skill_dir = root / ref.registry / ref.name
-    if not skill_dir.is_dir():
+    skill_dir = _find_catalog_skill_dir(ref)
+    if skill_dir is None:
         raise SkillNotFound(
             f"Skill {ref} not found. Run `clawctl skill registry get` to see "
             "available skills."

--- a/src/clawrium/core/skills.py
+++ b/src/clawrium/core/skills.py
@@ -41,6 +41,7 @@ _NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 """Slug pattern for `<name>` in `<registry>/<name>` and for directory names."""
 
 _CATALOG_OVERLAY_COLLISIONS_WARNED: set[str] = set()
+SOURCE_REF_FIELD = "x-clawrium-source"
 
 _EXTERNAL_PREFIXES = (
     "http://",
@@ -627,6 +628,23 @@ def materialize_skill_for_agent(skill: Skill, agent_type: str) -> Skill:
     return native_skill
 
 
+def render_skill_md(skill: Skill) -> str:
+    """Render a native ``Skill`` as canonical ``SKILL.md`` bytes.
+
+    Callers use this when persisting add-time materialized skills. Sync does
+    not call this helper; sync copies existing local files byte-for-byte.
+    """
+    frontmatter = yaml.safe_dump(
+        dict(skill.skill_md_frontmatter),
+        sort_keys=False,
+        allow_unicode=True,
+    ).strip()
+    body = (skill.body or "").lstrip("\n").rstrip("\n")
+    if body:
+        return f"---\n{frontmatter}\n---\n\n{body}\n"
+    return f"---\n{frontmatter}\n---\n"
+
+
 def _split_frontmatter(text: str) -> tuple[str, dict[str, Any]]:
     """Split a SKILL.md into (body, frontmatter dict).
 
@@ -755,6 +773,8 @@ __all__ = [
     "clear_schema_cache",
     "materialize_for_claw",
     "materialize_skill_for_agent",
+    "render_skill_md",
+    "SOURCE_REF_FIELD",
 ]
 # Note: `scripts/validate_skills.py` imports a handful of underscored
 # helpers from this module by explicit name (`_NAME_RE`, `_load_schema`,

--- a/src/clawrium/core/skills_apply.py
+++ b/src/clawrium/core/skills_apply.py
@@ -257,7 +257,12 @@ def _stage_skills(agent_name: str, agent_type: str, skills: list[Skill]) -> Path
             skill_dir.mkdir(parents=True, exist_ok=True)
             skill_dir.chmod(0o700)
             skill_md_path = skill_dir / "SKILL.md"
-            skill_md_path.write_bytes((skill.path / "SKILL.md").read_bytes())
+            try:
+                skill_md_path.write_bytes((skill.path / "SKILL.md").read_bytes())
+            except OSError as error:
+                raise SkillApplyError(
+                    f"Failed to stage local skill {skill.ref.name!r}: {error}"
+                ) from error
             os.chmod(skill_md_path, 0o600)
     except Exception:
         shutil.rmtree(staging, ignore_errors=True)

--- a/src/clawrium/core/skills_apply.py
+++ b/src/clawrium/core/skills_apply.py
@@ -1,4 +1,4 @@
-"""Materialize a per-agent skill desired-state onto a remote host.
+"""Apply per-agent local skill desired-state onto a remote host.
 
 `apply_state(agent_name)` is the single entry point both the CLI
 (`clm agent skill install/remove`) and (eventually) the GUI call into. It
@@ -6,10 +6,11 @@ is intentionally a tight orchestrator:
 
   1. Resolve `agent_name` → (host record, agent_type) via `core.hosts`.
   2. Read the desired-state file via `core.skills_state.read_state`.
-  3. For each ref, load + validate the skill and check compatibility
-     against the resolved `agent_type`. Failure aborts before any
-     remote I/O happens (no partial-apply states).
-  4. Materialize each skill's SKILL.md into a process-owned staging
+  3. For each bare local skill name, load the already-agent-native
+     `SKILL.md` from the control plane and validate it against the
+     resolved `agent_type`. Failure aborts before any remote I/O happens
+     (no partial-apply states).
+  4. Copy each local SKILL.md byte-for-byte into a process-owned staging
      directory inside the clawrium config tree.
   5. Dispatch to the per-claw `skills_apply.yaml` playbook with the
      staging dir + list of desired names as extravars. The playbook is
@@ -36,8 +37,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 from clawrium.core.config import get_config_dir
 from clawrium.core.hosts import get_agent_by_name
 from clawrium.core.keys import get_host_private_key
@@ -46,11 +45,7 @@ from clawrium.core.skills import (
     NATIVE_REGISTRIES,
     Skill,
     SkillError,
-    check_agent_compatibility,
-    load_skill,
-    materialize_for_claw,
-    parse_skill_ref,
-    validate_skill,
+    load_agent_skill,
 )
 from clawrium.core.skills_state import read_state
 
@@ -108,8 +103,8 @@ class ApplyResult:
         agent_name: The instance name that was applied to.
         agent_type: The resolved claw type.
         hostname: The host the playbook ran against.
-        applied_skills: Sorted list of `<registry>/<name>` refs that
-            now exist on the host (post-apply view).
+        applied_skills: Sorted list of bare local skill names that now
+            exist on the host (post-apply view).
         log_dir: ansible-runner work directory; kept for the user to
             inspect on failure or for the smoke-test transcript.
     """
@@ -162,17 +157,13 @@ def apply_state(agent_name: str, *, timeout: int = 60) -> ApplyResult:
             "Run `clm agent ps` to find a compatible agent."
         )
 
-    # Validate everything in the desired state BEFORE touching the
-    # remote. A bad ref in the file should not produce a half-applied
-    # host (e.g. some skills installed, then a validation error
-    # aborts the run mid-loop).
-    desired_refs = read_state(agent_name)
+    # Validate everything in the desired state BEFORE touching the remote.
+    # Desired state stores bare per-agent local skill names; the local
+    # SKILL.md files are already materialized for this agent type.
+    desired_names = read_state(agent_name)
     loaded: list[Skill] = []
-    for raw_ref in desired_refs:
-        ref = parse_skill_ref(raw_ref)
-        skill = load_skill(ref)
-        validate_skill(skill)
-        check_agent_compatibility(skill, agent_type)
+    for name in desired_names:
+        skill = load_agent_skill(agent_name, name, agent_type)
         loaded.append(skill)
 
     # Both staging and log-dir creation live inside the `try` so the
@@ -222,7 +213,7 @@ def apply_state(agent_name: str, *, timeout: int = 60) -> ApplyResult:
         agent_name=agent_name,
         agent_type=agent_type,
         hostname=host.get("hostname", "<unknown>"),
-        applied_skills=[str(skill.ref) for skill in loaded],
+        applied_skills=[skill.ref.name for skill in loaded],
         # log_dir was assigned before _run_apply_playbook ran; on the
         # successful-return path it is always populated.
         log_dir=log_dir if log_dir is not None else Path(""),
@@ -230,7 +221,7 @@ def apply_state(agent_name: str, *, timeout: int = 60) -> ApplyResult:
 
 
 def _stage_skills(agent_name: str, agent_type: str, skills: list[Skill]) -> Path:
-    """Render every desired skill's SKILL.md into a fresh staging dir.
+    """Copy every desired skill's local SKILL.md into a fresh staging dir.
 
     Layout::
 
@@ -238,7 +229,7 @@ def _stage_skills(agent_name: str, agent_type: str, skills: list[Skill]) -> Path
 
     The staging dir lives under `${clawrium_config}/staging/skills/`
     with 0700 perms so other users on the control machine can't read
-    rendered frontmatter mid-apply. Each apply gets a unique sibling
+    staged frontmatter mid-apply. Each apply gets a unique sibling
     (timestamp + agent name) so concurrent applies don't overwrite each
     other.
     """
@@ -262,35 +253,17 @@ def _stage_skills(agent_name: str, agent_type: str, skills: list[Skill]) -> Path
     # (ATX #382 iter 4 W-new6.)
     try:
         for skill in skills:
-            frontmatter, body = materialize_for_claw(skill, agent_type)
             skill_dir = staging / skill.ref.name
             skill_dir.mkdir(parents=True, exist_ok=True)
             skill_dir.chmod(0o700)
             skill_md_path = skill_dir / "SKILL.md"
-            skill_md_path.write_text(_render_skill_md(frontmatter, body))
+            skill_md_path.write_bytes((skill.path / "SKILL.md").read_bytes())
             os.chmod(skill_md_path, 0o600)
     except Exception:
         shutil.rmtree(staging, ignore_errors=True)
         raise
 
     return staging
-
-
-def _render_skill_md(frontmatter: dict[str, Any], body: str) -> str:
-    """Serialize a (frontmatter, body) pair into SKILL.md form.
-
-    Uses block-style YAML (`default_flow_style=False`) and preserves
-    insertion order via `sort_keys=False` so the materialized frontmatter
-    reads `name`/`description` first — matches every claw's `skills list`
-    UX (which keys off frontmatter order for the description column).
-    """
-    yaml_block = yaml.safe_dump(
-        frontmatter,
-        default_flow_style=False,
-        sort_keys=False,
-        allow_unicode=True,
-    ).strip()
-    return f"---\n{yaml_block}\n---\n\n{body.lstrip()}"
 
 
 def _make_log_dir(agent_name: str, agent_type: str, host: dict) -> Path:

--- a/src/clawrium/core/skills_state.py
+++ b/src/clawrium/core/skills_state.py
@@ -1,4 +1,4 @@
-"""Desired-state store for per-agent skills.
+"""Desired-state store for per-agent local skills.
 
 Local desired state is the source of truth for which skills are installed
 on each agent. Stored at::
@@ -7,16 +7,17 @@ on each agent. Stored at::
 
 The file is a JSON object with shape::
 
-    {"skills": ["clawrium/tdd", "clawrium/foo"]}
+    {"skills": ["tdd", "my-custom-skill"]}
 
-Entries are always `<registry>/<name>` strings (validated through
-``parse_skill_ref`` before being written), and the list is sorted and
-deduped on every write so the on-disk shape is canonical regardless of
-write order.
+Entries are bare per-agent local skill names. Registry refs such as
+``clawrium/tdd`` are template sources only at add time and are invalid in
+desired state; re-add the skill from template to create the local native
+copy. The list is sorted and deduped on every write so the on-disk shape
+is canonical regardless of write order.
 
-This module never touches a remote host. Materialization onto a host is
-``core/skills.py::apply_state`` — it reads here, calls the per-claw
-``skills_apply.yaml`` playbook, and lets the playbook do the I/O.
+This module never touches a remote host. ``core/skills_apply.py::apply_state``
+reads here, stages the already-agent-native local files as-is, calls the
+per-claw ``skills_apply.yaml`` playbook, and lets the playbook do the I/O.
 """
 
 from __future__ import annotations
@@ -30,11 +31,7 @@ import tempfile
 from pathlib import Path
 
 from clawrium.core.config import get_config_dir
-from clawrium.core.skills import (
-    InvalidSkillRef,
-    SkillRef,
-    parse_skill_ref,
-)
+from clawrium.core.skills import InvalidSkillRef, _NAME_RE
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +63,21 @@ def _validate_agent_name(agent_name: str) -> None:
         )
 
 
+def _validate_skill_name(name: str) -> str:
+    """Validate and return a bare per-agent skill name."""
+    if not isinstance(name, str) or not _NAME_RE.fullmatch(name):
+        if isinstance(name, str) and "/" in name:
+            raise InvalidSkillRef(
+                f"Invalid skill name {name!r}. skills.json now stores bare per-agent "
+                "skill names only. Registry refs are template sources; re-add with "
+                "`clawctl agent skill add <agent> --from-template <registry>/<name>`."
+            )
+        raise InvalidSkillRef(
+            f"Invalid skill name {name!r}. Names must match ^[a-z0-9][a-z0-9_-]*$."
+        )
+    return name
+
+
 def state_file_path(agent_name: str) -> Path:
     """Return the on-disk path for ``agent_name``'s skills state file.
 
@@ -79,15 +91,15 @@ def state_file_path(agent_name: str) -> Path:
 def agent_skills_dir(agent_name: str) -> Path:
     """Return the local directory containing ``agent_name``'s skill files.
 
-    Phase A only exposes the path helper; the desired-state file continues
-    to store registry refs until the issue #411 semantic switch lands.
+    Contains already-agent-native ``SKILL.md`` files. ``skills.json`` only
+    stores the bare directory names under this path.
     """
     _validate_agent_name(agent_name)
     return get_config_dir() / "agents" / agent_name / "skills"
 
 
 def read_state(agent_name: str) -> list[str]:
-    """Return the sorted list of skill refs in ``agent_name``'s state.
+    """Return the sorted list of bare skill names in ``agent_name``'s state.
 
     Missing file → empty list (the "no skills installed" state). A
     malformed file raises ``InvalidSkillRef`` so callers don't silently
@@ -109,24 +121,20 @@ def read_state(agent_name: str) -> list[str]:
         raise InvalidSkillRef(
             f"Skills state file {path}: `skills` must be a list of strings."
         )
-    # Every persisted entry has already passed parse_skill_ref on write,
-    # but re-validating on read catches hand-edited files before they
-    # reach apply_state.
     validated: list[str] = []
     for entry in skills:
-        ref = parse_skill_ref(entry)
-        validated.append(str(ref))
+        validated.append(_validate_skill_name(entry))
     return sorted(set(validated))
 
 
-def write_state(agent_name: str, refs: list[str | SkillRef]) -> list[str]:
-    """Persist ``refs`` as ``agent_name``'s desired state.
+def write_state(agent_name: str, refs: list[str]) -> list[str]:
+    """Persist bare skill names as ``agent_name``'s desired state.
 
-    Each entry is normalized through ``parse_skill_ref`` (so a hand-edited
-    or programmatic mistake — ``http://…``, bare name, unknown registry —
-    raises a stable error class instead of corrupting the file) and the
-    final list is sorted + deduped. Returns the canonicalized list that
-    was written, so callers can compare against the prior state.
+    Each entry is validated through ``_validate_skill_name`` (so registry
+    refs, URLs, paths, uppercase names, spaces, and traversal forms raise
+    a stable error class instead of corrupting the file) and the final
+    list is sorted + deduped. Returns the canonicalized list that was
+    written, so callers can compare against the prior state.
 
     Writes are atomic: content is staged to a sibling ``.tmp`` file and
     renamed into place so a concurrent reader (or a crash mid-write)
@@ -134,8 +142,7 @@ def write_state(agent_name: str, refs: list[str | SkillRef]) -> list[str]:
     """
     canonical: set[str] = set()
     for entry in refs:
-        ref = parse_skill_ref(entry) if isinstance(entry, str) else entry
-        canonical.add(str(ref))
+        canonical.add(_validate_skill_name(entry))
     sorted_refs = sorted(canonical)
 
     path = state_file_path(agent_name)
@@ -176,35 +183,37 @@ def write_state(agent_name: str, refs: list[str | SkillRef]) -> list[str]:
     return sorted_refs
 
 
-def add_skill(agent_name: str, ref: str | SkillRef) -> tuple[list[str], bool]:
-    """Add ``ref`` to ``agent_name``'s state. Returns (new_state, added).
+def add_skill(agent_name: str, name: str) -> tuple[list[str], bool]:
+    """Add bare ``name`` to ``agent_name``'s state. Returns (new_state, added).
 
     ``added`` is True if the ref was not previously present; False on
     no-op. This lets callers report "already installed, applying anyway"
     accurately while still re-running the apply playbook (idempotency +
     drift recovery).
     """
-    parsed = parse_skill_ref(ref) if isinstance(ref, str) else ref
+    parsed = _validate_skill_name(name)
     current = read_state(agent_name)
-    already_present = str(parsed) in current
+    already_present = parsed in current
     if already_present:
         return current, False
-    new_state = sorted({*current, str(parsed)})
+    new_state = sorted({*current, parsed})
     return write_state(agent_name, new_state), True
 
 
-def remove_skill(agent_name: str, ref: str | SkillRef) -> tuple[list[str], bool]:
-    """Remove ``ref`` from ``agent_name``'s state. Returns (new_state, removed).
+def remove_skill(agent_name: str, name: str) -> tuple[list[str], bool]:
+    """Remove bare ``name`` from ``agent_name``'s state.
+
+    Returns (new_state, removed).
 
     ``removed`` is True if the ref was previously present; False on
     no-op. Callers should treat a no-op as user-visible but not an
     error — removing an absent skill is idempotent.
     """
-    parsed = parse_skill_ref(ref) if isinstance(ref, str) else ref
+    parsed = _validate_skill_name(name)
     current = read_state(agent_name)
-    if str(parsed) not in current:
+    if parsed not in current:
         return current, False
-    new_state = [s for s in current if s != str(parsed)]
+    new_state = [s for s in current if s != parsed]
     return write_state(agent_name, new_state), True
 
 

--- a/src/clawrium/gui/routes/agents.py
+++ b/src/clawrium/gui/routes/agents.py
@@ -10,11 +10,13 @@ import asyncio
 import json
 import logging
 import re
+import shutil
 import shlex
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+import yaml
 
 from clawrium.core.keys import get_host_private_key
 from clawrium.gui.routes._common import resolve_agent as _resolve_agent
@@ -46,8 +48,10 @@ from clawrium.core.skills import (
     SkillError,
     SkillNotFound,
     check_agent_compatibility,
+    load_agent_skill,
     list_skills,
     load_skill,
+    materialize_skill_for_agent,
     parse_skill_ref,
 )
 from clawrium.core.skills_apply import (
@@ -58,6 +62,7 @@ from clawrium.core.skills_apply import (
 )
 from clawrium.core.skills_state import (
     add_skill,
+    agent_skills_dir,
     read_state,
     remove_skill,
 )
@@ -398,6 +403,24 @@ def _list_available_for_agent_type(agent_type: str) -> list[dict[str, object]]:
     return available
 
 
+def _render_skill_md(skill) -> str:
+    frontmatter = yaml.safe_dump(
+        skill.skill_md_frontmatter,
+        sort_keys=False,
+        allow_unicode=False,
+    ).strip()
+    body = skill.body.rstrip()
+    return f"---\n{frontmatter}\n---\n\n{body}\n"
+
+
+def _write_agent_local_skill(agent_name: str, skill_name: str, skill) -> bool:
+    target = agent_skills_dir(agent_name) / skill_name
+    existed = target.exists()
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "SKILL.md").write_text(_render_skill_md(skill), encoding="utf-8")
+    return not existed
+
+
 @router.get("/{agent_key}/skills")
 async def list_agent_skills(agent_key: str):
     """List installed skills + available-to-install skills for an agent.
@@ -427,45 +450,30 @@ async def list_agent_skills(agent_key: str):
 
     def _build() -> dict[str, object]:
         try:
-            installed_refs = read_state(agent_name)
+            installed_names = read_state(agent_name)
         except SkillError as error:
             logger.warning("skills state unreadable for %s: %s", agent_name, error)
-            installed_refs = []
+            installed_names = []
         installed: list[dict[str, object]] = []
-        for raw_ref in installed_refs:
-            try:
-                ref = parse_skill_ref(raw_ref)
-            except SkillError:
-                # State file has an entry that no longer validates — show
-                # the bare ref so the user can remove it.
-                installed.append(
-                    {
-                        "ref": raw_ref,
-                        "registry": None,
-                        "name": None,
-                        "description": None,
-                        "version": None,
-                    }
-                )
-                continue
+        for name in installed_names:
             description: str | None = None
             version: str | None = None
             try:
-                skill = load_skill(ref)
+                local_skill = load_agent_skill(agent_name, name, agent_type)
             except SkillError:
-                pass
+                local_skill = None
             else:
-                raw_desc = skill.metadata.get("description")
+                raw_desc = local_skill.skill_md_frontmatter.get("description")
                 if isinstance(raw_desc, str) and raw_desc.strip():
                     description = " ".join(raw_desc.split())
-                raw_ver = skill.metadata.get("version")
+                raw_ver = local_skill.skill_md_frontmatter.get("version")
                 if raw_ver is not None:
                     version = str(raw_ver)
             installed.append(
                 {
-                    "ref": str(ref),
-                    "registry": ref.registry,
-                    "name": ref.name,
+                    "ref": name,
+                    "registry": "local",
+                    "name": name,
                     "description": description,
                     "version": version,
                 }
@@ -498,19 +506,21 @@ def _install_or_remove(
     resolved = _resolve_agent(agent_key)
     if not resolved:
         raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
-    _host_record, _agent_type, agent_record = resolved
+    _host_record, agent_type, agent_record = resolved
     agent_name = agent_record.get("agent_name") or agent_key
 
     raw_ref = f"{registry}/{skill}"
     try:
-        # add_skill / remove_skill both call parse_skill_ref as their
-        # first operation, so a malformed ref short-circuits with 422
-        # before any state mutation. (W4: dropped the redundant pre-call
-        # that ATX flagged as dead code.)
+        ref = parse_skill_ref(raw_ref)
         if action == "install":
-            _new_state, changed = add_skill(agent_name, raw_ref)
+            template = load_skill(ref)
+            local_skill = materialize_skill_for_agent(template, agent_type)
+            wrote = _write_agent_local_skill(agent_name, ref.name, local_skill)
+            _new_state, changed = add_skill(agent_name, ref.name)
+            changed = changed or wrote
         else:
-            _new_state, changed = remove_skill(agent_name, raw_ref)
+            _new_state, changed = remove_skill(agent_name, ref.name)
+            shutil.rmtree(agent_skills_dir(agent_name) / ref.name, ignore_errors=True)
         result = apply_state(agent_name)
     except SkillError as error:
         raise HTTPException(
@@ -521,7 +531,7 @@ def _install_or_remove(
     return {
         "success": True,
         "agent_name": agent_name,
-        "ref": raw_ref,
+        "ref": ref.name,
         "changed": changed,
         "installed": list(result.applied_skills),
     }

--- a/src/clawrium/gui/routes/agents.py
+++ b/src/clawrium/gui/routes/agents.py
@@ -16,7 +16,6 @@ import shlex
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-import yaml
 
 from clawrium.core.keys import get_host_private_key
 from clawrium.gui.routes._common import resolve_agent as _resolve_agent
@@ -44,15 +43,19 @@ from clawrium.core.skills import (
     IncompatibleSkillRegistry,
     InvalidSkillRef,
     MissingRegistryPrefix,
+    SOURCE_REF_FIELD,
     SchemaValidationError,
+    Skill,
     SkillError,
     SkillNotFound,
+    SkillRef,
     check_agent_compatibility,
     load_agent_skill,
     list_skills,
     load_skill,
     materialize_skill_for_agent,
     parse_skill_ref,
+    render_skill_md,
 )
 from clawrium.core.skills_apply import (
     AgentNotFoundError,
@@ -403,22 +406,40 @@ def _list_available_for_agent_type(agent_type: str) -> list[dict[str, object]]:
     return available
 
 
-def _render_skill_md(skill) -> str:
-    frontmatter = yaml.safe_dump(
-        skill.skill_md_frontmatter,
-        sort_keys=False,
-        allow_unicode=False,
-    ).strip()
-    body = skill.body.rstrip()
-    return f"---\n{frontmatter}\n---\n\n{body}\n"
+def _skill_with_source_ref(skill: Skill, source_ref: str) -> Skill:
+    frontmatter = dict(skill.skill_md_frontmatter)
+    metadata = dict(skill.metadata)
+    frontmatter[SOURCE_REF_FIELD] = source_ref
+    metadata[SOURCE_REF_FIELD] = source_ref
+    sourced = Skill(
+        ref=SkillRef(skill.ref.registry, skill.ref.name),
+        path=skill.path,
+        metadata=metadata,
+        body=skill.body,
+        skill_md_frontmatter=frontmatter,
+    )
+    return sourced
 
 
-def _write_agent_local_skill(agent_name: str, skill_name: str, skill) -> bool:
+def _source_ref_for_local_skill(local_skill: Skill, name: str) -> SkillRef:
+    raw_source = local_skill.skill_md_frontmatter.get(SOURCE_REF_FIELD)
+    if isinstance(raw_source, str):
+        try:
+            source_ref = parse_skill_ref(raw_source)
+        except SkillError:
+            source_ref = None
+        else:
+            if source_ref.name == name:
+                return source_ref
+    return SkillRef(local_skill.ref.registry, name)
+
+
+def _write_agent_local_skill(agent_name: str, skill_name: str, skill: Skill) -> None:
     target = agent_skills_dir(agent_name) / skill_name
-    existed = target.exists()
-    target.mkdir(parents=True, exist_ok=True)
-    (target / "SKILL.md").write_text(_render_skill_md(skill), encoding="utf-8")
-    return not existed
+    if target.exists():
+        raise FileExistsError(target)
+    target.mkdir(parents=True, exist_ok=False)
+    (target / "SKILL.md").write_text(render_skill_md(skill), encoding="utf-8")
 
 
 @router.get("/{agent_key}/skills")
@@ -436,10 +457,10 @@ async def list_agent_skills(agent_key: str):
     }
     ```
 
-    ``installed`` is the local desired-state file's view — the same view
-    ``clawctl agent skill get`` shows. The agent-detail Skills tab merges
-    these in the UI, so the response keeps them separate to keep the
-    payload close to the underlying data.
+    ``installed`` is the local desired-state file's view. When a local
+    skill was copied from a catalog template, ``ref`` is that source ref so
+    the existing frontend can dedupe against ``available`` and issue the
+    matching registry/name DELETE request.
     """
     resolved = await asyncio.to_thread(_resolve_agent, agent_key)
     if not resolved:
@@ -469,10 +490,16 @@ async def list_agent_skills(agent_key: str):
                 raw_ver = local_skill.skill_md_frontmatter.get("version")
                 if raw_ver is not None:
                     version = str(raw_ver)
+                installed_ref = _source_ref_for_local_skill(local_skill, name)
+                registry = installed_ref.registry
+                ref_text = str(installed_ref)
+            if local_skill is None:
+                registry = "local"
+                ref_text = name
             installed.append(
                 {
-                    "ref": name,
-                    "registry": "local",
+                    "ref": ref_text,
+                    "registry": registry,
                     "name": name,
                     "description": description,
                     "version": version,
@@ -499,7 +526,8 @@ def _install_or_remove(
     """Shared body for POST/DELETE; runs synchronously inside a thread.
 
     Resolves the agent, mutates desired state, then unconditionally calls
-    ``apply_state`` — same drift-recovery contract the CLI uses. Returns
+    ``apply_state``. These legacy compatibility endpoints still reconcile
+    immediately; the new CLI local lifecycle is sync-driven. Returns
     a payload with the post-apply installed skills so the frontend can
     update its cache without an extra round-trip.
     """
@@ -513,11 +541,37 @@ def _install_or_remove(
     try:
         ref = parse_skill_ref(raw_ref)
         if action == "install":
+            target = agent_skills_dir(agent_name) / ref.name
+            if target.exists() or ref.name in read_state(agent_name):
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Local skill '{ref.name}' already exists for agent "
+                        f"'{agent_name}'. Remove or rename it before adding a replacement."
+                    ),
+                )
             template = load_skill(ref)
             local_skill = materialize_skill_for_agent(template, agent_type)
-            wrote = _write_agent_local_skill(agent_name, ref.name, local_skill)
+            local_skill = _skill_with_source_ref(local_skill, str(ref))
             _new_state, changed = add_skill(agent_name, ref.name)
-            changed = changed or wrote
+            try:
+                _write_agent_local_skill(agent_name, ref.name, local_skill)
+            except FileExistsError as error:
+                remove_skill(agent_name, ref.name)
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Local skill '{ref.name}' already exists for agent "
+                        f"'{agent_name}'. Remove or rename it before adding a replacement."
+                    ),
+                ) from error
+            except OSError as error:
+                remove_skill(agent_name, ref.name)
+                shutil.rmtree(target, ignore_errors=True)
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Failed to persist local skill '{ref.name}'.",
+                ) from error
         else:
             _new_state, changed = remove_skill(agent_name, ref.name)
             shutil.rmtree(agent_skills_dir(agent_name) / ref.name, ignore_errors=True)
@@ -531,7 +585,7 @@ def _install_or_remove(
     return {
         "success": True,
         "agent_name": agent_name,
-        "ref": ref.name,
+        "ref": str(ref),
         "changed": changed,
         "installed": list(result.applied_skills),
     }
@@ -541,9 +595,8 @@ def _install_or_remove(
 async def install_agent_skill(agent_key: str, registry: str, skill: str):
     """Install ``<registry>/<skill>`` on ``agent_key``.
 
-    Idempotent: re-installing an already-installed skill is a no-op
-    state mutation, but the apply playbook still runs to reconcile any
-    on-host drift (matches the CLI semantics).
+    Compatibility route for adding a catalog template from the current GUI.
+    Duplicate local names return 409; drift recovery is handled by sync.
     """
     return await asyncio.to_thread(
         _install_or_remove, agent_key, registry, skill, action="install"

--- a/src/clawrium/gui/routes/agents.py
+++ b/src/clawrium/gui/routes/agents.py
@@ -56,6 +56,7 @@ from clawrium.core.skills import (
     materialize_skill_for_agent,
     parse_skill_ref,
     render_skill_md,
+    with_source_ref,
 )
 from clawrium.core.skills_apply import (
     AgentNotFoundError,
@@ -406,21 +407,6 @@ def _list_available_for_agent_type(agent_type: str) -> list[dict[str, object]]:
     return available
 
 
-def _skill_with_source_ref(skill: Skill, source_ref: str) -> Skill:
-    frontmatter = dict(skill.skill_md_frontmatter)
-    metadata = dict(skill.metadata)
-    frontmatter[SOURCE_REF_FIELD] = source_ref
-    metadata[SOURCE_REF_FIELD] = source_ref
-    sourced = Skill(
-        ref=SkillRef(skill.ref.registry, skill.ref.name),
-        path=skill.path,
-        metadata=metadata,
-        body=skill.body,
-        skill_md_frontmatter=frontmatter,
-    )
-    return sourced
-
-
 def _source_ref_for_local_skill(local_skill: Skill, name: str) -> SkillRef:
     raw_source = local_skill.skill_md_frontmatter.get(SOURCE_REF_FIELD)
     if isinstance(raw_source, str):
@@ -438,8 +424,29 @@ def _write_agent_local_skill(agent_name: str, skill_name: str, skill: Skill) -> 
     target = agent_skills_dir(agent_name) / skill_name
     if target.exists():
         raise FileExistsError(target)
-    target.mkdir(parents=True, exist_ok=False)
-    (target / "SKILL.md").write_text(render_skill_md(skill), encoding="utf-8")
+    tmp = target.parent / f".{skill_name}.tmp"
+    shutil.rmtree(tmp, ignore_errors=True)
+    tmp.mkdir(parents=True, exist_ok=False)
+    try:
+        (tmp / "SKILL.md").write_text(render_skill_md(skill), encoding="utf-8")
+        tmp.rename(target)
+    except Exception:
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise
+
+
+def _rollback_local_install(agent_name: str, skill_name: str) -> None:
+    target = agent_skills_dir(agent_name) / skill_name
+    shutil.rmtree(target, ignore_errors=True)
+    try:
+        remove_skill(agent_name, skill_name)
+    except Exception as error:  # pragma: no cover - defensive logging only
+        logger.error(
+            "failed to roll back local skill state for %s/%s: %s",
+            agent_name,
+            skill_name,
+            error,
+        )
 
 
 @router.get("/{agent_key}/skills")
@@ -552,12 +559,12 @@ def _install_or_remove(
                 )
             template = load_skill(ref)
             local_skill = materialize_skill_for_agent(template, agent_type)
-            local_skill = _skill_with_source_ref(local_skill, str(ref))
+            local_skill = with_source_ref(local_skill, str(ref))
             _new_state, changed = add_skill(agent_name, ref.name)
             try:
                 _write_agent_local_skill(agent_name, ref.name, local_skill)
             except FileExistsError as error:
-                remove_skill(agent_name, ref.name)
+                _rollback_local_install(agent_name, ref.name)
                 raise HTTPException(
                     status_code=409,
                     detail=(
@@ -566,8 +573,7 @@ def _install_or_remove(
                     ),
                 ) from error
             except OSError as error:
-                remove_skill(agent_name, ref.name)
-                shutil.rmtree(target, ignore_errors=True)
+                _rollback_local_install(agent_name, ref.name)
                 raise HTTPException(
                     status_code=500,
                     detail=f"Failed to persist local skill '{ref.name}'.",
@@ -575,7 +581,12 @@ def _install_or_remove(
         else:
             _new_state, changed = remove_skill(agent_name, ref.name)
             shutil.rmtree(agent_skills_dir(agent_name) / ref.name, ignore_errors=True)
-        result = apply_state(agent_name)
+        try:
+            result = apply_state(agent_name)
+        except SkillError:
+            if action == "install":
+                _rollback_local_install(agent_name, ref.name)
+            raise
     except SkillError as error:
         raise HTTPException(
             status_code=_skill_error_status(error),

--- a/src/clawrium/gui/routes/fleet.py
+++ b/src/clawrium/gui/routes/fleet.py
@@ -604,11 +604,16 @@ async def agent_connection_token(agent_key: str) -> dict[str, Any]:
     # return a stale token and the user would see an opaque 401 in the
     # Control UI. Strip on return to defend against operators who
     # hand-edited the legacy field with trailing whitespace.
+    from clawrium.core.secrets import get_instance_key
     from clawrium.gui.routes.agents import _resolve_openclaw_credentials
 
+    hostname = _host_record.get("hostname", "")
+    agent_name = agent_record.get("agent_name") or agent_record.get("name") or ""
+    host_key = _host_record.get("key_id") or hostname
+    instance_key = get_instance_key(host_key, agent_type, agent_name)
     gateway = (agent_record.get("config") or {}).get("gateway") or {}
     bearer, _ = await asyncio.to_thread(
-        _resolve_openclaw_credentials, agent_key, gateway
+        _resolve_openclaw_credentials, instance_key, gateway
     )
     if not isinstance(bearer, str) or not bearer.strip():
         # No persisted bearer in either source means lifecycle ops have

--- a/src/clawrium/gui/routes/fleet.py
+++ b/src/clawrium/gui/routes/fleet.py
@@ -19,7 +19,6 @@ from clawrium.cli.tui.data import (
     get_agent_detail,
     get_fleet_data,
     get_fleet_data_local,
-    load_hosts_safe,
 )
 from clawrium.core import web_ui as web_ui_module
 from clawrium.core import web_ui_tunnel
@@ -71,7 +70,7 @@ def _host_is_local(host: str) -> bool:
     if not host:
         return False
     candidate = host.strip().lower()
-    if candidate in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}:
+    if candidate in {"localhost", "127.0.0.1", "::1"}:
         return True
     try:
         return ipaddress.ip_address(candidate).is_loopback
@@ -187,40 +186,35 @@ async def fleet_health(host: str | None = None):
 async def agent_detail(agent_key: str, host: str | None = None):
     """Get detailed info for a single agent.
 
-    Searches across all hosts unless host is specified.
+    Searches across all hosts unless host is specified. Uses resolve_agent
+    for consistent HostsFileCorruptedError / ambiguous-name / OSError handling.
     """
-    hosts = await asyncio.to_thread(load_hosts_safe)
+    resolved = await asyncio.to_thread(resolve_agent, agent_key)
+    if resolved is None:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
+    host_record, _agent_type, _ = resolved
 
-    # Find the agent across hosts
-    for h in hosts:
-        hostname = h.get("hostname", "")
-        alias = h.get("alias", "")
-        if host and hostname != host and alias != host:
-            continue
-        agents = h.get("agents", {})
-        if agent_key in agents:
-            detail = await asyncio.to_thread(get_agent_detail, agent_key, hostname)
-            if detail:
-                payload = _agent_to_dict(detail)
-                # Issue #592: surface the registry-derived max version for
-                # this host's hardware so the overview tab can render an
-                # "upgrade available" indicator. None when the host's
-                # os/arch has no matching platform entry.
-                from clawrium.core.registry import latest_supported_version
+    if host and host_record.get("hostname") != host and host_record.get("alias") != host:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent '{agent_key}' not found on host '{host}'",
+        )
 
-                try:
-                    # `.get("hardware", {})` does NOT fall back when the
-                    # value is explicitly `null` in hosts.json (pre-fact-
-                    # detection hosts). Use `or {}` to coerce. ATX W3
-                    # (issue #592).
-                    payload["latest_supported_version"] = latest_supported_version(
-                        detail["agent_type"], h.get("hardware") or {}
-                    )
-                except Exception:
-                    payload["latest_supported_version"] = None
-                return payload
+    hostname = host_record.get("hostname", "")
+    detail = await asyncio.to_thread(get_agent_detail, agent_key, hostname)
+    if not detail:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
 
-    raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
+    payload = _agent_to_dict(detail)
+    from clawrium.core.registry import latest_supported_version
+
+    try:
+        payload["latest_supported_version"] = latest_supported_version(
+            detail["agent_type"], host_record.get("hardware") or {}
+        )
+    except Exception:
+        payload["latest_supported_version"] = None
+    return payload
 
 
 @router.post("/agents/{agent_key}/start")
@@ -246,7 +240,7 @@ async def start_agent_endpoint(agent_key: str):
         }
     except LifecycleError as e:
         logger.error("start_agent failed for %s: %s", agent_key, e, exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=_sanitize_health_error(str(e)))
     except Exception as e:
         logger.error("start_agent failed for %s: %s", agent_key, e, exc_info=True)
         raise HTTPException(status_code=500, detail=_LIFECYCLE_GENERIC_ERROR)
@@ -275,7 +269,7 @@ async def stop_agent_endpoint(agent_key: str):
         }
     except LifecycleError as e:
         logger.error("stop_agent failed for %s: %s", agent_key, e, exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=_sanitize_health_error(str(e)))
     except Exception as e:
         logger.error("stop_agent failed for %s: %s", agent_key, e, exc_info=True)
         raise HTTPException(status_code=500, detail=_LIFECYCLE_GENERIC_ERROR)
@@ -304,7 +298,7 @@ async def restart_agent_endpoint(agent_key: str):
         }
     except LifecycleError as e:
         logger.error("restart_agent failed for %s: %s", agent_key, e, exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=_sanitize_health_error(str(e)))
     except Exception as e:
         logger.error("restart_agent failed for %s: %s", agent_key, e, exc_info=True)
         raise HTTPException(status_code=500, detail=_LIFECYCLE_GENERIC_ERROR)
@@ -653,19 +647,16 @@ async def reap_idle_tunnels(threshold_seconds: float = 1800.0) -> int:
         for key in stale:
             WEB_UI_LAST_ACCESS.pop(key, None)
     for key in stale:
-        # Hold the access-map lock across the close() call. The /web-ui
-        # handler stamps the map only after ensure() returns, so holding
-        # this lock keeps a fresh access stamp from landing mid-close.
-        # ensure() itself uses a different mutex (per-key) and may run
-        # concurrently — that's fine: the worst case is we kill a tunnel
-        # whose ensure() finished but whose handler hadn't stamped yet,
-        # in which case the next /web-ui call rebuilds the tunnel.
+        # Re-check under the lock: a concurrent /web-ui request may have
+        # re-stamped this key between the initial snapshot and now.
         async with _LAST_ACCESS_LOCK:
             if key in WEB_UI_LAST_ACCESS:
                 continue
-            try:
-                await asyncio.to_thread(web_ui_tunnel.close, key)
-                closed += 1
-            except Exception:  # noqa: BLE001
-                logger.debug("reaper close failed for %s", key, exc_info=True)
+        # Lock released before the blocking close() so concurrent /web-ui
+        # handlers are not stalled for the full SIGTERM→SIGKILL teardown.
+        try:
+            await asyncio.to_thread(web_ui_tunnel.close, key)
+            closed += 1
+        except Exception:  # noqa: BLE001
+            logger.debug("reaper close failed for %s", key, exc_info=True)
     return closed

--- a/src/clawrium/gui/server.py
+++ b/src/clawrium/gui/server.py
@@ -51,6 +51,11 @@ async def lifespan(app: FastAPI):
             except Exception:  # noqa: BLE001 — keep the loop alive
                 logger.exception("web-ui reaper iteration failed")
 
+    from concurrent.futures import ThreadPoolExecutor
+
+    fleet._FLEET_HEALTH_EXECUTOR = ThreadPoolExecutor(
+        max_workers=2, thread_name_prefix="fleet-health"
+    )
     task = asyncio.create_task(_reaper_loop(), name="web-ui-reaper")
     try:
         yield
@@ -60,6 +65,10 @@ async def lifespan(app: FastAPI):
             await task
         except (asyncio.CancelledError, Exception):  # noqa: BLE001
             pass
+        fleet._FLEET_HEALTH_EXECUTOR.shutdown(wait=False, cancel_futures=True)
+        fleet._FLEET_HEALTH_EXECUTOR = ThreadPoolExecutor(
+            max_workers=2, thread_name_prefix="fleet-health"
+        )
         # close() does a SIGTERM→busy-wait→SIGKILL dance that can block up
         # to ~2 s per tunnel. Run sequentially via asyncio.to_thread so the
         # event loop isn't blocked and uvicorn's graceful-shutdown budget

--- a/tests/cli/clawctl/agent/test_skill.py
+++ b/tests/cli/clawctl/agent/test_skill.py
@@ -1,0 +1,113 @@
+"""Tests for `clawctl agent skill` local skill lifecycle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+from clawrium.core.skills_state import agent_skills_dir, read_state
+
+runner = CliRunner()
+
+
+def test_add_from_template_materializes_local_skill_without_sync(fleet_dir) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "skill",
+            "add",
+            "wise-hypatia",
+            "--from-template",
+            "clawrium/tdd",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert read_state("wise-hypatia") == ["tdd"]
+    skill_md = agent_skills_dir("wise-hypatia") / "tdd" / "SKILL.md"
+    text = skill_md.read_text()
+    assert "name: tdd" in text
+    assert "description:" in text
+    assert "run `clawctl agent sync wise-hypatia`" in result.output
+
+
+def test_add_rejects_duplicate_local_name(fleet_dir) -> None:
+    first = runner.invoke(
+        app,
+        ["agent", "skill", "add", "wise-hypatia", "--from-template", "clawrium/tdd"],
+    )
+    assert first.exit_code == 0, first.output
+    second = runner.invoke(
+        app,
+        ["agent", "skill", "add", "wise-hypatia", "--from-template", "clawrium/tdd"],
+    )
+    assert second.exit_code != 0
+    assert "already exists" in second.output or "already in desired state" in second.output
+
+
+def test_add_path_uses_native_skill_format(fleet_dir, tmp_path: Path) -> None:
+    source = tmp_path / "SKILL.md"
+    source.write_text(
+        "---\nname: custom-tdd\ndescription: Custom local skill\n---\n\n# Custom\n"
+    )
+
+    result = runner.invoke(app, ["agent", "skill", "add", "wise-hypatia", str(source)])
+    assert result.exit_code == 0, result.output
+    assert read_state("wise-hypatia") == ["custom-tdd"]
+    assert (agent_skills_dir("wise-hypatia") / "custom-tdd" / "SKILL.md").read_text() == (
+        "---\nname: custom-tdd\ndescription: Custom local skill\n---\n\n# Custom\n"
+    )
+
+
+def test_list_renders_bare_local_names(fleet_dir) -> None:
+    runner.invoke(
+        app,
+        ["agent", "skill", "add", "wise-hypatia", "--from-template", "clawrium/tdd"],
+    )
+    result = runner.invoke(app, ["agent", "skill", "list", "wise-hypatia"])
+    assert result.exit_code == 0, result.output
+    assert "tdd" in result.output
+    assert "clawrium/tdd" not in result.output
+
+
+def test_remove_deletes_state_and_local_dir(fleet_dir) -> None:
+    runner.invoke(
+        app,
+        ["agent", "skill", "add", "wise-hypatia", "--from-template", "clawrium/tdd"],
+    )
+    result = runner.invoke(app, ["agent", "skill", "remove", "wise-hypatia", "tdd"])
+    assert result.exit_code == 0, result.output
+    assert read_state("wise-hypatia") == []
+    assert not (agent_skills_dir("wise-hypatia") / "tdd").exists()
+
+
+def test_removed_attach_verb_points_to_add(fleet_dir) -> None:
+    result = runner.invoke(
+        app,
+        ["agent", "skill", "attach", "clawrium/tdd", "--agent", "wise-hypatia"],
+    )
+    assert result.exit_code != 0
+    assert "was removed" in result.output
+    assert "skill add" in result.output
+
+
+def test_edit_restores_invalid_changes(fleet_dir, monkeypatch) -> None:
+    runner.invoke(
+        app,
+        ["agent", "skill", "add", "wise-hypatia", "--from-template", "clawrium/tdd"],
+    )
+    skill_md = agent_skills_dir("wise-hypatia") / "tdd" / "SKILL.md"
+    before = skill_md.read_text()
+
+    from clawrium.cli.clawctl.agent import skill as skill_cli
+
+    def corrupt(path: Path, editor: str | None) -> int:
+        path.write_text("---\nname: tdd\n---\n\nmissing description\n")
+        return 0
+
+    monkeypatch.setattr(skill_cli, "_run_editor", corrupt)
+    result = runner.invoke(app, ["agent", "skill", "edit", "wise-hypatia", "tdd"])
+    assert result.exit_code != 0
+    assert skill_md.read_text() == before

--- a/tests/cli/clawctl/agent/test_skill.py
+++ b/tests/cli/clawctl/agent/test_skill.py
@@ -30,6 +30,7 @@ def test_add_from_template_materializes_local_skill_without_sync(fleet_dir) -> N
     text = skill_md.read_text()
     assert "name: tdd" in text
     assert "description:" in text
+    assert "x-clawrium-source: clawrium/tdd" in text
     assert "run `clawctl agent sync wise-hypatia`" in result.output
 
 
@@ -72,6 +73,35 @@ def test_list_renders_bare_local_names(fleet_dir) -> None:
     assert "clawrium/tdd" not in result.output
 
 
+def test_list_supports_name_output(fleet_dir) -> None:
+    runner.invoke(
+        app,
+        ["agent", "skill", "add", "wise-hypatia", "--from-template", "clawrium/tdd"],
+    )
+    result = runner.invoke(app, ["agent", "skill", "list", "wise-hypatia", "-o", "name"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "skill/tdd"
+
+
+def test_add_rejects_path_and_template_together(fleet_dir, tmp_path: Path) -> None:
+    source = tmp_path / "SKILL.md"
+    source.write_text("---\nname: custom-tdd\ndescription: Custom local skill\n---\n\n# Custom\n")
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "skill",
+            "add",
+            "wise-hypatia",
+            str(source),
+            "--from-template",
+            "clawrium/tdd",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "either PATH or --from-template" in result.output
+
+
 def test_remove_deletes_state_and_local_dir(fleet_dir) -> None:
     runner.invoke(
         app,
@@ -91,6 +121,19 @@ def test_removed_attach_verb_points_to_add(fleet_dir) -> None:
     assert result.exit_code != 0
     assert "was removed" in result.output
     assert "skill add" in result.output
+
+
+def test_removed_detach_and_get_verbs_point_to_replacements(fleet_dir) -> None:
+    detach = runner.invoke(
+        app,
+        ["agent", "skill", "detach", "clawrium/tdd", "--agent", "wise-hypatia"],
+    )
+    assert detach.exit_code != 0
+    assert "skill remove" in detach.output
+
+    get = runner.invoke(app, ["agent", "skill", "get", "--agent", "wise-hypatia"])
+    assert get.exit_code != 0
+    assert "skill list" in get.output
 
 
 def test_edit_restores_invalid_changes(fleet_dir, monkeypatch) -> None:

--- a/tests/cli/clawctl/agent/test_skill.py
+++ b/tests/cli/clawctl/agent/test_skill.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pathlib
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -46,6 +47,31 @@ def test_add_rejects_duplicate_local_name(fleet_dir) -> None:
     )
     assert second.exit_code != 0
     assert "already exists" in second.output or "already in desired state" in second.output
+
+
+def test_add_persist_mkdir_race(fleet_dir, tmp_path: Path, monkeypatch) -> None:
+    """except FileExistsError branch in _persist_local_skill (TOCTOU race).
+
+    The pre-check (target_dir.exists()) passes because the directory doesn't
+    exist yet, but mkdir raises FileExistsError simulating a concurrent writer.
+    The handler must still surface InvalidSkillRef as a CLI error.
+    """
+    source = tmp_path / "SKILL.md"
+    source.write_text(
+        "---\nname: race-local\ndescription: Race test\n---\n\n# Body\n"
+    )
+
+    _original_mkdir = pathlib.Path.mkdir
+
+    def _mkdir_race(self, *args, **kwargs):
+        if not kwargs.get("exist_ok", False):
+            raise FileExistsError(f"[Errno 17] File exists: '{self}'")
+        return _original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "mkdir", _mkdir_race)
+    result = runner.invoke(app, ["agent", "skill", "add", "wise-hypatia", str(source)])
+    assert result.exit_code != 0
+    assert "already exists" in result.output
 
 
 def test_add_path_uses_native_skill_format(fleet_dir, tmp_path: Path) -> None:

--- a/tests/cli/clawctl/skill/test_add.py
+++ b/tests/cli/clawctl/skill/test_add.py
@@ -1,0 +1,38 @@
+"""Tests for `clawctl skill add` user overlay writes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+from clawrium.core.skills import _overlay_root
+
+runner = CliRunner()
+
+
+def test_skill_add_writes_native_overlay_and_registry_get_sees_it(
+    fleet_dir, tmp_path: Path
+) -> None:
+    source = tmp_path / "SKILL.md"
+    source.write_text("---\nname: local-hermes\ndescription: Local Hermes skill\n---\n\n# Body\n")
+
+    result = runner.invoke(app, ["skill", "add", str(source), "--registry", "hermes"])
+    assert result.exit_code == 0, result.output
+    assert (_overlay_root() / "hermes" / "local-hermes" / "SKILL.md").is_file()
+
+    listing = runner.invoke(app, ["skill", "registry", "get", "-o", "name"])
+    assert listing.exit_code == 0, listing.output
+    assert "skill/hermes/local-hermes" in listing.output
+
+
+def test_skill_add_rejects_overlay_collision(fleet_dir, tmp_path: Path) -> None:
+    source = tmp_path / "SKILL.md"
+    source.write_text("---\nname: local-hermes\ndescription: Local Hermes skill\n---\n\n# Body\n")
+    first = runner.invoke(app, ["skill", "add", str(source), "--registry", "hermes"])
+    assert first.exit_code == 0, first.output
+
+    second = runner.invoke(app, ["skill", "add", str(source), "--registry", "hermes"])
+    assert second.exit_code != 0
+    assert "already exists" in second.output

--- a/tests/cli/clawctl/skill/test_add.py
+++ b/tests/cli/clawctl/skill/test_add.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pathlib
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -36,3 +37,26 @@ def test_skill_add_rejects_overlay_collision(fleet_dir, tmp_path: Path) -> None:
     second = runner.invoke(app, ["skill", "add", str(source), "--registry", "hermes"])
     assert second.exit_code != 0
     assert "already exists" in second.output
+
+
+def test_skill_add_overlay_mkdir_race(fleet_dir, tmp_path: Path, monkeypatch) -> None:
+    """except FileExistsError branch in _write_overlay_skill (TOCTOU race).
+
+    The pre-check (target_dir.exists()) passes because the directory doesn't
+    exist yet, but mkdir raises FileExistsError simulating a concurrent writer.
+    The handler must still surface InvalidSkillRef as a CLI error.
+    """
+    source = tmp_path / "SKILL.md"
+    source.write_text("---\nname: race-skill\ndescription: Race test\n---\n\n# Body\n")
+
+    _original_mkdir = pathlib.Path.mkdir
+
+    def _mkdir_race(self, *args, **kwargs):
+        if not kwargs.get("exist_ok", False):
+            raise FileExistsError(f"[Errno 17] File exists: '{self}'")
+        return _original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "mkdir", _mkdir_race)
+    result = runner.invoke(app, ["skill", "add", str(source), "--registry", "hermes"])
+    assert result.exit_code != 0
+    assert "already exists" in result.output

--- a/tests/test_cli_agent_skill.py
+++ b/tests/test_cli_agent_skill.py
@@ -88,10 +88,10 @@ def test_list_empty_state_shows_hint(monkeypatch):
 
 
 def test_list_renders_table_of_installed_skills():
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    write_state("tdd-hermes", ["tdd"])
     result = runner.invoke(agent_skill_app, ["list", "tdd-hermes"])
     assert result.exit_code == 0, result.output
-    assert "clawrium/tdd" in result.output
+    assert "tdd" in result.output
 
 
 def test_list_rejects_invalid_agent_name():
@@ -110,12 +110,12 @@ def test_install_happy_path_adds_to_state_and_applies(monkeypatch):
     result = runner.invoke(agent_skill_app, ["install", "tdd-hermes", "clawrium/tdd"])
     assert result.exit_code == 0, result.output
     assert calls == ["tdd-hermes"]
-    assert read_state("tdd-hermes") == ["clawrium/tdd"]
+    assert read_state("tdd-hermes") == ["tdd"]
     assert "Installed" in result.output
 
 
 def test_install_already_present_still_reconciles(monkeypatch):
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    write_state("tdd-hermes", ["tdd"])
     calls = _stub_apply(monkeypatch)
     result = runner.invoke(agent_skill_app, ["install", "tdd-hermes", "clawrium/tdd"])
     assert result.exit_code == 0, result.output
@@ -323,7 +323,7 @@ def test_install_renders_schema_validation_error(monkeypatch):
 
 
 def test_remove_happy_path(monkeypatch):
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    write_state("tdd-hermes", ["tdd"])
     calls = _stub_apply(monkeypatch, applied=[])
     result = runner.invoke(agent_skill_app, ["remove", "tdd-hermes", "clawrium/tdd"])
     assert result.exit_code == 0, result.output
@@ -356,7 +356,7 @@ def test_state_file_canonicalized_after_install_remove_cycle(monkeypatch):
     runner.invoke(agent_skill_app, ["install", "tdd-hermes", "clawrium/tdd"])
 
     raw = json.loads(state_file_path("tdd-hermes").read_text())
-    assert raw == {"skills": ["clawrium/tdd"]}
+    assert raw == {"skills": ["tdd"]}
 
     runner.invoke(agent_skill_app, ["remove", "tdd-hermes", "clawrium/tdd"])
     raw = json.loads(state_file_path("tdd-hermes").read_text())
@@ -379,7 +379,6 @@ def test_install_rolls_back_state_on_apply_failure(monkeypatch):
     `assert read_state == []` would pass without exercising rollback).
     """
     _stub_agent_resolution(monkeypatch)
-    monkeypatch.setattr(cli_agent_skill, "load_skill", lambda ref: object())
     monkeypatch.setattr(cli_agent_skill, "validate_skill", lambda _skill: None)
     monkeypatch.setattr(
         cli_agent_skill,
@@ -411,7 +410,6 @@ def test_install_rollback_path_actually_runs(monkeypatch):
     skipped `add_skill` on failure would also pass the read-only
     assertion above."""
     _stub_agent_resolution(monkeypatch)
-    monkeypatch.setattr(cli_agent_skill, "load_skill", lambda ref: object())
     monkeypatch.setattr(cli_agent_skill, "validate_skill", lambda _skill: None)
     monkeypatch.setattr(
         cli_agent_skill,
@@ -451,7 +449,7 @@ def test_remove_rolls_back_state_on_apply_failure(monkeypatch):
     """Symmetric: if `apply_state` raises after `remove_skill` drops
     the entry, restore the prior state so the user sees the file
     matches the host."""
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    write_state("tdd-hermes", ["tdd"])
     _stub_agent_resolution(monkeypatch)
     monkeypatch.setattr(
         cli_agent_skill,
@@ -463,18 +461,18 @@ def test_remove_rolls_back_state_on_apply_failure(monkeypatch):
     result = runner.invoke(agent_skill_app, ["remove", "tdd-hermes", "clawrium/tdd"])
     assert result.exit_code == 1
     # Rollback contract: the entry is still there.
-    assert read_state("tdd-hermes") == ["clawrium/tdd"]
+    assert read_state("tdd-hermes") == ["tdd"]
 
 
 def test_install_preflight_failure_does_not_mutate_state(monkeypatch):
     """Bare-name validation lives upstream of `add_skill`; the state
     file must remain at its prior content."""
     _stub_apply(monkeypatch)
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    write_state("tdd-hermes", ["tdd"])
     result = runner.invoke(agent_skill_app, ["install", "tdd-hermes", "bare"])
     assert result.exit_code == 1
     # State unchanged.
-    assert read_state("tdd-hermes") == ["clawrium/tdd"]
+    assert read_state("tdd-hermes") == ["tdd"]
 
 
 def test_install_rollback_failure_surfaces_warning_to_user(monkeypatch):
@@ -484,7 +482,6 @@ def test_install_rollback_failure_surfaces_warning_to_user(monkeypatch):
     verify with `clm agent skill list`. Silent rollback failure
     would leave the state file lying about the host."""
     _stub_agent_resolution(monkeypatch)
-    monkeypatch.setattr(cli_agent_skill, "load_skill", lambda ref: object())
     monkeypatch.setattr(cli_agent_skill, "validate_skill", lambda _skill: None)
     monkeypatch.setattr(
         cli_agent_skill,
@@ -523,7 +520,7 @@ def test_remove_rollback_failure_surfaces_warning_to_user(monkeypatch):
     """Symmetric coverage for the remove path: a `write_state` failure
     during rollback after a failed `apply_state` must surface a yellow
     Warning + verification hint to stderr, not silently log."""
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    write_state("tdd-hermes", ["tdd"])
     _stub_agent_resolution(monkeypatch)
     monkeypatch.setattr(
         cli_agent_skill,

--- a/tests/test_core_skills.py
+++ b/tests/test_core_skills.py
@@ -206,7 +206,7 @@ def test_catalog_roots_raises_when_neither_root_exists(monkeypatch):
         skills._catalog_roots()
 
 
-def test_public_list_skills_ignores_overlay_until_wired(monkeypatch, tmp_path):
+def test_public_list_skills_includes_overlay(monkeypatch, tmp_path):
     bundled = tmp_path / "bundled"
     overlay = skills._overlay_root()
     bundled.mkdir()
@@ -217,10 +217,10 @@ def test_public_list_skills_ignores_overlay_until_wired(monkeypatch, tmp_path):
 
     refs = list_skills(registry="hermes")
     assert SkillRef("hermes", "bundled-skill") in refs
-    assert SkillRef("hermes", "overlay-only") not in refs
+    assert SkillRef("hermes", "overlay-only") in refs
 
 
-def test_public_load_skill_ignores_overlay_until_wired(monkeypatch, tmp_path):
+def test_public_load_skill_uses_overlay(monkeypatch, tmp_path):
     bundled = tmp_path / "bundled"
     overlay = skills._overlay_root()
     bundled.mkdir()
@@ -232,8 +232,7 @@ def test_public_load_skill_ignores_overlay_until_wired(monkeypatch, tmp_path):
     assert load_skill("hermes/bundled-skill").ref == SkillRef(
         "hermes", "bundled-skill"
     )
-    with pytest.raises(SkillNotFound):
-        load_skill("hermes/overlay-only")
+    assert load_skill("hermes/overlay-only").path == overlay / "hermes" / "overlay-only"
 
 
 def test_list_skills_includes_overlay_only(monkeypatch, tmp_path):

--- a/tests/test_core_skills.py
+++ b/tests/test_core_skills.py
@@ -27,6 +27,7 @@ from clawrium.core.skills import (
     NATIVE_REGISTRIES,
     REGISTRIES,
     SchemaValidationError,
+    Skill,
     SkillNotFound,
     SkillRef,
     list_agent_skills,
@@ -35,6 +36,7 @@ from clawrium.core.skills import (
     load_skill,
     materialize_skill_for_agent,
     parse_skill_ref,
+    render_skill_md,
     validate_skill,
 )
 from clawrium.core.skills_state import agent_skills_dir
@@ -504,6 +506,38 @@ def test_materialize_skill_for_agent_rejects_explicit_false_compatibility(
     skill = load_skill("clawrium/tdd")
     with pytest.raises(IncompatibleSkillRegistry, match="not compatible"):
         materialize_skill_for_agent(skill, agent_type)
+
+
+def test_render_skill_md_round_trips_frontmatter_and_body():
+    skill = Skill(
+        ref=SkillRef("hermes", "custom"),
+        path=Path("__materialized__"),
+        metadata={"name": "custom", "description": "Tést skill"},
+        body="\n# Custom\n\nBody\n",
+        skill_md_frontmatter={"name": "custom", "description": "Tést skill"},
+    )
+
+    rendered = render_skill_md(skill)
+    body, frontmatter = skills._split_frontmatter(rendered)
+
+    assert rendered.endswith("\n")
+    assert "Tést skill" in rendered
+    assert frontmatter == {"name": "custom", "description": "Tést skill"}
+    assert body == "\n# Custom\n\nBody\n"
+
+
+def test_render_skill_md_handles_empty_body():
+    skill = Skill(
+        ref=SkillRef("hermes", "empty"),
+        path=Path("__materialized__"),
+        metadata={"name": "empty", "description": "Empty"},
+        body="",
+        skill_md_frontmatter={"name": "empty", "description": "Empty"},
+    )
+
+    rendered = render_skill_md(skill)
+
+    assert rendered == "---\nname: empty\ndescription: Empty\n---\n"
 
 
 def test_validate_skill_enforces_slug_invariant(monkeypatch, tmp_path):

--- a/tests/test_core_skills_apply.py
+++ b/tests/test_core_skills_apply.py
@@ -22,6 +22,7 @@ from clawrium.core.skills import (
     IncompatibleSkillRegistry,
     InvalidSkillRef,
     NATIVE_REGISTRIES,
+    SkillNotFound,
     materialize_for_claw,
 )
 from clawrium.core.skills_apply import (
@@ -173,6 +174,16 @@ def test_apply_state_agent_not_found(monkeypatch):
     monkeypatch.setattr(skills_apply, "get_agent_by_name", lambda _name: None)
     with pytest.raises(AgentNotFoundError, match="not found"):
         apply_state("tdd-hermes")
+
+
+def test_apply_state_missing_local_skill_aborts_before_runner(monkeypatch):
+    write_state("tdd-hermes", ["tdd"])
+    runner = _patch_runtime(monkeypatch)
+
+    with pytest.raises(SkillNotFound, match="Local skill 'tdd'"):
+        apply_state("tdd-hermes")
+
+    runner.run.assert_not_called()
 
 
 def test_apply_state_ambiguous_agent_name(monkeypatch):

--- a/tests/test_core_skills_apply.py
+++ b/tests/test_core_skills_apply.py
@@ -550,7 +550,7 @@ def test_stage_skills_cleans_tempdir_on_partial_failure(monkeypatch, tmp_path):
 
     monkeypatch.setattr(Path, "read_bytes", boom)
 
-    with pytest.raises(OSError, match="disk-full"):
+    with pytest.raises(SkillApplyError, match="disk-full"):
         apply_state("tdd-hermes")
 
     staging_base = tmp_path / "clawrium" / "staging" / "skills"

--- a/tests/test_core_skills_apply.py
+++ b/tests/test_core_skills_apply.py
@@ -16,24 +16,21 @@ from unittest.mock import MagicMock
 import json
 
 import pytest
-import yaml
 
 from clawrium.core import skills_apply
 from clawrium.core.skills import (
-    ExternalSourceBlocked,
     IncompatibleSkillRegistry,
     InvalidSkillRef,
-    MissingRegistryPrefix,
     NATIVE_REGISTRIES,
+    materialize_for_claw,
 )
 from clawrium.core.skills_apply import (
     AgentNotFoundError,
     SkillApplyError,
     SkillApplyNotSupported,
     apply_state,
-    materialize_for_claw,
 )
-from clawrium.core.skills_state import state_file_path, write_state
+from clawrium.core.skills_state import agent_skills_dir, state_file_path, write_state
 
 
 @pytest.fixture(autouse=True)
@@ -88,6 +85,24 @@ def _patch_runtime(
     return runner_mock
 
 
+def _write_local_skill_state(
+    agent_name: str,
+    *,
+    skill_name: str = "tdd",
+    text: str | None = None,
+) -> str:
+    """Seed bare desired state plus an already-native local SKILL.md."""
+    text = text or (
+        f"---\nname: {skill_name}\ndescription: local native skill\n---\n\n"
+        f"# {skill_name}\nLocal skill body\n"
+    )
+    skill_dir = agent_skills_dir(agent_name) / skill_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(text)
+    write_state(agent_name, [skill_name])
+    return text
+
+
 # ---------------------------- happy-path apply ------------------------------
 
 
@@ -104,13 +119,13 @@ def test_apply_state_hermes_empty_state_runs_playbook(monkeypatch):
     assert extravars["desired_skill_names"] == []
 
 
-def test_apply_state_hermes_stages_and_applies_clawrium_tdd(monkeypatch, tmp_path):
-    write_state("tdd-hermes", ["clawrium/tdd"])
+def test_apply_state_hermes_stages_and_applies_local_tdd(monkeypatch, tmp_path):
+    _write_local_skill_state("tdd-hermes")
     runner = _patch_runtime(monkeypatch)
 
     result = apply_state("tdd-hermes")
 
-    assert result.applied_skills == ["clawrium/tdd"]
+    assert result.applied_skills == ["tdd"]
     _, kwargs = runner.run.call_args
     extravars = kwargs["inventory"]["all"]["vars"]
     assert extravars["desired_skill_names"] == ["tdd"]
@@ -120,10 +135,15 @@ def test_apply_state_hermes_stages_and_applies_clawrium_tdd(monkeypatch, tmp_pat
     assert not staging_dir.exists()
 
 
-def test_apply_state_stages_materialized_skill_md(monkeypatch, tmp_path):
-    """Capture the staging dir mid-run and assert SKILL.md was written
-    with the merged hermes-native frontmatter."""
-    write_state("tdd-hermes", ["clawrium/tdd"])
+def test_apply_state_stages_local_skill_md_bytes_unchanged(monkeypatch, tmp_path):
+    """Sync copies the already-native local SKILL.md without rendering."""
+    original = _write_local_skill_state(
+        "tdd-hermes",
+        text=(
+            "---\ndescription: custom first\nname: tdd\nmetadata:\n"
+            "  hermes:\n    tags:\n      - custom\n---\n\n# Local TDD\n"
+        ),
+    )
 
     captured = {}
 
@@ -138,22 +158,7 @@ def test_apply_state_stages_materialized_skill_md(monkeypatch, tmp_path):
 
     apply_state("tdd-hermes")
 
-    text = captured["text"]
-    assert text.startswith("---\n")
-    frontmatter_block, body = text.split("\n---\n", 1)
-    frontmatter = yaml.safe_load(frontmatter_block[len("---\n") :])
-    # The clawrium/* → hermes materializer must keep name/description
-    # and lift the native.hermes.metadata.hermes.tags override into
-    # the rendered frontmatter.
-    assert frontmatter["name"] == "tdd"
-    assert "description" in frontmatter
-    assert frontmatter.get("metadata", {}).get("hermes", {}).get("tags") == [
-        "tdd",
-        "testing",
-        "discipline",
-        "clawrium",
-    ]
-    assert body.strip().startswith("# TDD")
+    assert captured["text"] == original
 
 
 # ---------------------------- error paths -----------------------------------
@@ -186,7 +191,7 @@ def test_apply_state_unknown_agent_type(monkeypatch):
 
 
 def test_apply_state_missing_ssh_key(monkeypatch):
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    _write_local_skill_state("tdd-hermes")
     _patch_runtime(monkeypatch, ssh_key=None)
     with pytest.raises(SkillApplyError, match="SSH key"):
         apply_state("tdd-hermes")
@@ -525,20 +530,14 @@ def test_apply_state_log_dir_strips_bidi_in_host_alias(monkeypatch, tmp_path):
 
 
 def test_stage_skills_cleans_tempdir_on_partial_failure(monkeypatch, tmp_path):
-    """If `_stage_skills` raises mid-loop (e.g. `write_text` fails on
-    a disk-full simulator), the `mkdtemp` directory it just created
-    must be removed before the exception propagates. Without this,
-    `${clawrium_config}/staging/skills/` accumulates an orphan
-    tempdir on every failure.
-    """
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    """If `_stage_skills` raises mid-loop, its tempdir is removed."""
+    _write_local_skill_state("tdd-hermes")
     _patch_runtime(monkeypatch)
 
-    def boom(_frontmatter, _body):
-        # First skill raises; tempdir has already been created.
+    def boom(_self):
         raise OSError("simulated disk-full during render")
 
-    monkeypatch.setattr(skills_apply, "_render_skill_md", boom)
+    monkeypatch.setattr(Path, "read_bytes", boom)
 
     with pytest.raises(OSError, match="disk-full"):
         apply_state("tdd-hermes")
@@ -557,7 +556,7 @@ def test_apply_state_staging_cleaned_when_log_dir_creation_fails(monkeypatch, tm
     ordering, control-machine `${clawrium_config}/staging/skills/`
     would accumulate orphan tempdirs on partial failures.
     """
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    _write_local_skill_state("tdd-hermes")
     _patch_runtime(monkeypatch)
     monkeypatch.setattr(
         skills_apply,
@@ -579,7 +578,7 @@ def test_apply_state_drift_recovery_reapplies_same_state(monkeypatch):
     again. The playbook is responsible for restoring the file on the
     host if it was manually deleted — apply_state's job is just to
     invoke it idempotently."""
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    _write_local_skill_state("tdd-hermes")
     runner = _patch_runtime(monkeypatch)
 
     apply_state("tdd-hermes")
@@ -611,12 +610,12 @@ def test_apply_state_openclaw_empty_state_runs_playbook(monkeypatch):
 
 
 def test_apply_state_openclaw_stages_and_applies_clawrium_tdd(monkeypatch):
-    write_state("tdd-openclaw", ["clawrium/tdd"])
+    _write_local_skill_state("tdd-openclaw")
     runner = _patch_runtime(monkeypatch, agent_type="openclaw")
 
     result = apply_state("tdd-openclaw")
 
-    assert result.applied_skills == ["clawrium/tdd"]
+    assert result.applied_skills == ["tdd"]
     _, kwargs = runner.run.call_args
     extravars = kwargs["inventory"]["all"]["vars"]
     assert extravars["agent_type"] == "openclaw"
@@ -627,15 +626,14 @@ def test_apply_state_openclaw_stages_and_applies_clawrium_tdd(monkeypatch):
     assert not staging_dir.exists()
 
 
-def test_apply_state_openclaw_materialized_skill_md_has_no_hermes_overrides(
+def test_apply_state_openclaw_stages_local_skill_md_bytes_unchanged(
     monkeypatch,
 ):
-    """When materializing for openclaw, the per-claw override block under
-    `native.hermes` in `_meta.yaml` must NOT bleed into the openclaw
-    frontmatter — only `native.openclaw` (which is `{}` for clawrium/tdd)
-    is lifted. This guards against the materializer applying the wrong
-    claw's overrides."""
-    write_state("tdd-openclaw", ["clawrium/tdd"])
+    """OpenClaw sync stages the local native file byte-for-byte."""
+    original = _write_local_skill_state(
+        "tdd-openclaw",
+        text="---\nname: tdd\ndescription: openclaw custom\n---\n\nbody\n",
+    )
 
     captured = {}
 
@@ -650,14 +648,7 @@ def test_apply_state_openclaw_materialized_skill_md_has_no_hermes_overrides(
 
     apply_state("tdd-openclaw")
 
-    text = captured["text"]
-    frontmatter_block, _ = text.split("\n---\n", 1)
-    frontmatter = yaml.safe_load(frontmatter_block[len("---\n") :])
-    assert frontmatter["name"] == "tdd"
-    # Hermes-specific tags must not be present in the openclaw rendering.
-    assert "metadata" not in frontmatter or "hermes" not in (
-        frontmatter.get("metadata") or {}
-    )
+    assert captured["text"] == original
 
 
 # ---------------------------- zeroclaw dispatch (Phase 3) -------------------
@@ -678,12 +669,12 @@ def test_apply_state_zeroclaw_empty_state_runs_playbook(monkeypatch):
 
 
 def test_apply_state_zeroclaw_stages_and_applies_clawrium_tdd(monkeypatch):
-    write_state("tdd-zeroclaw", ["clawrium/tdd"])
+    _write_local_skill_state("tdd-zeroclaw")
     runner = _patch_runtime(monkeypatch, agent_type="zeroclaw")
 
     result = apply_state("tdd-zeroclaw")
 
-    assert result.applied_skills == ["clawrium/tdd"]
+    assert result.applied_skills == ["tdd"]
     _, kwargs = runner.run.call_args
     extravars = kwargs["inventory"]["all"]["vars"]
     # Source-dirname == slug per Phase 0 contract — the playbook will
@@ -709,7 +700,7 @@ def test_apply_state_drift_recovery_zeroclaw(monkeypatch):
     """Same drift-recovery contract as hermes: re-running install on a
     state that's already set must re-invoke the playbook so the
     playbook's idempotent install-if-missing branch runs."""
-    write_state("tdd-zeroclaw", ["clawrium/tdd"])
+    _write_local_skill_state("tdd-zeroclaw")
     runner = _patch_runtime(monkeypatch, agent_type="zeroclaw")
 
     apply_state("tdd-zeroclaw")
@@ -725,7 +716,7 @@ def test_apply_state_drift_recovery_openclaw(monkeypatch):
     not just hermes/zeroclaw. The playbook is responsible for restoring
     SKILL.md if it was manually deleted on host; apply_state's job is
     just to invoke it idempotently on every install/remove call."""
-    write_state("tdd-openclaw", ["clawrium/tdd"])
+    _write_local_skill_state("tdd-openclaw")
     runner = _patch_runtime(monkeypatch, agent_type="openclaw")
 
     apply_state("tdd-openclaw")
@@ -759,7 +750,7 @@ def _write_raw_state(agent_name: str, skills: list[str]) -> None:
         # Path traversal in name component
         ("clawrium/..", InvalidSkillRef),
         # Path traversal across separator
-        ("../etc/passwd", (InvalidSkillRef, MissingRegistryPrefix)),
+        ("../etc/passwd", InvalidSkillRef),
         # Path-segment-in-name
         ("clawrium/sub/dir", InvalidSkillRef),
         # Shell metacharacters in name
@@ -769,7 +760,7 @@ def _write_raw_state(agent_name: str, skills: list[str]) -> None:
         ("clawrium/tdd`id`", InvalidSkillRef),
         ("clawrium/tdd$(id)", InvalidSkillRef),
         # Backslash / Windows-style path
-        ("clawrium\\tdd", (InvalidSkillRef, MissingRegistryPrefix)),
+        ("clawrium\\tdd", InvalidSkillRef),
         # Null byte
         ("clawrium/tdd\x00", InvalidSkillRef),
         # Bidi-formatting codepoints — the slug regex bans these but
@@ -782,9 +773,9 @@ def _write_raw_state(agent_name: str, skills: list[str]) -> None:
         ("clawrium/tdd⁦inject", InvalidSkillRef),  # LRI
         ("clawrium/tdd⁩trailer", InvalidSkillRef),  # PDI (W-new5)
         # External-source URL forms
-        ("https://evil.example/skill", ExternalSourceBlocked),
-        ("file:///etc/passwd", ExternalSourceBlocked),
-        ("git+ssh://attacker.example/repo.git", ExternalSourceBlocked),
+        ("https://evil.example/skill", InvalidSkillRef),
+        ("file:///etc/passwd", InvalidSkillRef),
+        ("git+ssh://attacker.example/repo.git", InvalidSkillRef),
     ],
 )
 def test_apply_state_rejects_malicious_slugs_before_dispatch(
@@ -807,7 +798,7 @@ def test_apply_state_rejects_malicious_slug_on_openclaw_before_dispatch(monkeypa
     through the openclaw dispatch path so a future refactor that
     short-circuits openclaw's compatibility check can't quietly skip
     the slug rejection step."""
-    _write_raw_state("tdd-openclaw", ["clawrium/../etc/passwd"])
+    _write_raw_state("tdd-openclaw", ["../etc-passwd"])
     runner = _patch_runtime(monkeypatch, agent_type="openclaw")
     with pytest.raises(InvalidSkillRef):
         apply_state("tdd-openclaw")
@@ -820,7 +811,7 @@ def test_apply_state_rejects_malicious_slug_on_zeroclaw_before_dispatch(monkeypa
     `zeroclaw skills install <path>` and `zeroclaw skills remove <slug>`
     on the host — any escape from the slug regex is reachable as a
     command argument."""
-    _write_raw_state("tdd-zeroclaw", ["clawrium/tdd; rm -rf /"])
+    _write_raw_state("tdd-zeroclaw", ["tdd; rm -rf"])
     runner = _patch_runtime(monkeypatch, agent_type="zeroclaw")
     with pytest.raises(InvalidSkillRef):
         apply_state("tdd-zeroclaw")
@@ -946,15 +937,19 @@ def test_make_log_dir_error_does_not_leak_computed_path(monkeypatch, tmp_path):
 
 
 def test_stage_skills_internal_failure_cleans_tempdir(monkeypatch):
-    """W-new6: `_stage_skills` materializes the staging dir via
-    `tempfile.mkdtemp` BEFORE populating it. If `materialize_for_claw`
-    or any subsequent file operation raises mid-loop, the staging dir
-    would leak — `apply_state`'s None-sentinel guard doesn't help
-    because `_stage_skills` hasn't returned yet, so `staging_dir`
-    is still None.
+    """W-new6: `_stage_skills` creates the staging dir before populating it.
+
+    If copying a local SKILL.md raises mid-loop, the staging dir would leak —
+    `apply_state`'s None-sentinel guard doesn't help because `_stage_skills`
+    hasn't returned yet, so `staging_dir` is still None.
 
     The fix wraps the populate loop in try/except so the dir is rmtree'd
     before the exception propagates."""
+    _write_local_skill_state("tdd-hermes")
+    from clawrium.core.skills import load_agent_skill
+
+    skill = load_agent_skill("tdd-hermes", "tdd", "hermes")
+
     captured: list[Path] = []
     original_mkdtemp = skills_apply.tempfile.mkdtemp
 
@@ -965,21 +960,18 @@ def test_stage_skills_internal_failure_cleans_tempdir(monkeypatch):
 
     monkeypatch.setattr(skills_apply.tempfile, "mkdtemp", capture_mkdtemp)
 
-    def boom(_skill, _claw):
-        raise RuntimeError("forced materialize failure")
+    def boom(_self):
+        raise RuntimeError("forced copy failure")
 
-    monkeypatch.setattr(skills_apply, "materialize_for_claw", boom)
+    monkeypatch.setattr(Path, "read_bytes", boom)
 
-    from clawrium.core.skills import load_skill, parse_skill_ref
-
-    skill = load_skill(parse_skill_ref("clawrium/tdd"))
-    with pytest.raises(RuntimeError, match="forced materialize failure"):
+    with pytest.raises(RuntimeError, match="forced copy failure"):
         skills_apply._stage_skills("tdd-hermes", "hermes", [skill])
 
     assert captured, "mkdtemp was never called"
     staging = captured[0]
     assert not staging.exists(), (
-        f"staging tempdir leaked at {staging} when materialize raised — "
+        f"staging tempdir leaked at {staging} when copy raised — "
         "_stage_skills cleanup-on-raise regression"
     )
 
@@ -992,7 +984,7 @@ def test_make_log_dir_failure_cleans_up_staging_dir(monkeypatch, tmp_path):
     Without the None-sentinel guard, the staging dir is materialized
     but never reaches the `try:` block so `finally:` doesn't run.
     """
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    _write_local_skill_state("tdd-hermes")
     runner = _patch_runtime(monkeypatch)
 
     captured: dict[str, Path] = {}

--- a/tests/test_core_skills_state.py
+++ b/tests/test_core_skills_state.py
@@ -1,9 +1,9 @@
 """Tests for the per-agent skills desired-state store.
 
-Covers Phase 2 exit criteria for `core/skills_state.py`:
+Covers the per-agent local skill desired-state store:
 - state file path is XDG-respecting and namespaced by agent name
-- read/write round-trips through `parse_skill_ref` (rejects URLs,
-  bare names, malformed JSON)
+- read/write round-trips bare local skill names and rejects registry refs,
+  URLs, paths, uppercase names, and malformed JSON
 - add/remove are idempotent and report whether the call changed state
 - atomic writes (no `.tmp` left behind on success; concurrent reader
   never sees an empty file)
@@ -16,11 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from clawrium.core.skills import (
-    ExternalSourceBlocked,
-    InvalidSkillRef,
-    MissingRegistryPrefix,
-)
+from clawrium.core.skills import InvalidSkillRef
 from clawrium.core import skills_state
 from clawrium.core.skills_state import (
     add_skill,
@@ -81,13 +77,13 @@ def test_read_state_missing_file_returns_empty():
 
 
 def test_read_state_round_trips_after_write():
-    write_state("hermes-tdd", ["clawrium/tdd"])
-    assert read_state("hermes-tdd") == ["clawrium/tdd"]
+    write_state("hermes-tdd", ["tdd"])
+    assert read_state("hermes-tdd") == ["tdd"]
 
 
 def test_read_state_returns_sorted_deduped():
-    write_state("hermes-tdd", ["clawrium/tdd", "clawrium/tdd"])
-    assert read_state("hermes-tdd") == ["clawrium/tdd"]
+    write_state("hermes-tdd", ["zebra", "tdd", "tdd"])
+    assert read_state("hermes-tdd") == ["tdd", "zebra"]
 
 
 def test_read_state_malformed_json_raises():
@@ -101,7 +97,7 @@ def test_read_state_malformed_json_raises():
 def test_read_state_non_object_root_raises():
     path = state_file_path("hermes-tdd")
     path.parent.mkdir(parents=True)
-    path.write_text(json.dumps(["clawrium/tdd"]))
+    path.write_text(json.dumps(["tdd"]))
     with pytest.raises(InvalidSkillRef, match="must be a JSON object"):
         read_state("hermes-tdd")
 
@@ -109,7 +105,7 @@ def test_read_state_non_object_root_raises():
 def test_read_state_skills_field_must_be_list_of_strings():
     path = state_file_path("hermes-tdd")
     path.parent.mkdir(parents=True)
-    path.write_text(json.dumps({"skills": [{"ref": "clawrium/tdd"}]}))
+    path.write_text(json.dumps({"skills": [{"ref": "tdd"}]}))
     with pytest.raises(InvalidSkillRef, match="list of strings"):
         read_state("hermes-tdd")
 
@@ -120,7 +116,15 @@ def test_read_state_revalidates_persisted_entries():
     path = state_file_path("hermes-tdd")
     path.parent.mkdir(parents=True)
     path.write_text(json.dumps({"skills": ["http://evil.example/skill"]}))
-    with pytest.raises(ExternalSourceBlocked):
+    with pytest.raises(InvalidSkillRef, match="Invalid skill name"):
+        read_state("hermes-tdd")
+
+
+def test_read_state_rejects_legacy_registry_ref_with_remediation():
+    path = state_file_path("hermes-tdd")
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"skills": ["clawrium/tdd"]}))
+    with pytest.raises(InvalidSkillRef, match="--from-template"):
         read_state("hermes-tdd")
 
 
@@ -128,30 +132,40 @@ def test_read_state_revalidates_persisted_entries():
 
 
 def test_write_state_creates_parent_dir(tmp_path: Path):
-    write_state("hermes-tdd", ["clawrium/tdd"])
+    write_state("hermes-tdd", ["tdd"])
     parent = tmp_path / "clawrium" / "agents" / "hermes-tdd"
     assert parent.is_dir()
 
 
 def test_write_state_persists_canonical_form():
-    canonical = write_state("hermes-tdd", ["clawrium/tdd", "clawrium/tdd"])
+    canonical = write_state("hermes-tdd", ["zebra", "tdd", "tdd"])
     raw = json.loads(state_file_path("hermes-tdd").read_text())
-    assert canonical == ["clawrium/tdd"]
-    assert raw == {"skills": ["clawrium/tdd"]}
+    assert canonical == ["tdd", "zebra"]
+    assert raw == {"skills": ["tdd", "zebra"]}
 
 
-def test_write_state_rejects_bare_name_in_payload():
-    with pytest.raises(MissingRegistryPrefix):
-        write_state("hermes-tdd", ["tdd"])
+def test_write_state_accepts_bare_name_in_payload():
+    assert write_state("hermes-tdd", ["tdd"]) == ["tdd"]
+
+
+def test_write_state_rejects_registry_ref_in_payload():
+    with pytest.raises(InvalidSkillRef, match="--from-template"):
+        write_state("hermes-tdd", ["clawrium/tdd"])
 
 
 def test_write_state_rejects_url_in_payload():
-    with pytest.raises(ExternalSourceBlocked):
+    with pytest.raises(InvalidSkillRef):
         write_state("hermes-tdd", ["https://example.com/skill.tgz"])
 
 
+@pytest.mark.parametrize("bad", ["", "UPPER", "bad name", "../escape", "tdd/extra"])
+def test_write_state_rejects_invalid_local_names(bad: str):
+    with pytest.raises(InvalidSkillRef):
+        write_state("hermes-tdd", [bad])
+
+
 def test_write_state_leaves_no_tmp_files_on_success(tmp_path: Path):
-    write_state("hermes-tdd", ["clawrium/tdd"])
+    write_state("hermes-tdd", ["tdd"])
     parent = tmp_path / "clawrium" / "agents" / "hermes-tdd"
     leftovers = [p for p in parent.iterdir() if p.name.startswith(".skills.")]
     assert leftovers == []
@@ -167,7 +181,7 @@ def test_write_state_atomic_against_failure(monkeypatch, tmp_path: Path):
 
     monkeypatch.setattr(skills_state.os, "replace", boom)
     with pytest.raises(OSError):
-        write_state("hermes-tdd", ["clawrium/tdd"])
+        write_state("hermes-tdd", ["tdd"])
     monkeypatch.setattr(skills_state.os, "replace", real_replace)
 
     parent = tmp_path / "clawrium" / "agents" / "hermes-tdd"
@@ -180,27 +194,32 @@ def test_write_state_atomic_against_failure(monkeypatch, tmp_path: Path):
 
 
 def test_add_skill_returns_added_flag_on_new_entry():
-    state, added = add_skill("hermes-tdd", "clawrium/tdd")
+    state, added = add_skill("hermes-tdd", "tdd")
     assert added is True
-    assert state == ["clawrium/tdd"]
+    assert state == ["tdd"]
 
 
 def test_add_skill_is_idempotent():
-    add_skill("hermes-tdd", "clawrium/tdd")
-    state, added = add_skill("hermes-tdd", "clawrium/tdd")
+    add_skill("hermes-tdd", "tdd")
+    state, added = add_skill("hermes-tdd", "tdd")
     assert added is False
-    assert state == ["clawrium/tdd"]
+    assert state == ["tdd"]
+
+
+def test_add_skill_rejects_registry_ref():
+    with pytest.raises(InvalidSkillRef, match="--from-template"):
+        add_skill("hermes-tdd", "clawrium/tdd")
 
 
 def test_remove_skill_returns_removed_flag():
-    add_skill("hermes-tdd", "clawrium/tdd")
-    state, removed = remove_skill("hermes-tdd", "clawrium/tdd")
+    add_skill("hermes-tdd", "tdd")
+    state, removed = remove_skill("hermes-tdd", "tdd")
     assert removed is True
     assert state == []
 
 
 def test_remove_skill_no_op_when_absent():
-    state, removed = remove_skill("hermes-tdd", "clawrium/tdd")
+    state, removed = remove_skill("hermes-tdd", "tdd")
     assert removed is False
     assert state == []
 
@@ -215,7 +234,7 @@ class TestCleanupAgentState:
         from clawrium.core.skills_state import cleanup_agent_state
 
         # Pre-seed a state directory
-        write_state("hermes-tdd", ["clawrium/tdd"])
+        write_state("hermes-tdd", ["tdd"])
         agent_dir = tmp_path / "clawrium" / "agents" / "hermes-tdd"
         assert agent_dir.is_dir()
 
@@ -260,7 +279,7 @@ class TestCleanupAgentState:
         from clawrium.core import skills_state
         from clawrium.core.skills_state import cleanup_agent_state
 
-        write_state("hermes-tdd", ["clawrium/tdd"])
+        write_state("hermes-tdd", ["tdd"])
 
         def boom(_path):
             raise OSError("permission denied")
@@ -272,7 +291,7 @@ class TestCleanupAgentState:
     def test_idempotent_on_already_removed_directory(self, tmp_path: Path):
         from clawrium.core.skills_state import cleanup_agent_state
 
-        write_state("hermes-tdd", ["clawrium/tdd"])
+        write_state("hermes-tdd", ["tdd"])
         agent_dir = tmp_path / "clawrium" / "agents" / "hermes-tdd"
 
         assert cleanup_agent_state("hermes-tdd") is True

--- a/tests/test_gui_agent_skills_routes.py
+++ b/tests/test_gui_agent_skills_routes.py
@@ -98,7 +98,8 @@ def _write_local_skill(agent_name: str = "tdd-hermes", name: str = "tdd") -> Non
     skill_dir = agent_skills_dir(agent_name) / name
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(
-        f"---\nname: {name}\ndescription: Test skill\nversion: '1.0'\n---\n\nBody\n",
+        f"---\nname: {name}\ndescription: Test skill\nversion: '1.0'\n"
+        f"x-clawrium-source: clawrium/{name}\n---\n\nBody\n",
         encoding="utf-8",
     )
     write_state(agent_name, [name])
@@ -124,11 +125,11 @@ def test_list_includes_installed_and_available_for_hermes(monkeypatch):
     assert result["agent_type"] == "hermes"
 
     installed_refs = [row["ref"] for row in result["installed"]]
-    assert installed_refs == ["tdd"]
+    assert installed_refs == ["clawrium/tdd"]
     # Installed row carries summary metadata so the UI can render the
     # description without a second round-trip.
     tdd_row = result["installed"][0]
-    assert tdd_row["registry"] == "local"
+    assert tdd_row["registry"] == "clawrium"
     assert tdd_row["name"] == "tdd"
     assert tdd_row["description"]
     assert tdd_row["version"]
@@ -176,25 +177,26 @@ def test_install_writes_state_and_calls_apply(monkeypatch):
     result = _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
 
     assert result["success"] is True
-    assert result["ref"] == "tdd"
+    assert result["ref"] == "clawrium/tdd"
     assert result["changed"] is True
     assert result["installed"] == ["tdd"]
     assert calls == ["tdd-hermes"]
     assert read_state("tdd-hermes") == ["tdd"]
-    assert (agent_skills_dir("tdd-hermes") / "tdd" / "SKILL.md").exists()
+    local_skill = agent_skills_dir("tdd-hermes") / "tdd" / "SKILL.md"
+    assert local_skill.exists()
+    assert "x-clawrium-source: clawrium/tdd" in local_skill.read_text()
 
 
-def test_install_is_idempotent_but_still_applies(monkeypatch):
-    """Re-installing an already-installed skill is the documented drift
-    recovery path — state is unchanged but the playbook still runs."""
+def test_install_rejects_duplicate_local_skill_without_apply(monkeypatch):
     _stub_resolved(monkeypatch)
     _write_local_skill("tdd-hermes", "tdd")
-    calls = _stub_apply(monkeypatch, applied=["tdd"])
 
-    result = _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
+    monkeypatch.setattr(agents_route, "apply_state", _raises_if_called("apply_state"))
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
 
-    assert result["changed"] is False
-    assert calls == ["tdd-hermes"], "apply_state must run on re-install"
+    assert exc.value.status_code == 409
+    assert read_state("tdd-hermes") == ["tdd"]
 
 
 def test_install_404_when_agent_missing(monkeypatch):
@@ -366,6 +368,7 @@ def test_remove_drops_state_and_calls_apply(monkeypatch):
     result = _run(agents_route.remove_agent_skill("tdd-hermes", "clawrium", "tdd"))
 
     assert result["success"] is True
+    assert result["ref"] == "clawrium/tdd"
     assert result["changed"] is True
     assert result["installed"] == []
     assert calls == ["tdd-hermes"]

--- a/tests/test_gui_agent_skills_routes.py
+++ b/tests/test_gui_agent_skills_routes.py
@@ -352,9 +352,25 @@ def test_install_502_on_apply_error(monkeypatch):
     assert "/home/op/.config/clawrium/logs" not in str(exc.value.detail)
     assert "/tmp/nope" not in str(exc.value.detail)
     assert "Check server logs" in str(exc.value.detail)
-    # State should still reflect the user's intent — apply failures
-    # don't roll back desired state; the user will retry.
-    assert read_state("tdd-hermes") == ["tdd"]
+    assert read_state("tdd-hermes") == []
+    assert not (agent_skills_dir("tdd-hermes") / "tdd").exists()
+
+
+def test_install_500_on_local_write_error_rolls_back_state(monkeypatch):
+    _stub_resolved(monkeypatch)
+    monkeypatch.setattr(
+        agents_route,
+        "_write_agent_local_skill",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk full")),
+    )
+    monkeypatch.setattr(agents_route, "apply_state", _raises_if_called("apply_state"))
+
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
+
+    assert exc.value.status_code == 500
+    assert read_state("tdd-hermes") == []
+    assert not (agent_skills_dir("tdd-hermes") / "tdd").exists()
 
 
 # ---------- DELETE /api/agents/{agent}/skills/{registry}/{skill} -------------
@@ -403,18 +419,14 @@ def test_remove_422_on_malformed_ref(monkeypatch):
 # ---------- Documented behavior on apply failure ------------------------------
 
 
-def test_state_is_not_rolled_back_on_apply_failure(monkeypatch):
-    """ATX-1 W3 documents the design choice (carried over from the CLI):
-    on apply failure the desired-state mutation is *kept*, so the user
-    can retry the apply without re-typing the ref. This test pins the
-    behavior so any future change to "validate-before-write" is
-    deliberate, not accidental.
-    """
+def test_install_state_is_rolled_back_on_apply_failure(monkeypatch):
+    """Compatibility POST applies inline, so apply failure restores local state."""
     _stub_resolved(monkeypatch)
     _stub_apply(monkeypatch, raises=SkillApplyError("host unreachable"))
     with pytest.raises(HTTPException):
         _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
-    assert read_state("tdd-hermes") == ["tdd"]
+    assert read_state("tdd-hermes") == []
+    assert not (agent_skills_dir("tdd-hermes") / "tdd").exists()
 
 
 # ---------- _is_compatible_for_agent_type unit tests --------------------------

--- a/tests/test_gui_agent_skills_routes.py
+++ b/tests/test_gui_agent_skills_routes.py
@@ -33,7 +33,7 @@ from clawrium.core.skills_apply import (
     SkillApplyError,
     SkillApplyNotSupported,
 )
-from clawrium.core.skills_state import read_state, write_state
+from clawrium.core.skills_state import agent_skills_dir, read_state, write_state
 from clawrium.gui.routes import agents as agents_route
 
 
@@ -94,6 +94,16 @@ def _stub_apply(
     return calls
 
 
+def _write_local_skill(agent_name: str = "tdd-hermes", name: str = "tdd") -> None:
+    skill_dir = agent_skills_dir(agent_name) / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Test skill\nversion: '1.0'\n---\n\nBody\n",
+        encoding="utf-8",
+    )
+    write_state(agent_name, [name])
+
+
 # ---------- GET /api/agents/{agent}/skills ----------------------------------
 
 
@@ -106,7 +116,7 @@ def test_list_returns_404_when_agent_not_resolved(monkeypatch):
 
 def test_list_includes_installed_and_available_for_hermes(monkeypatch):
     _stub_resolved(monkeypatch, agent_type="hermes")
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    _write_local_skill("tdd-hermes", "tdd")
 
     result = _run(agents_route.list_agent_skills("tdd-hermes"))
 
@@ -114,11 +124,11 @@ def test_list_includes_installed_and_available_for_hermes(monkeypatch):
     assert result["agent_type"] == "hermes"
 
     installed_refs = [row["ref"] for row in result["installed"]]
-    assert installed_refs == ["clawrium/tdd"]
+    assert installed_refs == ["tdd"]
     # Installed row carries summary metadata so the UI can render the
     # description without a second round-trip.
     tdd_row = result["installed"][0]
-    assert tdd_row["registry"] == "clawrium"
+    assert tdd_row["registry"] == "local"
     assert tdd_row["name"] == "tdd"
     assert tdd_row["description"]
     assert tdd_row["version"]
@@ -161,24 +171,25 @@ def test_list_handles_empty_desired_state(monkeypatch):
 
 def test_install_writes_state_and_calls_apply(monkeypatch):
     _stub_resolved(monkeypatch)
-    calls = _stub_apply(monkeypatch, applied=["clawrium/tdd"])
+    calls = _stub_apply(monkeypatch, applied=["tdd"])
 
     result = _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
 
     assert result["success"] is True
-    assert result["ref"] == "clawrium/tdd"
+    assert result["ref"] == "tdd"
     assert result["changed"] is True
-    assert result["installed"] == ["clawrium/tdd"]
+    assert result["installed"] == ["tdd"]
     assert calls == ["tdd-hermes"]
-    assert read_state("tdd-hermes") == ["clawrium/tdd"]
+    assert read_state("tdd-hermes") == ["tdd"]
+    assert (agent_skills_dir("tdd-hermes") / "tdd" / "SKILL.md").exists()
 
 
 def test_install_is_idempotent_but_still_applies(monkeypatch):
     """Re-installing an already-installed skill is the documented drift
     recovery path — state is unchanged but the playbook still runs."""
     _stub_resolved(monkeypatch)
-    write_state("tdd-hermes", ["clawrium/tdd"])
-    calls = _stub_apply(monkeypatch, applied=["clawrium/tdd"])
+    _write_local_skill("tdd-hermes", "tdd")
+    calls = _stub_apply(monkeypatch, applied=["tdd"])
 
     result = _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
 
@@ -267,7 +278,7 @@ def test_remove_502_on_apply_error(monkeypatch):
     the DELETE side so the redaction can't regress only for removes.
     """
     _stub_resolved(monkeypatch)
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    _write_local_skill("tdd-hermes", "tdd")
     raw_msg = (
         "Skills apply failed (status=failed): host unreachable "
         "(log: /home/op/.config/clawrium/logs/skills_apply-x)."
@@ -295,7 +306,20 @@ def test_install_422_on_incompatible_claw(monkeypatch):
     # Real apply_state will refuse: write the state then let the real
     # code path validate. But we don't want a real run — supply a fake
     # apply_state that raises IncompatibleSkillRegistry.
-    from clawrium.core.skills import IncompatibleSkillRegistry
+    from clawrium.core.skills import IncompatibleSkillRegistry, Skill, SkillRef
+
+    monkeypatch.setattr(agents_route, "load_skill", lambda _ref: object())
+    monkeypatch.setattr(
+        agents_route,
+        "materialize_skill_for_agent",
+        lambda _skill, _agent_type: Skill(
+            ref=SkillRef("openclaw", "foo"),
+            path=Path("__materialized__"),
+            metadata={},
+            body="Body",
+            skill_md_frontmatter={"name": "foo", "description": "Test"},
+        ),
+    )
 
     def fake(_name: str, **_kw):
         raise IncompatibleSkillRegistry(
@@ -328,7 +352,7 @@ def test_install_502_on_apply_error(monkeypatch):
     assert "Check server logs" in str(exc.value.detail)
     # State should still reflect the user's intent — apply failures
     # don't roll back desired state; the user will retry.
-    assert read_state("tdd-hermes") == ["clawrium/tdd"]
+    assert read_state("tdd-hermes") == ["tdd"]
 
 
 # ---------- DELETE /api/agents/{agent}/skills/{registry}/{skill} -------------
@@ -336,7 +360,7 @@ def test_install_502_on_apply_error(monkeypatch):
 
 def test_remove_drops_state_and_calls_apply(monkeypatch):
     _stub_resolved(monkeypatch)
-    write_state("tdd-hermes", ["clawrium/tdd"])
+    _write_local_skill("tdd-hermes", "tdd")
     calls = _stub_apply(monkeypatch, applied=[])
 
     result = _run(agents_route.remove_agent_skill("tdd-hermes", "clawrium", "tdd"))
@@ -387,7 +411,7 @@ def test_state_is_not_rolled_back_on_apply_failure(monkeypatch):
     _stub_apply(monkeypatch, raises=SkillApplyError("host unreachable"))
     with pytest.raises(HTTPException):
         _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
-    assert read_state("tdd-hermes") == ["clawrium/tdd"]
+    assert read_state("tdd-hermes") == ["tdd"]
 
 
 # ---------- _is_compatible_for_agent_type unit tests --------------------------

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -254,6 +254,61 @@ def test_reaper_closes_idle_tunnels():
     assert "stale" not in fleet_mod.WEB_UI_LAST_ACCESS
 
 
+def test_reaper_skips_close_for_restamped_key():
+    """Key re-stamped between snapshot-pop and re-check must not be closed (TOCTOU guard)."""
+    import time as time_module
+
+    fleet_mod.WEB_UI_LAST_ACCESS["restamped"] = time_module.time() - 3600
+
+    # Simulate concurrent /web-ui re-stamping the key after the reaper pops it:
+    # intercept the second _LAST_ACCESS_LOCK acquire (the per-key re-check)
+    # and re-insert the key so the guard fires.
+    original_lock = fleet_mod._LAST_ACCESS_LOCK
+    acquire_count = [0]
+    real_aenter = original_lock.__class__.__aenter__
+
+    async def _injecting_aenter(self):
+        result = await real_aenter(self)
+        if self is original_lock:
+            acquire_count[0] += 1
+            if acquire_count[0] == 2:
+                fleet_mod.WEB_UI_LAST_ACCESS["restamped"] = time_module.time()
+        return result
+
+    with (
+        patch.object(original_lock.__class__, "__aenter__", _injecting_aenter),
+        patch("clawrium.core.web_ui_tunnel.close") as mock_close,
+    ):
+        count = asyncio.run(fleet_mod.reap_idle_tunnels(threshold_seconds=1800.0))
+
+    assert count == 0
+    mock_close.assert_not_called()
+    assert "restamped" in fleet_mod.WEB_UI_LAST_ACCESS
+
+
+def test_reaper_continues_after_close_failure():
+    """close() raising must not increment count; subsequent stale keys are still processed."""
+    import time as time_module
+
+    fleet_mod.WEB_UI_LAST_ACCESS["bad"] = time_module.time() - 3600
+    fleet_mod.WEB_UI_LAST_ACCESS["good"] = time_module.time() - 3600
+
+    closed: list[str] = []
+
+    def _failing_close(key: str) -> None:
+        if key == "bad":
+            raise OSError("ssh disconnect")
+        closed.append(key)
+
+    with patch("clawrium.core.web_ui_tunnel.close", side_effect=_failing_close):
+        count = asyncio.run(fleet_mod.reap_idle_tunnels(threshold_seconds=1800.0))
+
+    assert count == 1
+    assert "good" in closed
+    assert "bad" not in fleet_mod.WEB_UI_LAST_ACCESS
+    assert "good" not in fleet_mod.WEB_UI_LAST_ACCESS
+
+
 def test_reaper_noop_when_all_fresh():
     import time as time_module
 
@@ -359,6 +414,7 @@ def test_pairing_code_409_when_bearer_blank(isolated_config: Path):
         with TestClient(app) as client:
             resp = client.post("/api/fleet/agents/demo/pairing-code")
     assert resp.status_code == 409
+    assert "clawctl agent configure" in resp.json()["detail"]
 
 
 def test_pairing_code_502_on_tunnel_failure(isolated_config: Path):
@@ -622,6 +678,23 @@ def test_pairing_code_502_on_non_json_response(isolated_config: Path):
 
     assert resp.status_code == 502
     assert "non-JSON" in resp.json()["detail"]
+
+
+def test_pairing_code_500_on_unexpected_tunnel_exception(isolated_config: Path):
+    """Non-TunnelError from ensure() in pairing-code path → 500 with generic message."""
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config("zc_bearer"))
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=_zeroclaw_resolved()),
+        patch(
+            "clawrium.core.web_ui_tunnel.ensure",
+            side_effect=RuntimeError("unexpected internal failure"),
+        ),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+    assert resp.status_code == 500
+    assert "Internal error" in resp.json()["detail"]
+    assert "unexpected internal failure" not in resp.json()["detail"]
 
 
 def test_pairing_code_504_on_upstream_timeout(isolated_config: Path):
@@ -980,6 +1053,8 @@ def test_fleet_health_returns_health_data(isolated_config: Path):
     assert data["summary"]["total"] == 1
     assert data["agents"][0]["agent_key"] == "demo"
     assert data["agents"][0]["process_running"] is True
+    assert "gateway_auth" not in data["agents"][0]
+    assert "secret_bearer_must_not_leak" not in resp.text
 
 
 def test_fleet_health_sanitizes_path_in_health_error(isolated_config: Path):
@@ -1028,6 +1103,7 @@ def test_fleet_health_returns_200_under_concurrent_clients(isolated_config: Path
         for t in threads:
             t.join(timeout=10)
 
+    assert len(results) == 3, f"only {len(results)} threads completed"
     assert all(s == 200 for s in results), results
 
 
@@ -1080,6 +1156,15 @@ def test_agent_detail_success(isolated_config: Path):
     assert data["latest_supported_version"] == "2026.6.0"
     assert captured["hostname"] == "192.168.1.100"
     assert captured["agent_key"] == "demo"
+
+
+def test_agent_detail_404_when_get_agent_detail_returns_none(isolated_config: Path):
+    """Second 404 path: resolve_agent succeeds but get_agent_detail returns None."""
+    _seed_hosts(isolated_config, "hermes")
+    with patch("clawrium.gui.routes.fleet.get_agent_detail", return_value=None):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo")
+    assert resp.status_code == 404
 
 
 def test_agent_detail_404_when_host_mismatch(isolated_config: Path):

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -887,6 +887,21 @@ def test_fleet_health_returns_health_data(isolated_config: Path):
     assert data["agents"][0]["process_running"] is True
 
 
+def test_fleet_health_sanitizes_path_in_health_error(isolated_config: Path):
+    """_sanitize_health_error regex branch must run when health_error contains a path."""
+    vm = _agent_vm(health_error="/home/user/.config/clawrium/secrets.json: permission denied")
+    with patch(
+        "clawrium.gui.routes.fleet.get_fleet_data",
+        return_value=([vm], _fleet_summary()),
+    ):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/health")
+    assert resp.status_code == 200
+    agent = resp.json()["agents"][0]
+    assert "/home/user/.config" not in agent["health_error"]
+    assert "<path>" in agent["health_error"]
+
+
 def test_fleet_health_504_on_timeout(isolated_config: Path):
     with patch(
         "asyncio.wait_for", side_effect=asyncio.TimeoutError
@@ -937,8 +952,14 @@ def test_agent_detail_404_for_unknown(isolated_config: Path):
 def test_agent_detail_success(isolated_config: Path):
     _seed_hosts(isolated_config, "hermes")
     vm = _agent_vm()
+    captured: dict = {}
+
+    def _capture_detail(agent_key, hostname):
+        captured["hostname"] = hostname
+        return vm
+
     with (
-        patch("clawrium.gui.routes.fleet.get_agent_detail", return_value=vm),
+        patch("clawrium.gui.routes.fleet.get_agent_detail", side_effect=_capture_detail),
         patch(
             "clawrium.core.registry.latest_supported_version",
             return_value="2026.6.0",
@@ -950,6 +971,7 @@ def test_agent_detail_success(isolated_config: Path):
     data = resp.json()
     assert data["agent_key"] == "demo"
     assert data["latest_supported_version"] == "2026.6.0"
+    assert captured["hostname"] == "192.168.1.100"
 
 
 def test_agent_detail_hardware_null_coercion(isolated_config: Path):

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -1088,6 +1088,8 @@ def test_agent_detail_404_when_host_mismatch(isolated_config: Path):
     with TestClient(app) as client:
         resp = client.get("/api/fleet/agents/demo?host=wronghost")
     assert resp.status_code == 404
+    assert "demo" in resp.json()["detail"]
+    assert "wronghost" in resp.json()["detail"]
 
 
 def test_agent_detail_hardware_null_coercion(isolated_config: Path):

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -22,6 +22,8 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
+from clawrium.core.health import ClawStatus
+from clawrium.core.lifecycle import LifecycleError
 from clawrium.core.web_ui import ResolvedUI
 from clawrium.gui.routes import fleet as fleet_mod
 from clawrium.gui.server import app
@@ -776,3 +778,368 @@ def test_connection_token_get_does_not_leak_bearer(isolated_config: Path):
     # Either 405 (route refuses GET) or 200 (SPA fallback). The
     # invariant is that the bearer never appears in the GET body.
     assert "oc_should_not_leak" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by B1–B6 tests
+# ---------------------------------------------------------------------------
+
+def _agent_vm(**overrides) -> dict:
+    """Minimal AgentViewModel dict for mocking fleet data functions."""
+    base: dict = {
+        "agent_key": "demo",
+        "agent_name": "demo",
+        "agent_type": "hermes",
+        "host": "192.168.1.100",
+        "host_alias": "box",
+        "host_os_family": "linux",
+        "version": "2026.5.1",
+        "status": ClawStatus.RUNNING,
+        "model": "claude-sonnet",
+        "uptime": "2h",
+        "missing_secrets": [],
+        "onboarding_step": None,
+        "process_running": True,
+        "health_error": None,
+        "addresses": [],
+        "provider": "anthropic",
+        "provider_type": "anthropic",
+        "cpu_count": 4,
+        "memory_total_mb": 8192,
+        "gateway_port": 45001,
+        "gateway_url": "http://192.168.1.100:45001",
+        "gateway_auth": "secret_bearer_must_not_leak",
+        "device_id": None,
+        "device_private_key": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _fleet_summary(**overrides) -> dict:
+    base = {"total": 1, "running": 1, "provisioning": 0, "hosts": 1}
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# B1 — GET /fleet (fleet_overview)
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_overview_returns_agent_list(isolated_config: Path):
+    vm = _agent_vm()
+    with patch(
+        "clawrium.gui.routes.fleet.get_fleet_data_local",
+        return_value=([vm], _fleet_summary()),
+    ):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary"]["total"] == 1
+    assert data["summary"]["running"] == 1
+    assert len(data["agents"]) == 1
+    assert data["agents"][0]["agent_key"] == "demo"
+
+
+def test_fleet_overview_host_filter_forwarded(isolated_config: Path):
+    """host query param is forwarded to get_fleet_data_local."""
+    with patch(
+        "clawrium.gui.routes.fleet.get_fleet_data_local",
+        return_value=([], _fleet_summary(total=0, running=0, hosts=0)),
+    ) as mock_fn:
+        with TestClient(app) as client:
+            client.get("/api/fleet?host=box")
+    mock_fn.assert_called_once_with("box")
+
+
+def test_fleet_overview_excludes_gateway_auth(isolated_config: Path):
+    """gateway_auth must never appear in the /fleet response body (W3)."""
+    vm = _agent_vm()
+    with patch(
+        "clawrium.gui.routes.fleet.get_fleet_data_local",
+        return_value=([vm], _fleet_summary()),
+    ):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet")
+    assert "secret_bearer_must_not_leak" not in resp.text
+    assert "gateway_auth" not in resp.json()["agents"][0]
+
+
+# ---------------------------------------------------------------------------
+# B2 — GET /fleet/health (fleet_health)
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_health_returns_health_data(isolated_config: Path):
+    vm = _agent_vm()
+    with patch(
+        "clawrium.gui.routes.fleet.get_fleet_data",
+        return_value=([vm], _fleet_summary()),
+    ):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary"]["total"] == 1
+    assert data["agents"][0]["agent_key"] == "demo"
+    assert data["agents"][0]["process_running"] is True
+
+
+def test_fleet_health_504_on_timeout(isolated_config: Path):
+    with patch(
+        "asyncio.wait_for", side_effect=asyncio.TimeoutError
+    ):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/health")
+    assert resp.status_code == 504
+    assert "timed out" in resp.json()["detail"]
+
+
+def test_fleet_health_semaphore_blocks_concurrent_calls(isolated_config: Path):
+    """_FLEET_HEALTH_SEMAPHORE(2) allows up to 2 concurrent health probes."""
+    import threading
+
+    results = []
+    vm = _agent_vm()
+
+    def _probe():
+        with TestClient(app) as client:
+            r = client.get("/api/fleet/health")
+            results.append(r.status_code)
+
+    with patch(
+        "clawrium.gui.routes.fleet.get_fleet_data",
+        return_value=([vm], _fleet_summary()),
+    ):
+        threads = [threading.Thread(target=_probe) for _ in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+    assert all(s == 200 for s in results), results
+
+
+# ---------------------------------------------------------------------------
+# B3 — GET /fleet/agents/{key} (agent_detail)
+# ---------------------------------------------------------------------------
+
+
+def test_agent_detail_404_for_unknown(isolated_config: Path):
+    _seed_hosts(isolated_config, "hermes")
+    with TestClient(app) as client:
+        resp = client.get("/api/fleet/agents/nope")
+    assert resp.status_code == 404
+
+
+def test_agent_detail_success(isolated_config: Path):
+    _seed_hosts(isolated_config, "hermes")
+    vm = _agent_vm()
+    with (
+        patch("clawrium.gui.routes.fleet.get_agent_detail", return_value=vm),
+        patch(
+            "clawrium.core.registry.latest_supported_version",
+            return_value="2026.6.0",
+        ),
+    ):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["agent_key"] == "demo"
+    assert data["latest_supported_version"] == "2026.6.0"
+
+
+def test_agent_detail_hardware_null_coercion(isolated_config: Path):
+    """Regression: hardware=null in hosts.json must not raise — `or {}` coerces it."""
+    hosts = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "box",
+            "port": 22,
+            "user": "xclm",
+            "hardware": None,
+            "agents": {
+                "demo": {
+                    "type": "hermes",
+                    "agent_name": "demo",
+                    "name": "demo",
+                    "config": {},
+                }
+            },
+        }
+    ]
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+    vm = _agent_vm()
+    with patch("clawrium.gui.routes.fleet.get_agent_detail", return_value=vm):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo")
+    assert resp.status_code == 200
+    # latest_supported_version raises on hardware={} with no arch; caught → None
+    assert resp.json()["latest_supported_version"] is None
+
+
+def test_agent_detail_excludes_gateway_auth(isolated_config: Path):
+    """gateway_auth must never appear in the agent_detail response body (W3)."""
+    _seed_hosts(isolated_config, "hermes")
+    vm = _agent_vm()
+    with patch("clawrium.gui.routes.fleet.get_agent_detail", return_value=vm):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo")
+    assert "secret_bearer_must_not_leak" not in resp.text
+    assert "gateway_auth" not in resp.json()
+
+
+# ---------------------------------------------------------------------------
+# B4 — POST /agents/{key}/start
+# ---------------------------------------------------------------------------
+
+
+def test_start_agent_404_for_unknown(isolated_config: Path):
+    _seed_hosts(isolated_config, "hermes")
+    with TestClient(app) as client:
+        resp = client.post("/api/agents/nope/start")
+    assert resp.status_code == 404
+
+
+def test_start_agent_success(isolated_config: Path):
+    _seed_hosts(isolated_config, "hermes")
+    with patch(
+        "clawrium.gui.routes.fleet.start_agent", return_value={"success": True}
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/agents/demo/start")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert data["operation"] == "start"
+    assert data["agent"] == "demo"
+
+
+def test_start_agent_lifecycle_error_sanitized(isolated_config: Path):
+    """LifecycleError detail must be path-sanitized before reaching the browser (W1)."""
+    _seed_hosts(isolated_config, "hermes")
+    with patch(
+        "clawrium.gui.routes.fleet.start_agent",
+        side_effect=LifecycleError("failed at /home/user/.config/clawrium/secrets.json"),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/agents/demo/start")
+    assert resp.status_code == 500
+    assert "/home/user/.config" not in resp.json()["detail"]
+    assert "<path>" in resp.json()["detail"]
+
+
+def test_start_agent_generic_exception_uses_safe_message(isolated_config: Path):
+    _seed_hosts(isolated_config, "hermes")
+    with patch(
+        "clawrium.gui.routes.fleet.start_agent",
+        side_effect=RuntimeError("internal detail /etc/secrets"),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/agents/demo/start")
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Lifecycle operation failed. Check server logs."
+
+
+# ---------------------------------------------------------------------------
+# B5 — POST /agents/{key}/stop
+# ---------------------------------------------------------------------------
+
+
+def test_stop_agent_404_for_unknown(isolated_config: Path):
+    _seed_hosts(isolated_config, "hermes")
+    with TestClient(app) as client:
+        resp = client.post("/api/agents/nope/stop")
+    assert resp.status_code == 404
+
+
+def test_stop_agent_success(isolated_config: Path):
+    _seed_hosts(isolated_config, "hermes")
+    with patch(
+        "clawrium.gui.routes.fleet.stop_agent", return_value={"success": True}
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/agents/demo/stop")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert data["operation"] == "stop"
+
+
+def test_stop_agent_lifecycle_error_sanitized(isolated_config: Path):
+    _seed_hosts(isolated_config, "hermes")
+    with patch(
+        "clawrium.gui.routes.fleet.stop_agent",
+        side_effect=LifecycleError("failed at /home/user/.config/clawrium/hosts.json"),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/agents/demo/stop")
+    assert resp.status_code == 500
+    assert "/home/user/.config" not in resp.json()["detail"]
+    assert "<path>" in resp.json()["detail"]
+
+
+def test_stop_agent_generic_exception_uses_safe_message(isolated_config: Path):
+    _seed_hosts(isolated_config, "hermes")
+    with patch(
+        "clawrium.gui.routes.fleet.stop_agent",
+        side_effect=RuntimeError("boom"),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/agents/demo/stop")
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Lifecycle operation failed. Check server logs."
+
+
+# ---------------------------------------------------------------------------
+# B6 — POST /agents/{key}/restart
+# ---------------------------------------------------------------------------
+
+
+def test_restart_agent_404_for_unknown(isolated_config: Path):
+    _seed_hosts(isolated_config, "hermes")
+    with TestClient(app) as client:
+        resp = client.post("/api/agents/nope/restart")
+    assert resp.status_code == 404
+
+
+def test_restart_agent_success(isolated_config: Path):
+    _seed_hosts(isolated_config, "hermes")
+    with patch(
+        "clawrium.gui.routes.fleet.restart_agent", return_value={"success": True}
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/agents/demo/restart")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert data["operation"] == "restart"
+
+
+def test_restart_agent_lifecycle_error_sanitized(isolated_config: Path):
+    _seed_hosts(isolated_config, "hermes")
+    with patch(
+        "clawrium.gui.routes.fleet.restart_agent",
+        side_effect=LifecycleError("failed at /home/user/.config/clawrium/hosts.json"),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/agents/demo/restart")
+    assert resp.status_code == 500
+    assert "/home/user/.config" not in resp.json()["detail"]
+    assert "<path>" in resp.json()["detail"]
+
+
+def test_restart_agent_generic_exception_uses_safe_message(isolated_config: Path):
+    _seed_hosts(isolated_config, "hermes")
+    with patch(
+        "clawrium.gui.routes.fleet.restart_agent",
+        side_effect=RuntimeError("boom"),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/agents/demo/restart")
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Lifecycle operation failed. Check server logs."

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -255,39 +255,42 @@ def test_reaper_closes_idle_tunnels():
 
 
 def test_reaper_skips_close_for_restamped_key():
-    """Key re-stamped between snapshot-pop and re-check must not be closed (TOCTOU guard)."""
+    """Key re-stamped during a concurrent /web-ui call skips close() (TOCTOU guard).
+
+    Two stale entries are in the snapshot. close("first") side-effects a re-stamp
+    of "second" — simulating a /web-ui handler running between the snapshot pop and
+    the per-key re-check. The reaper must close "first" (count==1) but skip "second".
+    """
     import time as time_module
 
-    fleet_mod.WEB_UI_LAST_ACCESS["restamped"] = time_module.time() - 3600
+    fleet_mod.WEB_UI_LAST_ACCESS["first"] = time_module.time() - 3600
+    fleet_mod.WEB_UI_LAST_ACCESS["second"] = time_module.time() - 3600
 
-    # Simulate concurrent /web-ui re-stamping the key after the reaper pops it:
-    # intercept the second _LAST_ACCESS_LOCK acquire (the per-key re-check)
-    # and re-insert the key so the guard fires.
-    original_lock = fleet_mod._LAST_ACCESS_LOCK
-    acquire_count = [0]
-    real_aenter = original_lock.__class__.__aenter__
+    def _close_first_restamp_second(key: str) -> None:
+        if key == "first":
+            fleet_mod.WEB_UI_LAST_ACCESS["second"] = time_module.time()
 
-    async def _injecting_aenter(self):
-        result = await real_aenter(self)
-        if self is original_lock:
-            acquire_count[0] += 1
-            if acquire_count[0] == 2:
-                fleet_mod.WEB_UI_LAST_ACCESS["restamped"] = time_module.time()
-        return result
-
-    with (
-        patch.object(original_lock.__class__, "__aenter__", _injecting_aenter),
-        patch("clawrium.core.web_ui_tunnel.close") as mock_close,
-    ):
+    with patch(
+        "clawrium.core.web_ui_tunnel.close", side_effect=_close_first_restamp_second
+    ) as mock_close:
         count = asyncio.run(fleet_mod.reap_idle_tunnels(threshold_seconds=1800.0))
 
-    assert count == 0
-    mock_close.assert_not_called()
-    assert "restamped" in fleet_mod.WEB_UI_LAST_ACCESS
+    assert count == 1
+    mock_close.assert_called_once_with("first")
+    assert "second" in fleet_mod.WEB_UI_LAST_ACCESS
 
 
 def test_reaper_continues_after_close_failure():
-    """close() raising must not increment count; subsequent stale keys are still processed."""
+    """close() raising must not increment count; subsequent stale keys are still processed.
+
+    Pop-before-close trade-off: keys are removed from WEB_UI_LAST_ACCESS in the
+    initial snapshot (before close() is called) to avoid holding _LAST_ACCESS_LOCK
+    across the blocking SSH teardown. This means a close() failure permanently
+    removes tracking — the SSH process may still be alive but becomes un-reapable
+    in future cycles. This is intentional: the alternative (re-inserting on failure)
+    would require another lock acquire and make the reaper retry broken tunnels
+    indefinitely.
+    """
     import time as time_module
 
     fleet_mod.WEB_UI_LAST_ACCESS["bad"] = time_module.time() - 3600
@@ -432,6 +435,7 @@ def test_pairing_code_502_on_tunnel_failure(isolated_config: Path):
             resp = client.post("/api/fleet/agents/demo/pairing-code")
     assert resp.status_code == 502
     assert "ssh refused" in resp.json()["detail"]
+    assert "zc_test_bearer" not in resp.text
 
 
 def test_pairing_code_success(isolated_config: Path):
@@ -509,6 +513,7 @@ def test_pairing_code_409_on_daemon_401(isolated_config: Path):
 
     assert resp.status_code == 409
     assert "clawctl agent configure" in resp.json()["detail"]
+    assert "zc_test_bearer" not in resp.text
 
 
 def test_pairing_code_503_on_daemon_503(isolated_config: Path):
@@ -543,6 +548,7 @@ def test_pairing_code_503_on_daemon_503(isolated_config: Path):
 
     assert resp.status_code == 503
     assert "clawctl agent restart" in resp.json()["detail"]
+    assert "zc_test_bearer" not in resp.text
 
 
 def test_pairing_code_502_on_unexpected_daemon_status(isolated_config: Path):
@@ -577,6 +583,7 @@ def test_pairing_code_502_on_unexpected_daemon_status(isolated_config: Path):
 
     assert resp.status_code == 502
     assert "418" in resp.json()["detail"]
+    assert "zc_test_bearer" not in resp.text
 
 
 def test_pairing_code_502_on_empty_code(isolated_config: Path):
@@ -612,6 +619,7 @@ def test_pairing_code_502_on_empty_code(isolated_config: Path):
 
     assert resp.status_code == 502
     assert "empty pairing code" in resp.json()["detail"].lower()
+    assert "zc_test_bearer" not in resp.text
 
 
 def test_pairing_code_502_on_http_error(isolated_config: Path):
@@ -643,6 +651,7 @@ def test_pairing_code_502_on_http_error(isolated_config: Path):
 
     assert resp.status_code == 502
     assert "Could not reach the agent daemon" in resp.json()["detail"]
+    assert "zc_bearer" not in resp.text
 
 
 def test_pairing_code_502_on_non_json_response(isolated_config: Path):
@@ -678,6 +687,7 @@ def test_pairing_code_502_on_non_json_response(isolated_config: Path):
 
     assert resp.status_code == 502
     assert "non-JSON" in resp.json()["detail"]
+    assert "zc_bearer" not in resp.text
 
 
 def test_pairing_code_500_on_unexpected_tunnel_exception(isolated_config: Path):
@@ -695,6 +705,7 @@ def test_pairing_code_500_on_unexpected_tunnel_exception(isolated_config: Path):
     assert resp.status_code == 500
     assert "Internal error" in resp.json()["detail"]
     assert "unexpected internal failure" not in resp.json()["detail"]
+    assert "zc_bearer" not in resp.text
 
 
 def test_pairing_code_504_on_upstream_timeout(isolated_config: Path):
@@ -724,6 +735,7 @@ def test_pairing_code_504_on_upstream_timeout(isolated_config: Path):
             resp = client.post("/api/fleet/agents/demo/pairing-code")
 
     assert resp.status_code == 504
+    assert "zc_bearer" not in resp.text
 
 
 def test_pairing_code_local_host_skips_tunnel(isolated_config: Path):
@@ -1095,8 +1107,12 @@ def test_fleet_health_returns_200_under_concurrent_clients(isolated_config: Path
         "clawrium.gui.routes.fleet.get_fleet_data",
         return_value=([vm], _fleet_summary()),
     ):
-        with _TPE(max_workers=3) as executor:
-            results = [f.result(timeout=15) for f in [executor.submit(_probe) for _ in range(3)]]
+        executor = _TPE(max_workers=3)
+        try:
+            futures = [executor.submit(_probe) for _ in range(3)]
+            results = [f.result(timeout=15) for f in futures]
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
 
     assert len(results) == 3, f"only {len(results)} threads completed"
     assert all(s == 200 for s in results), results
@@ -1229,7 +1245,7 @@ def test_start_agent_success(isolated_config: Path):
     _seed_hosts(isolated_config, "hermes")
     with patch(
         "clawrium.gui.routes.fleet.start_agent", return_value={"success": True}
-    ):
+    ) as mock_start:
         with TestClient(app) as client:
             resp = client.post("/api/agents/demo/start")
     assert resp.status_code == 200
@@ -1237,6 +1253,7 @@ def test_start_agent_success(isolated_config: Path):
     assert data["success"] is True
     assert data["operation"] == "start"
     assert data["agent"] == "demo"
+    mock_start.assert_called_once_with("192.168.1.100", "hermes", agent_name="demo")
 
 
 def test_start_agent_lifecycle_error_sanitized(isolated_config: Path):
@@ -1281,13 +1298,14 @@ def test_stop_agent_success(isolated_config: Path):
     _seed_hosts(isolated_config, "hermes")
     with patch(
         "clawrium.gui.routes.fleet.stop_agent", return_value={"success": True}
-    ):
+    ) as mock_stop:
         with TestClient(app) as client:
             resp = client.post("/api/agents/demo/stop")
     assert resp.status_code == 200
     data = resp.json()
     assert data["success"] is True
     assert data["operation"] == "stop"
+    mock_stop.assert_called_once_with("192.168.1.100", "hermes", agent_name="demo")
 
 
 def test_stop_agent_lifecycle_error_sanitized(isolated_config: Path):
@@ -1331,13 +1349,14 @@ def test_restart_agent_success(isolated_config: Path):
     _seed_hosts(isolated_config, "hermes")
     with patch(
         "clawrium.gui.routes.fleet.restart_agent", return_value={"success": True}
-    ):
+    ) as mock_restart:
         with TestClient(app) as client:
             resp = client.post("/api/agents/demo/restart")
     assert resp.status_code == 200
     data = resp.json()
     assert data["success"] is True
     assert data["operation"] == "restart"
+    mock_restart.assert_called_once_with("192.168.1.100", "hermes", agent_name="demo")
 
 
 def test_restart_agent_lifecycle_error_sanitized(isolated_config: Path):

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -204,6 +204,34 @@ def test_web_ui_reports_tunnel_failure_as_unavailable(isolated_config: Path):
     assert "ssh failed" in body["reason"]
 
 
+def test_web_ui_returns_unavailable_on_unexpected_tunnel_exception(
+    isolated_config: Path,
+):
+    """Non-TunnelError exception from ensure() → available:false with generic reason."""
+    _seed_hosts(isolated_config, "hermes")
+    resolved = ResolvedUI(
+        host="192.168.1.100",
+        remote_port=9119,
+        bind="loopback",
+        ssh_config={"user": "xclm"},
+    )
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=resolved),
+        patch(
+            "clawrium.core.web_ui_tunnel.ensure",
+            side_effect=RuntimeError("unexpected internal failure"),
+        ),
+    ):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo/web-ui")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is False
+    assert body["local_url"] is None
+    assert "Internal error" in body["reason"]
+    assert "unexpected internal failure" not in body["reason"]
+
+
 def test_reaper_closes_idle_tunnels():
     """reap_idle_tunnels() must call web_ui_tunnel.close() for stale entries."""
     import time as time_module
@@ -389,6 +417,7 @@ def test_pairing_code_success(isolated_config: Path):
     assert resp.json() == {"pairing_code": "508333"}
     assert captured["url"] == "http://127.0.0.1:39211/api/pairing/initiate"
     assert captured["headers"] == {"Authorization": "Bearer zc_bearer"}
+    assert captured["timeout"] == 10.0
 
 
 def test_pairing_code_409_on_daemon_401(isolated_config: Path):
@@ -527,6 +556,72 @@ def test_pairing_code_502_on_empty_code(isolated_config: Path):
 
     assert resp.status_code == 502
     assert "empty pairing code" in resp.json()["detail"].lower()
+
+
+def test_pairing_code_502_on_http_error(isolated_config: Path):
+    """httpx.HTTPError (non-timeout, e.g. ConnectError) → 502."""
+    import httpx
+
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config("zc_bearer"))
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, headers=None):
+            raise httpx.ConnectError("connection refused")
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=_zeroclaw_resolved()),
+        patch("clawrium.core.web_ui_tunnel.ensure", return_value=39211),
+        patch("httpx.AsyncClient", _FakeClient),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+
+    assert resp.status_code == 502
+    assert "Could not reach the agent daemon" in resp.json()["detail"]
+
+
+def test_pairing_code_502_on_non_json_response(isolated_config: Path):
+    """resp.json() raising ValueError → 502 'non-JSON pairing response'."""
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config("zc_bearer"))
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self):
+            raise ValueError("not valid JSON")
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, headers=None):
+            return _FakeResp()
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=_zeroclaw_resolved()),
+        patch("clawrium.core.web_ui_tunnel.ensure", return_value=39211),
+        patch("httpx.AsyncClient", _FakeClient),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+
+    assert resp.status_code == 502
+    assert "non-JSON" in resp.json()["detail"]
 
 
 def test_pairing_code_504_on_upstream_timeout(isolated_config: Path):
@@ -898,8 +993,7 @@ def test_fleet_health_sanitizes_path_in_health_error(isolated_config: Path):
             resp = client.get("/api/fleet/health")
     assert resp.status_code == 200
     agent = resp.json()["agents"][0]
-    assert "/home/user/.config" not in agent["health_error"]
-    assert "<path>" in agent["health_error"]
+    assert agent["health_error"] == "<path>: permission denied"
 
 
 def test_fleet_health_504_on_timeout(isolated_config: Path):
@@ -912,8 +1006,8 @@ def test_fleet_health_504_on_timeout(isolated_config: Path):
     assert "timed out" in resp.json()["detail"]
 
 
-def test_fleet_health_semaphore_blocks_concurrent_calls(isolated_config: Path):
-    """_FLEET_HEALTH_SEMAPHORE(2) allows up to 2 concurrent health probes."""
+def test_fleet_health_returns_200_under_concurrent_clients(isolated_config: Path):
+    """Three concurrent clients all get 200 — smoke-tests basic concurrency."""
     import threading
 
     results = []
@@ -937,6 +1031,18 @@ def test_fleet_health_semaphore_blocks_concurrent_calls(isolated_config: Path):
     assert all(s == 200 for s in results), results
 
 
+def test_fleet_health_host_filter_forwarded(isolated_config: Path):
+    """?host= query param is forwarded to get_fleet_data on /fleet/health."""
+    with patch(
+        "clawrium.gui.routes.fleet.get_fleet_data",
+        return_value=([], _fleet_summary(total=0, running=0, hosts=0)),
+    ) as mock_fn:
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/health?host=box")
+    assert resp.status_code == 200
+    mock_fn.assert_called_once_with("box")
+
+
 # ---------------------------------------------------------------------------
 # B3 — GET /fleet/agents/{key} (agent_detail)
 # ---------------------------------------------------------------------------
@@ -955,6 +1061,7 @@ def test_agent_detail_success(isolated_config: Path):
     captured: dict = {}
 
     def _capture_detail(agent_key, hostname):
+        captured["agent_key"] = agent_key
         captured["hostname"] = hostname
         return vm
 
@@ -972,6 +1079,15 @@ def test_agent_detail_success(isolated_config: Path):
     assert data["agent_key"] == "demo"
     assert data["latest_supported_version"] == "2026.6.0"
     assert captured["hostname"] == "192.168.1.100"
+    assert captured["agent_key"] == "demo"
+
+
+def test_agent_detail_404_when_host_mismatch(isolated_config: Path):
+    """?host=wronghost for a known agent returns 404 (not 200 with wrong host data)."""
+    _seed_hosts(isolated_config, "hermes")
+    with TestClient(app) as client:
+        resp = client.get("/api/fleet/agents/demo?host=wronghost")
+    assert resp.status_code == 404
 
 
 def test_agent_detail_hardware_null_coercion(isolated_config: Path):

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -1083,25 +1083,20 @@ def test_fleet_health_504_on_timeout(isolated_config: Path):
 
 def test_fleet_health_returns_200_under_concurrent_clients(isolated_config: Path):
     """Three concurrent clients all get 200 — smoke-tests basic concurrency."""
-    import threading
+    from concurrent.futures import ThreadPoolExecutor as _TPE
 
-    results = []
     vm = _agent_vm()
 
-    def _probe():
+    def _probe() -> int:
         with TestClient(app) as client:
-            r = client.get("/api/fleet/health")
-            results.append(r.status_code)
+            return client.get("/api/fleet/health").status_code
 
     with patch(
         "clawrium.gui.routes.fleet.get_fleet_data",
         return_value=([vm], _fleet_summary()),
     ):
-        threads = [threading.Thread(target=_probe) for _ in range(3)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join(timeout=10)
+        with _TPE(max_workers=3) as executor:
+            results = [f.result(timeout=15) for f in [executor.submit(_probe) for _ in range(3)]]
 
     assert len(results) == 3, f"only {len(results)} threads completed"
     assert all(s == 200 for s in results), results

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -730,6 +730,37 @@ def test_connection_token_prefers_secrets_store_over_legacy_hosts_json(
     assert resp.json() == {"token": "oc_rotated"}
 
 
+def test_connection_token_uses_instance_key_not_raw_agent_key(isolated_config: Path):
+    """_resolve_openclaw_credentials must receive the host:type:name instance key,
+    not the raw agent_key URL param. Passing agent_key directly means
+    get_instance_secrets never matches and always falls back to hosts.json.
+    """
+    from clawrium.core.secrets import get_instance_key
+
+    _seed_hosts(isolated_config, "openclaw", _openclaw_config("oc_bearer"))
+    expected_key = get_instance_key("192.168.1.100", "openclaw", "demo")
+
+    captured: dict = {}
+
+    def _capture(instance_key, gateway):
+        captured["instance_key"] = instance_key
+        return ("oc_bearer", None)
+
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=_openclaw_resolved()),
+        patch(
+            "clawrium.gui.routes.agents._resolve_openclaw_credentials",
+            side_effect=_capture,
+        ),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/connection-token")
+
+    assert resp.status_code == 200
+    assert captured["instance_key"] == expected_key
+    assert captured["instance_key"] != "demo"
+
+
 def test_connection_token_get_does_not_leak_bearer(isolated_config: Path):
     """The endpoint is POST-only. The GUI server mounts the SPA on a
     catch-all GET, so a GET to this path falls through to index.html

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -2267,7 +2267,7 @@ class TestRemoveClaw:
         playbook_path.write_text("---\n- hosts: all\n")
 
         # Pre-seed the agent state directory with a skills.json
-        write_state("opc-work", ["clawrium/tdd"])
+        write_state("opc-work", ["tdd"])
         agent_state_dir = tmp_path / "clawrium" / "agents" / "opc-work"
         assert agent_state_dir.is_dir()
 

--- a/website/docs/skills/authoring.md
+++ b/website/docs/skills/authoring.md
@@ -6,10 +6,12 @@ keywords: [skills, authoring, schema, validator, ci, clawrium, openclaw, hermes,
 
 # Authoring Skills
 
-Skills are added by dropping a directory into the in-repo
+Bundled skills are added by dropping a directory into the in-repo
 `skills/<registry>/<name>/` tree, opening a PR, and letting the CI
-validator gate the schema. This page covers both flavours
-side-by-side. The repository
+validator gate the schema. For private reusable templates, use
+`clawctl skill add <path> --registry <registry>` to write a user overlay
+under `~/.config/clawrium/skills/`. This page covers bundled catalog
+authoring; the same schema rules apply to overlay entries. The repository
 [`docs/skills/`](https://github.com/ric03uec/clawrium/tree/main/docs/skills)
 guides go deeper on each.
 
@@ -141,15 +143,17 @@ make test
 
 ## Smoke-test against a real claw
 
-Before merging, exercise the install/list/remove round-trip against a
+Before merging, exercise the add/sync/list/remove round-trip against a
 real agent. For a `clawrium/<name>` skill, this means three agents
 (one per claw); for a `<claw>/<name>` native skill, one agent of the
 matching type.
 
 ```bash
-clawctl agent skill attach <agent> <registry>/<name>
-clawctl agent skill get --agent    <agent>
-clawctl agent skill detach  <agent> <registry>/<name>
+clawctl agent skill add <agent> --from-template <registry>/<name>
+clawctl agent sync <agent>
+clawctl agent skill list <agent>
+clawctl agent skill remove <agent> <name>
+clawctl agent sync <agent>
 ```
 
 The web dashboard's **Agents → `<agent>` → Skills** tab covers the

--- a/website/docs/skills/intro.md
+++ b/website/docs/skills/intro.md
@@ -7,15 +7,17 @@ keywords: [skills, registry, clawrium, openclaw, hermes, zeroclaw, install]
 # Skills
 
 Clawrium ships a curated **skills catalog** that any agent in your
-fleet can install with one command. A skill is a directory of
+fleet can copy into local agent state with one command. A skill is a directory of
 behaviour-shaping prompts and metadata that the underlying claw
 discovers at runtime — Test-Driven Development discipline, code-review
 guardrails, security-audit playbooks.
 
-Skills are sourced **only** from the in-repo `skills/` tree. There is no
-URL install, no arbitrary-path install, no third-party registry. The
-catalog is the source of truth, and every PR runs a dual-schema
-validator in CI.
+Bundled catalog skills live in the in-repo `skills/` tree. Operators can
+also add user-overlay entries under
+`~/.config/clawrium/skills/<registry>/<name>/` with `clawctl skill add`.
+Both sources use the same registry names and schema validation; overlay
+entries win if they define the same `<registry>/<name>` as bundled
+catalog entries.
 
 ## Quick start
 
@@ -26,14 +28,17 @@ clawctl skill registry get
 # Inspect a skill before installing
 clawctl skill registry describe clawrium/tdd
 
-# Install onto an agent
-clawctl agent skill attach my-agent clawrium/tdd
+# Copy the template into an agent-local skill
+clawctl agent skill add my-agent --from-template clawrium/tdd
+
+# Apply local skill state to the host
+clawctl agent sync my-agent
 
 # List skills installed on an agent
-clawctl agent skill get --agent my-agent
+clawctl agent skill list my-agent
 
 # Remove a skill
-clawctl agent skill detach my-agent clawrium/tdd
+clawctl agent skill remove my-agent tdd
 ```
 
 The web dashboard mirrors the same surface under **Agents → `<agent>`
@@ -52,25 +57,42 @@ schema its descriptor validates against.
 | `hermes`   | only `hermes` agents    | `native/hermes.schema.json`         |
 | `zeroclaw` | only `zeroclaw` agents  | `native/zeroclaw.schema.json`       |
 
-Skills are referenced as `<registry>/<name>` everywhere — CLI args,
-GUI URLs, desired-state files. Bare names (`tdd`) are rejected with a
-hint that suggests the matching `<registry>/<name>`.
+Catalog templates are referenced as `<registry>/<name>` when browsing or
+copying from the catalog. Once copied to an agent, the skill is local to
+that agent and is referenced by its bare name (`tdd`). The desired-state
+file at `~/.config/clawrium/agents/<agent>/skills.json` stores only bare
+local names.
 
 ### `clawrium/` — cross-agent
 
 Use the `clawrium/` registry when the skill is behaviour you want
 available on **every** kind of claw. The normalized `_meta.yaml` shape
-is materialized into each native frontmatter format at install time —
-a single source file ends up on disk as openclaw-shaped SKILL.md on an
-openclaw agent, hermes-shaped on a hermes agent, and zeroclaw-shaped
-(via `zeroclaw skills install`) on a zeroclaw agent.
+is materialized into each native frontmatter format at `clawctl agent
+skill add` time. `clawctl agent sync` later copies the already-native
+local file to the host unchanged.
 
 ### `openclaw/`, `hermes/`, `zeroclaw/` — native
 
 Use a native registry when the skill needs that claw's specific
 frontmatter fields. Native skills are installable **only** on agents
-of the matching type — `clawctl agent skill attach` fails fast if you try
+of the matching type — `clawctl agent skill add` fails fast if you try
 to mix them.
+
+## Local agent state
+
+```text
+~/.config/clawrium/agents/<agent>/skills/<name>/SKILL.md
+~/.config/clawrium/agents/<agent>/skills.json
+```
+
+`skills.json` stores bare local names such as `{"skills": ["tdd"]}`.
+Registry refs such as `"clawrium/tdd"` are invalid desired state. Re-add
+old refs from the template and sync:
+
+```bash
+clawctl agent skill add <agent> --from-template clawrium/tdd
+clawctl agent sync <agent>
+```
 
 ## On-host install path
 
@@ -89,15 +111,18 @@ after install, switch users on the remote host with
 `sudo -u <agent-name> ls /home/<agent-name>/...`.
 :::
 
-Re-running `clawctl agent skill attach` is the drift recovery — the local
-desired-state file at
-`~/.config/clawrium/agents/<agent>/skills.json` is the source of truth,
-and every install/remove re-applies it end-to-end. There is no separate
-`reconcile` command.
+`clawctl agent sync <agent>` is the drift recovery. It reads the bare
+names in `~/.config/clawrium/agents/<agent>/skills.json`, stages each
+local `SKILL.md` byte-for-byte, and applies that state to the host.
 
 ## Troubleshooting
 
-### Install reports success but the file isn't where I expect
+### Add succeeds but the host file is missing
+
+`clawctl agent skill add` writes the local control-plane copy only. Run
+`clawctl agent sync <agent>` to push it to the host.
+
+### Sync reports success but the file isn't where I expect
 
 Common pitfall — the `~` in the on-host paths is the **agent user's**
 home, not yours. When verifying via SSH:

--- a/website/docs/skills/local.md
+++ b/website/docs/skills/local.md
@@ -1,0 +1,86 @@
+---
+sidebar_position: 2
+description: Manage editable per-agent skill copies and sync them to hosts.
+keywords: [skills, local skills, sync, agent skills, clawctl]
+---
+
+# Local Agent Skills
+
+Local agent skills are the editable, per-agent copies that Clawrium syncs
+to hosts. Catalog skills are templates. Adding one to an agent copies and
+materializes it into that agent's native format.
+
+## Layout
+
+```text
+~/.config/clawrium/agents/<agent>/skills/<name>/SKILL.md
+~/.config/clawrium/agents/<agent>/skills.json
+```
+
+`skills.json` stores only bare local names:
+
+```json
+{"skills": ["tdd", "incident-review"]}
+```
+
+Registry refs such as `"clawrium/tdd"` are invalid in `skills.json`.
+Re-add old refs from their template:
+
+```bash
+clawctl agent skill add <agent> --from-template clawrium/tdd
+clawctl agent sync <agent>
+```
+
+## Add Skills
+
+```bash
+# Copy and materialize a catalog template
+clawctl agent skill add my-agent --from-template clawrium/tdd
+
+# Copy a local native SKILL.md or normalized clawrium directory
+clawctl agent skill add my-agent ./SKILL.md
+clawctl agent skill add my-agent ./my-skill --name incident-review
+```
+
+If `--name` is omitted, Clawrium derives the local name from the validated
+frontmatter `name:` field.
+
+## Sync Skills
+
+`add`, `edit`, and `remove` only change local control-plane state. Push
+that state to the host explicitly:
+
+```bash
+clawctl agent sync my-agent
+```
+
+Sync does not convert formats. It copies each already-agent-native local
+`SKILL.md` into staging unchanged, then runs the agent type's apply
+playbook.
+
+## Edit And Remove
+
+```bash
+clawctl agent skill list my-agent
+clawctl agent skill edit my-agent tdd
+clawctl agent skill remove my-agent tdd
+clawctl agent sync my-agent
+```
+
+`edit` validates the local native `SKILL.md` and restores the prior bytes
+if validation fails. `add` never overwrites an existing local skill; there
+is no `--force`.
+
+## User Overlay Catalog
+
+Use `clawctl skill add` for reusable templates:
+
+```bash
+clawctl skill add ./my-hermes-skill --registry hermes
+clawctl skill registry get
+clawctl agent skill add my-hermes-agent --from-template hermes/my-hermes-skill
+```
+
+Overlay entries live under `~/.config/clawrium/skills/<registry>/<name>/`
+and appear in `skill registry get` / `describe`. An overlay entry wins
+over a bundled catalog entry with the same `<registry>/<name>`.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -42,6 +42,7 @@ const sidebars: SidebarsConfig = {
       collapsed: true,
       items: [
         'skills/intro',
+        'skills/local',
         'skills/authoring',
       ],
     },


### PR DESCRIPTION
## Summary
- Switch skill desired state to agent-local bare names and make sync copy already-native local SKILL.md files unchanged.
- Add the new clawctl skill lifecycle: agent skill add/list/edit/remove, plus top-level skill add for user overlay catalog entries.
- Keep legacy clm/GUI compatibility routes working by materializing templates into local skill files before apply, and update docs for the new add + sync model.
- Fix fleet.py: sanitize LifecycleError paths, remove 0.0.0.0 from _host_is_local, agent_detail via resolve_agent, executor lifecycle in lifespan, lock released before close() in reaper.

## Testing
- \`make lint\`
- \`make test\` (\`3972 passed, 2 skipped\`; GUI \`254 passed\`)
- CI: ubuntu-latest ✅ · macos-14 ✅

## Scope Notes
- Implements issue #411 Phase B from \`.itx/411/01_SCAFFOLD.md\`.
- Phase C GUI UX remains separate; existing GUI compatibility endpoints are adapted to the new bare-name state model.
- Docs build CI failure is pre-existing on \`main\` (broken since 2026-06-07, MDX parse error in \`hermes.md\` unrelated to this PR).

## ATX Review

| Review | Rating | Blocking | Status |
|---|---:|---|---|
| 1 | 2/5 | B1-B6 | Fixed \`5351e2e\` |
| 2 | 2/5 | B1-B6 | Fixed \`16242f3\` |
| 3 | 2/5 | B1-B3 | Fixed \`c9a7e3f\` |
| 4 | 2/5 | B1-B6 (fleet.py coverage) | Fixed \`6eccd46\` |
| 5 | 2/5 | B2-B3 (test assertions) | Fixed \`00e21e9\` |
| 6 | 3/5 | None | Warnings fixed \`d01bfee\` |
| 7 | 2/5 | B1 | Fixed \`147e30d\` |
| 8 | 2/5 | B1 | Fixed \`68d6717\` + CI fix \`f71b712\` |
| 9 | 4/5 | None | Warnings fixed \`9038f98\` |
| **10** | **4/5** | **None** | ✅ **Ready to merge** |

**Final: 4/5, no blocking issues.**

Closes #411

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>