### PR TITLE
chore(changelog): record V6 SDLC smoke test (#668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,3 +140,5 @@ release.
 - Smoke test V2 — pipeline validation (#646)
 - V4 SDLC smoke test ran end-to-end: clawrium-maurice filed the issue, clawrium-triage labeled and planned, clawrium-exec implemented this entry, clawrium-gtm announced. (#660)
 - V5 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #670 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#667)
+- V6 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #672 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#668)
+- V6 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #672 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#668)


### PR DESCRIPTION
## Summary
Records V6 SDLC smoke test in CHANGELOG.md under [Unreleased] / ### Internal.

## Test Results
- [x] make test-py passes
- [x] make lint-py passes

## DoD (from #668)
- [x] CHANGELOG.md updated

Closes #668
