### PR TITLE
feat(workspace): #760 Phase 1 — openclaw workspace overlay end-to-end on Ubuntu

### DIFF
--- a/.itx/760/01_EXECUTION.md
+++ b/.itx/760/01_EXECUTION.md
@@ -455,3 +455,53 @@ openclaw — the simplest agent — so the cross-cutting contracts get
 stress-tested on `wolf-i` before zeroclaw's bearer-rotation invariant
 and hermes' exclude semantics are layered on top. No subtask issues
 created; no labels touched; no execution started.
+
+## Prompt Log
+
+**Stage**: scaffolding (re-invocation — workflow completion)
+**Skill**: /itx:plan-scaffold
+**Timestamp**: 2026-06-20T18:45:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx:plan-scaffold 760
+```
+
+**Output**: Existing scaffold (committed in #766) re-used as-is. Posted
+scaffold summary as comment on #760
+([comment-4760561028](https://github.com/ric03uec/clawrium/issues/760#issuecomment-4760561028)),
+added `ready` label, and created three subtask issues linked as
+sub-issues of #760:
+
+- #767 — Phase 1: openclaw workspace overlay end-to-end on Ubuntu
+- #768 — Phase 2: zeroclaw workspace overlay end-to-end on Ubuntu
+- #769 — Phase 3: hermes workspace overlay end-to-end on Ubuntu
+- #770 — Phase 4: openclaw workspace overlay end-to-end on macOS (deferred)
+- #771 — Phase 5: zeroclaw workspace overlay end-to-end on macOS (deferred)
+- #772 — Phase 6: hermes workspace overlay end-to-end on macOS (deferred)
+
+macOS Phases 4–6 filed as deferred tracking issues per user request
+(will be closed if `mac-test` capacity does not materialize).
+
+## Execute (orchestrate)
+
+**Stage**: execution (orchestrate mode)
+**Skill**: /itx:execute
+**Timestamp**: 2026-06-20T18:55:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx:execute 760 orchestrate all the ubuntu tasks. run in worktrees and tell subtasks to use atx cli for reviews. go
+```
+
+**Output**: Orchestrator session `clawrium-issue-760` (tmux) spawning
+Ubuntu subtasks (#767 → #768 → #769) in stacked-PR layout. macOS
+subtasks (#770–#772) intentionally skipped — out of orchestrate scope.
+
+- Worktrees: `~/workspace/ric03uec/clawrium-issue-<N>/`
+- Branches: `issue-<N>-<agent>-workspace-overlay`
+- PR base chain: #767 → main, #768 → issue-767-…, #769 → issue-768-…
+- Children directed to use ATX **via CLI** (not MCP) per user
+  directive — `atx review` invoked from inside each worktree.
+- Polling cadence: 10 min (per memory `orchestrate_auto_advance`).
+- Orchestrator does not touch source, does not merge, does not block.

--- a/.itx/767/02_EXECUTE.md
+++ b/.itx/767/02_EXECUTE.md
@@ -1,0 +1,123 @@
+# Issue #767 — Phase 1: openclaw workspace overlay end-to-end on Ubuntu
+
+Execution log for subtask #767 of parent #760. Drives the shared
+foundation (workspace_sync module, manifest loader, CLI flags, install
+scaffold) alongside the openclaw-specific manifest entry and Ansible
+playbook.
+
+Source plan: [`../760/00_PLAN.md`](../760/00_PLAN.md). Execution
+scaffold: [`../760/01_EXECUTION.md`](../760/01_EXECUTION.md).
+
+## What landed
+
+**Code:**
+
+- `src/clawrium/core/workspace_sync.py` — NEW. Enumerator + stager +
+  push_workspace_phase helper. No paramiko, no OS literals; OS seam is
+  `core/playbook_resolver.py`. Secret-pattern files (`*.key`, `*.pem`,
+  `*.env`, `.env`, `*credentials*`, `*secret*`, `*token*`,
+  `*password*`) floor to mode 0600. NDJSON state field is the frozen
+  enum `{queued, pushed, excluded, skipped, failed, complete}`. All
+  operator-controlled strings pass through
+  `cli/output/_sanitize.py:sanitize_passthrough` before emission (W4
+  iter-1, W3 iter-3).
+- `src/clawrium/core/registry.py` — typed `WorkspaceOverlayConfig`
+  TypedDict added to `FeaturesConfig`; `_validate_workspace_overlay`
+  handles missing / null-excludes / trailing-slash / malformed entries
+  (U31 iter-2).
+- `src/clawrium/core/lifecycle_canonical.py` —
+  `CanonicalSyncResult` carries `workspace_files_pushed` /
+  `workspace_files_excluded`. `sync_agent_canonical` gained
+  `push_workspace`, `workspace_only`, `dry_run` kwargs. Phase order
+  matches §1.4: workspace push lands between canonical write loop and
+  restart; workspace failure short-circuits before restart (W2 iter-1,
+  I8). `--workspace-only` short-circuits before render and intentionally
+  does NOT transition state (W5 iter-3).
+- `src/clawrium/core/lifecycle.py:configure_agent` — workspace push
+  fires after the configure playbook succeeds and `update_host`
+  commits, so non-CLI callers (install retries, GUI integration,
+  programmatic flows) inherit the overlay through this layer
+  (W3 iter-3). Workspace failure here logs a warning rather than
+  failing the configure (canonical configure already succeeded; next
+  sync will surface the workspace error with full diagnostics).
+- `src/clawrium/core/install.py` — opportunistic local workspace dir
+  scaffold under
+  `~/.config/clawrium/agents/<type>/<name>/workspace/`. Mode 0700.
+  Idempotent on pre-existing scaffolds (U18). Non-fatal on failure.
+- `src/clawrium/cli/clawctl/agent/sync.py` —
+  - `--workspace-only` (push overlay only) and `--no-restart`
+    (canonical + overlay, no restart) added.
+  - `--workspace` is a HARD ERROR (BREAKING) routed through
+    `emit_error` with exit code 2 (U32, W6 iter-2).
+  - `--workspace-only --diff` mutex (I7).
+  - Phase pre-emission updated to skip restart/verify when
+    `--workspace-only` or `--no-restart`.
+- `src/clawrium/cli/clawctl/agent/__init__.py` — short-help string
+  updated to mention workspace overlay (W10 iter-2).
+- `src/clawrium/platform/registry/openclaw/manifest.yaml` —
+  `features.workspace_overlay.destination_root: ~/.openclaw/workspace`,
+  empty excludes.
+- `src/clawrium/platform/registry/openclaw/playbooks/workspace.yaml`
+  — NEW. `become_user: {{ agent_name }}`. Asserts agent_name slug,
+  workspace_dest_root starts with `/home/{{ agent_name }}/`,
+  staging_dir under clawrium staging tree, each `item.rel` is a safe
+  relative path. NEVER references `ansible_user_dir` (B1 iter-3).
+  `ansible.builtin.copy` with `mode: "{{ item.mode }}"`, `follow: no`.
+- `src/clawrium/platform/registry/openclaw/playbooks/workspace_macos.yaml`
+  — NEW stub. Single Ansible `fail:` task; macOS support deferred to
+  follow-up subtasks (#760 #4–#6) (W9 iter-3 — single error surface).
+
+**Docs:**
+
+- `AGENTS.md` — new **Workspace Overlay (issue #760)** section
+  documents the manifest contract, per-type destinations,
+  Ansible-only architecture, secret-pattern floor, and trust boundary.
+- `CHANGELOG.md` — `### BREAKING` entry for `--workspace` removal and
+  `### Added` entry for the workspace overlay feature (W1 iter-3 hook
+  reminder: BREAKING lands in THIS PR, not deferred).
+
+**Tests (47 new pass; 3712 total green):**
+
+- `tests/test_workspace_sync.py` — 30 unit tests covering openclaw
+  subset of plan §3.1 (U2/U4/U6/U7/U9/U10/U12/U13/U14/U15/U19/U20/U21/
+  U22/U23/U24/U35).
+- `tests/test_manifest_workspace_overlay.py` — 11 tests covering U31
+  iter-2 (parser edge cases), U2/U4 (openclaw pins).
+- `tests/cli/clawctl/test_workspace_bidi_safety.py` — bidi
+  spoofing regression (W3 iter-3). Centralised sanitiser already
+  exists at `cli/output/_sanitize.py:sanitize_passthrough`.
+- `tests/cli/clawctl/agent/test_sync_workspace_flags.py` — CLI
+  contract: `--workspace` hard error (U32), mutex (I7),
+  `--workspace-only` short-circuits (I4), workspace-phase failure
+  exits non-zero (S-cli-ux iter-3 hook).
+- `tests/cli/clawctl/agent/test_sync.py` — updated two existing tests
+  to match the renamed flag (`--workspace` → `--no-restart`) and the
+  new `sync_agent_canonical` kwargs.
+
+## Out of scope for this subtask (deferred to siblings under #760)
+
+- **zeroclaw vertical (Phase 2)** — bearer-rotation invariant on top
+  of the shared foundation. The `workspace_only` short-circuit in
+  `sync_agent_canonical` carries a `NOTE(zeroclaw bearer rotation)`
+  comment marking where Phase 2 wires the unconditional
+  `_zeroclaw_repair_after_start` call. Openclaw has no bearer to
+  rotate.
+- **hermes vertical (Phase 3)** — hermes manifest entry + workspace
+  playbook + the full exclude list (`config.yaml`, `.env`,
+  `auth.json`, `state.db*`, `sessions/`, `logs/`, `skills/clawrium/`).
+  U3 / U33 / I3 / I14 land with that subtask.
+- **macOS verticals (Phases 4–6)** — the `workspace_macos.yaml` stub
+  here makes the dispatcher contract live; the stubs are replaced as
+  each macOS subtask lands.
+- **E2E on wolf-i** — captured in
+  `.itx/760/02_E2E_openclaw_wolf-i.md`; this PR ships the unit +
+  integration coverage. Real-host E2E is a separate run.
+
+## Lint + tests
+
+- `make lint-py` → All checks passed!
+- `make test-py` → 3712 passed, 2 skipped.
+
+## ATX iteration log
+
+See `atx-session.json` in this directory.

--- a/.itx/767/atx-session.json
+++ b/.itx/767/atx-session.json
@@ -1,32 +1,27 @@
 {
   "transport": "cli",
-  "session_id": "atx-review-request-iter-1",
-  "commit_sha": "fad7274a842f5b371520ecac69d1c9063291f8e3",
-  "iteration": 1,
-  "last_rating": null,
+  "session_id": "atx-review-request-iter-2",
+  "commit_sha": "527e167",
+  "iteration": 2,
+  "last_rating": "2/5",
   "last_blockers": [
     {
-      "id": "B1",
-      "domain": "cli-ux",
-      "location": "cli/clawctl/agent/sync.py",
-      "issue": "--workspace-only / --no-restart mutex not enforced",
-      "status": "fixing"
+      "id": "B1-NEW",
+      "domain": "lifecycle-core/cli-ux",
+      "location": "lifecycle_canonical.py workspace_only path + sync.py",
+      "issue": "workspace_only failure returned CanonicalSyncResult(success=False) → CLI fell through to exit 0",
+      "status": "fixed: raise CanonicalSyncError, symmetric with in-loop path; added canonical-level test"
     },
     {
-      "id": "B2",
-      "domain": "test-coverage",
-      "location": "lifecycle_canonical.py phase 3 short-circuit",
-      "issue": "Plan I8 unimplemented: no test asserts workspace failure -> _restart_unit NOT called",
-      "status": "fixing"
-    },
-    {
-      "id": "B3",
-      "domain": "test-coverage",
-      "location": "lifecycle_canonical.py",
-      "issue": "Phase ordering [push_workspace, restart, verify] not pinned by call-order assertion",
-      "status": "fixing"
+      "id": "B2-NEW",
+      "domain": "cli-ux/security",
+      "location": "sync.py help text + runtime gate",
+      "issue": "--workspace-only / --no-restart claimed zeroclaw bearer rotation that isn't wired in Phase 1",
+      "status": "fixed: gate both flags away from zeroclaw with exit 2; help text updated; paired test added"
     }
   ],
+  "iter_1_blockers": ["B1 (mutex)", "B2 (I8 short-circuit test)", "B3 (phase order pin)"],
+  "iter_1_resolutions": "all fixed in commit 527e167",
   "started_at": "2026-06-20T00:00:00Z",
-  "updated_at": "2026-06-20T00:00:00Z"
+  "updated_at": "2026-06-20T19:30:00Z"
 }

--- a/.itx/767/atx-session.json
+++ b/.itx/767/atx-session.json
@@ -1,27 +1,36 @@
 {
   "transport": "cli",
-  "session_id": "atx-review-request-iter-2",
-  "commit_sha": "527e167",
-  "iteration": 2,
-  "last_rating": "2/5",
-  "last_blockers": [
-    {
-      "id": "B1-NEW",
-      "domain": "lifecycle-core/cli-ux",
-      "location": "lifecycle_canonical.py workspace_only path + sync.py",
-      "issue": "workspace_only failure returned CanonicalSyncResult(success=False) → CLI fell through to exit 0",
-      "status": "fixed: raise CanonicalSyncError, symmetric with in-loop path; added canonical-level test"
-    },
-    {
-      "id": "B2-NEW",
-      "domain": "cli-ux/security",
-      "location": "sync.py help text + runtime gate",
-      "issue": "--workspace-only / --no-restart claimed zeroclaw bearer rotation that isn't wired in Phase 1",
-      "status": "fixed: gate both flags away from zeroclaw with exit 2; help text updated; paired test added"
-    }
+  "session_id": "atx-review-request-iter-3",
+  "commit_sha": "dd9dd2e",
+  "iteration": 3,
+  "last_rating": "4/5",
+  "iter_1_blockers": [
+    "B1: --workspace-only / --no-restart mutex (fixed in 527e167)",
+    "B2: I8 short-circuit test (fixed in 527e167)",
+    "B3: phase-order pin test (fixed in 527e167)"
   ],
-  "iter_1_blockers": ["B1 (mutex)", "B2 (I8 short-circuit test)", "B3 (phase order pin)"],
-  "iter_1_resolutions": "all fixed in commit 527e167",
+  "iter_2_blockers": [
+    "B1-NEW: workspace_only failure returned success=False (fixed in dd9dd2e)",
+    "B2-NEW: --workspace-only/--no-restart claimed zeroclaw bearer rotation (fixed in dd9dd2e: gated)"
+  ],
+  "iter_3_blockers": [],
+  "iter_3_verdict": "Clear to merge. Composite 4/5. test-coverage 3/5, cli-ux 4/5, lifecycle-core 4/5, platform-playbooks 4/5, security 4/5.",
+  "iter_3_warnings_addressed_inline": [
+    "W4: parametrized the zeroclaw-gate loop test",
+    "W6: hoisted safe_resolve_agent above the gate; removed bare except",
+    "S5: pinned agent_name in CanonicalSyncError match regex"
+  ],
+  "iter_3_warnings_deferred_as_callouts": [
+    "W1: configure_agent asymmetric failure handling (log warning vs raise) — track in follow-up",
+    "W2: defense-in-depth zeroclaw guard in sync_agent_canonical — Phase 2 lands the wiring + removes the guard",
+    "W3: TOCTOU on stage-time symlink re-check — low-risk, document",
+    "W5: ws_result.error not bidi-sanitized at every emit site — file standalone sec issue",
+    "W7: workspace.yaml additive-only semantics undocumented — quick docs follow-up",
+    "S1: 0o7777 mask preserves setuid/setgid/sticky — narrow to 0o777",
+    "S2: destination_root validation moved to Python layer",
+    "S3: dead returns after emit_error",
+    "S4: gateway_token_rotated yellow notice helper"
+  ],
   "started_at": "2026-06-20T00:00:00Z",
-  "updated_at": "2026-06-20T19:30:00Z"
+  "updated_at": "2026-06-20T19:40:00Z"
 }

--- a/.itx/767/atx-session.json
+++ b/.itx/767/atx-session.json
@@ -1,0 +1,32 @@
+{
+  "transport": "cli",
+  "session_id": "atx-review-request-iter-1",
+  "commit_sha": "fad7274a842f5b371520ecac69d1c9063291f8e3",
+  "iteration": 1,
+  "last_rating": null,
+  "last_blockers": [
+    {
+      "id": "B1",
+      "domain": "cli-ux",
+      "location": "cli/clawctl/agent/sync.py",
+      "issue": "--workspace-only / --no-restart mutex not enforced",
+      "status": "fixing"
+    },
+    {
+      "id": "B2",
+      "domain": "test-coverage",
+      "location": "lifecycle_canonical.py phase 3 short-circuit",
+      "issue": "Plan I8 unimplemented: no test asserts workspace failure -> _restart_unit NOT called",
+      "status": "fixing"
+    },
+    {
+      "id": "B3",
+      "domain": "test-coverage",
+      "location": "lifecycle_canonical.py",
+      "issue": "Phase ordering [push_workspace, restart, verify] not pinned by call-order assertion",
+      "status": "fixing"
+    }
+  ],
+  "started_at": "2026-06-20T00:00:00Z",
+  "updated_at": "2026-06-20T00:00:00Z"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,70 @@ The hermes dashboard binds `127.0.0.1:<port>` only (`features.web_ui.bind: loopb
 
 **No `default_port` in bundled manifests.** Hermes, zeroclaw, and openclaw manifests all omit `features.web_ui.default_port`. install.py always persists a per-instance port at `port_field`; a manifest-wide default would silently collide on hosts running multiple agents of the same type. The resolver surfaces a missing persisted port as "no UI available" rather than inventing one. Third-party manifests may still opt into `default_port` — the schema accepts it.
 
+## Workspace Overlay (issue #760)
+
+Operator-supplied files dropped under
+`~/.config/clawrium/agents/<type>/<name>/workspace/` are mirrored onto
+the agent host at the manifest-declared destination root on every
+`clawctl agent sync` and `clawctl agent configure`. The shared push
+helper is `src/clawrium/core/workspace_sync.py:push_workspace_phase`;
+both `lifecycle_canonical.sync_agent_canonical` and
+`lifecycle.configure_agent` call it.
+
+Manifest contract — per-agent `manifest.yaml`:
+
+```yaml
+features:
+  workspace_overlay:
+    destination_root: "<absolute path under agent's home>"
+    excludes:                  # optional, relative-path strings
+      - <relpath>              # exact-file match
+      - <relpath>/             # trailing slash = dir-prefix match
+```
+
+Per-type destinations (Ubuntu, this iteration):
+
+| Agent | `destination_root` | Notes |
+|---|---|---|
+| openclaw | `~/.openclaw/workspace` | No excludes — workspace zone is operator-owned |
+| zeroclaw | _Phase 2 (#760 subtask 2)_ | |
+| hermes   | _Phase 3 (#760 subtask 3)_ | Renderer-output paths excluded |
+
+CLI flags on `clawctl agent sync`:
+
+- `--workspace-only` — push the overlay alone, skip canonical render /
+  restart / verify. Mutually exclusive with `--diff`. For zeroclaw the
+  bearer rotation still runs (lands in Phase 2).
+- `--no-restart` — canonical + overlay, skip restart. Bearer rotation
+  still runs for zeroclaw.
+- `--workspace` — **removed** (BREAKING). Exits 2 with a hint to the
+  two replacements above. No automated migration.
+
+Host-write path is **Ansible only** — per-agent
+`playbooks/workspace.yaml` (Linux) and `playbooks/workspace_macos.yaml`
+(stub until Phases 4–6). The Python side stages files into a managed
+`tempfile.TemporaryDirectory` under
+`${clawrium_config}/staging/workspace/<name>/` and passes the file
+list as the `workspace_files` extravar; ansible-runner reads the
+staged copies, never the operator's original path. Symlinks are
+rejected at enumeration (`os.path.islink`); `follow: no` on the
+`ansible.builtin.copy` task is belt-and-suspenders. The playbook
+asserts the rendered destination starts with `/home/{{ agent_name }}/`
+and NEVER references `ansible_user_dir` (B1 iter-3: `become_user`
+does not re-run `setup`, so the fact would resolve to the SSH user,
+not the agent user).
+
+Secret-pattern files (`*.key`, `*.pem`, `*.env`, `.env`,
+`*credentials*`, `*secret*`, `*token*`, `*password*`) get `mode: '0600'`
+regardless of local perms. Operator-controlled strings in NDJSON
+event payloads (`path`, `remote_path`, `reason`) are passed through
+`cli/output/_sanitize.py:sanitize_passthrough` so bidi/zero-width
+codepoints cannot spoof terminal output.
+
+Workspace-phase failure short-circuits before restart — the daemon is
+never restarted on a half-applied overlay. The failure surfaces as
+`CanonicalSyncError` → CLI `emit_error` → `typer.Exit(code=1)`.
+
 ## Tech Stack
 
 - **CLI**: Python + Typer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ cut. The `itx:release` skill archives this section into a new
 
 ### BREAKING
 
+- **`clawctl agent sync --workspace` is removed.** Use `--no-restart`
+  for canonical render + workspace overlay without a unit restart, or
+  `--workspace-only` to push the operator overlay alone. There is no
+  automated migration — operators must update any scripts or CI that
+  pass `--workspace`. The deprecated flag now exits 2 with the
+  replacement guidance on stderr; in `-o json` mode it produces a
+  parseable error object on stderr and zero stdout bytes. Issue #760.
 - **openclaw brave plugin now requires openclaw `>= 2026.6.8`** (previously
   `>= 2026.4.10`). Any host running openclaw in the `2026.4.10..2026.6.7`
   range with the brave integration attached will hit a hard
@@ -25,6 +32,27 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Added
 
+- **Workspace overlay sync (openclaw, Ubuntu).** Files dropped under
+  `~/.config/clawrium/agents/openclaw/<name>/workspace/` are now
+  mirrored onto the agent host at `~/.openclaw/workspace/` on every
+  `clawctl agent sync` and `clawctl agent configure`. Two new sync
+  flags: `--workspace-only` pushes the overlay alone (skips canonical
+  render / restart / verify) and `--no-restart` runs canonical +
+  overlay without flapping the unit. The per-agent manifest declares
+  its overlay shape via `features.workspace_overlay.destination_root`
+  (manifest-driven so third-party manifests can opt in) plus an
+  optional `excludes` list. The architecture is Ansible-only: a new
+  per-agent `playbooks/workspace.yaml` is the single host-write path;
+  Python `core/workspace_sync.py` is a thin enumerator/stager that
+  filters symlinks, applies manifest excludes, and floors
+  secret-pattern files (`*.key`, `*.pem`, `*.env`, `*credentials*`,
+  `*secret*`, `*token*`, `*password*`) to mode 0600 regardless of
+  local perms. Bidi/zero-width codepoints in operator-controlled
+  paths are stripped at the NDJSON / text emission boundary so a
+  hostile workspace filename cannot spoof terminal output. macOS
+  support is deferred to follow-up subtasks under #760 (the
+  `workspace_macos.yaml` stub returns a clean Ansible
+  `fail:` for now). Closes Phase 1 of #760 (openclaw on Ubuntu).
 - New `brave` integration type for the Brave Search API. Register once
   with `clawctl integration registry create my-brave --type brave
   --api-key <key>` (or pipe the key via `--api-key-stdin`), attach to

--- a/src/clawrium/cli/clawctl/agent/__init__.py
+++ b/src/clawrium/cli/clawctl/agent/__init__.py
@@ -65,9 +65,10 @@ agent_app.command(name="configure", help="Configure an agent (per stage).")(
 agent_app.command(name="start", help="Start an agent.")(_start.start)
 agent_app.command(name="stop", help="Stop an agent.")(_stop.stop)
 agent_app.command(name="restart", help="Restart an agent.")(_restart.restart)
-agent_app.command(name="sync", help="Flush local control-plane state to the agent.")(
-    _sync.sync
-)
+agent_app.command(
+    name="sync",
+    help="Sync local control-plane state and workspace overlay to the agent.",
+)(_sync.sync)
 agent_app.command(
     name="upgrade",
     help="Upgrade an agent to the manifest's max supported version.",

--- a/src/clawrium/cli/clawctl/agent/sync.py
+++ b/src/clawrium/cli/clawctl/agent/sync.py
@@ -308,33 +308,36 @@ def sync(
     # daemon restart, with `clawctl agent chat` returning 401 and no
     # diagnostic. Block with a clear error rather than ship the
     # footgun.
-    if workspace_only or no_restart:
-        # Type lookup is deferred until after the mutex checks so a
-        # mistyped flag combination fails on the flag wiring first
-        # rather than on the agent-record lookup.
-        try:
-            _host_lookup, _agent_type_lookup, _claw_record_lookup = (
-                safe_resolve_agent(name)
-            )
-            _resolved_type = _claw_record_lookup.get("type", _agent_type_lookup)
-        except Exception:
-            _resolved_type = None
-        if _resolved_type == "zeroclaw":
-            chosen = "--workspace-only" if workspace_only else "--no-restart"
-            emit_error(
-                f"{chosen} is not supported for zeroclaw agents in this "
-                f"release (#760 Phase 1). Bearer rotation wiring lands "
-                f"in Phase 2 (#760); until then, running {chosen} on a "
-                f"zeroclaw agent would leave the stored gateway bearer "
-                f"stale on the next daemon restart. Use `clawctl agent "
-                f"sync {name}` without the flag.",
-                exit_code=2,
-            )
-            return
     # Bug #516: see configure.py for full rationale.
+    # ATX iter-3 W6: hoisted above the zeroclaw gate so resolver
+    # exceptions surface with their normal messages and the gate uses
+    # the same lookup result as the rest of the function (no double
+    # call, no silent bypass on transient lookup failure).
     host, _agent_type, claw_record = safe_resolve_agent(name)
     agent_key = resolve_agent_key(host, name)
     agent_type = claw_record.get("type", _agent_type)
+
+    if (workspace_only or no_restart) and agent_type == "zeroclaw":
+        # ATX iter-2 B2-NEW: Both flags skip the restart branch where
+        # the canonical pipeline currently rotates the zeroclaw gateway
+        # bearer. Phase 2 wires `_zeroclaw_repair_after_start` into the
+        # workspace-only and no-restart paths unconditionally per
+        # AGENTS.md "Gateway Token Lifecycle (zeroclaw)" — until then,
+        # allowing these flags for zeroclaw leaves
+        # `hosts.json.gateway.auth` stale on the next daemon restart,
+        # with `clawctl agent chat` returning 401 and no diagnostic.
+        # Block with a clear error rather than ship the footgun.
+        chosen = "--workspace-only" if workspace_only else "--no-restart"
+        emit_error(
+            f"{chosen} is not supported for zeroclaw agents in this "
+            f"release (#760 Phase 1). Bearer rotation wiring lands "
+            f"in Phase 2 (#760); until then, running {chosen} on a "
+            f"zeroclaw agent would leave the stored gateway bearer "
+            f"stale on the next daemon restart. Use `clawctl agent "
+            f"sync {name}` without the flag.",
+            exit_code=2,
+        )
+        return
 
     # F8 (parent #555): `--diff` implies `--dry-run`. Promote here so
     # the phase-emission and short-circuit logic below sees the

--- a/src/clawrium/cli/clawctl/agent/sync.py
+++ b/src/clawrium/cli/clawctl/agent/sync.py
@@ -279,6 +279,20 @@ def sync(
             exit_code=2,
         )
         return
+
+    # ATX iter-1 B1: `--workspace-only` already implies skip-restart;
+    # passing `--no-restart` alongside is ambiguous (no-restart preserves
+    # the canonical render phase, workspace-only skips it). Reject
+    # explicitly rather than silently collapse to workspace-only.
+    if workspace_only and no_restart:
+        emit_error(
+            "--workspace-only and --no-restart are mutually exclusive. "
+            "--workspace-only already skips restart and verify; use it "
+            "alone for overlay-only behavior, or use --no-restart for "
+            "canonical+overlay-no-restart.",
+            exit_code=2,
+        )
+        return
     # Bug #516: see configure.py for full rationale.
     host, _agent_type, claw_record = safe_resolve_agent(name)
     agent_key = resolve_agent_key(host, name)

--- a/src/clawrium/cli/clawctl/agent/sync.py
+++ b/src/clawrium/cli/clawctl/agent/sync.py
@@ -20,7 +20,9 @@ numbered phase line so the user-visible sequence stays at 4 steps.
 Flags:
 - `--timeout 120` — 2-minute default; advisory (canonical pipeline
   does not honor a timeout parameter today).
-- `--workspace` — workspace files only, no restart.
+- `--workspace-only` — workspace overlay only, no canonical render/restart.
+- `--no-restart` — canonical render + workspace overlay, no restart.
+- `--workspace` — removed (issue #760); exits 2 with a hint.
 - `--dry-run` — validate + show intent, no push.
 - `--diff` — (F8, parent #555) host-vs-rendered unified diff per file.
   Implies `--dry-run`. Reads on-host files via SSH so you can verify
@@ -203,8 +205,31 @@ def _emit_diff_error(
 
 def sync(
     name: str = typer.Argument(..., help="Agent name."),
-    workspace: bool = typer.Option(
-        False, "--workspace", help="Workspace files only; no restart."
+    workspace_only: bool = typer.Option(
+        False,
+        "--workspace-only",
+        help=(
+            "Push workspace overlay only (rotates zeroclaw bearer). "
+            "Skips canonical render, restart, verify. "
+            "Mutually exclusive with --diff."
+        ),
+    ),
+    no_restart: bool = typer.Option(
+        False,
+        "--no-restart",
+        help=(
+            "Canonical render + workspace overlay; skip restart and verify. "
+            "Still rotates zeroclaw bearer."
+        ),
+    ),
+    workspace_deprecated: bool = typer.Option(
+        False,
+        "--workspace",
+        hidden=True,
+        help=(
+            "[REMOVED] Use --no-restart for canonical+overlay-no-restart, "
+            "or --workspace-only for overlay-only."
+        ),
     ),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Validate + show intent; no push."
@@ -227,7 +252,33 @@ def sync(
         OutputFormat.table, "--output", "-o", help="Output format (table or json)."
     ),
 ) -> None:
-    """Flush local control-plane state to the agent (drift-to-zero)."""
+    """Flush local control-plane state and workspace overlay to the agent."""
+    # Issue #760 W6 iter-2 / W2 iter-3: `--workspace` is a HARD ERROR,
+    # not a deprecation alias. The flag prints both candidate
+    # replacements and exits 2 immediately. Routed through emit_error
+    # so JSON mode produces zero stdout bytes and one parseable error
+    # object on stderr (U32).
+    if workspace_deprecated:
+        emit_error(
+            "the --workspace flag was removed. "
+            "Use --no-restart for canonical+overlay-no-restart, "
+            "or --workspace-only for overlay-only.",
+            exit_code=2,
+        )
+        return
+
+    # Issue #760 §1.3 mutex rejection: --workspace-only --diff is
+    # ambiguous (workspace-only pushes a fresh overlay; diff is
+    # rendered-vs-host for the canonical pipeline). Reject explicitly
+    # (I7).
+    if workspace_only and diff:
+        emit_error(
+            "--workspace-only and --diff are mutually exclusive. "
+            "Use --workspace-only --dry-run for a non-mutating overlay "
+            "preview.",
+            exit_code=2,
+        )
+        return
     # Bug #516: see configure.py for full rationale.
     host, _agent_type, claw_record = safe_resolve_agent(name)
     agent_key = resolve_agent_key(host, name)
@@ -270,7 +321,12 @@ def sync(
     for key, label in zip(phase_keys, _PHASES):
         if key == "validate" and skip_validate:
             continue
-        if key == "restart" and workspace:
+        if key == "restart" and (no_restart or workspace_only):
+            continue
+        if key in ("validate", "push") and workspace_only:
+            # `--workspace-only` short-circuits before canonical render.
+            continue
+        if key == "verify" and (no_restart or workspace_only):
             continue
         # ATX iter-1 W3: in dry-run mode every phase short-circuits
         # before the canonical pipeline runs (the early return at the
@@ -376,14 +432,24 @@ def sync(
         canonical_result = sync_agent_canonical(
             on_host_name,
             force=False,
-            restart=not workspace,
-            verify=not workspace,
+            restart=not (no_restart or workspace_only),
+            verify=not (no_restart or workspace_only),
+            push_workspace=True,
+            workspace_only=workspace_only,
+            dry_run=dry_run,
             on_event=canonical_event,
         )
     except SecretRemovalRefused as exc:
         emit_error(str(exc))
         return
     except (AgentConfigError, CanonicalSyncError, RemoteReadError) as exc:
+        # Issue #760 S-cli-ux: workspace-phase failures from
+        # `sync_agent_canonical` come up as CanonicalSyncError with a
+        # "workspace overlay push failed" prefix. The exception flow
+        # is unchanged — `emit_error` already calls `sys.exit(1)` /
+        # raises `typer.Exit(code=1)` internally — but the integration
+        # test pins this contract so a future refactor cannot silently
+        # downgrade workspace failures to a non-zero-but-non-1 code.
         emit_error(f"sync failed: {exc}")
         return
 

--- a/src/clawrium/cli/clawctl/agent/sync.py
+++ b/src/clawrium/cli/clawctl/agent/sync.py
@@ -209,9 +209,11 @@ def sync(
         False,
         "--workspace-only",
         help=(
-            "Push workspace overlay only (rotates zeroclaw bearer). "
+            "Push workspace overlay only. "
             "Skips canonical render, restart, verify. "
-            "Mutually exclusive with --diff."
+            "Mutually exclusive with --diff and --no-restart. "
+            "NOT supported for zeroclaw in Phase 1 of #760 — bearer "
+            "rotation wiring lands in Phase 2."
         ),
     ),
     no_restart: bool = typer.Option(
@@ -219,7 +221,8 @@ def sync(
         "--no-restart",
         help=(
             "Canonical render + workspace overlay; skip restart and verify. "
-            "Still rotates zeroclaw bearer."
+            "NOT supported for zeroclaw in Phase 1 of #760 — bearer "
+            "rotation wiring lands in Phase 2."
         ),
     ),
     workspace_deprecated: bool = typer.Option(
@@ -293,6 +296,41 @@ def sync(
             exit_code=2,
         )
         return
+
+    # ATX iter-2 B2-NEW: gate `--workspace-only` / `--no-restart` away
+    # from zeroclaw in Phase 1 of #760. Both flags skip the restart
+    # branch where the canonical pipeline currently rotates the
+    # zeroclaw gateway bearer. Phase 2 wires
+    # `_zeroclaw_repair_after_start` into the workspace-only and
+    # no-restart paths unconditionally per AGENTS.md "Gateway Token
+    # Lifecycle (zeroclaw)" — until then, allowing these flags for
+    # zeroclaw leaves `hosts.json.gateway.auth` stale on the next
+    # daemon restart, with `clawctl agent chat` returning 401 and no
+    # diagnostic. Block with a clear error rather than ship the
+    # footgun.
+    if workspace_only or no_restart:
+        # Type lookup is deferred until after the mutex checks so a
+        # mistyped flag combination fails on the flag wiring first
+        # rather than on the agent-record lookup.
+        try:
+            _host_lookup, _agent_type_lookup, _claw_record_lookup = (
+                safe_resolve_agent(name)
+            )
+            _resolved_type = _claw_record_lookup.get("type", _agent_type_lookup)
+        except Exception:
+            _resolved_type = None
+        if _resolved_type == "zeroclaw":
+            chosen = "--workspace-only" if workspace_only else "--no-restart"
+            emit_error(
+                f"{chosen} is not supported for zeroclaw agents in this "
+                f"release (#760 Phase 1). Bearer rotation wiring lands "
+                f"in Phase 2 (#760); until then, running {chosen} on a "
+                f"zeroclaw agent would leave the stored gateway bearer "
+                f"stale on the next daemon restart. Use `clawctl agent "
+                f"sync {name}` without the flag.",
+                exit_code=2,
+            )
+            return
     # Bug #516: see configure.py for full rationale.
     host, _agent_type, claw_record = safe_resolve_agent(name)
     agent_key = resolve_agent_key(host, name)

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -935,6 +935,37 @@ def run_installation(
         }
     }
 
+    # Issue #760: scaffold the local control-plane workspace slot for
+    # agent types whose manifest declares `features.workspace_overlay`.
+    # The directory is created with 0700 perms so the staging copies of
+    # operator-supplied files (which may include `*.env`, `*.key`,
+    # `*credentials*` etc.) are not group/world readable on the control
+    # machine. Idempotent: re-running install over an existing scaffold
+    # leaves user-dropped files and any custom mode bits untouched
+    # (B5 iter-1, U18).
+    try:
+        from clawrium.core.workspace_sync import WorkspaceOverlaySpec
+
+        overlay_spec = WorkspaceOverlaySpec.from_manifest(claw_name)
+        if overlay_spec is not None:
+            from clawrium.core.config import get_config_dir as _gcd
+
+            local_ws = (
+                _gcd() / "agents" / claw_name / agent_name / "workspace"
+            )
+            if not local_ws.exists():
+                local_ws.mkdir(parents=True, exist_ok=True, mode=0o700)
+                logger.info("Scaffolded local workspace at %s", local_ws)
+    except Exception as ws_exc:
+        # Non-fatal — workspace scaffold is opportunistic. Operator can
+        # mkdir the dir themselves; the playbook will still pick up
+        # files dropped in via the next sync.
+        logger.warning(
+            "Could not scaffold local workspace for %s: %s",
+            agent_name,
+            ws_exc,
+        )
+
     # Step 7: Setup persistent logs directory
     logs_dir = _get_logs_dir()
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -2950,6 +2950,44 @@ def configure_agent(
                 )
                 emit("configure", f"Stored ETHOS_CHAT_TOKEN for {agent_key}")
 
+        # Issue #760 W3 iter-3: push operator workspace overlay
+        # alongside the configure flow so non-CLI callers (install
+        # retries, GUI integration, programmatic flows) inherit the
+        # overlay through this layer. The CLI shim does NOT call
+        # push_workspace_phase separately on the configure path.
+        #
+        # Failure here is logged but does not fail the configure call —
+        # the canonical configure already succeeded and the operator's
+        # next `clawctl agent sync` will surface the workspace error
+        # with full diagnostics. Crashing the configure on overlay
+        # failure would leave hosts.json updated with no recovery hook.
+        try:
+            from clawrium.core.workspace_sync import push_workspace_phase
+
+            def _ws_event_str(stage: str, payload: dict) -> None:
+                import json as _json
+
+                emit(stage, _json.dumps(payload))
+
+            ws_result = push_workspace_phase(
+                host=host,
+                agent_type=resolved_type,
+                agent_name=agent_key,
+                on_event=_ws_event_str if on_event is not None else None,
+            )
+            if not ws_result.success:
+                emit(
+                    "configure",
+                    f"warning: workspace overlay push failed: "
+                    f"{ws_result.error}",
+                )
+        except Exception as ws_exc:
+            logger.warning(
+                "workspace overlay push raised during configure_agent: %s",
+                ws_exc,
+                exc_info=True,
+            )
+
         emit("configure", f"Successfully configured {agent_key}")
         return True, None
 

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -325,6 +325,12 @@ class CanonicalSyncResult:
     files_unchanged: tuple[str, ...]
     diffs: tuple[FileDiff, ...]
     error: str | None = None
+    # Issue #760: per-sync workspace overlay phase counters. Always
+    # populated (empty tuples when the agent type has no
+    # `features.workspace_overlay` block, or in failure paths that
+    # short-circuit before the phase runs).
+    workspace_files_pushed: tuple[str, ...] = ()
+    workspace_files_excluded: tuple[str, ...] = ()
 
 
 def _extract_secret_keys(body: str) -> set[str]:
@@ -716,6 +722,9 @@ def sync_agent_canonical(
     force: bool = False,
     restart: bool = True,
     verify: bool = True,
+    push_workspace: bool = True,
+    workspace_only: bool = False,
+    dry_run: bool = False,
     on_event: Callable[[str, str], None] | None = None,
 ) -> CanonicalSyncResult:
     """Sync `agent_name` via the canonical pipeline.
@@ -754,9 +763,6 @@ def sync_agent_canonical(
             f"no canonical renderer for agent type {inputs.agent_type!r}"
         )
 
-    emit("render", f"rendering canonical config for {inputs.agent_type}")
-    rendered = renderer(inputs)
-
     resolved = get_agent_by_name(agent_name)
     if resolved is None:
         raise CanonicalSyncError(
@@ -764,6 +770,71 @@ def sync_agent_canonical(
         )
     host, agent_key, _claw_record = resolved
     hostname = host.get("hostname", "")
+
+    # Issue #760 §1.4 `--workspace-only` short-circuit. Skip canonical
+    # render / diff / write / restart / verify entirely; push the
+    # operator overlay and (for zeroclaw, in later phases) rotate the
+    # bearer. State transition is intentionally NOT executed
+    # (W5 iter-3): workspace-only preserves the current lifecycle
+    # position so an operator may overlay onto a STOPPED agent without
+    # silently flipping it to READY.
+    if workspace_only:
+        from clawrium.core.workspace_sync import push_workspace_phase
+
+        def _ws_event(stage: str, payload: dict) -> None:
+            if on_event is None:
+                return
+            import json as _json
+
+            on_event(stage, _json.dumps(payload))
+
+        ws_result = push_workspace_phase(
+            host=host,
+            agent_type=inputs.agent_type,
+            agent_name=agent_name,
+            on_event=_ws_event,
+            dry_run=dry_run,
+        )
+        if not ws_result.success:
+            return CanonicalSyncResult(
+                success=False,
+                agent=agent_name,
+                host=hostname,
+                files_written=(),
+                files_unchanged=(),
+                diffs=(),
+                error=ws_result.error,
+                workspace_files_pushed=ws_result.files_pushed,
+                workspace_files_excluded=ws_result.files_excluded,
+            )
+        # NOTE(zeroclaw bearer rotation): the plan §1.4 contract
+        # requires phase 6a (`_zeroclaw_repair_after_start`) to run
+        # unconditionally for zeroclaw across all three sync modes,
+        # including `--workspace-only`. Wiring that here is part of the
+        # zeroclaw vertical slice (parent #760 Phase 2 — issue
+        # filed as the second subtask). Openclaw (this Phase 1 subtask)
+        # has no bearer rotation so the workspace-only path is complete
+        # for openclaw without it.
+        emit(
+            "sync",
+            f"workspace-only sync of {agent_name}: "
+            f"{len(ws_result.files_pushed)} pushed, "
+            f"{len(ws_result.files_excluded)} excluded",
+        )
+        return CanonicalSyncResult(
+            success=True,
+            agent=agent_name,
+            host=hostname,
+            files_written=(),
+            files_unchanged=(),
+            diffs=(),
+            error=None,
+            workspace_files_pushed=ws_result.files_pushed,
+            workspace_files_excluded=ws_result.files_excluded,
+        )
+
+    emit("render", f"rendering canonical config for {inputs.agent_type}")
+    rendered = renderer(inputs)
 
     emit("diff", f"reading on-host files from {hostname}")
     diffs = diff_files(
@@ -856,6 +927,41 @@ def sync_agent_canonical(
                 body=d.rendered_body,
             )
             files_written.append(d.path)
+
+        # Issue #760 §1.4 phase 3: push operator workspace overlay.
+        # Runs between the canonical write loop and restart so the
+        # daemon picks up both canonical config drift AND operator
+        # overlay drift in a single restart. Failure here MUST
+        # short-circuit before restart (W2 iter-1, I8 frozen-enum
+        # payload check) — restarting on a half-applied overlay is the
+        # regression class iter-2 protected.
+        workspace_files_pushed_t: tuple[str, ...] = ()
+        workspace_files_excluded_t: tuple[str, ...] = ()
+        if push_workspace:
+            from clawrium.core.workspace_sync import push_workspace_phase
+
+            def _ws_event(stage: str, payload: dict) -> None:
+                if on_event is None:
+                    return
+                import json as _json
+
+                on_event(stage, _json.dumps(payload))
+
+            ws_result = push_workspace_phase(
+                host=host,
+                agent_type=inputs.agent_type,
+                agent_name=agent_name,
+                on_event=_ws_event,
+                dry_run=dry_run,
+            )
+            workspace_files_pushed_t = ws_result.files_pushed
+            workspace_files_excluded_t = ws_result.files_excluded
+            if not ws_result.success:
+                raise CanonicalSyncError(
+                    f"workspace overlay push failed for {agent_name!r}: "
+                    f"{ws_result.error}. Skipping restart to avoid "
+                    f"flapping the unit on a half-applied overlay."
+                )
 
         # Restart policy:
         #
@@ -1009,4 +1115,6 @@ def sync_agent_canonical(
         files_unchanged=tuple(files_unchanged),
         diffs=tuple(diffs),
         error=transition_error,
+        workspace_files_pushed=workspace_files_pushed_t,
+        workspace_files_excluded=workspace_files_excluded_t,
     )

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -796,16 +796,15 @@ def sync_agent_canonical(
             dry_run=dry_run,
         )
         if not ws_result.success:
-            return CanonicalSyncResult(
-                success=False,
-                agent=agent_name,
-                host=hostname,
-                files_written=(),
-                files_unchanged=(),
-                diffs=(),
-                error=ws_result.error,
-                workspace_files_pushed=ws_result.files_pushed,
-                workspace_files_excluded=ws_result.files_excluded,
+            # ATX iter-2 B1-NEW: raise rather than return
+            # `CanonicalSyncResult(success=False)`. The CLI only catches
+            # raised exceptions — returning a falsy result falls through
+            # to `synced (drift=0)` with exit 0, violating the AGENTS.md
+            # short-circuit contract. Symmetric with the in-loop path
+            # below.
+            raise CanonicalSyncError(
+                f"workspace overlay push failed for {agent_name!r}: "
+                f"{ws_result.error}"
             )
         # NOTE(zeroclaw bearer rotation): the plan §1.4 contract
         # requires phase 6a (`_zeroclaw_repair_after_start`) to run

--- a/src/clawrium/core/registry.py
+++ b/src/clawrium/core/registry.py
@@ -161,12 +161,39 @@ class WebUIFeatureConfig(TypedDict):
     port_field: str
 
 
+class WorkspaceOverlayConfig(TypedDict):
+    """Operator-overlay descriptor for `features.workspace_overlay`.
+
+    `destination_root` is the absolute path on the agent host (under the
+    agent's home dir) where files from the local
+    `~/.config/clawrium/agents/<type>/<name>/workspace/` slot are mirrored
+    on every `clawctl agent sync`. The leading `~` is expanded against
+    the agent's home (`/home/<agent_name>` on Linux). The Python
+    enumerator and Ansible playbook agree on this expansion via the
+    `workspace_dest_root` extravar; the playbook asserts the rendered
+    path begins with `/home/{{ agent_name }}/` and never references
+    `ansible_user_dir` (B1 iter-3).
+
+    `excludes` is a list of relative-path strings interpreted with two
+    shapes (W10):
+      * No trailing slash → exact file match (`config.yaml` excludes
+        only the workspace-root `config.yaml`, never a nested
+        `profiles/x/config.yaml`).
+      * Trailing slash → directory prefix (`sessions/` excludes every
+        descendant of `sessions/`).
+    """
+
+    destination_root: str
+    excludes: NotRequired[list[str]]
+
+
 class FeaturesConfig(TypedDict):
     """Capability flags advertised by an agent manifest."""
 
     memory: NotRequired[bool]
     chat: NotRequired[ChatFeatureConfig]
     web_ui: NotRequired[WebUIFeatureConfig]
+    workspace_overlay: NotRequired[WorkspaceOverlayConfig]
 
 
 class AgentManifest(TypedDict):
@@ -641,6 +668,74 @@ def _validate_features(features_value: object, agent_type: str) -> FeaturesConfi
 
     if "web_ui" in features:
         validated["web_ui"] = _validate_web_ui(features["web_ui"], agent_type)
+
+    if "workspace_overlay" in features:
+        validated["workspace_overlay"] = _validate_workspace_overlay(
+            features["workspace_overlay"], agent_type
+        )
+
+    return validated
+
+
+def _validate_workspace_overlay(
+    overlay_value: object, agent_type: str
+) -> WorkspaceOverlayConfig:
+    """Validate `features.workspace_overlay` block.
+
+    Required: `destination_root` (non-empty string, absolute or `~`-rooted).
+    Optional: `excludes` (list of strings). `null` is normalized to `[]`.
+    Trailing-slash entries are dir-prefix; bare entries are exact-file.
+    """
+    overlay = _as_dict(overlay_value, "features.workspace_overlay", agent_type)
+    dest = overlay.get("destination_root")
+    if not isinstance(dest, str) or not dest.strip():
+        _raise_parse_error(
+            agent_type,
+            "has invalid `features.workspace_overlay.destination_root` "
+            "(expected non-empty string)",
+        )
+    dest = dest.strip()
+    if not (dest.startswith("/") or dest.startswith("~")):
+        _raise_parse_error(
+            agent_type,
+            "has invalid `features.workspace_overlay.destination_root` "
+            f"(expected absolute path or `~`-rooted, got {dest!r})",
+        )
+
+    validated: WorkspaceOverlayConfig = {"destination_root": dest}
+
+    if "excludes" in overlay:
+        raw_excludes = overlay["excludes"]
+        if raw_excludes is None:
+            validated["excludes"] = []
+        elif isinstance(raw_excludes, list):
+            cleaned: list[str] = []
+            for entry in raw_excludes:
+                if not isinstance(entry, str) or not entry.strip():
+                    _raise_parse_error(
+                        agent_type,
+                        "has invalid entry in "
+                        "`features.workspace_overlay.excludes` "
+                        "(expected non-empty string)",
+                    )
+                stripped = entry.strip()
+                if stripped.startswith("/") or ".." in stripped.split("/"):
+                    _raise_parse_error(
+                        agent_type,
+                        "has invalid entry in "
+                        "`features.workspace_overlay.excludes` "
+                        f"(must be a workspace-relative path, got {stripped!r})",
+                    )
+                cleaned.append(stripped)
+            validated["excludes"] = cleaned
+        else:
+            _raise_parse_error(
+                agent_type,
+                "has invalid `features.workspace_overlay.excludes` "
+                "(expected list or null)",
+            )
+    else:
+        validated["excludes"] = []
 
     return validated
 

--- a/src/clawrium/core/workspace_sync.py
+++ b/src/clawrium/core/workspace_sync.py
@@ -1,0 +1,665 @@
+"""Operator-overlay workspace sync (issue #760).
+
+Mirrors files dropped under
+`~/.config/clawrium/agents/<type>/<name>/workspace/` onto the agent
+host at the manifest-declared `features.workspace_overlay.destination_root`.
+
+Architecture (plan §1.5):
+
+- Python side enumerates the local workspace, applies manifest excludes,
+  filters symlinks + `.clawrium-*` dotfiles, stages an exact byte-copy
+  into a managed `tempfile.TemporaryDirectory`, and hands an extravar
+  payload off to ansible-runner.
+- The per-type `playbooks/workspace.yaml` is the single host-write
+  channel. No paramiko, no SFTP, no OS-family branch in this file —
+  `core.playbook_resolver` is the OS seam.
+- Bidi/control codepoints are stripped from every operator-controlled
+  string at the NDJSON / text emission boundary via
+  `cli.output._sanitize.sanitize_passthrough` (W4 iter-1).
+- Secret-pattern files get a 0600 mode floor regardless of local mode
+  (W13 iter-1). Pattern matching is case-insensitive (S4 iter-3).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import os
+import shutil
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from clawrium.cli.output._sanitize import sanitize_passthrough
+from clawrium.core.config import get_config_dir
+from clawrium.core.names import validate_agent_name
+from clawrium.core.playbook_resolver import resolve_agent_playbook
+from clawrium.core.registry import load_manifest
+
+logger = logging.getLogger(__name__)
+
+
+# Closed enum for NDJSON `state` field (W3 iter-1). Any new state value
+# requires a corresponding test update (U24).
+WORKSPACE_STATE_QUEUED = "queued"
+WORKSPACE_STATE_PUSHED = "pushed"
+WORKSPACE_STATE_EXCLUDED = "excluded"
+WORKSPACE_STATE_SKIPPED = "skipped"
+WORKSPACE_STATE_FAILED = "failed"
+WORKSPACE_STATE_COMPLETE = "complete"
+
+WORKSPACE_STATES: frozenset[str] = frozenset(
+    {
+        WORKSPACE_STATE_QUEUED,
+        WORKSPACE_STATE_PUSHED,
+        WORKSPACE_STATE_EXCLUDED,
+        WORKSPACE_STATE_SKIPPED,
+        WORKSPACE_STATE_FAILED,
+        WORKSPACE_STATE_COMPLETE,
+    }
+)
+
+
+# Secret-pattern globs (W13 iter-1). Case-insensitive matching (S4 iter-3).
+_SECRET_PATTERNS: tuple[str, ...] = (
+    "*.key",
+    "*.pem",
+    "*.env",
+    ".env",
+    "*credentials*",
+    "*secret*",
+    "*token*",
+    "*password*",
+)
+
+
+# Reserved prefix for future clawrium control-plane state inside the
+# workspace slot. Always skipped at enumeration (U7).
+_RESERVED_PREFIX = ".clawrium-"
+
+
+class WorkspaceSyncError(Exception):
+    """Any failure in the workspace overlay pipeline."""
+
+
+@dataclass(frozen=True)
+class WorkspaceOverlaySpec:
+    """Typed view of `features.workspace_overlay` from a loaded manifest.
+
+    `destination_root` is the absolute path on the agent host (under the
+    agent's home dir) where workspace files land. `~`-rooted manifests
+    are expanded against `/home/<agent_name>` at push time.
+
+    `excludes_files` are exact-path (relative) entries; `excludes_dirs`
+    are directory prefixes (originally trailing-slash entries in the
+    manifest, stored without the slash here).
+    """
+
+    destination_root: str
+    excludes_files: frozenset[str] = field(default_factory=frozenset)
+    excludes_dirs: tuple[str, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_manifest(cls, agent_type: str) -> "WorkspaceOverlaySpec | None":
+        """Build a spec from the bundled manifest, or return None if the
+        agent has no `features.workspace_overlay` block.
+        """
+        manifest = load_manifest(agent_type)
+        features = manifest.get("features") or {}
+        overlay = features.get("workspace_overlay")
+        if overlay is None:
+            return None
+
+        dest = overlay["destination_root"]
+        excludes = list(overlay.get("excludes") or [])
+
+        files: set[str] = set()
+        dirs: list[str] = []
+        for entry in excludes:
+            if entry.endswith("/"):
+                dirs.append(entry.rstrip("/"))
+            else:
+                files.add(entry)
+
+        return cls(
+            destination_root=dest,
+            excludes_files=frozenset(files),
+            excludes_dirs=tuple(dirs),
+        )
+
+
+@dataclass(frozen=True)
+class WorkspaceFileEntry:
+    """One enumerated workspace file ready for staging."""
+
+    rel: str
+    local_path: Path
+    mode: str  # octal string, e.g. "0644"
+    owner: str
+    group: str
+
+    def to_extravar(self, staged_path: str) -> dict[str, str]:
+        return {
+            "rel": self.rel,
+            "src": staged_path,
+            "mode": self.mode,
+            "owner": self.owner,
+            "group": self.group,
+        }
+
+
+@dataclass(frozen=True)
+class WorkspacePhaseResult:
+    """Outcome of one push_workspace_phase invocation."""
+
+    success: bool
+    files_pushed: tuple[str, ...]
+    files_excluded: tuple[str, ...]
+    files_skipped: tuple[str, ...] = ()
+    error: str | None = None
+
+
+def _local_workspace_root(agent_type: str, agent_name: str) -> Path:
+    """Return the local control-plane workspace slot for an agent.
+
+    Layout:
+        <get_config_dir()>/agents/<type>/<name>/workspace/
+
+    The dir may not exist; callers must treat a missing dir as
+    "empty workspace, no-op" (U15).
+    """
+    return (
+        get_config_dir()
+        / "agents"
+        / agent_type
+        / agent_name
+        / "workspace"
+    )
+
+
+def _is_secret_pattern(rel: str) -> bool:
+    """Return True if the workspace file matches a secret-pattern glob.
+
+    Match against the lowercased basename so `MyAPI.KEY` and `.ENV`
+    trigger the 0600 floor (S4 iter-3, U35).
+    """
+    basename = os.path.basename(rel).lower()
+    return any(fnmatch.fnmatch(basename, p) for p in _SECRET_PATTERNS)
+
+
+def _floor_mode_for(rel: str, local_mode: int) -> str:
+    """Return the octal mode string honoring the secret-pattern floor.
+
+    Secret-pattern files get exactly 0600. Other files keep their local
+    mode bits (rwx for user/group/other) with executability preserved.
+    """
+    if _is_secret_pattern(rel):
+        return "0600"
+    # Mask to the permission bits only (0o7777 covers setuid/setgid/sticky
+    # in addition to rwx, which we deliberately preserve here).
+    return f"0{local_mode & 0o7777:o}"
+
+
+def enumerate_workspace_files(
+    workspace_root: Path,
+    spec: WorkspaceOverlaySpec,
+    *,
+    agent_name: str,
+    on_event: Callable[[str, dict[str, Any]], None] | None = None,
+) -> tuple[list[WorkspaceFileEntry], list[str], list[str]]:
+    """Walk `workspace_root` and return enumerated entries + skip/excl lists.
+
+    Returns a 3-tuple `(entries, excluded_paths, skipped_paths)`:
+        - `entries`: in deterministic sorted order, one per file to push.
+        - `excluded_paths`: rels matched by the manifest exclude set.
+        - `skipped_paths`: rels skipped for safety reasons (symlinks,
+          `.clawrium-*` reserved dotfiles).
+
+    The function does NOT touch the host. It does enforce:
+        * symlink rejection at enumeration (U6, W18 iter-2 first line)
+        * path traversal rejection (U8)
+        * relative-path preservation (U9)
+        * `.clawrium-*` skip (U7)
+    """
+    entries: list[WorkspaceFileEntry] = []
+    excluded: list[str] = []
+    skipped: list[str] = []
+
+    if not workspace_root.exists():
+        return entries, excluded, skipped
+
+    # `Path.walk` would be cleaner but is Python 3.12+; the repo targets
+    # Python 3.11 (see pyproject.toml). Use `os.walk` for broader compat.
+    workspace_root_resolved = workspace_root.resolve()
+
+    for dirpath, dirnames, filenames in os.walk(workspace_root, followlinks=False):
+        # Stable enumeration order — same input → same payload.
+        dirnames.sort()
+        filenames.sort()
+
+        for fname in filenames:
+            abs_path = Path(dirpath) / fname
+            try:
+                rel = str(abs_path.relative_to(workspace_root))
+            except ValueError:
+                # Should be impossible under os.walk(workspace_root), but
+                # guard so a future change to the walk loop cannot bypass
+                # the containment invariant.
+                skipped.append(fname)
+                _emit_skip(
+                    on_event, fname, reason="outside_workspace_root"
+                )
+                continue
+
+            # POSIX-style separators in the manifest exclude payload and
+            # the playbook extravar.
+            rel = rel.replace(os.sep, "/")
+
+            if abs_path.is_symlink():
+                skipped.append(rel)
+                _emit_skip(on_event, rel, reason="symlink")
+                continue
+
+            if any(
+                part.startswith(_RESERVED_PREFIX)
+                for part in rel.split("/")
+            ):
+                skipped.append(rel)
+                _emit_skip(on_event, rel, reason="reserved_dotfile")
+                continue
+
+            # Path-traversal containment check (U8). `Path.resolve()`
+            # follows symlinks on intermediate dirs; combine with the
+            # symlink-leaf check above to keep the workspace sealed.
+            try:
+                resolved = abs_path.resolve(strict=True)
+            except (FileNotFoundError, OSError):
+                skipped.append(rel)
+                _emit_skip(on_event, rel, reason="unreadable")
+                continue
+            try:
+                resolved.relative_to(workspace_root_resolved)
+            except ValueError:
+                skipped.append(rel)
+                _emit_skip(on_event, rel, reason="path_traversal")
+                continue
+
+            if _is_excluded(rel, spec):
+                excluded.append(rel)
+                _emit_excluded(on_event, rel, agent_type_excl=True)
+                continue
+
+            try:
+                stat = abs_path.stat()
+            except OSError:
+                skipped.append(rel)
+                _emit_skip(on_event, rel, reason="stat_failed")
+                continue
+
+            mode = _floor_mode_for(rel, stat.st_mode)
+            entries.append(
+                WorkspaceFileEntry(
+                    rel=rel,
+                    local_path=abs_path,
+                    mode=mode,
+                    owner=agent_name,
+                    group=agent_name,
+                )
+            )
+
+    return entries, excluded, skipped
+
+
+def _is_excluded(rel: str, spec: WorkspaceOverlaySpec) -> bool:
+    """Apply manifest exclude semantics (W10).
+
+    File entries match exactly. Directory entries (originally
+    trailing-slash) match every descendant.
+    """
+    if rel in spec.excludes_files:
+        return True
+    for d in spec.excludes_dirs:
+        prefix = d.rstrip("/") + "/"
+        if rel == d or rel.startswith(prefix):
+            return True
+    return False
+
+
+def _emit_excluded(
+    on_event: Callable[[str, dict[str, Any]], None] | None,
+    rel: str,
+    *,
+    agent_type_excl: bool,
+) -> None:
+    if on_event is None:
+        return
+    on_event(
+        "push_workspace",
+        {
+            "state": WORKSPACE_STATE_EXCLUDED,
+            "path": sanitize_passthrough(rel),
+            "reason": "manifest_exclude",
+        },
+    )
+
+
+def _emit_skip(
+    on_event: Callable[[str, dict[str, Any]], None] | None,
+    rel: str,
+    *,
+    reason: str,
+) -> None:
+    if on_event is None:
+        return
+    on_event(
+        "push_workspace",
+        {
+            "state": WORKSPACE_STATE_SKIPPED,
+            "path": sanitize_passthrough(rel),
+            "reason": reason,
+        },
+    )
+
+
+def _expand_destination_root(spec: WorkspaceOverlaySpec, agent_name: str) -> str:
+    """Expand `~` in `destination_root` to `/home/<agent_name>`.
+
+    The Ansible playbook re-asserts the result begins with
+    `/home/<agent_name>/`. We do the expansion Python-side too so the
+    extravar payload is unambiguous and the playbook assert sees the
+    final rendered string (B1 iter-3 backstop).
+    """
+    dest = spec.destination_root
+    if dest.startswith("~/"):
+        dest = f"/home/{agent_name}/" + dest[2:]
+    elif dest == "~":
+        dest = f"/home/{agent_name}"
+    return dest
+
+
+def _build_inventory(host: dict, ssh_key_path: str) -> dict:
+    """Build the ansible-runner inventory dict for the workspace playbook.
+
+    Mirrors the shape used by `core/lifecycle.py:configure_agent` so the
+    same host conventions apply (ServerAlive tuning, become timeout).
+    """
+    return {
+        "all": {
+            "hosts": {
+                host["hostname"]: {
+                    "ansible_host": host["hostname"],
+                    "ansible_user": host.get("user", "xclm"),
+                    "ansible_port": host.get("port", 22),
+                    "ansible_ssh_private_key_file": ssh_key_path,
+                    "ansible_become_timeout": 120,
+                    "ansible_pipelining": True,
+                    "ansible_ssh_extra_args": (
+                        "-o ServerAliveInterval=30 "
+                        "-o ServerAliveCountMax=10 -o ConnectTimeout=60"
+                    ),
+                }
+            },
+        }
+    }
+
+
+def _stage_files(
+    entries: list[WorkspaceFileEntry], staging_dir: Path
+) -> list[dict[str, str]]:
+    """Copy each enumerated file into `staging_dir` with `shutil.copy2`.
+
+    Returns the extravar payload list (one dict per file) the playbook
+    consumes via `workspace_files`. `shutil.copy2` preserves mode bits
+    so the playbook's `mode: "{{ item.mode }}"` matches the staged
+    file's perms (S3 iter-3).
+    """
+    payload: list[dict[str, str]] = []
+    for entry in entries:
+        staged_path = staging_dir / entry.rel
+        staged_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(entry.local_path, staged_path)
+        # Re-apply the floored mode on the staged copy so a 0600
+        # secret-pattern file is not group/world readable inside the
+        # staging dir while ansible-runner is still reading it.
+        os.chmod(staged_path, int(entry.mode, 8))
+        payload.append(entry.to_extravar(str(staged_path)))
+    return payload
+
+
+def push_workspace_phase(
+    *,
+    host: dict,
+    agent_type: str,
+    agent_name: str,
+    on_event: Callable[[str, dict[str, Any]], None] | None = None,
+    dry_run: bool = False,
+) -> WorkspacePhaseResult:
+    """Push the operator workspace overlay for one agent.
+
+    The shared helper called by both `core/lifecycle_canonical.py`
+    (`sync_agent_canonical`) and `core/lifecycle.py:configure_agent`
+    so the two surface paths cannot drift (W9 iter-1, U27).
+
+    Args:
+        host: hosts.json host record (provides hostname, user, ssh key).
+        agent_type: registry agent type (e.g. "openclaw").
+        agent_name: unix user / agent instance name on host.
+        on_event: optional `(phase, payload_dict)` callback for NDJSON.
+        dry_run: when True, the workspace playbook runs in ansible-runner
+            check mode (`--check`); no host writes occur (I6).
+
+    Returns a `WorkspacePhaseResult`. A `False` `success` carries the
+    failure message in `.error`; callers (sync / configure) decide
+    whether to short-circuit downstream phases (W2 iter-1: workspace
+    failure does not advance to restart).
+    """
+    valid, msg = validate_agent_name(agent_name)
+    if not valid:
+        return WorkspacePhaseResult(
+            success=False,
+            files_pushed=(),
+            files_excluded=(),
+            error=f"agent name rejected: {msg}",
+        )
+
+    spec = WorkspaceOverlaySpec.from_manifest(agent_type)
+    if spec is None:
+        # Agent has no overlay feature declared — silent no-op.
+        return WorkspacePhaseResult(
+            success=True, files_pushed=(), files_excluded=()
+        )
+
+    workspace_root = _local_workspace_root(agent_type, agent_name)
+    entries, excluded, skipped = enumerate_workspace_files(
+        workspace_root,
+        spec,
+        agent_name=agent_name,
+        on_event=on_event,
+    )
+
+    if not entries:
+        if on_event is not None:
+            on_event(
+                "push_workspace",
+                {
+                    "state": WORKSPACE_STATE_COMPLETE,
+                    "files_pushed": [],
+                    "files_excluded": [sanitize_passthrough(e) for e in excluded],
+                },
+            )
+        return WorkspacePhaseResult(
+            success=True,
+            files_pushed=(),
+            files_excluded=tuple(excluded),
+            files_skipped=tuple(skipped),
+        )
+
+    # `ssh_key_path` is loaded lazily so the no-op path above doesn't
+    # require host key state to be initialized.
+    from clawrium.core.keys import get_host_private_key
+
+    key_id = host.get("key_id") or host.get("hostname")
+    ssh_key = get_host_private_key(key_id) if key_id else None
+    if ssh_key is None:
+        return WorkspacePhaseResult(
+            success=False,
+            files_pushed=(),
+            files_excluded=tuple(excluded),
+            files_skipped=tuple(skipped),
+            error=f"no SSH key registered for host {key_id!r}",
+        )
+
+    os_family = host.get("os_family", "linux")
+    try:
+        playbook_path = resolve_agent_playbook(
+            agent_type, "workspace", os_family
+        )
+    except FileNotFoundError as exc:
+        return WorkspacePhaseResult(
+            success=False,
+            files_pushed=(),
+            files_excluded=tuple(excluded),
+            files_skipped=tuple(skipped),
+            error=str(exc),
+        )
+
+    workspace_dest_root = _expand_destination_root(spec, agent_name)
+
+    # Stage under `${clawrium_config}/staging/workspace/<name>/` so the
+    # playbook's defense-in-depth substring check ('/clawrium/staging/
+    # workspace/' in staging_dir) passes. Managed by
+    # `tempfile.TemporaryDirectory` so the dir is cleaned up on every
+    # exit path including ansible-runner crashes (W16 iter-2, U29/U30).
+    staging_root = get_config_dir() / "staging" / "workspace"
+    staging_root.mkdir(parents=True, exist_ok=True)
+
+    import ansible_runner  # Local import keeps module import-cheap.
+
+    success = True
+    error: str | None = None
+    private_data_dir_path: Path | None = None
+
+    with tempfile.TemporaryDirectory(
+        prefix=f"{agent_name}-", dir=str(staging_root)
+    ) as staging_dir_str:
+        staging_dir = Path(staging_dir_str)
+        payload = _stage_files(entries, staging_dir)
+
+        # Emit per-file queued events so NDJSON consumers see the intent
+        # before ansible-runner begins.
+        if on_event is not None:
+            for entry in entries:
+                on_event(
+                    "push_workspace",
+                    {
+                        "state": WORKSPACE_STATE_QUEUED,
+                        "path": sanitize_passthrough(entry.rel),
+                        "remote_path": sanitize_passthrough(
+                            f"{workspace_dest_root}/{entry.rel}"
+                        ),
+                        "mode": entry.mode,
+                        "owner": entry.owner,
+                    },
+                )
+
+        inventory = _build_inventory(host, str(ssh_key))
+        # extravars carry the file list and destination root; they live
+        # at the play level (passed via `extravars=`), not host vars,
+        # so they appear under `private_data_dir/env/extravars` and are
+        # cleaned up alongside the staging dir.
+        extravars = {
+            "agent_name": agent_name,
+            "agent_type": agent_type,
+            "workspace_dest_root": workspace_dest_root,
+            "workspace_files": payload,
+            "staging_dir": str(staging_dir),
+        }
+
+        private_data_dir = tempfile.mkdtemp(
+            prefix=f"ws-{agent_name}-", dir=str(staging_root)
+        )
+        private_data_dir_path = Path(private_data_dir)
+
+        try:
+            run_result = ansible_runner.run(
+                private_data_dir=private_data_dir,
+                inventory=inventory,
+                playbook=str(playbook_path),
+                extravars=extravars,
+                envvars={
+                    "ANSIBLE_HOST_KEY_CHECKING": "False",
+                    "ANSIBLE_PIPELINING": "True",
+                },
+                cmdline="--check" if dry_run else None,
+                quiet=True,
+                timeout=300,
+            )
+
+            status = getattr(run_result, "status", None)
+            rc = getattr(run_result, "rc", None)
+            if status != "successful" or rc not in (0, None):
+                success = False
+                error = (
+                    f"workspace playbook failed for {agent_name!r} "
+                    f"(status={status}, rc={rc})"
+                )
+        except Exception as exc:  # ansible-runner raised
+            success = False
+            error = f"workspace playbook crashed: {exc}"
+        finally:
+            # CWE-312: ansible-runner caches extravars under
+            # `<private_data_dir>/env/extravars` and artifacts under
+            # `<private_data_dir>/artifacts/<uuid>/`. Wipe the whole
+            # temp dir tree so no operator path stays on disk past
+            # the sync (S7 iter-3, U30).
+            if private_data_dir_path is not None:
+                shutil.rmtree(private_data_dir_path, ignore_errors=True)
+
+    files_pushed_payload: list[str] = []
+    if success:
+        files_pushed_payload = [e.rel for e in entries]
+        if on_event is not None:
+            for entry in entries:
+                on_event(
+                    "push_workspace",
+                    {
+                        "state": WORKSPACE_STATE_PUSHED,
+                        "path": sanitize_passthrough(entry.rel),
+                        "remote_path": sanitize_passthrough(
+                            f"{workspace_dest_root}/{entry.rel}"
+                        ),
+                        "mode": entry.mode,
+                        "owner": entry.owner,
+                    },
+                )
+            on_event(
+                "push_workspace",
+                {
+                    "state": WORKSPACE_STATE_COMPLETE,
+                    "files_pushed": [
+                        sanitize_passthrough(p) for p in files_pushed_payload
+                    ],
+                    "files_excluded": [
+                        sanitize_passthrough(e) for e in excluded
+                    ],
+                },
+            )
+    else:
+        if on_event is not None:
+            on_event(
+                "push_workspace",
+                {
+                    "state": WORKSPACE_STATE_FAILED,
+                    "reason": sanitize_passthrough(error or "unknown"),
+                },
+            )
+
+    return WorkspacePhaseResult(
+        success=success,
+        files_pushed=tuple(files_pushed_payload),
+        files_excluded=tuple(excluded),
+        files_skipped=tuple(skipped),
+        error=error,
+    )

--- a/src/clawrium/platform/registry/openclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/openclaw/manifest.yaml
@@ -47,6 +47,16 @@ features:
     enabled: true
     bind: wildcard
     port_field: gateway.port
+  # Operator-owned overlay slot. Files dropped under
+  # ~/.config/clawrium/agents/openclaw/<name>/workspace/ are mirrored to
+  # `destination_root` on the agent host on every `clawctl agent sync`.
+  # Openclaw separates config (~/.openclaw/) from workspace
+  # (~/.openclaw/workspace/) per upstream — overlay writes only into the
+  # workspace zone, never into ~/.openclaw/ proper, so excludes can be
+  # empty.
+  workspace_overlay:
+    destination_root: "~/.openclaw/workspace"
+    excludes: []
 
 # Secrets configuration
 # Note: Provider-specific API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)

--- a/src/clawrium/platform/registry/openclaw/playbooks/workspace.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/workspace.yaml
@@ -1,0 +1,135 @@
+---
+# Openclaw workspace overlay — mirrors operator-supplied files from the
+# control-plane staging tree onto the agent host under
+# `workspace_dest_root` (declared in openclaw/manifest.yaml).
+#
+# Inputs (extravars):
+#   - agent_name:          unix user that owns the openclaw install
+#   - staging_dir:         control-machine path; staged copies of the
+#                          enumerated workspace files (see
+#                          core/workspace_sync.py). Files live at
+#                          `<staging_dir>/<item.rel>`.
+#   - workspace_dest_root: absolute path under the agent's home, e.g.
+#                          `/home/<agent_name>/.openclaw/workspace`.
+#                          Sourced from manifest.features.workspace_overlay
+#                          via extravar (S2 iter-2). Do NOT hardcode the
+#                          suffix here — the manifest is the single source.
+#   - workspace_files:     list of `{rel, src, mode, owner, group}` dicts;
+#                          the Python enumerator carries local mode bits
+#                          and floors secret-pattern files to 0600
+#                          (W13 iter-1, U20).
+#
+# Why no `ansible_user_dir` (B1 iter-3): `become_user` does NOT re-run
+# the `setup` module, so `ansible_user_dir` keeps the SSH-connecting
+# user's home (`/home/xclm`), not the agent user's. The literal
+# `/home/{{ agent_name }}/...` pattern matches what
+# `hermes/playbooks/skills_apply.yaml:27` uses. The assert task below
+# pins the rendered `workspace_dest_root` to that prefix.
+- hosts: all
+  become: yes
+  become_user: "{{ agent_name }}"
+  gather_facts: false
+  tasks:
+    - name: Assert agent_name matches the safe slug pattern
+      ansible.builtin.assert:
+        that:
+          - agent_name is string
+          - agent_name is match('^[a-z][a-z0-9_-]{0,31}$')
+        fail_msg: "Invalid agent_name: {{ agent_name | default('<unset>') }}"
+        quiet: true
+
+    - name: Assert workspace_dest_root is under /home/{{ agent_name }}/
+      # B1 iter-3 backstop: the manifest is the source of truth, but a
+      # tampered extravar pointing at e.g. `/etc/openclaw` must bail
+      # before any copy task runs.
+      ansible.builtin.assert:
+        that:
+          - workspace_dest_root is string
+          - workspace_dest_root | length > 0
+          - workspace_dest_root.startswith('/home/' ~ agent_name ~ '/')
+        fail_msg: >-
+          workspace_dest_root must start with `/home/{{ agent_name }}/`
+          (got '{{ workspace_dest_root | default('<unset>') }}')
+        quiet: true
+
+    - name: Assert staging_dir is a non-empty absolute path under the clawrium staging tree
+      # Defense-in-depth: the Python entry point always passes a
+      # `tempfile.TemporaryDirectory` path under
+      # `${clawrium_config}/staging/workspace/`, so a tampered inventory
+      # pointing at `/etc` or `/root` would not match the expected
+      # substring and the playbook bails before any `copy` task runs.
+      ansible.builtin.assert:
+        that:
+          - staging_dir is string
+          - staging_dir | length > 0
+          - staging_dir.startswith('/')
+          - "'/clawrium/staging/workspace/' in staging_dir"
+        fail_msg: >-
+          staging_dir must be an absolute path under
+          `${clawrium_config}/staging/workspace/` (got '{{ staging_dir }}')
+        quiet: true
+
+    - name: Assert workspace_files is a list
+      ansible.builtin.assert:
+        that:
+          - workspace_files is iterable
+          - workspace_files is not string
+          - workspace_files is not mapping
+        fail_msg: "workspace_files must be a list"
+        quiet: true
+
+    - name: Assert each workspace file entry is a relative path
+      # W12 iter-2 belt-and-suspenders: even if Python enumeration filters
+      # symlinks/traversal, this re-asserts inside the playbook so a future
+      # bypass cannot land hostile paths on host.
+      ansible.builtin.assert:
+        that:
+          - item.rel is string
+          - item.rel | length > 0
+          - not item.rel.startswith('/')
+          - "'..' not in (item.rel.split('/'))"
+        fail_msg: >-
+          workspace file entry has unsafe rel: '{{ item.rel | default('<unset>') }}'
+        quiet: true
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel | default('<unset>') }}"
+
+    - name: Ensure workspace destination root exists
+      ansible.builtin.file:
+        path: "{{ workspace_dest_root }}"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0755"
+
+    - name: Ensure parent directories exist for each workspace file
+      # The `dirname` is computed Python-side too, but doing it here keeps
+      # the playbook self-contained against a stripped extravar payload.
+      ansible.builtin.file:
+        path: "{{ workspace_dest_root }}/{{ item.rel | dirname }}"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0755"
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel }}"
+      when: item.rel | dirname | length > 0
+
+    - name: Push each workspace file onto the host
+      # `copy` writes to a tempfile in the dest dir and renames atomically.
+      # `follow: no` is the W12 iter-2 / W18 iter-2 symlink defense: even
+      # though Python enumerates with `os.path.islink` filtering and stages
+      # via `shutil.copy2` into a managed `tempfile.TemporaryDirectory`,
+      # the playbook re-asserts the no-symlink invariant at the copy boundary.
+      ansible.builtin.copy:
+        src: "{{ staging_dir }}/{{ item.rel }}"
+        dest: "{{ workspace_dest_root }}/{{ item.rel }}"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "{{ item.mode }}"
+        follow: no
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel }}"

--- a/src/clawrium/platform/registry/openclaw/playbooks/workspace_macos.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/workspace_macos.yaml
@@ -1,0 +1,13 @@
+---
+# Stub playbook — macOS workspace overlay is deferred to subtasks #4–#6
+# of parent #760. Single source of error surface: the Ansible `fail:`
+# task here. Python side does NOT short-circuit darwin (W8/W9 iter-3);
+# the dispatcher routes via `core/playbook_resolver.resolve_agent_playbook`
+# and the non-zero rc surfaces as a `WorkspaceSyncError` in
+# `core/workspace_sync.py` with this `fail.msg` propagated.
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: workspace overlay deferred to macOS subtask
+      ansible.builtin.fail:
+        msg: "workspace overlay deferred to macOS subtask"

--- a/tests/cli/clawctl/agent/test_sync.py
+++ b/tests/cli/clawctl/agent/test_sync.py
@@ -54,12 +54,24 @@ def test_sync_skip_validate_drops_phase_1(fleet_dir) -> None:
     assert "pushing config" in result.output
 
 
-def test_sync_workspace_skips_restart(fleet_dir) -> None:
+def test_sync_no_restart_skips_restart(fleet_dir) -> None:
+    """Issue #760: `--workspace` is removed; `--no-restart` replaces the
+    canonical+overlay-no-restart shape."""
     result = runner.invoke(
-        app, ["agent", "sync", "wise-hypatia", "--dry-run", "--workspace"]
+        app, ["agent", "sync", "wise-hypatia", "--dry-run", "--no-restart"]
     )
     assert result.exit_code == 0
     assert "restarting unit" not in result.output
+
+
+def test_sync_workspace_flag_is_removed_hard_error(fleet_dir) -> None:
+    """Issue #760 W6 iter-2: `--workspace` is removed (BREAKING)."""
+    result = runner.invoke(
+        app, ["agent", "sync", "wise-hypatia", "--workspace"]
+    )
+    assert result.exit_code == 2
+    assert "--workspace-only" in result.output
+    assert "--no-restart" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -118,11 +130,15 @@ def test_sync_rejects_removed_force_flag(fleet_dir) -> None:
     assert "--force" in result.output
 
 
-def test_sync_workspace_flag_disables_restart_and_verify(
+def test_sync_no_restart_flag_disables_restart_and_verify(
     fleet_dir, monkeypatch
 ) -> None:
+    """Issue #760: `--no-restart` replaces the old `--workspace` alias for
+    canonical+overlay without flapping the unit."""
     captured = _patch_canonical_capture(monkeypatch)
-    result = runner.invoke(app, ["agent", "sync", "wise-hypatia", "--workspace"])
+    result = runner.invoke(
+        app, ["agent", "sync", "wise-hypatia", "--no-restart"]
+    )
     assert result.exit_code == 0, result.output
     assert captured.get("restart") is False
     assert captured.get("verify") is False
@@ -480,7 +496,7 @@ def test_sync_renders_gateway_token_rotated_as_yellow_notice(
     operators see when remote chat sessions need to reconnect."""
     import json as _json
 
-    def fake_sync(name, *, force, restart, verify, on_event):
+    def fake_sync(name, *, force, restart, verify, on_event, **_extra):
         on_event(
             "gateway_token_rotated",
             _json.dumps(
@@ -520,7 +536,7 @@ def test_sync_gateway_token_rotated_escapes_rich_markup_in_agent_key(
 
     hostile_key = "evil[/yellow][bold red]INJECTED[/bold red]"
 
-    def fake_sync(name, *, force, restart, verify, on_event):
+    def fake_sync(name, *, force, restart, verify, on_event, **_extra):
         on_event(
             "gateway_token_rotated",
             _json.dumps(

--- a/tests/cli/clawctl/agent/test_sync_workspace_flags.py
+++ b/tests/cli/clawctl/agent/test_sync_workspace_flags.py
@@ -1,0 +1,112 @@
+"""CLI flag contracts for `clawctl agent sync` workspace overlay (#760).
+
+Covers:
+- `--workspace` hard error path (U32).
+- `--workspace-only --diff` mutex (I7).
+- `--workspace-only` short-circuit (no canonical render call) (I4).
+- workspace-phase failure surfaces as a non-zero exit (S-cli-ux).
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+
+runner = CliRunner()
+
+
+def test_deprecated_workspace_flag_is_hard_error(fleet_dir) -> None:
+    """U32 — `--workspace` exits 2 with a hint to the replacement flags."""
+    result = runner.invoke(app, ["agent", "sync", "wise-hypatia", "--workspace"])
+    assert result.exit_code == 2
+    assert "--workspace-only" in result.output
+    assert "--no-restart" in result.output
+
+
+def test_workspace_only_and_diff_are_mutually_exclusive(fleet_dir) -> None:
+    """I7 — exits 2 with a clear message."""
+    result = runner.invoke(
+        app,
+        ["agent", "sync", "wise-hypatia", "--workspace-only", "--diff"],
+    )
+    assert result.exit_code == 2
+    assert "mutually exclusive" in result.output
+
+
+def test_workspace_only_short_circuits_canonical_render(
+    fleet_dir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """I4 — `--workspace-only` skips canonical render / restart / verify
+    and invokes only the workspace push branch of
+    `sync_agent_canonical`. The CLI is exercised end-to-end via Typer's
+    CliRunner; `sync_agent_canonical` is stubbed to capture kwargs."""
+    captured: dict = {}
+
+    def fake_sync(agent_name: str, **kwargs):
+        captured["agent_name"] = agent_name
+        captured.update(kwargs)
+        from clawrium.core.lifecycle_canonical import CanonicalSyncResult
+
+        return CanonicalSyncResult(
+            success=True,
+            agent=agent_name,
+            host="10.0.0.1",
+            files_written=(),
+            files_unchanged=(),
+            diffs=(),
+            workspace_files_pushed=("MARKER.md",),
+            workspace_files_excluded=(),
+        )
+
+    monkeypatch.setattr(
+        "clawrium.cli.clawctl.agent.sync.sync_agent_canonical",
+        fake_sync,
+        raising=False,
+    )
+    # Above patch path may not exist (sync_agent_canonical is imported
+    # inside the function). Patch the source binding too.
+    monkeypatch.setattr(
+        "clawrium.core.lifecycle_canonical.sync_agent_canonical",
+        fake_sync,
+    )
+
+    result = runner.invoke(
+        app,
+        ["agent", "sync", "wise-hypatia", "--workspace-only"],
+    )
+    assert result.exit_code == 0, result.output
+    # workspace_only=True flows through.
+    assert captured.get("workspace_only") is True
+    # restart/verify are suppressed.
+    assert captured.get("restart") is False
+    assert captured.get("verify") is False
+
+
+def test_workspace_phase_failure_exits_nonzero(
+    fleet_dir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """S-cli-ux — workspace-phase failure surfaces as a non-zero exit.
+
+    The CanonicalSyncError prefix `"workspace overlay push failed"` is
+    what `lifecycle_canonical.sync_agent_canonical` raises when the
+    inserted phase fails before restart; the CLI must surface this as a
+    non-zero exit (the existing `emit_error` path already raises
+    `typer.Exit(code=1)` internally).
+    """
+    from clawrium.core.lifecycle_canonical import CanonicalSyncError
+
+    def fake_sync(*_args, **_kwargs):
+        raise CanonicalSyncError(
+            "workspace overlay push failed for wise-hypatia: stub failure"
+        )
+
+    monkeypatch.setattr(
+        "clawrium.core.lifecycle_canonical.sync_agent_canonical",
+        fake_sync,
+    )
+
+    result = runner.invoke(app, ["agent", "sync", "wise-hypatia"])
+    assert result.exit_code != 0
+    assert "workspace overlay push failed" in result.output

--- a/tests/cli/clawctl/agent/test_sync_workspace_flags.py
+++ b/tests/cli/clawctl/agent/test_sync_workspace_flags.py
@@ -126,3 +126,41 @@ def test_workspace_phase_failure_exits_nonzero(
     result = runner.invoke(app, ["agent", "sync", "wise-hypatia"])
     assert result.exit_code != 0
     assert "workspace overlay push failed" in result.output
+
+
+def test_workspace_only_rejected_for_zeroclaw_in_phase_1(
+    fleet_dir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ATX iter-2 B2-NEW: `--workspace-only` and `--no-restart` are
+    gated away from zeroclaw in Phase 1 because bearer rotation wiring
+    is deferred to Phase 2. Without this gate, running these flags
+    against a zeroclaw agent silently leaves `hosts.json.gateway.auth`
+    stale and `clawctl agent chat` returns 401 on the next daemon
+    restart with no diagnostic.
+    """
+    # Patch the resolved agent type to zeroclaw without rebuilding the
+    # fleet fixture. The CLI's safe_resolve_agent looks up by name; the
+    # `wise-hypatia` agent in the fleet is openclaw, so we monkeypatch
+    # the lookup to return a zeroclaw type.
+    import clawrium.cli.clawctl.agent.sync as sync_mod
+
+    real_resolve = sync_mod.safe_resolve_agent
+
+    def fake_resolve(name: str):
+        host, _agent_type, claw_record = real_resolve(name)
+        claw_record = dict(claw_record)
+        claw_record["type"] = "zeroclaw"
+        return host, "zeroclaw", claw_record
+
+    monkeypatch.setattr(sync_mod, "safe_resolve_agent", fake_resolve)
+
+    for flag in ("--workspace-only", "--no-restart"):
+        result = runner.invoke(
+            app, ["agent", "sync", "wise-hypatia", flag]
+        )
+        assert result.exit_code == 2, (
+            f"{flag} on zeroclaw must exit 2 with a clear error; got "
+            f"exit_code={result.exit_code}, output:\n{result.output}"
+        )
+        assert "zeroclaw" in result.output
+        assert "Phase 2" in result.output

--- a/tests/cli/clawctl/agent/test_sync_workspace_flags.py
+++ b/tests/cli/clawctl/agent/test_sync_workspace_flags.py
@@ -128,8 +128,9 @@ def test_workspace_phase_failure_exits_nonzero(
     assert "workspace overlay push failed" in result.output
 
 
-def test_workspace_only_rejected_for_zeroclaw_in_phase_1(
-    fleet_dir, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("flag", ["--workspace-only", "--no-restart"])
+def test_flag_rejected_for_zeroclaw_in_phase_1(
+    fleet_dir, monkeypatch: pytest.MonkeyPatch, flag: str
 ) -> None:
     """ATX iter-2 B2-NEW: `--workspace-only` and `--no-restart` are
     gated away from zeroclaw in Phase 1 because bearer rotation wiring
@@ -154,13 +155,12 @@ def test_workspace_only_rejected_for_zeroclaw_in_phase_1(
 
     monkeypatch.setattr(sync_mod, "safe_resolve_agent", fake_resolve)
 
-    for flag in ("--workspace-only", "--no-restart"):
-        result = runner.invoke(
-            app, ["agent", "sync", "wise-hypatia", flag]
-        )
-        assert result.exit_code == 2, (
-            f"{flag} on zeroclaw must exit 2 with a clear error; got "
-            f"exit_code={result.exit_code}, output:\n{result.output}"
-        )
-        assert "zeroclaw" in result.output
-        assert "Phase 2" in result.output
+    result = runner.invoke(app, ["agent", "sync", "wise-hypatia", flag])
+    assert result.exit_code == 2, (
+        f"{flag} on zeroclaw must exit 2 with a clear error; got "
+        f"exit_code={result.exit_code}, output:\n{result.output}"
+    )
+    # Pin the canonical error-fragment string, not just a substring of
+    # the agent type (W4 iter-3 tightening).
+    assert "not supported for zeroclaw" in result.output
+    assert "Phase 2" in result.output

--- a/tests/cli/clawctl/agent/test_sync_workspace_flags.py
+++ b/tests/cli/clawctl/agent/test_sync_workspace_flags.py
@@ -35,6 +35,22 @@ def test_workspace_only_and_diff_are_mutually_exclusive(fleet_dir) -> None:
     assert "mutually exclusive" in result.output
 
 
+def test_workspace_only_and_no_restart_are_mutually_exclusive(
+    fleet_dir,
+) -> None:
+    """ATX iter-1 B1: `--workspace-only` already implies skip-restart;
+    `--no-restart` alongside it is ambiguous and must be rejected, not
+    silently collapsed to workspace-only behavior."""
+    result = runner.invoke(
+        app,
+        ["agent", "sync", "wise-hypatia", "--workspace-only", "--no-restart"],
+    )
+    assert result.exit_code == 2
+    assert "mutually exclusive" in result.output
+    assert "--workspace-only" in result.output
+    assert "--no-restart" in result.output
+
+
 def test_workspace_only_short_circuits_canonical_render(
     fleet_dir, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/cli/clawctl/test_workspace_bidi_safety.py
+++ b/tests/cli/clawctl/test_workspace_bidi_safety.py
@@ -1,0 +1,39 @@
+"""Workspace overlay bidi-safety regression (issue #760 W3 iter-3).
+
+A workspace filename containing U+202E (RTL override) must reach the
+NDJSON path field and the text-mode banner with the bidi marker
+stripped. Otherwise a malicious `evil-‮gpj.exe` renders as
+`evil-exe.jpg` in operator terminals — the spoof class iter-3 W3 calls
+out explicitly.
+"""
+
+from __future__ import annotations
+
+from clawrium.cli.output._sanitize import sanitize_passthrough
+from clawrium.core.workspace_sync import _emit_excluded, _emit_skip
+
+
+def test_emit_excluded_strips_bidi_from_path() -> None:
+    captured: list[dict] = []
+
+    def cb(stage: str, payload: dict) -> None:
+        captured.append(payload)
+
+    bidi_name = "evil-‮gpj.exe"
+    _emit_excluded(cb, bidi_name, agent_type_excl=True)
+    assert captured
+    assert "‮" not in captured[0]["path"]
+    # Sanity: sanitizer collapses the codepoint, leaving the rest.
+    assert captured[0]["path"] == sanitize_passthrough(bidi_name)
+
+
+def test_emit_skip_strips_bidi_from_path() -> None:
+    captured: list[dict] = []
+
+    def cb(stage: str, payload: dict) -> None:
+        captured.append(payload)
+
+    bidi_name = "secret-‮fdp.png"
+    _emit_skip(cb, bidi_name, reason="symlink")
+    assert captured
+    assert "‮" not in captured[0]["path"]

--- a/tests/test_manifest_workspace_overlay.py
+++ b/tests/test_manifest_workspace_overlay.py
@@ -1,0 +1,107 @@
+"""Manifest workspace_overlay parsing tests (issue #760).
+
+Covers U1/U2/U4/U31 from the plan: every agent type with a canonical
+renderer must declare `features.workspace_overlay`, destination_root
+values are pinned to upstream, and the parser handles missing /
+malformed / trailing-slash / null-excludes shapes correctly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clawrium.core.registry import (
+    ManifestParseError,
+    _validate_workspace_overlay,
+    load_manifest,
+)
+
+
+def test_openclaw_workspace_overlay_destination_root_pinned() -> None:
+    """U2 (openclaw subset): destination_root sourced from manifest, not
+    hard-coded in core."""
+    manifest = load_manifest("openclaw")
+    overlay = manifest["features"]["workspace_overlay"]
+    assert overlay["destination_root"] == "~/.openclaw/workspace"
+
+
+def test_openclaw_workspace_overlay_has_no_excludes() -> None:
+    """U4: openclaw declares an empty exclude list — workspace zone is
+    operator-owned and disjoint from canonical-render paths."""
+    manifest = load_manifest("openclaw")
+    overlay = manifest["features"]["workspace_overlay"]
+    assert overlay.get("excludes", []) == []
+
+
+def test_workspace_overlay_parser_accepts_minimal_block() -> None:
+    spec = _validate_workspace_overlay(
+        {"destination_root": "/home/agent/.x/workspace"}, "openclaw"
+    )
+    assert spec["destination_root"] == "/home/agent/.x/workspace"
+    assert spec["excludes"] == []
+
+
+def test_workspace_overlay_parser_rejects_missing_destination_root() -> None:
+    with pytest.raises(ManifestParseError, match="destination_root"):
+        _validate_workspace_overlay({"excludes": []}, "openclaw")
+
+
+def test_workspace_overlay_parser_rejects_relative_destination_root() -> None:
+    with pytest.raises(ManifestParseError, match="absolute path"):
+        _validate_workspace_overlay(
+            {"destination_root": "relative/path"}, "openclaw"
+        )
+
+
+def test_workspace_overlay_parser_normalizes_null_excludes_to_empty_list() -> None:
+    """U31: `excludes: null` in YAML → empty list, not crash."""
+    spec = _validate_workspace_overlay(
+        {"destination_root": "~/.x", "excludes": None}, "openclaw"
+    )
+    assert spec["excludes"] == []
+
+
+def test_workspace_overlay_parser_accepts_trailing_slash_entry() -> None:
+    """U31: trailing-slash entry stays trailing-slash (dir-prefix shape)."""
+    spec = _validate_workspace_overlay(
+        {"destination_root": "~/.x", "excludes": ["sessions/", "config.yaml"]},
+        "openclaw",
+    )
+    assert "sessions/" in spec["excludes"]
+    assert "config.yaml" in spec["excludes"]
+
+
+def test_workspace_overlay_parser_rejects_path_traversal_in_excludes() -> None:
+    with pytest.raises(ManifestParseError, match="workspace-relative"):
+        _validate_workspace_overlay(
+            {"destination_root": "~/.x", "excludes": ["../etc/passwd"]},
+            "openclaw",
+        )
+
+
+def test_workspace_overlay_parser_rejects_absolute_excludes() -> None:
+    with pytest.raises(ManifestParseError, match="workspace-relative"):
+        _validate_workspace_overlay(
+            {"destination_root": "~/.x", "excludes": ["/etc/passwd"]},
+            "openclaw",
+        )
+
+
+def test_workspace_overlay_parser_rejects_malformed_exclude_entry() -> None:
+    with pytest.raises(ManifestParseError, match="non-empty string"):
+        _validate_workspace_overlay(
+            {"destination_root": "~/.x", "excludes": [42]}, "openclaw"
+        )
+
+
+def test_workspace_overlay_block_absent_yields_no_overlay() -> None:
+    """An agent type with no `features.workspace_overlay` block must
+    return None from the typed accessor (the in-source contract used by
+    `workspace_sync.WorkspaceOverlaySpec.from_manifest`)."""
+    from clawrium.core.workspace_sync import WorkspaceOverlaySpec
+
+    spec = WorkspaceOverlaySpec.from_manifest("hermes")
+    # hermes does not yet have a workspace_overlay block (lands in
+    # Phase 3 of #760). Until then, the helper returns None and any
+    # caller treats it as "no overlay for this agent type".
+    assert spec is None or spec.destination_root  # tolerate Phase 3 landing

--- a/tests/test_workspace_phase_ordering.py
+++ b/tests/test_workspace_phase_ordering.py
@@ -137,6 +137,45 @@ def test_workspace_failure_short_circuits_before_restart(
     )
 
 
+def test_workspace_only_failure_raises_canonical_sync_error(
+    canonical_stubs,
+) -> None:
+    """ATX iter-2 B1-NEW: the workspace_only early-return path used to
+    return `CanonicalSyncResult(success=False)` rather than raising.
+    The CLI never inspects `.success`, so the operator would see
+    `synced (drift=0)` with exit 0. Pin that the path raises
+    `CanonicalSyncError` so the CLI's existing `except` clause routes
+    it to `emit_error` (exit code 1).
+    """
+
+    def fake_push(**_kwargs):
+        canonical_stubs.append("push_workspace")
+        return WorkspacePhaseResult(
+            success=False,
+            files_pushed=(),
+            files_excluded=(),
+            error="forced workspace_only failure",
+        )
+
+    with patch(
+        "clawrium.core.workspace_sync.push_workspace_phase",
+        side_effect=fake_push,
+    ):
+        with pytest.raises(CanonicalSyncError, match="workspace overlay push failed"):
+            sync_agent_canonical(
+                "alice",
+                workspace_only=True,
+                restart=False,
+                verify=False,
+            )
+
+    # No restart/verify in the workspace_only path either.
+    assert canonical_stubs == ["push_workspace"], (
+        f"workspace_only short-circuit broken: expected only "
+        f"push_workspace, got {canonical_stubs}"
+    )
+
+
 def test_phase_order_is_push_workspace_then_restart_then_verify(
     canonical_stubs,
 ) -> None:

--- a/tests/test_workspace_phase_ordering.py
+++ b/tests/test_workspace_phase_ordering.py
@@ -161,7 +161,12 @@ def test_workspace_only_failure_raises_canonical_sync_error(
         "clawrium.core.workspace_sync.push_workspace_phase",
         side_effect=fake_push,
     ):
-        with pytest.raises(CanonicalSyncError, match="workspace overlay push failed"):
+        with pytest.raises(
+            CanonicalSyncError,
+            # S5 iter-3: pin the agent name in the message so a regression
+            # that drops `{agent_name!r}` from the raise is caught.
+            match=r"workspace overlay push failed for 'alice'",
+        ):
             sync_agent_canonical(
                 "alice",
                 workspace_only=True,

--- a/tests/test_workspace_phase_ordering.py
+++ b/tests/test_workspace_phase_ordering.py
@@ -1,0 +1,180 @@
+"""Phase ordering + short-circuit pins for the canonical workspace phase
+(issue #760 ATX iter-1 B2 + B3).
+
+- B2 (plan I8): when the workspace push returns failure,
+  `_restart_unit` MUST NOT be called. The canonical pipeline raises
+  `CanonicalSyncError` and exits before restart so the daemon is never
+  flapped on a half-applied overlay.
+- B3: the phase order is [push_workspace → restart → verify]. A
+  refactor that reordered these would silently pass every other test;
+  this test pins the sequence with a shared call-order list.
+
+Both tests patch the dependencies of `sync_agent_canonical` at the
+import sites so the canonical function's own logic exercises end-to-end
+without SSH / Ansible / network. The shared helper
+`_invoke_canonical_with_stubs` wires the minimum mock surface needed
+for the canonical pipeline to reach the workspace + restart branch.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clawrium.core import lifecycle_canonical
+from clawrium.core.lifecycle_canonical import (
+    CanonicalSyncError,
+    sync_agent_canonical,
+)
+from clawrium.core.workspace_sync import WorkspacePhaseResult
+
+
+@pytest.fixture
+def canonical_stubs(monkeypatch: pytest.MonkeyPatch):
+    """Patch the dependencies of `sync_agent_canonical` so the function's
+    own phase-ordering logic is exercised without touching SSH / Ansible.
+
+    Returns a `calls` list that downstream patches push into in the
+    order the canonical pipeline invokes them.
+    """
+    calls: list[str] = []
+
+    inputs = MagicMock()
+    inputs.agent_type = "openclaw"
+    inputs.integrations = []
+
+    def fake_build_render_inputs(agent_name: str):
+        return inputs
+
+    def fake_renderer(_inputs):
+        return MagicMock(files={})
+
+    def fake_get_agent_by_name(agent_name: str):
+        host = {
+            "hostname": "h.example",
+            "key_id": "h.example",
+            "user": "xclm",
+            "os_family": "linux",
+        }
+        return (host, agent_name, {"type": "openclaw"})
+
+    def fake_diff_files(**_kwargs):
+        return []  # no canonical drift → no writes
+
+    fake_client = MagicMock()
+    fake_client.close = lambda: None
+
+    def fake_open_ssh(_host, *, timeout=15):
+        return fake_client
+
+    def fake_restart_unit(_client, *, agent_type, agent_name):
+        calls.append("restart")
+
+    def fake_verify_health(_client, *, agent_type, agent_name):
+        calls.append("verify")
+
+    monkeypatch.setattr(
+        lifecycle_canonical, "build_render_inputs", fake_build_render_inputs
+    )
+    monkeypatch.setitem(
+        lifecycle_canonical._RENDERERS, "openclaw", fake_renderer
+    )
+    monkeypatch.setattr(
+        lifecycle_canonical, "get_agent_by_name", fake_get_agent_by_name
+    )
+    monkeypatch.setattr(
+        lifecycle_canonical, "diff_files", fake_diff_files
+    )
+    monkeypatch.setattr(
+        lifecycle_canonical, "_open_ssh", fake_open_ssh
+    )
+    monkeypatch.setattr(
+        lifecycle_canonical, "_restart_unit", fake_restart_unit
+    )
+    monkeypatch.setattr(
+        lifecycle_canonical, "_verify_health", fake_verify_health
+    )
+
+    # Suppress the onboarding state transition — it pokes hosts.json and
+    # is unrelated to the phase-ordering invariants we are asserting.
+    monkeypatch.setattr(
+        "clawrium.core.onboarding.transition_state",
+        lambda *_a, **_k: None,
+    )
+
+    return calls
+
+
+def test_workspace_failure_short_circuits_before_restart(
+    canonical_stubs,
+) -> None:
+    """B2 / plan I8: workspace push failure raises CanonicalSyncError
+    and `_restart_unit` is NEVER called."""
+
+    def fake_push(**_kwargs):
+        canonical_stubs.append("push_workspace")
+        return WorkspacePhaseResult(
+            success=False,
+            files_pushed=(),
+            files_excluded=(),
+            error="simulated workspace failure",
+        )
+
+    with patch(
+        "clawrium.core.workspace_sync.push_workspace_phase",
+        side_effect=fake_push,
+    ):
+        with pytest.raises(CanonicalSyncError, match="workspace overlay push failed"):
+            sync_agent_canonical(
+                "alice", force=False, restart=True, verify=True
+            )
+
+    # The workspace push ran exactly once; restart + verify never did.
+    assert canonical_stubs == ["push_workspace"], (
+        f"phase short-circuit broken: expected only push_workspace, "
+        f"got {canonical_stubs}"
+    )
+
+
+def test_phase_order_is_push_workspace_then_restart_then_verify(
+    canonical_stubs,
+) -> None:
+    """B3: pins the canonical sequence so a refactor that reordered
+    these would fail loudly."""
+
+    def fake_push(**_kwargs):
+        canonical_stubs.append("push_workspace")
+        return WorkspacePhaseResult(
+            success=True,
+            files_pushed=(),
+            files_excluded=(),
+        )
+
+    # Force a canonical write so the restart branch is reached. Provide
+    # one synthetic file with a non-empty diff so the write loop fires
+    # and `files_written` is non-empty.
+    written_diff = MagicMock()
+    written_diff.unified_diff = "--- a\n+++ b\n"
+    written_diff.path = ".openclaw/openclaw.json"
+    written_diff.remote_path = "/home/alice/.openclaw/openclaw.json"
+    written_diff.rendered_body = "{}"
+    written_diff.remote_body = ""
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            side_effect=fake_push,
+        ),
+        patch.object(lifecycle_canonical, "diff_files", return_value=[written_diff]),
+        patch.object(lifecycle_canonical, "_atomic_write", return_value=None),
+    ):
+        result = sync_agent_canonical(
+            "alice", force=False, restart=True, verify=True
+        )
+
+    assert result.success is True
+    assert canonical_stubs == ["push_workspace", "restart", "verify"], (
+        f"phase order regression: expected "
+        f"['push_workspace', 'restart', 'verify'], got {canonical_stubs}"
+    )

--- a/tests/test_workspace_sync.py
+++ b/tests/test_workspace_sync.py
@@ -1,0 +1,362 @@
+"""Workspace overlay sync unit tests (issue #760, Phase 1 openclaw subset).
+
+Covers a focused subset of plan §3.1 — the openclaw-applicable invariants
+that gate every later phase: enumeration filters, exclude semantics,
+secret-pattern mode floor, dispatcher routing, no-paramiko, agent-name
+validation, no `ansible_user_dir` in the playbook body.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+from pathlib import Path
+
+import pytest
+
+from clawrium.core import workspace_sync
+from clawrium.core.workspace_sync import (
+    WORKSPACE_STATES,
+    WorkspaceOverlaySpec,
+    WorkspacePhaseResult,
+    enumerate_workspace_files,
+    push_workspace_phase,
+)
+
+
+# ---------------------------------------------------------------------------
+# spec parsing
+# ---------------------------------------------------------------------------
+
+
+def test_openclaw_spec_from_manifest_has_no_excludes() -> None:
+    """U4 (openclaw subset)."""
+    spec = WorkspaceOverlaySpec.from_manifest("openclaw")
+    assert spec is not None
+    assert spec.destination_root == "~/.openclaw/workspace"
+    assert spec.excludes_files == frozenset()
+    assert spec.excludes_dirs == ()
+
+
+def test_unknown_agent_type_raises_from_manifest() -> None:
+    from clawrium.core.registry import ManifestNotFoundError
+
+    with pytest.raises(ManifestNotFoundError):
+        WorkspaceOverlaySpec.from_manifest("definitely-not-an-agent")
+
+
+# ---------------------------------------------------------------------------
+# enumeration
+# ---------------------------------------------------------------------------
+
+
+def _empty_spec() -> WorkspaceOverlaySpec:
+    return WorkspaceOverlaySpec(destination_root="~/.openclaw/workspace")
+
+
+def test_enumerate_missing_workspace_dir_is_noop(tmp_path: Path) -> None:
+    """U15."""
+    entries, excluded, skipped = enumerate_workspace_files(
+        tmp_path / "does-not-exist",
+        _empty_spec(),
+        agent_name="alice",
+    )
+    assert entries == []
+    assert excluded == []
+    assert skipped == []
+
+
+def test_enumerate_empty_workspace_is_noop(tmp_path: Path) -> None:
+    """U14."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    entries, _, _ = enumerate_workspace_files(
+        workspace, _empty_spec(), agent_name="alice"
+    )
+    assert entries == []
+
+
+def test_enumerate_preserves_relative_path_structure(tmp_path: Path) -> None:
+    """U9."""
+    workspace = tmp_path / "workspace"
+    nested = workspace / "profiles" / "coder"
+    nested.mkdir(parents=True)
+    (nested / "SOUL.md").write_text("hi")
+
+    entries, _, _ = enumerate_workspace_files(
+        workspace, _empty_spec(), agent_name="alice"
+    )
+    assert len(entries) == 1
+    assert entries[0].rel == "profiles/coder/SOUL.md"
+
+
+def test_enumerate_skips_symlinks(tmp_path: Path) -> None:
+    """U6 — symlink leaf rejected."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    target = tmp_path / "target.txt"
+    target.write_text("evil")
+    (workspace / "link").symlink_to(target)
+
+    entries, _, skipped = enumerate_workspace_files(
+        workspace, _empty_spec(), agent_name="alice"
+    )
+    assert entries == []
+    assert "link" in skipped
+
+
+def test_enumerate_skips_clawrium_reserved_dotfiles(tmp_path: Path) -> None:
+    """U7."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".clawrium-state.json").write_text("{}")
+    (workspace / "good.md").write_text("ok")
+
+    entries, _, skipped = enumerate_workspace_files(
+        workspace, _empty_spec(), agent_name="alice"
+    )
+    rels = [e.rel for e in entries]
+    assert "good.md" in rels
+    assert ".clawrium-state.json" not in rels
+    assert ".clawrium-state.json" in skipped
+
+
+def test_enumerate_applies_dir_prefix_exclude(tmp_path: Path) -> None:
+    """U19 — `sessions/` excludes every descendant."""
+    workspace = tmp_path / "workspace"
+    (workspace / "sessions").mkdir(parents=True)
+    (workspace / "sessions" / "x.json").write_text("{}")
+    (workspace / "keep.md").write_text("k")
+
+    spec = WorkspaceOverlaySpec(
+        destination_root="~/x",
+        excludes_dirs=("sessions",),
+    )
+    entries, excluded, _ = enumerate_workspace_files(
+        workspace, spec, agent_name="alice"
+    )
+    rels = [e.rel for e in entries]
+    assert rels == ["keep.md"]
+    assert "sessions/x.json" in excluded
+
+
+def test_enumerate_applies_exact_file_exclude(tmp_path: Path) -> None:
+    """U19 — `config.yaml` excludes only the root file."""
+    workspace = tmp_path / "workspace"
+    (workspace / "profiles").mkdir(parents=True)
+    (workspace / "config.yaml").write_text("x")
+    (workspace / "profiles" / "config.yaml").write_text("y")
+
+    spec = WorkspaceOverlaySpec(
+        destination_root="~/x",
+        excludes_files=frozenset({"config.yaml"}),
+    )
+    entries, excluded, _ = enumerate_workspace_files(
+        workspace, spec, agent_name="alice"
+    )
+    rels = sorted(e.rel for e in entries)
+    assert rels == ["profiles/config.yaml"]
+    assert excluded == ["config.yaml"]
+
+
+# ---------------------------------------------------------------------------
+# mode-bit handling (U10, U20, U35)
+# ---------------------------------------------------------------------------
+
+
+def test_extravar_carries_local_mode_bits(tmp_path: Path) -> None:
+    """U10 — non-secret files preserve their on-disk mode."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    f = workspace / "README.md"
+    f.write_text("x")
+    os.chmod(f, 0o644)
+
+    entries, _, _ = enumerate_workspace_files(
+        workspace, _empty_spec(), agent_name="alice"
+    )
+    assert entries[0].mode == "0644"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "secrets.env",
+        "service.key",
+        "agent.pem",
+        ".env",
+        "my-credentials.json",
+        "my-secret-stuff",
+        "github.token",
+        "user-password.txt",
+    ],
+)
+def test_secret_pattern_files_floor_to_0600(
+    tmp_path: Path, name: str
+) -> None:
+    """U20 — secret-pattern globs floor to 0600 regardless of local mode."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    f = workspace / name
+    f.write_text("x")
+    os.chmod(f, 0o666)
+
+    entries, _, _ = enumerate_workspace_files(
+        workspace, _empty_spec(), agent_name="alice"
+    )
+    assert entries[0].mode == "0600"
+
+
+@pytest.mark.parametrize("name", ["MyAPI.KEY", "OAuth_Token.json", ".ENV"])
+def test_secret_pattern_match_is_case_insensitive(
+    tmp_path: Path, name: str
+) -> None:
+    """U35 — mixed-case fixtures still floor to 0600."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / name).write_text("x")
+    os.chmod(workspace / name, 0o644)
+
+    entries, _, _ = enumerate_workspace_files(
+        workspace, _empty_spec(), agent_name="alice"
+    )
+    assert entries[0].mode == "0600"
+
+
+# ---------------------------------------------------------------------------
+# NDJSON state enum (U24)
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_states_are_a_closed_enum() -> None:
+    assert WORKSPACE_STATES == frozenset(
+        {"queued", "pushed", "excluded", "skipped", "failed", "complete"}
+    )
+
+
+# ---------------------------------------------------------------------------
+# no paramiko (U13) — Ansible is the only host-write channel
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_sync_module_does_not_import_paramiko() -> None:
+    """U13 — the source must not import paramiko or reference SFTP."""
+    src = inspect.getsource(workspace_sync)
+    assert "import paramiko" not in src
+    assert "from paramiko" not in src
+    assert "SFTPClient" not in src
+
+
+def test_workspace_sync_module_has_no_os_family_literals() -> None:
+    """U13 / S4 iter-3 — playbook_resolver is the OS seam, not core."""
+    src = inspect.getsource(workspace_sync)
+    assert "sys.platform" not in src
+    assert "platform.system" not in src
+    # The literal string `os_family ==` must not appear (host dict
+    # lookups like `host.get("os_family", ...)` are fine).
+    assert "os_family ==" not in src
+    assert 'os_family == "darwin"' not in src
+
+
+# ---------------------------------------------------------------------------
+# agent-name injection (U21)
+# ---------------------------------------------------------------------------
+
+
+def test_push_rejects_invalid_agent_name(tmp_path: Path) -> None:
+    """U21 — names with shell-injection chars are rejected upfront via
+    the shared `core/names.py` validator (no duplicate validator)."""
+    result = push_workspace_phase(
+        host={"hostname": "x", "key_id": "x"},
+        agent_type="openclaw",
+        agent_name="foo; rm -rf /",
+    )
+    assert result.success is False
+    assert "rejected" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# empty workspace short-circuits ansible-runner (U14, I5)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_workspace_does_not_invoke_ansible_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """U14 — `ansible_runner.run` is never called when there are no
+    files to push."""
+
+    class _Boom:
+        def __getattr__(self, name: str):
+            raise AssertionError(
+                "ansible_runner must not be invoked on an empty workspace"
+            )
+
+    monkeypatch.setitem(
+        __import__("sys").modules, "ansible_runner", _Boom()
+    )
+
+    result = push_workspace_phase(
+        host={"hostname": "h", "key_id": "h"},
+        agent_type="openclaw",
+        agent_name="alice",
+    )
+    assert isinstance(result, WorkspacePhaseResult)
+    assert result.success is True
+    assert result.files_pushed == ()
+
+
+# ---------------------------------------------------------------------------
+# playbook dispatcher (U12)
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_returns_correct_path_per_os() -> None:
+    """U12 — `resolve_agent_playbook` is the OS seam."""
+    from clawrium.core.playbook_resolver import resolve_agent_playbook
+
+    linux_path = resolve_agent_playbook("openclaw", "workspace", "linux")
+    assert linux_path.name == "workspace.yaml"
+    assert linux_path.parent.name == "playbooks"
+
+    darwin_path = resolve_agent_playbook("openclaw", "workspace", "darwin")
+    assert darwin_path.name == "workspace_macos.yaml"
+
+
+# ---------------------------------------------------------------------------
+# playbook body invariants (U22, U23) — AST-grep on YAML
+# ---------------------------------------------------------------------------
+
+
+def _openclaw_workspace_yaml_body() -> str:
+    from clawrium.core.playbook_resolver import resolve_agent_playbook
+
+    return resolve_agent_playbook("openclaw", "workspace", "linux").read_text()
+
+
+def test_workspace_playbook_does_not_reference_ansible_user_dir() -> None:
+    """U22 — B1 iter-3: `ansible_user_dir` resolves to SSH user, not
+    agent user. The playbook MUST NOT reference it in any task body.
+    Comments explaining the rationale are allowed.
+    """
+    body = _openclaw_workspace_yaml_body()
+    non_comment_lines: list[str] = []
+    for line in body.splitlines():
+        stripped = line.split("#", 1)[0]
+        non_comment_lines.append(stripped)
+    assert "ansible_user_dir" not in "\n".join(non_comment_lines)
+
+
+def test_workspace_playbook_uses_copy_with_follow_no() -> None:
+    """U23 — symlink defense at the playbook copy boundary."""
+    body = _openclaw_workspace_yaml_body()
+    assert "ansible.builtin.copy" in body
+    # The copy task carries `follow: no`. Loose match — YAML whitespace
+    # may vary.
+    assert "follow: no" in body or "follow: false" in body.lower()
+
+
+def test_workspace_playbook_asserts_home_agent_name_prefix() -> None:
+    """U22 — the assert task pins rendered dest under /home/{{ agent_name }}/."""
+    body = _openclaw_workspace_yaml_body()
+    assert "workspace_dest_root.startswith('/home/' ~ agent_name ~ '/')" in body


### PR DESCRIPTION
## Summary

Phase 1 of #760 — ships the **shared workspace-overlay foundation**
(workspace_sync module, manifest loader, CLI flags, install scaffold)
alongside the **openclaw vertical** on Ubuntu, end-to-end.

Files dropped under `~/.config/clawrium/agents/openclaw/<name>/workspace/`
are now mirrored onto the agent host at `~/.openclaw/workspace/` on
every `clawctl agent sync` and `clawctl agent configure`.

- **`core/workspace_sync.py`** (NEW) — enumerator + stager +
  `push_workspace_phase` shared helper. No paramiko; OS seam is
  `core/playbook_resolver.py`. Secret-pattern files
  (`*.key`, `*.pem`, `*.env`, `*credentials*`, `*secret*`, `*token*`,
  `*password*`) floor to mode 0600 regardless of local perms. NDJSON
  state field is the frozen enum
  `{queued, pushed, excluded, skipped, failed, complete}`.
  Operator-controlled strings pass through
  `cli/output/_sanitize.py:sanitize_passthrough` so bidi/zero-width
  codepoints cannot spoof terminal output.
- **`core/registry.py`** — typed `WorkspaceOverlayConfig` added to
  `FeaturesConfig`; parser handles null-excludes, trailing-slash
  dir-prefix entries, traversal rejection.
- **`core/lifecycle_canonical.py`** — `CanonicalSyncResult` carries
  `workspace_files_pushed`/`_excluded`. `sync_agent_canonical` gains
  `push_workspace`, `workspace_only`, `dry_run` kwargs. Phase order
  is `validate → render → diff → write → push_workspace → restart →
  verify`; workspace failure short-circuits before restart on both
  the in-loop and the `workspace_only` early-return paths.
- **`core/lifecycle.py:configure_agent`** — wires
  `push_workspace_phase` for non-CLI callers (install retries, GUI,
  programmatic flows).
- **`core/install.py`** — opportunistic local workspace scaffold
  under `~/.config/clawrium/agents/<type>/<name>/workspace/`
  (mode 0700, idempotent).
- **`cli/clawctl/agent/sync.py`** — `--workspace-only` and
  `--no-restart` added. `--workspace` is a HARD ERROR (BREAKING) via
  `emit_error` with exit code 2. `--workspace-only` is mutex with
  `--diff` AND `--no-restart`. Both `--workspace-only` and
  `--no-restart` are gated away from zeroclaw in Phase 1 — bearer
  rotation wiring lands in Phase 2.
- **`platform/registry/openclaw/`** — manifest `features.workspace_overlay`
  block added; `playbooks/workspace.yaml` (NEW) and
  `playbooks/workspace_macos.yaml` (NEW stub). Linux playbook uses
  `become_user: "{{ agent_name }}"`, asserts agent_name slug,
  workspace_dest_root prefix, staging containment, per-entry safe
  relative paths. `ansible.builtin.copy` with `mode: "{{ item.mode }}"`,
  `follow: no`. NEVER references `ansible_user_dir` (B1 iter-3:
  `become_user` does not re-run `setup`).
- **`AGENTS.md`** — new "Workspace Overlay (issue #760)" section.
- **`CHANGELOG.md`** — `### BREAKING` entry for `--workspace`
  removal (no automated migration) and `### Added` entry for the
  workspace overlay feature.

## Testing

### Test Results

- [x] All existing tests pass (`make test-py`) — **3718 passed, 2 skipped**
- [x] Linter passes (`make lint-py`)
- [x] New tests added: 56 across 5 new test files

### Test Coverage

- New unit tests: `tests/test_workspace_sync.py` (30),
  `tests/test_manifest_workspace_overlay.py` (11),
  `tests/test_workspace_phase_ordering.py` (3),
  `tests/cli/clawctl/test_workspace_bidi_safety.py` (2),
  `tests/cli/clawctl/agent/test_sync_workspace_flags.py` (6).
- Updated existing: `tests/cli/clawctl/agent/test_sync.py` —
  renamed `--workspace` test paths to `--no-restart`; added a
  hard-error regression test for `--workspace`; widened two
  `fake_sync` signatures to accept the new kwargs.

### Manual Testing

E2E on `wolf-i` is the next step (captured separately under
`.itx/760/02_E2E_openclaw_wolf-i.md`). This PR ships the unit +
integration coverage that gates real-host execution.

### Security Checklist

- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (agent_name validator
  reused from `core/names.py`; manifest excludes parser rejects
  absolute paths and `..` traversal; agent-name regex enforced in
  both the playbook assert and the Python entry point)
- [x] No SQL injection, XSS, or command injection risks (every host
  write goes through `ansible.builtin.copy` with structured args;
  no shell interpolation)
- [x] Dependencies are from trusted sources (no new deps)
- [x] Bidi/zero-width codepoints stripped at NDJSON / text emission
  boundary

## ATX Review Summary

**Final Review: Rating 4/5**

Composite from five specialists: lifecycle-core 4/5, cli-ux 4/5,
platform-playbooks 4/5, security 4/5, test-coverage 3/5. ATX leader
verdict: **"Clear to merge."**

| Review | Rating | Blocking Issues | Status | Cost | Time |
|--------|--------|-----------------|--------|------|------|
| 1 | 3/5 (est.) | B1, B2, B3 | All fixed in commit `527e167` | $5.30 | 7m 35s |
| 2 | 2/5 | B1-NEW, B2-NEW | All fixed in commit `dd9dd2e` | $5.88 | 8m 18s |
| 3 | 4/5 | None | Clear to merge | $5.36 | 7m 26s |

<details>
<summary>Review 1 (initial)</summary>

| # | Issue | Resolution |
|---|-------|------------|
| B1 | `--workspace-only` / `--no-restart` mutex not enforced | Fixed in `527e167` — explicit `emit_error(exit_code=2)` guard + paired CLI test |
| B2 | Plan I8 missing: no test asserts workspace failure → no `_restart_unit` | Fixed in `527e167` — canonical-pipeline-level test patches `push_workspace_phase` to return failure and pins that `_restart_unit` is never invoked |
| B3 | Phase order `[push_workspace, restart, verify]` not pinned by a call-order test | Fixed in `527e167` — sibling test with shared call-order list equality assertion |

</details>

<details>
<summary>Review 2 (after iter-1 fixes)</summary>

| # | Issue | Resolution |
|---|-------|------------|
| B1-NEW | `workspace_only=True` + failed push returned `CanonicalSyncResult(success=False)` rather than raising; CLI fell through to exit 0 | Fixed in `dd9dd2e` — raise `CanonicalSyncError` from the workspace_only branch, symmetric with the in-loop path; canonical-pipeline-level test asserts the exception is raised AND no restart happens |
| B2-NEW | `--workspace-only` / `--no-restart` help text claimed to rotate zeroclaw bearer, but Phase 1 doesn't wire bearer rotation into these paths — operator footgun (silent stale `hosts.json.gateway.auth`) | Fixed in `dd9dd2e` — gated both flags away from zeroclaw in Phase 1 with a clear exit-2 error pointing at Phase 2; help text updated; parametrized test asserts both flags are blocked on a zeroclaw-typed agent |

</details>

<details>
<summary>Review 3 (final — clear to merge)</summary>

No blockers. 7 warnings (W1–W7) and 5 suggestions (S1–S5). Trivial
warnings addressed inline in commit `aa1aec7`: W4 (parametrize the
loop test), W6 (hoist `safe_resolve_agent` above the zeroclaw gate to
remove the bare `except`), S5 (tighten `pytest.raises` match regex
to include the agent name). The remaining warnings are deferred —
see **Callouts** below.

</details>

## Callouts

- **[DECISION]** `--workspace-only` and `--no-restart` are **gated
  away from zeroclaw** in Phase 1.
  - Why: bearer rotation for these two flag paths is Phase 2 work.
    Allowing the flags now would silently leave
    `hosts.json.gateway.auth` stale on the next daemon restart,
    with `clawctl agent chat` returning 401 and no diagnostic.
    AGENTS.md §"Gateway Token Lifecycle (zeroclaw)" is explicit:
    "There is no idempotent-skip path."
  - Alternatives considered: (a) ship the help text correction
    only — rejected, leaves the footgun; (b) wire
    `_zeroclaw_repair_after_start` into the workspace_only branch
    now — rejected, that's the Phase 2 vertical's scope.
  - Reviewer: confirm the gate is the right Phase 1 posture.

- **[DECISION]** `configure_agent` workspace push is **non-fatal**
  on failure (logs a warning, returns `(True, None)`), while
  `sync_agent_canonical` is **fatal** (raises `CanonicalSyncError`).
  - Why: the configure playbook has already run and succeeded by
    the time the workspace push fires; raising would leave
    hosts.json updated with no recovery hook. The next `clawctl
    agent sync` surfaces the workspace error with full diagnostics
    (where the user expects the operator-overlay touch point).
  - ATX iter-3 W1 flagged the asymmetry. Decision: keep the
    asymmetry, document it, file a follow-up to make non-CLI
    callers surface the warning via their event stream.
  - Reviewer: confirm or push back.

- **[DECISION]** Defense-in-depth zeroclaw guard inside
  `sync_agent_canonical` (ATX iter-3 W2) is **NOT added** here.
  - Why: the CLI-layer gate covers every user-facing path today.
    Adding a duplicate guard at the lifecycle layer would have to
    be removed in Phase 2 when bearer rotation is wired (or it'd
    block the very behavior Phase 2 enables). Phase 2 will land
    the bearer wiring AND remove the CLI gate atomically.
  - Reviewer: confirm.

- **[DECISION]** Workspace push is **additive only** — local file
  deletions don't propagate to host (ATX iter-3 W7).
  - Why: per the source plan §1.1 — the workspace zone is shared
    with non-clawrium-managed files. Recursive prune would risk
    deleting operator content the canonical pipeline doesn't own.
  - Reviewer: confirm. Will add an explicit note to
    `docs/operations/sync.md` in a follow-up (this PR ships the
    feature; the dedicated operations doc was deferred to keep
    Phase 1 reviewable).

- **[TODO-FOLLOWUP]** ATX iter-3 deferred warnings (none
  blocking):
  - W1 — `configure_agent` asymmetric failure handling. Track in
    a follow-up; either propagate as `(False, error)` or document
    explicitly in AGENTS.md.
  - W2 — defense-in-depth zeroclaw guard in
    `sync_agent_canonical`. Lands with Phase 2 bearer wiring.
  - W3 — TOCTOU at staging-copy time: `_stage_files` should
    `os.path.islink` re-check (or use `O_NOFOLLOW`) before
    `shutil.copy2`. Low-risk on operator's own machine; track for
    Phase 1 cleanup.
  - W5 — `ws_result.error` and ansible-runner stderr should pass
    through `sanitize_passthrough` before `emit()` /
    `CanonicalSyncError`. File a standalone security issue.
  - W7 — Document overlay additive-only semantics in
    `workspace.yaml` header and `manifest.yaml` block.
  - S1 — `_floor_mode_for` masks with `0o7777`; narrow to `0o0777`
    in Phase 1 cleanup.
  - S2 — move `destination_root` shape validation from playbook
    assert into `WorkspaceOverlaySpec.from_manifest`.
  - S4 — extract `gateway_token_rotated` yellow-notice helper —
    replicated across sync/configure/upgrade/restart today.
  - Tracking: to be filed as Phase 1 cleanup + Phase 2
    bearer-wiring umbrella issues. None blocks merge per ATX
    iter-3 verdict.

- **[ENVIRONMENT]** ATX review ran via the `atx review request`
  CLI (not MCP) per the orchestrate-chain prompt. Session metadata
  is persisted at
  [`.itx/767/atx-session.json`](.itx/767/atx-session.json) with
  the full iteration history, blocker list, and resolutions for
  every round.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
