### PR TITLE
chore(changelog): record V10 SDLC smoke test (#679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - V7 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #674 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#669)
 - V8 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #680 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#677)
 - V9 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #684 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#678)
+- V10 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #686 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#679)


### PR DESCRIPTION
## Summary
Records V10 SDLC smoke test in CHANGELOG.md under [Unreleased] / ### Internal.

## Test Results
- [x] make test-py passes
- [x] make lint-py passes

## DoD (from #679)
- [x] CHANGELOG.md updated

Closes #679
