### PR TITLE
chore(release): v26.6.3 (recovers v26.6.2 burn)

### DIFF
--- a/.itx/release-v26.6.3/00_RELEASE.md
+++ b/.itx/release-v26.6.3/00_RELEASE.md
@@ -1,0 +1,54 @@
+# Release v26.6.3 prompt log
+
+## Release
+
+**Stage**: release
+**Skill**: /itx-release
+**Timestamp**: 2026-06-15T05:16:48Z
+**Model**: claude-opus-4-7
+
+```prompt
+plan the next release
+```
+
+(Continuation of the same `/itx-release` invocation that produced the
+abandoned `v26.6.2` artifact.)
+
+**Output**: Cut `release/v26.6.3` after `v26.6.2` was burned by GitHub's
+immutable-releases policy. The original release branch landed via PR
+#709 and a `v26.6.2` GitHub release was created, but `publish.yml`
+failed at the `make test` step on a test-isolation race in
+`src/clawrium/gui/routes/fleet.py` (module-level `asyncio.Semaphore` +
+lifespan-shutdown executor races, both surfaced by PR #706's collection
+re-ordering). A hotfix PR #710 landed the fleet.py + server.py fix on
+main. Deleting the `v26.6.2` GitHub release and tag succeeded, but
+re-tagging `v26.6.2` was permanently rejected with
+`tag_name was used by an immutable release` (HTTP 422). GitHub locks
+tag names forever once attached to a published release, so the cleanest
+path forward was to ship the same content (release bumps + hotfix)
+under `v26.6.3`.
+
+This release PR therefore:
+
+- Bumps `pyproject.toml` / `uv.lock` / `AGENTS.md` to `26.6.3`.
+- Syncs `clawrium==26.6.3` / `clawctl 26.6.3` in
+  `docs/installation.md`, `website/docs/installation.md`,
+  `website/docs/guides/quickstart.md`, `website/docs/scenarios/101.md`.
+- Renames `docs/releases/26.6.2/` → `docs/releases/26.6.3/`, updates
+  the archive heading to `[26.6.3]`, rewrites the "Curation at release
+  cut" preamble to capture the `v26.6.2` → `v26.6.3` pivot, and adds
+  the #710 hotfix under `### Fixed`.
+- Leaves the root `CHANGELOG.md` as the empty `[Unreleased]` template
+  that PR #709 already reset it to.
+
+**Test status at cut**:
+
+- `make lint` — pass (ruff + next-lint)
+- `make test` — 3402 passed / 2 skipped (backend); 278 passed
+  (frontend, 26 files)
+- Stale-mention scan (`git grep '\b26\.6\.2\b'` excluding
+  `docs/releases/26.6.2/` and `website/build/`) — only the
+  intentional historical references in
+  `docs/releases/26.6.3/CHANGELOG.md` remain
+- The hotfix in #710 was reproduced locally on Python 3.14 before the
+  fix and verified to clear after.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ Currently available:
 
 - Repository: https://github.com/ric03uec/clawrium
 - Project Board: https://github.com/users/ric03uec/projects/1
-- Version: 26.6.2
+- Version: 26.6.3
 - Changelog: [`CHANGELOG.md`](CHANGELOG.md) (current unreleased) · [`docs/releases/`](docs/releases/) (per-release archive)
 
 ## Gateway Token Lifecycle (zeroclaw)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,7 +54,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.6.2
+ + clawrium==26.6.3
 ```
 
 ### Run Without Installing
@@ -101,7 +101,7 @@ Check the version:
 clawctl --version
 ```
 ```
-clawctl 26.6.2
+clawctl 26.6.3
 ```
 
 ## Initialize Clawrium

--- a/docs/releases/26.6.3/CHANGELOG.md
+++ b/docs/releases/26.6.3/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Release 26.6.2
+# Release 26.6.3
 
-Archived changelog for the **26.6.2** release. This is the frozen record of
+Archived changelog for the **26.6.3** release. This is the frozen record of
 everything that shipped in this version; the working changelog for the next
 release lives at the repository root in [`CHANGELOG.md`](../../../CHANGELOG.md).
 
@@ -9,21 +9,26 @@ calendar versioning convention: `YY.M.PATCH`.
 
 ### Curation at release cut
 
-This archive is not a verbatim copy of the working `CHANGELOG.md` at the
-time of the cut — two curation decisions were applied:
+This archive bundles two layers of curation:
 
-- **Added** to this archive (was missing from the working log when the
-  cut began): #697 (GUI Providers page UX follow-ups). This was a
-  documentation gap, not a behavioural change to ship.
-- **Omitted** from this archive (were in the working log but do not
-  belong in user-facing release notes): the V7–V11 SDLC smoke-test
-  entries (#669, #677, #678, #679, #682). They remain visible in the git
-  history and on the PR list.
+- **Replaces the never-shipped `v26.6.2` release.** A `v26.6.2` tag was
+  cut and a GitHub release was published, but the publish workflow
+  failed at the test step (test-isolation race in
+  `gui/routes/fleet.py`). No artifact ever reached PyPI. The tag name
+  was burned by GitHub's immutable-releases policy, so this content
+  ships as `26.6.3` with the test fix folded in (#710).
+- **Working-log curation at the original cut**: #697 (GUI Providers page
+  UX follow-ups) was added to this archive even though the working
+  `CHANGELOG.md` at cut time omitted it — that was a documentation gap,
+  not a behavioural change. The V7–V11 SDLC smoke-test entries (#669,
+  #677, #678, #679, #682) were omitted from this archive; they live in
+  git history and the PR list and do not belong in user-facing release
+  notes.
 
 Future releases should keep the working log strictly synchronised so the
 working-log → archive diff is purely a heading rename.
 
-## [26.6.2]
+## [26.6.3]
 
 ### BREAKING
 
@@ -81,5 +86,15 @@ working-log → archive diff is purely a heading rename.
   triggering button (WCAG 2.4.3). (#702)
 
 ### Fixed
+
+- Test-isolation race in the GUI's fleet-health route surfaced after the
+  pytest collection order shifted in 26.6.2-prep. The module-level
+  `asyncio.Semaphore` latched to whichever event loop touched it first,
+  so subsequent tests on a different loop crashed with "is bound to a
+  different event loop"; the lifespan-managed `ThreadPoolExecutor` was
+  shut down on every lifespan exit, racing concurrent TestClient
+  lifespans into "cannot schedule new futures after shutdown". Both
+  resources are now lazy per-loop / process-singleton with no
+  lifespan-driven shutdown. (#710)
 
 ### Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawrium"
-version = "26.6.2"
+version = "26.6.3"
 description = "CLI tool for managing AI assistant fleets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "clawrium"
-version = "26.6.2"
+version = "26.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -33,7 +33,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.6.2
+ + clawrium==26.6.3
 ```
 
 Verify installation:

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -62,7 +62,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.6.2
+ + clawrium==26.6.3
 ```
 
 ### Run Without Installing
@@ -109,7 +109,7 @@ Check the version:
 clawctl --version
 ```
 ```
-clawctl 26.6.2
+clawctl 26.6.3
 ```
 
 ## Initialize Clawrium

--- a/website/docs/scenarios/101.md
+++ b/website/docs/scenarios/101.md
@@ -43,7 +43,7 @@ Verify the installation:
 
 ```bash
 $ clawctl --version
-clawctl 26.6.2
+clawctl 26.6.3
 ```
 
 ## Step 2: Register the Host (first run — surface the manual setup)


### PR DESCRIPTION
## Summary
- Bump `clawrium` to **v26.6.3** (pyproject.toml, uv.lock, AGENTS.md)
- Sync `clawrium==26.6.3` / `clawctl 26.6.3` in engineering + website docs
- Rename `docs/releases/26.6.2/` → `docs/releases/26.6.3/`; update archive heading to `[26.6.3]`, rewrite "Curation at release cut" preamble to capture the v26.6.2 → v26.6.3 pivot, add #710 hotfix under `### Fixed`
- Root `CHANGELOG.md` already at the empty `[Unreleased]` template from #709 — unchanged

## Why v26.6.3 and not v26.6.2

PR #709 cut `v26.6.2` and `gh release create v26.6.2 --generate-notes` fired `publish.yml`. The workflow failed at the `make test` step on a test-isolation race in `src/clawrium/gui/routes/fleet.py` (PR #706 changed pytest collection order and surfaced two latent bugs — module-level `asyncio.Semaphore` binding to a dead loop, and concurrent TestClient lifespans racing over a shared `ThreadPoolExecutor`). **No PyPI artifact was ever published for v26.6.2.**

The hotfix landed via PR #710. Before re-running the publish flow, the v26.6.2 GH release was deleted and the v26.6.2 tag deleted on both local and origin. `gh release create v26.6.2` then returned `HTTP 422: tag_name was used by an immutable release`. GitHub's immutable-releases policy permanently locks a tag name once it has been attached to a published release, even after the release and tag are deleted. This is a supply-chain safety feature with no API-level override.

This PR therefore ships the same intended contents under v26.6.3.

## Notable contents of this release

Same as the (never-shipped) v26.6.2 contents, plus the test-isolation hotfix:

- **BREAKING (#706):** legacy `clm` CLI entry point removed. Users must switch to `clawctl`. No automated migration; pin `clawrium==26.6.1` if migration cannot happen immediately.
- **Added (#705):** new `litellm` provider type for OpenAI-compatible proxies (LiteLLM, vLLM, etc.), supported on hermes.
- **Changed:** hermes bedrock multi-attach with shared creds (#692); GUI Providers page rework + Bedrock AWS-creds flow (#694, #697); GUI sidebar reorg + Agents tab (#701); GUI sidebar coming-soon modal (#702).
- **Fixed:** fleet-health route test-isolation race (#710).

## Testing
- [x] `make lint` passes
- [x] `make test` — 3402 passed / 2 skipped (backend) + 278 passed (frontend, 26 files)
- [x] Stale-version scan clean — remaining `26.6.2` mentions are intentional historical context in `docs/releases/26.6.3/CHANGELOG.md`
- [x] `docs/installation.md` ↔ `website/docs/installation.md` body diff is empty (mirror in sync)

## Reviewer Notes
- Release PR — manual review only.
- After merge: tag v26.6.3, push tag, `gh release create v26.6.3 --generate-notes` to trigger `publish.yml`.
- Untracked working-tree files (`.sdlc/`, `docs-drift-watchdog-cron.md`) intentionally not touched; they were not staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)