### PR TITLE
feat(integrations): brave web-search API key

### DIFF
--- a/.itx/734/02_EXECUTE.md
+++ b/.itx/734/02_EXECUTE.md
@@ -1,0 +1,29 @@
+# Issue #734 — Execution log
+
+## Execute (run 2)
+
+**Stage**: execute
+**Skill**: /itx-execute
+**Timestamp**: 2026-06-19T19:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 734 — continuation run.
+
+CRITICAL OOM CONSTRAINT (root-cause confirmed via journalctl):
+  Prior two attempts died because `make test` triggered the kernel OOM killer.
+  Single pytest process consumed 50+ GB RSS; box has 5 other active claude
+  sessions consuming most RAM. DO NOT run `make test` (the full suite). Run
+  pytest NARROWLY on only the test files touched by the staged changes.
+
+The rest of the contract is unchanged from .itx/734/CONTINUATION.md — ATX
+CLI only, do not recreate worktree, do not reset staged work, no live host
+verification (record as [TODO-FOLLOWUP]).
+```
+
+**Output**:
+- Branch `issue-734-brave-integration` carried 23 files (~1,372 lines) of pre-staged work from run 1; this run drove it to PR.
+- 4 commits added on top: implementation commit, ATX iter 1 fixes, ATX iter 2 fixes, ATX iter 3 follow-up test, ATX session metadata.
+- 3 ATX iterations (CLI, via `atx review request --format json --timeout 15m`). Final rating 4/5 (leader 3/5), blocking_overall=false on every iteration. Cost total ~$17.01 across ~22 min.
+- PR #749 opened against `main`. PR body includes the full ATX iteration history per `<pr-format-atx>` in AGENTS.md and a `## Callouts` section with [ENVIRONMENT] OOM context, [ENVIRONMENT] ATX-CLI path, [TODO-FOLLOWUP] Phase 3 live verification (per-agent smoke checklist), and [DECISION] entries documenting non-obvious choices.
+- 350 narrow tests pass; `make lint` clean.

--- a/.itx/734/CONTINUATION.md
+++ b/.itx/734/CONTINUATION.md
@@ -1,0 +1,73 @@
+# Issue #734 — Execution Continuation
+
+**Read this BEFORE any other action.** Spawned by parent session on 2026-06-19 to drive existing staged work to a PR. **Updated at 20:44** after first child claude died — see "Run 1 history" below.
+
+## State on entry (Run 2)
+
+- Worktree: `/home/devashish/workspace/ric03uec/clawrium-issue-734` — **already exists; DO NOT recreate**.
+- Branch: `issue-734-brave-integration` (tracking `origin/main`; no upstream of its own yet).
+- HEAD: at the merge commit of PR #735 (the planning-doc PR). The branch is even with main; nothing committed yet for the feature work.
+- **~23 files staged, no commits.** Includes most of Phase 1 (registry, render, templates, lifecycle, CLI, openclaw playbook + macOS sibling, tests) and Phase 2 (docs + CHANGELOG + website mirror), plus run-1's hermes name-mapping fix and the planning docs themselves. See `git status --short` for the full list.
+- **`.itx/734/01_SCAFFOLD.md` is now present** (was missing from run 1 — fixed).
+
+## Run 1 history (what already happened)
+
+A previous claude session was spawned with this same CONTINUATION.md and worked for a short time before exiting (tmux session disappeared, no commits, no PR). What it did before dying:
+
+- Moved hermes `BRAVE_API_KEY` → `BRAVE_SEARCH_API_KEY` name-mapping **out of Jinja and into `render_hermes()` Python** (`src/clawrium/core/render.py` around line 961). This is the correct #622 invariant fix — DO NOT revert.
+- Simplified the hermes Jinja template's brave branch to just read the already-normalized `BRAVE_SEARCH_API_KEY` from creds. Comment in the template explains where the rename lives.
+- That's it. No commit. No tests run. No ATX call. No PR.
+
+Both of run 1's edits are already `git add`-staged by the parent before Run 2 starts. You do not need to redo them.
+
+## Likely cause of run-1 death
+
+Run 1 was spawned without `.itx/734/01_SCAFFOLD.md` in the worktree (the scaffold lived only on `main`, not on `issue-734-brave-integration`). Without the scaffold, run 1 had no per-phase exit criteria to march against. It likely fixed the most obvious gap from this file's "gap-check" list (hermes name-mapping), couldn't orient on what was next, and exited.
+
+For run 2: the scaffold is now in place. Use it. Phases 1 and 2 are 90% done; your job is to drive to PR.
+- Phase 3 (live host verification) is NOT in scope for this autonomous session — it requires operator action on `espresso` / `clawrium-d01` / an openclaw ≥2026.4.10 host.
+
+## Hard overrides for this run
+
+1. **ATX CLI ONLY.** Use `atx review --format json` (CLI). Do NOT call `mcp__atx__request_review`. Override `.claude/itx-config.json`'s `mcp.review_enabled: true` for this run — treat MCP as unavailable and go straight to the CLI step of the detection chain. Reason: user explicitly asked for CLI in this run.
+2. **DO NOT recreate the worktree.** It already exists. The `/itx-execute` skill's worktree-mode steps don't apply — you're already inside the worktree and running in regular mode.
+3. **DO NOT reset the branch or unstage existing work.** The previous session staged ~1169 lines across 21 files; verify and build on it, don't throw it away.
+4. **No live host verification.** Phase 3 of `.itx/734/01_SCAFFOLD.md` is NOT in scope here. Record it as `[TODO-FOLLOWUP]` in the PR Callouts section with the per-agent smoke checklist from the scaffold's Phase 3 exit criteria.
+5. **No `git push` to main, ever.** This branch only.
+
+## Required execution sequence
+
+1. `git status --short` and `git diff --cached --stat` to inventory the staged work.
+2. Read `.itx/734/00_PLAN.md` (plan) and `.itx/734/01_SCAFFOLD.md` (scaffold).
+3. Compare staged work against Phase 1 + Phase 2 exit criteria. Identify gaps. Specifically check:
+   - Is `src/clawrium/gui/routes/integrations.py` updated, or only the test file? If route is missing, add it.
+   - Are byte-locks present for hermes / zeroclaw / openclaw brave renders?
+   - Does the zeroclaw template emit BOTH `Environment=BRAVE_API_KEY=…` AND `Environment=ZEROCLAW_web_search__search_provider="brave"`? Negative test asserting both?
+   - Does `render_hermes` (Python) name-map `BRAVE_API_KEY` → `BRAVE_SEARCH_API_KEY`, NOT the Jinja template?
+   - Openclaw lifecycle preflight at `< 2026.4.10` → `typer.Exit(1)` with the documented message?
+   - `_do_pair()` invariant pinned (#437) — no `--no-rotate` branch added?
+   - Openclaw playbook task `no_log: true` + sentinel-guarded plugin install pinned to `@openclaw/brave-plugin@2026.6.8`?
+   - macOS sibling `configure_macos.yaml` present; no `when: ansible_os_family == 'Darwin'` in `configure.yaml`?
+4. Fix any identified gaps.
+5. Run `make test` from the worktree root. Fix failures until green.
+6. Run `make lint`. Fix until clean.
+7. Commit on `issue-734-brave-integration` with a Conventional Commits message: `feat(integrations): add brave web-search API key integration\n\nCloses #734`. **Never commit to main.**
+8. `git push -u origin issue-734-brave-integration`.
+9. **Run ATX review via CLI**: `atx review --format json --timeout 15m`. Parse the JSON output. Persist `.itx/734/atx-session.json` per the skill's session-id-persistence rules — note `transport: "cli"`.
+10. Iterate up to 3 times. Address every `B*` blocker. After each fix, re-run `make test` + `make lint`, commit, push, re-run `atx review`.
+11. If the 3rd iteration still has unresolved blockers, open the PR anyway (per skill non-blocking contract) with `[ITX-STUCK]` marker comment and every unresolved blocker as a Callout.
+12. PR title: `feat(integrations): brave web-search API key`. PR body MUST follow the `<pr-format-atx>` template in `AGENTS.md` (Summary / ATX Review Summary / iteration history / Callouts). Use `Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>` and `Co-Authored-By: Claude <noreply@anthropic.com>`.
+13. PR Callouts MUST include:
+    - `[TODO-FOLLOWUP]` for Phase 3 live verification with the hermes/zeroclaw/openclaw smoke checklist from the scaffold.
+    - `[DECISION]` for any non-obvious choices made during gap-fixing.
+    - `[ENVIRONMENT] ATX review path: CLI (per operator override; MCP available but not used).`
+
+## Invariants pinned by the plan — verify in tests
+
+- **#437** — `_do_pair()` called unconditionally on every sync that touches `.zeroclaw/env` or `~/.openclaw/env`. No `--no-rotate`. Assertable via mock on `_do_pair`.
+- **#622** — Hermes `BRAVE_SEARCH_API_KEY` written exclusively by `render_hermes()` via canonical Jinja; `configure.yaml` uses `ansible.builtin.copy` of pre-rendered bytes. No `lineinfile`, no Ansible-side `template:`.
+- **Dispatcher-only OS fork** — macOS branching lives in `playbook_resolver.py`; `*_macos.yaml` siblings. NO `when: ansible_os_family == 'Darwin'` inside `configure.yaml`.
+
+## What "done" looks like
+
+PR open against `main`, ATX review iteration history attached, all blockers Fixed or Out-of-scope, Callouts section present including the `[TODO-FOLLOWUP]` for Phase 3. Then this session stands down.

--- a/.itx/734/atx-session.json
+++ b/.itx/734/atx-session.json
@@ -1,0 +1,45 @@
+{
+  "transport": "cli",
+  "iterations": [
+    {
+      "iteration": 1,
+      "task_id": "a0cf4040-6986-42e6-ae82-fc030d2b6d59",
+      "rating": 3,
+      "blockers": ["B1", "B2", "B3", "B4"],
+      "warnings": 10,
+      "cost_usd": 5.28,
+      "duration_ms": 427083,
+      "blocking_overall": false,
+      "commit_sha": "d886860"
+    },
+    {
+      "iteration": 2,
+      "task_id": "e0f1b90b-95c0-4475-88f2-5a071753db40",
+      "rating": 3.5,
+      "blockers": ["B1 (configure_agent preflight)", "B2 (rotate test scope)"],
+      "warnings": 6,
+      "cost_usd": 5.36,
+      "duration_ms": 460917,
+      "blocking_overall": false,
+      "commit_sha": "3983d11"
+    },
+    {
+      "iteration": 3,
+      "task_id": "bc6bb230-a735-4a96-969e-2971c57d6661",
+      "rating": 4,
+      "leader_rating": 3,
+      "blockers": ["B_NEW1 (configure_agent preflight tests)"],
+      "warnings": 5,
+      "cost_usd": 6.37,
+      "duration_ms": 469941,
+      "blocking_overall": false,
+      "commit_sha": "f7c222b"
+    }
+  ],
+  "final_commit_sha": "9bc4c0a",
+  "total_cost_usd": 17.01,
+  "total_duration_ms": 1357941,
+  "models": ["claude-opus-4-7", "claude-sonnet-4-6"],
+  "last_status": "iter-3-blocker-B_NEW1-addressed-by-followup-test-commit",
+  "updated_at": "2026-06-19T19:00:00Z"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Added
 
+- New `brave` integration type for the Brave Search API. Register once
+  with `clawctl integration registry create my-brave --type brave
+  --api-key <key>` (or pipe the key via `--api-key-stdin`), attach to
+  any supported agent with `clawctl agent integration attach <agent>
+  my-brave`, and `clawctl agent sync` writes the per-agent env shape:
+  `BRAVE_SEARCH_API_KEY` on hermes (name-mapped from the
+  operator-facing `BRAVE_API_KEY`), `BRAVE_API_KEY` plus
+  `ZEROCLAW_web_search__search_provider=brave` on zeroclaw (both lines
+  are required to actually flip the provider router off the
+  duckduckgo default), and `BRAVE_API_KEY` on openclaw. Openclaw also
+  installs `@openclaw/brave-plugin@2026.6.8` automatically on
+  configure (idempotent, sentinel-gated) and preflights the on-host
+  openclaw version against the plugin's `minHostVersion` (>= 2026.4.10)
+  before any sync write. New `clawctl integration rotate <name>`
+  rotates the credential and re-syncs every bound agent in one shot.
+  Closes #734.
 - OpenCode inference provider support. `clawctl provider registry create` now
   accepts `--type opencode` and `--type opencode-go`, with model catalog
   entries for both hosted gateways and renderer wiring for hermes, zeroclaw,

--- a/docs/agent-support/integrations/brave.md
+++ b/docs/agent-support/integrations/brave.md
@@ -1,0 +1,108 @@
+# Brave Search
+
+**Status:** ✅ Supported on Hermes, ZeroClaw, and OpenClaw (#734).
+
+Brave Search integration gives agents a real web-search tool. The credential
+is a Brave Search API subscription token (free tier available at
+https://brave.com/search/api/). Operators store the key once in the
+clawrium registry and attach the integration to any supported agent —
+clawrium handles the per-agent env var shape (including the upstream
+name mapping on hermes and the search-provider router override on
+zeroclaw) so the operator never sees those details.
+
+---
+
+## Per-Agent Env Shape
+
+The credential the operator passes is always `BRAVE_API_KEY`. Each
+agent's renderer maps it to the env var(s) the upstream daemon
+actually reads:
+
+| Agent | Env vars written | Notes |
+|---|---|---|
+| **hermes** | `BRAVE_SEARCH_API_KEY=<key>` | Name-mapped in the template. Hermes' `web_search` tool reads `BRAVE_SEARCH_API_KEY`, **not** `BRAVE_API_KEY` (see upstream PR `nousresearch/hermes-agent#21337`). |
+| **zeroclaw** | `BRAVE_API_KEY=<key>` **and** `ZEROCLAW_web_search__search_provider=brave` | Both lines are required. Setting the key alone leaves the provider router on its `duckduckgo` default. The companion env-prefix override (`web_search_provider_routing.rs:33`) flips the router to brave. |
+| **openclaw** | `BRAVE_API_KEY=<key>` | Openclaw's brave plugin reads the env var directly (plugin manifest declares it as the first-class fallback for `webSearch.apiKey`). Plugin install happens automatically on `clawctl agent configure` (see below). |
+
+The same registry entry can be attached to multiple agents of different
+types — each agent's renderer produces the correct shape independently.
+
+---
+
+## Openclaw plugin install + min-version preflight
+
+Openclaw needs the `@openclaw/brave-plugin` npm package installed
+locally on the agent host. `clawctl agent configure` and
+`clawctl agent sync` handle that automatically when a brave
+integration is attached — installation is idempotent and gated by a
+per-version sentinel file at
+`~/.openclaw/.brave-plugin-installed.<version>`.
+
+Pinned version: **`@openclaw/brave-plugin@2026.6.8`**. The pin lives in
+`src/clawrium/platform/registry/openclaw/manifest.yaml`
+(`plugins.brave.version`) so a bump is a single-line change.
+
+The plugin declares `minHostVersion >= 2026.4.10`. `clawctl agent sync`
+preflights the on-host openclaw version over SSH before any write —
+if the host is older the sync exits with a clear message:
+
+```
+openclaw on <host> is <ver>; brave plugin requires >= 2026.4.10.
+Run `clawctl agent upgrade <agent>` first.
+```
+
+This is intentional friction. Silently working with a missing plugin
+would surface as an opaque daemon-side error much later.
+
+---
+
+## Get a Brave Search API key
+
+1. Sign up at https://brave.com/search/api/ (free tier available).
+2. From the dashboard, create a new subscription token.
+3. Copy the value — Brave does not show it twice.
+
+---
+
+## Use with Clawrium
+
+### Register the integration
+
+```bash
+# Convenience flag for single-credential types — value never lands in
+# `ps`/shell history via a positional argument.
+clawctl integration registry create my-brave --type brave --api-key bsk-xxxxx
+
+# Or, for CI / secret-manager pipelines:
+printf %s "$BRAVE_API_KEY" | clawctl integration registry create my-brave \
+  --type brave --api-key-stdin
+```
+
+### Attach to an agent
+
+```bash
+clawctl agent integration attach <agent-name> my-brave
+clawctl agent sync <agent-name>
+```
+
+### Rotate the key
+
+When the upstream key changes:
+
+```bash
+clawctl integration rotate my-brave --api-key bsk-new-xxxxx --yes
+```
+
+This updates the credential **and** re-syncs every agent currently
+bound to `my-brave` in one shot. Any sync failure surfaces as
+non-zero exit so cron-driven rotations don't silently leave
+half-rotated state.
+
+### Delete
+
+```bash
+clawctl integration registry delete my-brave
+```
+
+Refuses if any agent is still attached unless `--force` is passed
+(which detaches + re-syncs all bound agents).

--- a/docs/agent-support/integrations/index.md
+++ b/docs/agent-support/integrations/index.md
@@ -7,6 +7,7 @@ Integrations allow agents to interact with external tools and services, extendin
 | Integration | Status | Agents | Use Case |
 |-------------|:------:|--------|----------|
 | **[Atlassian (Jira + Confluence)](atlassian.md)** | ✅ | Hermes (MCP), OpenClaw, ZeroClaw | Issue tracking, docs / knowledge base |
+| **[Brave Search](brave.md)** | ✅ | Hermes, OpenClaw, ZeroClaw | Web search tool |
 | **[GitHub](github.md)** | 🚧 | OpenClaw (planned) | PR reviews, issues |
 | **[GitLab](gitlab.md)** | 📋 | Not planned | Alternative to GitHub |
 | **[Linear](linear.md)** | 📋 | Not planned | Issue tracking |

--- a/src/clawrium/cli/clawctl/integration.py
+++ b/src/clawrium/cli/clawctl/integration.py
@@ -271,9 +271,10 @@ def create(
         None,
         "--api-key",
         help=(
-            "Convenience: bearer key for single-required-credential types "
-            "(brave, linear, notion, ...). Avoids shell-history leaks vs "
-            "passing the value as a positional."
+            "Convenience flag: bearer key for single-required-credential "
+            "types (brave, linear, notion, ...). The value still appears "
+            "in shell history — pipe through `--api-key-stdin` to avoid "
+            "that."
         ),
     ),
     api_key_stdin: bool = typer.Option(
@@ -578,13 +579,16 @@ def rotate(
         )
 
     agents = find_agents_using_integration(name)
-    confirm_destructive(
-        prompt=(
-            f"Rotate {name!r} credentials and re-sync "
-            f"{len(agents)} agent(s)?"
-        ),
-        yes=yes,
-    )
+    # No agents → this is effectively an `edit` with no sync side
+    # effect; skip the destructive confirmation prompt.
+    if agents:
+        confirm_destructive(
+            prompt=(
+                f"Rotate {name!r} credentials and re-sync "
+                f"{len(agents)} agent(s)?"
+            ),
+            yes=yes,
+        )
 
     def apply(rec: dict) -> dict:
         rec["updated_at"] = _now_iso()

--- a/src/clawrium/cli/clawctl/integration.py
+++ b/src/clawrium/cli/clawctl/integration.py
@@ -621,9 +621,10 @@ def rotate(
             typer.echo(f"  {hostname}:{agent_key}: SYNC FAILED ({exc})")
 
     if failures:
+        failed_list = ", ".join(a for _h, a, _e in failures)
         emit_error(
             f"rotation completed but {len(failures)} sync(s) failed; "
-            "re-run `clawctl agent sync <name>` on each.",
+            f"re-run `clawctl agent sync` for: {failed_list}.",
         )
     typer.echo(f"integration/{name}: rotated and synced {len(agents)} agent(s)")
 

--- a/src/clawrium/cli/clawctl/integration.py
+++ b/src/clawrium/cli/clawctl/integration.py
@@ -148,6 +148,83 @@ def _resolve_credentials(
     return {}
 
 
+def _single_required_credential_key(integration_type: str) -> Optional[str]:
+    """If the type's credential schema is a single required entry, return
+    its key; otherwise None. Used by the `--api-key` convenience flag to
+    map a bare bearer onto the right credential key (#734)."""
+    creds = INTEGRATION_TYPES.get(integration_type, {}).get("credentials") or []
+    required = [c["key"] for c in creds if c.get("required")]
+    if len(required) == 1:
+        return required[0]
+    return None
+
+
+def _resolve_api_key(
+    integration_type: str,
+    api_key: Optional[str],
+    api_key_stdin: bool,
+) -> Optional[str]:
+    """Read the value for `--api-key` / `--api-key-stdin`.
+
+    Returns None when neither flag is supplied. Issues:
+    - Mutual exclusion with each other.
+    - `--api-key-stdin` MUST NOT read from a TTY (interactive prompt is
+      not a substitute; the operator should pipe input). Empty stdin
+      exits non-zero with a clear error rather than silently creating a
+      blank credential (#734 W1).
+    """
+    if api_key is not None and api_key_stdin:
+        emit_error(
+            "cannot combine --api-key with --api-key-stdin",
+            hint="pass exactly one",
+        )
+    if api_key is not None:
+        if not api_key:
+            emit_error("--api-key value is empty")
+        return api_key
+    if api_key_stdin:
+        if sys.stdin.isatty():
+            emit_error(
+                "--api-key-stdin requires a non-TTY stdin",
+                hint="pipe the key in, e.g. `printf %s $KEY | clawctl ...`",
+            )
+        data = sys.stdin.read().strip()
+        if not data:
+            emit_error(
+                "empty stdin for --api-key-stdin",
+                hint="pipe the key in, e.g. `printf %s $KEY | clawctl ...`",
+            )
+        return data
+    return None
+
+
+def _merge_api_key_into_credentials(
+    creds: dict[str, str],
+    integration_type: str,
+    api_key_value: Optional[str],
+) -> dict[str, str]:
+    """If `--api-key` / `--api-key-stdin` was supplied, fold it into the
+    `creds` dict under the type's single required credential key. The
+    flag is rejected on types whose schema does not have exactly one
+    required credential — otherwise the mapping would be ambiguous."""
+    if api_key_value is None:
+        return creds
+    key = _single_required_credential_key(integration_type)
+    if key is None:
+        emit_error(
+            f"--api-key is not supported for type {integration_type!r}",
+            hint="use --credential KEY=VALUE for multi-credential types",
+        )
+    if key in creds:
+        emit_error(
+            f"conflicting values for {key!r}",
+            hint="pass --api-key OR --credential, not both",
+        )
+    merged = dict(creds)
+    merged[key] = api_key_value
+    return merged
+
+
 def _integration_to_row(record: dict) -> dict:
     name = record.get("name", "")
     itype = record.get("type", "")
@@ -190,6 +267,20 @@ def create(
     credential_stdin: bool = typer.Option(
         False, "--credential-stdin", help="Read KEY=VALUE per line from stdin."
     ),
+    api_key: Optional[str] = typer.Option(
+        None,
+        "--api-key",
+        help=(
+            "Convenience: bearer key for single-required-credential types "
+            "(brave, linear, notion, ...). Avoids shell-history leaks vs "
+            "passing the value as a positional."
+        ),
+    ),
+    api_key_stdin: bool = typer.Option(
+        False,
+        "--api-key-stdin",
+        help="Read the api key from stdin (TTY rejected).",
+    ),
 ) -> None:
     """Register an integration non-interactively when flags are supplied."""
     try:
@@ -211,6 +302,8 @@ def create(
         emit_error(str(exc), hint="check ~/.config/clawrium/integrations.json")
 
     creds = _resolve_credentials(credentials, credential_stdin)
+    api_key_value = _resolve_api_key(integration_type, api_key, api_key_stdin)
+    creds = _merge_api_key_into_credentials(creds, integration_type, api_key_value)
 
     # ATX iter-2 W5: required-credential enforcement now applies on
     # both TTY and non-TTY paths. The previous gate was non-TTY-only,
@@ -394,14 +487,33 @@ def edit(
     credential_stdin: bool = typer.Option(
         False, "--credential-stdin", help="Read KEY=VALUE per line from stdin."
     ),
+    api_key: Optional[str] = typer.Option(
+        None,
+        "--api-key",
+        help=(
+            "Convenience: bearer key for single-required-credential types. "
+            "See `create --help`."
+        ),
+    ),
+    api_key_stdin: bool = typer.Option(
+        False,
+        "--api-key-stdin",
+        help="Read the api key from stdin (TTY rejected).",
+    ),
 ) -> None:
     """Edit credentials on an existing integration."""
-    _safe_get_integration(name)
+    record = _safe_get_integration(name)
     creds = _resolve_credentials(credentials, credential_stdin)
+    api_key_value = _resolve_api_key(
+        record.get("type", ""), api_key, api_key_stdin
+    )
+    creds = _merge_api_key_into_credentials(
+        creds, record.get("type", ""), api_key_value
+    )
     if not creds:
         emit_error(
             "no changes specified",
-            hint="pass --credential KEY=VALUE or --credential-stdin",
+            hint="pass --credential KEY=VALUE, --api-key, or --credential-stdin",
         )
 
     def apply(rec: dict) -> dict:
@@ -415,6 +527,101 @@ def edit(
         set_integration_credential(name, key, value)
 
     typer.echo(f"integration/{name}: updated ({len(creds)} credential(s) set)")
+
+
+# ---------------------------------------------------------------------------
+# rotate (#734)
+# ---------------------------------------------------------------------------
+
+
+@integration_app.command("rotate")
+def rotate(
+    name: str = typer.Argument(..., help="Integration name."),
+    api_key: Optional[str] = typer.Option(
+        None,
+        "--api-key",
+        help="New bearer key for single-required-credential types.",
+    ),
+    api_key_stdin: bool = typer.Option(
+        False,
+        "--api-key-stdin",
+        help="Read the new api key from stdin (TTY rejected).",
+    ),
+    credentials: Optional[list[str]] = typer.Option(
+        None,
+        "--credential",
+        help="Set credential KEY=VALUE. Repeatable.",
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation."),
+) -> None:
+    """Rotate an integration's credentials and re-sync every bound agent.
+
+    Convenience wrapper over `registry edit` + `agent sync` for every
+    agent currently attached to the integration. Surfaces sync failures
+    as non-zero exit so cron-driven rotations never silently leave
+    half-rotated state.
+    """
+    from clawrium.core.integrations import find_agents_using_integration
+
+    record = _safe_get_integration(name)
+    creds = _resolve_credentials(credentials, False)
+    api_key_value = _resolve_api_key(
+        record.get("type", ""), api_key, api_key_stdin
+    )
+    creds = _merge_api_key_into_credentials(
+        creds, record.get("type", ""), api_key_value
+    )
+    if not creds:
+        emit_error(
+            "no new credential specified",
+            hint="pass --api-key, --api-key-stdin, or --credential KEY=VALUE",
+        )
+
+    agents = find_agents_using_integration(name)
+    confirm_destructive(
+        prompt=(
+            f"Rotate {name!r} credentials and re-sync "
+            f"{len(agents)} agent(s)?"
+        ),
+        yes=yes,
+    )
+
+    def apply(rec: dict) -> dict:
+        rec["updated_at"] = _now_iso()
+        return rec
+
+    if not update_integration(name, apply):
+        emit_error(f"failed to update integration {name!r}")
+    for key, value in creds.items():
+        set_integration_credential(name, key, value)
+
+    if not agents:
+        typer.echo(
+            f"integration/{name}: rotated (no agents attached; nothing to sync)"
+        )
+        return
+
+    from clawrium.core.lifecycle_canonical import (
+        CanonicalSyncError,
+        SecretRemovalRefused,
+        sync_agent_canonical,
+    )
+
+    failures: list[tuple[str, str, str]] = []
+    for hostname, agent_key in agents:
+        try:
+            sync_agent_canonical(agent_key)
+            typer.echo(f"  {hostname}:{agent_key}: synced")
+        except (CanonicalSyncError, SecretRemovalRefused) as exc:
+            failures.append((hostname, agent_key, str(exc)))
+            typer.echo(f"  {hostname}:{agent_key}: SYNC FAILED ({exc})")
+
+    if failures:
+        emit_error(
+            f"rotation completed but {len(failures)} sync(s) failed; "
+            "re-run `clawctl agent sync <name>` on each.",
+        )
+    typer.echo(f"integration/{name}: rotated and synced {len(agents)} agent(s)")
 
 
 # Register sub-group on the top-level `integration` app.

--- a/src/clawrium/core/integrations.py
+++ b/src/clawrium/core/integrations.py
@@ -131,6 +131,16 @@ INTEGRATION_TYPES: dict[str, dict] = {
             },
         ],
     },
+    "brave": {
+        "description": "Brave Search API for web-search tooling",
+        "credentials": [
+            {
+                "key": "BRAVE_API_KEY",
+                "description": "Brave Search API subscription token (https://brave.com/search/api/)",
+                "required": True,
+            },
+        ],
+    },
     "git": {
         "description": "Git commit identity and ~/.gitconfig defaults (forge-agnostic)",
         "credentials": [

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -2514,6 +2514,35 @@ def configure_agent(
             # the lifecycle state machine half-walked.
             return False, f"Hermes render failed: {exc}"
 
+    # #734 Openclaw brave plugin pin. Hydrated from the openclaw
+    # manifest's `plugins.brave` block so a version bump is a one-line
+    # change in `manifest.yaml`. Default values keep the playbook
+    # parseable for hermes/zeroclaw runs where these vars are unused
+    # (Ansible's `when:` guard already skips the install task).
+    openclaw_brave_plugin_package = "@openclaw/brave-plugin"
+    openclaw_brave_plugin_version = ""
+    if resolved_type == "openclaw":
+        try:
+            import yaml as _yaml
+
+            manifest_path = (
+                Path(__file__).parent.parent
+                / "platform"
+                / "registry"
+                / "openclaw"
+                / "manifest.yaml"
+            )
+            manifest = _yaml.safe_load(manifest_path.read_text())
+            brave_cfg = (manifest.get("plugins") or {}).get("brave") or {}
+            openclaw_brave_plugin_package = (
+                brave_cfg.get("npm_package") or openclaw_brave_plugin_package
+            )
+            openclaw_brave_plugin_version = brave_cfg.get("version") or ""
+        except Exception as exc:
+            logger.warning(
+                "Failed to read openclaw plugin pins from manifest: %s", exc
+            )
+
     # Build Ansible inventory with API key passed directly
     ansible_vars = {
         "agent_name": unix_agent_name,
@@ -2528,6 +2557,8 @@ def configure_agent(
         "slack_bot_token": slack_bot_token,
         "slack_app_token": slack_app_token,
         "integrations": integrations_data,
+        "openclaw_brave_plugin_package": openclaw_brave_plugin_package,
+        "openclaw_brave_plugin_version": openclaw_brave_plugin_version,
         "prerendered_zeroclaw_config_toml": prerendered_files.get(
             ".zeroclaw/config.toml", ""
         ),

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -2514,34 +2514,29 @@ def configure_agent(
             # the lifecycle state machine half-walked.
             return False, f"Hermes render failed: {exc}"
 
-    # #734 Openclaw brave plugin pin. Hydrated from the openclaw
-    # manifest's `plugins.brave` block so a version bump is a one-line
-    # change in `manifest.yaml`. Default values keep the playbook
-    # parseable for hermes/zeroclaw runs where these vars are unused
-    # (Ansible's `when:` guard already skips the install task).
-    openclaw_brave_plugin_package = "@openclaw/brave-plugin"
+    # #734 Openclaw brave plugin pin. Single source of truth lives in
+    # `lifecycle_canonical._load_openclaw_brave_pin()` (W2 ATX iter 1),
+    # which reads `plugins.brave` from the openclaw manifest and
+    # hard-fails if any of (npm_package, version, min_host_version) is
+    # missing — so a typo'd manifest never lets npm install
+    # `@openclaw/brave-plugin@` with an empty version (W3 ATX iter 1).
+    # Default empty strings are used for non-openclaw runs where the
+    # vars are referenced but the install task is skipped by
+    # `integrations | selectattr(...)`.
+    openclaw_brave_plugin_package = ""
     openclaw_brave_plugin_version = ""
     if resolved_type == "openclaw":
-        try:
-            import yaml as _yaml
+        from clawrium.core.lifecycle_canonical import (
+            CanonicalSyncError,
+            _load_openclaw_brave_pin,
+        )
 
-            manifest_path = (
-                Path(__file__).parent.parent
-                / "platform"
-                / "registry"
-                / "openclaw"
-                / "manifest.yaml"
-            )
-            manifest = _yaml.safe_load(manifest_path.read_text())
-            brave_cfg = (manifest.get("plugins") or {}).get("brave") or {}
-            openclaw_brave_plugin_package = (
-                brave_cfg.get("npm_package") or openclaw_brave_plugin_package
-            )
-            openclaw_brave_plugin_version = brave_cfg.get("version") or ""
-        except Exception as exc:
-            logger.warning(
-                "Failed to read openclaw plugin pins from manifest: %s", exc
-            )
+        try:
+            _pin = _load_openclaw_brave_pin()
+        except CanonicalSyncError as exc:
+            return False, str(exc)
+        openclaw_brave_plugin_package = _pin["npm_package"]
+        openclaw_brave_plugin_version = _pin["version"]
 
     # Build Ansible inventory with API key passed directly
     ansible_vars = {

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -2528,6 +2528,7 @@ def configure_agent(
     if resolved_type == "openclaw":
         from clawrium.core.lifecycle_canonical import (
             CanonicalSyncError,
+            _get_host_openclaw_version,
             _load_openclaw_brave_pin,
         )
 
@@ -2537,6 +2538,63 @@ def configure_agent(
             return False, str(exc)
         openclaw_brave_plugin_package = _pin["npm_package"]
         openclaw_brave_plugin_version = _pin["version"]
+
+        # ATX iter 2 B1: openclaw minHostVersion preflight now runs on
+        # the configure path too. Without it, `clawctl agent attach +
+        # configure` on a host below 2026.4.10 would fire `npm install
+        # @openclaw/brave-plugin@2026.6.8` against a host the plugin's
+        # manifest does not support, and surface as an opaque runtime
+        # failure later. Mirrors the `sync_agent_canonical` preflight.
+        if any(
+            (entry or {}).get("type") == "brave"
+            for entry in integrations_data.values()
+        ):
+            _min_ver = _pin["min_host_version"]
+            _min_str = ".".join(str(p) for p in _min_ver)
+            _private_key = get_host_private_key(key_id)
+            if not _private_key:
+                return False, (
+                    f"openclaw brave preflight failed: no SSH key "
+                    f"registered for host {key_id!r}. Re-run "
+                    f"`clawctl host create`."
+                )
+            _client = paramiko.SSHClient()
+            _client.load_system_host_keys()
+            _client.set_missing_host_key_policy(paramiko.WarningPolicy())
+            try:
+                _client.connect(
+                    hostname=hostname,
+                    port=int(host.get("port", 22)),
+                    username=host.get("user", "xclm"),
+                    key_filename=str(_private_key),
+                    timeout=10,
+                )
+                _ver = _get_host_openclaw_version(_client, unix_agent_name)
+            except Exception as exc:
+                _client.close()
+                return False, (
+                    f"openclaw brave preflight failed: could not probe "
+                    f"{hostname!r} ({exc}). Resolve SSH access first."
+                )
+            finally:
+                try:
+                    _client.close()
+                except Exception:
+                    pass
+            if _ver is None:
+                return False, (
+                    f"openclaw on {hostname!r} is <unknown> (binary missing "
+                    f"or `--version` unparseable); brave plugin requires "
+                    f">= {_min_str}. Run `clawctl agent install "
+                    f"{unix_agent_name}` first."
+                )
+            if _ver < _min_ver:
+                return False, (
+                    f"openclaw on {hostname!r} is "
+                    f"{'.'.join(str(p) for p in _ver)}; brave plugin "
+                    f"requires >= {_min_str}. Run `clawctl agent upgrade "
+                    f"{unix_agent_name}` first."
+                )
 
     # Build Ansible inventory with API key passed directly
     ansible_vars = {

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -43,6 +43,7 @@ import logging
 import re
 import shlex
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable
 
 import paramiko
@@ -103,18 +104,66 @@ _SECRET_KEY_SUFFIXES = (
 )
 
 
-# Minimum on-host openclaw version that ships with the brave plugin
-# manifest (`@openclaw/brave-plugin` declares `minHostVersion`). Brave
-# attach on an older openclaw fails the preflight before any SSH write,
-# pointing the operator at `clawctl agent upgrade <name>` instead of
-# letting the plugin install land on an unsupported host (#734).
-_OPENCLAW_BRAVE_MIN_VERSION = (2026, 4, 10)
+# Openclaw brave plugin pin is loaded from `manifest.yaml` so the
+# Python preflight and Ansible playbook never drift on the version or
+# minHostVersion (W2 ATX iter 1). The loader hard-fails on a missing
+# or malformed entry — silently falling back to an empty version would
+# let `npm install @openclaw/brave-plugin@` run with an unbounded
+# version and surface as an opaque error under `no_log: true`
+# (W3 ATX iter 1).
+
+
+def _load_openclaw_brave_pin() -> dict:
+    """Read `plugins.brave` from the openclaw manifest. Returns a dict
+    with `npm_package`, `version` (str), and `min_host_version` (tuple).
+    Raises `CanonicalSyncError` on any structural problem so the caller
+    never proceeds with an undefined pin."""
+    import yaml as _yaml
+
+    manifest_path = (
+        Path(__file__).parent.parent
+        / "platform"
+        / "registry"
+        / "openclaw"
+        / "manifest.yaml"
+    )
+    manifest = _yaml.safe_load(manifest_path.read_text())
+    brave = (manifest.get("plugins") or {}).get("brave") or {}
+    pkg = brave.get("npm_package")
+    ver = brave.get("version")
+    minv = brave.get("min_host_version")
+    if not pkg or not ver or not minv:
+        raise CanonicalSyncError(
+            "openclaw manifest is missing plugins.brave.{npm_package, "
+            "version, min_host_version} — clawrium build is corrupt; "
+            "reinstall via `uv tool install clawrium`."
+        )
+    minv_tuple = _parse_semver_tuple(minv)
+    if minv_tuple is None:
+        raise CanonicalSyncError(
+            f"openclaw manifest plugins.brave.min_host_version={minv!r} "
+            "is not a valid X.Y.Z version."
+        )
+    return {
+        "npm_package": pkg,
+        "version": ver,
+        "min_host_version": minv_tuple,
+    }
 
 
 def _parse_semver_tuple(raw: str) -> tuple[int, int, int] | None:
     """Parse a leading `X.Y.Z` out of `raw`. Returns None when no triple
-    is present (treated as unknown, NOT zero — see preflight)."""
-    m = re.search(r"(\d+)\.(\d+)\.(\d+)", raw or "")
+    is present (treated as unknown, NOT zero — see preflight).
+
+    Anchors at line start to avoid picking up a runtime/Node version
+    that some future `openclaw --version` build might print first
+    (W8 ATX iter 1). Falls back to first-anywhere as a safety net so
+    operator-friendly output like `openclaw 2026.5.28` still parses.
+    """
+    if not raw:
+        return None
+    first_line = raw.splitlines()[0]
+    m = re.search(r"\b(\d+)\.(\d+)\.(\d+)\b", first_line)
     if not m:
         return None
     return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
@@ -652,15 +701,21 @@ def sync_agent_canonical(
         if inputs.agent_type == "openclaw" and any(
             i.type == "brave" for i in inputs.integrations
         ):
+            pin = _load_openclaw_brave_pin()
+            min_ver = pin["min_host_version"]
             version = _get_host_openclaw_version(client, agent_name)
-            min_ver = _OPENCLAW_BRAVE_MIN_VERSION
-            if version is None or version < min_ver:
-                actual = (
-                    ".".join(str(p) for p in version)
-                    if version is not None
-                    else "<unknown>"
+            min_str = ".".join(str(p) for p in min_ver)
+            if version is None:
+                # Binary missing or unparseable — distinct hint from
+                # "version too old": install vs upgrade (W9 ATX iter 1).
+                raise CanonicalSyncError(
+                    f"openclaw on {hostname!r} is <unknown> "
+                    f"(binary missing or `--version` unparseable); brave "
+                    f"plugin requires >= {min_str}. Run "
+                    f"`clawctl agent install {agent_name}` first."
                 )
-                min_str = ".".join(str(p) for p in min_ver)
+            if version < min_ver:
+                actual = ".".join(str(p) for p in version)
                 raise CanonicalSyncError(
                     f"openclaw on {hostname!r} is {actual}; brave plugin "
                     f"requires >= {min_str}. Run "

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -103,6 +103,48 @@ _SECRET_KEY_SUFFIXES = (
 )
 
 
+# Minimum on-host openclaw version that ships with the brave plugin
+# manifest (`@openclaw/brave-plugin` declares `minHostVersion`). Brave
+# attach on an older openclaw fails the preflight before any SSH write,
+# pointing the operator at `clawctl agent upgrade <name>` instead of
+# letting the plugin install land on an unsupported host (#734).
+_OPENCLAW_BRAVE_MIN_VERSION = (2026, 4, 10)
+
+
+def _parse_semver_tuple(raw: str) -> tuple[int, int, int] | None:
+    """Parse a leading `X.Y.Z` out of `raw`. Returns None when no triple
+    is present (treated as unknown, NOT zero — see preflight)."""
+    m = re.search(r"(\d+)\.(\d+)\.(\d+)", raw or "")
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def _get_host_openclaw_version(
+    client: paramiko.SSHClient, agent_name: str, *, timeout: int = 10
+) -> tuple[int, int, int] | None:
+    """Run `openclaw --version` on the host as the agent user and parse
+    the X.Y.Z triple. Returns None when the binary is missing or its
+    output cannot be parsed — the preflight treats that as a hard fail
+    so we never let a brave attach proceed against an unknown version.
+
+    Uses the agent user's login shell (`bash -lc`) so the binary is
+    resolved via the same `PATH` that `install.yaml` configures —
+    `/usr/local/bin`, `/usr/bin`, or `~/.openclaw/bin` are all
+    acceptable per the install playbook's safelist.
+    """
+    quoted_agent = shlex.quote(agent_name)
+    cmd = (
+        f"sudo -n -u {quoted_agent} bash -lc "
+        f"{shlex.quote('command -v openclaw >/dev/null 2>&1 && openclaw --version')}"
+    )
+    _, out, _ = client.exec_command(cmd, timeout=timeout)
+    body = out.read().decode("utf-8", errors="replace").strip()
+    if out.channel.recv_exit_status() != 0:
+        return None
+    return _parse_semver_tuple(body)
+
+
 class CanonicalSyncError(Exception):
     """Any failure in the canonical sync pipeline."""
 
@@ -600,6 +642,36 @@ def sync_agent_canonical(
 
     client = _open_ssh(host)
     try:
+        # #734 openclaw brave plugin requires minHostVersion 2026.4.10. We
+        # check on the live host (not on hosts.json cached state) because
+        # an operator may have upgraded out-of-band since the last
+        # `clawctl agent get` and we'd otherwise reject a now-valid host.
+        # Done after `_open_ssh` so the connect/auth errors surface with
+        # their normal messages instead of getting swallowed by the
+        # preflight error formatting.
+        if inputs.agent_type == "openclaw" and any(
+            i.type == "brave" for i in inputs.integrations
+        ):
+            version = _get_host_openclaw_version(client, agent_name)
+            min_ver = _OPENCLAW_BRAVE_MIN_VERSION
+            if version is None or version < min_ver:
+                actual = (
+                    ".".join(str(p) for p in version)
+                    if version is not None
+                    else "<unknown>"
+                )
+                min_str = ".".join(str(p) for p in min_ver)
+                raise CanonicalSyncError(
+                    f"openclaw on {hostname!r} is {actual}; brave plugin "
+                    f"requires >= {min_str}. Run "
+                    f"`clawctl agent upgrade {agent_name}` first."
+                )
+            emit(
+                "brave_integration_configured",
+                f"openclaw {'.'.join(str(p) for p in version)} on {hostname} "
+                f"satisfies brave plugin min version",
+            )
+
         for d in diffs:
             if not d.unified_diff:
                 files_unchanged.append(d.path)

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -965,12 +965,15 @@ def render_hermes(inputs: RenderInputs) -> RenderedFiles:
             # #734: hermes upstream (PR #21337) reads
             # `BRAVE_SEARCH_API_KEY` from the env, but the operator-facing
             # credential is `BRAVE_API_KEY` (single key name across all
-            # three agent types). Rename here — in the Python view
-            # builder, NOT in the Jinja template — so the template stays
-            # a dumb formatter and the rename is unit-testable in
-            # isolation from Jinja.
+            # three agent types). Mirror the value under the hermes-
+            # specific name — in the Python view builder, NOT in the
+            # Jinja template — so the template stays a dumb formatter
+            # and the rename is unit-testable in isolation from Jinja.
+            # Do NOT pop the source key (ATX iter 1 render-engine
+            # suggestion): a future consumer needing the operator name
+            # downstream would silently see an empty string.
             if "BRAVE_API_KEY" in creds:
-                creds["BRAVE_SEARCH_API_KEY"] = creds.pop("BRAVE_API_KEY")
+                creds["BRAVE_SEARCH_API_KEY"] = creds["BRAVE_API_KEY"]
         if integration.type == "atlassian":
             lo_slug = slug.lower()
             if not lo_slug:

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -886,7 +886,7 @@ _HERMES_SUPPORTED_PROVIDERS = frozenset(
 )
 _HERMES_SUPPORTED_CHANNELS = frozenset({"discord", "slack"})
 _HERMES_SUPPORTED_INTEGRATIONS = frozenset(
-    {"github", "atlassian", "linear", "notion", "gitlab", "git"}
+    {"github", "atlassian", "linear", "notion", "gitlab", "git", "brave"}
 )
 # Lockstep with hermes' configure.yaml playbook
 # (`mcp_atlassian_version: "0.21.1"`). Without this pin in the rendered
@@ -961,6 +961,16 @@ def render_hermes(inputs: RenderInputs) -> RenderedFiles:
         slug = _integration_slug(integration.name)
         if integration.type == "github":
             last_github_token = creds.get("GITHUB_TOKEN", "")
+        if integration.type == "brave":
+            # #734: hermes upstream (PR #21337) reads
+            # `BRAVE_SEARCH_API_KEY` from the env, but the operator-facing
+            # credential is `BRAVE_API_KEY` (single key name across all
+            # three agent types). Rename here — in the Python view
+            # builder, NOT in the Jinja template — so the template stays
+            # a dumb formatter and the rename is unit-testable in
+            # isolation from Jinja.
+            if "BRAVE_API_KEY" in creds:
+                creds["BRAVE_SEARCH_API_KEY"] = creds.pop("BRAVE_API_KEY")
         if integration.type == "atlassian":
             lo_slug = slug.lower()
             if not lo_slug:
@@ -1125,7 +1135,7 @@ def _render_hermes_template(template_name: str, **context) -> str:
 _ZEROCLAW_PROVIDER_KINDS = frozenset(
     {"anthropic", "openai", "ollama", "openrouter", "opencode", "opencode-go"}
 )
-_ZEROCLAW_SUPPORTED_INTEGRATIONS = frozenset({"github", "git"})
+_ZEROCLAW_SUPPORTED_INTEGRATIONS = frozenset({"github", "git", "brave"})
 
 
 def render_zeroclaw(inputs: RenderInputs) -> RenderedFiles:
@@ -1242,15 +1252,29 @@ def render_zeroclaw(inputs: RenderInputs) -> RenderedFiles:
                 f"{integration.type!r} (zeroclaw supports: "
                 f"{sorted(_ZEROCLAW_SUPPORTED_INTEGRATIONS)})"
             )
-        if integration.type != "github":
-            continue
-        creds = dict(integration.credentials)
-        token = creds.get("GITHUB_TOKEN", "")
-        slug = _integration_slug(integration.name)
-        env_lines.append(
-            f"Environment=GITHUB_TOKEN_{slug}={_systemd_quote(token)}"
-        )
-        last_github_token = token
+        if integration.type == "github":
+            creds = dict(integration.credentials)
+            token = creds.get("GITHUB_TOKEN", "")
+            slug = _integration_slug(integration.name)
+            env_lines.append(
+                f"Environment=GITHUB_TOKEN_{slug}={_systemd_quote(token)}"
+            )
+            last_github_token = token
+        elif integration.type == "brave":
+            # #734: brave web-search routing. Both lines are required —
+            # `BRAVE_API_KEY` alone leaves the search provider on its
+            # duckduckgo default. The `ZEROCLAW_web_search__search_provider`
+            # env-prefix override flips the router (zeroclaw-tools'
+            # `web_search_provider_routing.rs:33`). Mirror of the j2
+            # template branch so canonical + Ansible paths stay in lockstep.
+            creds = dict(integration.credentials)
+            key = creds.get("BRAVE_API_KEY", "")
+            env_lines.append(
+                f"Environment=BRAVE_API_KEY={_systemd_quote(key)}"
+            )
+            env_lines.append(
+                'Environment=ZEROCLAW_web_search__search_provider="brave"'
+            )
     if last_github_token:
         env_lines.append(
             f"Environment=GITHUB_TOKEN={_systemd_quote(last_github_token)}"
@@ -1337,7 +1361,7 @@ _OPENCLAW_SUPPORTED_PROVIDERS = frozenset(
 )
 _OPENCLAW_SUPPORTED_CHANNELS = frozenset({"discord", "slack"})
 _OPENCLAW_SUPPORTED_INTEGRATIONS = frozenset(
-    {"github", "atlassian", "linear", "notion", "gitlab", "git"}
+    {"github", "atlassian", "linear", "notion", "gitlab", "git", "brave"}
 )
 _OPENCLAW_MODEL_PREFIX = {
     "openrouter": "openrouter/",
@@ -1457,6 +1481,8 @@ def render_openclaw(inputs: RenderInputs) -> RenderedFiles:
             view["linear_api_key"] = creds.get("LINEAR_API_KEY", "")
         elif integration.type == "notion":
             view["notion_api_key"] = creds.get("NOTION_API_KEY", "")
+        elif integration.type == "brave":
+            view["brave_api_key"] = creds.get("BRAVE_API_KEY", "")
         integration_views.append(view)
 
     env_body = _render_openclaw_template(

--- a/src/clawrium/platform/registry/hermes/templates/hermes-env.canonical.j2
+++ b/src/clawrium/platform/registry/hermes/templates/hermes-env.canonical.j2
@@ -117,6 +117,11 @@ GITLAB_TOKEN={{ intg.creds.get('GITLAB_TOKEN', '') | shq }}
 {% if 'GITLAB_URL' in intg.creds %}
 GITLAB_URL={{ intg.creds.get('GITLAB_URL', '') | shq }}
 {% endif %}
+{% elif intg.type == 'brave' %}
+{# #734: name mapping (`BRAVE_API_KEY` → `BRAVE_SEARCH_API_KEY`) lives
+   in `render_hermes` (core/render.py); creds here are already
+   normalized. Template is a dumb formatter. #}
+BRAVE_SEARCH_API_KEY={{ intg.creds.get('BRAVE_SEARCH_API_KEY', '') | shq }}
 {% endif %}
 {% endfor %}
 {% if last_github_token %}

--- a/src/clawrium/platform/registry/openclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/openclaw/manifest.yaml
@@ -2,6 +2,16 @@ agent:
   type: openclaw
   description: "Open-source AI assistant framework"
 
+# Plugin pin table — versions are referenced by configure.yaml so a
+# bump is a single-line change. `min_host_version` mirrors the
+# upstream plugin's `minHostVersion` so `lifecycle_canonical` and
+# Ansible agree on the floor.
+plugins:
+  brave:
+    npm_package: "@openclaw/brave-plugin"
+    version: "2026.6.8"
+    min_host_version: "2026.4.10"
+
 # Workspace metadata consumed by cross-claw subsystems (memory CLI, etc.).
 # Path matches the location previously hard-coded in core/memory.py so the
 # memory dispatcher can read it without behavior change.

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -81,18 +81,26 @@
     #
     # Sentinel-gated by the pinned version: a bump in
     # `openclaw_brave_plugin_version` automatically re-triggers
-    # install on every host on the next configure. `no_log: true`
-    # because the install touches the agent's npm registry token if
-    # one is configured. (#734)
+    # install on every host on the next configure.
+    #
+    # `no_log` deliberately NOT set: the install pulls a public npm
+    # package with no secrets in scope, and suppressing output here
+    # hides legitimate failures (network 403, ENOSPC, postinstall
+    # error) which under the previous `no_log: true` masked all
+    # diagnostics. (#734 ATX iter 2 W4)
+    #
+    # PATH is exported so nvm/Homebrew Node hosts can resolve `npm`
+    # without an interactive login shell. (ATX iter 2 W3)
     - name: Install openclaw brave plugin (idempotent, gated by sentinel)
       become: yes
       become_user: "{{ agent_name }}"
+      environment:
+        PATH: "/home/{{ agent_name }}/.local/bin:/usr/local/bin:/usr/bin:/bin"
       ansible.builtin.command: >-
         npm install --prefix /home/{{ agent_name }}/.openclaw
         {{ openclaw_brave_plugin_package }}@{{ openclaw_brave_plugin_version }}
       args:
         creates: "/home/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
-      no_log: true
       when:
         - integrations is defined
         - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -74,6 +74,40 @@
         mode: "0644"
       when: identity_files is defined and identity_files.sync_workspace | default(false)
 
+    # Install the brave web-search plugin BEFORE writing the env file
+    # so that a fresh `BRAVE_API_KEY` lands on a host that already has
+    # the plugin manifest the env var feeds — avoids a one-restart-late
+    # state where the env exists but the plugin doesn't.
+    #
+    # Sentinel-gated by the pinned version: a bump in
+    # `openclaw_brave_plugin_version` automatically re-triggers
+    # install on every host on the next configure. `no_log: true`
+    # because the install touches the agent's npm registry token if
+    # one is configured. (#734)
+    - name: Install openclaw brave plugin (idempotent, gated by sentinel)
+      become: yes
+      become_user: "{{ agent_name }}"
+      ansible.builtin.command: >-
+        npm install --prefix /home/{{ agent_name }}/.openclaw
+        {{ openclaw_brave_plugin_package }}@{{ openclaw_brave_plugin_version }}
+      args:
+        creates: "/home/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
+      no_log: true
+      when:
+        - integrations is defined
+        - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0
+
+    - name: Stamp brave plugin install sentinel
+      become: yes
+      become_user: "{{ agent_name }}"
+      ansible.builtin.file:
+        path: "/home/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
+        state: touch
+        mode: "0600"
+      when:
+        - integrations is defined
+        - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0
+
     - name: Write openclaw .env from template
       ansible.builtin.template:
         src: "{{ template_path }}/.env.j2"

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure_macos.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure_macos.yaml
@@ -87,6 +87,34 @@
         mode: "0644"
       when: identity_files is defined and identity_files.sync_workspace | default(false)
 
+    # See configure.yaml (Linux) for the rationale on plugin install
+    # ordering, sentinel gating, and `no_log: true`. macOS uses the
+    # same npm path; nvm/Homebrew Node both expose `npm` on PATH for
+    # the agent user under default install paths. (#734)
+    - name: Install openclaw brave plugin (idempotent, gated by sentinel)
+      become: yes
+      become_user: "{{ agent_name }}"
+      ansible.builtin.command: >-
+        npm install --prefix /Users/{{ agent_name }}/.openclaw
+        {{ openclaw_brave_plugin_package }}@{{ openclaw_brave_plugin_version }}
+      args:
+        creates: "/Users/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
+      no_log: true
+      when:
+        - integrations is defined
+        - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0
+
+    - name: Stamp brave plugin install sentinel
+      become: yes
+      become_user: "{{ agent_name }}"
+      ansible.builtin.file:
+        path: "/Users/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
+        state: touch
+        mode: "0600"
+      when:
+        - integrations is defined
+        - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0
+
     - name: Write openclaw .env from template
       ansible.builtin.template:
         src: "{{ template_path }}/.env.j2"

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure_macos.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure_macos.yaml
@@ -88,18 +88,21 @@
       when: identity_files is defined and identity_files.sync_workspace | default(false)
 
     # See configure.yaml (Linux) for the rationale on plugin install
-    # ordering, sentinel gating, and `no_log: true`. macOS uses the
-    # same npm path; nvm/Homebrew Node both expose `npm` on PATH for
-    # the agent user under default install paths. (#734)
+    # ordering and sentinel gating. `no_log` is intentionally omitted
+    # so npm errors surface; the npm package is public and no secrets
+    # are in scope. macOS PATH covers Homebrew (/opt/homebrew/bin on
+    # Apple Silicon, /usr/local/bin on Intel) plus nvm's default shim
+    # under /Users/<user>/.nvm. (#734 ATX iter 2 W3, W4)
     - name: Install openclaw brave plugin (idempotent, gated by sentinel)
       become: yes
       become_user: "{{ agent_name }}"
+      environment:
+        PATH: "/Users/{{ agent_name }}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
       ansible.builtin.command: >-
         npm install --prefix /Users/{{ agent_name }}/.openclaw
         {{ openclaw_brave_plugin_package }}@{{ openclaw_brave_plugin_version }}
       args:
         creates: "/Users/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
-      no_log: true
       when:
         - integrations is defined
         - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0

--- a/src/clawrium/platform/registry/openclaw/templates/.env.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/.env.j2
@@ -104,6 +104,13 @@ LINEAR_API_KEY={{ shell_quote(integration.LINEAR_API_KEY) }}
 {% if integration.NOTION_API_KEY is defined %}
 NOTION_API_KEY={{ shell_quote(integration.NOTION_API_KEY) }}
 {% endif %}
+{# #734 brave. Plain `BRAVE_API_KEY` — openclaw's brave plugin reads
+   it directly via the plugin manifest's `webSearch.apiKey` env
+   fallback. #}
+{% elif integration.type == 'brave' %}
+{% if integration.BRAVE_API_KEY is defined %}
+BRAVE_API_KEY={{ shell_quote(integration.BRAVE_API_KEY) }}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/src/clawrium/platform/registry/openclaw/templates/openclaw-env.canonical.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw-env.canonical.j2
@@ -69,6 +69,8 @@ CONFLUENCE_API_TOKEN={{ integration.atlassian_api_token | shq }}
 LINEAR_API_KEY={{ integration.linear_api_key | shq }}
 {% elif integration.type == 'notion' %}
 NOTION_API_KEY={{ integration.notion_api_key | shq }}
+{% elif integration.type == 'brave' %}
+BRAVE_API_KEY={{ integration.brave_api_key | shq }}
 {% endif %}
 {% endfor %}
 {% if last_github_token %}

--- a/src/clawrium/platform/registry/zeroclaw/templates/zeroclaw-env.conf.j2
+++ b/src/clawrium/platform/registry/zeroclaw/templates/zeroclaw-env.conf.j2
@@ -57,5 +57,17 @@
 Environment=GITHUB_TOKEN_{{ _name | upper | replace('-', '_') | regex_replace('[^A-Z0-9_]', '') }}={{ systemd_quote(_integration.GITHUB_TOKEN) }}
 Environment=GITHUB_TOKEN={{ systemd_quote(_integration.GITHUB_TOKEN) }}
 {% endif %}
+{# Brave Search routing — see #734.
+   `BRAVE_API_KEY` is consumed by zeroclaw-tools' web_search crate at
+   boot. The companion `ZEROCLAW_web_search__search_provider=brave`
+   line forces the provider router off its duckduckgo default (the
+   crate's env-prefix override convention from
+   `web_search_provider_routing.rs`). Both lines are required —
+   omitting the second one means a working key with silent fallback
+   to duckduckgo. #}
+{% if _integration.type == 'brave' and _integration.BRAVE_API_KEY is defined %}
+Environment=BRAVE_API_KEY={{ systemd_quote(_integration.BRAVE_API_KEY) }}
+Environment=ZEROCLAW_web_search__search_provider="brave"
+{% endif %}
 {% endfor %}
 {% endif %}

--- a/tests/cli/clawctl/integration/test_registry.py
+++ b/tests/cli/clawctl/integration/test_registry.py
@@ -608,16 +608,20 @@ def test_rotate_partial_failure_surfaces_nonzero_exit(
     assert "simulated sync failure" in result.output
 
 
-def test_rotate_zeroclaw_bearer_rotation_invariant(
+def test_rotate_routes_through_sync_agent_canonical_no_skip_path(
     fleet_dir, stdin_not_tty, monkeypatch
 ) -> None:
-    """#437 invariant — every zeroclaw sync that lands env bytes MUST
-    re-pair the gateway bearer unconditionally. `rotate` routes through
-    `sync_agent_canonical`, which calls `_zeroclaw_repair_after_start`;
-    asserting the sync is invoked is sufficient to pin the invariant
-    (the repair-call assertion lives in `tests/test_lifecycle.py`).
-    A regression adding a `--no-rotate` branch on rotate would skip
-    the sync entirely and fail this test. (B2 ATX iter 1)"""
+    """`rotate` MUST route every attached agent through
+    `sync_agent_canonical` — the only entry point that triggers the
+    zeroclaw `_zeroclaw_repair_after_start` bearer rotation (#437) and
+    the openclaw min-version preflight (#734). A regression adding an
+    "idempotent skip" branch on rotate would call the sync function
+    zero times and fail this assertion.
+
+    This test pins the *routing* invariant. The actual bearer-write
+    semantics (`hosts.json.gateway.auth` overwritten on a zeroclaw
+    sync) are covered by `tests/test_lifecycle.py`'s `#437` suite —
+    not duplicated here. (ATX iter 2 B2)"""
     runner.invoke(
         app,
         [

--- a/tests/cli/clawctl/integration/test_registry.py
+++ b/tests/cli/clawctl/integration/test_registry.py
@@ -283,3 +283,206 @@ def test_delete_with_yes_removes(fleet_dir, stdin_not_tty) -> None:
     )
     result = runner.invoke(app, ["integration", "registry", "delete", "dy", "--yes"])
     assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Brave (#734) — --api-key convenience flag + rotate command.
+# ---------------------------------------------------------------------------
+
+
+def test_create_brave_with_api_key_flag(fleet_dir, stdin_not_tty) -> None:
+    """`--api-key` is the documented entry point for single-credential
+    types like brave. Avoids shell-history leaks vs `--credential KEY=V`
+    (the value still ends up in `ps`/history, but the key name doesn't
+    leak the operator's intent the same way)."""
+    result = runner.invoke(
+        app,
+        [
+            "integration",
+            "registry",
+            "create",
+            "my-brave",
+            "--type",
+            "brave",
+            "--api-key",
+            "bsk-123",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "integration/my-brave" in result.output
+
+    from clawrium.core.integrations import get_integration_credentials
+
+    assert get_integration_credentials("my-brave") == {"BRAVE_API_KEY": "bsk-123"}
+
+
+def test_create_brave_with_api_key_stdin(fleet_dir, stdin_not_tty) -> None:
+    """`--api-key-stdin` reads the bearer from non-TTY stdin. The
+    `stdin_not_tty` fixture flips isatty() to False so the CLI accepts
+    the piped value."""
+    result = runner.invoke(
+        app,
+        [
+            "integration",
+            "registry",
+            "create",
+            "my-brave-2",
+            "--type",
+            "brave",
+            "--api-key-stdin",
+        ],
+        input="bsk-stdin\n",
+    )
+    assert result.exit_code == 0, result.output
+
+    from clawrium.core.integrations import get_integration_credentials
+
+    assert get_integration_credentials("my-brave-2") == {"BRAVE_API_KEY": "bsk-stdin"}
+
+
+def test_create_brave_api_key_stdin_empty_rejected(fleet_dir, stdin_not_tty) -> None:
+    """Empty stdin to `--api-key-stdin` is an error, not a silent empty
+    credential. The CLI must exit non-zero with a clear message."""
+    result = runner.invoke(
+        app,
+        [
+            "integration",
+            "registry",
+            "create",
+            "my-brave-3",
+            "--type",
+            "brave",
+            "--api-key-stdin",
+        ],
+        input="",
+    )
+    assert result.exit_code != 0
+    assert "empty stdin" in result.output
+
+
+def test_create_brave_api_key_rejects_empty_value(fleet_dir, stdin_not_tty) -> None:
+    """`--api-key ''` is an error — the operator most likely fat-fingered
+    a shell variable. Silently creating an empty credential would
+    surface later as an opaque upstream 401."""
+    result = runner.invoke(
+        app,
+        [
+            "integration",
+            "registry",
+            "create",
+            "my-brave-4",
+            "--type",
+            "brave",
+            "--api-key",
+            "",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "empty" in result.output
+
+
+def test_create_api_key_rejected_for_multi_cred_type(
+    fleet_dir, stdin_not_tty
+) -> None:
+    """`--api-key` is single-credential-type-only. atlassian has three
+    required credentials; the flag cannot disambiguate so it must
+    refuse rather than guess."""
+    result = runner.invoke(
+        app,
+        [
+            "integration",
+            "registry",
+            "create",
+            "atl",
+            "--type",
+            "atlassian",
+            "--api-key",
+            "tk",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "not supported" in result.output
+
+
+def test_create_api_key_conflicts_with_matching_credential(
+    fleet_dir, stdin_not_tty
+) -> None:
+    """If both `--api-key VAL1` and `--credential BRAVE_API_KEY=VAL2` are
+    passed, the CLI rejects the ambiguous input. Silently picking one
+    would be a foot-gun during credential rotation."""
+    result = runner.invoke(
+        app,
+        [
+            "integration",
+            "registry",
+            "create",
+            "conflict",
+            "--type",
+            "brave",
+            "--api-key",
+            "v1",
+            "--credential",
+            "BRAVE_API_KEY=v2",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "conflict" in result.output.lower()
+
+
+def test_rotate_brave_no_attached_agents(fleet_dir, stdin_not_tty) -> None:
+    """`integration rotate` on an unattached integration updates the
+    credential and exits 0 with a clear "nothing to sync" message."""
+    runner.invoke(
+        app,
+        [
+            "integration",
+            "registry",
+            "create",
+            "rot1",
+            "--type",
+            "brave",
+            "--api-key",
+            "bsk-old",
+        ],
+    )
+    result = runner.invoke(
+        app,
+        [
+            "integration",
+            "rotate",
+            "rot1",
+            "--api-key",
+            "bsk-new",
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "no agents attached" in result.output
+
+    from clawrium.core.integrations import get_integration_credentials
+
+    assert get_integration_credentials("rot1") == {"BRAVE_API_KEY": "bsk-new"}
+
+
+def test_rotate_requires_new_credential(fleet_dir, stdin_not_tty) -> None:
+    """`integration rotate` with no `--api-key`/`--credential` is an
+    error — a no-op rotate would silently re-sync agents without any
+    cred change, which is misleading."""
+    runner.invoke(
+        app,
+        [
+            "integration",
+            "registry",
+            "create",
+            "rot2",
+            "--type",
+            "brave",
+            "--api-key",
+            "k",
+        ],
+    )
+    result = runner.invoke(
+        app, ["integration", "rotate", "rot2", "--yes"]
+    )
+    assert result.exit_code != 0
+    assert "no new credential" in result.output

--- a/tests/cli/clawctl/integration/test_registry.py
+++ b/tests/cli/clawctl/integration/test_registry.py
@@ -486,3 +486,176 @@ def test_rotate_requires_new_credential(fleet_dir, stdin_not_tty) -> None:
     )
     assert result.exit_code != 0
     assert "no new credential" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Brave (#734) — `integration rotate` multi-agent sync loop
+# (ATX iter 1 B1, B2).
+# ---------------------------------------------------------------------------
+
+
+def _attach_integration_to_agent(
+    integration_name: str, hostname: str, agent_key: str
+) -> None:
+    """Helper: register an attachment in `integrations.json` so
+    `find_agents_using_integration` returns the bound agent. Mirrors
+    the registry shape produced by `clawctl agent integration attach`
+    without going through the SSH-touching CLI."""
+    from clawrium.core.integrations import add_agent_integration
+
+    add_agent_integration(hostname, agent_key, integration_name)
+
+
+def test_rotate_syncs_every_attached_agent_in_order(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """`rotate` MUST re-sync every agent currently attached so a
+    rotated key actually lands on disk. Without this, the credential
+    update is silent — agents keep authenticating with the old key
+    until the next manual sync. (B1 ATX iter 1)"""
+    runner.invoke(
+        app,
+        [
+            "integration",
+            "registry",
+            "create",
+            "rot-multi",
+            "--type",
+            "brave",
+            "--api-key",
+            "bsk-old",
+        ],
+    )
+    # Attach to the fleet_dir openclaw agent.
+    _attach_integration_to_agent(
+        "rot-multi", "10.0.0.1", "openclaw"
+    )
+
+    synced: list[str] = []
+    monkeypatch.setattr(
+        "clawrium.core.lifecycle_canonical.sync_agent_canonical",
+        lambda agent_key, **_kw: synced.append(agent_key),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "integration",
+            "rotate",
+            "rot-multi",
+            "--api-key",
+            "bsk-new",
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert synced == ["openclaw"]
+
+    from clawrium.core.integrations import get_integration_credentials
+
+    assert get_integration_credentials("rot-multi") == {
+        "BRAVE_API_KEY": "bsk-new"
+    }
+
+
+def test_rotate_partial_failure_surfaces_nonzero_exit(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """If any sync fails the CLI MUST exit non-zero. A cron-driven
+    rotation that returned 0 with one agent half-rotated would silently
+    leave a credential-mismatch in production. Other agents still
+    attempted (loop does not short-circuit). (B1 ATX iter 1)"""
+    runner.invoke(
+        app,
+        [
+            "integration",
+            "registry",
+            "create",
+            "rot-fail",
+            "--type",
+            "brave",
+            "--api-key",
+            "k",
+        ],
+    )
+    _attach_integration_to_agent(
+        "rot-fail", "10.0.0.1", "openclaw"
+    )
+
+    from clawrium.core.lifecycle_canonical import CanonicalSyncError
+
+    def _failing_sync(_agent_key, **_kw):
+        raise CanonicalSyncError("simulated sync failure")
+
+    monkeypatch.setattr(
+        "clawrium.core.lifecycle_canonical.sync_agent_canonical",
+        _failing_sync,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "integration",
+            "rotate",
+            "rot-fail",
+            "--api-key",
+            "k2",
+            "--yes",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "SYNC FAILED" in result.output
+    assert "simulated sync failure" in result.output
+
+
+def test_rotate_zeroclaw_bearer_rotation_invariant(
+    fleet_dir, stdin_not_tty, monkeypatch
+) -> None:
+    """#437 invariant — every zeroclaw sync that lands env bytes MUST
+    re-pair the gateway bearer unconditionally. `rotate` routes through
+    `sync_agent_canonical`, which calls `_zeroclaw_repair_after_start`;
+    asserting the sync is invoked is sufficient to pin the invariant
+    (the repair-call assertion lives in `tests/test_lifecycle.py`).
+    A regression adding a `--no-rotate` branch on rotate would skip
+    the sync entirely and fail this test. (B2 ATX iter 1)"""
+    runner.invoke(
+        app,
+        [
+            "integration",
+            "registry",
+            "create",
+            "rot-zc",
+            "--type",
+            "brave",
+            "--api-key",
+            "k",
+        ],
+    )
+    # Attach to a zeroclaw agent (seeded by fleet_dir? if not, attach
+    # to the openclaw agent — the test is about the sync invocation,
+    # not the agent type).
+    _attach_integration_to_agent(
+        "rot-zc", "10.0.0.1", "openclaw"
+    )
+
+    sync_calls: list[str] = []
+    monkeypatch.setattr(
+        "clawrium.core.lifecycle_canonical.sync_agent_canonical",
+        lambda agent_key, **_kw: sync_calls.append(agent_key),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "integration",
+            "rotate",
+            "rot-zc",
+            "--api-key",
+            "k2",
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # Sync must be called once per attached agent — no idempotent-skip
+    # path on rotate.
+    assert len(sync_calls) == 1

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -1475,3 +1475,202 @@ class TestOpenclawBraveVersionPreflight:
         )
         sync_agent_canonical("oc", restart=False, verify=False)
         assert called == [], "_get_host_openclaw_version was invoked"
+
+
+# ---------------------------------------------------------------------------
+# Brave (#734) — semver parsing + SSH probe (ATX iter 1 B3).
+# ---------------------------------------------------------------------------
+
+
+class TestParseSemverTuple:
+    """`_parse_semver_tuple` is the security-relevant gate that decides
+    whether the brave plugin install proceeds. Direct tests rather than
+    going through the SSH-mocked happy path so a parser regression
+    surfaces on its own."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("2026.5.28", (2026, 5, 28)),
+            ("openclaw 2026.4.10", (2026, 4, 10)),
+            ("openclaw version 2026.5.28\nbuilt 2026-05-28", (2026, 5, 28)),
+            ("openclaw 1.2.3", (1, 2, 3)),
+            ("  2026.4.10  \n", (2026, 4, 10)),
+        ],
+    )
+    def test_parses_realistic_version_strings(self, raw, expected):
+        assert lc._parse_semver_tuple(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            "not a version",
+            "openclaw",
+            "12.34",  # only two components
+            "version unavailable",
+        ],
+    )
+    def test_returns_none_for_unparseable_input(self, raw):
+        assert lc._parse_semver_tuple(raw) is None
+
+    def test_picks_first_line_only(self):
+        """If a future build prints a Node/Rust runtime version after
+        the openclaw version, we want the openclaw line, not the
+        runtime line. (W8 ATX iter 1)"""
+        raw = "openclaw 2026.5.28\nnode v22.1.0\n"
+        assert lc._parse_semver_tuple(raw) == (2026, 5, 28)
+
+
+class TestGetHostOpenclawVersion:
+    """`_get_host_openclaw_version` issues an SSH `bash -lc 'command -v
+    openclaw && openclaw --version'`. Assert the command shape and the
+    non-zero-exit -> None branch. (B3 ATX iter 1)"""
+
+    def _make_client(
+        self, stdout: str, exit_status: int
+    ) -> tuple[MagicMock, list[str]]:
+        commands: list[str] = []
+        client = MagicMock()
+
+        def _exec_command(cmd, **_kw):
+            commands.append(cmd)
+            channel = MagicMock()
+            channel.recv_exit_status.return_value = exit_status
+            out = MagicMock()
+            out.read.return_value = stdout.encode("utf-8")
+            out.channel = channel
+            return MagicMock(), out, MagicMock()
+
+        client.exec_command.side_effect = _exec_command
+        return client, commands
+
+    def test_happy_path_returns_parsed_tuple(self):
+        client, commands = self._make_client("openclaw 2026.5.28\n", 0)
+        assert lc._get_host_openclaw_version(client, "wolf-i") == (2026, 5, 28)
+        assert len(commands) == 1
+        # Login shell so PATH-resolved binaries (install.yaml's
+        # /usr/local/bin or ~/.openclaw/bin) are reachable.
+        assert " bash -lc " in commands[0]
+        assert "openclaw --version" in commands[0]
+        # User context is quoted to prevent shell injection.
+        assert "sudo -n -u wolf-i" in commands[0]
+
+    def test_nonzero_exit_returns_none(self):
+        """Binary missing → exit 127 → None. Preflight maps None to
+        a `clawctl agent install` hint."""
+        client, _ = self._make_client("openclaw: command not found\n", 127)
+        assert lc._get_host_openclaw_version(client, "wolf-i") is None
+
+    def test_unparseable_output_returns_none(self):
+        client, _ = self._make_client("garbage output\n", 0)
+        assert lc._get_host_openclaw_version(client, "wolf-i") is None
+
+    def test_agent_name_is_shell_quoted(self):
+        """Defensive: a hostile agent name (e.g. `; rm -rf` injected via
+        a misconfigured hosts.json) must not break out of the sudo
+        shell. The `shlex.quote` wrap is the safety net."""
+        client, commands = self._make_client("0.0.0\n", 0)
+        lc._get_host_openclaw_version(client, "a;rm -rf /")
+        # The injection attempt is single-quoted; it never reaches sudo
+        # as separate tokens.
+        assert "'a;rm -rf /'" in commands[0]
+
+
+class TestLoadOpenclawBravePin:
+    """`_load_openclaw_brave_pin` is the single source of truth for the
+    plugin pin (npm package, version, min host version). Both
+    `lifecycle.configure_agent` and `lifecycle_canonical.sync_agent_canonical`
+    consume it; a manifest drift would silently desync the playbook
+    install version from the preflight floor. (W2 + W3 ATX iter 1)"""
+
+    def test_loads_pin_from_manifest(self):
+        pin = lc._load_openclaw_brave_pin()
+        assert pin["npm_package"] == "@openclaw/brave-plugin"
+        assert pin["version"] == "2026.6.8"
+        assert pin["min_host_version"] == (2026, 4, 10)
+
+    def test_raises_when_pin_block_missing(self, monkeypatch):
+        """Manifest with no `plugins.brave` block → hard fail. Never
+        let `npm install @openclaw/brave-plugin@` run with an empty
+        version under `no_log: true` masking. (W3)"""
+        import yaml
+
+        monkeypatch.setattr(
+            yaml,
+            "safe_load",
+            lambda _txt: {"agent": {"type": "openclaw"}},
+        )
+        with pytest.raises(
+            CanonicalSyncError,
+            match=r"openclaw manifest is missing plugins\.brave",
+        ):
+            lc._load_openclaw_brave_pin()
+
+    def test_raises_when_min_host_version_is_invalid(self, monkeypatch):
+        """A typo in the manifest (`min_host_version: "not-a-version"`)
+        must hard fail, not silently fall back to (0, 0, 0)."""
+        import yaml
+
+        monkeypatch.setattr(
+            yaml,
+            "safe_load",
+            lambda _txt: {
+                "plugins": {
+                    "brave": {
+                        "npm_package": "@openclaw/brave-plugin",
+                        "version": "2026.6.8",
+                        "min_host_version": "not-a-version",
+                    }
+                }
+            },
+        )
+        with pytest.raises(
+            CanonicalSyncError, match=r"not a valid X\.Y\.Z version"
+        ):
+            lc._load_openclaw_brave_pin()
+
+
+# ---------------------------------------------------------------------------
+# Brave (#734) — playbook dispatch routing (ATX iter 1 B4).
+# ---------------------------------------------------------------------------
+
+
+class TestOpenclawConfigureDispatch:
+    """The macOS sibling `configure_macos.yaml` MUST be the file
+    selected by `resolve_agent_playbook` for `os_family="darwin"`.
+    Without this test a regression renaming the file (or breaking the
+    `_macos` suffix convention) would only surface on a real Mac
+    host."""
+
+    def test_darwin_routes_to_configure_macos(self):
+        from clawrium.core.playbook_resolver import resolve_agent_playbook
+
+        path = resolve_agent_playbook("openclaw", "configure", "darwin")
+        assert path.name == "configure_macos.yaml"
+        assert path.exists()
+
+    def test_linux_routes_to_configure(self):
+        from clawrium.core.playbook_resolver import resolve_agent_playbook
+
+        path = resolve_agent_playbook("openclaw", "configure", "linux")
+        assert path.name == "configure.yaml"
+        assert path.exists()
+
+    def test_both_configure_playbooks_contain_brave_install_task(self):
+        """Symmetric brave plugin install on Linux + macOS. If a future
+        edit removes the install task from one but not the other the
+        dispatch test still passes — pin both files explicitly."""
+        from clawrium.core.playbook_resolver import resolve_agent_playbook
+
+        linux = resolve_agent_playbook("openclaw", "configure", "linux")
+        darwin = resolve_agent_playbook("openclaw", "configure", "darwin")
+        for path in (linux, darwin):
+            body = path.read_text()
+            assert "openclaw_brave_plugin_package" in body, path
+            assert "openclaw_brave_plugin_version" in body, path
+            assert "no_log: true" in body, path
+            # No Darwin-conditional inside either file (dispatcher-only
+            # OS fork — #734 invariant).
+            assert "ansible_os_family == 'Darwin'" not in body, path
+            assert 'ansible_os_family == "Darwin"' not in body, path

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -1337,3 +1337,141 @@ class TestVerifyHealthDiagnosticWrap:
         # Crucial: the catalog raise must NOT mask the verdict.
         assert "Diagnosis:" not in msg
         assert "catalog blew up" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Brave (#734) — openclaw version preflight.
+# ---------------------------------------------------------------------------
+
+
+class TestOpenclawBraveVersionPreflight:
+    """`sync_agent_canonical` must refuse to write `.openclaw/env` with a
+    brave block when the host openclaw is older than the plugin's
+    `minHostVersion`. Without the preflight the plugin would install
+    against a host it doesn't support and surface as a daemon-side
+    error that's much harder to diagnose."""
+
+    def _setup(self, monkeypatch, host_version: tuple[int, int, int] | None):
+        from clawrium.core.render import (
+            GatewayInputs,
+            IntegrationInputs,
+            ProviderInputs,
+            RenderInputs,
+            RenderedFiles,
+        )
+
+        inputs = RenderInputs(
+            agent_name="oc",
+            agent_type="openclaw",
+            provider=ProviderInputs(
+                name="or",
+                type="openrouter",
+                api_key="sk",
+                default_model="m",
+            ),
+            gateway=GatewayInputs(host="h", port=40000, auth="a"),
+            integrations=(
+                IntegrationInputs(
+                    name="my-brave",
+                    type="brave",
+                    credentials=(("BRAVE_API_KEY", "bsk-1"),),
+                ),
+            ),
+        )
+        monkeypatch.setattr(lc, "build_render_inputs", lambda _: inputs)
+        rendered = RenderedFiles(
+            files={
+                ".openclaw/env": "BRAVE_API_KEY='bsk-1'\n",
+                ".openclaw/openclaw.json": "{}",
+            }
+        )
+        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _: rendered)
+        monkeypatch.setattr(
+            lc,
+            "get_agent_by_name",
+            lambda _: ({"hostname": "h"}, "openclaw:oc", {}),
+        )
+        monkeypatch.setattr(lc, "diff_files", lambda **_: [])
+        monkeypatch.setattr(lc, "_open_ssh", lambda _h, **__: MagicMock())
+        monkeypatch.setattr(
+            lc,
+            "_get_host_openclaw_version",
+            lambda *_a, **_kw: host_version,
+        )
+
+    def test_below_min_version_raises(self, monkeypatch):
+        self._setup(monkeypatch, (2026, 3, 13))
+        with pytest.raises(
+            CanonicalSyncError,
+            match=r"openclaw on 'h' is 2026\.3\.13; brave plugin requires >= 2026\.4\.10",
+        ):
+            sync_agent_canonical("oc", restart=False, verify=False)
+
+    def test_exact_min_version_passes(self, monkeypatch):
+        self._setup(monkeypatch, (2026, 4, 10))
+        # Should not raise on the preflight; diffs are empty so the rest
+        # of the pipeline is a no-op.
+        sync_agent_canonical("oc", restart=False, verify=False)
+
+    def test_newer_than_min_version_passes(self, monkeypatch):
+        self._setup(monkeypatch, (2026, 5, 28))
+        sync_agent_canonical("oc", restart=False, verify=False)
+
+    def test_unknown_version_raises(self, monkeypatch):
+        """Unknown version (binary missing / unparseable output) is a
+        hard fail — never let the brave plugin install land on an
+        unknown host where the plugin's minHostVersion contract cannot
+        be evaluated."""
+        self._setup(monkeypatch, None)
+        with pytest.raises(
+            CanonicalSyncError, match=r"openclaw on 'h' is <unknown>"
+        ):
+            sync_agent_canonical("oc", restart=False, verify=False)
+
+    def test_preflight_skipped_when_no_brave_integration(self, monkeypatch):
+        """The preflight has a measurable cost (one SSH exec). When no
+        brave integration is attached we MUST NOT invoke it — otherwise
+        every openclaw sync pays for a feature that's not in use."""
+        from clawrium.core.render import (
+            GatewayInputs,
+            ProviderInputs,
+            RenderInputs,
+            RenderedFiles,
+        )
+
+        inputs = RenderInputs(
+            agent_name="oc",
+            agent_type="openclaw",
+            provider=ProviderInputs(
+                name="or",
+                type="openrouter",
+                api_key="sk",
+                default_model="m",
+            ),
+            gateway=GatewayInputs(host="h", port=40000, auth="a"),
+        )
+        monkeypatch.setattr(lc, "build_render_inputs", lambda _: inputs)
+        rendered = RenderedFiles(
+            files={".openclaw/env": "", ".openclaw/openclaw.json": "{}"}
+        )
+        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _: rendered)
+        monkeypatch.setattr(
+            lc,
+            "get_agent_by_name",
+            lambda _: ({"hostname": "h"}, "openclaw:oc", {}),
+        )
+        monkeypatch.setattr(lc, "diff_files", lambda **_: [])
+        monkeypatch.setattr(lc, "_open_ssh", lambda _h, **__: MagicMock())
+
+        # Sentinel that fails the test if invoked.
+        called = []
+
+        def _should_not_be_called(*_a, **_kw):
+            called.append(True)
+            return (2026, 5, 28)
+
+        monkeypatch.setattr(
+            lc, "_get_host_openclaw_version", _should_not_be_called
+        )
+        sync_agent_canonical("oc", restart=False, verify=False)
+        assert called == [], "_get_host_openclaw_version was invoked"

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -4193,3 +4193,126 @@ def test_openclaw_litellm_preserves_unmanaged_baseline_keys():
     assert blob["session"]["dmScope"] == "per-channel-peer"
     assert blob["env"]["shellEnv"] == {"enabled": True, "timeoutMs": 15000}
     assert blob["agents"]["defaults"]["workspace"] == "~/.openclaw/workspace"
+
+
+# ---------------------------------------------------------------------------
+# Brave integration (#734) — per-agent env render shape.
+# ---------------------------------------------------------------------------
+
+
+def test_hermes_brave_integration_emits_search_api_key_envvar():
+    """Hermes maps the operator-facing `BRAVE_API_KEY` credential to the
+    upstream-required `BRAVE_SEARCH_API_KEY=` env var (hermes #21337). The
+    name mapping is template-only — operators never see the upstream var
+    name."""
+    base = _baseline_inputs(ptype="anthropic")
+    inputs = RenderInputs(
+        agent_name="alpha",
+        agent_type="hermes",
+        provider=base.provider,
+        channels=(),
+        integrations=(
+            IntegrationInputs(
+                name="my-brave",
+                type="brave",
+                credentials=(("BRAVE_API_KEY", "bsk-1"),),
+            ),
+        ),
+        api_server=None,
+    )
+    env = render_hermes(inputs).files[".hermes/.env"]
+    assert "BRAVE_SEARCH_API_KEY='bsk-1'" in env
+    # The operator-facing key name MUST NOT appear in the rendered env.
+    assert "BRAVE_API_KEY=" not in env
+
+
+def test_zeroclaw_brave_integration_emits_key_and_provider_override():
+    """Zeroclaw needs BOTH env vars — the key alone leaves the search
+    provider on its duckduckgo default. The companion override flips the
+    router. Both lines are required and asserted together."""
+    base = _zeroclaw_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        channels=base.channels,
+        integrations=(
+            IntegrationInputs(
+                name="my-brave",
+                type="brave",
+                credentials=(("BRAVE_API_KEY", "bsk-1"),),
+            ),
+        ),
+        gateway=base.gateway,
+    )
+    env = render_zeroclaw(inputs).files[".zeroclaw/zeroclaw-env.conf"]
+    assert 'Environment=BRAVE_API_KEY="bsk-1"' in env
+    assert 'Environment=ZEROCLAW_web_search__search_provider="brave"' in env
+
+
+def test_openclaw_brave_integration_emits_api_key_envvar():
+    """Openclaw's brave plugin reads `BRAVE_API_KEY` directly from the
+    process env (plugin manifest declares it as the first-class fallback
+    for `webSearch.apiKey`). No name mapping."""
+    inputs = _openclaw_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=inputs.agent_name,
+        agent_type=inputs.agent_type,
+        provider=inputs.provider,
+        channels=(),
+        integrations=(
+            IntegrationInputs(
+                name="my-brave",
+                type="brave",
+                credentials=(("BRAVE_API_KEY", "bsk-1"),),
+            ),
+        ),
+        gateway=inputs.gateway,
+    )
+    env = render_openclaw(inputs).files[".openclaw/env"]
+    assert "BRAVE_API_KEY='bsk-1'" in env
+
+
+def test_brave_integration_supported_on_all_three_agents():
+    """Whitelist assertion — `brave` must be in every supported set. Catches
+    accidental removal during refactor."""
+    from clawrium.core.render import (
+        _HERMES_SUPPORTED_INTEGRATIONS,
+        _OPENCLAW_SUPPORTED_INTEGRATIONS,
+        _ZEROCLAW_SUPPORTED_INTEGRATIONS,
+    )
+
+    assert "brave" in _HERMES_SUPPORTED_INTEGRATIONS
+    assert "brave" in _ZEROCLAW_SUPPORTED_INTEGRATIONS
+    assert "brave" in _OPENCLAW_SUPPORTED_INTEGRATIONS
+
+
+def test_zeroclaw_brave_alongside_github_renders_both():
+    """Multi-integration: brave + github attached on the same zeroclaw
+    agent both emit their env-var blocks. Order independence is asserted
+    via membership (the iteration order is documented as stable but the
+    test does not pin it)."""
+    base = _zeroclaw_inputs(ptype="openrouter")
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        channels=base.channels,
+        integrations=(
+            IntegrationInputs(
+                name="gh-1",
+                type="github",
+                credentials=(("GITHUB_TOKEN", "ghp_a"),),
+            ),
+            IntegrationInputs(
+                name="my-brave",
+                type="brave",
+                credentials=(("BRAVE_API_KEY", "bsk-1"),),
+            ),
+        ),
+        gateway=base.gateway,
+    )
+    env = render_zeroclaw(inputs).files[".zeroclaw/zeroclaw-env.conf"]
+    assert 'Environment=GITHUB_TOKEN_GH_1="ghp_a"' in env
+    assert 'Environment=BRAVE_API_KEY="bsk-1"' in env
+    assert 'Environment=ZEROCLAW_web_search__search_provider="brave"' in env

--- a/tests/test_core_integrations.py
+++ b/tests/test_core_integrations.py
@@ -115,7 +115,15 @@ class TestIntegrationTypes:
 
     def test_integration_types_has_expected_types(self):
         """INTEGRATION_TYPES contains expected integration types."""
-        expected_types = {"github", "gitlab", "atlassian", "linear", "notion", "git"}
+        expected_types = {
+            "github",
+            "gitlab",
+            "atlassian",
+            "linear",
+            "notion",
+            "git",
+            "brave",
+        }
         assert set(INTEGRATION_TYPES.keys()) == expected_types
 
     def test_each_type_has_description_and_credentials(self):

--- a/tests/test_gui_integrations.py
+++ b/tests/test_gui_integrations.py
@@ -55,10 +55,42 @@ def test_list_returns_summaries_without_credential_values(isolated_config):
 def test_types_endpoint_returns_all_known_types(isolated_config):
     result = _run(integrations_route.list_integration_types())
     types = result["types"]
-    for type_key in ("github", "gitlab", "atlassian", "linear", "notion"):
+    for type_key in ("github", "gitlab", "atlassian", "linear", "notion", "brave"):
         assert type_key in types
         assert "credentials" in types[type_key]
         assert "description" in types[type_key]
+
+
+def test_brave_type_credential_schema_is_single_api_key(isolated_config):
+    """#734: brave has a single required credential `BRAVE_API_KEY`.
+    The GUI consumes the types catalog to render one masked field — a
+    schema drift here would silently break the create modal."""
+    result = _run(integrations_route.list_integration_types())
+    brave = result["types"]["brave"]
+    keys = brave["credentials"]
+    assert [c["key"] for c in keys] == ["BRAVE_API_KEY"]
+    assert keys[0]["required"] is True
+
+
+def test_create_brave_integration_persists_only_credential_key(isolated_config):
+    """#734: POST /api/integrations with `type: brave` round-trips the
+    credential key (NOT the value) into the summary. The summary
+    endpoint MUST NOT leak the raw key value."""
+    req = integrations_route.IntegrationCreate(
+        name="my-brave",
+        type="brave",
+        credentials={"BRAVE_API_KEY": "bsk-secret-123"},
+    )
+    _run(integrations_route.create_integration(req))
+
+    result = _run(integrations_route.list_integrations())
+    [summary] = result["integrations"]
+    assert summary["type"] == "brave"
+    assert summary["configured_credential_keys"] == ["BRAVE_API_KEY"]
+    # The raw value MUST NOT appear anywhere in the response.
+    import json as _json
+
+    assert "bsk-secret-123" not in _json.dumps(result)
 
 
 def test_create_rejects_invalid_name(isolated_config):

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -3139,3 +3139,220 @@ class TestConfigureAgentSlackTokens:
                 )
                 assert vars.get("slack_bot_token") == "xoxb-123-test"
                 assert vars.get("slack_app_token") == "xapp-1-ABC-test"
+
+
+class TestConfigureAgentBravePreflight:
+    """ATX iter 3 B_NEW1: pin the openclaw brave preflight inside
+    `configure_agent` directly. The canonical preflight in
+    `sync_agent_canonical` is independently covered in
+    `tests/core/test_lifecycle_canonical.py`; the configure path has
+    its own SSH+key plumbing and error formatting that must be tested
+    on its own."""
+
+    def _oc_host(self) -> dict:
+        return {
+            "hostname": "10.0.0.1",
+            "key_id": "test",
+            "agent_name": "wolf-i",
+            "port": 22,
+            "user": "xclm",
+            "agents": {
+                "oc-test": {
+                    "type": "openclaw",
+                    "agent_name": "openc",
+                    "onboarding": {"state": "ready"},
+                    "config": {"gateway": {"port": 40000}},
+                }
+            },
+        }
+
+    def _run_with_preflight(
+        self,
+        tmp_path: Path,
+        *,
+        host_version: tuple[int, int, int] | None,
+        attach_brave: bool = True,
+        pin_raises: bool = False,
+        no_ssh_key: bool = False,
+    ) -> tuple[bool, str | None]:
+        host = self._oc_host()
+        key_path = tmp_path / "k"
+        key_path.write_text("k")
+        playbook_path = tmp_path / "configure.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+
+        integrations_for_agent = ["my-brave"] if attach_brave else []
+        brave_integration = {
+            "name": "my-brave",
+            "type": "brave",
+        }
+        brave_creds = {"BRAVE_API_KEY": "bsk-1"}
+
+        runner = MagicMock()
+        runner.status = "successful"
+        runner.events = []
+        artifacts_dir = tmp_path / "artifacts"
+        (artifacts_dir / "fact_cache").mkdir(parents=True)
+        runner.config.artifact_dir = str(artifacts_dir)
+
+        from clawrium.core.lifecycle_canonical import CanonicalSyncError
+
+        def _fake_load_pin():
+            if pin_raises:
+                raise CanonicalSyncError("manifest corrupt")
+            return {
+                "npm_package": "@openclaw/brave-plugin",
+                "version": "2026.6.8",
+                "min_host_version": (2026, 4, 10),
+            }
+
+        patches = [
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key",
+                return_value=None if no_ssh_key else key_path,
+            ),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook_path,
+            ),
+            patch(
+                "clawrium.core.lifecycle.ansible_runner.run",
+                return_value=runner,
+            ),
+            patch(
+                "clawrium.core.lifecycle.update_host", return_value=True
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_config_dir",
+                return_value=tmp_path,
+            ),
+            patch(
+                "clawrium.core.providers.get_provider_api_key",
+                return_value="",
+            ),
+            patch(
+                "clawrium.core.providers.get_provider_aws_credentials",
+                return_value=("", ""),
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                return_value={},
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_instance_key",
+                return_value="test-key",
+            ),
+            patch(
+                "clawrium.core.integrations.get_agent_integrations",
+                return_value=integrations_for_agent,
+            ),
+            patch(
+                "clawrium.core.integrations.get_integration",
+                return_value=brave_integration,
+            ),
+            patch(
+                "clawrium.core.integrations.get_integration_credentials",
+                return_value=brave_creds,
+            ),
+            patch(
+                "clawrium.core.lifecycle_canonical._load_openclaw_brave_pin",
+                side_effect=_fake_load_pin,
+            ),
+            patch(
+                "clawrium.core.lifecycle_canonical._get_host_openclaw_version",
+                return_value=host_version,
+            ),
+            patch(
+                "clawrium.core.lifecycle.paramiko.SSHClient",
+                return_value=MagicMock(),
+            ),
+            patch.object(Path, "exists", return_value=True),
+        ]
+        from contextlib import ExitStack
+
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            from clawrium.core.lifecycle import configure_agent
+
+            success, error = configure_agent(
+                "10.0.0.1",
+                "openclaw",
+                {"providers": {"anthropic": {"model": "claude-opus-4-7"}}},
+                agent_name="oc-test",
+            )
+        return success, error
+
+    def test_pin_load_failure_returns_false_with_message(self, tmp_path: Path):
+        """`_load_openclaw_brave_pin` raises (corrupt manifest) →
+        configure_agent returns (False, msg) instead of letting the
+        npm install run with an empty version."""
+        success, error = self._run_with_preflight(
+            tmp_path, host_version=(2026, 5, 28), pin_raises=True
+        )
+        assert success is False
+        assert "manifest corrupt" in (error or "")
+
+    def test_missing_ssh_key_returns_false(self, tmp_path: Path):
+        """If `get_host_private_key` returns None, configure_agent
+        must fail closed before any host-side work. The existing
+        early-return at `lifecycle.py:2433` covers this; the preflight
+        is downstream of it, so we just verify the call fails."""
+        success, error = self._run_with_preflight(
+            tmp_path, host_version=(2026, 5, 28), no_ssh_key=True
+        )
+        assert success is False
+        assert error is not None and "SSH key" in error
+
+    def test_version_below_minimum_returns_upgrade_hint(self, tmp_path: Path):
+        """Host openclaw < 2026.4.10 → upgrade hint, not install hint."""
+        success, error = self._run_with_preflight(
+            tmp_path, host_version=(2026, 3, 13)
+        )
+        assert success is False
+        assert "2026.3.13" in (error or "")
+        assert "clawctl agent upgrade" in (error or "")
+
+    def test_unknown_version_returns_install_hint(self, tmp_path: Path):
+        """`_get_host_openclaw_version` returns None (binary missing) →
+        install hint, distinct from upgrade hint (W9 ATX iter 1)."""
+        success, error = self._run_with_preflight(
+            tmp_path, host_version=None
+        )
+        assert success is False
+        assert "<unknown>" in (error or "")
+        assert "clawctl agent install" in (error or "")
+
+    def test_exact_minimum_version_proceeds_past_preflight(
+        self, tmp_path: Path
+    ):
+        """Host openclaw == minHostVersion → preflight passes; the
+        rest of configure_agent runs (we don't assert deep on the
+        ansible-runner mock; success vs falsy is enough to pin the
+        preflight has not short-circuited)."""
+        success, _ = self._run_with_preflight(
+            tmp_path, host_version=(2026, 4, 10)
+        )
+        # The rest of configure_agent has many side effects; this test
+        # only pins that preflight did not return False. `success` may
+        # be False for other reasons but the error must not be a
+        # preflight error.
+        success_or_no_preflight_error = (
+            success is True
+            or "brave plugin requires" not in (str(_) if _ else "")
+        )
+        assert success_or_no_preflight_error
+
+    def test_no_brave_integration_skips_preflight(self, tmp_path: Path):
+        """When no brave integration is attached, the preflight MUST
+        NOT run — every openclaw configure would otherwise pay for an
+        SSH version probe it doesn't need."""
+        # _get_host_openclaw_version returning None would normally trip
+        # the preflight; with no brave attachment the test passes
+        # because the preflight branch is never entered.
+        success, error = self._run_with_preflight(
+            tmp_path, host_version=None, attach_brave=False
+        )
+        # If preflight ran, error would mention 'brave plugin requires'.
+        assert "brave plugin requires" not in (error or "")

--- a/website/docs/agent-support/integrations/brave.md
+++ b/website/docs/agent-support/integrations/brave.md
@@ -1,0 +1,108 @@
+# Brave Search
+
+**Status:** ✅ Supported on Hermes, ZeroClaw, and OpenClaw (#734).
+
+Brave Search integration gives agents a real web-search tool. The credential
+is a Brave Search API subscription token (free tier available at
+https://brave.com/search/api/). Operators store the key once in the
+clawrium registry and attach the integration to any supported agent —
+clawrium handles the per-agent env var shape (including the upstream
+name mapping on hermes and the search-provider router override on
+zeroclaw) so the operator never sees those details.
+
+---
+
+## Per-Agent Env Shape
+
+The credential the operator passes is always `BRAVE_API_KEY`. Each
+agent's renderer maps it to the env var(s) the upstream daemon
+actually reads:
+
+| Agent | Env vars written | Notes |
+|---|---|---|
+| **hermes** | `BRAVE_SEARCH_API_KEY=<key>` | Name-mapped in the template. Hermes' `web_search` tool reads `BRAVE_SEARCH_API_KEY`, **not** `BRAVE_API_KEY` (see upstream PR `nousresearch/hermes-agent#21337`). |
+| **zeroclaw** | `BRAVE_API_KEY=<key>` **and** `ZEROCLAW_web_search__search_provider=brave` | Both lines are required. Setting the key alone leaves the provider router on its `duckduckgo` default. The companion env-prefix override (`web_search_provider_routing.rs:33`) flips the router to brave. |
+| **openclaw** | `BRAVE_API_KEY=<key>` | Openclaw's brave plugin reads the env var directly (plugin manifest declares it as the first-class fallback for `webSearch.apiKey`). Plugin install happens automatically on `clawctl agent configure` (see below). |
+
+The same registry entry can be attached to multiple agents of different
+types — each agent's renderer produces the correct shape independently.
+
+---
+
+## Openclaw plugin install + min-version preflight
+
+Openclaw needs the `@openclaw/brave-plugin` npm package installed
+locally on the agent host. `clawctl agent configure` and
+`clawctl agent sync` handle that automatically when a brave
+integration is attached — installation is idempotent and gated by a
+per-version sentinel file at
+`~/.openclaw/.brave-plugin-installed.<version>`.
+
+Pinned version: **`@openclaw/brave-plugin@2026.6.8`**. The pin lives in
+`src/clawrium/platform/registry/openclaw/manifest.yaml`
+(`plugins.brave.version`) so a bump is a single-line change.
+
+The plugin declares `minHostVersion >= 2026.4.10`. `clawctl agent sync`
+preflights the on-host openclaw version over SSH before any write —
+if the host is older the sync exits with a clear message:
+
+```
+openclaw on <host> is <ver>; brave plugin requires >= 2026.4.10.
+Run `clawctl agent upgrade <agent>` first.
+```
+
+This is intentional friction. Silently working with a missing plugin
+would surface as an opaque daemon-side error much later.
+
+---
+
+## Get a Brave Search API key
+
+1. Sign up at https://brave.com/search/api/ (free tier available).
+2. From the dashboard, create a new subscription token.
+3. Copy the value — Brave does not show it twice.
+
+---
+
+## Use with Clawrium
+
+### Register the integration
+
+```bash
+# Convenience flag for single-credential types — value never lands in
+# `ps`/shell history via a positional argument.
+clawctl integration registry create my-brave --type brave --api-key bsk-xxxxx
+
+# Or, for CI / secret-manager pipelines:
+printf %s "$BRAVE_API_KEY" | clawctl integration registry create my-brave \
+  --type brave --api-key-stdin
+```
+
+### Attach to an agent
+
+```bash
+clawctl agent integration attach <agent-name> my-brave
+clawctl agent sync <agent-name>
+```
+
+### Rotate the key
+
+When the upstream key changes:
+
+```bash
+clawctl integration rotate my-brave --api-key bsk-new-xxxxx --yes
+```
+
+This updates the credential **and** re-syncs every agent currently
+bound to `my-brave` in one shot. Any sync failure surfaces as
+non-zero exit so cron-driven rotations don't silently leave
+half-rotated state.
+
+### Delete
+
+```bash
+clawctl integration registry delete my-brave
+```
+
+Refuses if any agent is still attached unless `--force` is passed
+(which detaches + re-syncs all bound agents).

--- a/website/docs/agent-support/integrations/index.md
+++ b/website/docs/agent-support/integrations/index.md
@@ -7,6 +7,7 @@ Integrations allow agents to interact with external tools and services, extendin
 | Integration | Status | Agents | Use Case |
 |-------------|:------:|--------|----------|
 | **[Atlassian (Jira + Confluence)](atlassian.md)** | ✅ | Hermes (MCP), OpenClaw | Issue tracking, docs / knowledge base |
+| **[Brave Search](brave.md)** | ✅ | Hermes, OpenClaw, ZeroClaw | Web search tool |
 | **[GitHub](github.md)** | 🚧 | OpenClaw (planned) | PR reviews, issues |
 | **[GitLab](gitlab.md)** | 📋 | Not planned | Alternative to GitHub |
 | **[Linear](linear.md)** | 📋 | Not planned | Issue tracking |


### PR DESCRIPTION
## Summary

Adds a single `brave` integration type for the Brave Search API across all three agent types (hermes / zeroclaw / openclaw). The operator stores `BRAVE_API_KEY` once in the clawrium registry; `clawctl agent integration attach` + `sync` produces the correct per-agent env shape including the name mapping on hermes (`BRAVE_SEARCH_API_KEY`), the search-provider router override on zeroclaw, and an idempotent npm install of `@openclaw/brave-plugin@2026.6.8` on openclaw with a min-version preflight (`>= 2026.4.10`).

Closes #734.

## Highlights

- **Hermes**: `BRAVE_SEARCH_API_KEY` env var, name-mapped in Python `render_hermes` (not in the Jinja template) so the rename stays unit-testable and the #622 single-render-path invariant holds.
- **Zeroclaw**: emits BOTH `Environment=BRAVE_API_KEY=...` AND `Environment=ZEROCLAW_web_search__search_provider="brave"`. The provider override is required; the key alone leaves the router on duckduckgo.
- **Openclaw**: `BRAVE_API_KEY` env var + sentinel-gated npm install of the brave plugin, with the plugin's `minHostVersion` preflighted both in `configure_agent` and `sync_agent_canonical` via the same `_load_openclaw_brave_pin()` helper (single source of truth at `manifest.yaml`).
- **CLI**: `--api-key` / `--api-key-stdin` convenience flags on `create`/`edit` for single-required-credential types; new `clawctl integration rotate <name>` command — updates the credential and re-syncs every bound agent in one shot. Positional credential is NOT accepted (shell-history leak avoidance).
- **macOS sibling** `configure_macos.yaml` for the brave plugin install. Dispatcher-only OS fork (per project invariant) — no `when: ansible_os_family == 'Darwin'` inside `configure.yaml`.

## Testing

### Test Results
- **Narrow pytest selection** (`uv run pytest -x` on the 5 touched test files): 350 tests pass.
- `make lint` clean (ruff + ESLint).
- See `[ENVIRONMENT]` Callout below for OOM constraint context and the narrow-pytest gap CI surfaced.

### Test Coverage
- `tests/core/test_render.py` — hermes/zeroclaw/openclaw byte-locks for brave + multi-integration scenarios.
- `tests/core/test_lifecycle_canonical.py` — openclaw preflight (version below/equal/above min, unknown, no-brave-skip), `_parse_semver_tuple` (5 happy + 5 error), `_get_host_openclaw_version` (SSH command shape, exit-status, shell-quoting), `_load_openclaw_brave_pin` (happy + missing block + invalid version).
- `tests/cli/clawctl/integration/test_registry.py` — `--api-key` happy/empty/stdin/conflict paths; `rotate` no-attach/multi-agent/partial-failure/routing-through-sync.
- `tests/test_lifecycle.py::TestConfigureAgentBravePreflight` — 6 branches of `configure_agent` brave preflight (pin failure, missing SSH key, version below/unknown/equal/no-brave-skip).
- `tests/test_gui_integrations.py` — `brave` in the types catalog with the correct credential schema; create round-trip + raw-key-not-in-response.
- Dispatch routing test pins `configure_macos.yaml` selection for `os_family="darwin"` and asserts no in-file Darwin guards.

## ATX Review Summary

**Final Review: Rating 4/5 (iter 3, leader 3/5)**
**Total Cost: $17.01 | Total Duration: ~22 min across 3 iterations**
**Blocking overall: false on every iteration**

| Review | Rating | Blockers | Status | Cost | Duration | Agents |
|--------|--------|----------|--------|------|----------|--------|
| 1 | 3/5 | B1, B2, B3, B4 | All addressed (commit `3983d11`) | $5.28 | 7m 7s | leader, security, test-coverage, render-engine, lifecycle-core, cli-ux, platform-playbooks |
| 2 | 3.5/5 (leader 2/5) | B1, B2 | All addressed (commit `f7c222b`) | $5.36 | 7m 41s | leader, lifecycle-core, test-coverage, platform-playbooks, security, cli-ux, render-engine |
| 3 | 4/5 (leader 3/5) | B_NEW1 | Addressed (commit `9bc4c0a` — `TestConfigureAgentBravePreflight`) | $6.37 | 7m 50s | leader, lifecycle-core, test-coverage, platform-playbooks, security, cli-ux, render-engine |

> **Note**: ATX does not expose per-agent model attribution. Models used overall: `claude-opus-4-7`, `claude-sonnet-4-6`.

<details>
<summary>Review 1 Details (Rating 3/5 — 4 blockers, 10 warnings)</summary>

**Blockers:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/cli/clawctl/integration/test_registry.py` | `integration rotate` multi-agent sync loop untested | Fixed — added happy-path + partial-failure tests |
| B2 | `tests/cli/clawctl/integration/test_registry.py` | #437 invariant not asserted on rotate→sync | Fixed — added `test_rotate_routes_through_sync_agent_canonical_no_skip_path` |
| B3 | `src/clawrium/core/lifecycle_canonical.py` | `_get_host_openclaw_version` + `_parse_semver_tuple` fully monkeypatched in every test | Fixed — `TestParseSemverTuple` (10 cases) + `TestGetHostOpenclawVersion` (4 cases) |
| B4 | `configure_macos.yaml` | No dispatch routing test | Fixed — `TestOpenclawConfigureDispatch` |

**Warnings (10):** W1 (preflight not in configure_agent), W2 (duplicated min version), W3 (`except Exception → version=""` fallback), W4 (no_log on env template), W5 (substring tests not byte-locks), W6 (zeroclaw search_provider literal duplicated Py+Jinja), W7 (sentinel touch reports changed every run), W8 (regex picks first triple anywhere), W9 (binary-missing vs old maps to same hint), W10 (3 near-identical render tests).

Fixed in iter 1 commits: W1, W2, W3, W4, W8, W9.
Acknowledged / out-of-scope: W6 (Jinja+Python parallel paths are pre-existing zeroclaw design), W5+W10 (substring tests are sufficient; byte-locks live in `test_zeroclaw_renders_*` golden tests), W7 (sentinel touch idempotent at npm-install level is acceptable).

</details>

<details>
<summary>Review 2 Details (Rating 3.5/5, leader 2/5 — 2 blockers, 6 warnings)</summary>

**Blockers:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `lifecycle.py` `configure_agent` | minHostVersion preflight missing from configure path | Fixed — preflight now runs in `configure_agent` before `ansible_vars` build |
| B2 | `tests/cli/clawctl/integration/test_registry.py` | `test_rotate_zeroclaw_bearer_rotation_invariant` mis-scoped (uses openclaw fixture) | Fixed — renamed to `test_rotate_routes_through_sync_agent_canonical_no_skip_path` with honest docstring |

**Warnings (6):** W1 (paramiko timeout per-recv vs total), W2 (docstring drift), W3 (npm PATH for nvm/Homebrew), W4 (no_log scope on npm install hides errors), W5 (literal `<name>` placeholder in failure hint), W6 (single-agent partial-failure test doesn't exercise loop continuation).

Fixed in iter 2 commits: W3, W4, W5.
Acknowledged / followup: W1 (paramiko timeout semantics are a wider concern; not regression-introduced by this PR), W2 (docstring fixed in iter 2 W8 work), W6 (fleet_dir only seeds one openclaw agent; multi-agent partial-failure test requires fleet_dir refactor — captured as TODO).

</details>

<details>
<summary>Review 3 Details (Rating 4/5, leader 3/5 — 1 new blocker)</summary>

**Blockers:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B_NEW1 | `tests/test_lifecycle.py` (missing) | Zero direct unit tests for `configure_agent` brave preflight | Fixed — `TestConfigureAgentBravePreflight` covers 6 branches |

**Warnings:** W_NEW1 (configure_agent inlines SSH setup vs reusing `_open_ssh`), W_NEW2 (`rotate` placement on `integration` vs `integration.registry`), W_NEW3 (mid-write atomicity for `set_integration_credential`), W_NEW4 (rotate failure hint omits hostname), W_NEW5 (empty BRAVE_API_KEY render passthrough — last line of defense vs externally-edited integrations.json).

Acknowledged / followup (see Callouts below). None are correctness blockers given the CLI already prevents empty keys and the canonical preflight covers the SSH duplication risk in practice.

</details>

## Callouts

- **[ENVIRONMENT]** Full `make test` skipped locally due to OOM pressure on the shared dev box (5 concurrent claude sessions; prior runs OOM-killed at >50 GB RSS per pytest process). Narrow pytest selection initially covered the touched files only and missed `tests/test_core_integrations.py::TestIntegrationTypes::test_integration_types_has_expected_types` — that test hardcodes the integration roster and CI on ubuntu-latest caught the missing `"brave"` entry. Fixed in a follow-up commit. **Lesson:** narrow pytest must include any file that hardcodes the registry, even when it imports nothing else this PR touched. Expanded reproduction command going forward:
  ```
  uv run pytest -x tests/test_core_integrations.py \
                   tests/core/test_render.py \
                   tests/core/test_lifecycle_canonical.py \
                   tests/cli/clawctl/integration/test_registry.py \
                   tests/test_gui_integrations.py \
                   tests/test_lifecycle.py::TestConfigureAgentBravePreflight
  ```
  CI runs the full suite on this PR.

- **[TODO-FOLLOWUP]** Phase 3 live host verification was NOT performed in this autonomous session (no live SSH access). Per scaffold Phase 3 exit criteria, the following per-agent smoke checklist remains for an operator to walk through manually after merge:
  - **hermes (`espresso`)**: attach `my-brave`, `clawctl agent sync`, fire a chat turn invoking `web_search`. Confirm Brave-routed result via `BRAVE_SEARCH_API_KEY` resolution log line; verify no DDGS fallback.
  - **zeroclaw (`clawrium-d01`)**: attach + sync, fire `web_search`. Critically: confirm the routing is brave, not silently duckduckgo. If env-prefix override fails at boot, fall back to TOML deep-update of `[web_search]` in `zeroclaw-config.toml.j2` (separate follow-up PR; not blocking the v1 landing).
  - **openclaw (≥2026.4.10)**: attach + sync, `openclaw plugins list` shows `@openclaw/brave-plugin@2026.6.8`, then `openclaw agent --message "search the web for clawrium"` returns Brave-routed.
  - Preflight rejection: verify once on a deliberately-old openclaw host (`< 2026.4.10`) — the configure/sync should fail fast with the `clawctl agent upgrade` hint.

- **[ENVIRONMENT]** ATX review path: CLI (per operator override; MCP available in `.claude/itx-config.json` but not used this run). All 3 iterations invoked via `atx review request --format json --timeout 15m`. Session metadata persisted at `.itx/734/atx-session.json`.

- **[DECISION]** Iter 3's leader rating dropped to 3/5 with one new blocker (`B_NEW1`: missing direct tests for `configure_agent` preflight). Per the `/itx-execute` skill's 3-iteration ATX ceiling, the PR opens here. The blocker was nonetheless addressed in commit `9bc4c0a` with a focused `TestConfigureAgentBravePreflight` (6 branches) — not by re-running ATX (would have been iteration 4). Reviewer: verify the test coverage is satisfactory; if not, push back and I (or a follow-up) can re-run ATX.

- **[DECISION]** ATX iter 3 W_NEW2 suggested moving `clawctl integration rotate` under `integration registry` to match the rest of the CRUD verbs. I kept it on the top-level `integration` app intentionally: `rotate` is a workflow command (registry update + multi-agent re-sync), not a registry CRUD verb. Mirrors the placement of e.g. `clawctl agent integration attach` (workflow) vs `clawctl integration registry create` (CRUD). Reviewer: push back if you prefer the registry-subgroup placement.

- **[DECISION]** ATX iter 3 W_NEW5 suggested adding empty-key validation in the render layer as a defense-in-depth measure against externally-edited `integrations.json`. Deferred — the CLI guards empty values at credential-set time, and a corrupt integrations.json file is a much broader concern that touches every integration type, not just brave. A follow-up PR adding render-time non-empty assertions across all integration types would be more cohesive than a brave-only patch.

- **[TODO-FOLLOWUP]** Iter 2 W6 (single-agent partial-failure test) requires extending `fleet_dir` to seed multiple agents on different hosts. Out of scope for this PR — captured for a future fleet_dir cleanup.

- **[TODO-FOLLOWUP]** Iter 1 W6 (zeroclaw `ZEROCLAW_web_search__search_provider="brave"` literal duplicated in `render.py` Python and `zeroclaw-env.conf.j2` Jinja) is a pre-existing zeroclaw rendering-path design (Python writes canonical, Jinja writes during `configure_agent`). Consolidating onto a single render path is a separate refactor; for now the literal must be kept in lockstep in both files (a test would help — captured as follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>

