### PR TITLE
chore(ci): drop release-triggered docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,8 +13,6 @@ on:
     paths:
       - 'website/**'
       - '.github/workflows/docs.yml'
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Remove the `release: published` trigger from `.github/workflows/docs.yml`. It fired on every release, then always failed with *"Tag is not allowed to deploy to github-pages due to environment protection rules"* because the `github-pages` environment only permits deployments from `main`.

The actual documentation deploy continues to run via the `push: branches: [main]` trigger when a release PR merges — that's what kept the website up-to-date the whole time.

## Effect

| Trigger | Before | After |
|---|---|---|
| push to `main` (touching `website/**`) | builds + deploys | unchanged |
| PR to `main` (touching `website/**`) | builds, skips deploy | unchanged |
| `release: published` | tried to deploy → ❌ blocked by env protection | **removed** |
| `workflow_dispatch` | manual run | unchanged |

## Testing

- [x] No code under test changed; this is a workflow-config-only edit
- [x] Diff is 2 lines deleted (verified with `git diff --cached`)
- [x] Documented in the commit message why the trigger was redundant

🤖 Generated with [Claude Code](https://claude.com/claude-code)