### PR TITLE
chore(release): v26.6.2

### DIFF
--- a/.itx/release-v26.6.2/00_RELEASE.md
+++ b/.itx/release-v26.6.2/00_RELEASE.md
@@ -1,0 +1,35 @@
+# Release v26.6.2 prompt log
+
+## Release
+
+**Stage**: release
+**Skill**: /itx-release
+**Timestamp**: 2026-06-15T04:26:31Z
+**Model**: claude-opus-4-7
+
+```prompt
+plan the next release
+```
+
+**Output**: Cut `release/v26.6.2` (PR #709) — bumped `pyproject.toml` /
+`uv.lock` / `AGENTS.md` to 26.6.2; synced `clawrium==26.6.2` /
+`clawctl 26.6.2` in `docs/installation.md`, `website/docs/installation.md`,
+`website/docs/guides/quickstart.md`, `website/docs/scenarios/101.md`;
+restructured root `CHANGELOG.md` with BREAKING / Added / Changed / Fixed /
+Documentation sections, then archived to `docs/releases/26.6.2/CHANGELOG.md`
+and reset root to the empty `[Unreleased]` template. Documented BREAKING
+removal of the legacy `clm` CLI entry point (#706). Manual review only —
+no ATX requested for the release PR (Stop-hook ATX still ran and returned
+4/5 with 4 non-blocking suggestions; S1–S4 addressed in a follow-up commit
+on the same branch).
+
+**Test status at cut**:
+
+- `make lint` — pass (ruff + next-lint)
+- `make test` (pre-edit) — 3402 passed / 2 skipped (backend); 278 passed
+  (frontend, 26 files)
+- `make test` (post-edit, after all release-bump edits) — 3402 passed / 2
+  skipped (backend); 278 passed (frontend, 26 files)
+- Stale-mention scan (`git grep '\b26\.6\.1\b'` excluding
+  `docs/releases/26.6.1/` and `website/build/`) — clean
+- Diff-scope guard (9 files vs known-set regex) — clean

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ Currently available:
 
 - Repository: https://github.com/ric03uec/clawrium
 - Project Board: https://github.com/users/ric03uec/projects/1
-- Version: 26.6.1
+- Version: 26.6.2
 - Changelog: [`CHANGELOG.md`](CHANGELOG.md) (current unreleased) · [`docs/releases/`](docs/releases/) (per-release archive)
 
 ## Gateway Token Lifecycle (zeroclaw)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,23 @@
-- V7 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #674 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#669)
-- V8 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #680 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#677)
-- V9 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #684 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#678)
-- V10 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #686 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#679)
-- V11 SDLC smoke test ran end-to-end with clawrium-maurice (issue prep), clawrium-triage (plan #689 merged), clawrium-exec (this PR), clawrium-gtm (announcement). (#682)
-- Changed: hermes bedrock multi-attach is now allowed when every bedrock attachment shares the same `(access_key, secret_key, region)` triple — previously any second bedrock attachment raised. Divergent credentials or regions still raise upfront with an updated error message. (#692)
-- Changed: GUI Providers page reworked — Configured providers now render as a table (provider, type, default model, used by, created, actions) with an inline "describe" row-expand, and the model catalog moved to a new "Registry" tab. Adding/editing a Bedrock provider now prompts for AWS Access Key ID, Secret Access Key, and Region (free text, default `us-east-1`) instead of an API key; the API surface gains `requires_aws_credentials` / `default_region` on `/types` and `region` / `has_aws_credentials` on `/providers`. (#694)
-- Changed: GUI sidebar reorganized — added an **Agents** entry (after Dashboard) that hosts the fleet table previously embedded on the Dashboard; **Integrations** moved above the not-yet-built rows; added placeholder **Scheduled Jobs** and **Agent Builder** entries alongside the existing **MCPs**. (#701)
-- Changed: GUI sidebar — **MCPs**, **Scheduled Jobs**, and **Agent Builder** rows render as grayed-out clickable buttons that open a "coming soon" modal with three actions: **Upvote on GitHub** (per-item issue #698 / #699 / #700), **Join the discussion on Discord**, and **Request a different feature** (feature-request template). **Settings** moved out of the main nav into the footer section above GitHub / Docs / Discord (gear icon, active-state highlighting). Modal close restores focus to the triggering button (WCAG 2.4.3). (#702)
-- Added: new `litellm` provider type for OpenAI-compatible proxies (LiteLLM, vLLM, etc.). `clawctl provider add --type litellm --url <proxy> --model <id>` registers a provider with a bearer master key; `clawctl provider refresh` populates `available_models` from the proxy's `/v1/models` endpoint. Supported on hermes agents — `render_hermes` emits `provider: "custom"` with `base_url: <url>/v1` (matching the existing ollama OpenAI-bypass shape) plus `LITELLM_API_KEY=` for the primary attachment and `LITELLM_<ROLE_UPPER>_API_KEY=` for each auxiliary attachment. (#705)
+# Changelog
+
+All notable changes to this project are documented here. Per-release frozen
+archives live under [`docs/releases/`](docs/releases/) — that directory is
+the single place to read the full history of what shipped in each version.
+
+The project follows a `YY.M.PATCH` calendar versioning convention; the
+`## [Unreleased]` section below is the working log for the next release
+cut. The `itx:release` skill archives this section into a new
+`docs/releases/<version>/CHANGELOG.md` and resets this file to an empty
+`[Unreleased]` template on every release.
+
+## [Unreleased]
+
+### BREAKING
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Documentation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,7 +54,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.6.1
+ + clawrium==26.6.2
 ```
 
 ### Run Without Installing
@@ -101,7 +101,7 @@ Check the version:
 clawctl --version
 ```
 ```
-clawctl 26.6.1
+clawctl 26.6.2
 ```
 
 ## Initialize Clawrium

--- a/docs/releases/26.6.2/CHANGELOG.md
+++ b/docs/releases/26.6.2/CHANGELOG.md
@@ -7,6 +7,22 @@ release lives at the repository root in [`CHANGELOG.md`](../../../CHANGELOG.md).
 Versions follow [SemVer](https://semver.org/), and the project tracks a
 calendar versioning convention: `YY.M.PATCH`.
 
+### Curation at release cut
+
+This archive is not a verbatim copy of the working `CHANGELOG.md` at the
+time of the cut — two curation decisions were applied:
+
+- **Added** to this archive (was missing from the working log when the
+  cut began): #697 (GUI Providers page UX follow-ups). This was a
+  documentation gap, not a behavioural change to ship.
+- **Omitted** from this archive (were in the working log but do not
+  belong in user-facing release notes): the V7–V11 SDLC smoke-test
+  entries (#669, #677, #678, #679, #682). They remain visible in the git
+  history and on the PR list.
+
+Future releases should keep the working log strictly synchronised so the
+working-log → archive diff is purely a heading rename.
+
 ## [26.6.2]
 
 ### BREAKING
@@ -19,6 +35,9 @@ calendar versioning convention: `YY.M.PATCH`.
   - The same cleanup removed 21 legacy test files. Out-of-tree
     integrations that targeted `src/clawrium/cli/main.py` must be
     re-pointed at `src/clawrium/cli/clawctl/`.
+  - **No compatibility shim.** If you cannot migrate immediately, pin
+    `clawrium==26.6.1` (the last release that ships the `clm` entry
+    point) until your scripts and aliases are updated.
 
 ### Added
 

--- a/docs/releases/26.6.2/CHANGELOG.md
+++ b/docs/releases/26.6.2/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Release 26.6.2
+
+Archived changelog for the **26.6.2** release. This is the frozen record of
+everything that shipped in this version; the working changelog for the next
+release lives at the repository root in [`CHANGELOG.md`](../../../CHANGELOG.md).
+
+Versions follow [SemVer](https://semver.org/), and the project tracks a
+calendar versioning convention: `YY.M.PATCH`.
+
+## [26.6.2]
+
+### BREAKING
+
+- The legacy `clm` CLI entry point has been removed. The wired CLI is now
+  exclusively `clawctl`. (#706)
+  - **No automated migration.** Update scripts, shell aliases, and CI
+    invocations from `clm <command>` to `clawctl <command>`. Argument
+    surfaces are unchanged — only the binary name differs.
+  - The same cleanup removed 21 legacy test files. Out-of-tree
+    integrations that targeted `src/clawrium/cli/main.py` must be
+    re-pointed at `src/clawrium/cli/clawctl/`.
+
+### Added
+
+- New `litellm` provider type for OpenAI-compatible proxies (LiteLLM,
+  vLLM, etc.). `clawctl provider add --type litellm --url <proxy> --model
+  <id>` registers a provider with a bearer master key; `clawctl provider
+  refresh` populates `available_models` from the proxy's `/v1/models`
+  endpoint. Supported on hermes agents — `render_hermes` emits `provider:
+  "custom"` with `base_url: <url>/v1` (matching the existing ollama
+  OpenAI-bypass shape) plus `LITELLM_API_KEY=` for the primary attachment
+  and `LITELLM_<ROLE_UPPER>_API_KEY=` for each auxiliary attachment. (#705)
+
+### Changed
+
+- Hermes bedrock multi-attach is now allowed when every bedrock attachment
+  shares the same `(access_key, secret_key, region)` triple — previously
+  any second bedrock attachment raised. Divergent credentials or regions
+  still raise upfront with an updated error message. (#692)
+- GUI Providers page reworked — Configured providers now render as a
+  table (provider, type, default model, used by, created, actions) with
+  an inline "describe" row-expand, and the model catalog moved to a new
+  "Registry" tab. Adding/editing a Bedrock provider now prompts for AWS
+  Access Key ID, Secret Access Key, and Region (free text, default
+  `us-east-1`) instead of an API key; the API surface gains
+  `requires_aws_credentials` / `default_region` on `/types` and `region`
+  / `has_aws_credentials` on `/providers`. (#694)
+- GUI Providers page follow-ups — registry dropdown, fleet-style table,
+  and button-label refinements on top of #694. (#697)
+- GUI sidebar reorganized — added an **Agents** entry (after Dashboard)
+  that hosts the fleet table previously embedded on the Dashboard;
+  **Integrations** moved above the not-yet-built rows; added placeholder
+  **Scheduled Jobs** and **Agent Builder** entries alongside the existing
+  **MCPs**. (#701)
+- GUI sidebar — **MCPs**, **Scheduled Jobs**, and **Agent Builder** rows
+  render as grayed-out clickable buttons that open a "coming soon" modal
+  with three actions: **Upvote on GitHub** (per-item issue #698 / #699 /
+  #700), **Join the discussion on Discord**, and **Request a different
+  feature** (feature-request template). **Settings** moved out of the
+  main nav into the footer section above GitHub / Docs / Discord (gear
+  icon, active-state highlighting). Modal close restores focus to the
+  triggering button (WCAG 2.4.3). (#702)
+
+### Fixed
+
+### Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawrium"
-version = "26.6.1"
+version = "26.6.2"
 description = "CLI tool for managing AI assistant fleets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "clawrium"
-version = "26.6.1"
+version = "26.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -33,7 +33,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.6.1
+ + clawrium==26.6.2
 ```
 
 Verify installation:

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -62,7 +62,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.6.1
+ + clawrium==26.6.2
 ```
 
 ### Run Without Installing
@@ -109,7 +109,7 @@ Check the version:
 clawctl --version
 ```
 ```
-clawctl 26.6.1
+clawctl 26.6.2
 ```
 
 ## Initialize Clawrium

--- a/website/docs/scenarios/101.md
+++ b/website/docs/scenarios/101.md
@@ -43,7 +43,7 @@ Verify the installation:
 
 ```bash
 $ clawctl --version
-clawctl 26.6.1
+clawctl 26.6.2
 ```
 
 ## Step 2: Register the Host (first run — surface the manual setup)


### PR DESCRIPTION
## Summary
- Bump `clawrium` to **v26.6.2** (pyproject.toml, uv.lock, AGENTS.md)
- Sync `clawrium==26.6.2` / `clawctl 26.6.2` in engineering docs (`docs/installation.md`) and website docs (`website/docs/installation.md`, `website/docs/guides/quickstart.md`, `website/docs/scenarios/101.md`)
- Archive working changelog into `docs/releases/26.6.2/CHANGELOG.md`; reset root `CHANGELOG.md` to the empty `[Unreleased]` template

## Notable contents of this release
- **BREAKING (#706):** legacy `clm` CLI entry point removed. Users must switch to `clawctl`. No automated migration — pin `clawrium==26.6.1` if migration cannot happen immediately. See `docs/releases/26.6.2/CHANGELOG.md` for exact migration steps.
- **Added (#705):** new `litellm` provider type for OpenAI-compatible proxies (LiteLLM, vLLM, etc.), supported on hermes.
- **Changed:** hermes bedrock multi-attach with shared creds (#692); GUI Providers page rework + Bedrock AWS-creds flow (#694, #697); GUI sidebar reorg + Agents tab (#701); GUI sidebar coming-soon modal (#702).

## Testing
- [x] `make lint` passes (pre + post-edit)
- [x] `make test` passes (3402 backend / 2 skipped + 278 frontend, both pre + post-edit)
- [x] Stale-version scan clean (no `26.6.1` outside `docs/releases/26.6.1/`)
- [x] Diff-scope guard: all 9 modified files in the known set
- [x] `docs/installation.md` ↔ `website/docs/installation.md` body diff is empty (mirror in sync)

## ATX Review Summary

**Final Review: Rating 4/5** — no blocking issues

| Review | Rating | Blocking | Status | Agents |
|--------|--------|----------|--------|--------|
| 1 | 4/5 | None | All 4 suggestions addressed in `403b2a0` | test-coverage |

<details>
<summary>Review 1 — Suggestions (Rating 4/5)</summary>

| # | File | Suggestion | Action |
|---|------|------------|--------|
| S1 | `.itx/release-v26.6.2/00_RELEASE.md` | File listed in scope but not committed to HEAD | Fixed — added in follow-up commit |
| S2 | `docs/releases/26.6.2/CHANGELOG.md` vs working `CHANGELOG.md` | Asymmetric add (#697) + drop (V7-V11 SDLC) makes diff non-auditable | Fixed — added "Curation at release cut" preamble note documenting both decisions |
| S3 | `docs/releases/26.6.2/CHANGELOG.md` BREAKING | `clm` removal missing pin-downgrade path | Fixed — added "Pin `clawrium==26.6.1`" guidance to BREAKING entry |
| S4 | Prompt log | `make test` status not recorded for release artifact | Fixed — appended pre + post-edit lint/test status to `00_RELEASE.md` |

</details>

## Reviewer Notes
- Release PR — release skill's mechanical-content carve-out applies, but Stop-hook ATX still ran and returned a useful 4/5. Findings addressed in `403b2a0`.
- After merge: tag `v26.6.2`, push tag, `gh release create v26.6.2 --generate-notes` to trigger `publish.yml`.
- Untracked files in the working tree (`.sdlc/`, `docs-drift-watchdog-cron.md`) intentionally not touched per ask; they were not staged.

Closes nothing — release housekeeping.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>