### PR TITLE
fix(gui): test-isolation race in fleet health route

### DIFF
--- a/src/clawrium/gui/routes/fleet.py
+++ b/src/clawrium/gui/routes/fleet.py
@@ -38,14 +38,38 @@ router = APIRouter(prefix="/api", tags=["fleet"])
 # Cap concurrent SSH probe sweeps. Each /fleet/health call dispatches one
 # ansible-runner subprocess per agent, so a tight polling loop can
 # exhaust fd / thread-pool limits on small homelab hardware.
-_FLEET_HEALTH_SEMAPHORE = asyncio.Semaphore(2)
 _FLEET_HEALTH_TIMEOUT_S = 60.0
 # Dedicated thread pool so a leaked / still-running SSH thread (asyncio
 # can't actually cancel a sync function past `wait_for`) cannot starve
 # the default executor that backs every other `asyncio.to_thread` site.
-_FLEET_HEALTH_EXECUTOR = ThreadPoolExecutor(
-    max_workers=2, thread_name_prefix="fleet-health"
-)
+#
+# Both the semaphore and executor are lazy-initialized rather than
+# bound at module import. `asyncio.Semaphore` latches to the event loop
+# active on first use, so a module-level instance breaks under pytest
+# (each TestClient spins up a fresh loop). The executor is rebound by
+# the FastAPI lifespan in `gui/server.py`, but tests that hit the route
+# outside the lifespan, or after the lifespan has shut down, can race
+# against a stale handle. The accessors below give us per-loop
+# semaphores and a "recreate-if-shutdown" executor.
+_FLEET_HEALTH_EXECUTOR: ThreadPoolExecutor | None = None
+
+
+def _get_fleet_health_semaphore() -> asyncio.Semaphore:
+    loop = asyncio.get_running_loop()
+    sem = getattr(loop, "_clawrium_fleet_sem", None)
+    if sem is None:
+        sem = asyncio.Semaphore(2)
+        loop._clawrium_fleet_sem = sem  # type: ignore[attr-defined]
+    return sem
+
+
+def _get_fleet_health_executor() -> ThreadPoolExecutor:
+    global _FLEET_HEALTH_EXECUTOR
+    if _FLEET_HEALTH_EXECUTOR is None or _FLEET_HEALTH_EXECUTOR._shutdown:
+        _FLEET_HEALTH_EXECUTOR = ThreadPoolExecutor(
+            max_workers=2, thread_name_prefix="fleet-health"
+        )
+    return _FLEET_HEALTH_EXECUTOR
 
 # Strip absolute filesystem paths from error strings before sending them
 # to the browser. Some `HealthResult.error` strings constructed inside
@@ -146,10 +170,12 @@ async def fleet_health(host: str | None = None):
     fleet overview has rendered.
     """
     loop = asyncio.get_running_loop()
-    async with _FLEET_HEALTH_SEMAPHORE:
+    async with _get_fleet_health_semaphore():
         try:
             agents, summary = await asyncio.wait_for(
-                loop.run_in_executor(_FLEET_HEALTH_EXECUTOR, get_fleet_data, host),
+                loop.run_in_executor(
+                    _get_fleet_health_executor(), get_fleet_data, host
+                ),
                 timeout=_FLEET_HEALTH_TIMEOUT_S,
             )
         except asyncio.TimeoutError as e:

--- a/src/clawrium/gui/server.py
+++ b/src/clawrium/gui/server.py
@@ -51,11 +51,6 @@ async def lifespan(app: FastAPI):
             except Exception:  # noqa: BLE001 — keep the loop alive
                 logger.exception("web-ui reaper iteration failed")
 
-    from concurrent.futures import ThreadPoolExecutor
-
-    fleet._FLEET_HEALTH_EXECUTOR = ThreadPoolExecutor(
-        max_workers=2, thread_name_prefix="fleet-health"
-    )
     task = asyncio.create_task(_reaper_loop(), name="web-ui-reaper")
     try:
         yield
@@ -65,10 +60,13 @@ async def lifespan(app: FastAPI):
             await task
         except (asyncio.CancelledError, Exception):  # noqa: BLE001
             pass
-        fleet._FLEET_HEALTH_EXECUTOR.shutdown(wait=False, cancel_futures=True)
-        fleet._FLEET_HEALTH_EXECUTOR = ThreadPoolExecutor(
-            max_workers=2, thread_name_prefix="fleet-health"
-        )
+        # Intentionally NOT shutting down the fleet-health executor here.
+        # It's a process-wide singleton (lazy-init in fleet.py), and tests
+        # frequently run multiple TestClient lifespans concurrently — if
+        # one lifespan exit shut down the shared executor, an in-flight
+        # request on another lifespan would race into
+        # "cannot schedule new futures after shutdown". Python's atexit
+        # in ThreadPoolExecutor cleans the pool up at process exit.
         # close() does a SIGTERM→busy-wait→SIGKILL dance that can block up
         # to ~2 s per tunnel. Run sequentially via asyncio.to_thread so the
         # event loop isn't blocked and uvicorn's graceful-shutdown budget


### PR DESCRIPTION
## Summary

Hotfix for the publish-workflow failure that blocked v26.6.2 from reaching PyPI. Two latent bugs in `src/clawrium/gui/routes/fleet.py` + `src/clawrium/gui/server.py` surfaced after PR #706 changed pytest collection order.

## Root cause

1. **`_FLEET_HEALTH_SEMAPHORE` was a module-level `asyncio.Semaphore`.** It latches to whichever event loop hits it first. Every `TestClient(app)` spins up a fresh loop — the second test that does `async with _FLEET_HEALTH_SEMAPHORE` on a different loop dies with *"is bound to a different event loop"*.
2. **`_FLEET_HEALTH_EXECUTOR` lifecycle was tied to FastAPI lifespan.** Each lifespan shutdown shut the executor down and reassigned a fresh one. With `test_fleet_health_returns_200_under_concurrent_clients` running three concurrent `TestClient` lifespans, one lifespan's shutdown could race into another lifespan's in-flight `submit`, giving *"cannot schedule new futures after shutdown"*.

Local Python 3.14 + `anyio` plugin happened to share a session loop and masked both. CI's Python 3.11 collection order made them deterministic.

## Fix

- `fleet.py`: replace the two module-level singletons with lazy accessors.
  - `_get_fleet_health_semaphore()` stashes one `Semaphore` per running loop on the loop object itself (`loop._clawrium_fleet_sem`). Per-loop → no cross-loop binding.
  - `_get_fleet_health_executor()` lazy-creates the shared `ThreadPoolExecutor` and recreates it if the prior instance has been shut down (`._shutdown` guard).
- `server.py`: drop the executor lifecycle from the FastAPI lifespan. The executor is a process-wide singleton; Python's atexit on `ThreadPoolExecutor` handles cleanup at interpreter exit. Removing the lifespan shutdown closes the cross-lifespan race entirely.

## Testing

- [x] `make lint` passes (ruff + next-lint)
- [x] `make test` — 3402 passed / 2 skipped (backend) + 278 passed (frontend)
- [x] Reproduced the failure locally before the fix (with partial fix in place); verified all 65 `tests/test_gui_routes_fleet.py` tests pass after both files patched.

## Reviewer Notes

- This will be followed by a destructive re-tag of `v26.6.2` at the merge commit (the original tag still points at `e33ded2` and was never published to PyPI), so PyPI gets a single `v26.6.2` release with this fix included.
- No version bump in this PR. `pyproject.toml` stays at `26.6.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)