### PR TITLE
chore(triage): draft plan for #660

### DIFF
--- a/.itx/660/00_PLAN.md
+++ b/.itx/660/00_PLAN.md
@@ -1,0 +1,15 @@
+# Issue #660 — smoke test for SDLC
+
+## Outcome
+The V4 SDLC pipeline run is recorded in CHANGELOG.md [Unreleased] / ### Internal with one line naming the four agents that touched it.
+
+## Approach
+- Add one `### Internal` line to CHANGELOG.md under `[Unreleased]`
+- Do not change any other file
+- GTM posts the Discord announcement after merge
+
+## Files
+- CHANGELOG.md
+
+## Risk
+Agent touches unrelated files or omits the agent attribution.


### PR DESCRIPTION
## Summary
Drafts plan file for #660 (V4 SDLC smoke test). Orchestrator-opened workaround after Triage failed to execute its env-skill — see .sdlc/SMOKE-TEST-V4.md.

## Closes
Refs #660
