### PR TITLE
chore(changelog): record V11 SDLC smoke test (#682)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - V8 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #680 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#677)
 - V9 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #684 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#678)
 - V10 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #686 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#679)
+- V11 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #689 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#682)


### PR DESCRIPTION
## Summary
Records V11 SDLC smoke test in CHANGELOG.md under [Unreleased] / ### Internal.

## Test Results
- [ ] make test-py passes
- [x] make lint-py passes

## DoD (from #682)
- [x] CHANGELOG.md updated

Closes #682
