### PR TITLE
docs(landing): restructure first-success path and rename Claw→Agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Clawrium - An aquarium for *claws
+# Clawrium
 
 ## How It Works
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,23 @@ cut. The `itx:release` skill archives this section into a new
 ### Fixed
 
 ### Documentation
+
+- Landing page audit: restructured the GitHub README first-success path —
+  added a Support Matrix near the top (control/host OS, agent runtimes,
+  providers, channels), dropped the deliberate `xclm SSH verification
+  failed` step from the 5-Minute Setup, added **Tested on Ubuntu** and
+  **Tested on macOS** badges, and updated FAQ #1 to reflect macOS
+  end-to-end support.
+- Renamed the generic noun "Claw" / "Claws" → "Agent" / "Agents" across
+  the README, AGENTS.md, the Docusaurus landing (tagline, hero,
+  HomepageFeatures), website docs (intro, architecture, configuration,
+  CLI reference, skills, fleet management, hermes/memory pages), and the
+  repo-rooted docs index. Brand names (Clawrium, OpenClaw, ZeroClaw,
+  IronClaw, NemoClaw, Hermes) are preserved, as are real on-disk
+  identifiers (`*claw` systemd glob, `claw_supports_memory` Python
+  symbol).
+- Replaced remaining `clm` references with `clawctl` on the website
+  landing's `HomepageFeatures` ASCII diagram and sample output, and in
+  the `troubleshooting.md` setup-snippet placeholder. Dated migration
+  blog posts and `docs/releases/*/CHANGELOG.md` archives are intentionally
+  left untouched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,20 @@ cut. The `itx:release` skill archives this section into a new
   the `troubleshooting.md` setup-snippet placeholder. Dated migration
   blog posts and `docs/releases/*/CHANGELOG.md` archives are intentionally
   left untouched.
+- Added the **"Agent Fleet Manager"** subtitle to the Clawrium hero on
+  the Docusaurus landing (via the site tagline) and to the centered
+  intro on the GitHub README.
+- Upgraded Hermes and ZeroClaw status from 🚧 in-development to ✅
+  fully supported across the README Support Matrix, README "What is an
+  Agent?", `HomepageFeatures` TSX card, `website/docs/intro.md` (list +
+  FAQ #2), and `website/docs/architecture.md`. OpenClaw / Hermes /
+  ZeroClaw are now uniformly listed as the three fully-supported
+  agent types; IronClaw remains planned.
+- Rewrote the README 5-Minute Setup to surface the xclm bootstrap as
+  explicit numbered steps: (1) `clawctl service init` on the control
+  machine, (2) `clawctl host create` on the control machine to generate
+  the per-host keypair and print the host setup commands, (3) SSH into
+  the host and paste the printed block (Linux example inlined), (4)
+  re-run `clawctl host create` to register the host, (5) provider +
+  agent install + start + chat. Replaces the implicit "prerequisite"
+  callout that hid the bootstrap step.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="docs/assets/clawrium-logo.png" alt="Clawrium" height="40" align="center"> Clawrium - An aquarium for *claws
+# <img src="docs/assets/clawrium-logo.png" alt="Clawrium" height="40" align="center"> Clawrium
 
 <p align="center">
   Fleet management for AI agents on your local network.
@@ -9,6 +9,8 @@
   <a href="https://pypi.org/project/clawrium/"><img src="https://img.shields.io/pypi/v/clawrium" alt="PyPI"></a>
   <a href="https://pypi.org/project/clawrium/"><img src="https://img.shields.io/pypi/pyversions/clawrium" alt="Python"></a>
   <a href="https://github.com/ric03uec/clawrium/blob/main/LICENSE"><img src="https://img.shields.io/github/license/ric03uec/clawrium" alt="License"></a>
+  <img src="https://img.shields.io/badge/Tested_on-Ubuntu-E95420?logo=ubuntu&logoColor=white" alt="Tested on Ubuntu">
+  <img src="https://img.shields.io/badge/Tested_on-macOS-000000?logo=apple&logoColor=white" alt="Tested on macOS">
 </p>
 
 <p align="center">
@@ -16,6 +18,17 @@
 </p>
 
 ---
+
+## Support matrix
+
+| What | Supported today | Notes |
+|------|-----------------|-------|
+| **Control machine OS** | Ubuntu, macOS | Tested end-to-end |
+| **Target host OS** | Ubuntu, macOS | macOS hosts must enable Remote Login first ([host setup](docs/host-preparation.md)) |
+| **Agent runtimes** | OpenClaw ✅, Hermes 🚧, ZeroClaw 🚧 | IronClaw planned. ✅ = fully supported, 🚧 = in development |
+| **Inference providers** | Anthropic, OpenAI, OpenRouter, Ollama | Claude subscription is NOT supported — API keys only |
+| **Messaging channels** | Discord, Slack | OpenClaw only |
+| **Container runtime** | None required | No Docker, no Kubernetes — SSH + Ansible |
 
 ## How it works
 
@@ -38,13 +51,14 @@ Clawrium gives you `kubectl`-style fleet control for AI agents:
 - **Lifecycle management.** Upgrades, rollbacks, secrets rotation, backups - handled.
 - **Token tracking & guardrails.** See spend across your fleet. Set limits before someone's experiment burns through your API budget.
 
-## What is a "Claw" or an Agent?
+## What is an Agent?
 
-A **Claw** or an Agent is a general-purpose AI assistant that runs on a host in your network. Unlike coding-focused assistants (Copilot, Cursor), Claws are designed for broader tasks:
+A Clawrium **agent** is a general-purpose AI assistant that runs on a host in your network. Unlike coding-focused assistants (Copilot, Cursor), these agents are designed for broader tasks. Agent implementations:
 
-- **[OpenClaw](https://github.com/openclaw/openclaw)** - Open-source general assistant
-- **[ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw)** - Lightweight assistant for resource-constrained hosts
-- **[IronClaw](https://github.com/nearai/ironclaw)** - High-performance assistant for demanding workloads
+- **[OpenClaw](https://github.com/openclaw/openclaw)** ✅ - Open-source general assistant; fully supported end-to-end
+- **[Hermes](https://github.com/NousResearch/hermes-agent)** 🚧 (Nous Research) - Install + configure + OpenAI-compatible API working; chat + channels in progress. See [Hermes Support Matrix](https://ric03uec.github.io/clawrium/docs/agent-support/hermes)
+- **[ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw)** 🚧 - Lightweight assistant for resource-constrained hosts; in development
+- **[IronClaw](https://github.com/nearai/ironclaw)** _(planned)_ - High-performance assistant for demanding workloads
 
 Clawrium manages the lifecycle of these agents across your fleet - install, configure, start, stop, upgrade, monitor.
 
@@ -83,40 +97,22 @@ For full installation instructions including how to install `uv`, see [docs/inst
 
 ### 5-Minute Setup
 
+> **Prerequisite:** the target host must have an `xclm` user with passwordless sudo and the Clawrium-generated SSH key in `authorized_keys`. The first `clawctl host create` prints the exact commands to run on the host. See [docs/host-preparation.md](docs/host-preparation.md) (~3 minutes).
+
 ```bash
 # Initialize config
 clawctl service init
-# → Created /home/user/.config/clawrium/config.yaml
 
-# Register your host. First run generates a per-host SSH keypair and
-# prints the manual xclm setup commands (Linux + macOS) you need to
-# run on the host — see docs/host-preparation.md.
+# Register your host (re-run after pasting the printed xclm setup commands on the host)
 clawctl host create 192.168.1.100 --user xclm --alias worker-1
-# → Generating SSH keypair for '192.168.1.100'...
-# → xclm SSH verification failed: Authentication failed - check SSH keys
-# → Manual setup required. (paste printed block on the host, then re-run)
-
-# Re-run after running the printed setup commands on the host:
-clawctl host create 192.168.1.100 --user xclm --alias worker-1
-# → host/worker-1 created on 192.168.1.100:22
 
 # Register an inference provider
 clawctl provider registry create anthropic --type anthropic --api-key-stdin
-# → Provider 'anthropic' configured
 
-# Install OpenClaw agent
+# Install, configure, and start an OpenClaw agent
 clawctl agent create my-assistant --type openclaw --host worker-1 --provider anthropic
-# → Installing openclaw on worker-1...
-# → Agent 'my-assistant' installed
-
-# Configure and start
 clawctl agent configure my-assistant
 clawctl agent start my-assistant
-# → Agent 'my-assistant' started
-
-# Copy a catalog skill into the agent's local state and sync it
-clawctl agent skill add my-assistant --from-template clawrium/tdd
-clawctl agent sync my-assistant
 
 # Check fleet status
 clawctl agent get
@@ -125,12 +121,9 @@ clawctl agent get
 
 # Chat with your agent
 clawctl agent chat my-assistant
-# → Connected to my-assistant
-# → Type your message...
 
 # Or open the local web dashboard
 clawctl gui
-# → Clawrium GUI starting on http://127.0.0.1:36000 — press Ctrl+C to stop
 ```
 
 **You should see:** A running agent in `clawctl agent get` output with status `running`.
@@ -151,9 +144,7 @@ clawctl gui
 
 ### 1. What operating systems are supported?
 
-Right now, Clawrium is only tested on Ubuntu hosts and Ubuntu control machines.
-
-Other Linux distributions may work, but they are not currently part of the test matrix.
+Ubuntu and macOS are in the test matrix — both as the control machine and as target hosts. On macOS hosts you must enable Remote Login before registering them; see [docs/host-preparation.md](docs/host-preparation.md). Other Linux distributions may work but aren't tested.
 
 ### 2. Which agents are supported today?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # <img src="docs/assets/clawrium-logo.png" alt="Clawrium" height="40" align="center"> Clawrium
 
 <p align="center">
+  <strong>Agent Fleet Manager</strong>
+  <br>
   Fleet management for AI agents on your local network.
 </p>
 
@@ -25,7 +27,7 @@
 |------|-----------------|-------|
 | **Control machine OS** | Ubuntu, macOS | Tested end-to-end |
 | **Target host OS** | Ubuntu, macOS | macOS hosts must enable Remote Login first ([host setup](docs/host-preparation.md)) |
-| **Agent runtimes** | OpenClaw ✅, Hermes 🚧, ZeroClaw 🚧 | IronClaw planned. ✅ = fully supported, 🚧 = in development |
+| **Agent runtimes** | OpenClaw ✅, Hermes ✅, ZeroClaw ✅ | IronClaw planned |
 | **Inference providers** | Anthropic, OpenAI, OpenRouter, Ollama | Claude subscription is NOT supported — API keys only |
 | **Messaging channels** | Discord, Slack | OpenClaw only |
 | **Container runtime** | None required | No Docker, no Kubernetes — SSH + Ansible |
@@ -55,9 +57,9 @@ Clawrium gives you `kubectl`-style fleet control for AI agents:
 
 A Clawrium **agent** is a general-purpose AI assistant that runs on a host in your network. Unlike coding-focused assistants (Copilot, Cursor), these agents are designed for broader tasks. Agent implementations:
 
-- **[OpenClaw](https://github.com/openclaw/openclaw)** ✅ - Open-source general assistant; fully supported end-to-end
-- **[Hermes](https://github.com/NousResearch/hermes-agent)** 🚧 (Nous Research) - Install + configure + OpenAI-compatible API working; chat + channels in progress. See [Hermes Support Matrix](https://ric03uec.github.io/clawrium/docs/agent-support/hermes)
-- **[ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw)** 🚧 - Lightweight assistant for resource-constrained hosts; in development
+- **[OpenClaw](https://github.com/openclaw/openclaw)** ✅ - Open-source general assistant
+- **[Hermes](https://github.com/NousResearch/hermes-agent)** ✅ (Nous Research) - OpenAI-compatible local API
+- **[ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw)** ✅ - Lightweight assistant for resource-constrained hosts
 - **[IronClaw](https://github.com/nearai/ironclaw)** _(planned)_ - High-performance assistant for demanding workloads
 
 Clawrium manages the lifecycle of these agents across your fleet - install, configure, start, stop, upgrade, monitor.
@@ -97,16 +99,54 @@ For full installation instructions including how to install `uv`, see [docs/inst
 
 ### 5-Minute Setup
 
-> **Prerequisite:** the target host must have an `xclm` user with passwordless sudo and the Clawrium-generated SSH key in `authorized_keys`. The first `clawctl host create` prints the exact commands to run on the host. See [docs/host-preparation.md](docs/host-preparation.md) (~3 minutes).
+**Step 1 — On your control machine: initialize Clawrium**
 
 ```bash
-# Initialize config
 clawctl service init
+```
 
-# Register your host (re-run after pasting the printed xclm setup commands on the host)
+**Step 2 — On your control machine: generate the xclm setup commands for the host**
+
+```bash
 clawctl host create 192.168.1.100 --user xclm --alias worker-1
+```
 
-# Register an inference provider
+This generates a per-host SSH keypair and, because the `xclm` user doesn't exist on the host yet, prints the **exact setup block** (Linux and macOS variants) with your fresh public key inlined. Example output (Linux):
+
+```bash
+## Linux
+# Create xclm user
+sudo useradd -m -s /bin/bash xclm
+# Passwordless sudo
+echo "xclm ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/xclm
+sudo chmod 440 /etc/sudoers.d/xclm
+# Authorized key
+sudo mkdir -p /home/xclm/.ssh && sudo chmod 700 /home/xclm/.ssh
+echo 'ssh-ed25519 AAAA…' | sudo tee /home/xclm/.ssh/authorized_keys
+sudo chmod 600 /home/xclm/.ssh/authorized_keys
+sudo chown -R xclm:xclm /home/xclm/.ssh
+```
+
+**Step 3 — SSH into the host and paste the printed block**
+
+```bash
+ssh you@192.168.1.100   # log in as any sudo-capable user
+# paste the block from Step 2, exit
+```
+
+(Full Linux + macOS variants and rationale: [docs/host-preparation.md](docs/host-preparation.md).)
+
+**Step 4 — On your control machine: re-run `clawctl host create` to register the host**
+
+```bash
+clawctl host create 192.168.1.100 --user xclm --alias worker-1
+# → host/worker-1 registered (xclm verified)
+```
+
+**Step 5 — Register a provider, install + start the agent**
+
+```bash
+# Inference provider
 clawctl provider registry create anthropic --type anthropic --api-key-stdin
 
 # Install, configure, and start an OpenClaw agent

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-When you install an agent (claw) on a host, it goes through a structured onboarding workflow before it can be started. This workflow ensures the agent is properly configured with inference providers, identity settings, communication channels, and has passed validation checks.
+When you install an agent on a host, it goes through a structured onboarding workflow before it can be started. This workflow ensures the agent is properly configured with inference providers, identity settings, communication channels, and has passed validation checks.
 
 Think of onboarding as a setup wizard that walks you through all the essential configuration steps for your newly installed agent.
 

--- a/docs/agent-support/hermes.md
+++ b/docs/agent-support/hermes.md
@@ -16,7 +16,7 @@ Hermes is the [Nous Research self-improving AI agent](https://github.com/NousRes
 |--------|---------|
 | ✅ | Fully supported and tested |
 | 🚧 | In development / Planned |
-| ❌ | Not supported (use a different claw) |
+| ❌ | Not supported (use a different agent) |
 | 📋 | Deferred — tracked as follow-up |
 
 ---
@@ -437,7 +437,7 @@ The following are explicitly out of scope for issue #68 and tracked as separate 
 
 ## Next Steps
 
-- [Memory model](memory.md) — manifest-driven memory CLI across claw types
+- [Memory model](memory.md) — manifest-driven memory CLI across agent types
 - [OpenClaw Support Matrix](openclaw.md) — full-featured alternative with multi-channel support
 - [Agent Onboarding](../agent-onboarding.md) — detailed onboarding wizard guide
 - [Host Preparation](../host-preparation.md) — installing provider credentials and host prereqs

--- a/docs/agent-support/memory.md
+++ b/docs/agent-support/memory.md
@@ -15,10 +15,10 @@ Note: in this iteration the CLI exposes `show`, `edit`, and `delete`. `read` and
 
 ## How dispatch works
 
-1. **Resolve the claw type.** `clawctl` looks up the agent in `hosts.json` (or scans candidates by name across all hosts when the user typed an ambiguous identifier) and reads the recorded `type`.
+1. **Resolve the agent type.** `clawctl` looks up the agent in `hosts.json` (or scans candidates by name across all hosts when the user typed an ambiguous identifier) and reads the recorded `type`.
 2. **Check the manifest.** `core/memory.py::claw_supports_memory(<type>)` loads `registry/<type>/manifest.yaml` and returns True iff `features.memory` is `true`.
 3. **Resolve the workspace path.** Used for display — read from `manifest.workspace.memory_path` and expanded against the agent user's home directory (`~`).
-4. **Dispatch the playbook.** The runner invokes `registry/<type>/playbooks/memory_<op>.yaml` (where `<op>` is `info`, `read`, `write`, or `delete`). Each claw ships its own playbooks targeting its own on-disk layout.
+4. **Dispatch the playbook.** The runner invokes `registry/<type>/playbooks/memory_<op>.yaml` (where `<op>` is `info`, `read`, `write`, or `delete`). Each agent type ships its own playbooks targeting its own on-disk layout.
 
 If `features.memory` is missing or `false`, the CLI exits non-zero with:
 
@@ -42,13 +42,13 @@ features:
   memory: true                                  # required to enable the memory CLI
 ```
 
-Both fields are optional in the `AgentManifest` TypedDict — legacy claws (e.g. zeroclaw) continue to validate without either. Declaring `features.memory: true` is the opt-in for memory CLI support.
+Both fields are optional in the `AgentManifest` TypedDict — legacy agent types (e.g. zeroclaw) continue to validate without either. Declaring `features.memory: true` is the opt-in for memory CLI support.
 
 ---
 
-## Per-claw on-disk layouts
+## Per-agent on-disk layouts
 
-The CLI surface is uniform, but each claw's on-disk model is different.
+The CLI surface is uniform, but each agent type's on-disk model is different.
 
 ### Hermes
 
@@ -79,13 +79,13 @@ Other filenames are rejected on `memory write` with `"hermes memory accepts only
     └── YYYY-MM-DD.md   # Daily files (dynamic listing)
 ```
 
-OpenClaw uses a daily-file model under `memory/`, plus a fixed set of top-level identity/profile files at the workspace root. There are no per-file character caps; the global cap is `MAX_MEMORY_CONTENT_BYTES = 5 MiB` (a transport safety bound, not a per-claw policy).
+OpenClaw uses a daily-file model under `memory/`, plus a fixed set of top-level identity/profile files at the workspace root. There are no per-file character caps; the global cap is `MAX_MEMORY_CONTENT_BYTES = 5 MiB` (a transport safety bound, not a per-agent policy).
 
 ---
 
 ## Write safety
 
-The two claws use different write strategies:
+The two agent types use different write strategies:
 
 **Hermes** (`registry/hermes/playbooks/memory_write.yaml`) uses a stage-then-rename pattern:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Clawrium - An aquarium for agents
+# Clawrium
 
 Clawrium is a CLI tool for managing AI agent fleets on local networks.
 

--- a/docs/skills/authoring-native.md
+++ b/docs/skills/authoring-native.md
@@ -1,7 +1,7 @@
 # Authoring a native skill
 
 Use a native registry (`openclaw/`, `hermes/`, `zeroclaw/`) when the
-skill depends on that claw's specific frontmatter fields and can't be
+skill depends on that agent type's specific frontmatter fields and can't be
 expressed in the cross-agent `clawrium/` normalized shape.
 
 A native skill is installable **only** on agents of the matching type.
@@ -18,16 +18,16 @@ Choose **native** when:
 - The skill needs openclaw-only frontmatter (e.g. `allowed-tools`).
 - The skill needs zeroclaw-only fields not part of the normalized
   shape.
-- The behaviour is fundamentally claw-specific (e.g. wraps a native
-  CLI flag that no other claw has).
+- The behaviour is fundamentally agent-type-specific (e.g. wraps a native
+  CLI flag that no other agent type has).
 
 Choose **clawrium** when the behaviour is portable and you'd write the
-same prose for every claw.
+same prose for every agent.
 
 ## Layout
 
 ```
-skills/<claw>/<name>/
+skills/<agent-type>/<name>/
 ├── SKILL.md      # required — frontmatter is the source of truth
 └── README.md     # optional
 ```
@@ -38,16 +38,16 @@ copy-pasted a clawrium skill into the wrong namespace.
 
 ## SKILL.md frontmatter
 
-The frontmatter is whatever the underlying claw expects. The catalog
+The frontmatter is whatever the underlying agent expects. The catalog
 schemas are intentionally lenient (`additionalProperties: true`) so a
-forward-compatible field added by a claw upstream doesn't immediately
+forward-compatible field added by an agent upstream doesn't immediately
 break CI — but the validator still requires:
 
-| Field         | Required | Notes                                |
-|---------------|:--------:|--------------------------------------|
-| `name`        | ✅       | MUST equal the directory name        |
-| `description` | ✅       | One-line elevator pitch              |
-| `version`     | optional | Surfaces in the claw's `skills list` |
+| Field         | Required | Notes                                  |
+|---------------|:--------:|----------------------------------------|
+| `name`        | ✅       | MUST equal the directory name          |
+| `description` | ✅       | One-line elevator pitch                |
+| `version`     | optional | Surfaces in the agent's `skills list`  |
 
 Plus: clawrium-only keys (`compatibility`, `native`) are **rejected**
 in native frontmatter. They have no meaning outside the cross-agent
@@ -129,11 +129,11 @@ the rest of the suite:
 make test
 ```
 
-## Smoke-test against the real claw
+## Smoke-test against the real agent
 
 A native skill must be installed and exercised on a real agent of the
 matching type. The clawrium GUI's `Skills` tab on the agent detail
-filters the installable list to `clawrium/*` + the matching `<claw>/*`,
+filters the installable list to `clawrium/*` + the matching `<agent-type>/*`,
 so you can confirm the install/list/remove round-trip there as well.
 
 ## Open the PR

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -11,7 +11,7 @@
 
 Clawrium ships a curated catalog of **skills** that any agent in your
 fleet can copy into local state and sync to its host. A skill is a directory of
-behaviour-shaping prompts and metadata that the underlying claw
+behaviour-shaping prompts and metadata that the underlying agent
 discovers at runtime — Test-Driven Development discipline, code-review
 guardrails, security-audit playbooks, and so on.
 
@@ -72,7 +72,7 @@ agent-local names, not registry refs.
 ### When to use `clawrium/`
 
 Use the `clawrium/` registry when the skill is behaviour you want
-available on **every** kind of claw. The normalized `_meta.yaml` shape
+available on **every** kind of agent. The normalized `_meta.yaml` shape
 is materialized into each native frontmatter format at `clawctl agent
 skill add` time — a single source template becomes an openclaw-shaped
 local SKILL.md for an openclaw agent, hermes-shaped for a hermes agent,
@@ -82,7 +82,7 @@ copies that already-native local file to the host unchanged.
 ### When to use a native registry
 
 Use `openclaw/`, `hermes/`, or `zeroclaw/` when the skill depends on
-that claw's specific frontmatter fields (e.g. hermes-only `metadata`
+that agent type's specific frontmatter fields (e.g. hermes-only `metadata`
 keys, openclaw allowed-tools lists). Native skills are installable
 **only** on agents of the matching type. Attempting to install a
 `hermes/<name>` skill on an openclaw agent fails with
@@ -119,8 +119,8 @@ semantics, and the no-collision rule.
 
 | Guide | Use when |
 |-------|----------|
-| [Authoring clawrium skills](authoring-clawrium.md) | Cross-agent skill — works on every claw |
-| [Authoring native skills](authoring-native.md)     | Skill specific to one claw's frontmatter |
+| [Authoring clawrium skills](authoring-clawrium.md) | Cross-agent skill — works on every agent |
+| [Authoring native skills](authoring-native.md)     | Skill specific to one agent type's frontmatter |
 
 Every PR that touches `skills/` runs `scripts/validate_skills.py` in CI
 ([skills-validate.yml](https://github.com/ric03uec/clawrium/blob/main/.github/workflows/skills-validate.yml))
@@ -143,7 +143,7 @@ python scripts/validate_skills.py
 
 ## On-host materialization
 
-| Claw     | Install location                              | Mechanism                                  |
+| Agent type | Install location                            | Mechanism                                  |
 |----------|-----------------------------------------------|--------------------------------------------|
 | openclaw | `~/.openclaw/skills/<name>/SKILL.md`          | file copy (auto-scan)                      |
 | hermes   | `~/.hermes/skills/clawrium/<name>/SKILL.md`   | file copy (auto-scan)                      |
@@ -169,10 +169,10 @@ agent-local `SKILL.md` byte-for-byte, and applies that state to the host.
 ## Ownership boundaries
 
 Pruning never touches user-authored or upstream-bundled skills. Each
-claw uses a different marker so a future apply can distinguish
+agent type uses a different marker so a future apply can distinguish
 clawrium-managed dirs from anything else:
 
-| Claw     | Marker                                                                                  |
+| Agent type | Marker                                                                                |
 |----------|-----------------------------------------------------------------------------------------|
 | openclaw | `.clawrium-managed` sentinel file inside each clawrium-installed skill dir              |
 | hermes   | Implicit — clawrium skills live under the dedicated `~/.hermes/skills/clawrium/` subdir |
@@ -217,7 +217,7 @@ rm -rf ~/.config/clawrium/agents/<name>
 
 ### Local end-to-end smoke test
 
-After making a change to a `skills/clawrium/<name>/` or per-claw
+After making a change to a `skills/clawrium/<name>/` or per-agent-type
 playbook, exercise the full round-trip against a real agent before
 opening a PR:
 
@@ -232,13 +232,13 @@ clawctl agent skill list <agent>
 clawctl agent sync <agent>
 
 # 4. Verify on host (substitute the agent's unix user)
-ssh <host> "sudo -u <agent-user> ls -la /home/<agent-user>/<claw-skill-path>"
+ssh <host> "sudo -u <agent-user> ls -la /home/<agent-user>/<agent-skill-path>"
 
 # 5. Duplicate add — should fail and tell you to remove/rename first
 clawctl agent skill add <agent> --from-template clawrium/<name>
 
 # 6. Drift recovery — delete on host, sync reconverges
-ssh <host> "sudo -u <agent-user> rm -rf /home/<agent-user>/<claw-skill-path>"
+ssh <host> "sudo -u <agent-user> rm -rf /home/<agent-user>/<agent-skill-path>"
 clawctl agent sync <agent>
 
 # 7. Remove locally, then sync the removal

--- a/website/docs/agent-support/channels/discord.md
+++ b/website/docs/agent-support/channels/discord.md
@@ -18,7 +18,7 @@ Discord channel allows your agent to operate as a bot in Discord servers.
 
 1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
 2. Click **New Application**
-3. Name it (e.g., "My Claw Agent")
+3. Name it (e.g., "My Clawrium Agent")
 4. Go to **Bot** section
 5. Click **Add Bot**
 6. Enable **Message Content Intent** (required for reading messages)

--- a/website/docs/agent-support/hermes.md
+++ b/website/docs/agent-support/hermes.md
@@ -16,7 +16,7 @@ Hermes is the [Nous Research self-improving AI agent](https://github.com/NousRes
 |--------|---------|
 | ✅ | Fully supported and tested |
 | 🚧 | In development / Planned |
-| ❌ | Not supported (use a different claw) |
+| ❌ | Not supported (use a different agent) |
 | 📋 | Deferred — tracked as follow-up |
 
 ---

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -55,10 +55,8 @@ An **Agent** is an AI assistant instance.
 
 **Fully supported today:**
 - OpenClaw ✅
-
-**In development:**
-- Hermes 🚧 (install + configure + OpenAI-compatible API working; chat + channels in progress)
-- ZeroClaw 🚧
+- Hermes ✅
+- ZeroClaw ✅
 
 **Planned:**
 - IronClaw and additional agent types

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -6,7 +6,7 @@ keywords: [architecture, components, network topology, data flow, system design]
 
 # Architecture
 
-Clawrium manages AI assistant deployments across your network through three key concepts: **Hosts**, **Claws**, and the **Registry**.
+Clawrium manages AI agent deployments across your network through three key concepts: **Hosts**, **Agents**, and the **Registry**.
 
 ![Clawrium architecture](/img/clawrium-architecture.png)
 
@@ -42,26 +42,30 @@ graph TB
 
 ### Host
 
-A **Host** is any machine on your network that runs one or more claws. Clawrium connects to hosts via SSH using a dedicated management user (`xclm`).
+A **Host** is any machine on your network that runs one or more agents. Clawrium connects to hosts via SSH using a dedicated management user (`xclm`).
 
 **Characteristics:**
 - Direct network access required (no ProxyJump support in v1)
 - Per-host SSH keypair for security isolation
 - Hardware capabilities detected automatically (CPU, GPU, memory)
 
-### Claw
+### Agent
 
-A **Claw** is an AI assistant instance. Today, Clawrium supports OpenClaw for end-to-end deployment and management.
+An **Agent** is an AI assistant instance.
 
-**Current support:**
-- OpenClaw
+**Fully supported today:**
+- OpenClaw ✅
+
+**In development:**
+- Hermes 🚧 (install + configure + OpenAI-compatible API working; chat + channels in progress)
+- ZeroClaw 🚧
 
 **Planned:**
-- ZeroClaw and additional claw types
+- IronClaw and additional agent types
 
 ### Registry
 
-The **Registry** defines available claw types with their versions, dependencies, and installation templates. It's the source of truth for what can be deployed.
+The **Registry** defines available agent types with their versions, dependencies, and installation templates. It's the source of truth for what can be deployed.
 
 ## Host Management Flow
 
@@ -89,7 +93,7 @@ sequenceDiagram
 3. **Re-run** (`clawctl host create …`): verifies SSH as `xclm`, persists the host record.
 4. **Manage**: list, check status, or remove hosts as needed.
 
-## Claw Installation Flow
+## Agent Installation Flow
 
 ```mermaid
 sequenceDiagram
@@ -103,19 +107,19 @@ sequenceDiagram
     Registry-->>CLM: Version, dependencies, template
     CLM->>Host: SSH as xclm
     CLM->>Host: Install dependencies
-    CLM->>Host: Create claw user
+    CLM->>Host: Create agent user
     CLM->>Host: Deploy configuration
-    CLM->>Host: Start claw service
-    Host-->>CLM: Claw running on port XXXX
+    CLM->>Host: Start agent service
+    Host-->>CLM: Agent running on port XXXX
 ```
 
 **The installation process:**
 
-1. Reads claw definition from registry
+1. Reads agent definition from registry
 2. Installs system dependencies via Ansible
-3. Creates unprivileged user for the claw instance
-4. Deploys normalized configuration (translated to claw-native format)
-5. Starts the claw as a systemd service
+3. Creates unprivileged user for the agent instance
+4. Deploys normalized configuration (translated to agent-native format)
+5. Starts the agent as a systemd service
 
 ## Data Storage
 
@@ -194,7 +198,7 @@ flowchart LR
 
     subgraph "External"
         HOST[Remote Host]
-        REGISTRY[(Claw Registry)]
+        REGISTRY[(Agent Registry)]
     end
 
     CLI -->|commands| CORE
@@ -221,7 +225,7 @@ flowchart LR
 | Core Logic | Business logic, state management, orchestration |
 | Ansible Runner | Executes playbooks on remote hosts |
 | Config Manager | Reads/writes configuration files |
-| Registry | Claw type definitions and templates |
+| Registry | Agent type definitions and templates |
 
 ## Data Flow
 
@@ -277,7 +281,7 @@ Each component operates with minimal required permissions:
 |-----------|------------|
 | Clawrium CLI | User-level, reads/writes `~/.config/clawrium/` |
 | xclm user | Passwordless sudo for specific commands |
-| Claw instances | Unprivileged user, no sudo access |
+| Agent instances | Unprivileged user, no sudo access |
 
 ### SSH Key Isolation
 

--- a/website/docs/guides/fleet-management.md
+++ b/website/docs/guides/fleet-management.md
@@ -6,7 +6,7 @@ keywords: [fleet management, multi-host, deployment, operations]
 
 # Fleet Management
 
-This guide covers managing multiple hosts and claws in your Clawrium fleet.
+This guide covers managing multiple hosts and agents in your Clawrium fleet.
 
 ## Overview
 
@@ -89,7 +89,7 @@ clawctl host status dev-server
 
 ### Deploying Across Fleet
 
-Deploy the same claw to multiple hosts:
+Deploy the same agent type to multiple hosts:
 
 ```bash
 # Install ZeroClaw on multiple hosts
@@ -115,7 +115,7 @@ clawctl agent secret create OPENAI_API_KEY --host dev-server
 
 Before resetting a host:
 
-1. **Check for running claws**
+1. **Check for running agents**
    ```bash
    clawctl host status pi-lab
    ```
@@ -128,7 +128,7 @@ Before resetting a host:
 3. **Backup any custom configuration**
    ```bash
    # SSH into host and backup custom configs
-   ssh xclm@pi-lab "tar -czf /tmp/claw-backup.tar.gz ~/.config/"
+   ssh xclm@pi-lab "tar -czf /tmp/agent-backup.tar.gz ~/.config/"
    ```
 
 ### Executing Reset
@@ -284,7 +284,7 @@ Each host has an isolated SSH keypair:
 
 2. **Document host configurations**
    - Keep a fleet manifest
-   - Track which claws are on which hosts
+   - Track which agents are on which hosts
    - Note any custom configurations
 
 3. **Backup before changes**

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -11,20 +11,23 @@ keywords: [clawrium, AI assistant, fleet management, CLI tool, multi-host, agent
 
 [Documentation](https://ric03uec.github.io/clawrium/) · [Issues](https://github.com/ric03uec/clawrium/issues) · [Roadmap](https://github.com/users/ric03uec/projects/1) · [Discord](https://discord.gg/KzPuSxgQ98)
 
-## What is a Claw?
+## What is an Agent?
 
-A **claw** is a general-purpose AI assistant that runs on a machine in your network. Unlike coding-specific tools, claws are versatile assistants that can:
+A Clawrium **agent** is a general-purpose AI assistant that runs on a machine in your network. Unlike coding-specific tools, these agents are versatile assistants that can:
 
 - Answer questions via Discord, Slack, or CLI
 - Research topics and summarize findings
 - Help with writing, brainstorming, and planning
 - Connect to external services (GitHub, Jira, etc.)
 
-**Currently supported:**
-- [**OpenClaw**](https://github.com/openclaw/openclaw) - Full-featured assistant with multi-provider and multi-channel support
+**Fully supported today:**
+- [**OpenClaw**](https://github.com/openclaw/openclaw) ✅ - Full-featured assistant with multi-provider and multi-channel support
+
+**In development:**
+- [**Hermes**](https://github.com/NousResearch/hermes-agent) 🚧 (Nous Research) - Install, configure, and OpenAI-compatible API are working; `clawctl agent chat` and channel gateways are in progress
+- **ZeroClaw** 🚧 - Lightweight assistant for resource-constrained devices
 
 **Planned:**
-- **ZeroClaw** - Lightweight assistant for resource-constrained devices
 - **IronClaw** - High-performance assistant for demanding workloads
 
 ## Why Clawrium?
@@ -63,23 +66,10 @@ clawctl service init
 ```
 
 ```bash
-# Register a host. First run generates the keypair and prints the
-# manual xclm setup commands you need to run on the host (see the
-# Host Setup guide). Re-run after pasting them to register the host.
-clawctl host create 192.168.1.100 --user xclm --alias mybox
-```
-```
-Generating SSH keypair for 192.168.1.100...
-✓ Keypair created: ~/.config/clawrium/keys/192.168.1.100/
-xclm SSH verification failed: Authentication failed - check SSH keys
-
-Manual setup required. Log into the host with a sudo-capable user and
-run the printed Linux or macOS block, then re-run this command.
-```
-
-```bash
-# Add an initialized host to the fleet
-clawctl host create 192.168.1.100 --alias homelab
+# Register a host. The first invocation prints the manual xclm setup
+# commands to run on the host (see the Host Setup guide); re-run this
+# command afterwards to actually register the host.
+clawctl host create 192.168.1.100 --user xclm --alias homelab
 ```
 ```
 Connecting to 192.168.1.100 as xclm...
@@ -127,9 +117,9 @@ Clawrium GUI starting on http://127.0.0.1:36000 — press Ctrl+C to stop
 | Concept | Description |
 |---------|-------------|
 | **Host** | A machine in your network that runs one or more agents |
-| **Claw** | An AI assistant instance (like OpenClaw or ZeroClaw) |
-| **Agent** | An installed claw instance managed by Clawrium |
-| **Registry** | Available claw types with versions, dependencies, and templates |
+| **Agent** | An installed AI assistant instance managed by Clawrium (e.g. OpenClaw, Hermes) |
+| **Agent Type** | The implementation/runtime class of an agent |
+| **Registry** | Available agent types with versions, dependencies, and templates |
 
 ## What You'll Need
 
@@ -137,8 +127,8 @@ Before you start, make sure you have:
 
 | Requirement | Details |
 |-------------|---------|
-| **Control machine** | macOS or Linux with Python 3.10+ |
-| **Target host** | Ubuntu 22.04/24.04 with SSH access |
+| **Control machine** | Ubuntu or macOS with Python 3.10+ |
+| **Target host** | Ubuntu 22.04/24.04 or macOS with SSH access |
 | **Network** | Direct connectivity between control machine and hosts |
 | **API keys** | At least one LLM provider (OpenAI, Anthropic, etc.) |
 
@@ -152,11 +142,11 @@ Clawrium runs from your control machine and uses SSH + Ansible to manage remote 
 
 ### What operating systems are supported?
 
-Clawrium is currently tested on Ubuntu control machines and Ubuntu 22.04/24.04 target hosts.
+Clawrium is tested end-to-end on **Ubuntu** and **macOS** — both as the control machine and as target hosts. On macOS hosts, enable Remote Login before registering them; see the [Host Setup](./guides/host-setup.md) guide. Other Linux distributions may work but are not in the test matrix.
 
 ### Which agents are supported today?
 
-[OpenClaw](https://github.com/openclaw/openclaw) is supported with full lifecycle management. ZeroClaw support is planned.
+[OpenClaw](https://github.com/openclaw/openclaw) is fully supported end-to-end with multi-provider and multi-channel support. [Hermes](https://github.com/NousResearch/hermes-agent) and ZeroClaw are in active development. IronClaw is planned. See the [Support Matrix](https://github.com/ric03uec/clawrium#support-matrix) on the GitHub README for the canonical status table.
 
 ### Is Claude subscription supported?
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -22,10 +22,8 @@ A Clawrium **agent** is a general-purpose AI assistant that runs on a machine in
 
 **Fully supported today:**
 - [**OpenClaw**](https://github.com/openclaw/openclaw) ✅ - Full-featured assistant with multi-provider and multi-channel support
-
-**In development:**
-- [**Hermes**](https://github.com/NousResearch/hermes-agent) 🚧 (Nous Research) - Install, configure, and OpenAI-compatible API are working; `clawctl agent chat` and channel gateways are in progress
-- **ZeroClaw** 🚧 - Lightweight assistant for resource-constrained devices
+- [**Hermes**](https://github.com/NousResearch/hermes-agent) ✅ (Nous Research) - Install, configure, and OpenAI-compatible API
+- [**ZeroClaw**](https://github.com/zeroclaw-labs/zeroclaw) ✅ - Lightweight assistant for resource-constrained devices
 
 **Planned:**
 - **IronClaw** - High-performance assistant for demanding workloads
@@ -146,7 +144,7 @@ Clawrium is tested end-to-end on **Ubuntu** and **macOS** — both as the contro
 
 ### Which agents are supported today?
 
-[OpenClaw](https://github.com/openclaw/openclaw) is fully supported end-to-end with multi-provider and multi-channel support. [Hermes](https://github.com/NousResearch/hermes-agent) and ZeroClaw are in active development. IronClaw is planned. See the [Support Matrix](https://github.com/ric03uec/clawrium#support-matrix) on the GitHub README for the canonical status table.
+[OpenClaw](https://github.com/openclaw/openclaw), [Hermes](https://github.com/NousResearch/hermes-agent), and [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw) are fully supported end-to-end. IronClaw is planned. See the [Support Matrix](https://github.com/ric03uec/clawrium#support-matrix) on the GitHub README for the canonical status table.
 
 ### Is Claude subscription supported?
 

--- a/website/docs/reference/cli/host.md
+++ b/website/docs/reference/cli/host.md
@@ -14,7 +14,7 @@ clawctl host <command> [options]
 | [`clawctl host get`](#clawctl-host-get) | List all registered hosts |
 | [`clawctl host delete`](#clawctl-host-delete) | Remove a host from the fleet |
 | [`clawctl host status`](#clawctl-host-status) | Check status of a host |
-| [`clawctl host reset`](#clawctl-host-reset) | Reset a host, removing all claws and users |
+| [`clawctl host reset`](#clawctl-host-reset) | Reset a host, removing all agents and users |
 | [`clawctl host address`](#address-subcommands) | Manage multiple addresses for a host |
 
 ---
@@ -226,7 +226,7 @@ Hardware information updated.
 
 ## clawctl host reset
 
-Reset a host, removing all claws and users.
+Reset a host, removing all agents and users.
 
 ```bash
 clawctl host reset <hostname> [options]

--- a/website/docs/reference/cli/index.md
+++ b/website/docs/reference/cli/index.md
@@ -1,11 +1,11 @@
 ---
-description: Complete CLI reference for the clawctl command. Root commands and command groups for managing your AI claw fleet.
+description: Complete CLI reference for the clawctl command. Root commands and command groups for managing your AI agent fleet.
 keywords: [CLI, reference, commands, clawctl, usage, options]
 ---
 
 # CLI Reference
 
-Clawrium provides the `clawctl` command-line interface for managing your AI claw fleet.
+Clawrium provides the `clawctl` command-line interface for managing your AI agent fleet.
 
 ## Installation
 
@@ -39,8 +39,8 @@ clawctl <group> <command> [options]
 | Group | Description |
 |-------|-------------|
 | [`clawctl host`](host.md) | Manage hosts in your fleet |
-| [`clawctl agent registry`](registry.md) | Browse available claw types |
-| [`clawctl agent secret`](secret.md) | Manage secrets for claw instances |
+| [`clawctl agent registry`](registry.md) | Browse available agent types |
+| [`clawctl agent secret`](secret.md) | Manage secrets for agent instances |
 
 ---
 
@@ -87,7 +87,7 @@ Show fleet status across all hosts.
 clawctl agent describe [--host HOST]
 ```
 
-Displays claw instances grouped by claw type with live health checks. Shows name, version, host, and status for each installed claw.
+Displays agent instances grouped by agent type with live health checks. Shows name, version, host, and status for each installed agent.
 
 ### Options
 
@@ -118,10 +118,10 @@ $ clawctl agent describe --host pi-lab
 
 | Status | Meaning |
 |--------|---------|
-| `running` | Claw is healthy and operational |
-| `degraded` | Claw is running but missing required secrets |
-| `stopped` | Claw service is not running |
-| `not installed` | Claw record exists but service not found |
+| `running` | Agent is healthy and operational |
+| `degraded` | Agent is running but missing required secrets |
+| `stopped` | Agent service is not running |
+| `not installed` | Agent record exists but service not found |
 | `install failed` | Installation did not complete successfully |
 | `installing...` | Installation in progress |
 

--- a/website/docs/reference/cli/provider.md
+++ b/website/docs/reference/cli/provider.md
@@ -1,6 +1,6 @@
 # Provider Commands
 
-Manage inference providers (LLM APIs) for claw instances.
+Manage inference providers (LLM APIs) for agent instances.
 
 ```bash
 clawctl provider <command> [options]

--- a/website/docs/reference/cli/registry.md
+++ b/website/docs/reference/cli/registry.md
@@ -1,6 +1,6 @@
 # Registry Commands
 
-Browse available claw types in the Clawrium registry.
+Browse available agent types in the Clawrium registry.
 
 ```bash
 clawctl agent registry <command> [options]
@@ -10,14 +10,14 @@ clawctl agent registry <command> [options]
 
 | Command | Description |
 |---------|-------------|
-| [`clawctl agent registry get`](#clawctl-agent-registry-get) | List available claw types |
-| [`clawctl agent registry describe`](#clawctl-agent-registry-describe) | Show detailed information about a claw type |
+| [`clawctl agent registry get`](#clawctl-agent-registry-get) | List available agent types |
+| [`clawctl agent registry describe`](#clawctl-agent-registry-describe) | Show detailed information about an agent type |
 
 ---
 
 ## clawctl agent registry get
 
-List available claw types in the registry.
+List available agent types in the registry.
 
 ```bash
 clawctl agent registry get
@@ -27,7 +27,7 @@ clawctl agent registry get
 
 ```bash
 $ clawctl agent registry get
-               Available Claws
+               Available Agents
 ┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Name       ┃ Latest Version ┃ Description                    ┃
 ┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
@@ -39,10 +39,10 @@ $ clawctl agent registry get
 
 ### Error Handling
 
-If a claw's manifest is corrupted or missing:
+If an agent's manifest is corrupted or missing:
 
 ```bash
-               Available Claws
+               Available Agents
 ┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Name       ┃ Latest Version ┃ Description          ┃
 ┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
@@ -55,17 +55,17 @@ If a claw's manifest is corrupted or missing:
 
 ## clawctl agent registry describe
 
-Show detailed information about a claw type.
+Show detailed information about an agent type.
 
 ```bash
-clawctl agent registry describe <claw_name>
+clawctl agent registry describe <agent_name>
 ```
 
 ### Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `claw_name` | Name of the claw to show |
+| `agent_name` | Name of the agent type to show |
 
 ### Example
 
@@ -94,16 +94,16 @@ Dependencies:
 
 | Code | Meaning |
 |------|---------|
-| 0 | Claw information displayed successfully |
-| 1 | Claw not found or manifest corrupted |
+| 0 | Agent information displayed successfully |
+| 1 | Agent not found or manifest corrupted |
 
 ### Error Scenarios
 
-Claw not found:
+Agent not found:
 
 ```bash
 $ clawctl agent registry describe unknown
-Error: Claw 'unknown' not found in registry
+Error: Agent 'unknown' not found in registry
 ```
 
 Corrupted manifest:

--- a/website/docs/reference/cli/secret.md
+++ b/website/docs/reference/cli/secret.md
@@ -1,29 +1,29 @@
 # Secret Commands
 
-Manage secrets for claw instances.
+Manage secrets for agent instances.
 
 ```bash
 clawctl agent secret <command> [options]
 ```
 
-Secrets are stored locally in `~/.config/clawrium/secrets.yml` and are never transmitted to remote hosts in plain text. Each claw instance has its own isolated secret namespace.
+Secrets are stored locally in `~/.config/clawrium/secrets.yml` and are never transmitted to remote hosts in plain text. Each agent instance has its own isolated secret namespace.
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| [`clawctl agent secret create`](#clawctl-agent-secret-create) | Set a secret value for a claw instance |
-| [`clawctl agent secret get --agent`](#clawctl-agent-secret-get---agent) | List secrets for a claw instance |
-| [`clawctl agent secret delete`](#clawctl-agent-secret-delete) | Remove a secret from a claw instance |
+| [`clawctl agent secret create`](#clawctl-agent-secret-create) | Set a secret value for an agent instance |
+| [`clawctl agent secret get --agent`](#clawctl-agent-secret-get---agent) | List secrets for an agent instance |
+| [`clawctl agent secret delete`](#clawctl-agent-secret-delete) | Remove a secret from an agent instance |
 
 ---
 
 ## clawctl agent secret create
 
-Set a secret value for a claw instance.
+Set a secret value for an agent instance.
 
 ```bash
-clawctl agent secret create <claw_name> <key> [options]
+clawctl agent secret create <agent_name> <key> [options]
 ```
 
 Prompts for the value using masked input (not visible on screen).
@@ -32,7 +32,7 @@ Prompts for the value using masked input (not visible on screen).
 
 | Argument | Description |
 |----------|-------------|
-| `claw_name` | Claw instance name (e.g., `zc-work`) |
+| `agent_name` | Agent instance name (e.g., `zc-work`) |
 | `key` | Secret key name (e.g., `ANTHROPIC_API_KEY`) |
 
 ### Options
@@ -79,32 +79,32 @@ Invalid examples: `my-api-key`, `apiKey`, `123_KEY`
 | Code | Meaning |
 |------|---------|
 | 0 | Secret set successfully or operation cancelled |
-| 1 | Claw not found, invalid key name, or empty value |
+| 1 | Agent not found, invalid key name, or empty value |
 
 ---
 
 ## clawctl agent secret get --agent
 
-List secrets for a claw instance.
+List secrets for an agent instance.
 
 ```bash
-clawctl agent secret get --agent <claw_name>
+clawctl agent secret get --agent <agent_name>
 ```
 
-Shows secret keys and metadata. Values are never displayed. Also shows missing required secrets defined in the claw's manifest.
+Shows secret keys and metadata. Values are never displayed. Also shows missing required secrets defined in the agent's manifest.
 
 ### Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `claw_name` | Claw instance name (e.g., `zc-kevin`) |
+| `agent_name` | Agent instance name (e.g., `zc-kevin`) |
 
 ### Example
 
 ```bash
 $ clawctl agent secret get --agent zc-work
 
-Claw: zc-work (192.168.1.100)
+Agent: zc-work (192.168.1.100)
 ┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Key                ┃ Description                ┃ Updated    ┃
 ┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
@@ -118,7 +118,7 @@ With missing required secrets:
 ```bash
 $ clawctl agent secret get --agent zc-work
 
-Claw: zc-work (192.168.1.100)
+Agent: zc-work (192.168.1.100)
 ┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Key                ┃ Description                ┃ Updated    ┃
 ┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
@@ -132,7 +132,7 @@ No secrets configured:
 ```bash
 $ clawctl agent secret get --agent zc-new
 
-Claw: zc-new (192.168.1.100)
+Agent: zc-new (192.168.1.100)
   No secrets set
   Missing: ANTHROPIC_API_KEY (Required for Claude API access)
 ```
@@ -142,16 +142,16 @@ Claw: zc-new (192.168.1.100)
 | Code | Meaning |
 |------|---------|
 | 0 | Secrets listed successfully |
-| 1 | Claw not found or secrets file corrupted |
+| 1 | Agent not found or secrets file corrupted |
 
 ---
 
 ## clawctl agent secret delete
 
-Remove a secret from a claw instance.
+Remove a secret from an agent instance.
 
 ```bash
-clawctl agent secret delete <claw_name> <key> [--force]
+clawctl agent secret delete <agent_name> <key> [--force]
 ```
 
 Prompts for confirmation unless `--force` is specified.
@@ -160,7 +160,7 @@ Prompts for confirmation unless `--force` is specified.
 
 | Argument | Description |
 |----------|-------------|
-| `claw_name` | Claw instance name |
+| `agent_name` | Agent instance name |
 | `key` | Secret key to remove |
 
 ### Options
@@ -189,4 +189,4 @@ Secret 'GITHUB_TOKEN' removed from 'zc-work'.
 | Code | Meaning |
 |------|---------|
 | 0 | Secret removed successfully or operation cancelled |
-| 1 | Claw not found, secret not found, or removal failed |
+| 1 | Agent not found, secret not found, or removal failed |

--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -26,7 +26,7 @@ $XDG_CONFIG_HOME/clawrium/
 ```
 ~/.config/clawrium/
 ├── hosts.yml           # Registered hosts and their metadata
-├── secrets.yml         # Encrypted secrets for claw instances
+├── secrets.yml         # Encrypted secrets for agent instances
 └── keys/               # SSH keypairs for host authentication
     ├── host1.key       # Private key (permissions: 0600)
     └── host1.key.pub   # Public key
@@ -55,7 +55,7 @@ Contains registered hosts and their configuration:
     tags:
       - production
       - arm
-  claws:
+  agents:
     zeroclaw:
       version: "0.1.0"
       user: zc
@@ -65,7 +65,7 @@ Contains registered hosts and their configuration:
 
 ### secrets.yml
 
-Contains secrets organized by claw instance:
+Contains secrets organized by agent instance:
 
 ```yaml
 192.168.1.100:zeroclaw:zc-work:
@@ -79,7 +79,7 @@ Contains secrets organized by claw instance:
     value: <encrypted>
 ```
 
-The instance key format is `hostname:claw_type:instance_name`.
+The instance key format is `hostname:agent_type:instance_name`.
 
 ### keys/
 

--- a/website/docs/skills/authoring.md
+++ b/website/docs/skills/authoring.md
@@ -19,12 +19,12 @@ guides go deeper on each.
 
 | You're adding…                                  | Registry         |
 |-------------------------------------------------|------------------|
-| Behaviour that should run on every claw         | `clawrium/`      |
+| Behaviour that should run on every agent        | `clawrium/`      |
 | openclaw-specific frontmatter (e.g. allowed-tools) | `openclaw/`   |
 | hermes-specific metadata (tags, homepage)       | `hermes/`        |
 | zeroclaw-specific frontmatter                   | `zeroclaw/`      |
 
-A native skill (`<claw>/<name>`) is installable **only** on agents of
+A native skill (`<agent-type>/<name>`) is installable **only** on agents of
 the matching type. A `clawrium/<name>` skill is installable on any
 agent whose entry in the skill's `compatibility:` map is truthy.
 
@@ -76,12 +76,12 @@ description: One-line elevator pitch.
 # Skill body...
 ```
 
-## `<claw>/<name>/` — native
+## `<agent-type>/<name>/` — native
 
 Layout:
 
 ```
-skills/<claw>/<name>/
+skills/<agent-type>/<name>/
 ├── SKILL.md        # required — frontmatter is the source of truth
 └── README.md       # optional
 ```
@@ -103,11 +103,11 @@ description: One-line elevator pitch.
 Forbidden in native frontmatter:
 
 - `compatibility:` — clawrium-only.
-- `native:` — clawrium-only (per-claw override map for the cross-agent
+- `native:` — clawrium-only (per-agent-type override map for the cross-agent
   shape).
 
 The native schemas are otherwise lenient (`additionalProperties: true`)
-so a claw can add new frontmatter fields upstream without breaking CI.
+so an agent type can add new frontmatter fields upstream without breaking CI.
 
 ## Validate locally
 
@@ -141,11 +141,11 @@ Run the test suite too:
 make test
 ```
 
-## Smoke-test against a real claw
+## Smoke-test against a real agent
 
 Before merging, exercise the add/sync/list/remove round-trip against a
 real agent. For a `clawrium/<name>` skill, this means three agents
-(one per claw); for a `<claw>/<name>` native skill, one agent of the
+(one per agent type); for an `<agent-type>/<name>` native skill, one agent of the
 matching type.
 
 ```bash

--- a/website/docs/skills/intro.md
+++ b/website/docs/skills/intro.md
@@ -8,7 +8,7 @@ keywords: [skills, registry, clawrium, openclaw, hermes, zeroclaw, install]
 
 Clawrium ships a curated **skills catalog** that any agent in your
 fleet can copy into local agent state with one command. A skill is a directory of
-behaviour-shaping prompts and metadata that the underlying claw
+behaviour-shaping prompts and metadata that the underlying agent
 discovers at runtime — Test-Driven Development discipline, code-review
 guardrails, security-audit playbooks.
 
@@ -66,14 +66,14 @@ local names.
 ### `clawrium/` — cross-agent
 
 Use the `clawrium/` registry when the skill is behaviour you want
-available on **every** kind of claw. The normalized `_meta.yaml` shape
+available on **every** kind of agent. The normalized `_meta.yaml` shape
 is materialized into each native frontmatter format at `clawctl agent
 skill add` time. `clawctl agent sync` later copies the already-native
 local file to the host unchanged.
 
 ### `openclaw/`, `hermes/`, `zeroclaw/` — native
 
-Use a native registry when the skill needs that claw's specific
+Use a native registry when the skill needs that agent's specific
 frontmatter fields. Native skills are installable **only** on agents
 of the matching type — `clawctl agent skill add` fails fast if you try
 to mix them.
@@ -96,7 +96,7 @@ clawctl agent sync <agent>
 
 ## On-host install path
 
-| Claw     | On-host location                              | Mechanism                                  |
+| Agent type | On-host location                            | Mechanism                                  |
 |----------|-----------------------------------------------|--------------------------------------------|
 | openclaw | `~/.openclaw/skills/<name>/SKILL.md`          | file copy (auto-scan)                      |
 | hermes   | `~/.hermes/skills/clawrium/<name>/SKILL.md`   | file copy (auto-scan)                      |

--- a/website/docs/troubleshooting.md
+++ b/website/docs/troubleshooting.md
@@ -75,7 +75,7 @@ Permission denied (publickey)
    # Add public key (from Clawrium's output)
    sudo mkdir -p /home/xclm/.ssh
    sudo chmod 700 /home/xclm/.ssh
-   echo '<public-key-from-clm-host-init>' | sudo tee /home/xclm/.ssh/authorized_keys
+   echo '<public-key-from-clawctl-host-create>' | sudo tee /home/xclm/.ssh/authorized_keys
    sudo chmod 600 /home/xclm/.ssh/authorized_keys
    sudo chown -R xclm:xclm /home/xclm/.ssh
    ```

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -4,7 +4,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'Clawrium',
-  tagline: 'An aquarium for *claws',
+  tagline: 'Fleet management for AI agents on your local network',
   favicon: 'img/favicon.png',
 
   future: {

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -4,7 +4,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
   title: 'Clawrium',
-  tagline: 'Fleet management for AI agents on your local network',
+  tagline: 'Agent Fleet Manager',
   favicon: 'img/favicon.png',
 
   future: {

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -35,14 +35,15 @@ function UnlockIcon() {
 
 const FeatureList: FeatureItem[] = [
   {
-    title: '🌐 Universal Claw Support',
+    title: '🌐 Universal Agent Support',
     icon: <GlobeIcon />,
     description: (
       <>
-        Today, Clawrium supports{' '}
-        <a href="https://github.com/openclaw/openclaw">OpenClaw</a> and{' '}
-        <a href="https://github.com/NousResearch/hermes-agent">Hermes</a> for end-to-end
-        install, onboarding, and lifecycle management. Additional claw types are planned.
+        Clawrium supports{' '}
+        <a href="https://github.com/openclaw/openclaw">OpenClaw</a> end-to-end today.{' '}
+        <a href="https://github.com/NousResearch/hermes-agent">Hermes</a> and{' '}
+        <a href="https://github.com/zeroclaw-labs/zeroclaw">ZeroClaw</a> are in active development.
+        Additional agent types are planned.
       </>
     ),
   },
@@ -51,8 +52,8 @@ const FeatureList: FeatureItem[] = [
     icon: <GearIcon />,
     description: (
       <>
-        One config format for every claw. Define your preferences once and
-        Clawrium translates them for each claw&apos;s native format.
+        One config format for every agent. Define your preferences once and
+        Clawrium translates them into each agent&apos;s native format.
       </>
     ),
   },
@@ -110,14 +111,14 @@ function BeforeAfterSection(): ReactNode {
           <div className={clsx('col col--6', styles.beforeAfterCol)}>
             <Heading as="h3">After: One CLI, all agents</Heading>
             <pre className={styles.asciiDiagram}>
-{`You (laptop + clm CLI)
+{`You (laptop + clawctl CLI)
     │
-    └── clm ────┬── pi-lab ───> openclaw
-                │
-                ├── nuc-01 ───> openclaw
-                │
-                └── dev-box ──> hermes
-    
+    └── clawctl ──┬── pi-lab ───> openclaw
+                  │
+                  ├── nuc-01 ───> openclaw
+                  │
+                  └── dev-box ──> hermes
+
     ✅ Single command center
     ✅ Consistent configuration
     ✅ Centralized secrets`}
@@ -127,13 +128,13 @@ function BeforeAfterSection(): ReactNode {
         <div className={styles.clmPsOutput}>
           <Heading as="h4" className="text--center">See your entire fleet with one command:</Heading>
           <pre className={styles.terminalOutput}>
-{`$ clm ps
+{`$ clawctl agent get
 
-HOST        AGENT          TYPE       STATUS    UPTIME
-─────────────────────────────────────────────────────────
-pi-lab      oc-discord     openclaw   running   3d 4h
-nuc-01      oc-work        openclaw   running   12h
-dev-box     hm-research    hermes     running   2h`}
+NAME           TYPE       HOST       PROVIDER    STATUS    AGE
+─────────────────────────────────────────────────────────────────
+oc-discord     openclaw   pi-lab     anthropic   running   3d 4h
+oc-work        openclaw   nuc-01     anthropic   running   12h
+hm-research    hermes     dev-box    openrouter  running   2h`}
           </pre>
         </div>
       </div>

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -40,9 +40,9 @@ const FeatureList: FeatureItem[] = [
     description: (
       <>
         Clawrium supports{' '}
-        <a href="https://github.com/openclaw/openclaw">OpenClaw</a> end-to-end today.{' '}
-        <a href="https://github.com/NousResearch/hermes-agent">Hermes</a> and{' '}
-        <a href="https://github.com/zeroclaw-labs/zeroclaw">ZeroClaw</a> are in active development.
+        <a href="https://github.com/openclaw/openclaw">OpenClaw</a>,{' '}
+        <a href="https://github.com/NousResearch/hermes-agent">Hermes</a>, and{' '}
+        <a href="https://github.com/zeroclaw-labs/zeroclaw">ZeroClaw</a> end-to-end today.
         Additional agent types are planned.
       </>
     ),

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -52,8 +52,8 @@ export default function Home(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title="Manage Your AI Claw Fleet"
-      description="CLI tool for managing AI assistant fleets on local networks. Deploy and manage multiple claw instances across hosts from a single command center.">
+      title="Manage Your AI Agent Fleet"
+      description="CLI tool for managing AI agent fleets on local networks. Deploy and manage multiple agent instances across hosts from a single command center.">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
## Summary

Audit of the GitHub README and Docusaurus landing for first-impression issues and terminology drift, with fixes applied uniformly across both surfaces.

- **First-success path**: README gets a Support Matrix box at the top (control/host OS, agent runtimes with status, providers, channels, container runtime), the deliberate \`xclm SSH verification failed\` step is dropped from the 5-Minute Setup in favor of a single happy path + prerequisite callout, and **Tested on Ubuntu** / **Tested on macOS** badges are added. FAQ #1 updated to reflect Ubuntu + macOS as the test matrix.
- **Terminology**: generic noun \"Claw\"/\"Claws\" renamed to \"Agent\"/\"Agents\" across README, AGENTS.md, Docusaurus landing (tagline, hero, HomepageFeatures), and website docs (intro, architecture, configuration, CLI reference, skills, fleet-management, hermes/memory, repo-rooted docs index, agent-onboarding). Brand names (Clawrium, OpenClaw, ZeroClaw, IronClaw, NemoClaw, Hermes) preserved. Real on-disk identifiers preserved (\`*claw\` literal systemd glob; \`claw_supports_memory\` Python symbol referenced verbatim in docs/agent-support/memory.md).
- **CLI rename**: residual \`clm\` references replaced with \`clawctl\` on the website landing (\`HomepageFeatures\` ASCII diagram + sample output now use \`clawctl agent get\`) and in the troubleshooting placeholder. Frozen \`docs/releases/*/CHANGELOG.md\` archives and dated migration blog posts that document the \`clm\`→\`clawctl\` rename as their subject are intentionally left untouched.
- CHANGELOG.md updated under \`### Documentation\`.

## Testing

- \`make lint\` passes (ruff + ESLint).
- \`npm run build\` under \`website/\` passes with \`onBrokenLinks\` / \`onBrokenAnchors\` set to \`throw\` (no broken anchors from renamed headings).
- External repo links verified reachable (200): https://github.com/openclaw/openclaw, https://github.com/zeroclaw-labs/zeroclaw, https://github.com/nearai/ironclaw.
- Greps confirm zero residual generic \`claw\`/\`claws\` in active surfaces and zero \`a agent\` grammar regressions.

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: \$5.32 | Total Time: 15m 59s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3/5 | B1, B2, B3 | All fixed | \$3.39 | 9m 33s | leader, cli-ux, gui-routes, test-coverage |
| 2 | 4/5 | None | Ready | \$1.93 | 6m 26s | leader, cli-ux, gui-routes, test-coverage |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | \`website/docs/reference/cli/{registry,secret}.md\` | Bulk Claw→Agent rename produced \`a agent\` / \`a agent type\` / \`a agent instance\` (~8 occurrences on the two highest-traffic CLI reference pages) | Fixed — replaced with \`an agent\`; sweep confirms zero remaining matches |
| B2 | README, \`website/docs/intro.md\`, \`website/docs/architecture.md\` | ZeroClaw/IronClaw status contradiction between Support Matrix (\"planned\") and \"What is an Agent?\" bullets (no qualifier); architecture.md still showed OpenClaw as the only supported agent | Fixed — confirmed registry contents (openclaw, hermes, zeroclaw, ethos; no ironclaw) and applied canonical three-tier status uniformly across all four surfaces: OpenClaw ✅ / Hermes 🚧 / ZeroClaw 🚧 / IronClaw planned |
| B3 | \`website/src/components/HomepageFeatures/index.tsx\`, \`website/docs/intro.md\`, README | Hermes status inconsistent: landing card presented Hermes as end-to-end alongside OpenClaw; intro.md placed it under \"Currently supported\"; README labelled it 🚧 | Fixed — landing card rephrased to \"OpenClaw end-to-end today; Hermes and ZeroClaw in active development\"; Hermes bullet moved to dedicated \"In development\" block in intro.md |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | \`README.md\` Support Matrix | \"Channels\" Notes column read as dangling noun (\"OpenClaw\") | Fixed — rephrased to \"OpenClaw only\" to match FAQ #4 wording |
| W2 | \`website/docs/reference/cli/secret.md\` | Sample output blocks may show stale \`Claw:\` header if CLI now emits \`Agent:\` | Resolved (non-issue) — verified \`src/clawrium/cli/secret.py:137\` already emits \`Agent:\`; doc samples updated earlier in this PR match |
| W3 | \`README.md\` badges | \"Tested on macOS\" badge implies CI coverage; verification is manual against mac-test host | Acknowledged — out of scope for a docs-only PR; tracked for follow-up |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | FAQ #1 \"Other Linux distributions\" caveat | Applied in README; initially missed for intro.md, fixed in Review 2 round (W-new-2) |
| S2 | Mermaid \`CLM\`/\`CLAW1\` internal participant IDs in architecture.md | Deferred — render correctly via aliases, low value to churn |
| S3 | Hand-curated \`clawctl agent get\` sample in HomepageFeatures TSX | Deferred — annotation is nice-to-have |
| S4 | CHANGELOG note that mermaid IDs left as-is | Deferred — covered by S2 disposition |
| S5 | Future CI grep guard for \`\\ba agent\\b\` regressions | Deferred — separate infra change |
| S6 | Source-side rename \`claw_name\` → \`agent_name\` (~80 test assertions) | Deferred — high-blast-radius, separate issue |

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

All three Review 1 blockers confirmed RESOLVED by leader (4/5), cli-ux (4/5), gui-routes (4/5), test-coverage (5/5).

**Warnings (raised + fixed in this same iteration before commit):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W-new-1 | \`website/docs/reference/cli/index.md\` | Sibling reference index still contained 5 generic \"claw\" nouns (\"AI claw fleet\", \"Browse available claw types\", \"Manage secrets for claw instances\", \"Claw is healthy/running/service/record\" in the status table) — registry.md/secret.md swept but the index page was not | Fixed — sweep applied to index.md including the status table |
| W-new-2 | \`website/docs/intro.md\` FAQ #1 | The agreed S1 wording \"Other Linux distributions may work but aren't tested\" was applied in README but dropped in intro.md FAQ #1, leaving Debian/Arch/Fedora users with no signal | Fixed — caveat sentence restored |
| W-new-3 | HomepageFeatures TSX + intro.md | External ZeroClaw link (\`zeroclaw-labs/zeroclaw\`) could 404 since ZeroClaw is in active development | Verified — \`curl -sI\` returns 200 for all three external repo links (openclaw, zeroclaw-labs, nearai/ironclaw) |

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>