### PR TITLE
fix(website): land ATX review warning fixes for blog UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,21 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Added
 
+- Right-hand rail on the `/blog` listing (About, Tags, Community sections),
+  filling the previously empty `col--2` slot. Sticky-positioned with its own
+  scroll on short viewports; hidden below 996px. Individual post pages still
+  render the standard table of contents in that column.
+
 ### Changed
+
+- Blog post titles shrunk from 3rem to 2.25rem (1.6rem on screens ≤576px).
+  In-post body headings (`h1`–`h4`) reduced by one step. All overrides scoped
+  to `.blog-wrapper` so docs typography is unaffected.
+- Left blog sidebar now groups posts by month (e.g. "June 2026") instead of
+  year and shows every post (`blogSidebarCount: 'ALL'`).
+- Sidebar "All posts" label is now a link back to `/blog` so readers can
+  navigate back from any post page.
 
 ### Fixed
 
 ### Documentation
-
-- Website blog UI improvements: post titles shrunk to 2.25rem; in-post body
-  headings (`h1`–`h4`) reduced by one step; left sidebar groups posts by
-  month (e.g. "June 2026") instead of year and shows all posts; the
-  sidebar's "All posts" title now links back to `/blog`; the `/blog` listing
-  page gains a right-hand rail with About, Tags, and Community sections so
-  the previously empty `col--2` slot is no longer dead space.

--- a/website/src/components/BlogRightRail/index.tsx
+++ b/website/src/components/BlogRightRail/index.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
+import React, {type ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
 
 type Tag = {label: string; to: string};
 
+// Slugs must match the keys in website/blog/tags.yml — Docusaurus generates
+// /blog/tags/<slug> from those frontmatter entries. Renaming a tag there
+// requires updating this list to avoid 404s from the right rail.
 const TAGS: Tag[] = [
   {label: 'Announcements', to: '/blog/tags/announcements'},
   {label: 'Release Notes', to: '/blog/tags/release-notes'},
@@ -16,9 +19,11 @@ const GITHUB_REPO = 'https://github.com/ric03uec/clawrium';
 const DISCUSSIONS = 'https://github.com/ric03uec/clawrium/discussions';
 const ISSUES = 'https://github.com/ric03uec/clawrium/issues';
 
-export default function BlogRightRail(): React.JSX.Element {
+export default function BlogRightRail(): ReactNode {
   return (
-    <aside className={styles.rail} aria-label="Blog sidebar">
+    <aside
+      className={styles.rail}
+      aria-label="About Clawrium and blog tags">
       <section className={styles.section}>
         <Heading as="h3" className={styles.heading}>
           About Clawrium
@@ -51,13 +56,28 @@ export default function BlogRightRail(): React.JSX.Element {
         </Heading>
         <ul className={styles.linkList}>
           <li>
-            <Link to={GITHUB_REPO}>GitHub repository</Link>
+            <Link
+              to={GITHUB_REPO}
+              target="_blank"
+              rel="noopener noreferrer">
+              GitHub repository
+            </Link>
           </li>
           <li>
-            <Link to={DISCUSSIONS}>Discussions</Link>
+            <Link
+              to={DISCUSSIONS}
+              target="_blank"
+              rel="noopener noreferrer">
+              Discussions
+            </Link>
           </li>
           <li>
-            <Link to={ISSUES}>Report an issue</Link>
+            <Link
+              to={ISSUES}
+              target="_blank"
+              rel="noopener noreferrer">
+              Report an issue
+            </Link>
           </li>
         </ul>
       </section>

--- a/website/src/components/BlogRightRail/styles.module.css
+++ b/website/src/components/BlogRightRail/styles.module.css
@@ -1,6 +1,8 @@
 .rail {
   position: sticky;
   top: calc(var(--ifm-navbar-height) + 2rem);
+  max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem));
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;

--- a/website/src/theme/BlogListPage/index.tsx
+++ b/website/src/theme/BlogListPage/index.tsx
@@ -1,3 +1,7 @@
+// Full eject (not a @theme-original wrapper): upstream BlogListPage instantiates
+// BlogLayout internally without exposing the `toc` slot, so the only way to mount
+// a right rail on the listing is to re-implement the page body. Re-sync this file
+// from @docusaurus/theme-classic on every minor bump.
 import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 

--- a/website/src/theme/BlogSidebar/Content/index.tsx
+++ b/website/src/theme/BlogSidebar/Content/index.tsx
@@ -59,6 +59,10 @@ function BlogSidebarContent({
   ListComponent,
 }: Props): ReactNode {
   const themeConfig = useThemeConfig();
+  // We repurpose Docusaurus' `blog.sidebar.groupByYear` flag as a generic
+  // "group by date" switch — when true we render month-level buckets
+  // ("June 2026") instead of upstream's year-level ones. The flag name stays
+  // because there is no public custom-themeConfig API in classic preset.
   if (themeConfig.blog.sidebar.groupByYear) {
     const grouped = groupItemsByMonth(items);
     return (


### PR DESCRIPTION
## Summary

Lands the ATX warning-fix commit that was pushed to `feat/blog-page-ui-improvements` **after** PR #717 was merged. Those fixes never made it to `main`.

This is a cherry-pick of `810c9d7` from the orphaned branch — no new code, no scope change.

## Why this PR exists

Sequence on PR #717:
1. `e8f3528 feat(website): refresh blog page UI` — pushed, merged into main.
2. ATX review surfaced W1–W6 + S1–S2 warnings.
3. `810c9d7 fix(website): address ATX review warnings on blog UI PR` — pushed to the branch after merge → never landed.

This PR brings #2's fixes onto main.

## What's in this PR

Verbatim from the cherry-picked commit:

- **W1** CHANGELOG entry moved from `### Documentation` to `### Added` (right rail) + `### Changed` (typography, sidebar monthly grouping, back-link).
- **W2** Kept the full eject of `BlogListPage` and added a re-sync comment — upstream instantiates `BlogLayout` internally without exposing the `toc` slot, so a `@theme-original` wrapper would silently drop the prop.
- **W3** `BlogRightRail/.rail` gained `max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem))` + `overflow-y: auto`. Bottom is now reachable on short viewports.
- **W4** `aria-label` on the rail changed from generic `"Blog sidebar"` (collided with the left landmark) to `"About Clawrium and blog tags"`.
- **W5** GitHub / Discussions / Issues `<Link>` elements gained `target="_blank" rel="noopener noreferrer"`.
- **W6** Added a code comment in `BlogSidebar/Content/index.tsx` documenting that `themeConfig.blog.sidebar.groupByYear` is repurposed as a "group by date" switch.
- **S1** Comment on `TAGS` array noting slugs must match `blog/tags.yml`.
- **S2** `BlogRightRail` return type aligned to `ReactNode` for consistency with sibling theme overrides.

## Files changed

- `CHANGELOG.md`
- `website/src/components/BlogRightRail/index.tsx`
- `website/src/components/BlogRightRail/styles.module.css`
- `website/src/theme/BlogListPage/index.tsx`
- `website/src/theme/BlogSidebar/Content/index.tsx`

## Testing

### Test Results
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (only the unrelated upstream `vscode-languageserver-types/mermaid` warning)
- [ ] `make test` / `make lint` — N/A for this change (website-only)

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] External links carry `target="_blank" rel="noopener noreferrer"` (no `window.opener` leakage — this is one of the fixes)
- [x] No SQL / shell / XSS surface

## ATX Review Summary

**Status: Pending** — please run `mcp__atx__request_review` on this PR. The original review on #717 (Rating 3.5/5, no blockers, 6 warnings + 4 suggestions) is what motivated this follow-up; a fresh pass against the current state of `main` is appropriate per `.claude/itx-config.json` (`mcp.review_enabled: true`).

## Follow-up

After merge: the stale `feat/blog-page-ui-improvements` branch can be deleted (it'll be fully ancestor of `main`).

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>