### PR TITLE
blog: v26.6.3 release notes

### DIFF
--- a/website/blog/2026-06-15-v26.6.3-release.md
+++ b/website/blog/2026-06-15-v26.6.3-release.md
@@ -1,0 +1,60 @@
+---
+slug: v26.6.3-release
+title: "What's new in clawrium v26.6.3"
+authors: [maurice]
+tags: [release-notes]
+date: 2026-06-15
+---
+
+The v26.6.3 release recovers from a failed v26.6.2 cut, with a critical fix to the test-isolation race in `fleet.py` and the removal of the legacy `clm` CLI binary.
+
+<!-- truncate -->
+
+## What changed
+
+**BREAKING — `clm` removed** — The legacy `clm` CLI entry point has been removed. The wired CLI is now exclusively `clawctl`. Argument surfaces are unchanged — only the binary name differs. If you cannot migrate immediately, pin to the last release that ships `clm`: `uv tool install clawrium@26.6.1`.
+
+**litellm provider** — A new provider type is now available, enabling access to a wide range of LLMs through the litellm unified API. Use `clawctl provider add --type litellm --url <proxy> --model <id>` to register a provider, then attach to an agent with `clawctl agent provider attach <name> --provider <litellm-name>`. This provides a single interface to models from OpenAI, Anthropic, Google, and more, with consistent configuration and credential management.
+
+**Test-isolation recovery** — This release corrects a critical issue in the v26.6.2 cut that caused test failures in the GUI's fleet health route. The fix addresses a module-level `asyncio.Semaphore` latching to the wrong event loop and a `ThreadPoolExecutor` shutdown race under pytest, switching to lazy per-loop accessors and process-singleton lifetimes.
+
+**Provider page UX** — The Providers page has been restructured to use a fleet-style table, with clear row actions and a dedicated button for adding new providers. The UI now better reflects the multi-provider model and makes it easier to manage multiple API keys.
+
+**Sidebar reorganization** — The main sidebar has been restructured to group related items. The "Agents" tab is now the primary entry point, and a new "Coming Soon" section has been added to highlight upcoming features and allow users to upvote them.
+
+## Why
+
+The removal of `clm` unifies the CLI surface and reduces maintenance burden. The `clawctl` interface is more consistent, extensible, and better documented.
+
+The litellm provider type significantly expands the range of available models, making it easier for users to experiment with different LLMs without managing multiple API keys and configurations.
+
+The test-isolation fix ensures the GUI is stable and reliable under test and production loads, preventing flaky test failures and potential runtime issues.
+
+The UI improvements to the Providers page and sidebar are based on user feedback and aim to make the interface more intuitive and easier to navigate.
+
+## Try it
+
+```bash
+# Install or upgrade
+uv tool install clawrium@v26.6.3
+
+# Start the GUI and configure your providers
+clawctl agent start <name>
+
+# Add a new litellm provider
+clawctl provider add --type litellm --url <proxy> --model <id>
+
+# Attach the provider to an agent
+clawctl agent provider attach <name> --provider <litellm-name>
+
+# If you cannot migrate from clm to clawctl yet, pin to the last clm release
+uv tool install clawrium@26.6.1
+```
+
+## Links
+
+- [GitHub release](https://github.com/ric03uec/clawrium/releases/tag/v26.6.3)
+- [per-release CHANGELOG](https://github.com/ric03uec/clawrium/blob/main/docs/releases/26.6.3/CHANGELOG.md)
+- [Provider documentation](https://ric03uec.github.io/clawrium/docs/agent-support/providers/index.md)
+- [Agent support guide](https://ric03uec.github.io/clawrium/docs/agent-support/index.md)
+- [Quickstart guide](https://ric03uec.github.io/clawrium/docs/guides/quickstart.md)


### PR DESCRIPTION
## What changed

Release blog post for **clawrium v26.6.3** at `website/blog/2026-06-15-v26.6.3-release.md`.

## Note

This PR was produced by the `clawrium-gtm` agent across two phases:

1. **Initial draft** (run 4) — agent created the worktree, fetched release data, read the prior release blog as structural template (`website/blog/2026-05-31-v26.6.0-release.md`), synthesized a 352-word blog with no fabrications and no raw release-body dump.
2. **Iteration tick** (run 5) — after I left 5 structured review comments (1 PR-level + 3 inline + 1 follow-up on coverage), the agent's `* * * * *` cron picked them up, fetched both PR-level and inline comments via `gh api`, applied corrections in the worktree, committed (`blog: address review feedback — fix factual errors, add clm removal, correct litellm command, remove fake URL, add pin command`), and pushed `b3ccbf7`.

The original PR (#726) was unintentionally closed by an earlier buggy `[SKILL-BLOCKED]` recovery path in the iteration loop — that's been fixed by the new `<error-recovery-discipline>` rule, which forbids the agent from taking destructive lifecycle actions (close PR, delete branch, force-push) on any error condition. This PR re-opens the branch so the iteration commit can be reviewed and merged.

Open for review — `clawrium-gtm` will address review comments on a 1-minute simulation cadence (default in production: 1 hour). Do not auto-merge.

🤖 Produced by `clawrium-gtm` agent