### PR TITLE
feat(gui): #411 Phase C — per-agent local skill lifecycle in GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,21 @@ release.
   attachment while auxiliary attachments remain — detach those first.
   Singleton agents keep the `single-provider invariant` rejection
   message verbatim. (#612, parent #589)
+- GUI: **Add skill** modal on the Agent Detail → Skills tab with three
+  input modes — **From catalog** (template picker), **From file** (paste
+  raw `SKILL.md`), and **Inline** (name + description + body form). Each
+  mode writes a per-agent local skill without immediately syncing the
+  host. (#411)
+- GUI: **Edit** button on `LOCAL`-origin installed skill rows opens an
+  in-browser `SKILL.md` editor; re-validates the schema before writing.
+  (#411)
+- GUI: origin chips (**LOCAL** / **BUNDLED** / **OVERLAY**) on every
+  installed skill row so the provenance of each skill is visible at a
+  glance. (#411)
+- GUI: **Add to catalog** button on the Skills page writes a skill to the
+  user overlay (`~/.config/clawrium/skills/<registry>/<name>/`) via a new
+  `POST /api/skills` endpoint; the skill appears in the catalog picker
+  immediately. (#411)
 
 ### Changed
 

--- a/docs/skills/local.md
+++ b/docs/skills/local.md
@@ -112,3 +112,63 @@ Overlay entries are stored under:
 They appear in `clawctl skill registry get` and `describe` alongside the
 bundled catalog. If an overlay entry has the same `<registry>/<name>` as
 a bundled skill, the overlay wins.
+
+## Using the web UI
+
+The Clawrium GUI surfaces the same per-agent skill lifecycle on the
+**Agent Detail → Skills** tab.
+
+### Adding a skill
+
+Click **Add skill** on the Skills tab to open the add-skill modal. Three
+input modes are available as tabs:
+
+| Tab | What it does |
+|---|---|
+| **From catalog** | Pick any bundled or overlay catalog skill by name and click **Install**. |
+| **From file** | Paste the full contents of a `SKILL.md` file. The skill name is read from the `name:` frontmatter field. |
+| **Inline** | Type a name, description, and optional markdown body directly. |
+
+All three modes write a per-agent local skill immediately, without touching
+the agent host. Click **Sync** (the existing agent Sync control) to flush
+the change to the host.
+
+### Editing an on-agent skill
+
+Only **LOCAL** skills (created via File or Inline mode) show an **Edit**
+button. Click it to open an in-browser editor with the raw `SKILL.md`
+text. Save to update the local copy; Sync to apply on the host.
+
+Catalog-sourced skills (**BUNDLED** or **OVERLAY**) are read-only in the
+editor — remove and re-add them from the catalog picker to update.
+
+### Removing a skill
+
+Click **Remove** on any installed skill row. A confirmation step prevents
+accidental removal. After confirming:
+- The skill is removed from local desired state immediately.
+- The on-host file is pruned on the next **Sync**.
+
+### Adding to the user overlay
+
+To make a skill available across all your agents, click **Add to catalog**
+(top-right of the Skills page) and fill in the registry, name, and
+`SKILL.md` content. The skill appears in the catalog picker with an
+**OVERLAY** origin chip.
+
+### Origin chips
+
+Each installed skill row shows an origin chip:
+
+| Chip | Meaning |
+|---|---|
+| **LOCAL** | Created via File or Inline mode; no source template. |
+| **BUNDLED** | Copied from the bundled in-repo catalog. |
+| **OVERLAY** | Copied from your user overlay catalog. |
+
+### Flushing via Sync
+
+After any add, edit, or remove in the GUI, use the agent's existing
+**Sync** control to apply the changes on the host. The skill endpoints
+do not call `apply_state` automatically — this is by design so you can
+stage multiple changes before a single flush.

--- a/gui/src/app/skills/page.test.tsx
+++ b/gui/src/app/skills/page.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@/hooks", () => ({
   useSkill: () => skillState,
   useFleet: () => ({ data: { agents: [], summary: { total: 0, running: 0, provisioning: 0, hosts: 0 } } }),
   useInstallAgentSkill: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useAddOverlaySkill: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 // The Modal component uses HTMLDialogElement#showModal which jsdom only

--- a/gui/src/app/skills/page.tsx
+++ b/gui/src/app/skills/page.tsx
@@ -5,9 +5,11 @@ import { PageHeader } from "@/components/layout";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui";
 import { SkillCard, SkillDetail } from "@/components/skills";
-import { useSkill, useSkills, useInstallAgentSkill } from "@/hooks";
+import { useSkill, useSkills, useInstallAgentSkill, useAddOverlaySkill } from "@/hooks";
 import { useFleet } from "@/hooks";
 import type { SkillRegistry, SkillSummary } from "@/lib/types";
+
+const REGISTRIES: SkillRegistry[] = ["clawrium", "hermes", "openclaw", "zeroclaw"];
 
 const REGISTRY_LABELS: Record<SkillRegistry, string> = {
   clawrium: "Clawrium",
@@ -22,6 +24,7 @@ export default function SkillsPage() {
     "clawrium",
   );
   const [selected, setSelected] = useState<SkillSummary | null>(null);
+  const [addOverlayOpen, setAddOverlayOpen] = useState(false);
 
   const counts = useMemo(() => {
     if (!catalog) return {} as Record<SkillRegistry, number>;
@@ -37,10 +40,20 @@ export default function SkillsPage() {
 
   return (
     <div className="space-y-6">
-      <PageHeader
-        title="Skills"
-        description="Browse and install skills onto your agents. Skills add capabilities like TDD workflows, code review, and more."
-      />
+      <div className="flex items-start justify-between">
+        <PageHeader
+          title="Skills"
+          description="Browse and install skills onto your agents. Skills add capabilities like TDD workflows, code review, and more."
+        />
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => setAddOverlayOpen(true)}
+          className="mt-1 shrink-0"
+        >
+          Add to catalog
+        </Button>
+      </div>
 
       {error ? (
         <div
@@ -140,7 +153,141 @@ export default function SkillsPage() {
         skill={selected}
         onClose={() => setSelected(null)}
       />
+
+      <AddOverlaySkillModal
+        open={addOverlayOpen}
+        onClose={() => setAddOverlayOpen(false)}
+      />
     </div>
+  );
+}
+
+function AddOverlaySkillModal({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [registry, setRegistry] = useState<SkillRegistry>("clawrium");
+  const [name, setName] = useState("");
+  const [content, setContent] = useState("");
+  const [localError, setLocalError] = useState<string | null>(null);
+  const addMutation = useAddOverlaySkill();
+
+  const handleClose = () => {
+    setRegistry("clawrium");
+    setName("");
+    setContent("");
+    setLocalError(null);
+    onClose();
+  };
+
+  const handleAdd = async () => {
+    setLocalError(null);
+    if (!name.trim()) {
+      setLocalError("Skill name is required.");
+      return;
+    }
+    if (!content.trim()) {
+      setLocalError("SKILL.md content is required.");
+      return;
+    }
+    try {
+      await addMutation.mutateAsync({ registry, name: name.trim(), content });
+      handleClose();
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : "Add failed");
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title="Add skill to user overlay"
+      footer={
+        <div className="flex items-center gap-2">
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleAdd}
+            disabled={addMutation.isPending || !name.trim() || !content.trim()}
+          >
+            {addMutation.isPending ? "Adding…" : "Add skill"}
+          </Button>
+          <Button variant="secondary" size="sm" onClick={handleClose}>
+            Cancel
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-3">
+        {localError ? (
+          <div
+            role="alert"
+            className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+          >
+            {localError}
+          </div>
+        ) : null}
+        <p className="text-xs text-muted">
+          Add a skill to your local user overlay. It will appear in the catalog
+          alongside bundled skills and can be installed on any compatible agent.
+        </p>
+        <div>
+          <label
+            className="block text-xs font-medium text-secondary mb-1"
+            htmlFor="overlay-registry"
+          >
+            Registry
+          </label>
+          <select
+            id="overlay-registry"
+            className="w-full rounded-lg border border-default bg-surface px-3 py-2 text-sm text-primary-text focus:outline-none focus:ring-2 focus:ring-accent"
+            value={registry}
+            onChange={(e) => setRegistry(e.target.value as SkillRegistry)}
+          >
+            {REGISTRIES.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label
+            className="block text-xs font-medium text-secondary mb-1"
+            htmlFor="overlay-name"
+          >
+            Name <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="overlay-name"
+            type="text"
+            className="w-full rounded-lg border border-default bg-surface px-3 py-2 text-sm text-primary-text focus:outline-none focus:ring-2 focus:ring-accent"
+            placeholder="my-skill"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label
+            className="block text-xs font-medium text-secondary mb-1"
+            htmlFor="overlay-content"
+          >
+            SKILL.md content <span className="text-red-500">*</span>
+          </label>
+          <textarea
+            id="overlay-content"
+            className="w-full h-48 rounded-lg border border-default bg-surface p-3 text-sm font-mono text-primary-text resize-y focus:outline-none focus:ring-2 focus:ring-accent"
+            placeholder={"---\nname: my-skill\ndescription: What this skill does\n---\n\n# My Skill\n..."}
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+          />
+        </div>
+      </div>
+    </Modal>
   );
 }
 

--- a/gui/src/components/agent-detail/skills-tab.test.tsx
+++ b/gui/src/components/agent-detail/skills-tab.test.tsx
@@ -19,11 +19,26 @@ const removeMutation = {
   mutateAsync: vi.fn(),
   isPending: false,
 };
+const addMutation = {
+  mutateAsync: vi.fn(),
+  isPending: false,
+};
+const editMutation = {
+  mutateAsync: vi.fn(),
+  isPending: false,
+};
+const removeLocalMutation = {
+  mutateAsync: vi.fn(),
+  isPending: false,
+};
 
 vi.mock("@/hooks", () => ({
   useAgentSkills: () => agentSkillsState,
   useInstallAgentSkill: () => installMutation,
   useRemoveAgentSkill: () => removeMutation,
+  useAddAgentSkill: () => addMutation,
+  useEditAgentSkill: () => editMutation,
+  useRemoveLocalAgentSkill: () => removeLocalMutation,
 }));
 
 vi.mock("@/components/ui/modal", () => ({
@@ -128,14 +143,14 @@ describe("SkillsTab", () => {
   it("opens the install picker filtered to compatible skills", () => {
     agentSkillsState.data = makeAgentSkills();
     render(<SkillsTab agentKey="tdd-hermes" />);
-    fireEvent.click(screen.getByRole("button", { name: /Install skill/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Add skill/ }));
     const modal = screen.getByTestId("modal");
     expect(modal).toBeInTheDocument();
     // The picker shows the available skill that isn't yet installed.
     expect(modal.textContent).toContain("clawrium/tdd");
   });
 
-  it("hides already-installed skills from the picker", () => {
+  it("hides already-installed skills from the template tab picker", () => {
     agentSkillsState.data = makeAgentSkills({
       installed: [
         {
@@ -148,16 +163,20 @@ describe("SkillsTab", () => {
       ],
     });
     render(<SkillsTab agentKey="tdd-hermes" />);
-    // The Install button disables when nothing is available beyond installed.
+    // Add skill button stays enabled — the multi-mode modal always opens.
     expect(
-      screen.getByRole("button", { name: /Install skill/ }),
-    ).toBeDisabled();
+      screen.getByRole("button", { name: /Add skill/ }),
+    ).not.toBeDisabled();
+    // Open the modal and check the template tab shows empty state
+    fireEvent.click(screen.getByRole("button", { name: /Add skill/ }));
+    const modal = screen.getByTestId("modal");
+    expect(modal.textContent).toContain("No compatible skills");
   });
 
   it("calls install mutation with parsed registry+name", async () => {
     agentSkillsState.data = makeAgentSkills();
     render(<SkillsTab agentKey="tdd-hermes" />);
-    fireEvent.click(screen.getByRole("button", { name: /Install skill/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Add skill/ }));
     // Per-row picker button is labeled "Install <ref>" (ATX-1 W7).
     fireEvent.click(
       screen.getByRole("button", { name: /Install clawrium\/tdd/ }),
@@ -245,7 +264,7 @@ describe("SkillsTab", () => {
       .fn()
       .mockRejectedValue(new Error("host unreachable"));
     render(<SkillsTab agentKey="tdd-hermes" />);
-    fireEvent.click(screen.getByRole("button", { name: /Install skill/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Add skill/ }));
     fireEvent.click(
       screen.getAllByRole("button", { name: /Install clawrium\/tdd/ })[0],
     );
@@ -389,7 +408,7 @@ describe("SkillsTab", () => {
     // ATX-1 W9: post-install modal-close path was previously uncovered.
     agentSkillsState.data = makeAgentSkills();
     render(<SkillsTab agentKey="tdd-hermes" />);
-    fireEvent.click(screen.getByRole("button", { name: /Install skill/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Add skill/ }));
     expect(screen.getByTestId("modal")).toBeInTheDocument();
     fireEvent.click(
       screen.getAllByRole("button", { name: /Install clawrium\/tdd/ })[0],

--- a/gui/src/components/agent-detail/skills-tab.tsx
+++ b/gui/src/components/agent-detail/skills-tab.tsx
@@ -8,8 +8,11 @@ import {
   useAgentSkills,
   useInstallAgentSkill,
   useRemoveAgentSkill,
+  useAddAgentSkill,
+  useEditAgentSkill,
+  useRemoveLocalAgentSkill,
 } from "@/hooks";
-import type { AgentSkillRow } from "@/lib/types";
+import type { AgentSkillRow, SkillOrigin } from "@/lib/types";
 
 interface SkillsTabProps {
   agentKey: string;
@@ -20,6 +23,12 @@ const REGISTRY_BADGES: Record<string, { label: string; color: string }> = {
   openclaw: { label: "OC", color: "bg-emerald-100 text-emerald-700" },
   hermes: { label: "HE", color: "bg-violet-100 text-violet-700" },
   zeroclaw: { label: "ZC", color: "bg-amber-100 text-amber-700" },
+};
+
+const ORIGIN_CHIPS: Record<SkillOrigin, { label: string; color: string }> = {
+  local: { label: "LOCAL", color: "bg-gray-100 text-gray-600" },
+  bundled: { label: "BUNDLED", color: "bg-blue-50 text-blue-600" },
+  overlay: { label: "OVERLAY", color: "bg-purple-50 text-purple-600" },
 };
 
 function RegistryBadge({ registry }: { registry: string | null }) {
@@ -36,12 +45,363 @@ function RegistryBadge({ registry }: { registry: string | null }) {
   );
 }
 
+function OriginChip({ origin }: { origin?: SkillOrigin }) {
+  const chip = origin ? ORIGIN_CHIPS[origin] : ORIGIN_CHIPS.local;
+  return (
+    <span
+      className={`inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-semibold tracking-wide ${chip.color}`}
+    >
+      {chip.label}
+    </span>
+  );
+}
+
+type AddTab = "template" | "file" | "inline";
+
+function AddSkillModal({
+  open,
+  onClose,
+  agentKey,
+  agentName,
+  agentType,
+  installable,
+  installMutation,
+  addMutation,
+}: {
+  open: boolean;
+  onClose: () => void;
+  agentKey: string;
+  agentName: string;
+  agentType: string;
+  installable: AgentSkillRow[];
+  installMutation: ReturnType<typeof useInstallAgentSkill>;
+  addMutation: ReturnType<typeof useAddAgentSkill>;
+}) {
+  const [tab, setTab] = useState<AddTab>("template");
+  const [fileContent, setFileContent] = useState("");
+  const [inlineName, setInlineName] = useState("");
+  const [inlineDesc, setInlineDesc] = useState("");
+  const [inlineBody, setInlineBody] = useState("");
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const isPending = installMutation.isPending || addMutation.isPending;
+
+  const handleClose = () => {
+    setTab("template");
+    setFileContent("");
+    setInlineName("");
+    setInlineDesc("");
+    setInlineBody("");
+    setLocalError(null);
+    onClose();
+  };
+
+  const handleInstallTemplate = async (registry: string, name: string) => {
+    setLocalError(null);
+    try {
+      await installMutation.mutateAsync({ agentKey, registry, name });
+      handleClose();
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : "Install failed");
+    }
+  };
+
+  const handleAddFile = async () => {
+    setLocalError(null);
+    if (!fileContent.trim()) {
+      setLocalError("Paste the SKILL.md content above.");
+      return;
+    }
+    try {
+      await addMutation.mutateAsync({
+        agentKey,
+        payload: { input_mode: "file", content: fileContent },
+      });
+      handleClose();
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : "Add failed");
+    }
+  };
+
+  const handleAddInline = async () => {
+    setLocalError(null);
+    if (!inlineName.trim()) {
+      setLocalError("Skill name is required.");
+      return;
+    }
+    try {
+      await addMutation.mutateAsync({
+        agentKey,
+        payload: {
+          input_mode: "inline",
+          name: inlineName.trim(),
+          description: inlineDesc.trim(),
+          body: inlineBody,
+        },
+      });
+      handleClose();
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : "Add failed");
+    }
+  };
+
+  const TABS: { id: AddTab; label: string }[] = [
+    { id: "template", label: "From catalog" },
+    { id: "file", label: "From file" },
+    { id: "inline", label: "Inline" },
+  ];
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title={`Add skill to ${agentName}`}
+      footer={
+        <div className="flex items-center justify-between w-full">
+          <p className="text-xs text-muted">
+            Run{" "}
+            <code className="bg-surface px-1 rounded">
+              clawctl agent sync {agentKey}
+            </code>{" "}
+            to apply.
+          </p>
+          <Button variant="secondary" onClick={handleClose}>
+            Close
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-4">
+        {localError ? (
+          <div
+            role="alert"
+            className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+          >
+            {localError}
+          </div>
+        ) : null}
+
+        <div
+          className="flex border-b border-default"
+          role="tablist"
+          aria-label="Add skill mode"
+        >
+          {TABS.map((t) => (
+            <button
+              key={t.id}
+              role="tab"
+              aria-selected={tab === t.id}
+              onClick={() => {
+                setTab(t.id);
+                setLocalError(null);
+              }}
+              className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+                tab === t.id
+                  ? "border-accent text-accent"
+                  : "border-transparent text-muted hover:text-primary-text"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {tab === "template" && (
+          <SkillPicker
+            installable={installable}
+            onPick={handleInstallTemplate}
+            pending={isPending}
+          />
+        )}
+
+        {tab === "file" && (
+          <div className="space-y-3">
+            <p className="text-xs text-muted">
+              Paste the full contents of a{" "}
+              <code className="bg-surface px-1 rounded">SKILL.md</code> file.
+              The skill name is read from the frontmatter{" "}
+              <code className="bg-surface px-1 rounded">name:</code> field.
+            </p>
+            <textarea
+              className="w-full h-48 rounded-lg border border-default bg-surface p-3 text-sm font-mono text-primary-text resize-y focus:outline-none focus:ring-2 focus:ring-accent"
+              placeholder="---&#10;name: my-skill&#10;description: What this skill does&#10;---&#10;&#10;# My Skill&#10;..."
+              value={fileContent}
+              onChange={(e) => setFileContent(e.target.value)}
+              aria-label="SKILL.md content"
+            />
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleAddFile}
+              disabled={isPending || !fileContent.trim()}
+            >
+              {isPending ? "Adding…" : "Add skill"}
+            </Button>
+          </div>
+        )}
+
+        {tab === "inline" && (
+          <div className="space-y-3">
+            <p className="text-xs text-muted">
+              Create a new skill directly. The skill targets{" "}
+              <strong>{agentType}</strong>. Sync to deploy to the agent host.
+            </p>
+            <div>
+              <label
+                className="block text-xs font-medium text-secondary mb-1"
+                htmlFor="inline-name"
+              >
+                Name <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="inline-name"
+                type="text"
+                className="w-full rounded-lg border border-default bg-surface px-3 py-2 text-sm text-primary-text focus:outline-none focus:ring-2 focus:ring-accent"
+                placeholder="my-skill"
+                value={inlineName}
+                onChange={(e) => setInlineName(e.target.value)}
+              />
+            </div>
+            <div>
+              <label
+                className="block text-xs font-medium text-secondary mb-1"
+                htmlFor="inline-desc"
+              >
+                Description
+              </label>
+              <input
+                id="inline-desc"
+                type="text"
+                className="w-full rounded-lg border border-default bg-surface px-3 py-2 text-sm text-primary-text focus:outline-none focus:ring-2 focus:ring-accent"
+                placeholder="What this skill does"
+                value={inlineDesc}
+                onChange={(e) => setInlineDesc(e.target.value)}
+              />
+            </div>
+            <div>
+              <label
+                className="block text-xs font-medium text-secondary mb-1"
+                htmlFor="inline-body"
+              >
+                Skill body (markdown)
+              </label>
+              <textarea
+                id="inline-body"
+                className="w-full h-32 rounded-lg border border-default bg-surface p-3 text-sm font-mono text-primary-text resize-y focus:outline-none focus:ring-2 focus:ring-accent"
+                placeholder="# My Skill&#10;&#10;Instructions for the agent..."
+                value={inlineBody}
+                onChange={(e) => setInlineBody(e.target.value)}
+              />
+            </div>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleAddInline}
+              disabled={isPending || !inlineName.trim()}
+            >
+              {isPending ? "Adding…" : "Add skill"}
+            </Button>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+function EditSkillModal({
+  open,
+  skillName,
+  initialContent,
+  agentKey,
+  onClose,
+  editMutation,
+}: {
+  open: boolean;
+  skillName: string;
+  initialContent: string;
+  agentKey: string;
+  onClose: () => void;
+  editMutation: ReturnType<typeof useEditAgentSkill>;
+}) {
+  const [content, setContent] = useState(initialContent);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setContent(initialContent);
+      setLocalError(null);
+    }
+  }, [open, initialContent]);
+
+  const handleSave = async () => {
+    setLocalError(null);
+    try {
+      await editMutation.mutateAsync({ agentKey, name: skillName, content });
+      onClose();
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : "Save failed");
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={`Edit skill: ${skillName}`}
+      footer={
+        <div className="flex items-center gap-2">
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleSave}
+            disabled={editMutation.isPending}
+          >
+            {editMutation.isPending ? "Saving…" : "Save"}
+          </Button>
+          <Button variant="secondary" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-3">
+        {localError ? (
+          <div
+            role="alert"
+            className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+          >
+            {localError}
+          </div>
+        ) : null}
+        <p className="text-xs text-muted">
+          Edit the raw <code className="bg-surface px-1 rounded">SKILL.md</code>{" "}
+          content. Run{" "}
+          <code className="bg-surface px-1 rounded">
+            clawctl agent sync {agentKey}
+          </code>{" "}
+          to apply changes on the host.
+        </p>
+        <textarea
+          className="w-full h-64 rounded-lg border border-default bg-surface p-3 text-sm font-mono text-primary-text resize-y focus:outline-none focus:ring-2 focus:ring-accent"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          aria-label="SKILL.md content"
+        />
+      </div>
+    </Modal>
+  );
+}
+
 export function SkillsTab({ agentKey }: SkillsTabProps) {
   const { data, isLoading, error, refetch } = useAgentSkills(agentKey);
   const installMutation = useInstallAgentSkill();
   const removeMutation = useRemoveAgentSkill();
+  const addMutation = useAddAgentSkill();
+  const editMutation = useEditAgentSkill();
+  const removeLocalMutation = useRemoveLocalAgentSkill();
 
-  const [pickerOpen, setPickerOpen] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
+  const [editingSkill, setEditingSkill] = useState<AgentSkillRow | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   const installedRefs = useMemo(
@@ -55,11 +415,6 @@ export function SkillsTab({ agentKey }: SkillsTabProps) {
     [data?.available, installedRefs],
   );
 
-  // ATX-3 W1: the live region is rendered unconditionally at the
-  // SkillsTab root so that the transition from loading → loaded shows
-  // up as a DOM *mutation* (which is what NVDA / JAWS / VoiceOver
-  // actually announce). When the load completes the text flips from
-  // "Loading skills…" to "Skills loaded." once, then clears.
   const [justLoaded, setJustLoaded] = useState(false);
   const wasLoadingRef = useRef(isLoading);
   useEffect(() => {
@@ -74,10 +429,6 @@ export function SkillsTab({ agentKey }: SkillsTabProps) {
 
   const liveRegion = (
     <div
-      // role=status implies aria-live=polite per WAI-ARIA §5.3.1, so
-      // we don't set aria-live explicitly (ATX-3 W2). aria-busy
-      // tracks the load state so ATs that honor it can suppress
-      // partial reads of the subtree below.
       role="status"
       aria-busy={isLoading}
       aria-label="Skills tab status"
@@ -127,20 +478,25 @@ export function SkillsTab({ agentKey }: SkillsTabProps) {
     );
   }
 
-  const handleInstall = async (registry: string, name: string) => {
-    setActionError(null);
-    try {
-      await installMutation.mutateAsync({ agentKey, registry, name });
-      setPickerOpen(false);
-    } catch (err) {
-      setActionError(err instanceof Error ? err.message : "Install failed");
-    }
-  };
+  const anyPending =
+    removeMutation.isPending ||
+    installMutation.isPending ||
+    addMutation.isPending ||
+    removeLocalMutation.isPending;
 
-  const handleRemove = async (registry: string, name: string) => {
+  const handleRemoveCatalog = async (registry: string, name: string) => {
     setActionError(null);
     try {
       await removeMutation.mutateAsync({ agentKey, registry, name });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Remove failed");
+    }
+  };
+
+  const handleRemoveLocal = async (name: string) => {
+    setActionError(null);
+    try {
+      await removeLocalMutation.mutateAsync({ agentKey, name });
     } catch (err) {
       setActionError(err instanceof Error ? err.message : "Remove failed");
     }
@@ -173,18 +529,16 @@ export function SkillsTab({ agentKey }: SkillsTabProps) {
           <Button
             variant="primary"
             size="sm"
-            onClick={() => setPickerOpen(true)}
-            disabled={installable.length === 0}
+            onClick={() => setAddOpen(true)}
           >
-            Install skill
+            Add skill
           </Button>
         </div>
 
         {data.installed.length === 0 ? (
           <div className="py-8 text-center text-sm text-muted">
             No skills installed yet. Click{" "}
-            <span className="font-medium">Install skill</span> to add one from
-            the catalog.
+            <span className="font-medium">Add skill</span> to add one.
           </div>
         ) : (
           <ul
@@ -196,63 +550,75 @@ export function SkillsTab({ agentKey }: SkillsTabProps) {
               <InstalledRow
                 key={row.ref}
                 row={row}
-                onRemove={handleRemove}
-                disabled={removeMutation.isPending || installMutation.isPending}
+                onRemoveCatalog={handleRemoveCatalog}
+                onRemoveLocal={handleRemoveLocal}
+                onEdit={() => setEditingSkill(row)}
+                disabled={anyPending}
               />
             ))}
           </ul>
         )}
       </Card>
 
-      <Modal
-        open={pickerOpen}
-        onClose={() => setPickerOpen(false)}
-        title={`Install skill on ${data.agent_name}`}
-        footer={
-          <Button variant="secondary" onClick={() => setPickerOpen(false)}>
-            Close
-          </Button>
-        }
-      >
-        <SkillPicker
-          installable={installable}
-          onPick={handleInstall}
-          pending={installMutation.isPending}
+      <AddSkillModal
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        agentKey={agentKey}
+        agentName={data.agent_name}
+        agentType={data.agent_type}
+        installable={installable}
+        installMutation={installMutation}
+        addMutation={addMutation}
+      />
+
+      {editingSkill?.name ? (
+        <EditSkillModal
+          open={!!editingSkill}
+          skillName={editingSkill.name}
+          initialContent={`---\nname: ${editingSkill.name}\ndescription: ${editingSkill.description ?? ""}\n---\n\n`}
+          agentKey={agentKey}
+          onClose={() => setEditingSkill(null)}
+          editMutation={editMutation}
         />
-      </Modal>
+      ) : null}
     </div>
   );
 }
 
 function InstalledRow({
   row,
-  onRemove,
+  onRemoveCatalog,
+  onRemoveLocal,
+  onEdit,
   disabled,
 }: {
   row: AgentSkillRow;
-  onRemove: (registry: string, name: string) => void;
+  onRemoveCatalog: (registry: string, name: string) => void;
+  onRemoveLocal: (name: string) => void;
+  onEdit: () => void;
   disabled: boolean;
 }) {
-  // ATX-1 B2: remove is destructive (re-running install brings the host
-  // back in sync, but the desired-state file is mutated immediately).
-  // First click arms the confirm/cancel pair instead of firing the
-  // mutation directly. Confirm button carries the skill ref in its
-  // accessible name so a screen-reader scan can't conflate two rows.
   const [confirming, setConfirming] = useState(false);
-  const canRemove = !!row.registry && !!row.name;
-  // ATX-2 B2a: focus the Confirm button when the row enters the
-  // confirming state — without this a keyboard user has no indication
-  // that anything happened on the first click.
+  const isLocal = row.origin === "local" || !row.registry;
+  const canRemove = isLocal ? !!row.name : !!row.registry && !!row.name;
+
   const confirmRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
     if (confirming) confirmRef.current?.focus();
   }, [confirming]);
-  // ATX-2 W3: if a concurrent install/remove disables the row while a
-  // confirm is open, drop back to the un-armed state so the user
-  // doesn't see a stuck/disabled Confirm button.
   useEffect(() => {
     if (disabled && confirming) setConfirming(false);
   }, [disabled, confirming]);
+
+  const handleConfirmRemove = () => {
+    if (!canRemove) return;
+    setConfirming(false);
+    if (isLocal) {
+      onRemoveLocal(row.name!);
+    } else {
+      onRemoveCatalog(row.registry!, row.name!);
+    }
+  };
 
   return (
     <li className="flex items-start gap-3 px-4 py-3">
@@ -265,6 +631,7 @@ function InstalledRow({
           {row.version ? (
             <span className="text-xs text-muted">v{row.version}</span>
           ) : null}
+          <OriginChip origin={row.origin} />
         </div>
         {row.description ? (
           <p className="mt-0.5 text-xs text-secondary line-clamp-2">
@@ -272,64 +639,62 @@ function InstalledRow({
           </p>
         ) : null}
       </div>
-      {confirming ? (
-        <div
-          className="flex items-center gap-2"
-          role="group"
-          aria-label={`Confirm removal of ${row.ref}`}
-          // ATX-2 B2b + ATX-3 W5: ARIA APG requires confirm patterns
-          // to support Escape. The native <dialog> handles this for
-          // the picker modal; this inline group needs an explicit
-          // handler. preventDefault (not stopPropagation) — we're
-          // saying "I handled this Escape" without silencing
-          // ancestor JS listeners (toasts, command palettes, etc.).
-          onKeyDown={(e) => {
-            if (e.key === "Escape") {
-              e.preventDefault();
-              setConfirming(false);
-            }
-          }}
-        >
-          <span className="text-xs text-secondary">Remove {row.ref}?</span>
-          <Button
-            ref={confirmRef}
-            variant="danger"
-            size="sm"
-            // S4: confirming is cleared SYNCHRONOUSLY here (before
-            // the async mutation fires), so an Escape key arriving
-            // mid-mutation cannot race the removal — the group is
-            // already gone. Don't move this to onSettled / onSuccess.
-            onClick={() => {
-              if (canRemove) {
-                setConfirming(false);
-                onRemove(row.registry!, row.name!);
-              }
-            }}
-            disabled={disabled || !canRemove}
-            aria-label={`Confirm remove ${row.ref}`}
-          >
-            Confirm
-          </Button>
+      <div className="flex items-center gap-1 shrink-0">
+        {isLocal && !confirming ? (
           <Button
             variant="secondary"
             size="sm"
-            onClick={() => setConfirming(false)}
-            aria-label={`Cancel remove ${row.ref}`}
+            onClick={onEdit}
+            disabled={disabled}
+            aria-label={`Edit ${row.ref}`}
           >
-            Cancel
+            Edit
           </Button>
-        </div>
-      ) : (
-        <Button
-          variant="danger"
-          size="sm"
-          onClick={() => setConfirming(true)}
-          disabled={disabled || !canRemove}
-          aria-label={`Remove ${row.ref}`}
-        >
-          Remove
-        </Button>
-      )}
+        ) : null}
+        {confirming ? (
+          <div
+            className="flex items-center gap-2"
+            role="group"
+            aria-label={`Confirm removal of ${row.ref}`}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                e.preventDefault();
+                setConfirming(false);
+              }
+            }}
+          >
+            <span className="text-xs text-secondary">Remove {row.ref}?</span>
+            <Button
+              ref={confirmRef}
+              variant="danger"
+              size="sm"
+              onClick={handleConfirmRemove}
+              disabled={disabled || !canRemove}
+              aria-label={`Confirm remove ${row.ref}`}
+            >
+              Confirm
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setConfirming(false)}
+              aria-label={`Cancel remove ${row.ref}`}
+            >
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={() => setConfirming(true)}
+            disabled={disabled || !canRemove}
+            aria-label={`Remove ${row.ref}`}
+          >
+            Remove
+          </Button>
+        )}
+      </div>
     </li>
   );
 }

--- a/gui/src/components/agent-detail/skills-tab.tsx
+++ b/gui/src/components/agent-detail/skills-tab.tsx
@@ -47,7 +47,7 @@ function RegistryBadge({ registry }: { registry: string | null }) {
 }
 
 function OriginChip({ origin }: { origin?: SkillOrigin }) {
-  const chip = origin ? ORIGIN_CHIPS[origin] : ORIGIN_CHIPS.local;
+  const chip = (origin && ORIGIN_CHIPS[origin]) ?? ORIGIN_CHIPS.local;
   return (
     <span
       className={`inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-semibold tracking-wide ${chip.color}`}

--- a/gui/src/components/agent-detail/skills-tab.tsx
+++ b/gui/src/components/agent-detail/skills-tab.tsx
@@ -12,6 +12,7 @@ import {
   useEditAgentSkill,
   useRemoveLocalAgentSkill,
 } from "@/hooks";
+import { api } from "@/lib/api";
 import type { AgentSkillRow, SkillOrigin } from "@/lib/types";
 
 interface SkillsTabProps {
@@ -311,27 +312,35 @@ function AddSkillModal({
 function EditSkillModal({
   open,
   skillName,
-  initialContent,
   agentKey,
   onClose,
   editMutation,
 }: {
   open: boolean;
   skillName: string;
-  initialContent: string;
   agentKey: string;
   onClose: () => void;
   editMutation: ReturnType<typeof useEditAgentSkill>;
 }) {
-  const [content, setContent] = useState(initialContent);
+  const [content, setContent] = useState("");
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [localError, setLocalError] = useState<string | null>(null);
+  const [fetchLoading, setFetchLoading] = useState(false);
 
   useEffect(() => {
-    if (open) {
-      setContent(initialContent);
-      setLocalError(null);
-    }
-  }, [open, initialContent]);
+    if (!open || !skillName) return;
+    setContent("");
+    setFetchError(null);
+    setLocalError(null);
+    setFetchLoading(true);
+    api
+      .getLocalAgentSkill(agentKey, skillName)
+      .then((res) => setContent(res.content))
+      .catch((err) =>
+        setFetchError(err instanceof Error ? err.message : "Failed to load skill"),
+      )
+      .finally(() => setFetchLoading(false));
+  }, [open, agentKey, skillName]);
 
   const handleSave = async () => {
     setLocalError(null);
@@ -354,7 +363,7 @@ function EditSkillModal({
             variant="primary"
             size="sm"
             onClick={handleSave}
-            disabled={editMutation.isPending}
+            disabled={editMutation.isPending || fetchLoading || !!fetchError}
           >
             {editMutation.isPending ? "Saving…" : "Save"}
           </Button>
@@ -365,6 +374,14 @@ function EditSkillModal({
       }
     >
       <div className="space-y-3">
+        {fetchError ? (
+          <div
+            role="alert"
+            className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+          >
+            Failed to load skill: {fetchError}
+          </div>
+        ) : null}
         {localError ? (
           <div
             role="alert"
@@ -381,12 +398,17 @@ function EditSkillModal({
           </code>{" "}
           to apply changes on the host.
         </p>
-        <textarea
-          className="w-full h-64 rounded-lg border border-default bg-surface p-3 text-sm font-mono text-primary-text resize-y focus:outline-none focus:ring-2 focus:ring-accent"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          aria-label="SKILL.md content"
-        />
+        {fetchLoading ? (
+          <div className="h-64 rounded-lg border border-default bg-surface animate-pulse" />
+        ) : (
+          <textarea
+            className="w-full h-64 rounded-lg border border-default bg-surface p-3 text-sm font-mono text-primary-text resize-y focus:outline-none focus:ring-2 focus:ring-accent"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            aria-label="SKILL.md content"
+            disabled={!!fetchError}
+          />
+        )}
       </div>
     </Modal>
   );
@@ -575,7 +597,6 @@ export function SkillsTab({ agentKey }: SkillsTabProps) {
         <EditSkillModal
           open={!!editingSkill}
           skillName={editingSkill.name}
-          initialContent={`---\nname: ${editingSkill.name}\ndescription: ${editingSkill.description ?? ""}\n---\n\n`}
           agentKey={agentKey}
           onClose={() => setEditingSkill(null)}
           editMutation={editMutation}

--- a/gui/src/components/agent-detail/skills-tab.tsx
+++ b/gui/src/components/agent-detail/skills-tab.tsx
@@ -329,17 +329,20 @@ function EditSkillModal({
 
   useEffect(() => {
     if (!open || !skillName) return;
+    let cancelled = false;
     setContent("");
     setFetchError(null);
     setLocalError(null);
     setFetchLoading(true);
     api
       .getLocalAgentSkill(agentKey, skillName)
-      .then((res) => setContent(res.content))
-      .catch((err) =>
-        setFetchError(err instanceof Error ? err.message : "Failed to load skill"),
-      )
-      .finally(() => setFetchLoading(false));
+      .then((res) => { if (!cancelled) setContent(res.content); })
+      .catch((err) => {
+        if (!cancelled)
+          setFetchError(err instanceof Error ? err.message : "Failed to load skill");
+      })
+      .finally(() => { if (!cancelled) setFetchLoading(false); });
+    return () => { cancelled = true; };
   }, [open, agentKey, skillName]);
 
   const handleSave = async () => {

--- a/gui/src/hooks/index.ts
+++ b/gui/src/hooks/index.ts
@@ -27,4 +27,8 @@ export {
   useAgentSkills,
   useInstallAgentSkill,
   useRemoveAgentSkill,
+  useAddAgentSkill,
+  useEditAgentSkill,
+  useRemoveLocalAgentSkill,
+  useAddOverlaySkill,
 } from "./use-skills";

--- a/gui/src/hooks/use-skills.ts
+++ b/gui/src/hooks/use-skills.ts
@@ -62,3 +62,72 @@ export function useRemoveAgentSkill() {
     },
   });
 }
+
+export function useAddAgentSkill() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      agentKey,
+      payload,
+    }: {
+      agentKey: string;
+      payload: Parameters<typeof api.addAgentSkill>[1];
+    }) => api.addAgentSkill(agentKey, payload),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({
+        queryKey: ["agent-skills", vars.agentKey],
+      });
+    },
+  });
+}
+
+export function useEditAgentSkill() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      agentKey,
+      name,
+      content,
+    }: {
+      agentKey: string;
+      name: string;
+      content: string;
+    }) => api.editAgentSkill(agentKey, name, content),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({
+        queryKey: ["agent-skills", vars.agentKey],
+      });
+    },
+  });
+}
+
+export function useRemoveLocalAgentSkill() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ agentKey, name }: { agentKey: string; name: string }) =>
+      api.removeLocalAgentSkill(agentKey, name),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({
+        queryKey: ["agent-skills", vars.agentKey],
+      });
+    },
+  });
+}
+
+export function useAddOverlaySkill() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      registry,
+      name,
+      content,
+    }: {
+      registry: string;
+      name: string;
+      content: string;
+    }) => api.addOverlaySkill(registry, name, content),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["skills"] });
+    },
+  });
+}

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -256,6 +256,40 @@ export const api = {
       )}/${encodeURIComponent(name)}`,
       { method: "DELETE" },
     ),
+
+  // Phase C: per-agent local skill lifecycle
+  addAgentSkill: (
+    key: string,
+    payload: {
+      input_mode: "template" | "file" | "inline";
+      registry?: string;
+      name?: string;
+      content?: string;
+      description?: string;
+      body?: string;
+    },
+  ) =>
+    request<AddLocalSkillResponse>(
+      `/agents/${encodeURIComponent(key)}/skills`,
+      { method: "POST", body: JSON.stringify(payload) },
+    ),
+  editAgentSkill: (key: string, name: string, content: string) =>
+    request<AddLocalSkillResponse>(
+      `/agents/${encodeURIComponent(key)}/skills/local/${encodeURIComponent(name)}`,
+      { method: "PUT", body: JSON.stringify({ content }) },
+    ),
+  removeLocalAgentSkill: (key: string, name: string) =>
+    request<AddLocalSkillResponse>(
+      `/agents/${encodeURIComponent(key)}/skills/local/${encodeURIComponent(name)}`,
+      { method: "DELETE" },
+    ),
+
+  // Phase C: user overlay catalog write
+  addOverlaySkill: (registry: string, name: string, content: string) =>
+    request<AddOverlaySkillResponse>("/skills", {
+      method: "POST",
+      body: JSON.stringify({ registry, name, content }),
+    }),
 };
 
 // Type imports (re-exported from types.ts for convenience)
@@ -291,4 +325,6 @@ import type {
   SkillDetail,
   AgentSkills,
   AgentSkillMutationResponse,
+  AddLocalSkillResponse,
+  AddOverlaySkillResponse,
 } from "./types";

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -258,6 +258,10 @@ export const api = {
     ),
 
   // Phase C: per-agent local skill lifecycle
+  getLocalAgentSkill: (key: string, name: string) =>
+    request<{ agent_name: string; skill_name: string; content: string }>(
+      `/agents/${encodeURIComponent(key)}/skills/local/${encodeURIComponent(name)}`,
+    ),
   addAgentSkill: (
     key: string,
     payload: {

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -410,12 +410,16 @@ export interface SkillDetail {
 // Per-agent skills (Phase 5). Both installed and available rows reuse
 // SkillSummary but allow `registry`/`name` to be null on installed rows
 // when the state file carries a ref that no longer parses.
+export type SkillOrigin = "local" | "bundled" | "overlay";
+
 export interface AgentSkillRow {
   ref: string;
   registry: SkillRegistry | null;
   name: string | null;
   description: string | null;
   version: string | null;
+  /** Phase C: where this skill came from — local (no template), bundled catalog, or user overlay. */
+  origin?: SkillOrigin;
 }
 
 export interface AgentSkills {
@@ -431,4 +435,15 @@ export interface AgentSkillMutationResponse {
   ref: string;
   changed: boolean;
   installed: string[];
+}
+
+export interface AddLocalSkillResponse {
+  success: boolean;
+  agent_name: string;
+  skill_name: string;
+}
+
+export interface AddOverlaySkillResponse {
+  success: boolean;
+  ref: string;
 }

--- a/src/clawrium/gui/routes/agents.py
+++ b/src/clawrium/gui/routes/agents.py
@@ -49,6 +49,8 @@ from clawrium.core.skills import (
     SkillError,
     SkillNotFound,
     SkillRef,
+    _overlay_root,
+    _split_frontmatter,
     check_agent_compatibility,
     load_agent_skill,
     list_skills,
@@ -56,6 +58,7 @@ from clawrium.core.skills import (
     materialize_skill_for_agent,
     parse_skill_ref,
     render_skill_md,
+    validate_skill,
     with_source_ref,
 )
 from clawrium.core.skills_apply import (
@@ -407,6 +410,19 @@ def _list_available_for_agent_type(agent_type: str) -> list[dict[str, object]]:
     return available
 
 
+def _origin_for_local_skill(local_skill: Skill) -> str:
+    """Return "local", "bundled", or "overlay" based on source metadata."""
+    raw_source = local_skill.skill_md_frontmatter.get(SOURCE_REF_FIELD)
+    if not isinstance(raw_source, str):
+        return "local"
+    try:
+        source_ref = parse_skill_ref(raw_source)
+    except SkillError:
+        return "local"
+    overlay_dir = _overlay_root() / source_ref.registry / source_ref.name
+    return "overlay" if overlay_dir.exists() else "bundled"
+
+
 def _source_ref_for_local_skill(local_skill: Skill, name: str) -> SkillRef:
     raw_source = local_skill.skill_md_frontmatter.get(SOURCE_REF_FIELD)
     if isinstance(raw_source, str):
@@ -486,6 +502,7 @@ async def list_agent_skills(agent_key: str):
         for name in installed_names:
             description: str | None = None
             version: str | None = None
+            origin: str = "local"
             try:
                 local_skill = load_agent_skill(agent_name, name, agent_type)
             except SkillError:
@@ -500,6 +517,7 @@ async def list_agent_skills(agent_key: str):
                 installed_ref = _source_ref_for_local_skill(local_skill, name)
                 registry = installed_ref.registry
                 ref_text = str(installed_ref)
+                origin = _origin_for_local_skill(local_skill)
             if local_skill is None:
                 registry = "local"
                 ref_text = name
@@ -510,6 +528,7 @@ async def list_agent_skills(agent_key: str):
                     "name": name,
                     "description": description,
                     "version": version,
+                    "origin": origin,
                 }
             )
         available = _list_available_for_agent_type(agent_type)
@@ -625,6 +644,239 @@ async def remove_agent_skill(agent_key: str, registry: str, skill: str):
     return await asyncio.to_thread(
         _install_or_remove, agent_key, registry, skill, action="remove"
     )
+
+
+class AddSkillBody(BaseModel):
+    input_mode: str  # "template" | "file" | "inline"
+    # template mode
+    registry: str | None = None
+    name: str | None = None
+    # file mode
+    content: str | None = None
+    # inline mode
+    description: str | None = None
+    body: str | None = None
+
+
+class EditSkillBody(BaseModel):
+    content: str  # full SKILL.md text
+
+
+@router.post("/{agent_key}/skills")
+async def add_agent_skill(agent_key: str, payload: AddSkillBody):
+    """Add a per-agent local skill (template / file / inline).
+
+    Does NOT call apply_state — flush via ``clawctl agent sync`` or the GUI
+    Sync control. Returns immediately after writing local state.
+
+    Input modes:
+    - ``template``: copy and materialize a catalog skill.
+    - ``file``: parse and materialize SKILL.md text provided in ``content``.
+    - ``inline``: build a skill from ``name``, ``description``, and optional ``body``.
+    """
+
+    def _add() -> dict[str, object]:
+        resolved = _resolve_agent(agent_key)
+        if not resolved:
+            raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
+        _host_record, agent_type, agent_record = resolved
+        agent_name = agent_record.get("agent_name") or agent_key
+
+        try:
+            if payload.input_mode == "template":
+                if not payload.registry or not payload.name:
+                    raise HTTPException(
+                        status_code=422,
+                        detail="template mode requires registry and name",
+                    )
+                raw_ref = f"{payload.registry}/{payload.name}"
+                ref = parse_skill_ref(raw_ref)
+                template = load_skill(ref)
+                skill = materialize_skill_for_agent(template, agent_type)
+                skill = with_source_ref(skill, raw_ref)
+                skill_name = ref.name
+
+            elif payload.input_mode == "file":
+                if not payload.content:
+                    raise HTTPException(
+                        status_code=422, detail="file mode requires content"
+                    )
+                body_text, fm = _split_frontmatter(payload.content)
+                skill_name = payload.name or fm.get("name") or ""
+                if not skill_name:
+                    raise HTTPException(
+                        status_code=422,
+                        detail="skill name missing — provide --name or include name: in frontmatter",
+                    )
+                raw_skill = Skill(
+                    ref=SkillRef(agent_type, skill_name),
+                    path=None,
+                    metadata=fm,
+                    body=body_text,
+                    skill_md_frontmatter=fm,
+                )
+                skill = materialize_skill_for_agent(raw_skill, agent_type)
+
+            elif payload.input_mode == "inline":
+                if not payload.name:
+                    raise HTTPException(
+                        status_code=422, detail="inline mode requires name"
+                    )
+                skill_name = payload.name
+                fm = {
+                    "name": skill_name,
+                    "description": payload.description or "",
+                }
+                raw_skill = Skill(
+                    ref=SkillRef(agent_type, skill_name),
+                    path=None,
+                    metadata=fm,
+                    body=payload.body or "",
+                    skill_md_frontmatter=fm,
+                )
+                skill = materialize_skill_for_agent(raw_skill, agent_type)
+
+            else:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"unknown input_mode {payload.input_mode!r}",
+                )
+
+            validate_skill(skill)
+
+            if agent_skills_dir(agent_name) / skill_name:
+                target = agent_skills_dir(agent_name) / skill_name
+                if target.exists() or skill_name in read_state(agent_name):
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"Local skill '{skill_name}' already exists for agent '{agent_name}'. "
+                            "Remove or rename it first."
+                        ),
+                    )
+
+            add_skill(agent_name, skill_name)
+            try:
+                _write_agent_local_skill(agent_name, skill_name, skill)
+            except FileExistsError as error:
+                _rollback_local_install(agent_name, skill_name)
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Local skill '{skill_name}' already exists for agent '{agent_name}'.",
+                ) from error
+            except OSError as error:
+                _rollback_local_install(agent_name, skill_name)
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Failed to persist local skill '{skill_name}'.",
+                ) from error
+
+        except SkillError as error:
+            raise HTTPException(
+                status_code=_skill_error_status(error),
+                detail=_skill_error_detail(error),
+            ) from error
+
+        return {"success": True, "agent_name": agent_name, "skill_name": skill_name}
+
+    return await asyncio.to_thread(_add)
+
+
+@router.put("/{agent_key}/skills/local/{name}")
+async def edit_agent_skill(agent_key: str, name: str, payload: EditSkillBody):
+    """Replace the body of a per-agent local skill.
+
+    Re-validates against the target agent's native schema before writing.
+    Does NOT call apply_state.
+    """
+
+    def _edit() -> dict[str, object]:
+        resolved = _resolve_agent(agent_key)
+        if not resolved:
+            raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
+        _host_record, agent_type, agent_record = resolved
+        agent_name = agent_record.get("agent_name") or agent_key
+
+        target = agent_skills_dir(agent_name) / name / "SKILL.md"
+        if not target.exists():
+            raise HTTPException(
+                status_code=404,
+                detail=f"Local skill '{name}' not found for agent '{agent_name}'.",
+            )
+
+        try:
+            body_text, fm = _split_frontmatter(payload.content)
+            edited = Skill(
+                ref=SkillRef(agent_type, name),
+                path=None,
+                metadata=fm,
+                body=body_text,
+                skill_md_frontmatter=fm,
+            )
+            skill = materialize_skill_for_agent(edited, agent_type)
+            validate_skill(skill)
+        except SkillError as error:
+            raise HTTPException(
+                status_code=_skill_error_status(error),
+                detail=_skill_error_detail(error),
+            ) from error
+
+        tmp = target.parent / ".SKILL.md.tmp"
+        try:
+            tmp.write_text(render_skill_md(skill), encoding="utf-8")
+            tmp.replace(target)
+        except OSError as error:
+            tmp.unlink(missing_ok=True)
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to write local skill '{name}'.",
+            ) from error
+
+        return {"success": True, "agent_name": agent_name, "skill_name": name}
+
+    return await asyncio.to_thread(_edit)
+
+
+@router.delete("/{agent_key}/skills/local/{name}")
+async def delete_local_agent_skill(agent_key: str, name: str):
+    """Remove a per-agent local skill from state and disk.
+
+    Does NOT call apply_state — the skill file is still on the agent host
+    until the next ``clawctl agent sync``.
+    """
+
+    def _delete() -> dict[str, object]:
+        resolved = _resolve_agent(agent_key)
+        if not resolved:
+            raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
+        _host_record, _agent_type, agent_record = resolved
+        agent_name = agent_record.get("agent_name") or agent_key
+
+        try:
+            current = read_state(agent_name)
+        except SkillError as error:
+            raise HTTPException(
+                status_code=500, detail="Failed to read skill state."
+            ) from error
+
+        if name not in current:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Local skill '{name}' not found in desired state for '{agent_name}'.",
+            )
+
+        try:
+            remove_skill(agent_name, name)
+        except SkillError as error:
+            raise HTTPException(
+                status_code=_skill_error_status(error),
+                detail=_skill_error_detail(error),
+            ) from error
+
+        shutil.rmtree(agent_skills_dir(agent_name) / name, ignore_errors=True)
+        return {"success": True, "agent_name": agent_name, "skill_name": name}
+
+    return await asyncio.to_thread(_delete)
 
 
 # --- Internal helpers ---

--- a/src/clawrium/gui/routes/agents.py
+++ b/src/clawrium/gui/routes/agents.py
@@ -15,6 +15,8 @@ import shlex
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import StreamingResponse
+from typing import Literal
+
 from pydantic import BaseModel
 
 from clawrium.core.keys import get_host_private_key
@@ -68,6 +70,7 @@ from clawrium.core.skills_apply import (
     apply_state,
 )
 from clawrium.core.skills_state import (
+    _validate_skill_name,
     add_skill,
     agent_skills_dir,
     read_state,
@@ -647,7 +650,7 @@ async def remove_agent_skill(agent_key: str, registry: str, skill: str):
 
 
 class AddSkillBody(BaseModel):
-    input_mode: str  # "template" | "file" | "inline"
+    input_mode: Literal["template", "file", "inline"]
     # template mode
     registry: str | None = None
     name: str | None = None
@@ -744,16 +747,15 @@ async def add_agent_skill(agent_key: str, payload: AddSkillBody):
 
             validate_skill(skill)
 
-            if agent_skills_dir(agent_name) / skill_name:
-                target = agent_skills_dir(agent_name) / skill_name
-                if target.exists() or skill_name in read_state(agent_name):
-                    raise HTTPException(
-                        status_code=409,
-                        detail=(
-                            f"Local skill '{skill_name}' already exists for agent '{agent_name}'. "
-                            "Remove or rename it first."
-                        ),
-                    )
+            target = agent_skills_dir(agent_name) / skill_name
+            if target.exists() or skill_name in read_state(agent_name):
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Local skill '{skill_name}' already exists for agent '{agent_name}'. "
+                        "Remove or rename it first."
+                    ),
+                )
 
             add_skill(agent_name, skill_name)
             try:
@@ -782,6 +784,43 @@ async def add_agent_skill(agent_key: str, payload: AddSkillBody):
     return await asyncio.to_thread(_add)
 
 
+@router.get("/{agent_key}/skills/local/{name}")
+async def get_local_agent_skill(agent_key: str, name: str):
+    """Return the raw SKILL.md text for a per-agent local skill.
+
+    Used by the GUI Edit modal to seed the textarea with the current
+    on-disk content before the user makes changes.
+    """
+
+    def _get() -> dict[str, object]:
+        try:
+            _validate_skill_name(name)
+        except InvalidSkillRef as error:
+            raise HTTPException(status_code=422, detail=str(error)) from error
+
+        resolved = _resolve_agent(agent_key)
+        if not resolved:
+            raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
+        _host_record, _agent_type, agent_record = resolved
+        agent_name = agent_record.get("agent_name") or agent_key
+
+        target = agent_skills_dir(agent_name) / name / "SKILL.md"
+        if not target.exists():
+            raise HTTPException(
+                status_code=404,
+                detail=f"Local skill '{name}' not found for agent '{agent_name}'.",
+            )
+        try:
+            content = target.read_text(encoding="utf-8")
+        except OSError as error:
+            raise HTTPException(
+                status_code=500, detail=f"Failed to read local skill '{name}'."
+            ) from error
+        return {"agent_name": agent_name, "skill_name": name, "content": content}
+
+    return await asyncio.to_thread(_get)
+
+
 @router.put("/{agent_key}/skills/local/{name}")
 async def edit_agent_skill(agent_key: str, name: str, payload: EditSkillBody):
     """Replace the body of a per-agent local skill.
@@ -791,6 +830,11 @@ async def edit_agent_skill(agent_key: str, name: str, payload: EditSkillBody):
     """
 
     def _edit() -> dict[str, object]:
+        try:
+            _validate_skill_name(name)
+        except InvalidSkillRef as error:
+            raise HTTPException(status_code=422, detail=str(error)) from error
+
         resolved = _resolve_agent(agent_key)
         if not resolved:
             raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
@@ -846,6 +890,11 @@ async def delete_local_agent_skill(agent_key: str, name: str):
     """
 
     def _delete() -> dict[str, object]:
+        try:
+            _validate_skill_name(name)
+        except InvalidSkillRef as error:
+            raise HTTPException(status_code=422, detail=str(error)) from error
+
         resolved = _resolve_agent(agent_key)
         if not resolved:
             raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")

--- a/src/clawrium/gui/routes/skills.py
+++ b/src/clawrium/gui/routes/skills.py
@@ -18,9 +18,11 @@ Status mapping for ``SkillError`` subclasses:
 
 import asyncio
 import logging
+import shutil
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Path as FastAPIPath
+from pydantic import BaseModel
 
 from clawrium.core.skills import (
     NATIVE_REGISTRIES,
@@ -29,12 +31,16 @@ from clawrium.core.skills import (
     InvalidSkillRef,
     MissingRegistryPrefix,
     SchemaValidationError,
+    Skill,
     SkillError,
     SkillNotFound,
     SkillRef,
+    _overlay_root,
+    _split_frontmatter,
     list_skills,
     load_skill,
     parse_skill_ref,
+    render_skill_md,
     validate_skill,
 )
 
@@ -308,3 +314,80 @@ async def get_skill_route(
     # needed. A bare `await` here keeps the call path clean and lets a
     # truly unhandled exception 500 visibly rather than silently swallow.
     return await asyncio.to_thread(_resolve)
+
+
+class AddOverlaySkillBody(BaseModel):
+    registry: str
+    name: str
+    content: str  # full SKILL.md text
+
+
+@router.post("")
+async def add_overlay_skill(payload: AddOverlaySkillBody) -> dict[str, Any]:
+    """Write a skill to the user overlay catalog.
+
+    Validates against the per-registry schema; rejects 422 on schema
+    failure and 409 on existing overlay collision.
+    """
+
+    def _write() -> dict[str, Any]:
+        if payload.registry not in REGISTRIES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unknown registry {payload.registry!r}. Must be one of {sorted(REGISTRIES)}.",
+            )
+
+        target_dir = _overlay_root() / payload.registry / payload.name
+        if target_dir.exists():
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Skill {payload.registry}/{payload.name} already exists in the user overlay. "
+                    "Remove or rename it before adding a replacement."
+                ),
+            )
+
+        try:
+            body_text, fm = _split_frontmatter(payload.content)
+        except Exception as error:
+            raise HTTPException(
+                status_code=422, detail=f"Failed to parse SKILL.md: {error}"
+            ) from error
+
+        fm.setdefault("name", payload.name)
+        skill = Skill(
+            ref=SkillRef(payload.registry, payload.name),
+            path=None,
+            metadata=fm,
+            body=body_text,
+            skill_md_frontmatter=fm,
+        )
+
+        try:
+            validate_skill(skill)
+        except SkillError as error:
+            raise HTTPException(
+                status_code=422, detail=str(error)
+            ) from error
+
+        tmp_dir = target_dir.parent / f".{payload.name}.tmp"
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        try:
+            tmp_dir.mkdir(parents=True, exist_ok=False)
+            (tmp_dir / "SKILL.md").write_text(render_skill_md(skill), encoding="utf-8")
+            tmp_dir.rename(target_dir)
+        except FileExistsError as error:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            raise HTTPException(
+                status_code=409,
+                detail=f"Skill {payload.registry}/{payload.name} already exists in the user overlay.",
+            ) from error
+        except OSError as error:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            raise HTTPException(
+                status_code=500, detail="Failed to write skill to overlay."
+            ) from error
+
+        return {"success": True, "ref": f"{payload.registry}/{payload.name}"}
+
+    return await asyncio.to_thread(_write)

--- a/src/clawrium/gui/routes/skills.py
+++ b/src/clawrium/gui/routes/skills.py
@@ -24,6 +24,8 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Path as FastAPIPath
 from pydantic import BaseModel
 
+import yaml
+
 from clawrium.core.skills import (
     NATIVE_REGISTRIES,
     REGISTRIES,
@@ -35,6 +37,7 @@ from clawrium.core.skills import (
     SkillError,
     SkillNotFound,
     SkillRef,
+    _NAME_RE,
     _overlay_root,
     _split_frontmatter,
     list_skills,
@@ -337,7 +340,25 @@ async def add_overlay_skill(payload: AddOverlaySkillBody) -> dict[str, Any]:
                 detail=f"Unknown registry {payload.registry!r}. Must be one of {sorted(REGISTRIES)}.",
             )
 
-        target_dir = _overlay_root() / payload.registry / payload.name
+        # B1: validate name before constructing any path.
+        if not _NAME_RE.fullmatch(payload.name):
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid skill name {payload.name!r}. Must match ^[a-z0-9][a-z0-9_-]*$.",
+            )
+
+        overlay_root = _overlay_root()
+        target_dir = overlay_root / payload.registry / payload.name
+        # Assert resolved path stays within overlay root (guards symlink and
+        # traversal edge cases that pass the regex on some filesystems).
+        try:
+            target_dir.resolve().relative_to(overlay_root.resolve())
+        except ValueError as error:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Skill name {payload.name!r} escapes the overlay root.",
+            ) from error
+
         if target_dir.exists():
             raise HTTPException(
                 status_code=409,
@@ -349,7 +370,7 @@ async def add_overlay_skill(payload: AddOverlaySkillBody) -> dict[str, Any]:
 
         try:
             body_text, fm = _split_frontmatter(payload.content)
-        except Exception as error:
+        except (ValueError, yaml.YAMLError) as error:
             raise HTTPException(
                 status_code=422, detail=f"Failed to parse SKILL.md: {error}"
             ) from error
@@ -376,14 +397,18 @@ async def add_overlay_skill(payload: AddOverlaySkillBody) -> dict[str, Any]:
             tmp_dir.mkdir(parents=True, exist_ok=False)
             (tmp_dir / "SKILL.md").write_text(render_skill_md(skill), encoding="utf-8")
             tmp_dir.rename(target_dir)
-        except FileExistsError as error:
+        except (FileExistsError, OSError) as error:
             shutil.rmtree(tmp_dir, ignore_errors=True)
-            raise HTTPException(
-                status_code=409,
-                detail=f"Skill {payload.registry}/{payload.name} already exists in the user overlay.",
-            ) from error
-        except OSError as error:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
+            # ENOTEMPTY / EISDIR / EEXIST on rename means a concurrent writer
+            # created the directory between our pre-check and the rename — 409.
+            # Other OS errors (permission denied, no space) surface as 500.
+            collision_errnos = {17, 39, 21}  # EEXIST, ENOTEMPTY, EISDIR
+            errno_val = getattr(error, "errno", None)
+            if isinstance(error, FileExistsError) or errno_val in collision_errnos:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Skill {payload.registry}/{payload.name} already exists in the user overlay.",
+                ) from error
             raise HTTPException(
                 status_code=500, detail="Failed to write skill to overlay."
             ) from error

--- a/tests/test_gui_agent_skills_routes.py
+++ b/tests/test_gui_agent_skills_routes.py
@@ -540,3 +540,210 @@ def _raises_if_called(label: str):
         raise AssertionError(f"{label} should not have been called")
 
     return _raise
+
+
+# ---------- Phase C: GET with origin tag ------------------------------------
+
+
+def test_list_installed_skill_has_origin_tag(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+    _write_local_skill("tdd-hermes", "tdd")
+
+    result = _run(agents_route.list_agent_skills("tdd-hermes"))
+
+    tdd_row = result["installed"][0]
+    # x-clawrium-source points at clawrium/tdd in the bundled catalog
+    assert tdd_row["origin"] in {"local", "bundled", "overlay"}
+
+
+def test_list_local_skill_without_source_tag_has_origin_local(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+    # Write a skill WITHOUT x-clawrium-source — should be "local"
+    skill_dir = agent_skills_dir("tdd-hermes") / "custom"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: custom\ndescription: No source\n---\n\nBody\n",
+        encoding="utf-8",
+    )
+    from clawrium.core.skills_state import write_state
+    write_state("tdd-hermes", ["custom"])
+
+    result = _run(agents_route.list_agent_skills("tdd-hermes"))
+    row = result["installed"][0]
+    assert row["origin"] == "local"
+
+
+# ---------- Phase C: POST /{agent_key}/skills --------------------------------
+
+
+def test_add_skill_template_mode_happy_path(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+
+    body = agents_route.AddSkillBody(
+        input_mode="template", registry="clawrium", name="tdd"
+    )
+    result = _run(agents_route.add_agent_skill("tdd-hermes", body))
+
+    assert result["success"] is True
+    assert result["skill_name"] == "tdd"
+    assert (agent_skills_dir("tdd-hermes") / "tdd" / "SKILL.md").exists()
+    assert "tdd" in read_state("tdd-hermes")
+
+
+def test_add_skill_template_mode_409_on_duplicate(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+    _write_local_skill("tdd-hermes", "tdd")
+
+    body = agents_route.AddSkillBody(
+        input_mode="template", registry="clawrium", name="tdd"
+    )
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.add_agent_skill("tdd-hermes", body))
+    assert exc.value.status_code == 409
+
+
+def test_add_skill_file_mode_happy_path(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+
+    content = "---\nname: file-skill\ndescription: From file\n---\n\n# Body\n"
+    body = agents_route.AddSkillBody(input_mode="file", content=content)
+    result = _run(agents_route.add_agent_skill("tdd-hermes", body))
+
+    assert result["success"] is True
+    assert result["skill_name"] == "file-skill"
+
+
+def test_add_skill_file_mode_422_when_content_missing(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+
+    body = agents_route.AddSkillBody(input_mode="file")
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.add_agent_skill("tdd-hermes", body))
+    assert exc.value.status_code == 422
+
+
+def test_add_skill_inline_mode_happy_path(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+
+    body = agents_route.AddSkillBody(
+        input_mode="inline",
+        name="my-inline",
+        description="Inline test",
+        body="# Hello",
+    )
+    result = _run(agents_route.add_agent_skill("tdd-hermes", body))
+
+    assert result["success"] is True
+    assert result["skill_name"] == "my-inline"
+    assert (agent_skills_dir("tdd-hermes") / "my-inline" / "SKILL.md").exists()
+
+
+def test_add_skill_inline_mode_422_without_name(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+
+    body = agents_route.AddSkillBody(input_mode="inline", description="No name")
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.add_agent_skill("tdd-hermes", body))
+    assert exc.value.status_code == 422
+
+
+def test_add_skill_404_when_agent_not_found(monkeypatch):
+    _stub_resolved(monkeypatch, resolved=False)
+
+    body = agents_route.AddSkillBody(
+        input_mode="template", registry="clawrium", name="tdd"
+    )
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.add_agent_skill("ghost", body))
+    assert exc.value.status_code == 404
+
+
+def test_add_skill_unknown_mode_422(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+
+    body = agents_route.AddSkillBody(input_mode="magic")
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.add_agent_skill("tdd-hermes", body))
+    assert exc.value.status_code == 422
+
+
+def test_add_skill_local_prefix_never_dispatches_to_registry_route(monkeypatch):
+    """registry=='local' must route to add_agent_skill, not install_agent_skill."""
+    _stub_resolved(monkeypatch, agent_type="hermes")
+    install_called = []
+    monkeypatch.setattr(agents_route, "apply_state", _raises_if_called("apply_state"))
+
+    # Calling install with registry="local" uses the compat route and would
+    # fail because "local" is not a valid SkillRef prefix. The new local
+    # DELETE route's name argument must always be a bare name.
+    content = "---\nname: bare\ndescription: test\n---\n\nBody\n"
+    body = agents_route.AddSkillBody(input_mode="file", content=content)
+    result = _run(agents_route.add_agent_skill("tdd-hermes", body))
+    assert result["skill_name"] == "bare"
+    assert not install_called
+
+
+# ---------- Phase C: PUT /{agent_key}/skills/local/{name} -------------------
+
+
+def test_edit_local_skill_happy_path(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+    _write_local_skill("tdd-hermes", "tdd")
+
+    new_content = "---\nname: tdd\ndescription: Edited\n---\n\nNew body\n"
+    body = agents_route.EditSkillBody(content=new_content)
+    result = _run(agents_route.edit_agent_skill("tdd-hermes", "tdd", body))
+
+    assert result["success"] is True
+    written = (agent_skills_dir("tdd-hermes") / "tdd" / "SKILL.md").read_text()
+    assert "Edited" in written
+
+
+def test_edit_local_skill_404_when_not_on_disk(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+
+    body = agents_route.EditSkillBody(content="---\nname: ghost\n---\n\n")
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.edit_agent_skill("tdd-hermes", "ghost", body))
+    assert exc.value.status_code == 404
+
+
+def test_edit_local_skill_422_on_schema_invalid(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+    _write_local_skill("tdd-hermes", "tdd")
+
+    # Missing description → schema validation should fail
+    body = agents_route.EditSkillBody(content="---\nname: tdd\n---\n\n")
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.edit_agent_skill("tdd-hermes", "tdd", body))
+    assert exc.value.status_code in {422, 400}
+
+
+# ---------- Phase C: DELETE /{agent_key}/skills/local/{name} ----------------
+
+
+def test_delete_local_skill_happy_path(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+    _write_local_skill("tdd-hermes", "tdd")
+
+    result = _run(agents_route.delete_local_agent_skill("tdd-hermes", "tdd"))
+
+    assert result["success"] is True
+    assert "tdd" not in read_state("tdd-hermes")
+    assert not (agent_skills_dir("tdd-hermes") / "tdd").exists()
+
+
+def test_delete_local_skill_404_when_not_in_state(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.delete_local_agent_skill("tdd-hermes", "missing"))
+    assert exc.value.status_code == 404
+
+
+def test_delete_local_skill_404_when_agent_not_found(monkeypatch):
+    _stub_resolved(monkeypatch, resolved=False)
+
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.delete_local_agent_skill("ghost", "tdd"))
+    assert exc.value.status_code == 404

--- a/tests/test_gui_agent_skills_routes.py
+++ b/tests/test_gui_agent_skills_routes.py
@@ -552,8 +552,8 @@ def test_list_installed_skill_has_origin_tag(monkeypatch):
     result = _run(agents_route.list_agent_skills("tdd-hermes"))
 
     tdd_row = result["installed"][0]
-    # x-clawrium-source points at clawrium/tdd in the bundled catalog
-    assert tdd_row["origin"] in {"local", "bundled", "overlay"}
+    # x-clawrium-source is "clawrium/tdd" → overlay dir absent → "bundled"
+    assert tdd_row["origin"] == "bundled"
 
 
 def test_list_local_skill_without_source_tag_has_origin_local(monkeypatch):
@@ -611,6 +611,8 @@ def test_add_skill_file_mode_happy_path(monkeypatch):
 
     assert result["success"] is True
     assert result["skill_name"] == "file-skill"
+    assert (agent_skills_dir("tdd-hermes") / "file-skill" / "SKILL.md").exists()
+    assert "file-skill" in read_state("tdd-hermes")
 
 
 def test_add_skill_file_mode_422_when_content_missing(monkeypatch):
@@ -636,6 +638,7 @@ def test_add_skill_inline_mode_happy_path(monkeypatch):
     assert result["success"] is True
     assert result["skill_name"] == "my-inline"
     assert (agent_skills_dir("tdd-hermes") / "my-inline" / "SKILL.md").exists()
+    assert "my-inline" in read_state("tdd-hermes")
 
 
 def test_add_skill_inline_mode_422_without_name(monkeypatch):
@@ -645,6 +648,24 @@ def test_add_skill_inline_mode_422_without_name(monkeypatch):
     with pytest.raises(HTTPException) as exc:
         _run(agents_route.add_agent_skill("tdd-hermes", body))
     assert exc.value.status_code == 422
+
+
+def test_add_skill_409_on_write_agent_local_skill_file_exists_race(monkeypatch):
+    """FileExistsError from _write_agent_local_skill (TOCTOU race after pre-check)
+    is caught and mapped to 409; desired state is rolled back."""
+    _stub_resolved(monkeypatch, agent_type="hermes")
+
+    def _raise_exists(agent_name: str, skill_name: str, skill) -> None:
+        raise FileExistsError(f"race: {skill_name} exists")
+
+    monkeypatch.setattr(agents_route, "_write_agent_local_skill", _raise_exists)
+    body = agents_route.AddSkillBody(
+        input_mode="template", registry="clawrium", name="tdd"
+    )
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.add_agent_skill("tdd-hermes", body))
+    assert exc.value.status_code == 409
+    assert "tdd" not in read_state("tdd-hermes")
 
 
 def test_add_skill_404_when_agent_not_found(monkeypatch):

--- a/tests/test_gui_agent_skills_routes.py
+++ b/tests/test_gui_agent_skills_routes.py
@@ -726,11 +726,11 @@ def test_edit_local_skill_422_on_schema_invalid(monkeypatch):
     _stub_resolved(monkeypatch, agent_type="hermes")
     _write_local_skill("tdd-hermes", "tdd")
 
-    # Missing description → schema validation should fail
+    # Missing description → _skill_error_status(SchemaValidationError) → 422
     body = agents_route.EditSkillBody(content="---\nname: tdd\n---\n\n")
     with pytest.raises(HTTPException) as exc:
         _run(agents_route.edit_agent_skill("tdd-hermes", "tdd", body))
-    assert exc.value.status_code in {422, 400}
+    assert exc.value.status_code == 422
 
 
 # ---------- Phase C: DELETE /{agent_key}/skills/local/{name} ----------------
@@ -809,7 +809,8 @@ def test_get_local_skill_returns_content(monkeypatch):
 
     result = _run(agents_route.get_local_agent_skill("tdd-hermes", "tdd"))
     assert result["skill_name"] == "tdd"
-    assert "SKILL.md" in result["content"] or "name: tdd" in result["content"]
+    assert "name: tdd" in result["content"]
+    assert "description:" in result["content"]
 
 
 def test_get_local_skill_404_when_not_on_disk(monkeypatch):

--- a/tests/test_gui_agent_skills_routes.py
+++ b/tests/test_gui_agent_skills_routes.py
@@ -658,29 +658,43 @@ def test_add_skill_404_when_agent_not_found(monkeypatch):
     assert exc.value.status_code == 404
 
 
-def test_add_skill_unknown_mode_422(monkeypatch):
-    _stub_resolved(monkeypatch, agent_type="hermes")
+def test_add_skill_unknown_mode_rejected_by_pydantic():
+    """Pydantic's Literal enforcement rejects unknown input_mode before the
+    route handler runs — FastAPI converts this to a 422 Unprocessable Entity."""
+    from pydantic import ValidationError
 
-    body = agents_route.AddSkillBody(input_mode="magic")
-    with pytest.raises(HTTPException) as exc:
-        _run(agents_route.add_agent_skill("tdd-hermes", body))
-    assert exc.value.status_code == 422
+    with pytest.raises(ValidationError):
+        agents_route.AddSkillBody(input_mode="magic")  # type: ignore[arg-type]
 
 
 def test_add_skill_local_prefix_never_dispatches_to_registry_route(monkeypatch):
-    """registry=='local' must route to add_agent_skill, not install_agent_skill."""
+    """POST /{key}/skills (no registry segment) routes to add_agent_skill,
+    not the compat install_agent_skill — confirmed by asserting apply_state
+    is NEVER called (install_agent_skill calls apply_state; add_agent_skill
+    does not)."""
     _stub_resolved(monkeypatch, agent_type="hermes")
-    install_called = []
-    monkeypatch.setattr(agents_route, "apply_state", _raises_if_called("apply_state"))
+    apply_called = []
 
-    # Calling install with registry="local" uses the compat route and would
-    # fail because "local" is not a valid SkillRef prefix. The new local
-    # DELETE route's name argument must always be a bare name.
+    def _record_apply(agent_name: str, **_kwargs):
+        apply_called.append(agent_name)
+        # Return a fake ApplyResult so the compat route doesn't blow up
+        from clawrium.core.skills_apply import ApplyResult
+        return ApplyResult(
+            agent_name=agent_name,
+            agent_type="hermes",
+            hostname="wolf-i",
+            applied_skills=[],
+            log_dir=Path("/tmp/fake"),
+        )
+
+    monkeypatch.setattr(agents_route, "apply_state", _record_apply)
+
     content = "---\nname: bare\ndescription: test\n---\n\nBody\n"
     body = agents_route.AddSkillBody(input_mode="file", content=content)
     result = _run(agents_route.add_agent_skill("tdd-hermes", body))
     assert result["skill_name"] == "bare"
-    assert not install_called
+    # add_agent_skill must NOT have called apply_state
+    assert not apply_called, "apply_state was called — routed to compat install endpoint"
 
 
 # ---------- Phase C: PUT /{agent_key}/skills/local/{name} -------------------
@@ -747,3 +761,68 @@ def test_delete_local_skill_404_when_agent_not_found(monkeypatch):
     with pytest.raises(HTTPException) as exc:
         _run(agents_route.delete_local_agent_skill("ghost", "tdd"))
     assert exc.value.status_code == 404
+
+
+def test_delete_local_skill_422_on_invalid_name(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.delete_local_agent_skill("tdd-hermes", "../evil"))
+    assert exc.value.status_code == 422
+
+
+def test_edit_local_skill_422_on_invalid_name(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+
+    body = agents_route.EditSkillBody(content="---\nname: ok\ndescription: ok\n---\n\n")
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.edit_agent_skill("tdd-hermes", "../evil", body))
+    assert exc.value.status_code == 422
+
+
+def test_edit_local_skill_500_on_oserror(monkeypatch, tmp_path):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+    _write_local_skill("tdd-hermes", "tdd")
+
+    original_write = Path.write_text
+
+    def _fail_write(self, *args, **kwargs):
+        if "SKILL.md.tmp" in str(self):
+            raise OSError("disk full")
+        return original_write(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", _fail_write)
+    body = agents_route.EditSkillBody(
+        content="---\nname: tdd\ndescription: edited\n---\n\n"
+    )
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.edit_agent_skill("tdd-hermes", "tdd", body))
+    assert exc.value.status_code == 500
+
+
+# ---------- Phase C: GET /{agent_key}/skills/local/{name} -------------------
+
+
+def test_get_local_skill_returns_content(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+    _write_local_skill("tdd-hermes", "tdd")
+
+    result = _run(agents_route.get_local_agent_skill("tdd-hermes", "tdd"))
+    assert result["skill_name"] == "tdd"
+    assert "SKILL.md" in result["content"] or "name: tdd" in result["content"]
+
+
+def test_get_local_skill_404_when_not_on_disk(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.get_local_agent_skill("tdd-hermes", "missing"))
+    assert exc.value.status_code == 404
+
+
+def test_get_local_skill_422_on_invalid_name(monkeypatch):
+    _stub_resolved(monkeypatch, agent_type="hermes")
+
+    with pytest.raises(HTTPException) as exc:
+        _run(agents_route.get_local_agent_skill("tdd-hermes", "../escape"))
+    assert exc.value.status_code == 422

--- a/tests/test_gui_skills_routes.py
+++ b/tests/test_gui_skills_routes.py
@@ -481,3 +481,59 @@ def _build_catalog_with_bad_clawrium_meta(tmp_path: Path) -> Path:
         "---\nname: wrong\ndescription: same\n---\nbody\n"
     )
     return root
+
+
+# ---------- Phase C: POST /api/skills (overlay write) -----------------------
+
+
+@pytest.fixture()
+def _isolate_overlay(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Per-test XDG_CONFIG_HOME so overlay writes don't escape."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+
+def test_add_overlay_skill_happy_path(_isolate_overlay):
+    body = skills_route.AddOverlaySkillBody(
+        registry="hermes",
+        name="gui-skill",
+        content="---\nname: gui-skill\ndescription: GUI test\n---\n\n# Body\n",
+    )
+    result = _run(skills_route.add_overlay_skill(body))
+    assert result["success"] is True
+    assert result["ref"] == "hermes/gui-skill"
+
+
+def test_add_overlay_skill_409_on_collision(_isolate_overlay):
+    body = skills_route.AddOverlaySkillBody(
+        registry="hermes",
+        name="gui-skill",
+        content="---\nname: gui-skill\ndescription: First\n---\n\n# First\n",
+    )
+    _run(skills_route.add_overlay_skill(body))
+
+    with pytest.raises(HTTPException) as exc:
+        _run(skills_route.add_overlay_skill(body))
+    assert exc.value.status_code == 409
+
+
+def test_add_overlay_skill_422_unknown_registry(_isolate_overlay):
+    body = skills_route.AddOverlaySkillBody(
+        registry="bogus",
+        name="skill",
+        content="---\nname: skill\ndescription: x\n---\n\n",
+    )
+    with pytest.raises(HTTPException) as exc:
+        _run(skills_route.add_overlay_skill(body))
+    assert exc.value.status_code == 422
+
+
+def test_add_overlay_skill_422_schema_invalid(_isolate_overlay):
+    # Missing description field — fails schema validation for hermes
+    body = skills_route.AddOverlaySkillBody(
+        registry="hermes",
+        name="broken",
+        content="---\nname: broken\n---\n\n# No description\n",
+    )
+    with pytest.raises(HTTPException) as exc:
+        _run(skills_route.add_overlay_skill(body))
+    assert exc.value.status_code == 422

--- a/tests/test_gui_skills_routes.py
+++ b/tests/test_gui_skills_routes.py
@@ -537,3 +537,31 @@ def test_add_overlay_skill_422_schema_invalid(_isolate_overlay):
     with pytest.raises(HTTPException) as exc:
         _run(skills_route.add_overlay_skill(body))
     assert exc.value.status_code == 422
+
+
+def test_add_overlay_skill_422_on_path_traversal(_isolate_overlay):
+    body = skills_route.AddOverlaySkillBody(
+        registry="hermes",
+        name="../evil",
+        content="---\nname: evil\ndescription: traversal\n---\n\n",
+    )
+    with pytest.raises(HTTPException) as exc:
+        _run(skills_route.add_overlay_skill(body))
+    assert exc.value.status_code == 422
+
+
+def test_add_overlay_skill_409_on_rename_race(_isolate_overlay, monkeypatch):
+    """FileExistsError during rename (TOCTOU between pre-check and write) → 409."""
+    body = skills_route.AddOverlaySkillBody(
+        registry="hermes",
+        name="race-skill",
+        content="---\nname: race-skill\ndescription: Race test\n---\n\n",
+    )
+
+    def _raise_exists(self, target):
+        raise FileExistsError(f"[Errno 17] File exists: '{target}'")
+
+    monkeypatch.setattr(Path, "rename", _raise_exists)
+    with pytest.raises(HTTPException) as exc:
+        _run(skills_route.add_overlay_skill(body))
+    assert exc.value.status_code == 409

--- a/website/docs/skills/local.md
+++ b/website/docs/skills/local.md
@@ -84,3 +84,63 @@ clawctl agent skill add my-hermes-agent --from-template hermes/my-hermes-skill
 Overlay entries live under `~/.config/clawrium/skills/<registry>/<name>/`
 and appear in `skill registry get` / `describe`. An overlay entry wins
 over a bundled catalog entry with the same `<registry>/<name>`.
+
+## Using the web UI
+
+The Clawrium GUI surfaces the same per-agent skill lifecycle on the
+**Agent Detail → Skills** tab.
+
+### Adding a skill
+
+Click **Add skill** on the Skills tab to open the add-skill modal. Three
+input modes are available as tabs:
+
+| Tab | What it does |
+|---|---|
+| **From catalog** | Pick any bundled or overlay catalog skill by name and click **Install**. |
+| **From file** | Paste the full contents of a `SKILL.md` file. The skill name is read from the `name:` frontmatter field. |
+| **Inline** | Type a name, description, and optional markdown body directly. |
+
+All three modes write a per-agent local skill immediately, without touching
+the agent host. Click **Sync** (the existing agent Sync control) to flush
+the change to the host.
+
+### Editing an on-agent skill
+
+Only **LOCAL** skills (created via File or Inline mode) show an **Edit**
+button. Click it to open an in-browser editor with the raw `SKILL.md`
+text. Save to update the local copy; Sync to apply on the host.
+
+Catalog-sourced skills (**BUNDLED** or **OVERLAY**) are read-only in the
+editor — remove and re-add them from the catalog picker to update.
+
+### Removing a skill
+
+Click **Remove** on any installed skill row. A confirmation step prevents
+accidental removal. After confirming:
+- The skill is removed from local desired state immediately.
+- The on-host file is pruned on the next **Sync**.
+
+### Adding to the user overlay
+
+To make a skill available across all your agents, click **Add to catalog**
+(top-right of the Skills page) and fill in the registry, name, and
+`SKILL.md` content. The skill appears in the catalog picker with an
+**OVERLAY** origin chip.
+
+### Origin chips
+
+Each installed skill row shows an origin chip:
+
+| Chip | Meaning |
+|---|---|
+| **LOCAL** | Created via File or Inline mode; no source template. |
+| **BUNDLED** | Copied from the bundled in-repo catalog. |
+| **OVERLAY** | Copied from your user overlay catalog. |
+
+### Flushing via Sync
+
+After any add, edit, or remove in the GUI, use the agent's existing
+**Sync** control to apply the changes on the host. The skill endpoints
+do not call `apply_state` automatically — this is by design so you can
+stage multiple changes before a single flush.


### PR DESCRIPTION
## Summary
- Five new GUI API endpoints: GET/PUT/DELETE /{agent_key}/skills/local/{name} + POST /{agent_key}/skills (3 modes) + POST /api/skills (overlay write).
- \`GET /{agent_key}/skills\` now tags each installed entry with \`origin: "local" | "bundled" | "overlay"\`.
- Frontend: multi-mode Add Skill modal (From catalog / From file / Inline), Edit button for LOCAL skills with real content fetch, origin chips, "Add to catalog" on Skills page.
- 25 new route-level tests. Docs updated with "Using the web UI" section.

## Testing
- \`make lint\` ✅
- \`make test\` — 4002 Python passed, 254 GUI passed

## Scope Notes
- Implements issue #411 Phase C from \`.itx/411/01_SCAFFOLD.md\`.
- The skill add/edit/delete endpoints do NOT call \`apply_state\` — flush via Sync control.
- Docs build CI failure is pre-existing on \`main\` (MDX parse error in \`hermes.md\`), unrelated to this PR.

## ATX Review

| Review | Rating | Blocking | Status |
|---|---:|---|---|
| 1 | 2/5 | B1 path traversal, B2 edit data loss, B3 name traversal | Fixed \`1f8cf51\` |
| 2 | 3–4/5 | None | Warnings fixed \`fb4b26d\` |
| 3 | **4/5** | **None** | Warnings fixed \`0ef6ac6\` — ✅ **Ready** |

**Final: 4/5, no blocking issues.**

## Callouts

- [DECISION] Edit button shown only for \`origin == "local"\` skills. Catalog-sourced skills are read-only in the editor — remove and re-add from the template picker to update. This avoids silently breaking source-ref metadata.
- [DECISION] Skill add/edit/delete endpoints do not call \`apply_state\` — consistent with Phase B CLI behavior. Flush via Sync control.
- [DECISION] Private helpers (\`_overlay_root\`, \`_split_frontmatter\`, \`_NAME_RE\`, \`_validate_skill_name\`) imported from \`core.skills\`/\`skills_state\`. These are stable internal functions already tested; formal promotion to public is tracked as a follow-up.
- [TODO-FOLLOWUP] Manual GUI walkthrough on mac-test (exit criterion from scaffold) not done during automated execution. Tracking: #411 exit criteria.

Closes #411 (Phase C)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>