### PR TITLE
fix(gui): Providers page follow-ups — registry dropdown, fleet-style table, button label

### DIFF
--- a/gui/src/app/providers/page.tsx
+++ b/gui/src/app/providers/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { PageHeader } from "@/components/layout";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { Modal } from "@/components/ui/modal";
 import {
   ProvidersTable,
@@ -78,58 +79,56 @@ export default function ProvidersPage() {
         description="Configure LLM providers once, apply them across your fleet. Each provider can power multiple agents."
       />
 
-      <div className="bg-surface rounded-xl border border-default">
-        <div className="flex items-center justify-between border-b border-default px-2">
-          <nav className="flex" aria-label="Providers tabs">
-            <TabButton
-              active={tab === "configured"}
-              onClick={() => setTab("configured")}
-            >
-              Configured {providerCount > 0 ? `(${providerCount})` : ""}
-            </TabButton>
-            <TabButton
-              active={tab === "registry"}
-              onClick={() => setTab("registry")}
-            >
-              Registry
-            </TabButton>
-          </nav>
-          {tab === "configured" && (
-            <Button variant="primary" onClick={() => setShowAdd(true)}>
-              + Add Provider
-            </Button>
-          )}
-        </div>
-
-        <div className="p-4">
-          {tab === "configured" ? (
-            isLoading ? (
-              <div className="p-8 text-center text-muted text-sm">
-                Loading providers...
-              </div>
-            ) : providers && providers.length > 0 ? (
-              <ProvidersTable
-                providers={providers}
-                usage={providerUsage}
-                onEdit={setEditProvider}
-                onRemove={setRemoveProvider}
-              />
-            ) : (
-              <div className="p-12 text-center">
-                <p className="text-sm text-muted mb-3">
-                  No providers configured yet — add one or browse the Registry
-                  tab.
-                </p>
-                <Button variant="primary" onClick={() => setShowAdd(true)}>
-                  + Add your first provider
-                </Button>
-              </div>
-            )
-          ) : (
-            <ModelCatalog />
-          )}
-        </div>
+      <div className="flex items-center justify-between border-b border-default">
+        <nav className="flex" aria-label="Providers tabs">
+          <TabButton
+            active={tab === "configured"}
+            onClick={() => setTab("configured")}
+          >
+            Configured {providerCount > 0 ? `(${providerCount})` : ""}
+          </TabButton>
+          <TabButton
+            active={tab === "registry"}
+            onClick={() => setTab("registry")}
+          >
+            Registry
+          </TabButton>
+        </nav>
+        {tab === "configured" && (
+          <Button variant="primary" onClick={() => setShowAdd(true)}>
+            + Add model provider
+          </Button>
+        )}
       </div>
+
+      <Card padding="md">
+        {tab === "configured" ? (
+          isLoading ? (
+            <div className="py-8 text-center text-muted text-sm">
+              Loading providers...
+            </div>
+          ) : providers && providers.length > 0 ? (
+            <ProvidersTable
+              providers={providers}
+              usage={providerUsage}
+              onEdit={setEditProvider}
+              onRemove={setRemoveProvider}
+            />
+          ) : (
+            <div className="py-12 text-center">
+              <p className="text-sm text-muted mb-3">
+                No providers configured yet — add one or browse the Registry
+                tab.
+              </p>
+              <Button variant="primary" onClick={() => setShowAdd(true)}>
+                + Add model provider
+              </Button>
+            </div>
+          )
+        ) : (
+          <ModelCatalog />
+        )}
+      </Card>
 
       {/* Add Provider Modal — conditionally mounted so closing the modal
           discards any partially-entered AWS credentials and starts fresh

--- a/gui/src/components/providers/model-catalog.tsx
+++ b/gui/src/components/providers/model-catalog.tsx
@@ -1,120 +1,208 @@
 "use client";
 
-import { useState, useMemo } from "react";
-import { Card } from "@/components/ui/card";
-import { useModelCatalog } from "@/hooks/use-providers";
+import { useState, useMemo, useEffect } from "react";
+import {
+  useProviderTypes,
+  useModelCatalog,
+} from "@/hooks/use-providers";
+
+const PAGE_SIZE = 50;
 
 export function ModelCatalog() {
+  const { data: providerTypes, isLoading: typesLoading } = useProviderTypes();
+  const [selected, setSelected] = useState<string>("__all__");
   const [search, setSearch] = useState("");
-  const [filterProvider, setFilterProvider] = useState<string>("");
+  const [page, setPage] = useState(1);
 
-  // Fetch the catalog with the server-side search when provided
-  const { data: models, isLoading } = useModelCatalog(
-    filterProvider || undefined,
-    search.length >= 2 ? search : undefined
+  const typeEntries = useMemo(() => {
+    if (!providerTypes) return [];
+    return Object.entries(providerTypes).sort((a, b) =>
+      a[0].localeCompare(b[0]),
+    );
+  }, [providerTypes]);
+
+  const totalAllModels = useMemo(
+    () =>
+      typeEntries.reduce(
+        (sum, [, info]) => sum + (info.models?.length ?? 0),
+        0,
+      ),
+    [typeEntries],
   );
 
-  // Client-side filtering for short search terms
-  const filteredModels = useMemo(() => {
+  // Reset page + search when provider changes
+  useEffect(() => {
+    setPage(1);
+    setSearch("");
+  }, [selected]);
+
+  const isAll = selected === "__all__";
+  const isOllama = selected === "ollama";
+  const { data: models, isLoading: modelsLoading } = useModelCatalog(
+    isAll || isOllama ? undefined : selected,
+    undefined,
+    isAll ? 500 : undefined,
+  );
+
+  const filtered = useMemo(() => {
     if (!models) return [];
-    if (search.length >= 2) return models; // Already filtered server-side
-    if (search.length === 1) {
-      return models.filter(
-        (m) =>
-          m.id.toLowerCase().includes(search.toLowerCase()) ||
-          m.name.toLowerCase().includes(search.toLowerCase())
-      );
-    }
-    return models;
+    const q = search.trim().toLowerCase();
+    if (!q) return models;
+    return models.filter(
+      (m) =>
+        m.id.toLowerCase().includes(q) ||
+        (m.name && m.name.toLowerCase().includes(q)),
+    );
   }, [models, search]);
 
-  // Get unique providers for filter dropdown
-  const providers = useMemo(() => {
-    if (!models) return [];
-    return [...new Set(models.map((m) => m.provider_type))].sort();
-  }, [models]);
+  const total = filtered.length;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const start = (currentPage - 1) * PAGE_SIZE;
+  const visible = filtered.slice(start, start + PAGE_SIZE);
+
+  if (typesLoading) {
+    return (
+      <div className="py-8 text-center text-sm text-muted">
+        Loading registry...
+      </div>
+    );
+  }
 
   return (
-    <Card padding="md">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-sm font-semibold text-primary-text">Model Catalog</h2>
-        <div className="flex gap-2">
-          <select
-            value={filterProvider}
-            onChange={(e) => setFilterProvider(e.target.value)}
-            className="px-2 py-1.5 text-xs border border-default rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-primary/30"
-          >
-            <option value="">All Providers</option>
-            {providers.map((p) => (
-              <option key={p} value={p}>
-                {p}
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-2">
+        <select
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
+          className="px-3 py-1.5 text-sm border border-default rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-primary/30"
+        >
+          <option value="__all__">All providers ({totalAllModels} models)</option>
+          {typeEntries.map(([ptype, info]) => {
+            const count = info.models?.length ?? 0;
+            const countLabel =
+              ptype === "ollama"
+                ? "per-host"
+                : count > 0
+                  ? `${count} models`
+                  : "—";
+            return (
+              <option key={ptype} value={ptype}>
+                {ptype} ({countLabel})
               </option>
-            ))}
-          </select>
+            );
+          })}
+        </select>
+        {!isOllama && (
           <input
             type="text"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(1);
+            }}
             placeholder="Search models..."
-            className="w-48 px-3 py-1.5 text-xs border border-default rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-primary/30"
+            className="w-64 px-3 py-1.5 text-sm border border-default rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-primary/30"
           />
-        </div>
+        )}
       </div>
 
-      {isLoading ? (
-        <div className="py-8 text-center text-sm text-muted">Loading catalog...</div>
+      {isOllama ? (
+        <div className="py-8 text-center text-sm text-muted">
+          Models are discovered per-host from the Ollama daemon. See the
+          configured Ollama provider in the Configured tab.
+        </div>
+      ) : modelsLoading ? (
+        <div className="py-8 text-center text-sm text-muted">
+          Loading models...
+        </div>
       ) : (
-        <div className="overflow-x-auto max-h-[400px] overflow-y-auto">
-          <table className="w-full text-xs">
-            <thead className="sticky top-0 bg-white">
-              <tr className="border-b border-default text-left text-muted">
-                <th className="py-2 px-2 font-medium">Provider</th>
-                <th className="py-2 px-2 font-medium">Model</th>
-                <th className="py-2 px-2 font-medium">Context</th>
-                <th className="py-2 px-2 font-medium">Tags</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredModels.slice(0, 100).map((model) => (
-                <tr key={`${model.provider_type}-${model.id}`} className="border-b border-default/50 hover:bg-surface">
-                  <td className="py-1.5 px-2 text-secondary">{model.provider_type}</td>
-                  <td className="py-1.5 px-2 font-medium text-primary-text font-mono">
-                    {model.id}
-                  </td>
-                  <td className="py-1.5 px-2 text-secondary">
-                    {formatContext(model.context_window)}
-                  </td>
-                  <td className="py-1.5 px-2">
-                    <div className="flex gap-1 flex-wrap">
-                      {model.tags.map((tag) => (
-                        <span
-                          key={tag}
-                          className="px-1.5 py-0.5 bg-surface text-muted rounded text-[10px]"
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                  </td>
+        <>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-default text-left">
+                  {isAll && (
+                    <th className="pb-3 pr-4 font-medium text-muted">Provider</th>
+                  )}
+                  <th className="pb-3 pr-4 font-medium text-muted">Model</th>
+                  <th className="pb-3 pr-4 font-medium text-muted">Context</th>
+                  <th className="pb-3 font-medium text-muted">Tags</th>
                 </tr>
-              ))}
-              {filteredModels.length === 0 && (
-                <tr>
-                  <td colSpan={4} className="py-6 text-center text-muted">
-                    No models found
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-          {filteredModels.length > 100 && (
-            <div className="py-2 text-center text-xs text-muted">
-              Showing 100 of {filteredModels.length} models
+              </thead>
+              <tbody>
+                {visible.map((model) => (
+                  <tr
+                    key={`${model.provider_type}-${model.id}`}
+                    className="border-b border-default last:border-0 hover:bg-surface"
+                  >
+                    {isAll && (
+                      <td className="py-3 pr-4 text-secondary">
+                        {model.provider_type}
+                      </td>
+                    )}
+                    <td className="py-3 pr-4 font-medium text-primary-text font-mono">
+                      {model.id}
+                    </td>
+                    <td className="py-3 pr-4 text-secondary">
+                      {formatContext(model.context_window)}
+                    </td>
+                    <td className="py-3">
+                      <div className="flex gap-1 flex-wrap">
+                        {model.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="px-1.5 py-0.5 bg-surface text-muted rounded text-[10px]"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+                {visible.length === 0 && (
+                  <tr>
+                    <td colSpan={isAll ? 4 : 3} className="py-6 text-center text-muted">
+                      No models found
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+          {total > 0 && (
+            <div className="flex items-center justify-between text-xs text-muted">
+              <span>
+                Showing {start + 1}–{Math.min(start + PAGE_SIZE, total)} of{" "}
+                {total}
+              </span>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={currentPage <= 1}
+                  className="px-2 py-1 border border-default rounded disabled:opacity-40 hover:bg-surface"
+                >
+                  ‹ Prev
+                </button>
+                <span>
+                  Page {currentPage}/{totalPages}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={currentPage >= totalPages}
+                  className="px-2 py-1 border border-default rounded disabled:opacity-40 hover:bg-surface"
+                >
+                  Next ›
+                </button>
+              </div>
             </div>
           )}
-        </div>
+        </>
       )}
-    </Card>
+    </div>
   );
 }
 

--- a/gui/src/components/providers/providers-table.tsx
+++ b/gui/src/components/providers/providers-table.tsx
@@ -25,16 +25,16 @@ export function ProvidersTable({
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-xs">
+      <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-default text-left text-muted">
-            <th className="py-2 px-2 font-medium w-8"></th>
-            <th className="py-2 px-2 font-medium">Provider</th>
-            <th className="py-2 px-2 font-medium">Type</th>
-            <th className="py-2 px-2 font-medium">Default Model</th>
-            <th className="py-2 px-2 font-medium">Used by</th>
-            <th className="py-2 px-2 font-medium">Created</th>
-            <th className="py-2 px-2 font-medium text-right">Actions</th>
+          <tr className="border-b border-default text-left">
+            <th className="pb-3 pr-4 font-medium text-muted w-8"></th>
+            <th className="pb-3 pr-4 font-medium text-muted">Provider</th>
+            <th className="pb-3 pr-4 font-medium text-muted">Type</th>
+            <th className="pb-3 pr-4 font-medium text-muted">Default Model</th>
+            <th className="pb-3 pr-4 font-medium text-muted">Used by</th>
+            <th className="pb-3 pr-4 font-medium text-muted">Created</th>
+            <th className="pb-3 font-medium text-muted text-right">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -89,8 +89,8 @@ function ProviderRow({
 
   return (
     <>
-      <tr className="border-b border-default/50 hover:bg-surface">
-        <td className="py-2 px-2 align-middle">
+      <tr className="border-b border-default last:border-0 hover:bg-surface">
+        <td className="py-3 pr-4 align-middle">
           <button
             type="button"
             onClick={onToggle}
@@ -100,17 +100,17 @@ function ProviderRow({
             {expanded ? "▾" : "▸"}
           </button>
         </td>
-        <td className="py-2 px-2">
+        <td className="py-3 pr-4">
           <div className="flex items-center gap-2">
             {brandIcon}
-            <span className="font-medium text-primary-text">{provider.name}</span>
+            <span className="font-medium text-primary">{provider.name}</span>
           </div>
         </td>
-        <td className="py-2 px-2 text-secondary">{provider.type}</td>
-        <td className="py-2 px-2 text-secondary font-mono">
+        <td className="py-3 pr-4 text-secondary">{provider.type}</td>
+        <td className="py-3 pr-4 text-secondary font-mono text-xs">
           {provider.default_model || "—"}
         </td>
-        <td className="py-2 px-2 text-secondary">
+        <td className="py-3 pr-4 text-secondary">
           {usedBy.length > 0 ? (
             usedBy.join(", ")
           ) : (
@@ -119,10 +119,10 @@ function ProviderRow({
             </span>
           )}
         </td>
-        <td className="py-2 px-2 text-muted whitespace-nowrap">
+        <td className="py-3 pr-4 text-muted whitespace-nowrap">
           {formatDate(provider.created_at)}
         </td>
-        <td className="py-2 px-2 text-right whitespace-nowrap">
+        <td className="py-3 text-right whitespace-nowrap">
           <Button variant="ghost" size="sm" onClick={onEdit}>
             Edit
           </Button>
@@ -132,9 +132,9 @@ function ProviderRow({
         </td>
       </tr>
       {expanded && (
-        <tr className="border-b border-default/50 bg-surface/50">
+        <tr className="border-b border-default bg-surface/50">
           <td></td>
-          <td colSpan={6} className="py-3 px-2">
+          <td colSpan={6} className="py-3 pr-4">
             <dl className="grid grid-cols-[140px_1fr] gap-y-1 text-xs">
               {provider.endpoint && (
                 <>

--- a/gui/src/hooks/use-providers.ts
+++ b/gui/src/hooks/use-providers.ts
@@ -16,10 +16,10 @@ export function useProviderTypes() {
   });
 }
 
-export function useModelCatalog(provider?: string, search?: string) {
+export function useModelCatalog(provider?: string, search?: string, limit?: number) {
   return useQuery({
-    queryKey: ["model-catalog", provider, search],
-    queryFn: () => api.getModelCatalog(provider, search),
+    queryKey: ["model-catalog", provider, search, limit],
+    queryFn: () => api.getModelCatalog(provider, search, limit),
   });
 }
 

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -92,10 +92,11 @@ export const api = {
     const res = await request<ProviderTypesResponse>("/providers/types");
     return res.types;
   },
-  getModelCatalog: async (provider?: string, search?: string): Promise<CatalogModel[]> => {
+  getModelCatalog: async (provider?: string, search?: string, limit?: number): Promise<CatalogModel[]> => {
     const params = new URLSearchParams();
     if (provider) params.set("provider", provider);
     if (search) params.set("search", search);
+    if (limit) params.set("limit", String(limit));
     const qs = params.toString();
     const res = await request<CatalogResponse>(`/providers/catalog${qs ? `?${qs}` : ""}`);
     return res.models;


### PR DESCRIPTION
## Summary
Follow-up to #694 addressing four UX issues spotted in the merged Providers page:

- **Registry tab** is now a provider dropdown (`All providers` default + every type from `/providers/types`, including `ollama`) with a paginated model list (page size 50). The `All providers` view fetches the full catalog (`limit=500`) and adds a `Provider` column. Fixes the bug where only ~openai was visible because the un-filtered catalog response was sliced at 100.
- **Openrouter pagination** — selecting openrouter now shows all ~354 models across pages instead of a hard-capped 100.
- **Ollama visibility** — ollama shows up as a dropdown option; selecting it swaps the table for a per-host helper message (its models are discovered live from the daemon, not the static catalog).
- **Configured tab styling** — dropped the `bg-surface` page wrapper that gave the table a teal tint. Content is now wrapped in `Card padding="md"` and the table cells/typography match `dashboard/agent-table.tsx` (`text-sm`, `pb-3 pr-4` / `py-3 pr-4`, `last:border-0`, hover-only highlight).
- **Button label** — `+ Add Provider` → `+ Add model provider` (tab header + empty state).

No backend changes — uses existing `/providers/types` and `/providers/catalog` endpoints.

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — 4056 py / 257 ui
- [x] Linter passes (`make lint`) — ruff + eslint clean
- [x] TypeScript compiles (`npx tsc --noEmit`)

### Manual Testing
- Built UI (`make build-ui`) and served via `clawctl gui` at `http://localhost:36000/providers`.
- Confirmed dropdown lists all supported types with model counts; ollama shows "per-host".
- Confirmed `All providers` view renders a `Provider` column and paginates ~476 models across pages.
- Confirmed openrouter view paginates ~354 models 50 per page with working Prev/Next.
- Confirmed configured-providers table renders in a white card matching the Fleet Agents table.
- Confirmed "+ Add model provider" copy in tab header and empty state.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — N/A, pure read/display path
- [x] No SQL injection, XSS, or command injection risks — search filter is client-side string match
- [x] Dependencies are from trusted sources — no new deps

## Callouts

- [DECISION] `All providers` view fetches with `limit=500` rather than introducing pagination params on the backend.
  - Why: Current catalog totals ~476 models (openrouter 354 + openai 54 + bedrock 42 + groq 18 + anthropic 8). `limit=500` fits within the existing backend cap (`le=500`) with headroom; no API surface change needed.
  - Reviewer: confirm or push back if the catalog is expected to grow past 500.

- [DECISION] `Add Provider` modal title (`<Modal title="Add Provider">`) was left as-is; only the button label changed.
  - Why: User feedback called out the button specifically. Modal title left consistent with the existing entry point.
  - Reviewer: please verify or ask for the modal title to be updated too.

- [ENVIRONMENT] ATX review path: per session instructions, MCP-based ATX was unavailable; review is intended via the `atx` CLI on this PR after open.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)