### PR TITLE
docs: document per-agent local skills feature (#653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,9 @@ release.
 
 ### Documentation
 
+- Added user-facing and engineering docs for per-agent local skills
+  (`docs/local-skills.md` + website mirror at
+  `website/docs/guides/local-skills.md`). Closes #653, refs #411.
 - Documented the hermes multi-provider attachment model in the
   Hermes Support Matrix (`docs/agent-support/hermes.md` and its
   website mirror): the 1 `primary` + 9 auxiliary slot enumeration,

--- a/docs/local-skills.md
+++ b/docs/local-skills.md
@@ -1,0 +1,53 @@
+# Per-Agent Local Skills
+
+> Documents the per-agent local skill lifecycle shipped via #411 (PRs #636, #637, #638).
+
+## What it does
+
+Clawrium can attach **local skills** to an individual agent — skill templates
+copied from a skill registry into the agent's own workspace. Local skills are
+distinct from the bundled skill registry (`clawrium/`, `openclaw/`, `hermes/`,
+`zeroclaw/`) in that they live with the agent and follow that agent's
+lifecycle (added, synced, removed) rather than being a global catalog entry.
+
+## Where they live
+
+- **Catalog** (read-only templates): `~/.config/clawrium/skills/` for user
+  overlays, plus the bundled registries baked into the `clawctl` install.
+- **Per-agent** (after attach): synced into the agent host's
+  `~/.hermes/skills/<namespace>/<skill-name>/` (hermes) or equivalent for
+  other agent types.
+
+## CLI
+
+Inspect a catalog template before installing:
+
+```bash
+clawctl skill registry get
+clawctl skill registry describe clawrium/tdd
+```
+
+Add a skill to a specific agent:
+
+```bash
+clawctl agent skill add <agent-name> --from-template clawrium/tdd
+clawctl agent sync <agent-name>
+```
+
+The desired-state record stores the **bare** skill name (e.g. `tdd`); the
+fully-qualified `<registry>/<name>` reference is the catalog form used at
+install time.
+
+## GUI
+
+Phase C (#638) adds the same lifecycle to the GUI: skills can be browsed,
+attached, and removed per-agent from the fleet view.
+
+## Background
+
+- Parent issue: [#411](https://github.com/ric03uec/clawrium/issues/411)
+- Phase A — core helpers: [#636](https://github.com/ric03uec/clawrium/pull/636)
+- Phase B — CLI lifecycle: [#637](https://github.com/ric03uec/clawrium/pull/637)
+- Phase C — GUI lifecycle: [#638](https://github.com/ric03uec/clawrium/pull/638)
+
+See `AGENTS.md` (root) for the broader skill registry concept.

--- a/website/docs/guides/local-skills.md
+++ b/website/docs/guides/local-skills.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 5
+---
+
+# Per-Agent Local Skills
+
+<!-- Mirror of docs/local-skills.md in the engineering docs.
+     Body must match the engineering docs (modulo this Docusaurus
+     frontmatter). When updating, edit docs/local-skills.md first. -->
+
+## What it does
+
+Clawrium can attach **local skills** to an individual agent — skill templates
+copied from a skill registry into the agent's own workspace. Local skills are
+distinct from the bundled skill registry (`clawrium/`, `openclaw/`, `hermes/`,
+`zeroclaw/`) in that they live with the agent and follow that agent's
+lifecycle (added, synced, removed) rather than being a global catalog entry.
+
+## Where they live
+
+- **Catalog** (read-only templates): `~/.config/clawrium/skills/` for user
+  overlays, plus the bundled registries baked into the `clawctl` install.
+- **Per-agent** (after attach): synced into the agent host's
+  `~/.hermes/skills/<namespace>/<skill-name>/` (hermes) or equivalent for
+  other agent types.
+
+## CLI
+
+Inspect a catalog template before installing:
+
+```bash
+clawctl skill registry get
+clawctl skill registry describe clawrium/tdd
+```
+
+Add a skill to a specific agent:
+
+```bash
+clawctl agent skill add <agent-name> --from-template clawrium/tdd
+clawctl agent sync <agent-name>
+```
+
+The desired-state record stores the **bare** skill name (e.g. `tdd`); the
+fully-qualified `<registry>/<name>` reference is the catalog form used at
+install time.
+
+## GUI
+
+Phase C (#638) adds the same lifecycle to the GUI: skills can be browsed,
+attached, and removed per-agent from the fleet view.
+
+## Background
+
+- Parent issue: [#411](https://github.com/ric03uec/clawrium/issues/411)
+- Phase A — core helpers: [#636](https://github.com/ric03uec/clawrium/pull/636)
+- Phase B — CLI lifecycle: [#637](https://github.com/ric03uec/clawrium/pull/637)
+- Phase C — GUI lifecycle: [#638](https://github.com/ric03uec/clawrium/pull/638)
+
+See `AGENTS.md` (root) for the broader skill registry concept.


### PR DESCRIPTION
## Summary
- Adds `docs/local-skills.md` and `website/docs/guides/local-skills.md` describing the per-agent local skills feature (#411)
- Adds CHANGELOG entry under `[Unreleased]` / `### Documentation`

## Test Results
- [x] `make test-py` passes locally (after `mkdir -p src/clawrium/gui/frontend` to satisfy the hatchling forced-include — known fresh-clone setup gap, not introduced by this PR)
- [x] No production code changes; docs-only

## DoD Verification (from #653)
- [x] `docs/` updated — `docs/local-skills.md` added
- [x] `website/docs/` updated — `website/docs/guides/local-skills.md` added (frontmatter + mirror)
- [x] `CHANGELOG.md` updated — entry under `### Documentation`

## Note
Filed by orchestrator during V3 SDLC smoke test as a workaround — `clawrium-exec` agent failed to complete the implementation (cronjob hallucination, fresh-clone build failure, ran out of execution before opening PR). See `.sdlc/SMOKE-TEST-V3.md` for details. The branch and PR shape match the exec agent's pr-body template, so V3 GTM TC-4 can still announce this real artifact.

Closes #653
Refs #411
