### PR TITLE
fix(openclaw): drop discord channel `allow:true` (rejected by 2026.5.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,15 @@ cut. The `itx:release` skill archives this section into a new
   channels map alone permits the channel under
   `groupPolicy: "allowlist"`. The legacy `clm` CLI's discord setup
   prompt (`cli/agent.py`) emitted the same shape and is patched in
-  the same change.
+  the same change. The canonical renderer also now emits
+  `channels.discord.groupPolicy: "allowlist"` explicitly so the
+  channel-presence semantics no longer depend on openclaw's implicit
+  default. **Operator action:** if you have hand-edited
+  `~/.openclaw/openclaw.json` on an agent host running openclaw
+  2026.5.28+, remove `"allow": true` from each
+  `channels.discord.guilds.<id>.channels.<id>` entry (leave the entry
+  as `{}`), or re-run `clawctl agent configure <agent>` /
+  `clawctl agent sync <agent>` to re-render the file.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Fixed
 
+- openclaw renderer no longer emits `{"allow": true}` for entries in
+  `channels.discord.guilds.<id>.channels.<id>`. openclaw 2026.5.28+
+  rejects `allow` as an additional property
+  (`must not have additional properties: "allow"`); presence in the
+  channels map alone permits the channel under
+  `groupPolicy: "allowlist"`. The legacy `clm` CLI's discord setup
+  prompt (`cli/agent.py`) emitted the same shape and is patched in
+  the same change.
+
 ### Documentation
 
 - Landing page audit: restructured the GitHub README first-success path —

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -757,6 +757,37 @@ def _sync_channel_config(
         raise RuntimeError(f"Failed to sync channel config: {error}")
 
 
+def _build_legacy_discord_channels_block(
+    *, guild_id: str, channel_id: str, user_id: str
+) -> dict:
+    """Build the `channels.discord` block emitted by the legacy `clm`
+    wizard (`_run_channels_stage` discord branch).
+
+    Each `guilds.<id>.channels.<id>` entry MUST be the empty object `{}`
+    (no `allow` key): openclaw 2026.5.28+ rejects `allow` as an additional
+    property — see `core/render.py:render_openclaw` for the canonical
+    render path that emits the same shape. `groupPolicy: "allowlist"` is
+    emitted explicitly so the channel-presence invariant does not depend
+    on the daemon's implicit default.
+    """
+    return {
+        "enabled": True,
+        "token": {
+            "source": "env",
+            "provider": "default",
+            "id": "DISCORD_BOT_TOKEN",
+        },
+        "allowFrom": [user_id],
+        "groupPolicy": "allowlist",
+        "guilds": {
+            guild_id: {
+                "users": [user_id],
+                "channels": {channel_id: {}},
+            }
+        },
+    }
+
+
 def _run_channels_stage(
     host: str,
     claw_type: str,
@@ -1129,22 +1160,11 @@ def _run_channels_stage(
                 return False
 
             channels_config = {
-                "discord": {
-                    "enabled": True,
-                    "token": {
-                        "source": "env",
-                        "provider": "default",
-                        "id": "DISCORD_BOT_TOKEN",
-                    },
-                    "allowFrom": [user_id],
-                    "groupPolicy": "allowlist",
-                    "guilds": {
-                        guild_id: {
-                            "users": [user_id],
-                            "channels": {channel_id: {}},
-                        }
-                    },
-                }
+                "discord": _build_legacy_discord_channels_block(
+                    guild_id=guild_id,
+                    channel_id=channel_id,
+                    user_id=user_id,
+                )
             }
 
         # Resolve canonical instance_key up-front so the token can be stored

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -1141,7 +1141,7 @@ def _run_channels_stage(
                     "guilds": {
                         guild_id: {
                             "users": [user_id],
-                            "channels": {channel_id: {"allow": True}},
+                            "channels": {channel_id: {}},
                         }
                     },
                 }

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -1672,6 +1672,12 @@ def _render_openclaw_json(
     if discord_channel is not None:
         discord["enabled"] = True
         discord["allowFrom"] = list(discord_channel.allowed_users)
+        # Pin `groupPolicy: "allowlist"` explicitly so the channel-presence
+        # invariant below does not depend on openclaw's implicit default.
+        # The legacy `clm` wizard at `cli/agent.py` writes the same value
+        # when it constructs `channels_config["discord"]`; emitting it here
+        # keeps the canonical render path semantically aligned.
+        discord["groupPolicy"] = "allowlist"
         # Reshape flat allowed_guilds[] + allowed_channels[] into the
         # nested {<guild>: {users: [...], channels: {<chan>: {}}}} structure
         # openclaw's daemon expects. Under `groupPolicy: "allowlist"`, mere

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -1673,15 +1673,18 @@ def _render_openclaw_json(
         discord["enabled"] = True
         discord["allowFrom"] = list(discord_channel.allowed_users)
         # Reshape flat allowed_guilds[] + allowed_channels[] into the
-        # nested {<guild>: {users: [...], channels: {<chan>: {allow: true}}}}
-        # structure openclaw's daemon expects.
+        # nested {<guild>: {users: [...], channels: {<chan>: {}}}} structure
+        # openclaw's daemon expects. Under `groupPolicy: "allowlist"`, mere
+        # presence in `channels` permits the channel — `{"allow": true}` was
+        # accepted by older openclaw but rejected as an additional property
+        # by 2026.5.28+ (`channels.discord.guilds.<id>.channels.<id>: must
+        # not have additional properties: "allow"`).
         guilds_block: dict = {}
         for guild_id in discord_channel.allowed_guilds:
             guilds_block[guild_id] = {
                 "users": list(discord_channel.allowed_users),
                 "channels": {
-                    chan_id: {"allow": True}
-                    for chan_id in discord_channel.allowed_channels
+                    chan_id: {} for chan_id in discord_channel.allowed_channels
                 },
             }
         discord["guilds"] = guilds_block

--- a/tests/cli/agent/test_legacy_discord_channels_block.py
+++ b/tests/cli/agent/test_legacy_discord_channels_block.py
@@ -1,0 +1,71 @@
+"""PR #747 W1 (ATX review): cover the legacy `clm` discord-wizard
+channel-block shape so a future revert to `{"allow": True}` is caught
+by `make test`, not by a human running `clawctl agent configure`.
+
+The wizard logic lives in `clawrium.cli.agent._run_channels_stage` and
+is partly-dead (per the clawctl-vs-legacy split) but still imported by
+the test suite and reachable via the legacy `clm` entrypoint. The data
+construction was extracted into `_build_legacy_discord_channels_block`
+specifically so this invariant can be exercised in isolation.
+"""
+
+from __future__ import annotations
+
+from clawrium.cli.agent import _build_legacy_discord_channels_block
+
+
+def test_legacy_discord_block_channel_entry_is_empty_object():
+    """Every `guilds.<id>.channels.<id>` entry MUST be `{}` (no `allow`).
+    openclaw 2026.5.28+ rejects `allow` as an additional property; the
+    canonical renderer emits the same shape — keep both paths aligned.
+    """
+    block = _build_legacy_discord_channels_block(
+        guild_id="111111111111111111",
+        channel_id="222222222222222222",
+        user_id="333333333333333333",
+    )
+
+    chan_entry = block["guilds"]["111111111111111111"]["channels"][
+        "222222222222222222"
+    ]
+    assert chan_entry == {}
+    assert "allow" not in chan_entry
+
+
+def test_legacy_discord_block_group_policy_pinned_allowlist():
+    """`groupPolicy: "allowlist"` is required so the channel-presence
+    invariant does not depend on openclaw's implicit default.
+    """
+    block = _build_legacy_discord_channels_block(
+        guild_id="111111111111111111",
+        channel_id="222222222222222222",
+        user_id="333333333333333333",
+    )
+    assert block["groupPolicy"] == "allowlist"
+
+
+def test_legacy_discord_block_full_structure():
+    """Pin the full emitted shape so changes are caught at the test
+    boundary, not at the on-host validator boundary.
+    """
+    block = _build_legacy_discord_channels_block(
+        guild_id="111111111111111111",
+        channel_id="222222222222222222",
+        user_id="333333333333333333",
+    )
+    assert block == {
+        "enabled": True,
+        "token": {
+            "source": "env",
+            "provider": "default",
+            "id": "DISCORD_BOT_TOKEN",
+        },
+        "allowFrom": ["333333333333333333"],
+        "groupPolicy": "allowlist",
+        "guilds": {
+            "111111111111111111": {
+                "users": ["333333333333333333"],
+                "channels": {"222222222222222222": {}},
+            }
+        },
+    }

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -2377,6 +2377,16 @@ def test_openclaw_json_managed_paths_populated():
             },
         }
     }
+    # 6. groupPolicy pinned + `allow` invariant: the canonical renderer
+    # emits `groupPolicy: "allowlist"` so the channel-presence semantics
+    # do not depend on the daemon's implicit default, and no channel entry
+    # carries the legacy `allow` key (W2: assert the upstream constraint
+    # that motivated the fix, not just today's literal shape).
+    assert blob["channels"]["discord"]["groupPolicy"] == "allowlist"
+    for chan_entry in blob["channels"]["discord"]["guilds"]["g1"][
+        "channels"
+    ].values():
+        assert "allow" not in chan_entry
 
 
 def test_openclaw_json_daemon_sections_preserved():
@@ -2573,7 +2583,8 @@ _OPENCLAW_JSON_BYTE_LOCK = """\
             "c2": {}
           }
         }
-      }
+      },
+      "groupPolicy": "allowlist"
     }
   },
   "browser": {
@@ -2792,11 +2803,73 @@ def test_openclaw_multi_guild_discord_renders_all_guilds():
     body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
     blob = json.loads(body)
     assert set(blob["channels"]["discord"]["guilds"].keys()) == {"g1", "g2"}
+    assert blob["channels"]["discord"]["groupPolicy"] == "allowlist"
     for guild_id in ("g1", "g2"):
         assert blob["channels"]["discord"]["guilds"][guild_id]["users"] == ["u1"]
         assert blob["channels"]["discord"]["guilds"][guild_id]["channels"] == {
             "c1": {}
         }
+        # `allow` invariant: openclaw 2026.5.28+ rejects it as additional
+        # property; assert absence directly rather than only checking the
+        # literal `{}` shape (W2).
+        for chan_entry in blob["channels"]["discord"]["guilds"][guild_id][
+            "channels"
+        ].values():
+            assert "allow" not in chan_entry
+
+
+@pytest.mark.parametrize(
+    "allowed_guilds,allowed_channels",
+    [
+        (("g1", "g2"), ("c1", "c2")),  # multi-guild × multi-channel
+        (("g1",), ()),  # guild without channels (empty channels map)
+    ],
+    ids=["2g_2c", "1g_0c"],
+)
+def test_openclaw_discord_guilds_channels_shape_parametrized(
+    allowed_guilds, allowed_channels
+):
+    """PR #747 W3 (ATX review): guard the `channels.<id>` payload shape
+    across multi-guild × multi-channel and empty-channels-per-guild
+    combinations. Every channel entry must be the empty object `{}` with
+    no `allow` key, and `groupPolicy: "allowlist"` must be emitted so the
+    channel-presence invariant holds regardless of upstream defaults.
+    """
+    import json
+
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="or", type="openrouter", default_model="m", api_key="sk-1"
+        ),
+        channels=(
+            ChannelInputs(
+                name="d",
+                type="discord",
+                bot_token="t",
+                allowed_users=("u1",),
+                allowed_guilds=allowed_guilds,
+                allowed_channels=allowed_channels,
+            ),
+        ),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, bind="lan"),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    blob = json.loads(body)
+    discord = blob["channels"]["discord"]
+
+    assert discord["enabled"] is True
+    assert discord["groupPolicy"] == "allowlist"
+    assert set(discord["guilds"].keys()) == set(allowed_guilds)
+
+    for guild_id in allowed_guilds:
+        guild_entry = discord["guilds"][guild_id]
+        assert guild_entry["users"] == ["u1"]
+        assert set(guild_entry["channels"].keys()) == set(allowed_channels)
+        for chan_id, chan_entry in guild_entry["channels"].items():
+            assert chan_entry == {}
+            assert "allow" not in chan_entry
 
 
 def test_openclaw_git_integration_skipped():

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -2365,13 +2365,15 @@ def test_openclaw_json_managed_paths_populated():
     # 4. channels.discord.enabled + allowFrom
     assert blob["channels"]["discord"]["enabled"] is True
     assert blob["channels"]["discord"]["allowFrom"] == ["u1", "u2"]
-    # 5. channels.discord.guilds — nested reshape
+    # 5. channels.discord.guilds — nested reshape. openclaw 2026.5.28+
+    # rejects `{"allow": true}` as an additional property; presence in the
+    # channels map alone permits the channel under `groupPolicy: "allowlist"`.
     assert blob["channels"]["discord"]["guilds"] == {
         "g1": {
             "users": ["u1", "u2"],
             "channels": {
-                "c1": {"allow": True},
-                "c2": {"allow": True},
+                "c1": {},
+                "c2": {},
             },
         }
     }
@@ -2567,12 +2569,8 @@ _OPENCLAW_JSON_BYTE_LOCK = """\
             "u2"
           ],
           "channels": {
-            "c1": {
-              "allow": true
-            },
-            "c2": {
-              "allow": true
-            }
+            "c1": {},
+            "c2": {}
           }
         }
       }
@@ -2797,7 +2795,7 @@ def test_openclaw_multi_guild_discord_renders_all_guilds():
     for guild_id in ("g1", "g2"):
         assert blob["channels"]["discord"]["guilds"][guild_id]["users"] == ["u1"]
         assert blob["channels"]["discord"]["guilds"][guild_id]["channels"] == {
-            "c1": {"allow": True}
+            "c1": {}
         }
 
 


### PR DESCRIPTION
## Summary

- openclaw 2026.5.28 hardened the channel-entry schema with `additionalProperties: false` and rejects `channels.discord.guilds.<id>.channels.<id>.allow`. The canonical renderer (`core/render.py:render_openclaw`) now writes `{}` for each channel entry and pins `channels.discord.groupPolicy: "allowlist"` explicitly so the channel-presence semantics no longer depend on the daemon's implicit default.
- The legacy `clm` wizard (`cli/agent.py`) emitted the same `{"allow": true}` shape and is patched in the same change. The dict-literal was extracted into `_build_legacy_discord_channels_block` so the invariant can be unit-tested in isolation.
- Discovered live during a `clawctl agent upgrade wolf-i` probe (2026.4.2 → 2026.5.28): the on-host config failed `openclaw config validate` and blocked `openclaw agent --message` turns.

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — **3470 Python + 278 GUI**, 0 failures.
- [x] Linter passes (`make lint`) — ruff + ESLint clean.
- [x] Existing byte-lock tests updated to the new shape (`tests/core/test_render.py`).
- [x] New invariant assertions added: `"allow" not in chan_entry` and `groupPolicy == "allowlist"` across canonical, multi-guild, and parametrized tests.
- [x] New parametrized test covers `2g_2c` (multi-guild × multi-channel) and `1g_0c` (guild with empty channels map) shapes.
- [x] New `tests/cli/agent/test_legacy_discord_channels_block.py` covers the legacy CLI dict construction in isolation (3 tests).

### Test Coverage
- Files changed: `src/clawrium/core/render.py`, `src/clawrium/cli/agent.py`, `tests/core/test_render.py`, `tests/cli/agent/test_legacy_discord_channels_block.py` (new), `CHANGELOG.md`
- New tests: +5 (3 in `test_legacy_discord_channels_block.py`, +2 parametrized cases in `test_render.py`)
- Coverage impact: increased — the legacy CLI discord-wizard payload now has direct unit coverage; the canonical renderer's `"allow"`-absence invariant is asserted explicitly rather than inferred from a literal `{}` comparison.

### Manual Testing
Live verification on **wolf-i** (host: `wolf.tailf7742d.ts.net`, per-agent openclaw binary at `2026.5.28`):
1. `uv run clawctl agent sync wolf-i` → clean write, drift=0.
2. `openclaw config validate` against the freshly-rendered file → **valid**.
3. `openclaw agent --session-id test-iter2-verify --message "Reply with exactly: PONG-iter2" --json` → returned `"PONG-iter2"` from `clawrium-gtm-litellm/writer` in ~4s.

Before the patch, step 2 failed with `channels.discord.guilds.<id>.channels.<id>: invalid config: must not have additional properties: "allow"`, and step 3 refused to run.

### Security Checklist
- [x] No hardcoded secrets or credentials in the change.
- [x] No input from external systems is parsed — the change is constant values in the rendered JSON; guild/channel/user IDs are already regex-validated upstream.
- [x] No SQL/XSS/command-injection surface introduced.
- [x] Dependencies unchanged.

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $4.15 | Total Time: 11m 2s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3/5 | W1, W2, W3 | All fixed | $2.36 | 5m 8s | leader, test-coverage, render-engine, cli-ux |
| 2 | 4/5 | None | Ready | $1.79 | 5m 54s | leader, render-engine, test-coverage, security-reviewer |

> **Note**: ATX does not expose model information per agent. Models used across both reviews: `claude-opus-4-7`, `claude-sonnet-4-6`.

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| W1 | `src/clawrium/cli/agent.py:1144` | CLI discord-wizard branch had zero test coverage | Fixed — extracted `_build_legacy_discord_channels_block` helper; added 3 unit tests in `tests/cli/agent/test_legacy_discord_channels_block.py` |
| W2 | `tests/core/test_render.py` | Tests only compared to literal `{}` — didn't assert the upstream constraint (`"allow"` must be absent) | Fixed — added explicit `assert "allow" not in chan_entry` in both existing tests and the new parametrized test |
| W3 | `tests/core/test_render.py` | No multi-guild × multi-channel or empty-channels-per-guild coverage | Fixed — added `test_openclaw_discord_guilds_channels_shape_parametrized` covering `2g_2c` and `1g_0c` |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Renderer should emit `groupPolicy: "allowlist"` rather than relying on the daemon's implicit default | Fixed — now emitted explicitly in `render.py` |
| S2 | Add inline comment on the `{}` in `agent.py` | Fixed (alternative) — extracted helper has a full docstring documenting the invariant |
| S3 | CHANGELOG missing operator migration note | Fixed — added operator action note for hand-edited `~/.openclaw/openclaw.json` files |
| S4 | Follow-up: retire the legacy discord wizard | Acknowledged — separate cleanup, not in scope here |

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**Blocking Issues:** None.

**Warning (verified):**

| # | File | Warning | Status |
|---|------|---------|--------|
| W1 | `tests/core/test_render.py:2586` | ATX predicted the byte-lock key ordering would conflict with the renderer's emit order | **Not a failure** — `make test` (3470 passed) confirms the byte-lock literal matches the actual emitted JSON. Python dict-insertion order on the baseline (`enabled`, `allowFrom`, `guilds`) combined with appending `groupPolicy` after `guilds` is set yields `enabled, allowFrom, guilds, groupPolicy`, which is exactly the literal. Reviewer's static analysis was based on assignment order, not on the baseline's pre-existing key order. |

**Suggestions (non-blocking):**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | `discord.pop("groupPolicy", None)` in the no-discord branch for symmetry | Deferred — baseline never contains `groupPolicy`, so no stale value can persist via the rendered path; only relevant if operators hand-edit the baseline file |
| S2 | Mention in CHANGELOG that re-rendering will surface the new `groupPolicy` key in diffs | Deferred — minor wording polish |
| S3 | Add `0g_0c` parametrized case | Deferred — covered structurally by the no-discord branch defaults |
| S4 | Tests 1–2 in the new CLI test file are partly subsumed by test 3 | Deferred — intentionally explicit: the focused per-invariant tests are easier to read and easier to point to in future reverts |
| S5 | Add internal `re.fullmatch` validation to `_build_legacy_discord_channels_block` | Deferred — caller already validates via the same regex; double-validation adds noise without raising the floor |
| S6 | One-line comment on the cross-guild user fan-out in `render.py:1691` | Deferred — existing block comment above already covers the reshape rationale |

**Security:** No blockers. Guild/channel/user IDs validated upstream with `^\d{17,19}$`; output is `json.dumps`-serialized — injection structurally precluded. Change reduces privilege risk by removing implicit-default reliance.

</details>

## Reviewer Notes

- The `channels.discord.streaming: "off"` rejection seen during the same probe is **upstream** (older daemon self-writes that key on startup; new validator no longer accepts the bare string). Not in scope — the renderer never emitted `streaming`. Will track separately if it persists once daemons are uniformly on 2026.5.28.
- The legacy `clm` CLI path in `cli/agent.py` is partly-dead per the team's prior split (`cli/clawctl/` is the wired CLI), but it's still imported by the test suite and may still be reached by direct `clm` invocations — patched defensively in the same change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>