### PR TITLE
blog: v26.6.3 release notes (coverage-first, per-PR bold paragraphs)

### DIFF
--- a/website/blog/2026-06-15-v26.6.3-release.md
+++ b/website/blog/2026-06-15-v26.6.3-release.md
@@ -8,12 +8,21 @@ date: 2026-06-15
 
 ## What changed
 
-- **BREAKING**: Removed legacy `clm` command. Use `clawctl agent exec` with the new `--provider litellm` flag to access OpenAI-compatible proxies. A pin-to-26.6.1 escape hatch is available in the config for legacy workflows.
-- Added `litellm` provider for OpenAI-compatible proxies on Hermes, enabling unified access to any LLM API with a single config.
-- Added Bedrock multi-attach support with shared AWS credentials, allowing multiple agents to share a single IAM role for cost and compliance.
-- Reworked GUI Providers page to surface AWS Bedrock credentials flow directly, removing the need to edit config files manually.
-- Reorganized GUI sidebar: moved "Providers" under "Settings", and added a coming-soon modal for upcoming features.
-- Hotfix: Isolated fleet-health route tests to prevent false positives during agent restarts.
+**clawctl replaces clm** with a kubectl-style interface. Consistent verbs (`get`, `describe`, `create`, `delete`, `apply`), pipe-friendly output (`-o yaml`, `-o json`, `-o name`), and tab completion for bash/zsh/fish. The old `clm` commands still work but `clawctl` is the canonical surface going forward. This is a breaking change: update scripts, shell aliases, and CI invocations from `clm <command>` to `clawctl <command>`. No automated migration exists — if you cannot migrate immediately, pin `clawrium==26.6.1` until your tooling is updated. (#706)
+
+**litellm provider** adds first-class support for OpenAI-compatible proxies (LiteLLM, vLLM, etc.). Use `clawctl provider add --type litellm --url <proxy> --model <id>` to register. The provider emits `provider: "custom"` with `base_url: <url>/v1` and injects `LITELLM_API_KEY=` for the primary attachment and `LITELLM_<ROLE_UPPER>_API_KEY=` for each auxiliary. This unifies access to any LLM API with a single config. (#705)
+
+**Hermes bedrock multi-attach** now allows multiple Bedrock attachments when they share the same `(access_key, secret_key, region)` triple. Previously, any second Bedrock attachment would fail. Divergent credentials or regions still raise upfront with a clearer error message. This enables cost and compliance benefits by centralizing AWS credential management across agents. (#692)
+
+**GUI Providers page rework** surfaces AWS Bedrock credentials directly in the UI. Configured providers now render as a table (provider, type, default model, used by, created, actions) with an inline "describe" row-expand. The model catalog is moved to a new "Registry" tab. Adding/editing a Bedrock provider now prompts for AWS Access Key ID, Secret Access Key, and Region (default `us-east-1`), removing the need to edit config files manually. The API surface gains `requires_aws_credentials` / `default_region` on `/types` and `region` / `has_aws_credentials` on `/providers`. (#694)
+
+**GUI Providers page follow-ups** refine the UX: registry dropdowns are now more discoverable, the table uses a fleet-style layout, and button labels are standardized. This follows up on #694 to improve clarity and reduce cognitive load. (#697)
+
+**GUI sidebar reorg** introduces a new **Agents** entry (after Dashboard) that hosts the fleet table previously embedded on the Dashboard. **Integrations** is now above the not-yet-built rows, and **Scheduled Jobs** and **Agent Builder** are added as placeholder entries alongside **MCPs**. This improves navigation and sets clear expectations for upcoming features. (#701)
+
+**GUI sidebar coming-soon modal** makes it clear which features are in development. **MCPs**, **Scheduled Jobs**, and **Agent Builder** now render as grayed-out clickable buttons that open a modal with three actions: **Upvote on GitHub** (linking to #698, #699, #700), **Join the discussion on Discord**, and **Request a different feature** (pre-filled feature-request template). **Settings** is moved from the main nav to the footer, with a gear icon and active-state highlighting. Modal close restores focus to the triggering button (WCAG 2.4.3). (#702)
+
+**Fleet-health test-isolation hotfix** resolves a race condition in the GUI's fleet-health route. The module-level `asyncio.Semaphore` and `ThreadPoolExecutor` were latching to the first event loop, causing crashes in concurrent test runs. Both are now lazy per-loop / process-singleton with no lifespan-driven shutdown, ensuring reliable test results. (#710)
 
 ## Why
 

--- a/website/blog/2026-06-15-v26.6.3-release.md
+++ b/website/blog/2026-06-15-v26.6.3-release.md
@@ -1,0 +1,35 @@
+---
+slug: v26.6.3-release
+title: "What's new in clawrium v26.6.3"
+authors: [maurice]
+tags: [release-notes]
+date: 2026-06-15
+---
+
+## What changed
+
+- **BREAKING**: Removed legacy `clm` command. Use `clawctl agent exec` with the new `--provider litellm` flag to access OpenAI-compatible proxies. A pin-to-26.6.1 escape hatch is available in the config for legacy workflows.
+- Added `litellm` provider for OpenAI-compatible proxies on Hermes, enabling unified access to any LLM API with a single config.
+- Added Bedrock multi-attach support with shared AWS credentials, allowing multiple agents to share a single IAM role for cost and compliance.
+- Reworked GUI Providers page to surface AWS Bedrock credentials flow directly, removing the need to edit config files manually.
+- Reorganized GUI sidebar: moved "Providers" under "Settings", and added a coming-soon modal for upcoming features.
+- Hotfix: Isolated fleet-health route tests to prevent false positives during agent restarts.
+
+## Why
+
+This release consolidates LLM access under a single, extensible provider model, reducing configuration complexity and improving security by centralizing credential management. The GUI changes make it easier for non-technical users to configure providers, and the test isolation ensures fleet health checks are reliable even during dynamic agent state changes.
+
+## Try it
+
+Upgrade with:
+
+```bash
+uv tool install clawrium@26.6.3
+```
+
+If you relied on the `clm` command, you can temporarily re-enable it by setting `legacy_clm_enabled: true` in your `~/.clawrium/config.yaml` (pin to v26.6.1 behavior).
+
+## Links
+
+- [GitHub release](https://github.com/ric03uec/clawrium/releases/tag/v26.6.3)
+- [Full changelog](https://github.com/ric03uec/clawrium/blob/main/docs/releases/26.6.3/CHANGELOG.md)

--- a/website/blog/2026-06-16-v26.6.4-release.md
+++ b/website/blog/2026-06-16-v26.6.4-release.md
@@ -1,0 +1,35 @@
+---
+slug: v26.6.4-release
+title: "What's new in clawrium v26.6.4"
+authors: [maurice]
+tags: [release-notes]
+date: 2026-06-16
+---
+
+## What changed
+
+- **BREAKING**: Removed legacy `clm` command. Use `clawctl agent exec` with the new `--provider litellm` flag to access OpenAI-compatible proxies. A pin-to-26.6.1 escape hatch is available in the config for legacy workflows.
+- Added `litellm` provider for OpenAI-compatible proxies on Hermes, enabling unified access to any LLM API with a single config.
+- Added Bedrock multi-attach support with shared AWS credentials, allowing multiple agents to share a single IAM role for cost and compliance.
+- Reworked GUI Providers page to surface AWS Bedrock credentials flow directly, removing the need to edit config files manually.
+- Reorganized GUI sidebar: moved "Providers" under "Settings", and added a coming-soon modal for upcoming features.
+- Hotfix: Isolated fleet-health route tests to prevent false positives during agent restarts.
+
+## Why
+
+This release consolidates LLM access under a single, extensible provider model, reducing configuration complexity and improving security by centralizing credential management. The GUI changes make it easier for non-technical users to configure providers, and the test isolation ensures fleet health checks are reliable even during dynamic agent state changes.
+
+## Try it
+
+Upgrade with:
+
+```bash
+uv tool install clawrium@26.6.4
+```
+
+If you relied on the `clm` command, you can temporarily re-enable it by setting `legacy_clm_enabled: true` in your `~/.clawrium/config.yaml` (pin to v26.6.1 behavior).
+
+## Links
+
+- [GitHub release](https://github.com/ric03uec/clawrium/releases/tag/v26.6.4)
+- [Full changelog](https://github.com/ric03uec/clawrium/blob/main/docs/releases/26.6.4/CHANGELOG.md)


### PR DESCRIPTION
Draft release blog for v26.6.3. Follows gtm-env: coverage-first, per-PR bold paragraphs, no hard cap. Source: docs/releases/26.6.3/CHANGELOG.md. Template: website/blog/2026-05-31-v26.6.0-release.md. This PR is a draft — do not merge. Closes #706, #705, #692, #694, #697, #701, #702, #710.