### PR TITLE
feat(openclaw): bump to 2026.6.8 + align brave preflight resolution with exec.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ cut. The `itx:release` skill archives this section into a new
 
 ### BREAKING
 
+- **openclaw brave plugin now requires openclaw `>= 2026.6.8`** (previously
+  `>= 2026.4.10`). Any host running openclaw in the `2026.4.10..2026.6.7`
+  range with the brave integration attached will hit a hard
+  `CanonicalSyncError` on the next `clawctl agent sync` with the message
+  `openclaw on '<host>' is <X.Y.Z>; brave plugin requires >= 2026.6.8`.
+  **Operator action:** run `clawctl agent upgrade <agent>` (which now
+  installs `2026.6.8` by default) before the next sync. There is no
+  automated migration — the upgrade must be initiated explicitly.
+
 ### Added
 
 - New `brave` integration type for the Brave Search API. Register once
@@ -28,7 +37,7 @@ cut. The `itx:release` skill archives this section into a new
   duckduckgo default), and `BRAVE_API_KEY` on openclaw. Openclaw also
   installs `@openclaw/brave-plugin@2026.6.8` automatically on
   configure (idempotent, sentinel-gated) and preflights the on-host
-  openclaw version against the plugin's `minHostVersion` (>= 2026.4.10)
+  openclaw version against the plugin's `minHostVersion` (>= 2026.6.8)
   before any sync write. New `clawctl integration rotate <name>`
   rotates the credential and re-syncs every bound agent in one shot.
   Closes #734.
@@ -38,6 +47,18 @@ cut. The `itx:release` skill archives this section into a new
   and openclaw agents (#722).
 
 ### Changed
+
+- Default openclaw install target bumped from `2026.5.28` to `2026.6.8`.
+  `clawctl agent create --type openclaw` and `clawctl agent upgrade`
+  now install `2026.6.8` by default; manifest entries added for
+  ubuntu 22.04 / 24.04 (x86_64) and macos arm64. Existing agents pinned
+  to a specific `--version` are unaffected.
+- Openclaw brave-plugin preflight (`_get_host_openclaw_version`) is now
+  forked per OS — Linux uses `/home/<agent>/.openclaw/bin/openclaw`,
+  macOS uses `/Users/<agent>/.openclaw/bin/openclaw`, with PATH-fallback
+  safelists matching each OS's install playbook. The Linux-only
+  hardcoded path that shipped earlier in `[Unreleased]` would have
+  silently fallen through to a system-PATH binary on Darwin.
 
 ### Fixed
 

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -169,32 +169,49 @@ def _parse_semver_tuple(raw: str) -> tuple[int, int, int] | None:
     return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
 
 
-def _build_openclaw_version_probe(
+def _build_openclaw_version_inner_script(
     agent_name: str, *, home_root: str, path_safelist: tuple[str, ...]
 ) -> str:
-    """Build the `sudo -n -u <agent> bash -lc '...'` command that
-    resolves the openclaw binary the same way exec.yaml does and
-    prints its `--version` output. Per-agent binary at
-    `<home_root>/<agent>/.openclaw/bin/openclaw` wins; PATH fallback
-    is accepted only when `command -v openclaw` resolves under one of
-    `path_safelist` (matches install.yaml's discovery gate).
+    """Return the bash body that resolves the openclaw binary (no
+    sudo wrap, no `bash -lc` shell quoting). Split out so tests can
+    execute the script directly via `subprocess.run(['bash', '-c',
+    ...])` against fixture binaries — mocked SSH cannot catch shell
+    semantics regressions like the one ATX iter 2 found.
+
+    Per-agent binary at `<home_root>/<agent>/.openclaw/bin/openclaw`
+    wins; PATH fallback is accepted only when `command -v openclaw`
+    resolves under one of `path_safelist` (matches install.yaml's
+    discovery gate).
     """
-    quoted_agent = shlex.quote(agent_name)
     per_agent = f"{home_root}/{agent_name}/.openclaw/bin/openclaw"
     quoted_per_agent = shlex.quote(per_agent)
-    safelist_test = " || ".join(
-        f'case "$resolved" in {shlex.quote(prefix)}*) ok=1 ;; esac'
-        for prefix in path_safelist
-    )
-    inner = (
+    # IMPORTANT: a single `case` with `|` alternation is the only
+    # shape that actually enforces every prefix. A chain of separate
+    # `case ... esac || case ... esac` short-circuits on the first
+    # one because `case` always exits 0 regardless of whether a
+    # pattern matched (ATX iter 2 B4).
+    patterns = "|".join(f"{shlex.quote(prefix)}*" for prefix in path_safelist)
+    return (
         f"if [ -x {quoted_per_agent} ] && [ -s {quoted_per_agent} ]; then "
         f"  {quoted_per_agent} --version; "
         f"elif resolved=$(command -v openclaw 2>/dev/null); then "
-        f"  ok=0; {safelist_test}; "
+        f"  ok=0; "
+        f'  case "$resolved" in {patterns}) ok=1 ;; esac; '
         f'  if [ "$ok" = 1 ]; then "$resolved" --version; '
         f'  else echo "openclaw on PATH is at unsafe path: $resolved" 1>&2; exit 2; fi; '
         f"else exit 1; fi"
     )
+
+
+def _build_openclaw_version_probe(
+    agent_name: str, *, home_root: str, path_safelist: tuple[str, ...]
+) -> str:
+    """Build the `sudo -n -u <agent> bash -lc '...'` command that
+    runs the inner version-probe script on the host."""
+    inner = _build_openclaw_version_inner_script(
+        agent_name, home_root=home_root, path_safelist=path_safelist
+    )
+    quoted_agent = shlex.quote(agent_name)
     return f"sudo -n -u {quoted_agent} bash -lc {shlex.quote(inner)}"
 
 
@@ -274,7 +291,7 @@ def _get_host_openclaw_version(
     dispatcher is the only place that knows about both, matching the
     dispatcher-only-OS-fork convention in AGENTS.md.
     """
-    if (os_family or "linux") == "darwin":
+    if (os_family or "linux").lower() == "darwin":
         return _get_host_openclaw_version_macos(
             client, agent_name, timeout=timeout
         )

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -169,41 +169,118 @@ def _parse_semver_tuple(raw: str) -> tuple[int, int, int] | None:
     return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
 
 
-def _get_host_openclaw_version(
-    client: paramiko.SSHClient, agent_name: str, *, timeout: int = 10
-) -> tuple[int, int, int] | None:
-    """Run `openclaw --version` on the host as the agent user and parse
-    the X.Y.Z triple. Returns None when the binary is missing or its
-    output cannot be parsed.
-
-    Resolution mirrors `playbooks/exec.yaml`: prefer the per-agent
-    binary at `/home/<agent>/.openclaw/bin/openclaw` when it exists +
-    is executable, else fall back to whatever `bash -lc 'command -v
-    openclaw'` resolves on the agent user's login PATH. Using the same
-    resolution as exec.yaml is the source of truth: if the operator
-    invokes `clawctl agent exec wolf-i -- --version`, the preflight
-    must read the same binary, otherwise an upgrade that moved the
-    per-agent binary still sees a stale system binary on PATH and
-    rejects sync forever.
+def _build_openclaw_version_probe(
+    agent_name: str, *, home_root: str, path_safelist: tuple[str, ...]
+) -> str:
+    """Build the `sudo -n -u <agent> bash -lc '...'` command that
+    resolves the openclaw binary the same way exec.yaml does and
+    prints its `--version` output. Per-agent binary at
+    `<home_root>/<agent>/.openclaw/bin/openclaw` wins; PATH fallback
+    is accepted only when `command -v openclaw` resolves under one of
+    `path_safelist` (matches install.yaml's discovery gate).
     """
     quoted_agent = shlex.quote(agent_name)
-    per_agent = f"/home/{agent_name}/.openclaw/bin/openclaw"
+    per_agent = f"{home_root}/{agent_name}/.openclaw/bin/openclaw"
     quoted_per_agent = shlex.quote(per_agent)
-    # `test -x` matches exec.yaml's stat(executable=True) + size>0 gate
-    # closely enough that the two will pick the same binary in practice.
+    safelist_test = " || ".join(
+        f'case "$resolved" in {shlex.quote(prefix)}*) ok=1 ;; esac'
+        for prefix in path_safelist
+    )
     inner = (
-        f"if [ -x {quoted_per_agent} ]; then "
+        f"if [ -x {quoted_per_agent} ] && [ -s {quoted_per_agent} ]; then "
         f"  {quoted_per_agent} --version; "
-        f"elif command -v openclaw >/dev/null 2>&1; then "
-        f"  openclaw --version; "
+        f"elif resolved=$(command -v openclaw 2>/dev/null); then "
+        f"  ok=0; {safelist_test}; "
+        f'  if [ "$ok" = 1 ]; then "$resolved" --version; '
+        f'  else echo "openclaw on PATH is at unsafe path: $resolved" 1>&2; exit 2; fi; '
         f"else exit 1; fi"
     )
-    cmd = f"sudo -n -u {quoted_agent} bash -lc {shlex.quote(inner)}"
-    _, out, _ = client.exec_command(cmd, timeout=timeout)
+    return f"sudo -n -u {quoted_agent} bash -lc {shlex.quote(inner)}"
+
+
+_LINUX_OPENCLAW_PATH_SAFELIST: tuple[str, ...] = (
+    "/usr/local/bin/",
+    "/usr/bin/",
+    "/home/",
+)
+_MACOS_OPENCLAW_PATH_SAFELIST: tuple[str, ...] = (
+    "/opt/homebrew/bin/",
+    "/usr/local/bin/",
+    "/usr/bin/",
+    "/Users/",
+)
+
+
+def _get_host_openclaw_version_linux(
+    client: paramiko.SSHClient, agent_name: str, *, timeout: int = 10
+) -> tuple[tuple[int, int, int] | None, str]:
+    """Linux variant: per-agent binary under `/home/<agent>/`, PATH
+    fallback safelist matches Linux install.yaml lines ~50-57.
+
+    Returns `(version, stderr_tail)`. `version` is `None` when the
+    binary is missing, the output is unparseable, or the resolved
+    PATH binary is rejected by the safelist; `stderr_tail` is the
+    last ~512 bytes of stderr so the caller can surface a diagnostic
+    instead of an opaque `<unknown>`.
+    """
+    cmd = _build_openclaw_version_probe(
+        agent_name,
+        home_root="/home",
+        path_safelist=_LINUX_OPENCLAW_PATH_SAFELIST,
+    )
+    return _run_openclaw_version_probe(client, cmd, timeout=timeout)
+
+
+def _get_host_openclaw_version_macos(
+    client: paramiko.SSHClient, agent_name: str, *, timeout: int = 10
+) -> tuple[tuple[int, int, int] | None, str]:
+    """macOS (arm64) variant: per-agent binary under `/Users/<agent>/`,
+    PATH fallback safelist matches install_macos.yaml line ~109.
+
+    Forked completely from the Linux variant — when a future macOS
+    x86_64 platform is added, dispatch should fork further rather
+    than retrofitting an arch branch into either function.
+    """
+    cmd = _build_openclaw_version_probe(
+        agent_name,
+        home_root="/Users",
+        path_safelist=_MACOS_OPENCLAW_PATH_SAFELIST,
+    )
+    return _run_openclaw_version_probe(client, cmd, timeout=timeout)
+
+
+def _run_openclaw_version_probe(
+    client: paramiko.SSHClient, cmd: str, *, timeout: int
+) -> tuple[tuple[int, int, int] | None, str]:
+    _, out, err = client.exec_command(cmd, timeout=timeout)
     body = out.read().decode("utf-8", errors="replace").strip()
+    err_bytes = err.read()
+    stderr_tail = err_bytes.decode("utf-8", errors="replace")[-512:].strip()
     if out.channel.recv_exit_status() != 0:
-        return None
-    return _parse_semver_tuple(body)
+        return None, stderr_tail
+    return _parse_semver_tuple(body), stderr_tail
+
+
+def _get_host_openclaw_version(
+    client: paramiko.SSHClient,
+    agent_name: str,
+    *,
+    os_family: str,
+    timeout: int = 10,
+) -> tuple[tuple[int, int, int] | None, str]:
+    """Dispatcher: routes to the Linux or macOS variant based on
+    `os_family` (the host record's `os_family` field). The Linux and
+    macOS resolvers are intentionally separate functions — the
+    dispatcher is the only place that knows about both, matching the
+    dispatcher-only-OS-fork convention in AGENTS.md.
+    """
+    if (os_family or "linux") == "darwin":
+        return _get_host_openclaw_version_macos(
+            client, agent_name, timeout=timeout
+        )
+    return _get_host_openclaw_version_linux(
+        client, agent_name, timeout=timeout
+    )
 
 
 class CanonicalSyncError(Exception):
@@ -715,16 +792,24 @@ def sync_agent_canonical(
         ):
             pin = _load_openclaw_brave_pin()
             min_ver = pin["min_host_version"]
-            version = _get_host_openclaw_version(client, agent_name)
+            version, probe_stderr = _get_host_openclaw_version(
+                client,
+                agent_name,
+                os_family=host.get("os_family", "linux"),
+            )
             min_str = ".".join(str(p) for p in min_ver)
             if version is None:
                 # Binary missing or unparseable — distinct hint from
                 # "version too old": install vs upgrade (W9 ATX iter 1).
+                # `probe_stderr` surfaces sudo failures, safelist
+                # rejections, or PATH-resolution errors so the operator
+                # has a starting point beyond <unknown>.
+                detail = f" stderr: {probe_stderr}" if probe_stderr else ""
                 raise CanonicalSyncError(
                     f"openclaw on {hostname!r} is <unknown> "
                     f"(binary missing or `--version` unparseable); brave "
                     f"plugin requires >= {min_str}. Run "
-                    f"`clawctl agent install {agent_name}` first."
+                    f"`clawctl agent install {agent_name}` first.{detail}"
                 )
             if version < min_ver:
                 actual = ".".join(str(p) for p in version)

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -797,8 +797,11 @@ def sync_agent_canonical(
 
     client = _open_ssh(host)
     try:
-        # #734 openclaw brave plugin requires minHostVersion 2026.4.10. We
-        # check on the live host (not on hosts.json cached state) because
+        # #734 openclaw brave plugin enforces a minHostVersion floor
+        # (sourced from `plugins.brave.min_host_version` in the
+        # openclaw manifest — do not duplicate the literal here, the
+        # manifest is the single source of truth). We check on the
+        # live host (not on hosts.json cached state) because
         # an operator may have upgraded out-of-band since the last
         # `clawctl agent get` and we'd otherwise reject a now-valid host.
         # Done after `_open_ssh` so the connect/auth errors surface with

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -1778,6 +1778,206 @@ class TestGetHostOpenclawVersionDispatcher:
         )
         assert "/home/wolf-i/.openclaw/bin/openclaw" in probe.commands[0]
 
+    def test_capitalized_darwin_routes_to_macos(self):
+        """S4 ATX iter 2: `Darwin` (capitalized) must route to the
+        macOS variant. Without lowercase normalization in the
+        dispatcher, a host record persisted with `Darwin` would
+        silently fall back to Linux and the macOS fork would be
+        dead code for that host."""
+        probe = _ProbeMockClient("openclaw 2026.6.8\n", "", 0)
+        lc._get_host_openclaw_version(
+            probe.as_client(), "wolf-m", os_family="Darwin"
+        )
+        assert "/Users/wolf-m/.openclaw/bin/openclaw" in probe.commands[0]
+
+
+class TestGetHostOpenclawVersionMacosInjection:
+    """S6 ATX iter 2: mirror the Linux shell-injection guard on the
+    macOS variant so a regression that drops `shlex.quote` from the
+    macOS path is caught symmetrically."""
+
+    def test_agent_name_is_shell_quoted_on_macos(self):
+        probe = _ProbeMockClient("0.0.0\n", "", 0)
+        lc._get_host_openclaw_version_macos(probe.as_client(), "a;rm -rf /")
+        cmd = probe.commands[0]
+        assert cmd.startswith("sudo -n -u 'a;rm -rf /' bash -lc '")
+        assert cmd.endswith("'")
+
+
+class TestRunOpenclawVersionProbeStderr:
+    """S7 ATX iter 2: pin the 512-byte cap on `stderr_tail` so a
+    regression flipping `[-512:]` to `[:512]` or dropping the slice
+    surfaces immediately. The cap exists to bound log size when a
+    runaway openclaw binary spews stderr."""
+
+    def test_stderr_tail_capped_at_512_bytes(self):
+        long_stderr = "ABCDEFGHIJ" * 200  # 2000 bytes
+        probe = _ProbeMockClient("", long_stderr, 1)
+        _, stderr_tail = lc._get_host_openclaw_version_linux(
+            probe.as_client(), "wolf-i"
+        )
+        assert len(stderr_tail) <= 512
+        # And it's the TAIL, not the head — last 512 chars (post-strip).
+        assert stderr_tail == long_stderr[-512:].strip()
+
+
+class TestOpenclawVersionProbeShellSemantics:
+    """B4 ATX iter 2: the safelist enforcement must be verified
+    against a real bash, not mocked SSH output. The previous
+    `' || '.join(case ...)` shape passed every substring assertion
+    while only enforcing the first safelist prefix at runtime
+    because `case` always exits 0. This class runs the inner script
+    via `subprocess.run(['bash', '-c', ...])` against fixture
+    binaries to pin the actual shell semantics."""
+
+    def _make_fake_openclaw(self, path):
+        """Write a minimal executable shim that prints the canonical
+        version line + a marker echoing the resolved path so tests
+        can confirm which binary actually ran."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "#!/bin/bash\n"
+            'echo "openclaw 2026.6.8"\n'
+        )
+        path.chmod(0o755)
+
+    def _run(self, inner_script, *, path_dirs):
+        import shutil
+        import subprocess
+
+        bash = shutil.which("bash") or "/bin/bash"
+        # Restrict PATH inside the script to ONLY the test-fixture
+        # dirs so `command -v openclaw` returns the fixture we set
+        # up — never the test runner's actual openclaw if one exists.
+        # `bash` itself is invoked by absolute path so it doesn't
+        # need PATH to start.
+        env = {"PATH": ":".join(str(p) for p in path_dirs)}
+        return subprocess.run(
+            [bash, "-c", inner_script],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def test_per_agent_binary_takes_precedence_over_path(self, tmp_path):
+        agent_home = tmp_path / "agents"
+        per_agent = agent_home / "x" / ".openclaw" / "bin" / "openclaw"
+        self._make_fake_openclaw(per_agent)
+
+        # PATH points elsewhere with a DIFFERENT version string so
+        # we can tell which binary ran.
+        path_bin = tmp_path / "path-fallback"
+        path_bin.mkdir()
+        (path_bin / "openclaw").write_text(
+            "#!/bin/bash\necho 'openclaw 1.0.0'\n"
+        )
+        (path_bin / "openclaw").chmod(0o755)
+
+        script = lc._build_openclaw_version_inner_script(
+            "x", home_root=str(agent_home), path_safelist=(str(path_bin) + "/",)
+        )
+        result = self._run(script, path_dirs=[path_bin])
+        assert result.returncode == 0, result.stderr
+        assert "2026.6.8" in result.stdout
+        assert "1.0.0" not in result.stdout
+
+    def test_path_fallback_accepts_first_safelisted_prefix(self, tmp_path):
+        """Single-prefix safelist with PATH binary inside it — must accept."""
+        safelist_dir = tmp_path / "good"
+        self._make_fake_openclaw(safelist_dir / "openclaw")
+
+        script = lc._build_openclaw_version_inner_script(
+            "x",
+            home_root=str(tmp_path / "missing"),
+            path_safelist=(str(safelist_dir) + "/",),
+        )
+        result = self._run(script, path_dirs=[safelist_dir])
+        assert result.returncode == 0, result.stderr
+        assert "2026.6.8" in result.stdout
+
+    def test_path_fallback_accepts_every_safelist_prefix(self, tmp_path):
+        """B4 regression catcher: a 3-prefix safelist with the
+        binary under the *third* prefix MUST be accepted. The
+        previous `||`-chained `case` shape would short-circuit on
+        the first `case` (always exits 0) and reject the binary as
+        unsafelisted even though the third prefix covers it."""
+        prefix_a = tmp_path / "a"
+        prefix_b = tmp_path / "b"
+        prefix_c = tmp_path / "c"
+        for p in (prefix_a, prefix_b, prefix_c):
+            p.mkdir()
+        self._make_fake_openclaw(prefix_c / "openclaw")
+
+        script = lc._build_openclaw_version_inner_script(
+            "x",
+            home_root=str(tmp_path / "missing"),
+            path_safelist=(
+                str(prefix_a) + "/",
+                str(prefix_b) + "/",
+                str(prefix_c) + "/",
+            ),
+        )
+        result = self._run(script, path_dirs=[prefix_c])
+        assert result.returncode == 0, (
+            f"3rd-prefix binary was rejected — case-chain regression "
+            f"(stderr: {result.stderr!r})"
+        )
+        assert "2026.6.8" in result.stdout
+
+    def test_path_fallback_rejects_unsafelisted_prefix(self, tmp_path):
+        """Binary outside the safelist → exit 2, stderr names the path."""
+        outside_dir = tmp_path / "outside"
+        self._make_fake_openclaw(outside_dir / "openclaw")
+
+        safelist_dir = tmp_path / "safe"
+        safelist_dir.mkdir()  # exists, but binary is NOT here
+
+        script = lc._build_openclaw_version_inner_script(
+            "x",
+            home_root=str(tmp_path / "missing"),
+            path_safelist=(str(safelist_dir) + "/",),
+        )
+        result = self._run(script, path_dirs=[outside_dir])
+        assert result.returncode == 2
+        assert "unsafe path" in result.stderr
+        assert str(outside_dir / "openclaw") in result.stderr
+
+    def test_no_binary_anywhere_exits_one(self, tmp_path):
+        """No per-agent binary, nothing on PATH → exit 1."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        script = lc._build_openclaw_version_inner_script(
+            "x",
+            home_root=str(tmp_path / "missing"),
+            path_safelist=(str(empty_dir) + "/",),
+        )
+        result = self._run(script, path_dirs=[empty_dir])
+        assert result.returncode == 1
+
+    def test_zero_byte_per_agent_binary_falls_through_to_path(self, tmp_path):
+        """W1 ATX iter 1: a 0-byte executable file in the per-agent
+        slot must NOT be used. With `[ -x ] && [ -s ]` the gate
+        fails (size==0) and we fall through to the PATH fallback,
+        which here finds a valid binary."""
+        agent_home = tmp_path / "agents"
+        per_agent = agent_home / "x" / ".openclaw" / "bin" / "openclaw"
+        per_agent.parent.mkdir(parents=True)
+        per_agent.touch()  # zero bytes
+        per_agent.chmod(0o755)
+
+        path_dir = tmp_path / "good"
+        self._make_fake_openclaw(path_dir / "openclaw")
+
+        script = lc._build_openclaw_version_inner_script(
+            "x",
+            home_root=str(agent_home),
+            path_safelist=(str(path_dir) + "/",),
+        )
+        result = self._run(script, path_dirs=[path_dir])
+        assert result.returncode == 0, result.stderr
+        assert "2026.6.8" in result.stdout
+
 
 class TestLoadOpenclawBravePin:
     """`_load_openclaw_brave_pin` is the single source of truth for the

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -1396,7 +1396,7 @@ class TestOpenclawBraveVersionPreflight:
         monkeypatch.setattr(
             lc,
             "_get_host_openclaw_version",
-            lambda *_a, **_kw: host_version,
+            lambda *_a, **_kw: (host_version, ""),
         )
 
     def test_below_min_version_raises(self, monkeypatch):
@@ -1404,6 +1404,17 @@ class TestOpenclawBraveVersionPreflight:
         with pytest.raises(
             CanonicalSyncError,
             match=r"openclaw on 'h' is 2026\.3\.13; brave plugin requires >= 2026\.6\.8",
+        ):
+            sync_agent_canonical("oc", restart=False, verify=False)
+
+    def test_one_below_floor_raises(self, monkeypatch):
+        """Off-by-one boundary: 2026.6.7 must be rejected. The far-below
+        case (2026.3.13) wouldn't catch a comparator regression that
+        treated the floor as `< min` instead of `<= min`. (W3 ATX iter 2)"""
+        self._setup(monkeypatch, (2026, 6, 7))
+        with pytest.raises(
+            CanonicalSyncError,
+            match=r"openclaw on 'h' is 2026\.6\.7; brave plugin requires >= 2026\.6\.8",
         ):
             sync_agent_canonical("oc", restart=False, verify=False)
 
@@ -1427,6 +1438,49 @@ class TestOpenclawBraveVersionPreflight:
             CanonicalSyncError, match=r"openclaw on 'h' is <unknown>"
         ):
             sync_agent_canonical("oc", restart=False, verify=False)
+
+    def test_unknown_version_includes_probe_stderr(self, monkeypatch):
+        """W5 ATX iter 2: when the probe returns `None`, the captured
+        stderr (sudo failure, unsafe-path rejection, etc.) is appended
+        to the error so the operator has a starting diagnostic instead
+        of a bare `<unknown>`."""
+        self._setup(monkeypatch, None)  # base wiring
+        # Override the probe to return None+a real stderr tail.
+        monkeypatch.setattr(
+            lc,
+            "_get_host_openclaw_version",
+            lambda *_a, **_kw: (None, "sudo: a password is required"),
+        )
+        with pytest.raises(
+            CanonicalSyncError,
+            match=r"stderr: sudo: a password is required",
+        ):
+            sync_agent_canonical("oc", restart=False, verify=False)
+
+    def test_macos_host_routes_to_macos_resolver(self, monkeypatch):
+        """The dispatcher must pass `os_family` from the host record
+        through to `_get_host_openclaw_version` — otherwise a Darwin
+        host falls back to the Linux variant and the macOS home-path
+        fork is dead code."""
+        self._setup(monkeypatch, (2026, 6, 8))
+        monkeypatch.setattr(
+            lc,
+            "get_agent_by_name",
+            lambda _: (
+                {"hostname": "h", "os_family": "darwin"},
+                "openclaw:oc",
+                {},
+            ),
+        )
+        captured: dict = {}
+
+        def _spy(_client, _agent_name, *, os_family, timeout=10):
+            captured["os_family"] = os_family
+            return (2026, 6, 8), ""
+
+        monkeypatch.setattr(lc, "_get_host_openclaw_version", _spy)
+        sync_agent_canonical("oc", restart=False, verify=False)
+        assert captured.get("os_family") == "darwin"
 
     def test_preflight_skipped_when_no_brave_integration(self, monkeypatch):
         """The preflight has a measurable cost (one SSH exec). When no
@@ -1468,7 +1522,7 @@ class TestOpenclawBraveVersionPreflight:
 
         def _should_not_be_called(*_a, **_kw):
             called.append(True)
-            return (2026, 5, 28)
+            return (2026, 5, 28), ""
 
         monkeypatch.setattr(
             lc, "_get_host_openclaw_version", _should_not_be_called
@@ -1522,59 +1576,207 @@ class TestParseSemverTuple:
         assert lc._parse_semver_tuple(raw) == (2026, 5, 28)
 
 
-class TestGetHostOpenclawVersion:
-    """`_get_host_openclaw_version` issues an SSH `bash -lc 'command -v
-    openclaw && openclaw --version'`. Assert the command shape and the
-    non-zero-exit -> None branch. (B3 ATX iter 1)"""
+class _ProbeMockClient:
+    """Helper that records the SSH commands issued and returns a
+    canned (stdout, stderr, exit_status) per invocation. The probe
+    issues exactly one `exec_command` per call, so a single entry is
+    enough."""
 
-    def _make_client(
-        self, stdout: str, exit_status: int
-    ) -> tuple[MagicMock, list[str]]:
-        commands: list[str] = []
+    def __init__(self, stdout: str = "", stderr: str = "", exit_status: int = 0):
+        self.commands: list[str] = []
+        self._stdout = stdout
+        self._stderr = stderr
+        self._exit_status = exit_status
+
+    def as_client(self) -> MagicMock:
         client = MagicMock()
 
         def _exec_command(cmd, **_kw):
-            commands.append(cmd)
+            self.commands.append(cmd)
             channel = MagicMock()
-            channel.recv_exit_status.return_value = exit_status
+            channel.recv_exit_status.return_value = self._exit_status
             out = MagicMock()
-            out.read.return_value = stdout.encode("utf-8")
+            out.read.return_value = self._stdout.encode("utf-8")
             out.channel = channel
-            return MagicMock(), out, MagicMock()
+            err = MagicMock()
+            err.read.return_value = self._stderr.encode("utf-8")
+            return MagicMock(), out, err
 
         client.exec_command.side_effect = _exec_command
-        return client, commands
+        return client
 
-    def test_happy_path_returns_parsed_tuple(self):
-        client, commands = self._make_client("openclaw 2026.5.28\n", 0)
-        assert lc._get_host_openclaw_version(client, "wolf-i") == (2026, 5, 28)
-        assert len(commands) == 1
-        # Login shell so PATH-resolved binaries (install.yaml's
-        # /usr/local/bin or ~/.openclaw/bin) are reachable.
-        assert " bash -lc " in commands[0]
-        assert "openclaw --version" in commands[0]
-        # User context is quoted to prevent shell injection.
-        assert "sudo -n -u wolf-i" in commands[0]
 
-    def test_nonzero_exit_returns_none(self):
-        """Binary missing → exit 127 → None. Preflight maps None to
-        a `clawctl agent install` hint."""
-        client, _ = self._make_client("openclaw: command not found\n", 127)
-        assert lc._get_host_openclaw_version(client, "wolf-i") is None
+class TestGetHostOpenclawVersionLinux:
+    """Linux variant: per-agent binary under `/home/<agent>/`, PATH
+    fallback safelist `/usr/local/bin`, `/usr/bin`, `/home/`.
+    (B1/B2 ATX iter 2 — completely forked from macOS variant.)"""
+
+    def test_command_shape_includes_linux_per_agent_path_and_safelist(self):
+        """Pin the exact shell construction so a regression that
+        dropped the per-agent branch (or the safelist check) would
+        fail the test rather than survive on generic substring
+        matches."""
+        probe = _ProbeMockClient("openclaw 2026.6.8\n", "", 0)
+        version, _ = lc._get_host_openclaw_version_linux(
+            probe.as_client(), "wolf-i"
+        )
+        assert version == (2026, 6, 8)
+        cmd = probe.commands[0]
+        # Per-agent path is Linux-rooted.
+        assert "/home/wolf-i/.openclaw/bin/openclaw" in cmd
+        # Size>0 gate (W1).
+        assert (
+            "[ -x /home/wolf-i/.openclaw/bin/openclaw ] && "
+            "[ -s /home/wolf-i/.openclaw/bin/openclaw ]" in cmd
+        )
+        # PATH fallback present.
+        assert "resolved=$(command -v openclaw" in cmd
+        # Safelist contains Linux prefixes.
+        assert "/usr/local/bin/" in cmd
+        assert "/usr/bin/" in cmd
+        assert "/home/" in cmd
+        # And NOT macOS prefixes.
+        assert "/Users/" not in cmd
+        assert "/opt/homebrew/bin/" not in cmd
+        # Login shell + sudo + agent-name quoting.
+        assert "sudo -n -u wolf-i bash -lc " in cmd
+        # Explicit exit 1 branch (binary missing / no PATH match).
+        assert "else exit 1; fi" in cmd
+
+    def test_path_fallback_safelist_reject_exits_two_with_stderr(self):
+        """If `command -v openclaw` resolves to an unsafelisted path
+        (e.g. `/tmp/openclaw`), the probe exits 2 and emits stderr
+        naming the path. This is the W2 defense-in-depth fix."""
+        probe = _ProbeMockClient(
+            "", "openclaw on PATH is at unsafe path: /tmp/openclaw\n", 2
+        )
+        version, stderr = lc._get_host_openclaw_version_linux(
+            probe.as_client(), "wolf-i"
+        )
+        assert version is None
+        assert "unsafe path: /tmp/openclaw" in stderr
+
+    def test_nonzero_exit_returns_none_with_stderr_tail(self):
+        """W5 ATX iter 2: stderr is captured and surfaced even when
+        the probe fails. Operator now sees sudo / pam errors instead
+        of an opaque `<unknown>`."""
+        probe = _ProbeMockClient(
+            "", "sudo: a password is required\n", 1
+        )
+        version, stderr = lc._get_host_openclaw_version_linux(
+            probe.as_client(), "wolf-i"
+        )
+        assert version is None
+        assert "sudo: a password is required" in stderr
 
     def test_unparseable_output_returns_none(self):
-        client, _ = self._make_client("garbage output\n", 0)
-        assert lc._get_host_openclaw_version(client, "wolf-i") is None
+        probe = _ProbeMockClient("garbage output\n", "", 0)
+        version, _ = lc._get_host_openclaw_version_linux(
+            probe.as_client(), "wolf-i"
+        )
+        assert version is None
 
     def test_agent_name_is_shell_quoted(self):
-        """Defensive: a hostile agent name (e.g. `; rm -rf` injected via
-        a misconfigured hosts.json) must not break out of the sudo
-        shell. The `shlex.quote` wrap is the safety net."""
-        client, commands = self._make_client("0.0.0\n", 0)
-        lc._get_host_openclaw_version(client, "a;rm -rf /")
-        # The injection attempt is single-quoted; it never reaches sudo
-        # as separate tokens.
-        assert "'a;rm -rf /'" in commands[0]
+        """Hostile agent name (e.g. `; rm -rf` injected via a
+        misconfigured hosts.json) must not break out of the sudo
+        shell. Both the agent-name position (`sudo -n -u`) and the
+        per-agent path (which contains `agent_name`) flow through
+        `shlex.quote` before reaching bash."""
+        probe = _ProbeMockClient("0.0.0\n", "", 0)
+        lc._get_host_openclaw_version_linux(probe.as_client(), "a;rm -rf /")
+        cmd = probe.commands[0]
+        # The agent-name position is single-quoted at the sudo level.
+        assert cmd.startswith("sudo -n -u 'a;rm -rf /' bash -lc '")
+        # The entire `bash -lc` body is single-quoted, so the `;rm`
+        # cannot escape into a top-level shell command separator —
+        # any inner single quotes are escaped by shlex.quote's
+        # standard `'\''` pattern. (Sanity check: no unescaped
+        # top-level `;` would appear after the closing wrapper quote
+        # other than as part of a balanced `'\''` sequence.)
+        assert cmd.endswith("'")
+
+
+class TestGetHostOpenclawVersionMacos:
+    """macOS (arm64) variant: per-agent binary under `/Users/<agent>/`,
+    PATH fallback safelist `/opt/homebrew/bin`, `/usr/local/bin`,
+    `/usr/bin`, `/Users/`. Completely forked from the Linux variant —
+    when macOS x86_64 support is added, dispatch should fork further
+    rather than retrofitting an arch branch into either function.
+    (B1/B2 ATX iter 2)"""
+
+    def test_command_shape_includes_macos_per_agent_path_and_safelist(self):
+        probe = _ProbeMockClient("openclaw 2026.6.8\n", "", 0)
+        version, _ = lc._get_host_openclaw_version_macos(
+            probe.as_client(), "wolf-m"
+        )
+        assert version == (2026, 6, 8)
+        cmd = probe.commands[0]
+        # Per-agent path is macOS-rooted.
+        assert "/Users/wolf-m/.openclaw/bin/openclaw" in cmd
+        # Size>0 gate (W1).
+        assert (
+            "[ -x /Users/wolf-m/.openclaw/bin/openclaw ] && "
+            "[ -s /Users/wolf-m/.openclaw/bin/openclaw ]" in cmd
+        )
+        # PATH fallback present.
+        assert "resolved=$(command -v openclaw" in cmd
+        # Safelist contains macOS prefixes (Homebrew first).
+        assert "/opt/homebrew/bin/" in cmd
+        assert "/Users/" in cmd
+        # And NOT Linux-only prefix.
+        assert "/home/" not in cmd
+
+    def test_path_fallback_safelist_reject_returns_none(self):
+        probe = _ProbeMockClient(
+            "", "openclaw on PATH is at unsafe path: /tmp/openclaw\n", 2
+        )
+        version, stderr = lc._get_host_openclaw_version_macos(
+            probe.as_client(), "wolf-m"
+        )
+        assert version is None
+        assert "unsafe path: /tmp/openclaw" in stderr
+
+    def test_per_agent_branch_uses_users_prefix(self):
+        """Regression guard: the macOS variant must NOT use `/home/`.
+        If anyone retrofits `if os_family ==` branching back into the
+        Linux variant, this assertion fails immediately."""
+        probe = _ProbeMockClient("openclaw 2026.6.8\n", "", 0)
+        lc._get_host_openclaw_version_macos(probe.as_client(), "wolf-m")
+        assert "/home/wolf-m" not in probe.commands[0]
+
+
+class TestGetHostOpenclawVersionDispatcher:
+    """The public `_get_host_openclaw_version(...)` is a thin dispatcher
+    that routes to the Linux or macOS variant based on `os_family`. The
+    dispatcher is the only place that knows about both — matches the
+    dispatcher-only-OS-fork convention (AGENTS.md)."""
+
+    def test_darwin_routes_to_macos_variant(self):
+        probe = _ProbeMockClient("openclaw 2026.6.8\n", "", 0)
+        version, _ = lc._get_host_openclaw_version(
+            probe.as_client(), "wolf-m", os_family="darwin"
+        )
+        assert version == (2026, 6, 8)
+        assert "/Users/wolf-m/.openclaw/bin/openclaw" in probe.commands[0]
+        assert "/home/" not in probe.commands[0]
+
+    def test_linux_routes_to_linux_variant(self):
+        probe = _ProbeMockClient("openclaw 2026.6.8\n", "", 0)
+        version, _ = lc._get_host_openclaw_version(
+            probe.as_client(), "wolf-i", os_family="linux"
+        )
+        assert version == (2026, 6, 8)
+        assert "/home/wolf-i/.openclaw/bin/openclaw" in probe.commands[0]
+        assert "/Users/" not in probe.commands[0]
+
+    def test_empty_os_family_defaults_to_linux(self):
+        """Older hosts.json records may pre-date os_family persistence;
+        treat missing/empty as Linux to match the install.yaml default."""
+        probe = _ProbeMockClient("openclaw 2026.6.8\n", "", 0)
+        lc._get_host_openclaw_version(
+            probe.as_client(), "wolf-i", os_family=""
+        )
+        assert "/home/wolf-i/.openclaw/bin/openclaw" in probe.commands[0]
 
 
 class TestLoadOpenclawBravePin:


### PR DESCRIPTION
## Summary

- Bumps the openclaw platform target from `2026.5.28` → `2026.6.8` across the manifest (new entries for ubuntu 22.04/24.04 x86_64 and macos arm64) and both install playbooks (Linux + macOS default `claw_version`).
- Raises the brave plugin's `min_host_version` pin from `2026.4.10` → `2026.6.8` so the preflight gate matches the new floor. **Breaking** — see CHANGELOG `### BREAKING` entry.
- Forks `_get_host_openclaw_version` into per-OS variants (Linux uses `/home/<agent>/`, macOS uses `/Users/<agent>/`) with PATH-fallback safelists matching each install playbook. Dispatcher routes by `host.os_family`. Per project guidance, macOS arm64 / macOS x86_64 are treated as distinct OS types — when x86_64 is added, dispatch should fork further rather than retrofitting an arch branch.

## Testing

- [x] `make test` — 3580 Python passed, 2 skipped (+19 new tests across iterations 2 & 3); 278 GUI passed
- [x] `make lint` — ruff + next lint clean across all iterations
- [x] B4 regression catcher: `TestOpenclawVersionProbeShellSemantics` runs the inner shell script via `subprocess.run(['bash', '-c', ...])` against fixture binaries — would have FAILED against the iter-2 case-chain implementation
- [ ] Real-host verification on `wolf-i` (openclaw) — **not yet performed**

## ATX Review Summary

**Final Review: Rating 4/5 — No blockers — Merge approved**
**Total Cost: $8.65 | Total Time: ~25 min across 3 iterations**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1, B2, B3 | All fixed in iter 2 | $3.28 | 8m 28s | leader, security-reviewer, test-coverage, lifecycle-core, platform-playbooks |
| 2 | 2/5 | B4 (new) | Fixed in iter 3 | $3.07 | 10m 7s | leader, lifecycle-core, security-reviewer, test-coverage |
| 3 | **4/5** | None | **Approved** | $2.30 | 5m 27s | leader, lifecycle-core, security-reviewer, test-coverage |

> ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `src/clawrium/core/lifecycle_canonical.py:~190` | macOS home path hardcoded as `/home/<agent>` — silently false on Darwin, falls through to PATH, reintroducing stale-binary trap. | **Fixed (iter 2)**: forked `_get_host_openclaw_version_linux` / `_get_host_openclaw_version_macos` with dispatcher; macOS variant uses `/Users/<agent>` and `/opt/homebrew/bin` safelist. |
| B2 | `tests/core/test_lifecycle_canonical.py:~1548` | New two-branch shell logic not exercised by any assertion. | **Fixed (iter 2)**: added `TestGetHostOpenclawVersionLinux`, `TestGetHostOpenclawVersionMacos`, `TestGetHostOpenclawVersionDispatcher` classes pinning literal shell construction. Hardened further in iter 3 with subprocess-against-real-bash class. |
| B3 | `CHANGELOG.md` | brave `min_host_version` 2026.4.10 → 2026.6.8 was a silent breaking change. | **Fixed (iter 2)**: added `### BREAKING` entry with exact error message and recovery command; added `### Changed` entries; corrected stale `(>= 2026.4.10)` parenthetical. |

**Warnings:** W1 (`test -x` ≠ size>0), W2 (PATH safelist gap), W3 (missing 2026.6.7 boundary test), W4 (no `### Changed` for default bump), W5 (no stderr capture) — all fixed in iter 2.

**Suggestions:** S1 (sha256 pins — deferred, pre-existing pattern), S2 (upstream brave `minHostVersion` verification — operator confirmation pending), S3 (username validator — out-of-band).

</details>

<details>
<summary>Review 2 Details (Rating 2/5)</summary>

**B1/B2/B3 confirmed resolved.** W1/W3/W4 resolved; W5 partial (truncation untested); **W2 introduced a new blocker**:

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B4 | `src/clawrium/core/lifecycle_canonical.py:185-188` | `' || '.join(case … esac)` short-circuits on the first case because bash `case` always exits 0. Only the FIRST safelist prefix was enforced — `/usr/bin/openclaw` rejected on Linux, Intel-Mac `/usr/local/bin/openclaw` rejected on macOS. **Verified empirically in bash by lifecycle-core.** | **Fixed (iter 3)**: collapsed into single `case "$resolved" in p1*|p2*|p3*) ok=1 ;; esac`. Added subprocess test class (`TestOpenclawVersionProbeShellSemantics`) running real bash against fixture binaries — test case #3 (binary under 3rd prefix) is the regression catcher. |

**New warnings raised in iter 2:** W6 (stderr control-char sanitization), W7 (per-agent home tightening), W8 (`bash -lc` profile sourcing), W9 (safelist accept branch not differentiable in mock).

**Suggestions taken in iter 3:** S4 (lowercase `os_family` in dispatcher), S6 (mirror shell-injection test on macOS), S7 (512-byte stderr cap test).

</details>

<details>
<summary>Review 3 Details (Rating 4/5) — Final</summary>

**B4 confirmed resolved.** All specialists verified the single `case` with `|` alternation evaluates every prefix; bash semantics validated empirically. The subprocess regression catcher (test #3) confirmed to fail against iter-2 code.

**Deferred items reasonably scoped out:**

| # | Status | Justification |
|---|--------|---------------|
| W6 (stderr sanitization) | Deferred | Per security-reviewer: not a fresh vulnerability — requires already owning the agent user. Track as separate issue. |
| W7 (per-agent home tighten) | Deferred | Per-agent explicit `[ -x ]` fires first; broad `/home/*` only applies in PATH fallback, which requires PATH control as the agent user. |
| W8 (bash -lc → bash -c) | Deferred | Profile-sourcing mirrors upstream Ansible convention; hijacking ~/.bashrc requires write access as the agent user — defense-in-depth only. |
| S1 (sha256 pins) | Deferred | Pre-existing pattern; not regressed. |
| S2 (upstream brave verification) | **Pending operator confirmation** | Before merge, confirm the upstream brave plugin actually raised `minHostVersion` to 2026.6.8. |
| S3/S5 (agent_name validator) | Deferred | Out-of-band. |

**New warnings raised in iter 3 (non-blocking):**

| # | Domain | Location | Recommendation |
|---|--------|----------|----------------|
| W1 (iter 3) | lifecycle-core | `lifecycle_canonical.py:294` | S4 `.lower()` fixes this consumer but other consumers (`playbook_resolver`, `lifecycle.py:581`, `render_diff.py`, CLI agent commands) still do strict equality. **Highest-priority follow-up** — track as separate issue: normalize `os_family` at the persistence boundary. |
| W2 (iter 3) | security | `lifecycle_canonical.py:193` | `shlex.quote()` on hardcoded prefixes is harmless today but would break case-pattern semantics if a future prefix contained whitespace/quotes. |
| W3 (iter 3) | security | `lifecycle_canonical.py:197` | `command -v` doesn't canonicalize; `..` segments could bypass safelist. Real-world exploitability nil (requires PATH control as agent user). |
| W4 (iter 3) | test-coverage | `test_lifecycle_canonical.py` | Add near-miss prefix test (without trailing slash) to pin the boundary invariant. |
| W5 (iter 3) | test-coverage | `test_lifecycle_canonical.py` | 512-cap is post-decode (chars not bytes); add multibyte case for accuracy. |
| W6 (iter 3) | test-coverage | `lifecycle_canonical.py:_build_openclaw_version_inner_script` | Empty `path_safelist` produces bash syntax error; add `assert path_safelist`. |

**Verdict from leader: Merge recommendation: approved.**

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)