### PR TITLE
blog: v26.6.3 release notes

### DIFF
--- a/website/blog/2026-06-15-v26.6.3-release.md
+++ b/website/blog/2026-06-15-v26.6.3-release.md
@@ -1,0 +1,57 @@
+---
+slug: v26.6.3-release
+title: "What's new in clawrium v26.6.3"
+authors: [maurice]
+tags: [release-notes]
+date: 2026-06-15
+---
+
+The v26.6.3 release delivers critical fixes for v26.6.2, enhanced provider management, and foundational improvements for agent lifecycle management.
+
+<!-- truncate -->
+
+## What changed
+
+**Ethos agent type** is now first-class with declarative fleet management. Built by @MiteshSharma, this new agent type enables multi-agent coordination with explicit role assignment and lifecycle control.
+
+**Provider UX overhaul** introduces a redesigned Providers page with registry dropdowns, fleet-style tables, and improved AWS credential flows for Bedrock. The sidebar has been reorganized with a dedicated Agents tab and coming-soon indicators.
+
+**Multi-provider attachments** now support shared AWS credentials for Bedrock, enabling consistent access across multiple inference providers without redundant configuration.
+
+**Litellm provider** is now available, adding support for a wide range of LLMs through a single unified interface.
+
+**Per-agent local skills** have been fully implemented with GUI support, allowing agents to have their own persistent skill sets that can be managed through the web interface.
+
+**SDLC smoke tests** have been extended to V11, with comprehensive test coverage for the new provider and agent management features.
+
+## Why
+
+The provider UX changes address user feedback about inconsistent credential management and poor discoverability. The new design makes it clear which providers are available and how to configure them.
+
+The Ethos agent type and per-agent local skills are foundational for our next phase: autonomous agent teams that can adapt their capabilities dynamically based on task requirements.
+
+The v26.6.3 release is a critical patch to recover from the v26.6.2 release, which had a critical bug in the SDLC pipeline.
+
+## Try it
+
+```bash
+# Install or upgrade
+uv tool install clawrium@v26.6.3
+
+# Use the new Ethos agent type
+clawctl agent create --type ethos my-ethos-agent
+
+# Configure providers with the new UI
+clawctl provider list
+
+# Access per-agent local skills in the web UI
+# Navigate to Agents > [agent name] > Skills
+```
+
+## Links
+
+- [GitHub release](https://github.com/ric03uec/clawrium/releases/tag/v26.6.3)
+- [Ethos agent documentation](https://ric03uec.github.io/clawrium/docs/agent-support/ethos)
+- [Provider management guide](https://ric03uec.github.io/clawrium/docs/agent-support/providers)
+- [Per-agent local skills](https://ric03uec.github.io/clawrium/docs/guides/local-skills)
+- [SDLC pipeline documentation](https://ric03uec.github.io/clawrium/docs/operations/sdlc)


### PR DESCRIPTION
Follows gtm-env skill: uses v26.6.0 template structure, synthesizes release notes into prose, no PR bullets