### PR TITLE
feat(openclaw): accept litellm provider type (extend support set + JSON render)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,6 @@ docs/demos/recordings/*
 !docs/demos/recordings/.gitkeep
 /gtm/
 tests/platform/fixtures/.ws_cache/
+
+# itx live-verification snapshots (may contain secrets from hosts.json/secrets.json)
+.itx/*/snapshots/

--- a/.itx/723/00_PLAN.md
+++ b/.itx/723/00_PLAN.md
@@ -1,0 +1,155 @@
+# Implementation Plan — #723
+
+feat(openclaw): accept litellm provider type (extend support set + JSON render)
+
+## Overview
+
+Wire `litellm` into the openclaw render path so an openclaw agent can attach a `type=litellm` provider (e.g. `clawrium-gtm-litellm` → Qwen3-Next-80B-A3B-Instruct-FP8 via the LiteLLM proxy at `inx:4000`) and have `clawctl agent configure` / `clawctl agent sync` emit a working `.openclaw/openclaw.json`.
+
+Reference target: `wolf-i` (openclaw on `wolf.tailf7742d.ts.net`) gets pointed at the same LiteLLM proxy + Qwen3-Next backbone that the gtm pipeline uses.
+
+## Resolved upstream research
+
+openclaw's native shape for custom OpenAI-compatible providers (incl. LiteLLM) is an in-`openclaw.json` `models.providers.<id>` block — there is no env-var path for this provider class. Per `docs.openclaw.ai/gateway/config-tools#custom-providers-and-base-urls`:
+
+```json5
+models: {
+  mode: "merge",
+  providers: {
+    "<provider-id>": {
+      baseUrl: "http://host:port/v1",
+      apiKey: "<bearer>",            // inline or "${ENV_VAR}"
+      api: "openai-completions",     // <- the value for LiteLLM
+      models: [{
+        id: "<model>", name: "<model>", reasoning: false, input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 65536, maxTokens: 16384
+      }]
+    }
+  }
+}
+```
+
+Model is then referenced as `"<provider-id>/<model>"` in `agents.defaults.model.primary`.
+
+Accepted `api` values: `openai-completions`, `openai-responses`, `anthropic-messages`, `google-generative-ai`. For LiteLLM (and vLLM, and any /v1/chat/completions endpoint) the value is **`openai-completions`**.
+
+Consequence for clawrium:
+
+- **No `.openclaw/env` template change.** LiteLLM's bearer goes inline in `openclaw.json` under `models.providers.<id>.apiKey`. No `OPENCLAW_LITELLM_URL` / `LITELLM_API_KEY` to invent.
+- **`_render_openclaw_json` grows a 6th managed path** — `models.providers.<provider-id>` — populated from the attached provider's `endpoint`, `api_key`, and `default_model`. This is the only meaningful render change.
+- Precedent: the legacy Ansible template `openclaw.json.j2` already writes an analogous `models.providers.ollama` block (`openclaw.json.j2:117-140`) with `api: "ollama"`. The shape is the same; only `api` and `apiKey` differ.
+
+## Files to Modify
+
+- `src/clawrium/core/render.py`
+  - Line 80–89: add `litellm` to `_AGENT_TYPE_PROVIDER_SUPPORT['openclaw']`. Update the deferred-work comment at lines 75–79 to narrow to zeroclaw only.
+  - Line 1292–1294: add `litellm` to `_OPENCLAW_SUPPORTED_PROVIDERS`.
+  - Line 1299–1302: `_OPENCLAW_MODEL_PREFIX` becomes per-attachment for litellm (the prefix is the clawctl provider name, not a static type-keyed string). Two options under "Open Implementation Detail" below.
+  - Line 1496 `_render_openclaw_json`: accept the full `provider` (currently only `provider_default_model`) so the litellm branch can read `endpoint`, `api_key`, and provider `name`. Add the 6th managed path. Update the docstring at lines 1313–1331 to document it.
+
+- `src/clawrium/core/render.py` (caller at line 1422): pass the provider through.
+
+- `tests/core/test_render.py`
+  - New positive test: `render_openclaw` succeeds for `type=litellm`; the resulting `.openclaw/openclaw.json` contains a well-formed `models.providers.<provider-name>` block with `api: "openai-completions"`, `baseUrl` ending in `/v1`, and `apiKey` matching the provider secret.
+  - Negative test update: the existing "unsupported provider" test that pinned `litellm` as the rejected case (if any) must be re-pointed at `vertex` to preserve negative-path coverage.
+  - Byte-lock fixture for openclaw + litellm — mirrors the existing openclaw + ollama / openclaw + openrouter byte-locks.
+  - Regression-pin: openclaw + bedrock / + ollama byte-locks unchanged (no surprise drift from the `_render_openclaw_json` signature change).
+
+- `tests/cli/test_provider_attach.py` (or whichever module covers attach validation today)
+  - Attach a litellm provider to an openclaw agent → succeeds; second attach → rejected with the existing single-provider-invariant message (preserves #426 behavior on openclaw).
+
+- `CHANGELOG.md`
+  - `## [Unreleased]` → `### Added` entry: "openclaw agents can now attach `type=litellm` providers (custom OpenAI-compatible endpoints, e.g. LiteLLM/vLLM proxies)."
+
+- `docs/agent-support/openclaw.md` (if present) and `docs/agent-support/index.md`
+  - Remove the openclaw-doesn't-support-litellm carve-out; mirror the hermes row.
+
+## Open Implementation Detail (decide during execution, not before)
+
+The model-prefix table `_OPENCLAW_MODEL_PREFIX` today is type-keyed and static (`"openrouter": "openrouter/"`). For litellm the prefix is the clawctl **provider name**, not the type. Two choices:
+
+1. **Bypass the table for litellm**: in `render_openclaw`, branch on `ptype == "litellm"` and compute `model_id = f"{provider.name}/{provider.default_model}"` directly. Smallest delta. Asymmetric with the other types but honest about the constraint.
+2. **Restructure the table to be a per-type callable** (e.g. `_OPENCLAW_MODEL_PREFIX["litellm"] = lambda p: f"{p.name}/"`). Cleaner extensibility for any future per-attachment-keyed provider. Bigger surface.
+
+Recommend (1) — three lines of branching, no API change.
+
+## Steps
+
+1. **Plan landing + AC sync** (this commit). Plan file + updated GitHub AC live on `feat/723-openclaw-litellm` off main. No source code touched yet.
+
+2. **Allow-list bump** in `render.py` (4 lines). Run `make test` — expected: any test that pinned `litellm` as openclaw-unsupported flips to passing-when-it-should-fail. Re-pin those tests to `vertex`. Commit.
+
+3. **`_render_openclaw_json` refactor.** Change signature to accept `provider` (full object). Update single call site. No behavioral change yet (the litellm branch is empty). `make test` green.
+
+4. **Add the `models.providers.<id>` writer for litellm.** Behavioral. `make test` should now have new failing tests in `tests/core/test_render.py` for the byte-lock — they don't exist yet; add them in this same commit.
+
+5. **Model-id prefixing** for litellm — implementation per "Open Implementation Detail" above. `make test` green.
+
+6. **Attach-validation test** in `tests/cli/test_provider_attach.py`. `make test` green.
+
+7. **Docs touch** — remove the openclaw-no-litellm carve-out in `docs/agent-support/*.md`. Mirror to `website/docs/agent-support/*.md` per the mirror rule in AGENTS.md.
+
+8. **CHANGELOG entry** under `[Unreleased]` → `### Added`.
+
+9. **Live verification on `wolf-i`.** Pre-state snapshot of `~/.config/clawrium/hosts.json` and `wolf-i`'s `.openclaw/openclaw.json` saved to `.itx/723/snapshots/`.
+   - `clawctl agent provider detach wolf-i clawrium-bedrock`
+   - `clawctl agent provider attach wolf-i clawrium-gtm-litellm --role primary`
+   - `clawctl agent sync wolf-i` — expect clean (1 written, 1 unchanged, drift=0).
+   - `clawctl agent exec wolf-i -- --version` — succeeds.
+   - SSH-direct smoke (curl one-shot) against the gateway chat endpoint with the persisted bearer — single-sentence completion routed via the Qwen3-Next backbone on inx. Capture command + response in `.itx/723/02_EXECUTE.md`.
+   - **Rollback:** detach litellm + re-attach `clawrium-bedrock` from snapshot. Documented in plan so it's not improvised at the wrong moment.
+
+10. **Update root `CHANGELOG.md`** if the docs touch in step 7 surfaced any user-visible behavior beyond the bare "openclaw + litellm now works" line.
+
+## Test Strategy
+
+- **Unit (deterministic):** byte-lock fixtures in `tests/core/test_render.py` for openclaw + litellm cover the `models.providers` block shape, the `agents.defaults.model.primary` prefix, and the absence of any new env-template branch (env body unchanged from openclaw + ollama baseline modulo the provider-specific section).
+- **CLI integration (in-process):** attach-validation against a fixture host config — no SSH, no network.
+- **Live (manual, on wolf-i):** sync + exec + smoke chat against the real LiteLLM/vLLM stack on inx. This is the acceptance bar from #723; non-negotiable for merge.
+
+## Acceptance Criteria (revised — replaces issue body AC)
+
+- [ ] `_AGENT_TYPE_PROVIDER_SUPPORT['openclaw']` and `_OPENCLAW_SUPPORTED_PROVIDERS` both include `litellm`. The deferred-work comment at `render.py:75-79` is narrowed to zeroclaw only.
+- [ ] `_render_openclaw_json` accepts a full provider and writes a `models.providers.<provider-name>` block with `baseUrl: <endpoint>/v1`, `apiKey: <bearer>`, `api: "openai-completions"`, and one `models[]` entry built from `default_model`. The 5 existing managed paths are unaffected.
+- [ ] `agents.defaults.model.primary` for an openclaw + litellm attachment is `"<provider-name>/<default_model>"` (e.g. `clawrium-gtm-litellm/writer`).
+- [ ] `.openclaw/env` is unchanged for litellm vs the openclaw + ollama baseline — no new env vars emitted, no template branch added.
+- [ ] `clawctl agent provider attach <openclaw-agent> <litellm-provider> --role primary` succeeds and writes the attachment in `hosts.json`.
+- [ ] `clawctl agent configure <openclaw-agent>` and `clawctl agent sync <openclaw-agent>` both succeed against an openclaw agent whose primary is a `litellm` provider. Sync reports drift=0 on a second consecutive invocation.
+- [ ] Byte-lock fixture added to `tests/core/test_render.py` for openclaw + litellm.
+- [ ] Existing openclaw byte-locks (ollama, openrouter, bedrock) are byte-identical after the refactor.
+- [ ] Single-provider invariant on openclaw still rejects a second provider attachment (preserves #426 behavior).
+- [ ] Live verification on `wolf-i`: provider swap to `clawrium-gtm-litellm`, sync clean, exec returns, smoke chat through the gateway routes via the Qwen3-Next-80B-A3B-Instruct-FP8 backbone on inx. Command + response recorded in `.itx/723/02_EXECUTE.md`.
+- [ ] `CHANGELOG.md` `[Unreleased]` → `### Added` entry shipped in the same PR.
+- [ ] `docs/agent-support/*.md` + the mirrored `website/docs/agent-support/*.md` updated to remove the openclaw-no-litellm carve-out.
+
+## Risks
+
+- **`_render_openclaw_json` signature change.** Callers: `lifecycle.py`, `lifecycle_canonical.py`. Both call sites must be updated in lockstep. Single-PR scope means any miss is caught by the test suite before merge.
+- **`baseUrl` normalization.** Providers' `endpoint` field may or may not include a trailing `/v1`. Inspect existing stored providers; normalize in `_render_openclaw_json` to always append `/v1` if absent (matching what hermes does for litellm). Add a unit test pinning both shapes.
+- **Discord pairing on wolf-i** (guild `1475252698466226357`, channel `1492934246052921344`) must survive the provider swap. Byte-lock test must pin that `channels.discord` is untouched by the litellm branch.
+- **Drift between gtm changelog and `hosts.json`** for the `clawrium-gtm` agent itself — `.sdlc/clawrium-gtm/CHANGELOG.md` claims rebind to `clawrium-gtm-litellm` but `hosts.json` still shows `clm-openrouter`. Out of scope here. Flag in PR description; do not fix in this PR.
+- **`contextWindow` / `maxTokens` defaults.** vLLM's Qwen3-Next is run with `--max-model-len 65536`. The legacy ollama branch defaults to `131072 / 16384`. Use `65536 / 16384` as the litellm defaults to match the gtm vLLM config; let the provider record optionally override via `provider.context_window` / `provider.max_tokens` (already supported on ollama, mirror it).
+
+## Subtasks
+
+None. Single contained PR. Three render-layer files + tests + docs + one live verification. `complexity:s` label is correct.
+
+## Prompt log
+
+### Plan
+
+**Stage**: planning
+**Skill**: /itx-plan-create
+**Timestamp**: 2026-06-15T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-plan-create 723 (dont create file yet)
+```
+
+```prompt
+ok. now write the plan and update acceptance tests. this should be part of one pr. write thie plan in a worktree off of main
+```
+
+**Output**: `.itx/723/00_PLAN.md` (this file) on branch `feat/723-openclaw-litellm` off `origin/main` in worktree `~/workspace/ric03uec/clawrium-issue-723/`. Issue #723 acceptance criteria rewritten in lockstep to reflect the Path B (in-JSON `models.providers`) resolution from upstream openclaw docs (`docs.openclaw.ai/gateway/config-tools#custom-providers-and-base-urls`). No source code changed yet.

--- a/.itx/723/02_EXECUTE.md
+++ b/.itx/723/02_EXECUTE.md
@@ -1,0 +1,173 @@
+# Execution log — #723
+
+feat(openclaw): accept litellm provider type (extend support set + JSON render)
+
+## Implementation
+
+Three contained edits in `src/clawrium/core/render.py`:
+
+1. **Allow-list bump** — added `litellm` to both
+   `_AGENT_TYPE_PROVIDER_SUPPORT['openclaw']` and
+   `_OPENCLAW_SUPPORTED_PROVIDERS`. Narrowed the deferred-work comment
+   to zeroclaw only (zeroclaw still has no `models.providers.<id>`
+   writer; tracked separately).
+2. **`_render_openclaw_json` refactor** — signature now accepts the
+   full `ProviderInputs` (was: just the prefixed model id). Single call
+   site updated. Docstring documents the new 6th managed path.
+3. **`models.providers.<provider-name>` writer** — when `provider.type
+   == "litellm"`, the renderer writes a custom-provider block matching
+   upstream openclaw's shape (`api: "openai-completions"`, `baseUrl`
+   normalized to `<endpoint>/v1`, inline `apiKey`, one `models[]` entry
+   built from `default_model` with `contextWindow: 65536`, `maxTokens:
+   16384` matching the gtm vLLM config). The model-id prefix for
+   litellm is the clawctl provider name (`<provider-name>/<model>`),
+   not a static type-keyed string.
+
+Tests added:
+- `tests/core/test_render.py`:
+  - `litellm` added to `test_renderer_is_idempotent` parametrize.
+  - `_OPENCLAW_ENV_LITELLM` byte-lock + parametrize entry — pins that
+    the env body is identical to the openclaw + ollama baseline modulo
+    the model id (no `LITELLM_*` env var emitted).
+  - `test_openclaw_litellm_env_has_no_litellm_specific_vars` — pins
+    that the bearer never lands in the env file (different blast radius
+    than `openclaw.json`).
+  - `test_openclaw_litellm_writes_models_providers_block` — full shape
+    assertion against the upstream openclaw docs.
+  - `test_openclaw_litellm_baseurl_with_v1_suffix_not_double_appended`
+    — `/v1` normalization invariant.
+  - `test_openclaw_non_litellm_does_not_emit_models_block` — only
+    litellm writes `models.providers`; a stray block would shadow the
+    daemon's built-in provider table.
+  - `test_openclaw_litellm_preserves_unmanaged_baseline_keys` — pins
+    that adding `models` doesn't perturb other baseline keys.
+- `tests/cli/clawctl/provider/test_agent_attach_openclaw_litellm.py` (new):
+  - `test_attach_litellm_to_openclaw_succeeds` — CLI-facing happy path.
+  - `test_openclaw_single_provider_invariant_still_holds_for_litellm`
+    — #426 invariant preserved across the allow-list change.
+  - `test_openclaw_litellm_passes_build_render_inputs` — end-to-end
+    assembly-layer signal.
+
+Docs + changelog:
+- `docs/agent-support/openclaw.md` and mirrored
+  `website/docs/agent-support/openclaw.md` — added a LiteLLM / vLLM /
+  custom OpenAI-compatible proxy row.
+- `CHANGELOG.md` — `[Unreleased]` → `### Added` entry citing the new
+  capability and the rendered shape.
+
+Existing byte-lock fixtures for openclaw + openrouter, anthropic,
+openai, bedrock, ollama, zai pass unchanged — the
+`_render_openclaw_json` signature change is non-behavioral for those
+types.
+
+## Verification
+
+### Local
+
+```
+$ make test-py
+3412 passed, 2 skipped in 33.80s
+
+$ make lint-py
+All checks passed!
+```
+
+### Live on wolf-i (openclaw, x86_64, `wolf.tailf7742d.ts.net`)
+
+Pre-state snapshot saved to `.itx/723/snapshots/hosts.json.pre`.
+
+```
+$ uv run clawctl agent provider detach clawrium-bedrock --agent wolf-i
+agent/wolf-i: detached provider 'clawrium-bedrock'
+
+$ uv run clawctl agent provider attach clawrium-gtm-litellm --agent wolf-i
+agent/wolf-i: attached provider 'clawrium-gtm-litellm'
+
+$ uv run clawctl agent sync wolf-i
+agent/wolf-i: validate: assembling render inputs for wolf-i
+agent/wolf-i: render: rendering canonical config for openclaw
+agent/wolf-i: diff: reading on-host files from wolf.tailf7742d.ts.net
+agent/wolf-i: write: writing /home/wolf-i/.openclaw/env
+agent/wolf-i: write: writing /home/wolf-i/.openclaw/openclaw.json
+agent/wolf-i: restart: restarting openclaw-wolf-i.service
+agent/wolf-i: verify: checking unit is active
+agent/wolf-i: synced  (drift=0, took 1s, 2 written, 0 unchanged)
+
+$ uv run clawctl agent sync wolf-i      # idempotent: second sync touches nothing
+agent/wolf-i: synced  (drift=0, took 0s, 0 written, 2 unchanged)
+
+$ uv run clawctl agent exec wolf-i -- --version
+OpenClaw 2026.3.13 (61d171a)
+```
+
+### On-host config visible via openclaw's own readout
+
+```
+$ uv run clawctl agent exec wolf-i -- models
+Config        : ~/.openclaw/openclaw.json
+Default       : clawrium-gtm-litellm/writer
+Providers w/ OAuth/tokens (0): -
+- clawrium-gtm-litellm effective=models.json:sk-99f4a...eabd6308 \
+    | models.json=sk-99f4a...eabd6308 \
+    | source=models.json: ~/.openclaw/agents/main/agent/models.json
+```
+
+Confirms:
+- `agents.defaults.model.primary` == `clawrium-gtm-litellm/writer` (the
+  per-attachment prefix in #723).
+- `models.providers.clawrium-gtm-litellm.apiKey` is the LiteLLM master
+  key (`sk-99f4a...eabd6308` matches the secret in `secrets.json`),
+  visible to the daemon's effective-auth store.
+
+### Smoke chat end-to-end
+
+```
+$ uv run clawctl agent exec wolf-i -- agent --agent main \
+    --message "Reply with exactly one word: pong"
+pong
+```
+
+Traffic flow:
+`clawctl` → openclaw gateway on `wolf.tailf7742d.ts.net:40198` →
+`models.providers.clawrium-gtm-litellm` (api: openai-completions, baseUrl
+`http://192.168.1.17:4000/v1`) → LiteLLM proxy → vLLM at `inx` running
+`Qwen3-Next-80B-A3B-Instruct-FP8`.
+
+Single-token reply (`pong`) confirms the full path works. The "gateway
+closed (1000 normal closure) … falling back to embedded" notice is
+openclaw's standard behavior for one-shot `agent --message` calls —
+not a regression introduced by this PR (the same notice appeared
+pre-change against bedrock).
+
+## Rollback (if needed)
+
+```
+$ uv run clawctl agent provider detach clawrium-gtm-litellm --agent wolf-i
+$ uv run clawctl agent provider attach clawrium-bedrock --agent wolf-i
+$ uv run clawctl agent sync wolf-i
+```
+
+Pre-state snapshot at `.itx/723/snapshots/hosts.json.pre` for
+deterministic restore if `provider attach` ever takes a non-default
+path.
+
+## Prompt log
+
+### Execution
+
+**Stage**: execution
+**Skill**: /itx-execute
+**Timestamp**: 2026-06-15T21:45:00-07:00
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 723
+```
+
+**Output**: Render-layer changes landed on `feat/723-openclaw-litellm`
+(this branch) per `.itx/723/00_PLAN.md`. Unit + CLI tests added (10
+new). `make test-py` + `make lint-py` green. Live verification on
+wolf-i: provider swap + sync clean (drift=0, idempotent), models
+readout confirms the new `models.providers` block, single-token smoke
+chat through openclaw → LiteLLM → Qwen3-Next backbone on inx returned
+`pong`.

--- a/.itx/723/atx-session.json
+++ b/.itx/723/atx-session.json
@@ -1,19 +1,39 @@
 {
   "session_id": "234be2b6-dc25-461b-8969-e6f2a22488e1",
   "transport": "cli",
-  "commit_sha": "7a293ff",
-  "iteration": 1,
-  "last_rating": 3,
-  "last_blockers": ["W1", "W2", "W3"],
-  "non_blocking": ["W4", "W5", "W6", "S1", "S2"],
-  "test_gaps": [
-    "parametrized baseUrl edge cases (incl. /v1/ trailing slash)",
-    "byte-lock for non-litellm openclaw.json across all 7 provider types",
-    "negative-path: missing endpoint, prefix idempotency, /-in-name rejection",
-    "CLI test: tighten assertion to pin provider name in output"
+  "iterations": [
+    {
+      "iteration": 1,
+      "commit_sha": "7a293ff",
+      "rating": 3,
+      "review_cost_usd": 3.45,
+      "duration_ms": 534930,
+      "blocking_warnings": ["W1", "W2", "W3"],
+      "non_blocking": ["W4", "W5", "W6", "S1", "S2"],
+      "specialists_completed": ["leader", "render-engine", "security-reviewer", "test-coverage"],
+      "blocking_field": false
+    },
+    {
+      "iteration": 2,
+      "commit_sha": "cac1046",
+      "rating": 4,
+      "review_cost_usd": 5.35,
+      "duration_ms": 697033,
+      "blocking_warnings": [],
+      "render_engine_followups": [
+        "W4-followup: empty-endpoint guard fires before strip/rstrip — whitespace/bare-slash slipped through",
+        "W1-followup: 'byte-for-byte hermes parity' comment is false (openclaw now has extra .strip())",
+        "W3-followup: only / rejected in provider.name; whitespace/control chars also break routing",
+        "S-suggestion: int() of context_window can raise bare ValueError",
+        "S-suggestion: S1 comment doesn't reference render_diff.py"
+      ],
+      "blocking_field": false,
+      "cleared_threshold": true
+    }
   ],
+  "iter3_polish_commit": "applied without requesting iter3 review — rating 4/5 already cleared; iter-3 fixes addressed real correctness bug (W4-followup) + comment honesty (W1-followup) + extended bad-char check (W3-followup) + 13 new parametrize cases",
+  "last_rating": 4,
+  "last_blockers": [],
   "started_at": "2026-06-15T21:50:54-07:00",
-  "updated_at": "2026-06-15T21:59:49-07:00",
-  "review_cost_usd": 3.45,
-  "duration_ms": 534930
+  "updated_at": "2026-06-15T22:20:00-07:00"
 }

--- a/.itx/723/atx-session.json
+++ b/.itx/723/atx-session.json
@@ -1,0 +1,19 @@
+{
+  "session_id": "234be2b6-dc25-461b-8969-e6f2a22488e1",
+  "transport": "cli",
+  "commit_sha": "7a293ff",
+  "iteration": 1,
+  "last_rating": 3,
+  "last_blockers": ["W1", "W2", "W3"],
+  "non_blocking": ["W4", "W5", "W6", "S1", "S2"],
+  "test_gaps": [
+    "parametrized baseUrl edge cases (incl. /v1/ trailing slash)",
+    "byte-lock for non-litellm openclaw.json across all 7 provider types",
+    "negative-path: missing endpoint, prefix idempotency, /-in-name rejection",
+    "CLI test: tighten assertion to pin provider name in output"
+  ],
+  "started_at": "2026-06-15T21:50:54-07:00",
+  "updated_at": "2026-06-15T21:59:49-07:00",
+  "review_cost_usd": 3.45,
+  "duration_ms": 534930
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Added
 
+- `openclaw` agents can now attach `type=litellm` providers — custom
+  OpenAI-compatible endpoints (LiteLLM, vLLM, any `/v1/chat/completions`
+  proxy). `clawctl agent configure` / `clawctl agent sync` render a
+  `models.providers.<provider-name>` block into `.openclaw/openclaw.json`
+  with `api: "openai-completions"`, inline `apiKey`, and `baseUrl`
+  normalized to `<endpoint>/v1`. The bearer lives in `openclaw.json`
+  exclusively — no new `.openclaw/env` var emitted. Closes #723.
 - Right-hand rail on the `/blog` listing (About, Tags, Community sections),
   filling the previously empty `col--2` slot. Sticky-positioned with its own
   scroll on short viewports; hidden below 996px. Individual post pages still

--- a/docs/agent-support/openclaw.md
+++ b/docs/agent-support/openclaw.md
@@ -32,6 +32,7 @@ OpenClaw supports all major LLM providers:
 | **[Google Vertex](providers/vertex.md)** | ✅ | [Setup Guide](providers/vertex.md) | Gemini series |
 | **[ZAI / BigModel](providers/zai.md)** | ✅ | [Setup Guide](providers/zai.md) | GLM series |
 | **[Ollama](providers/ollama.md)** | ✅ | [Setup Guide](providers/ollama.md) | Self-hosted models |
+| **LiteLLM / vLLM / custom OpenAI-compatible proxy** | ✅ | `clawctl provider registry create <name> --type litellm --litellm-url <proxy> --model <id> --api-key <bearer>` | Any model exposed by the proxy (rendered into `models.providers.<name>` in `openclaw.json` with `api: "openai-completions"`) |
 | **[Azure OpenAI](providers/azure-openai.md)** | 📋 | [Not Planned](providers/azure-openai.md) | — |
 
 **Quick Setup:**

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -165,6 +165,20 @@ def _diff_removes_secrets(diff: FileDiff) -> set[str]:
     # positives. The matrix test asserts this — if a future renderer
     # starts emitting bare secrets to e.g. `config.toml`, this branch
     # must extend.
+    #
+    # NOTE (#723 ATX W6): openclaw's `models.providers.<name>.apiKey`
+    # in `.openclaw/openclaw.json` is the first JSON-body inline
+    # secret in the canonical pipeline. It is intentionally NOT
+    # covered by this guard — a provider swap (litellm → ollama)
+    # legitimately drops the litellm block AND its `apiKey`, and a
+    # JSON-aware guard would falsely block the operator on every
+    # such swap. The boundary is enforced upstream instead:
+    # `build_render_inputs` raises `AgentConfigError` if the secret
+    # is missing in `secrets.json`, so a missing-bearer regression
+    # cannot reach this guard in the first place. If a future
+    # provider type carries a JSON-inline secret that should survive
+    # cross-provider transitions, extend the guard rather than
+    # papering over with `force=True`.
     if not diff.path.endswith(".env"):
         return set()
     host_keys = _extract_secret_keys(diff.remote_body)

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -1566,36 +1566,47 @@ def _render_openclaw_json(
 
     # 5. models.providers.<provider-name> — litellm only.
     if provider.type == "litellm":
-        # W4 (#723 ATX): defense-in-depth empty-endpoint guard. The
-        # `build_render_inputs` path already raises for litellm without
-        # an endpoint, but a future caller that bypasses assembly (e.g.
-        # a manifest-driven path) would otherwise silently emit
-        # `baseUrl: "/v1"` — a relative URL the openclaw daemon would
-        # interpret against its own host.
-        if not provider.endpoint:
-            raise AgentConfigError(
-                f"render_openclaw: litellm provider {provider.name!r} "
-                f"requires a non-empty endpoint"
-            )
         # W3 (#723 ATX): the provider name is used both as a JSON key in
         # `models.providers.<name>` AND as a routing prefix in
-        # `<name>/<model>`. A name containing `/` would silently produce
-        # ambiguous routing (`foo/bar/qwen3` → tokenizes as
-        # provider=`foo`, model=`bar/qwen3`). Reject early; the message
-        # points at the canonical fix surface.
-        if "/" in provider.name:
+        # `<name>/<model>`. A name containing `/`, whitespace, control
+        # chars, or backslash would silently corrupt the daemon's
+        # routing tokenizer or produce malformed JSON keys. Reject
+        # early; the message points at the canonical fix surface.
+        # Iteration 3 follow-up (ATX): the iter-2 check only covered
+        # `/`; whitespace and control chars also break tokenization.
+        bad_chars = [
+            c
+            for c in provider.name
+            if c == "/" or c == "\\" or c.isspace() or ord(c) < 0x20
+        ]
+        if bad_chars:
             raise AgentConfigError(
                 f"render_openclaw: litellm provider name "
-                f"{provider.name!r} must not contain '/' (used as a "
-                f"routing prefix in agents.defaults.model.primary). "
+                f"{provider.name!r} must not contain '/', '\\\\', "
+                f"whitespace, or control characters "
+                f"(used as a routing prefix in "
+                f"agents.defaults.model.primary). "
                 f"Recreate with `clawctl provider registry create "
                 f"<safe-name> --type litellm`."
             )
-        # W1 (#723 ATX): mirror hermes' normalization byte-for-byte —
-        # `rstrip('/')` BEFORE the endswith check, and `.strip()` first
-        # so a stray newline from providers.json doesn't survive into
-        # the JSON. Hermes equivalent: render.py:985-987.
+        # W1 + W4 (#723 ATX): normalization first, guard second. The
+        # iter-2 fix added `.strip()` here to defend against newlines
+        # surviving from providers.json — that extends hermes' simpler
+        # `rstrip('/')` normalization at render.py:985-987 with an
+        # additional whitespace defence rather than literal byte-for-byte
+        # parity (an iter-2 reviewer flagged the parity claim was
+        # false; corrected here). The empty-endpoint guard sits BELOW
+        # normalization so whitespace-only / bare-slash inputs ('   ',
+        # '/', '\\n') are caught — the iter-2 implementation checked
+        # `if not provider.endpoint` before strip+rstrip and let those
+        # cases through with `baseUrl: "/v1"`.
         base_url = provider.endpoint.strip().rstrip("/")
+        if not base_url:
+            raise AgentConfigError(
+                f"render_openclaw: litellm provider {provider.name!r} "
+                f"requires a non-empty endpoint "
+                f"(got {provider.endpoint!r})"
+            )
         if not base_url.endswith("/v1"):
             base_url = base_url + "/v1"
         model_name = provider.default_model

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -72,18 +72,19 @@ _BEARER_API_KEY_WITH_ENDPOINT_TYPES = frozenset({"litellm"})
 # instead of crashing later inside `render_hermes`. The membership
 # matches the renderer dispatch tables further below.
 #
-# `litellm` is hermes-only in this revision. Wiring zeroclaw/openclaw
-# would require validating that those renderers' "custom"/OpenAI-shape
-# branches accept a free-form base_url + per-aux key pattern; that
-# expansion belongs in a follow-up after the hermes E2E verifies the
-# render shape end to end (#705).
+# `litellm` on zeroclaw is still deferred — the zeroclaw renderer has no
+# `models.providers.<id>` writer and no env-var path for a free-form
+# OpenAI-compatible base_url + bearer pair. Openclaw gained litellm
+# support in #723: the renderer writes a `models.providers.<provider-name>`
+# block into `openclaw.json` with `api: "openai-completions"`, matching
+# upstream openclaw's custom-provider shape.
 _AGENT_TYPE_PROVIDER_SUPPORT: dict[str, frozenset[str]] = {
     "hermes": frozenset(
         {"openrouter", "anthropic", "openai", "bedrock", "ollama", "litellm"}
     ),
     "zeroclaw": frozenset({"openrouter", "anthropic", "openai", "ollama"}),
     "openclaw": frozenset(
-        {"openrouter", "anthropic", "openai", "bedrock", "ollama", "zai"}
+        {"openrouter", "anthropic", "openai", "bedrock", "ollama", "zai", "litellm"}
     ),
 }
 
@@ -1290,7 +1291,7 @@ def _render_zeroclaw_config_template(
 # strings. Vertex support belongs in a follow-up that extends the
 # credential schema with a credential-kind field (path vs bearer).
 _OPENCLAW_SUPPORTED_PROVIDERS = frozenset(
-    {"openrouter", "anthropic", "openai", "bedrock", "ollama", "zai"}
+    {"openrouter", "anthropic", "openai", "bedrock", "ollama", "zai", "litellm"}
 )
 _OPENCLAW_SUPPORTED_CHANNELS = frozenset({"discord", "slack"})
 _OPENCLAW_SUPPORTED_INTEGRATIONS = frozenset(
@@ -1317,13 +1318,16 @@ def render_openclaw(inputs: RenderInputs) -> RenderedFiles:
     Both files are loaded as canonical resources via `importlib.resources` so
     the wheel ships them. Env is rendered from
     `openclaw-env.canonical.j2`; JSON is loaded from `openclaw.json` baseline
-    and the five clawctl-managed paths are deep-updated from `inputs`:
+    and the clawctl-managed paths are deep-updated from `inputs`:
 
       - `channels.discord.enabled`
       - `channels.discord.allowFrom` (from inputs.channels[discord].allowed_users)
       - `channels.discord.guilds`    (nested reshape from allowed_guilds + allowed_channels)
       - `gateway.port` + `gateway.bind`
       - `agents.defaults.model.primary` (from inputs.provider.default_model + type prefix)
+      - `models.providers.<provider-name>` — litellm only (#723); writes a
+        custom OpenAI-compatible provider block so openclaw routes via the
+        operator-supplied proxy (LiteLLM, vLLM, etc.).
 
     Every other key in the baseline is preserved byte-identically (modulo
     `json.dumps` formatting), matching the silent-wipe-prevention contract
@@ -1371,7 +1375,14 @@ def render_openclaw(inputs: RenderInputs) -> RenderedFiles:
 
     # --- Build prefixed model id (used by both env + openclaw.json) -------
     model_id = inputs.provider.default_model
-    prefix = _OPENCLAW_MODEL_PREFIX.get(ptype, "")
+    if ptype == "litellm":
+        # The litellm prefix is the clawctl provider name, not a static
+        # type-keyed string — every litellm proxy is its own custom
+        # provider in `models.providers.<name>`, so the daemon picks the
+        # right block via `<provider-name>/<model>`.
+        prefix = f"{inputs.provider.name}/"
+    else:
+        prefix = _OPENCLAW_MODEL_PREFIX.get(ptype, "")
     if prefix and not model_id.startswith(prefix):
         model_id = prefix + model_id
 
@@ -1420,6 +1431,7 @@ def render_openclaw(inputs: RenderInputs) -> RenderedFiles:
 
     # --- openclaw.json: load baseline + deep-update managed paths ---------
     json_body = _render_openclaw_json(
+        provider=inputs.provider,
         provider_default_model=model_id,
         gateway=inputs.gateway,
         discord_channel=discord_channel,
@@ -1495,11 +1507,28 @@ def _openclaw_json_baseline() -> str:
 
 def _render_openclaw_json(
     *,
+    provider: "ProviderInputs",
     provider_default_model: str,
     gateway: "GatewayInputs | None",
     discord_channel: "ChannelInputs | None",
 ) -> str:
-    """Deep-update the openclaw.json baseline with the 5 clawctl-managed paths.
+    """Deep-update the openclaw.json baseline with the clawctl-managed paths.
+
+    Managed paths:
+      1. `agents.defaults.model.primary`
+      2. `gateway.port`
+      3. `gateway.bind` (+ `gateway.auth` when present)
+      4. `channels.discord.enabled` / `allowFrom` / `guilds`
+      5. (litellm only) `models.providers.<provider-name>` — a custom
+         OpenAI-compatible provider block matching upstream openclaw's
+         `models.providers` schema (see
+         `docs.openclaw.ai/gateway/config-tools#custom-providers-and-base-urls`).
+         The block sets `api: "openai-completions"`, `baseUrl` from the
+         provider's `endpoint` (`/v1` appended if missing), `apiKey` from
+         the provider's bearer, and one `models[]` entry built from
+         `default_model`. Non-litellm provider types do NOT write this
+         path — for them, model selection flows through `OPENCLAW_DEFAULT_MODEL`
+         in `.openclaw/env` only.
 
     Every other key in the baseline is preserved byte-for-byte (modulo
     json.dumps formatting). Output uses `indent=2, sort_keys=False` to keep
@@ -1514,6 +1543,36 @@ def _render_openclaw_json(
     defaults = agents.setdefault("defaults", {})
     model = defaults.setdefault("model", {})
     model["primary"] = provider_default_model
+
+    # 5. models.providers.<provider-name> — litellm only.
+    if provider.type == "litellm":
+        base_url = provider.endpoint
+        if not base_url.rstrip("/").endswith("/v1"):
+            base_url = base_url.rstrip("/") + "/v1"
+        model_name = provider.default_model
+        models_block = baseline.setdefault("models", {})
+        providers_block = models_block.setdefault("providers", {})
+        providers_block[provider.name] = {
+            "baseUrl": base_url,
+            "apiKey": provider.api_key,
+            "api": "openai-completions",
+            "models": [
+                {
+                    "id": model_name,
+                    "name": model_name,
+                    "reasoning": False,
+                    "input": ["text"],
+                    "cost": {
+                        "input": 0,
+                        "output": 0,
+                        "cacheRead": 0,
+                        "cacheWrite": 0,
+                    },
+                    "contextWindow": 65536,
+                    "maxTokens": 16384,
+                }
+            ],
+        }
 
     # 2. gateway.port + 3. gateway.bind + gateway.auth (managed bearer)
     #

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -127,9 +127,22 @@ class ProviderInputs:
     endpoint: str = ""
     default_model: str = ""
     region: str = ""
-    api_key: str = ""
-    aws_access_key: str = ""
-    aws_secret_key: str = ""
+    # Secret fields use `repr=False` so an exception traceback / pytest
+    # --showlocals / logging.debug(provider) never echoes the bearer.
+    # `FileDiff.remote_body` in core/render_diff.py uses the same
+    # hardening for the same reason. #723 ATX W5.
+    api_key: str = field(default="", repr=False)
+    aws_access_key: str = field(default="", repr=False)
+    aws_secret_key: str = field(default="", repr=False)
+    # Optional model-shape overrides used by the litellm branch of
+    # `_render_openclaw_json` (#723 ATX W2). Operator-supplied via
+    # provider record (`context_window` / `max_tokens` fields in
+    # providers.json). 0 means "renderer picks default". LiteLLM proxies
+    # front everything from 4K-context models to 256K — hard-coding any
+    # single value silently truncates or wastes capacity for whichever
+    # operator's model doesn't match.
+    context_window: int = 0
+    max_tokens: int = 0
 
 
 @dataclass(frozen=True)
@@ -152,7 +165,8 @@ class AttachedProviderInputs:
     model: str
     endpoint: str = ""
     region: str = ""
-    api_key: str = ""
+    # See ProviderInputs.api_key — same repr-leak rationale.
+    api_key: str = field(default="", repr=False)
     base_url: str = ""
 
 
@@ -420,6 +434,12 @@ def build_render_inputs(agent_name: str) -> RenderInputs:
         api_key=api_key,
         aws_access_key=aws_access_key,
         aws_secret_key=aws_secret_key,
+        # Optional model-shape overrides (#723 ATX W2). Mirrors what the
+        # legacy ollama playbook template already accepted at
+        # `openclaw.json.j2:132-133`; surfaced through ProviderInputs so
+        # `_render_openclaw_json`'s litellm branch can honor them.
+        context_window=int(provider_record.get("context_window") or 0),
+        max_tokens=int(provider_record.get("max_tokens") or 0),
     )
 
     # --- Channels ----------------------------------------------------------
@@ -1546,12 +1566,53 @@ def _render_openclaw_json(
 
     # 5. models.providers.<provider-name> — litellm only.
     if provider.type == "litellm":
-        base_url = provider.endpoint
-        if not base_url.rstrip("/").endswith("/v1"):
-            base_url = base_url.rstrip("/") + "/v1"
+        # W4 (#723 ATX): defense-in-depth empty-endpoint guard. The
+        # `build_render_inputs` path already raises for litellm without
+        # an endpoint, but a future caller that bypasses assembly (e.g.
+        # a manifest-driven path) would otherwise silently emit
+        # `baseUrl: "/v1"` — a relative URL the openclaw daemon would
+        # interpret against its own host.
+        if not provider.endpoint:
+            raise AgentConfigError(
+                f"render_openclaw: litellm provider {provider.name!r} "
+                f"requires a non-empty endpoint"
+            )
+        # W3 (#723 ATX): the provider name is used both as a JSON key in
+        # `models.providers.<name>` AND as a routing prefix in
+        # `<name>/<model>`. A name containing `/` would silently produce
+        # ambiguous routing (`foo/bar/qwen3` → tokenizes as
+        # provider=`foo`, model=`bar/qwen3`). Reject early; the message
+        # points at the canonical fix surface.
+        if "/" in provider.name:
+            raise AgentConfigError(
+                f"render_openclaw: litellm provider name "
+                f"{provider.name!r} must not contain '/' (used as a "
+                f"routing prefix in agents.defaults.model.primary). "
+                f"Recreate with `clawctl provider registry create "
+                f"<safe-name> --type litellm`."
+            )
+        # W1 (#723 ATX): mirror hermes' normalization byte-for-byte —
+        # `rstrip('/')` BEFORE the endswith check, and `.strip()` first
+        # so a stray newline from providers.json doesn't survive into
+        # the JSON. Hermes equivalent: render.py:985-987.
+        base_url = provider.endpoint.strip().rstrip("/")
+        if not base_url.endswith("/v1"):
+            base_url = base_url + "/v1"
         model_name = provider.default_model
+        # W2 (#723 ATX): operator-overridable context_window / max_tokens.
+        # Defaults match the issue spec (65536 / 16384) — tuned for
+        # vLLM's Qwen3-Next default `--max-model-len`. Operators with
+        # smaller (4K/8K) or larger (200K+) models override via
+        # `providers.json.context_window` / `.max_tokens`.
+        context_window = provider.context_window or 65536
+        max_tokens = provider.max_tokens or 16384
         models_block = baseline.setdefault("models", {})
         providers_block = models_block.setdefault("providers", {})
+        # S1 (#723 ATX): apiKey is written inline (no env-var hop). This
+        # is the upstream openclaw custom-provider contract — the
+        # daemon reads it from openclaw.json directly. The file is
+        # written atomically with mode 0600; any GUI/CLI dumper that
+        # emits the rendered JSON verbatim MUST redact this path.
         providers_block[provider.name] = {
             "baseUrl": base_url,
             "apiKey": provider.api_key,
@@ -1568,8 +1629,8 @@ def _render_openclaw_json(
                         "cacheRead": 0,
                         "cacheWrite": 0,
                     },
-                    "contextWindow": 65536,
-                    "maxTokens": 16384,
+                    "contextWindow": context_window,
+                    "maxTokens": max_tokens,
                 }
             ],
         }

--- a/tests/cli/clawctl/provider/test_agent_attach_openclaw_litellm.py
+++ b/tests/cli/clawctl/provider/test_agent_attach_openclaw_litellm.py
@@ -1,0 +1,151 @@
+"""Issue #723 — `litellm` provider type can attach to an openclaw agent.
+
+Before #723 the renderer's per-agent-type allow-list rejected
+`litellm` on openclaw, so `clawctl agent provider attach <openclaw>
+<litellm-provider>` failed up-front in `build_render_inputs` with
+`render_openclaw does not support provider type 'litellm'`. The fix
+extends `_AGENT_TYPE_PROVIDER_SUPPORT['openclaw']` and writes a
+`models.providers.<name>` block into `openclaw.json`. This test pins
+the CLI-facing contract: attach succeeds, and the openclaw
+single-provider invariant (#426) still rejects a second attachment.
+"""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+from clawrium.core.providers.storage import add_provider, set_provider_api_key
+
+runner = CliRunner()
+
+
+def _seed_litellm_provider(name: str = "lt") -> None:
+    """Seed providers.json + secrets.json with a litellm provider.
+
+    Bypasses `clawctl provider registry create --type litellm` so we
+    don't try to probe a real LiteLLM proxy in a unit test.
+    """
+    add_provider(
+        {
+            "name": name,
+            "type": "litellm",
+            "endpoint": "http://192.168.1.17:4000",
+            "default_model": "writer",
+            "available_models": ["writer"],
+        }
+    )
+    set_provider_api_key(name, "sk-master-1")
+
+
+def _seed_anthropic_provider(name: str = "anth") -> None:
+    runner.invoke(
+        app,
+        [
+            "provider",
+            "registry",
+            "create",
+            name,
+            "--type",
+            "anthropic",
+            "--api-key",
+            "k",
+        ],
+    )
+
+
+def test_attach_litellm_to_openclaw_succeeds(fleet_dir, stdin_not_tty) -> None:
+    """#723: a litellm provider attached to an openclaw agent is accepted
+    by the CLI and persisted in hosts.json."""
+    _seed_litellm_provider("clawrium-gtm-litellm")
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "clawrium-gtm-litellm",
+            "--agent",
+            "wise-hypatia",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "attached" in result.output
+
+    listed = runner.invoke(
+        app,
+        ["agent", "provider", "get", "--agent", "wise-hypatia", "-o", "json"],
+    )
+    assert listed.exit_code == 0
+    data = json.loads(listed.output)
+    assert any(p["name"] == "clawrium-gtm-litellm" for p in data)
+
+
+def test_openclaw_single_provider_invariant_still_holds_for_litellm(
+    fleet_dir, stdin_not_tty
+) -> None:
+    """#426 single-provider invariant survives the #723 allow-list change.
+
+    Attaching a second provider — of any type — to an openclaw agent
+    that already has a litellm primary must be rejected with the
+    existing "already has provider" message pointing operators at
+    `detach`.
+    """
+    _seed_litellm_provider("clawrium-gtm-litellm")
+    _seed_anthropic_provider("anth")
+
+    first = runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "clawrium-gtm-litellm",
+            "--agent",
+            "wise-hypatia",
+        ],
+    )
+    assert first.exit_code == 0, first.output
+
+    second = runner.invoke(
+        app,
+        ["agent", "provider", "attach", "anth", "--agent", "wise-hypatia"],
+    )
+    assert second.exit_code != 0
+    assert "already has provider" in second.output
+    assert "detach" in second.output
+    assert "clawrium-gtm-litellm" in second.output
+
+
+def test_openclaw_litellm_passes_build_render_inputs(
+    fleet_dir, stdin_not_tty
+) -> None:
+    """#723: `build_render_inputs` is the gate that previously blocked
+    the wire. Pin that an openclaw agent attached to a litellm provider
+    now assembles a valid RenderInputs bundle (provider.type == 'litellm',
+    api_key + endpoint populated) — the upstream signal that the
+    allow-list change works end-to-end through the assembly layer."""
+    from clawrium.core.render import build_render_inputs
+
+    _seed_litellm_provider("clawrium-gtm-litellm")
+    runner.invoke(
+        app,
+        [
+            "agent",
+            "provider",
+            "attach",
+            "clawrium-gtm-litellm",
+            "--agent",
+            "wise-hypatia",
+        ],
+    )
+
+    inputs = build_render_inputs("wise-hypatia")
+    assert inputs.agent_type == "openclaw"
+    assert inputs.provider.type == "litellm"
+    assert inputs.provider.name == "clawrium-gtm-litellm"
+    assert inputs.provider.endpoint == "http://192.168.1.17:4000"
+    assert inputs.provider.api_key == "sk-master-1"
+    assert inputs.provider.default_model == "writer"

--- a/tests/cli/clawctl/provider/test_agent_attach_openclaw_litellm.py
+++ b/tests/cli/clawctl/provider/test_agent_attach_openclaw_litellm.py
@@ -72,7 +72,11 @@ def test_attach_litellm_to_openclaw_succeeds(fleet_dir, stdin_not_tty) -> None:
         ],
     )
     assert result.exit_code == 0, result.output
+    # #723 ATX: pin the provider identity in the user-facing message,
+    # not just the verb. A bare `'attached' in output` substring match
+    # would pass even if the CLI silently attached the wrong provider.
     assert "attached" in result.output
+    assert "clawrium-gtm-litellm" in result.output
 
     listed = runner.invoke(
         app,

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -3612,10 +3612,31 @@ def test_openclaw_litellm_writes_models_providers_block():
     assert blob["agents"]["defaults"]["model"]["primary"] == "lt/gemma4:31b"
 
 
-def test_openclaw_litellm_baseurl_with_v1_suffix_not_double_appended():
-    """#723: endpoint already ending in `/v1` must not be double-suffixed.
-    Mirrors hermes' litellm normalization invariant (see
-    test_hermes_litellm_endpoint_with_v1_suffix_not_double_appended)."""
+@pytest.mark.parametrize(
+    "endpoint_in,expected_base_url",
+    [
+        # No /v1 suffix → appended.
+        ("http://h:4000", "http://h:4000/v1"),
+        # Trailing slash, no /v1 → rstrip + append.
+        ("http://h:4000/", "http://h:4000/v1"),
+        # /v1 already present → unchanged.
+        ("http://h:4000/v1", "http://h:4000/v1"),
+        # /v1/ with trailing slash → rstrip BEFORE endswith check (W1
+        # locks the hermes-parity bug ATX flagged: an earlier impl that
+        # checked `rstrip('/').endswith('/v1')` but assigned only inside
+        # the branch would leak the trailing slash into openclaw.json).
+        ("http://h:4000/v1/", "http://h:4000/v1"),
+        # Whitespace surviving from providers.json → strip().
+        ("  http://h:4000  ", "http://h:4000/v1"),
+        ("http://h:4000/v1\n", "http://h:4000/v1"),
+    ],
+)
+def test_openclaw_litellm_baseurl_normalization(endpoint_in, expected_base_url):
+    """#723 ATX W1: pin baseUrl normalization across all the input shapes
+    that have surfaced operationally. Mirrors hermes' equivalent at
+    `render.py:985-987` byte-for-byte. Pre-iteration the renderer
+    silently leaked a trailing slash for the `/v1/` input — this
+    parametrize locks the fix."""
     import json
 
     base = _baseline_inputs(ptype="litellm")
@@ -3623,7 +3644,7 @@ def test_openclaw_litellm_baseurl_with_v1_suffix_not_double_appended():
         name=base.provider.name,
         type=base.provider.type,
         default_model=base.provider.default_model,
-        endpoint=base.provider.endpoint + "/v1",
+        endpoint=endpoint_in,
         api_key=base.provider.api_key,
     )
     inputs = RenderInputs(
@@ -3636,25 +3657,238 @@ def test_openclaw_litellm_baseurl_with_v1_suffix_not_double_appended():
     )
     body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
     blob = json.loads(body)
-    assert blob["models"]["providers"]["lt"]["baseUrl"] == "http://10.0.0.5:4000/v1"
+    assert blob["models"]["providers"]["lt"]["baseUrl"] == expected_base_url
 
 
-def test_openclaw_non_litellm_does_not_emit_models_block():
+def test_openclaw_litellm_missing_endpoint_raises():
+    """#723 ATX W4: render_openclaw must raise AgentConfigError for a
+    litellm provider with an empty endpoint, rather than silently
+    emitting `baseUrl: "/v1"` (a relative URL the openclaw daemon
+    would interpret against its own host). Mirrors hermes' equivalent
+    guard at `test_render.py:test_hermes_litellm_missing_endpoint_raises`."""
+    base = _baseline_inputs(ptype="litellm")
+    provider = ProviderInputs(
+        name=base.provider.name,
+        type=base.provider.type,
+        default_model=base.provider.default_model,
+        endpoint="",
+        api_key=base.provider.api_key,
+    )
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type="openclaw",
+        provider=provider,
+        channels=(),
+        integrations=(),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tkn", bind="lan"),
+    )
+    with pytest.raises(AgentConfigError, match="non-empty endpoint"):
+        render_openclaw(inputs)
+
+
+def test_openclaw_litellm_provider_name_with_slash_raises():
+    """#723 ATX W3: a provider name containing `/` would silently
+    produce ambiguous routing (`foo/bar/model` tokenizes as
+    provider=`foo`, model=`bar/model` on openclaw's `<name>/<model>`
+    scheme). Reject at the render layer with a clear remediation."""
+    base = _baseline_inputs(ptype="litellm")
+    provider = ProviderInputs(
+        name="foo/bar",
+        type="litellm",
+        default_model=base.provider.default_model,
+        endpoint=base.provider.endpoint,
+        api_key=base.provider.api_key,
+    )
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type="openclaw",
+        provider=provider,
+        channels=(),
+        integrations=(),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tkn", bind="lan"),
+    )
+    with pytest.raises(AgentConfigError, match="must not contain '/'"):
+        render_openclaw(inputs)
+
+
+def test_openclaw_litellm_prefix_is_idempotent_when_default_model_already_prefixed():
+    """#723 ATX (test-coverage gap): the prefix-prepend branch must be
+    idempotent. If providers.json already carries
+    `default_model = "lt/gemma4:31b"` (operator-supplied or re-rendered
+    from a previous run), the result must NOT be `lt/lt/gemma4:31b`.
+    The guard at render_openclaw lives in the `not model_id.startswith(prefix)`
+    check — pin it explicitly."""
+    import json
+
+    base = _baseline_inputs(ptype="litellm")
+    provider = ProviderInputs(
+        name=base.provider.name,
+        type=base.provider.type,
+        default_model="lt/gemma4:31b",  # already prefixed
+        endpoint=base.provider.endpoint,
+        api_key=base.provider.api_key,
+    )
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type="openclaw",
+        provider=provider,
+        channels=(),
+        integrations=(),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tkn", bind="lan"),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    assert blob["agents"]["defaults"]["model"]["primary"] == "lt/gemma4:31b"
+
+
+def test_openclaw_litellm_honors_context_window_and_max_tokens_overrides():
+    """#723 ATX W2: provider record's `context_window` / `max_tokens`
+    fields, when populated, override the renderer defaults. Pins the
+    operator-override path so the next reviewer trusts the contract."""
+    import json
+
+    base = _baseline_inputs(ptype="litellm")
+    provider = ProviderInputs(
+        name=base.provider.name,
+        type=base.provider.type,
+        default_model=base.provider.default_model,
+        endpoint=base.provider.endpoint,
+        api_key=base.provider.api_key,
+        context_window=200000,
+        max_tokens=8192,
+    )
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type="openclaw",
+        provider=provider,
+        channels=(),
+        integrations=(),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tkn", bind="lan"),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    model_entry = blob["models"]["providers"]["lt"]["models"][0]
+    assert model_entry["contextWindow"] == 200000
+    assert model_entry["maxTokens"] == 8192
+
+
+def test_openclaw_litellm_context_window_default_when_unset():
+    """#723 ATX W2: when provider record carries no `context_window`/
+    `max_tokens`, the renderer falls back to the issue-spec defaults
+    (65536/16384, tuned for vLLM's Qwen3-Next default --max-model-len)."""
+    import json
+
+    inputs = _openclaw_inputs(ptype="litellm")
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    model_entry = blob["models"]["providers"]["lt"]["models"][0]
+    assert model_entry["contextWindow"] == 65536
+    assert model_entry["maxTokens"] == 16384
+
+
+def test_provider_inputs_secret_fields_redacted_in_repr():
+    """#723 ATX W5: bearer / AWS credentials must not appear in the
+    dataclass repr — a pytest --showlocals or stray log line would
+    otherwise echo cleartext. Matches FileDiff's hardening pattern in
+    core/render_diff.py."""
+    p = ProviderInputs(
+        name="lt",
+        type="litellm",
+        endpoint="http://h:4000",
+        default_model="m",
+        api_key="sk-master-do-not-leak-ABCDEFG",
+        aws_access_key="AKIA-DO-NOT-LEAK",
+        aws_secret_key="aws-secret-do-not-leak",
+    )
+    r = repr(p)
+    assert "sk-master-do-not-leak-ABCDEFG" not in r
+    assert "AKIA-DO-NOT-LEAK" not in r
+    assert "aws-secret-do-not-leak" not in r
+    # The non-secret fields are still useful for debugging.
+    assert "lt" in r
+    assert "litellm" in r
+    assert "http://h:4000" in r
+
+
+def test_attached_provider_inputs_api_key_redacted_in_repr():
+    """#723 ATX W5: same hardening on AttachedProviderInputs.api_key —
+    used by hermes' aux-litellm attachments."""
+    a = AttachedProviderInputs(
+        name="lt-aux",
+        type="litellm",
+        role="vision",
+        model="m",
+        api_key="sk-aux-do-not-leak-XYZ",
+        base_url="http://h:4000/v1",
+    )
+    r = repr(a)
+    assert "sk-aux-do-not-leak-XYZ" not in r
+    assert "lt-aux" in r
+
+
+@pytest.mark.parametrize(
+    "ptype",
+    ["openrouter", "anthropic", "openai", "bedrock", "ollama", "zai"],
+)
+def test_openclaw_non_litellm_does_not_emit_models_block(ptype):
     """#723: only litellm writes `models.providers`. The other openclaw
     provider types route via OPENCLAW_DEFAULT_MODEL env-var only — a
     stray `models` key in `openclaw.json` would shadow the daemon's
     built-in provider table for openrouter/anthropic/openai/bedrock/zai
-    and break those agents."""
+    and break those agents.
+
+    Parametrized (#723 ATX): a `for ptype in ...` loop lost per-case
+    pytest report granularity — a failure on `zai` reported the whole
+    test red without naming the offending ptype.
+    """
     import json
 
-    for ptype in ("openrouter", "anthropic", "openai", "bedrock", "ollama", "zai"):
-        inputs = _openclaw_inputs(ptype=ptype)
-        body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
-        blob = json.loads(body)
-        assert "models" not in blob, (
-            f"openclaw + {ptype} must not write models.providers; "
-            f"only litellm uses that path"
-        )
+    inputs = _openclaw_inputs(ptype=ptype)
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    assert "models" not in blob, (
+        f"openclaw + {ptype} must not write models.providers; "
+        f"only litellm uses that path"
+    )
+
+
+@pytest.mark.parametrize(
+    "ptype",
+    ["openrouter", "anthropic", "openai", "bedrock", "ollama", "zai"],
+)
+def test_openclaw_non_litellm_json_top_level_keys_match_baseline(ptype):
+    """#723 ATX (test-coverage gap): the `_render_openclaw_json` signature
+    refactor (now accepts full ProviderInputs vs just the prefixed model
+    id) widened the surface — pin that non-litellm rendered JSON
+    top-level key sets are byte-identical to the baseline shape
+    (no surprise `models` block, no key reordering at the top level).
+    Complements the existing `_OPENCLAW_JSON_BYTE_LOCK` for openrouter.
+    """
+    import json
+
+    inputs = _openclaw_inputs(ptype=ptype)
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    assert set(blob.keys()) == {
+        "agents",
+        "gateway",
+        "session",
+        "tools",
+        "channels",
+        "browser",
+        "env",
+    }, f"openclaw + {ptype} top-level keys drifted: {sorted(blob.keys())}"
+    # gateway baseline preserved (modulo managed port/bind/auth which
+    # the test fixture sets explicitly).
+    assert blob["gateway"]["mode"] == "local"
+    assert blob["gateway"]["reload"] == {"mode": "hybrid", "debounceMs": 300}
+    # agents.defaults skeleton preserved.
+    assert blob["agents"]["defaults"]["workspace"] == "~/.openclaw/workspace"
+    assert blob["agents"]["defaults"]["imageMaxDimensionPx"] == 1200
+    assert blob["agents"]["defaults"]["sandbox"] == {
+        "mode": "off",
+        "scope": "session",
+    }
 
 
 def test_openclaw_litellm_preserves_unmanaged_baseline_keys():

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -461,6 +461,7 @@ def _baseline_inputs(*, ptype: str = "openrouter") -> RenderInputs:
         (render_openclaw, "bedrock"),
         (render_openclaw, "ollama"),
         (render_openclaw, "zai"),
+        (render_openclaw, "litellm"),
     ],
 )
 def test_renderer_is_idempotent(renderer, ptype):
@@ -2275,6 +2276,22 @@ _OPENCLAW_ENV_ZAI = (
     "GITHUB_TOKEN='ghp_a'\n"
 )
 
+# #723: litellm emits NO provider-specific env var — the bearer + base URL
+# live inline in `openclaw.json` under `models.providers.<name>`. The
+# only litellm-visible difference vs the openclaw + ollama baseline is
+# the model id (which carries the provider-name prefix).
+_OPENCLAW_ENV_LITELLM = (
+    "# Managed by clawrium (clawctl). Re-render with `clawctl agent configure alpha`.\n"
+    "OPENCLAW_GATEWAY_BIND='lan'\n"
+    "OPENCLAW_GATEWAY_PORT=40000\n"
+    "OPENCLAW_GATEWAY_AUTH_MODE=token\n"
+    "OPENCLAW_GATEWAY_AUTH_TOKEN='tkn'\n"
+    "OPENCLAW_DEFAULT_MODEL='lt/gemma4:31b'\n"
+    "DISCORD_BOT_TOKEN='discord-bot'\n"
+    "GITHUB_TOKEN_GH_A='ghp_a'\n"
+    "GITHUB_TOKEN='ghp_a'\n"
+)
+
 
 @pytest.mark.parametrize(
     "ptype,expected",
@@ -2285,14 +2302,29 @@ _OPENCLAW_ENV_ZAI = (
         ("bedrock", _OPENCLAW_ENV_BEDROCK),
         ("ollama", _OPENCLAW_ENV_OLLAMA),
         ("zai", _OPENCLAW_ENV_ZAI),
+        ("litellm", _OPENCLAW_ENV_LITELLM),
     ],
 )
 def test_openclaw_env_byte_lock(ptype, expected):
-    """Phase 3: byte-equivalence lock for `.openclaw/env` across all 6
+    """Phase 3: byte-equivalence lock for `.openclaw/env` across all 7
     supported provider types. Any drift in the Jinja template must be
     intentional and surface here with a clear diff."""
     out = render_openclaw(_openclaw_inputs(ptype=ptype))
     assert out.files[".openclaw/env"] == expected
+
+
+def test_openclaw_litellm_env_has_no_litellm_specific_vars():
+    """#723: pin that the openclaw + litellm env body emits NO
+    LITELLM_*, OPENCLAW_LITELLM_*, or provider.api_key env var — the
+    bearer and base URL live inline in `openclaw.json` under
+    `models.providers.<name>`. If a future env-template branch leaks the
+    bearer to disk via systemd's EnvironmentFile (different blast radius
+    than `openclaw.json`), this test catches it before it ships."""
+    env = render_openclaw(_openclaw_inputs(ptype="litellm")).files[".openclaw/env"]
+    assert "LITELLM_" not in env
+    assert "OPENCLAW_LITELLM_" not in env
+    # The litellm bearer must NOT appear in the env file.
+    assert "sk-master-1" not in env
 
 
 def test_openclaw_json_managed_paths_populated():
@@ -3535,3 +3567,117 @@ def test_621_openclaw_render_ignores_hermes_bundle():
     out_base = render_openclaw(openclaw_base)
     out_with = render_openclaw(openclaw_with)
     assert out_base.files == out_with.files
+
+
+# ---------------------------------------------------------------------------
+# #723: openclaw + litellm — models.providers.<provider-name> writer.
+#
+# Shape pinned against upstream openclaw's custom-provider docs at
+# docs.openclaw.ai/gateway/config-tools#custom-providers-and-base-urls.
+# ---------------------------------------------------------------------------
+
+
+def test_openclaw_litellm_writes_models_providers_block():
+    """#723: render_openclaw must emit a `models.providers.<name>` block
+    keyed by the clawctl provider name, with api='openai-completions',
+    inline apiKey, baseUrl normalized to <endpoint>/v1, and one models[]
+    entry built from default_model. The block enables openclaw to route
+    requests at the LiteLLM/vLLM proxy without any env-var hop.
+    """
+    import json
+
+    inputs = _openclaw_inputs(ptype="litellm")
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+
+    assert "models" in blob, "models block must be added for litellm"
+    assert blob["models"]["providers"].keys() == {"lt"}
+    block = blob["models"]["providers"]["lt"]
+    assert block["baseUrl"] == "http://10.0.0.5:4000/v1"
+    assert block["apiKey"] == "sk-master-1"
+    assert block["api"] == "openai-completions"
+    assert block["models"] == [
+        {
+            "id": "gemma4:31b",
+            "name": "gemma4:31b",
+            "reasoning": False,
+            "input": ["text"],
+            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+            "contextWindow": 65536,
+            "maxTokens": 16384,
+        }
+    ]
+    # agents.defaults.model.primary carries the provider-name prefix so the
+    # daemon routes via `models.providers.lt`.
+    assert blob["agents"]["defaults"]["model"]["primary"] == "lt/gemma4:31b"
+
+
+def test_openclaw_litellm_baseurl_with_v1_suffix_not_double_appended():
+    """#723: endpoint already ending in `/v1` must not be double-suffixed.
+    Mirrors hermes' litellm normalization invariant (see
+    test_hermes_litellm_endpoint_with_v1_suffix_not_double_appended)."""
+    import json
+
+    base = _baseline_inputs(ptype="litellm")
+    provider = ProviderInputs(
+        name=base.provider.name,
+        type=base.provider.type,
+        default_model=base.provider.default_model,
+        endpoint=base.provider.endpoint + "/v1",
+        api_key=base.provider.api_key,
+    )
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type="openclaw",
+        provider=provider,
+        channels=base.channels,
+        integrations=base.integrations,
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tkn", bind="lan"),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    assert blob["models"]["providers"]["lt"]["baseUrl"] == "http://10.0.0.5:4000/v1"
+
+
+def test_openclaw_non_litellm_does_not_emit_models_block():
+    """#723: only litellm writes `models.providers`. The other openclaw
+    provider types route via OPENCLAW_DEFAULT_MODEL env-var only — a
+    stray `models` key in `openclaw.json` would shadow the daemon's
+    built-in provider table for openrouter/anthropic/openai/bedrock/zai
+    and break those agents."""
+    import json
+
+    for ptype in ("openrouter", "anthropic", "openai", "bedrock", "ollama", "zai"):
+        inputs = _openclaw_inputs(ptype=ptype)
+        body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+        blob = json.loads(body)
+        assert "models" not in blob, (
+            f"openclaw + {ptype} must not write models.providers; "
+            f"only litellm uses that path"
+        )
+
+
+def test_openclaw_litellm_preserves_unmanaged_baseline_keys():
+    """#723: adding the `models` block must not perturb any other key in
+    the baseline `openclaw.json`. Pin the full top-level key set."""
+    import json
+
+    inputs = _openclaw_inputs(ptype="litellm")
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    # `models` is the only addition vs the baseline top-level keys.
+    assert set(blob.keys()) == {
+        "agents",
+        "gateway",
+        "session",
+        "tools",
+        "channels",
+        "browser",
+        "env",
+        "models",
+    }
+    # Unmanaged sections survive the litellm branch byte-for-byte.
+    assert blob["tools"]["deny"] == ["browser"]
+    assert blob["session"]["dmScope"] == "per-channel-peer"
+    assert blob["env"]["shellEnv"] == {"enabled": True, "timeoutMs": 15000}
+    assert blob["agents"]["defaults"]["workspace"] == "~/.openclaw/workspace"

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -3660,18 +3660,35 @@ def test_openclaw_litellm_baseurl_normalization(endpoint_in, expected_base_url):
     assert blob["models"]["providers"]["lt"]["baseUrl"] == expected_base_url
 
 
-def test_openclaw_litellm_missing_endpoint_raises():
-    """#723 ATX W4: render_openclaw must raise AgentConfigError for a
-    litellm provider with an empty endpoint, rather than silently
-    emitting `baseUrl: "/v1"` (a relative URL the openclaw daemon
-    would interpret against its own host). Mirrors hermes' equivalent
-    guard at `test_render.py:test_hermes_litellm_missing_endpoint_raises`."""
+@pytest.mark.parametrize(
+    "endpoint_in",
+    [
+        "",
+        # Iter-3 ATX follow-up: the iter-2 guard checked
+        # `if not provider.endpoint` BEFORE strip/rstrip, so these
+        # inputs slipped through and produced `baseUrl: "/v1"`. Pin
+        # the fix that hoists normalization above the guard.
+        "   ",
+        "\n",
+        "\t",
+        "/",
+        "//",
+        "  /  ",
+    ],
+)
+def test_openclaw_litellm_empty_or_whitespace_endpoint_raises(endpoint_in):
+    """#723 ATX W4 (+ iter-3 follow-up): render_openclaw must raise
+    AgentConfigError for a litellm provider whose endpoint normalizes
+    to empty — including whitespace-only or bare-slash inputs — rather
+    than silently emitting `baseUrl: "/v1"` (a relative URL the
+    openclaw daemon would interpret against its own host).
+    """
     base = _baseline_inputs(ptype="litellm")
     provider = ProviderInputs(
         name=base.provider.name,
         type=base.provider.type,
         default_model=base.provider.default_model,
-        endpoint="",
+        endpoint=endpoint_in,
         api_key=base.provider.api_key,
     )
     inputs = RenderInputs(
@@ -3686,14 +3703,29 @@ def test_openclaw_litellm_missing_endpoint_raises():
         render_openclaw(inputs)
 
 
-def test_openclaw_litellm_provider_name_with_slash_raises():
-    """#723 ATX W3: a provider name containing `/` would silently
-    produce ambiguous routing (`foo/bar/model` tokenizes as
-    provider=`foo`, model=`bar/model` on openclaw's `<name>/<model>`
-    scheme). Reject at the render layer with a clear remediation."""
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        # Iter-2 case: `/` would tokenize as <provider>/<rest>.
+        "foo/bar",
+        # Iter-3 ATX follow-up cases: whitespace + control chars +
+        # backslash also corrupt the daemon's routing scheme or
+        # produce malformed JSON keys.
+        "foo bar",
+        "foo\tbar",
+        "foo\nbar",
+        "foo\\bar",
+        "foo\x01bar",
+    ],
+)
+def test_openclaw_litellm_provider_name_with_bad_chars_raises(bad_name):
+    """#723 ATX W3 (+ iter-3 follow-up): a provider name containing
+    `/`, `\\`, whitespace, or control chars would corrupt routing on
+    openclaw's `<name>/<model>` scheme or produce malformed JSON keys.
+    Reject at the render layer with a clear remediation."""
     base = _baseline_inputs(ptype="litellm")
     provider = ProviderInputs(
-        name="foo/bar",
+        name=bad_name,
         type="litellm",
         default_model=base.provider.default_model,
         endpoint=base.provider.endpoint,
@@ -3707,7 +3739,7 @@ def test_openclaw_litellm_provider_name_with_slash_raises():
         integrations=(),
         gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tkn", bind="lan"),
     )
-    with pytest.raises(AgentConfigError, match="must not contain '/'"):
+    with pytest.raises(AgentConfigError, match="must not contain"):
         render_openclaw(inputs)
 
 

--- a/website/docs/agent-support/openclaw.md
+++ b/website/docs/agent-support/openclaw.md
@@ -34,6 +34,7 @@ OpenClaw supports all major LLM providers:
 | **[Google Vertex](providers/vertex.md)** | ✅ | [Setup Guide](providers/vertex.md) | Gemini series |
 | **[ZAI / BigModel](providers/zai.md)** | ✅ | [Setup Guide](providers/zai.md) | GLM series |
 | **[Ollama](providers/ollama.md)** | ✅ | [Setup Guide](providers/ollama.md) | Self-hosted models |
+| **LiteLLM / vLLM / custom OpenAI-compatible proxy** | ✅ | `clawctl provider registry create <name> --type litellm --litellm-url <proxy> --model <id> --api-key <bearer>` | Any model exposed by the proxy (rendered into `models.providers.<name>` in `openclaw.json` with `api: "openai-completions"`) |
 | **[Azure OpenAI](providers/azure-openai.md)** | 📋 | [Not Planned](providers/azure-openai.md) | — |
 
 **Quick Setup:**


### PR DESCRIPTION
## Summary

Wire `litellm` providers into the openclaw renderer so an openclaw
agent can attach a `type=litellm` provider (LiteLLM, vLLM, any
OpenAI-compatible proxy). `clawctl agent configure` / `clawctl agent
sync` now write a `models.providers.<provider-name>` block into
`.openclaw/openclaw.json` matching upstream openclaw's
custom-provider shape (`api: "openai-completions"`, `baseUrl:
<endpoint>/v1` normalized, inline `apiKey`, one `models[]` entry built
from `default_model` with operator-overridable `contextWindow` /
`maxTokens`).

`agents.defaults.model.primary` carries the per-attachment prefix
`<provider-name>/<model>` so the daemon routes via the new
`models.providers` entry. The bearer never lands in `.openclaw/env`
(different blast radius than `openclaw.json`); the env body is
byte-identical to the openclaw + ollama baseline modulo the model id.

Closes #723.

## Testing

### Test Results
- 3446 tests pass (`make test-py`), lint clean (`make lint-py`)
- 33 new tests added across the three commits:
  - `tests/core/test_render.py`: byte-lock parametrize for litellm;
    `models.providers` shape; baseUrl `/v1` normalization
    parametrized over 6 input shapes; **empty-endpoint guard
    parametrized over 7 shapes** (including whitespace-only,
    bare-slash, `\n`, `\t`); **bad-char provider.name parametrized
    over 6 shapes** (`/`, `\\`, whitespace, control chars);
    prefix-idempotency when default_model already prefixed;
    `contextWindow`/`maxTokens` operator override + unset default;
    secret-field `repr=False` leak guards on both
    `ProviderInputs` and `AttachedProviderInputs`; parametrized
    non-litellm `openclaw.json` top-level-key byte-lock across all
    6 other provider types.
  - `tests/cli/clawctl/provider/test_agent_attach_openclaw_litellm.py`
    (new): CLI attach happy path; #426 single-provider invariant
    preserved on litellm; `build_render_inputs` end-to-end
    assembly-layer signal.

### Manual Testing — live on `wolf-i` (openclaw, `wolf.tailf7742d.ts.net`)

Recorded in detail at `.itx/723/02_EXECUTE.md`:

```
$ uv run clawctl agent provider detach clawrium-bedrock --agent wolf-i
$ uv run clawctl agent provider attach clawrium-gtm-litellm --agent wolf-i
$ uv run clawctl agent sync wolf-i        # 2 written, 0 unchanged
$ uv run clawctl agent sync wolf-i        # 0 written, 2 unchanged — idempotent
$ uv run clawctl agent exec wolf-i -- models
  Default       : clawrium-gtm-litellm/writer
  - clawrium-gtm-litellm effective=models.json:sk-99f4a...eabd6308 \
      | source=models.json
$ uv run clawctl agent exec wolf-i -- agent --agent main \
    --message "Reply with exactly one word: pong"
  pong
```

Traffic: `clawctl` → openclaw gateway on wolf-i:40198 →
`models.providers.clawrium-gtm-litellm` (api: openai-completions,
baseUrl `http://192.168.1.17:4000/v1`) → LiteLLM proxy → vLLM at
`inx` running `Qwen3-Next-80B-A3B-Instruct-FP8`.

Re-verified clean (drift=0) after the iteration 2 and iteration 3
commits.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data: empty/whitespace
      endpoint rejected after normalization; `/`, `\`, whitespace,
      and control chars in `provider.name` rejected; both gates
      raise `AgentConfigError` rather than emitting broken output
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources (no new deps)
- [x] Secret fields use `field(repr=False)` (`ProviderInputs.api_key`
      / `aws_access_key` / `aws_secret_key`,
      `AttachedProviderInputs.api_key`) so pytest `--showlocals`
      and stray log lines cannot echo the bearer

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $8.80 | Total Time: 20m 32s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3/5 | W1, W2, W3 | All fixed (cac1046) | $3.45 | 8m55s | leader, render-engine, security-reviewer, test-coverage |
| 2 | 4/5 | None (blocking=false) | Cleared bar; 3 render-engine follow-ups fixed (09046c9) | $5.35 | 11m37s | leader, render-engine + others |

Iteration 3 was a polish pass on the iteration-2 render-engine
follow-ups; not re-reviewed because iteration 2 already cleared the
AGENTS.md merge bar (`Rating > 3/5 AND no blocking issues`).

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking warnings (all fixed in `cac1046`):**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| W1 | `render.py` litellm branch | `/v1` normalization rstrip asymmetry — `http://h/v1/` survived with trailing slash | Mirrored hermes' approach (`.strip().rstrip('/')` BEFORE endswith check). Parametrize over 6 input shapes. Comment honesty corrected in iteration 3. |
| W2 | `render.py` litellm branch | `contextWindow: 65536` / `maxTokens: 16384` hardcoded — LiteLLM proxies front 4K-256K models | `ProviderInputs.context_window` / `.max_tokens` (read from provider record in `build_render_inputs`). Defaults unchanged at 65536/16384. |
| W3 | `render.py` litellm branch | Provider name with `/` produced ambiguous `<name>/<model>` routing | `AgentConfigError` raised. Extended in iteration 3 to also reject `\`, whitespace, control chars. |

**Non-blocking warnings (all fixed in `cac1046`):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W4 | `render.py` litellm branch | Empty endpoint not validated at render layer | Defense-in-depth guard added; **iteration 3 hoisted it below normalization so whitespace/bare-slash inputs are caught** (the iter-2 placement let those through). |
| W5 | `render.py` `ProviderInputs` | Secret fields default `repr=True` — bearer leaks via pytest `--showlocals` / stray log | `field(repr=False)` on `api_key` / `aws_access_key` / `aws_secret_key` / `AttachedProviderInputs.api_key`. Matches `FileDiff` hardening. |
| W6 | `lifecycle_canonical.py` | `_diff_removes_secrets` covers `.env` only, not JSON-body `apiKey` | Acknowledged — added an explicit comment explaining why JSON-body `apiKey` is intentionally not in the guard (a provider swap legitimately drops the block; the boundary is in `build_render_inputs`). |
| S1 | `render.py` apiKey write site | Add a comment re: blast radius | Added. |
| S2 | render-layer | Extract `_litellm_model_prefix` helper to share with hermes | Deferred — Callout. |

**Test coverage gaps (all closed):** parametrized baseUrl edges, parametrized non-litellm `openclaw.json` byte-lock, missing endpoint, `/` in name, prefix idempotency, override + default `contextWindow`, tightened CLI assertion.

</details>

<details>
<summary>Review 2 Details (Rating 4/5 — cleared the merge bar)</summary>

Blocking field: `false`. The render-engine specialist flagged three
follow-ups on the iteration-1 fixes that I addressed without a
third full review round:

| # | File | Follow-up | Resolution |
|---|------|-----------|------------|
| W4-fu | `render.py:1572-1577` | Empty-endpoint guard fired BEFORE strip/rstrip → whitespace-only / bare-slash / `\n` endpoints slipped through with `baseUrl: "/v1"` | Hoisted normalization above the guard (iteration 3 commit). 7-case parametrize pins the fix. |
| W1-fu | `render.py:1593-1597` | Iter-2 comment claimed "byte-for-byte hermes parity" but the openclaw branch had an extra `.strip()` that hermes lacks; the cited line range was the atlassian url block | Comment corrected (iteration 3). Whether to tighten hermes to match is deferred. |
| W3-fu | `render.py:1582-1591` | Iter-2 only rejected `/` in provider.name; whitespace, `\`, control chars also break routing | Extended check (iteration 3). 6-case bad-char parametrize. |

**Iter-2 suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| `int()` of context_window can raise bare `ValueError` for typoed input (`"64K"`, `"auto"`) | Deferred — PR Callout. |
| S1 comment doesn't reference `render_diff.py` by name | Deferred — PR Callout. |

</details>

## Callouts

- [DECISION] `contextWindow` / `maxTokens` defaults are `65536` / `16384`, not the legacy ollama-template's `131072` / `16384`.
  - Why: the gtm pipeline's vLLM (Qwen3-Next-80B) runs with `--max-model-len 65536`. A higher default would advertise capacity that the upstream model cannot honor and trigger truncation at runtime. Operators with larger models override via `providers.json.context_window`.
  - Alternatives considered: match the legacy ollama default (`131072`). Rejected — wrong for the canonical reference target (`clawrium-gtm-litellm`) that prompted this PR.
  - Reviewer: confirm 65536 is the right per-PR default, or push for a manifest-driven default registry.

- [DECISION] S2 (extract `_litellm_model_prefix` helper to share with hermes) deferred.
  - Why: hermes' aux-litellm prefix logic lives inside the multi-provider walk and doesn't currently share its routing scheme with the openclaw single-provider path. Forcing them into one helper without a planned shared schema would be premature abstraction.
  - Reviewer: file a follow-up if you want the consolidation tracked.

- [DECISION] The W6 `_diff_removes_secrets` carve-out for JSON-body `apiKey` is documented inline, not extended.
  - Why: extending the guard would falsely block a litellm → ollama provider swap (the legitimate drop of `models.providers.<name>.apiKey`). The upstream boundary at `build_render_inputs` raises `AgentConfigError` if the bearer is missing in `secrets.json`, so a regression cannot silently reach the guard.
  - Reviewer: revisit if a future renderer needs a JSON-inline secret that should survive cross-provider transitions.

- [DECISION] W1 iter-2 follow-up: openclaw's `.strip().rstrip("/")` chain is now intentionally MORE defensive than hermes' `.rstrip("/")` (no `.strip()`).
  - Why: tightening hermes in this PR would be scope creep — hermes already shipped its `/v1` normalization in #705 and is in production. The openclaw branch defends against newlines because that's a real failure mode the iter-2 reviewer surfaced.
  - Reviewer: file a follow-up if you want hermes hardened to match.

- [DECISION] Local hosts.json snapshot (`.itx/723/snapshots/hosts.json.pre`) added to `.gitignore` instead of committed.
  - Why: `hosts.json` carries bearers, AWS credentials, and OAuth tokens for the entire fleet. The snapshot exists locally for rollback fidelity; committing it would publish secrets.
  - How to apply: `.gitignore` now covers `.itx/*/snapshots/` for any future ITX live-verification snapshot. The PR body documents the rollback path verbally; operators can re-snapshot before any production swap.

- [DECISION] `context_window` / `max_tokens` casts in `build_render_inputs` use bare `int()` — a typoed `"64K"` raises `ValueError` rather than `AgentConfigError`.
  - Why: deferred because `providers.json` is operator-controlled (not exposed to end users) and the schema is documented; surfacing it as `AgentConfigError` with a clearer message is a polish, not a correctness gap. Filed as a follow-up to keep this PR scoped to the litellm wire.
  - Reviewer: push back if you want it raised as `AgentConfigError` before merge.

- [ENVIRONMENT] ATX review ran via the local CLI (`atx review request`), not via the MCP transport — `mcp__atx__request_review` was not available in the session that drove this PR. Two iterations + session metadata persisted at `.itx/723/atx-session.json`.

- [TODO-FOLLOWUP] Zeroclaw `litellm` support still deferred — `zeroclaw` has no `models.providers.<id>` writer and no env-var path for a free-form OpenAI-compatible base_url + bearer pair.
  - Tracking: to be filed.

- [TODO-FOLLOWUP] Hermes `/v1` normalization could be tightened to match the new openclaw `.strip().rstrip("/")` (defends against newlines surviving from providers.json). Today only openclaw has that defence.
  - Tracking: to be filed.

- [TODO-FOLLOWUP] Audit GUI/CLI dumpers that emit the full `openclaw.json` verbatim (`clawctl agent get --raw`, support-bundle exports, snapshot tooling) and add redaction at the `models.providers.<name>.apiKey` path. The renderer now writes the bearer inline per upstream contract; the read paths haven't yet been swept. The S1 comment at the write site documents the contract but doesn't enforce it.
  - Tracking: to be filed.

- [TODO-FOLLOWUP] `context_window` / `max_tokens` validation: convert bare `int()` casts in `build_render_inputs` to raise `AgentConfigError` with a clearer message for typoed inputs (`"64K"`, `"auto"`).
  - Tracking: to be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
