### PR TITLE
feat(workspace): #768 Phase 2 — zeroclaw workspace overlay + bearer rotation

### DIFF
--- a/.itx/768/atx-session.json
+++ b/.itx/768/atx-session.json
@@ -1,0 +1,21 @@
+{
+  "transport": "cli",
+  "session_id": "atx-review-request-iter-3",
+  "commit_sha": "8c1e54c",
+  "iteration": 3,
+  "last_rating": "4/5",
+  "iter_1_summary": "composite 4/5 with cli-ux 2/5 B1 blocker",
+  "iter_2_summary": "composite 4/5, no formal blockers, leader flagged W1-W4 as must-fix",
+  "iter_3_summary": "composite 4/5, ZERO blockers. cli-ux 4/5, lifecycle-core 5/5, test-coverage 4/5 (1 deferrable warning), security-reviewer 4/5",
+  "iter_3_verdict": "MERGE — all iter-2 W1-W4 confirmed resolved. Suggestions only.",
+  "iter_3_deferred_as_callouts": [
+    "iter-3 test-coverage: main-branch zeroclaw push-failure short-circuit symmetry gap (regression-resilience, structurally safe today)",
+    "iter-3 cli-ux: comment overstates sanitize() ANSI behaviour (cosmetic — strips ESC byte only, behaviour is safe)",
+    "iter-3 cli-ux: nested vs two-step binding style asymmetry between handlers (cosmetic)",
+    "iter-3 security: re-validate agent_label against _AGENT_NAME_RE before shell-snippet embedding (defense-in-depth; daemon already trusted)",
+    "iter-3 security: emit-side NDJSON sanitisation (same as iter-2 S6, broader convention)"
+  ],
+  "last_blockers": [],
+  "started_at": "2026-06-20T20:00:00Z",
+  "updated_at": "2026-06-20T20:55:00Z"
+}

--- a/src/clawrium/cli/clawctl/agent/sync.py
+++ b/src/clawrium/cli/clawctl/agent/sync.py
@@ -425,6 +425,8 @@ def sync(
             from rich.console import Console
             from rich.markup import escape as rich_escape
 
+            from clawrium.cli.output._sanitize import sanitize
+
             console = Console()
 
             agent_label: str | None = None
@@ -438,13 +440,15 @@ def sync(
                 pass
             if agent_label:
                 # `agent_label` originates from JSON-parsed daemon output;
-                # escape Rich markup metacharacters (`[`, `]`) before
-                # interpolating so a hostile or accidental `[bold]` in an
-                # agent_key cannot rewrite the rendered styling. Matches
-                # the pattern at cli/agent.py:145.
+                # iter-2 cli-ux W1 + W2: route through `sanitize` (strict —
+                # strips bidi + zero-width + C0/C1 controls + ANSI escapes;
+                # agent_key is a single-line token with no legitimate
+                # whitespace to preserve) BEFORE `rich_escape` (markup-only).
+                # Closes the same vector W3 patched in the
+                # `gateway_auth_stale` handler below.
                 console.print(
                     f"  [yellow]Gateway token rotated for "
-                    f"{rich_escape(agent_label)}. "
+                    f"{rich_escape(sanitize(agent_label))}. "
                     f"Active chat sessions on other machines will need to "
                     f"reconnect.[/yellow]"
                 )
@@ -473,7 +477,7 @@ def sync(
             from rich.console import Console
             from rich.markup import escape as rich_escape
 
-            from clawrium.cli.output._sanitize import sanitize_passthrough
+            from clawrium.cli.output._sanitize import sanitize
 
             stderr_console = Console(stderr=True)
 
@@ -491,30 +495,42 @@ def sync(
             except (_json.JSONDecodeError, TypeError):
                 pass
 
-            # iter-1 cli-ux W3 + security-reviewer warning: both
-            # `agent_label` (operator-chosen agent name) and
-            # `detail_text` (daemon-returned repair error) are
-            # operator-controlled. `rich.markup.escape` blocks Rich's
-            # `[...]` markup but not UAX#9 bidi or zero-width codepoints.
-            # Route through `sanitize_passthrough` FIRST (bidi strip)
-            # then `rich_escape` (markup) so the rendered banner cannot
-            # be terminal-spoofed via either vector.
+            # iter-1 cli-ux W3 + iter-2 cli-ux W2: both `agent_label`
+            # (operator-chosen agent name) and `detail_text` (raw
+            # `repair_err` from the pair playbook / ansible-runner) are
+            # operator-controlled, single-line tokens. `sanitize` is
+            # the strict primitive — strips bidi + zero-width + C0/C1
+            # controls + ANSI escape sequences. Use it (not
+            # `sanitize_passthrough`, which only strips bidi) so a
+            # hostile `\x1b[2J` or U+202E in the daemon's 401 echo
+            # can't manipulate the terminal. `rich_escape` second to
+            # block Rich's `[...]` markup metacharacters.
             if agent_label:
-                label = rich_escape(sanitize_passthrough(agent_label))
+                label_text = sanitize(agent_label)
+                label = rich_escape(label_text)
+                # iter-2 cli-ux S1: the recovery hint embeds the agent
+                # name in a `clawctl agent restart <name>` snippet. With
+                # a valid label the snippet is copy-pasteable; on the
+                # malformed-payload fallback we drop the name parameter
+                # entirely so the operator does not paste an
+                # unrunnable two-positional command.
+                restart_cmd = f"clawctl agent restart {label}"
+                doctor_cmd = f"clawctl agent doctor {label}"
             else:
                 label = "zeroclaw agent"
+                restart_cmd = "clawctl agent restart <agent-name>"
+                doctor_cmd = "clawctl agent doctor <agent-name>"
             stderr_console.print(
                 f"  [yellow]WARN: Gateway bearer for {label} is now stale "
                 f"on disk: the daemon is running but "
                 f"`hosts.json.gateway.auth` may not match the bearer it "
-                f"will enforce. Run `clawctl agent restart {label}` "
-                f"first; if that fails, `clawctl agent doctor` for "
-                f"diagnosis.[/yellow]"
+                f"will enforce. Run `{restart_cmd}` first; if that "
+                f"fails, `{doctor_cmd}` for diagnosis.[/yellow]"
             )
             if detail_text:
                 stderr_console.print(
                     f"    [dim]repair detail: "
-                    f"{rich_escape(sanitize_passthrough(detail_text))}"
+                    f"{rich_escape(sanitize(detail_text))}"
                     f"[/dim]"
                 )
             _sys.stderr.flush()

--- a/src/clawrium/cli/clawctl/agent/sync.py
+++ b/src/clawrium/cli/clawctl/agent/sync.py
@@ -481,6 +481,53 @@ def sync(
                     "on other machines will need to reconnect.[/yellow]"
                 )
             return
+        if stage == "gateway_auth_stale":
+            # Issue #760 Phase 2 (#768) W11 iter-3 stale-bearer banner.
+            # `lifecycle_canonical.sync_agent_canonical` emits this
+            # event right before raising when a successful restart was
+            # followed by a failed re-pair: the daemon will enforce a
+            # bearer the on-disk `hosts.json.gateway.auth` no longer
+            # matches. The error itself surfaces via the
+            # CanonicalSyncError path; this banner gives the operator a
+            # head-start on the diagnosis before that error lands.
+            import json as _json
+            import sys as _sys
+
+            from rich.console import Console
+            from rich.markup import escape as rich_escape
+
+            stderr_console = Console(stderr=True)
+
+            agent_label = None
+            detail_text = ""
+            try:
+                payload = _json.loads(message)
+                if isinstance(payload, dict):
+                    raw_key = payload.get("agent_key")
+                    if isinstance(raw_key, str) and raw_key:
+                        agent_label = raw_key
+                    raw_detail = payload.get("detail")
+                    if isinstance(raw_detail, str):
+                        detail_text = raw_detail
+            except (_json.JSONDecodeError, TypeError):
+                pass
+            label = (
+                rich_escape(agent_label) if agent_label else "zeroclaw agent"
+            )
+            stderr_console.print(
+                f"  [yellow]⚠ Gateway bearer for {label} is now stale on "
+                f"disk: the daemon is running but `hosts.json.gateway.auth` "
+                f"may not match the bearer it will enforce. Re-run "
+                f"`clawctl agent sync` or `clawctl agent restart` to "
+                f"recover.[/yellow]"
+            )
+            if detail_text:
+                stderr_console.print(
+                    f"    [dim]repair detail: {rich_escape(detail_text)}"
+                    f"[/dim]"
+                )
+            _sys.stderr.flush()
+            return
         stream_action(resource=resource, message=f"{stage}: {message}")
 
     try:

--- a/src/clawrium/cli/clawctl/agent/sync.py
+++ b/src/clawrium/cli/clawctl/agent/sync.py
@@ -212,8 +212,9 @@ def sync(
             "Push workspace overlay only. "
             "Skips canonical render, restart, verify. "
             "Mutually exclusive with --diff and --no-restart. "
-            "NOT supported for zeroclaw in Phase 1 of #760 — bearer "
-            "rotation wiring lands in Phase 2."
+            "Supported for zeroclaw — the gateway bearer is re-paired "
+            "after the overlay push so hosts.json.gateway.auth stays in "
+            "sync with the daemon."
         ),
     ),
     no_restart: bool = typer.Option(
@@ -221,8 +222,9 @@ def sync(
         "--no-restart",
         help=(
             "Canonical render + workspace overlay; skip restart and verify. "
-            "NOT supported for zeroclaw in Phase 1 of #760 — bearer "
-            "rotation wiring lands in Phase 2."
+            "Supported for zeroclaw — the gateway bearer is re-paired "
+            "even when restart is skipped, since any externally-driven "
+            "daemon restart invalidates the on-disk bearer."
         ),
     ),
     workspace_deprecated: bool = typer.Option(
@@ -297,47 +299,18 @@ def sync(
         )
         return
 
-    # ATX iter-2 B2-NEW: gate `--workspace-only` / `--no-restart` away
-    # from zeroclaw in Phase 1 of #760. Both flags skip the restart
-    # branch where the canonical pipeline currently rotates the
-    # zeroclaw gateway bearer. Phase 2 wires
-    # `_zeroclaw_repair_after_start` into the workspace-only and
-    # no-restart paths unconditionally per AGENTS.md "Gateway Token
-    # Lifecycle (zeroclaw)" — until then, allowing these flags for
-    # zeroclaw leaves `hosts.json.gateway.auth` stale on the next
-    # daemon restart, with `clawctl agent chat` returning 401 and no
-    # diagnostic. Block with a clear error rather than ship the
-    # footgun.
-    # Bug #516: see configure.py for full rationale.
-    # ATX iter-3 W6: hoisted above the zeroclaw gate so resolver
-    # exceptions surface with their normal messages and the gate uses
-    # the same lookup result as the rest of the function (no double
-    # call, no silent bypass on transient lookup failure).
+    # Phase 1 of #760 gated `--workspace-only` / `--no-restart` away
+    # from zeroclaw because the bearer-rotation invariant was not yet
+    # wired into either path. Phase 2 (#768) now invokes
+    # `_zeroclaw_repair_after_start` unconditionally in
+    # `lifecycle_canonical.sync_agent_canonical` for both flags, so the
+    # gate is dropped. The resolver call below is retained because
+    # downstream code (NDJSON emit, agent_key lookup) still relies on
+    # it, and ATX iter-3 W6 (hoisted above the old gate) keeps the
+    # single-lookup contract intact.
     host, _agent_type, claw_record = safe_resolve_agent(name)
     agent_key = resolve_agent_key(host, name)
     agent_type = claw_record.get("type", _agent_type)
-
-    if (workspace_only or no_restart) and agent_type == "zeroclaw":
-        # ATX iter-2 B2-NEW: Both flags skip the restart branch where
-        # the canonical pipeline currently rotates the zeroclaw gateway
-        # bearer. Phase 2 wires `_zeroclaw_repair_after_start` into the
-        # workspace-only and no-restart paths unconditionally per
-        # AGENTS.md "Gateway Token Lifecycle (zeroclaw)" — until then,
-        # allowing these flags for zeroclaw leaves
-        # `hosts.json.gateway.auth` stale on the next daemon restart,
-        # with `clawctl agent chat` returning 401 and no diagnostic.
-        # Block with a clear error rather than ship the footgun.
-        chosen = "--workspace-only" if workspace_only else "--no-restart"
-        emit_error(
-            f"{chosen} is not supported for zeroclaw agents in this "
-            f"release (#760 Phase 1). Bearer rotation wiring lands "
-            f"in Phase 2 (#760); until then, running {chosen} on a "
-            f"zeroclaw agent would leave the stored gateway bearer "
-            f"stale on the next daemon restart. Use `clawctl agent "
-            f"sync {name}` without the flag.",
-            exit_code=2,
-        )
-        return
 
     # F8 (parent #555): `--diff` implies `--dry-run`. Promote here so
     # the phase-emission and short-circuit logic below sees the
@@ -484,17 +457,23 @@ def sync(
         if stage == "gateway_auth_stale":
             # Issue #760 Phase 2 (#768) W11 iter-3 stale-bearer banner.
             # `lifecycle_canonical.sync_agent_canonical` emits this
-            # event right before raising when a successful restart was
-            # followed by a failed re-pair: the daemon will enforce a
-            # bearer the on-disk `hosts.json.gateway.auth` no longer
-            # matches. The error itself surfaces via the
-            # CanonicalSyncError path; this banner gives the operator a
-            # head-start on the diagnosis before that error lands.
+            # event right before raising when zeroclaw's re-pair fails:
+            # the daemon will enforce a bearer the on-disk
+            # `hosts.json.gateway.auth` no longer matches. The error
+            # itself surfaces via the CanonicalSyncError path; this
+            # banner gives the operator a head-start on the diagnosis
+            # before that error lands. The `detail` field is the raw
+            # `repair_err` string from the pair playbook — operator
+            # debuggability hint per recommendation in iter-1
+            # lifecycle-core review (we surface it explicitly so the
+            # operator doesn't have to scrape NDJSON).
             import json as _json
             import sys as _sys
 
             from rich.console import Console
             from rich.markup import escape as rich_escape
+
+            from clawrium.cli.output._sanitize import sanitize_passthrough
 
             stderr_console = Console(stderr=True)
 
@@ -511,19 +490,31 @@ def sync(
                         detail_text = raw_detail
             except (_json.JSONDecodeError, TypeError):
                 pass
-            label = (
-                rich_escape(agent_label) if agent_label else "zeroclaw agent"
-            )
+
+            # iter-1 cli-ux W3 + security-reviewer warning: both
+            # `agent_label` (operator-chosen agent name) and
+            # `detail_text` (daemon-returned repair error) are
+            # operator-controlled. `rich.markup.escape` blocks Rich's
+            # `[...]` markup but not UAX#9 bidi or zero-width codepoints.
+            # Route through `sanitize_passthrough` FIRST (bidi strip)
+            # then `rich_escape` (markup) so the rendered banner cannot
+            # be terminal-spoofed via either vector.
+            if agent_label:
+                label = rich_escape(sanitize_passthrough(agent_label))
+            else:
+                label = "zeroclaw agent"
             stderr_console.print(
-                f"  [yellow]⚠ Gateway bearer for {label} is now stale on "
-                f"disk: the daemon is running but `hosts.json.gateway.auth` "
-                f"may not match the bearer it will enforce. Re-run "
-                f"`clawctl agent sync` or `clawctl agent restart` to "
-                f"recover.[/yellow]"
+                f"  [yellow]WARN: Gateway bearer for {label} is now stale "
+                f"on disk: the daemon is running but "
+                f"`hosts.json.gateway.auth` may not match the bearer it "
+                f"will enforce. Run `clawctl agent restart {label}` "
+                f"first; if that fails, `clawctl agent doctor` for "
+                f"diagnosis.[/yellow]"
             )
             if detail_text:
                 stderr_console.print(
-                    f"    [dim]repair detail: {rich_escape(detail_text)}"
+                    f"    [dim]repair detail: "
+                    f"{rich_escape(sanitize_passthrough(detail_text))}"
                     f"[/dim]"
                 )
             _sys.stderr.flush()

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -806,14 +806,66 @@ def sync_agent_canonical(
                 f"workspace overlay push failed for {agent_name!r}: "
                 f"{ws_result.error}"
             )
-        # NOTE(zeroclaw bearer rotation): the plan §1.4 contract
-        # requires phase 6a (`_zeroclaw_repair_after_start`) to run
-        # unconditionally for zeroclaw across all three sync modes,
-        # including `--workspace-only`. Wiring that here is part of the
-        # zeroclaw vertical slice (parent #760 Phase 2 — issue
-        # filed as the second subtask). Openclaw (this Phase 1 subtask)
-        # has no bearer rotation so the workspace-only path is complete
-        # for openclaw without it.
+
+        # Issue #760 Phase 2 (#768) — bearer rotation invariant.
+        # AGENTS.md "Gateway Token Lifecycle (zeroclaw)" is explicit:
+        # `configure` / `sync` / `restart` MUST mint a fresh bearer and
+        # overwrite `hosts.json.gateway.auth` on every call. There is no
+        # idempotent-skip path; an out-of-sync `auth` field is the bug
+        # we are guarding against (#437). `--workspace-only` is just
+        # another sync entry point and is bound by the same contract.
+        #
+        # Dry-run gate (W6 iter-3): when the CLI passes `dry_run=True`
+        # we MUST NOT mint a bearer or emit `gateway_token_rotated` —
+        # the operator asked for an inspection, not a rotation. The CLI
+        # short-circuits before reaching this branch today (an early
+        # return at sync.py:396), but the gate here is defense-in-depth
+        # against any future programmatic caller that passes `dry_run`
+        # alongside `workspace_only`.
+        if inputs.agent_type == "zeroclaw" and not dry_run:
+            from clawrium.core.lifecycle import _zeroclaw_repair_after_start
+
+            emit(
+                "repair",
+                f"re-pairing zeroclaw gateway for {agent_name} "
+                f"(workspace-only sync)",
+            )
+            repair_ok, repair_err = _zeroclaw_repair_after_start(
+                hostname,
+                agent_name=agent_name,
+                on_event=on_event,
+                reason="sync",
+            )
+            if not repair_ok:
+                # Workspace push already landed on host; the daemon
+                # state is intact and the only fallout is that
+                # `hosts.json.gateway.auth` may now lag behind whatever
+                # bearer the daemon will enforce on the next request.
+                # That's the W11 stale-bearer case — surface it as a
+                # structured event before raising so the operator has a
+                # diagnostic instead of a silent 401 storm on the next
+                # `clawctl agent chat`.
+                if on_event is not None:
+                    import json as _json
+
+                    on_event(
+                        "gateway_auth_stale",
+                        _json.dumps(
+                            {
+                                "agent_key": agent_name,
+                                "reason": "workspace-only re-pair failed",
+                                "detail": repair_err or "",
+                            }
+                        ),
+                    )
+                raise CanonicalSyncError(
+                    f"workspace-only sync wrote overlay for {agent_name!r} "
+                    f"but the gateway re-pair failed: {repair_err}. "
+                    f"`clawctl agent chat` will return 401 until you "
+                    f"re-run `clawctl agent sync` or `clawctl agent "
+                    f"restart`."
+                )
+
         emit(
             "sync",
             f"workspace-only sync of {agent_name}: "
@@ -1021,7 +1073,16 @@ def sync_agent_canonical(
     # Round 1 B3 code introduced." Re-pair unconditionally on every
     # zeroclaw sync regardless of `restart`. The pair playbook is the
     # single source of truth for the handshake.
-    if inputs.agent_type == "zeroclaw":
+    #
+    # Issue #760 Phase 2 (#768): the same `--no-restart` path lands
+    # here too — the bearer rotates even when the operator asked to
+    # skip the systemd restart, because (per AGENTS.md) any externally-
+    # triggered daemon restart (host reboot, ops-driven `systemctl
+    # restart`) will have already invalidated the on-disk bearer.
+    # Dry-run gate (W6 iter-3): defense-in-depth against any future
+    # programmatic caller that passes `dry_run` into this layer (the
+    # CLI short-circuits before reaching here today).
+    if inputs.agent_type == "zeroclaw" and not dry_run:
         from clawrium.core.lifecycle import _zeroclaw_repair_after_start
 
         emit("repair", f"re-pairing zeroclaw gateway for {agent_name}")
@@ -1032,6 +1093,26 @@ def sync_agent_canonical(
             reason="sync",
         )
         if not repair_ok:
+            # W11 iter-3 stale-bearer banner: restart + verify succeeded
+            # above, so the daemon is now running and will enforce
+            # whatever bearer it minted on first /pair/code probe. The
+            # disk-side `hosts.json.gateway.auth` may now lag — surface
+            # the divergence as a structured NDJSON event before
+            # raising so operators get a starting point instead of
+            # chasing silent 401s on the next `clawctl agent chat`.
+            if on_event is not None:
+                import json as _json
+
+                on_event(
+                    "gateway_auth_stale",
+                    _json.dumps(
+                        {
+                            "agent_key": agent_name,
+                            "reason": "sync re-pair failed",
+                            "detail": repair_err or "",
+                        }
+                    ),
+                )
             raise CanonicalSyncError(
                 f"sync wrote and restarted {agent_name!r} but the gateway "
                 f"re-pair failed: {repair_err}. `clawctl agent chat` will "

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -830,11 +830,15 @@ def sync_agent_canonical(
                 f"re-pairing zeroclaw gateway for {agent_name} "
                 f"(workspace-only sync)",
             )
+            # iter-1 lifecycle-core S5: pass a distinct `reason` so
+            # post-mortem analysis can grep `gateway_token_rotated`
+            # events by entry point (workspace-only-sync vs default
+            # sync vs restart).
             repair_ok, repair_err = _zeroclaw_repair_after_start(
                 hostname,
                 agent_name=agent_name,
                 on_event=on_event,
-                reason="sync",
+                reason="workspace-only-sync",
             )
             if not repair_ok:
                 # Workspace push already landed on host; the daemon
@@ -858,12 +862,19 @@ def sync_agent_canonical(
                             }
                         ),
                     )
+                # iter-1 lifecycle-core W2: tightened remediation — a
+                # deterministic pair failure (port-bind issue, dead
+                # daemon) will repeat on a plain sync. `restart` first
+                # is more likely to recover; `doctor` is the fallback
+                # diagnostic.
                 raise CanonicalSyncError(
                     f"workspace-only sync wrote overlay for {agent_name!r} "
                     f"but the gateway re-pair failed: {repair_err}. "
-                    f"`clawctl agent chat` will return 401 until you "
-                    f"re-run `clawctl agent sync` or `clawctl agent "
-                    f"restart`."
+                    f"`clawctl agent chat` will return 401 until the "
+                    f"bearer rotates. Run `clawctl agent restart "
+                    f"{agent_name}` to recover; if that fails, "
+                    f"`clawctl agent doctor {agent_name}` for "
+                    f"diagnosis."
                 )
 
         emit(
@@ -1093,13 +1104,17 @@ def sync_agent_canonical(
             reason="sync",
         )
         if not repair_ok:
-            # W11 iter-3 stale-bearer banner: restart + verify succeeded
-            # above, so the daemon is now running and will enforce
-            # whatever bearer it minted on first /pair/code probe. The
-            # disk-side `hosts.json.gateway.auth` may now lag — surface
+            # W11 iter-3 stale-bearer banner: restart + verify already
+            # completed when applicable; in --no-restart mode any prior
+            # external restart already invalidated the on-disk bearer
+            # and the re-pair was the recovery path. Either way the
+            # disk-side `hosts.json.gateway.auth` may now lag whatever
+            # bearer the daemon enforces on the next request — surface
             # the divergence as a structured NDJSON event before
             # raising so operators get a starting point instead of
             # chasing silent 401s on the next `clawctl agent chat`.
+            # (iter-1 lifecycle-core W1: corrected from the misleading
+            # "restart + verify succeeded above" wording.)
             if on_event is not None:
                 import json as _json
 
@@ -1113,11 +1128,14 @@ def sync_agent_canonical(
                         }
                     ),
                 )
+            # iter-1 lifecycle-core W2: tightened remediation — see the
+            # workspace-only branch comment for rationale.
             raise CanonicalSyncError(
                 f"sync wrote and restarted {agent_name!r} but the gateway "
                 f"re-pair failed: {repair_err}. `clawctl agent chat` will "
-                f"return 401 until you re-run `clawctl agent sync` or "
-                f"`clawctl agent restart`."
+                f"return 401 until the bearer rotates. Run `clawctl agent "
+                f"restart {agent_name}` to recover; if that fails, "
+                f"`clawctl agent doctor {agent_name}` for diagnosis."
             )
 
     # B2: advance the onboarding state machine to READY so

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -1130,11 +1130,23 @@ def sync_agent_canonical(
                 )
             # iter-1 lifecycle-core W2: tightened remediation — see the
             # workspace-only branch comment for rationale.
+            # iter-2 lifecycle-core W3: branch the preamble on `restart`
+            # so the message does not claim a restart that did not run
+            # in --no-restart mode (operators would otherwise look for
+            # systemctl evidence of a restart that never happened).
+            if restart:
+                preamble = (
+                    f"sync wrote and restarted {agent_name!r}"
+                )
+            else:
+                preamble = (
+                    f"sync of {agent_name!r} (restart skipped)"
+                )
             raise CanonicalSyncError(
-                f"sync wrote and restarted {agent_name!r} but the gateway "
-                f"re-pair failed: {repair_err}. `clawctl agent chat` will "
-                f"return 401 until the bearer rotates. Run `clawctl agent "
-                f"restart {agent_name}` to recover; if that fails, "
+                f"{preamble} but the gateway re-pair failed: "
+                f"{repair_err}. `clawctl agent chat` will return 401 "
+                f"until the bearer rotates. Run `clawctl agent restart "
+                f"{agent_name}` to recover; if that fails, "
                 f"`clawctl agent doctor {agent_name}` for diagnosis."
             )
 

--- a/src/clawrium/platform/registry/zeroclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/manifest.yaml
@@ -34,6 +34,17 @@ features:
     enabled: true
     bind: wildcard
     port_field: gateway.port
+  # Operator-owned overlay slot. Files dropped under
+  # ~/.config/clawrium/agents/zeroclaw/<name>/workspace/ are mirrored to
+  # `destination_root` on the agent host on every `clawctl agent sync`.
+  # Zeroclaw's workspace dir is the same path that holds the canonical
+  # memory tree (see `workspace.memory_path` above), so the overlay
+  # writes alongside operator-edited memory files. Excludes are empty:
+  # zeroclaw does not render config or auth artifacts under the
+  # workspace root, so no path must be reserved.
+  workspace_overlay:
+    destination_root: "~/.zeroclaw/workspace"
+    excludes: []
 
 # Secrets for this agent. Provider URL and model are now sourced from the
 # providers system (selected during the onboarding `providers` stage and

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/workspace.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/workspace.yaml
@@ -1,0 +1,139 @@
+---
+# Zeroclaw workspace overlay — mirrors operator-supplied files from the
+# control-plane staging tree onto the agent host under
+# `workspace_dest_root` (declared in zeroclaw/manifest.yaml).
+#
+# Structurally identical to openclaw/playbooks/workspace.yaml — only
+# the manifest-declared destination changes. The zeroclaw workspace
+# dir is the same path holding the canonical memory tree, so an
+# operator drop sits alongside memory MD files.
+#
+# Inputs (extravars):
+#   - agent_name:          unix user that owns the zeroclaw install
+#   - staging_dir:         control-machine path; staged copies of the
+#                          enumerated workspace files (see
+#                          core/workspace_sync.py). Files live at
+#                          `<staging_dir>/<item.rel>`.
+#   - workspace_dest_root: absolute path under the agent's home, e.g.
+#                          `/home/<agent_name>/.zeroclaw/workspace`.
+#                          Sourced from manifest.features.workspace_overlay
+#                          via extravar (S2 iter-2). Do NOT hardcode the
+#                          suffix here — the manifest is the single source.
+#   - workspace_files:     list of `{rel, src, mode, owner, group}` dicts;
+#                          the Python enumerator carries local mode bits
+#                          and floors secret-pattern files to 0600
+#                          (W13 iter-1, U20).
+#
+# Why no `ansible_user_dir` (B1 iter-3): `become_user` does NOT re-run
+# the `setup` module, so `ansible_user_dir` keeps the SSH-connecting
+# user's home (`/home/xclm`), not the agent user's. The assert task
+# below pins the rendered `workspace_dest_root` to the
+# `/home/{{ agent_name }}/...` prefix.
+- hosts: all
+  become: yes
+  become_user: "{{ agent_name }}"
+  gather_facts: false
+  tasks:
+    - name: Assert agent_name matches the safe slug pattern
+      ansible.builtin.assert:
+        that:
+          - agent_name is string
+          - agent_name is match('^[a-z][a-z0-9_-]{0,31}$')
+        fail_msg: "Invalid agent_name: {{ agent_name | default('<unset>') }}"
+        quiet: true
+
+    - name: Assert workspace_dest_root is under /home/{{ agent_name }}/
+      # B1 iter-3 backstop: the manifest is the source of truth, but a
+      # tampered extravar pointing at e.g. `/etc/zeroclaw` must bail
+      # before any copy task runs.
+      ansible.builtin.assert:
+        that:
+          - workspace_dest_root is string
+          - workspace_dest_root | length > 0
+          - workspace_dest_root.startswith('/home/' ~ agent_name ~ '/')
+        fail_msg: >-
+          workspace_dest_root must start with `/home/{{ agent_name }}/`
+          (got '{{ workspace_dest_root | default('<unset>') }}')
+        quiet: true
+
+    - name: Assert staging_dir is a non-empty absolute path under the clawrium staging tree
+      # Defense-in-depth: the Python entry point always passes a
+      # `tempfile.TemporaryDirectory` path under
+      # `${clawrium_config}/staging/workspace/`, so a tampered inventory
+      # pointing at `/etc` or `/root` would not match the expected
+      # substring and the playbook bails before any `copy` task runs.
+      ansible.builtin.assert:
+        that:
+          - staging_dir is string
+          - staging_dir | length > 0
+          - staging_dir.startswith('/')
+          - "'/clawrium/staging/workspace/' in staging_dir"
+        fail_msg: >-
+          staging_dir must be an absolute path under
+          `${clawrium_config}/staging/workspace/` (got '{{ staging_dir }}')
+        quiet: true
+
+    - name: Assert workspace_files is a list
+      ansible.builtin.assert:
+        that:
+          - workspace_files is iterable
+          - workspace_files is not string
+          - workspace_files is not mapping
+        fail_msg: "workspace_files must be a list"
+        quiet: true
+
+    - name: Assert each workspace file entry is a relative path
+      # W12 iter-2 belt-and-suspenders: even if Python enumeration filters
+      # symlinks/traversal, this re-asserts inside the playbook so a future
+      # bypass cannot land hostile paths on host.
+      ansible.builtin.assert:
+        that:
+          - item.rel is string
+          - item.rel | length > 0
+          - not item.rel.startswith('/')
+          - "'..' not in (item.rel.split('/'))"
+        fail_msg: >-
+          workspace file entry has unsafe rel: '{{ item.rel | default('<unset>') }}'
+        quiet: true
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel | default('<unset>') }}"
+
+    - name: Ensure workspace destination root exists
+      ansible.builtin.file:
+        path: "{{ workspace_dest_root }}"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0755"
+
+    - name: Ensure parent directories exist for each workspace file
+      # The `dirname` is computed Python-side too, but doing it here keeps
+      # the playbook self-contained against a stripped extravar payload.
+      ansible.builtin.file:
+        path: "{{ workspace_dest_root }}/{{ item.rel | dirname }}"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0755"
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel }}"
+      when: item.rel | dirname | length > 0
+
+    - name: Push each workspace file onto the host
+      # `copy` writes to a tempfile in the dest dir and renames atomically.
+      # `follow: no` is the W12 iter-2 / W18 iter-2 symlink defense: even
+      # though Python enumerates with `os.path.islink` filtering and stages
+      # via `shutil.copy2` into a managed `tempfile.TemporaryDirectory`,
+      # the playbook re-asserts the no-symlink invariant at the copy boundary.
+      ansible.builtin.copy:
+        src: "{{ staging_dir }}/{{ item.rel }}"
+        dest: "{{ workspace_dest_root }}/{{ item.rel }}"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "{{ item.mode }}"
+        follow: no
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel }}"

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/workspace_macos.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/workspace_macos.yaml
@@ -1,0 +1,14 @@
+---
+# Stub playbook — macOS workspace overlay is deferred to subtask #5
+# of parent #760 (Phase 5). Single source of error surface: the
+# Ansible `fail:` task here. Python side does NOT short-circuit darwin
+# (W8/W9 iter-3); the dispatcher routes via
+# `core/playbook_resolver.resolve_agent_playbook` and the non-zero rc
+# surfaces as a `WorkspaceSyncError` in `core/workspace_sync.py` with
+# this `fail.msg` propagated.
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: workspace overlay deferred to macOS subtask
+      ansible.builtin.fail:
+        msg: "workspace overlay deferred to macOS subtask"

--- a/tests/cli/clawctl/agent/test_sync_workspace_flags.py
+++ b/tests/cli/clawctl/agent/test_sync_workspace_flags.py
@@ -128,21 +128,109 @@ def test_workspace_phase_failure_exits_nonzero(
     assert "workspace overlay push failed" in result.output
 
 
+def test_gateway_auth_stale_banner_renders_to_stderr(
+    fleet_dir, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """iter-1 test-coverage W1 + cli-ux W3 (Phase 2 / #768): the new
+    `gateway_auth_stale` banner is rendered to stderr (not stdout) with
+    a yellow warning, includes the recovery commands, and runs both
+    operator-controlled fields (`agent_key`, `detail`) through
+    `sanitize_passthrough` so bidi / zero-width codepoints cannot
+    spoof terminal output.
+    """
+    from clawrium.core.lifecycle_canonical import (
+        CanonicalSyncError,
+        CanonicalSyncResult,  # noqa: F401  imported for side-effect import path
+    )
+
+    # `sync_agent_canonical` is stubbed to:
+    #   1. emit a gateway_auth_stale event with a hostile agent_key
+    #      and detail (bidi LRE U+202A embedded)
+    #   2. raise CanonicalSyncError to mirror the real flow
+    HOSTILE_KEY = "alice‪hidden"
+    HOSTILE_DETAIL = "pair returned 500: gateway‫hung"
+
+    def fake_sync(_name: str, *, on_event=None, **_kwargs):
+        import json as _json
+
+        if on_event is not None:
+            on_event(
+                "gateway_auth_stale",
+                _json.dumps(
+                    {
+                        "agent_key": HOSTILE_KEY,
+                        "reason": "sync re-pair failed",
+                        "detail": HOSTILE_DETAIL,
+                    }
+                ),
+            )
+        raise CanonicalSyncError(
+            "sync wrote and restarted 'wise-hypatia' but the gateway "
+            "re-pair failed: stub failure"
+        )
+
+    monkeypatch.setattr(
+        "clawrium.core.lifecycle_canonical.sync_agent_canonical",
+        fake_sync,
+    )
+
+    # Use a runner that does not merge stderr into stdout so we can pin
+    # the stderr-only contract.
+    runner_split = CliRunner()
+    result = runner_split.invoke(app, ["agent", "sync", "wise-hypatia"])
+
+    assert result.exit_code != 0
+    # Banner must surface on stderr.
+    assert "Gateway bearer" in result.stderr
+    assert "stale" in result.stderr
+    # Tightened remediation text (lifecycle-core W2): includes restart,
+    # falls through to doctor.
+    assert "clawctl agent restart" in result.stderr
+    assert "doctor" in result.stderr
+    # Bidi-safety: U+202A / U+202B MUST NOT appear verbatim in either
+    # stream after sanitize_passthrough.
+    assert "‪" not in result.stderr
+    assert "‫" not in result.stderr
+
+
+def test_gateway_auth_stale_banner_tolerates_malformed_payload(
+    fleet_dir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The banner handler must not raise on a malformed JSON payload;
+    it falls back to the generic 'zeroclaw agent' label."""
+    from clawrium.core.lifecycle_canonical import CanonicalSyncError
+
+    def fake_sync(_name: str, *, on_event=None, **_kwargs):
+        if on_event is not None:
+            on_event("gateway_auth_stale", "{not valid json")
+        raise CanonicalSyncError("stub failure")
+
+    monkeypatch.setattr(
+        "clawrium.core.lifecycle_canonical.sync_agent_canonical",
+        fake_sync,
+    )
+
+    runner_split = CliRunner()
+    result = runner_split.invoke(app, ["agent", "sync", "wise-hypatia"])
+    # Must exit on the raised CanonicalSyncError, not on a banner-handler
+    # exception. Without the JSONDecodeError catch, the handler would
+    # raise inside `on_event` and the test would surface an unrelated
+    # exception trace in `result.exception`.
+    assert result.exit_code != 0
+    assert "zeroclaw agent" in result.stderr
+
+
 @pytest.mark.parametrize("flag", ["--workspace-only", "--no-restart"])
-def test_flag_rejected_for_zeroclaw_in_phase_1(
+def test_flag_accepted_for_zeroclaw_in_phase_2(
     fleet_dir, monkeypatch: pytest.MonkeyPatch, flag: str
 ) -> None:
-    """ATX iter-2 B2-NEW: `--workspace-only` and `--no-restart` are
-    gated away from zeroclaw in Phase 1 because bearer rotation wiring
-    is deferred to Phase 2. Without this gate, running these flags
-    against a zeroclaw agent silently leaves `hosts.json.gateway.auth`
-    stale and `clawctl agent chat` returns 401 on the next daemon
-    restart with no diagnostic.
-    """
-    # Patch the resolved agent type to zeroclaw without rebuilding the
-    # fleet fixture. The CLI's safe_resolve_agent looks up by name; the
-    # `wise-hypatia` agent in the fleet is openclaw, so we monkeypatch
-    # the lookup to return a zeroclaw type.
+    """ATX iter-1 cli-ux B1 (Phase 2 / #768): Phase 1 of #760 gated
+    `--workspace-only` / `--no-restart` away from zeroclaw because
+    bearer-rotation wiring was deferred. Phase 2 wires
+    `_zeroclaw_repair_after_start` into both branches of
+    `sync_agent_canonical` so the gate is lifted. This test pins the
+    inversion: a zeroclaw agent invoked with either flag must reach the
+    canonical sync layer (no exit-2, no "not supported" error)."""
     import clawrium.cli.clawctl.agent.sync as sync_mod
 
     real_resolve = sync_mod.safe_resolve_agent
@@ -155,12 +243,40 @@ def test_flag_rejected_for_zeroclaw_in_phase_1(
 
     monkeypatch.setattr(sync_mod, "safe_resolve_agent", fake_resolve)
 
+    # Stub the canonical pipeline so we can assert it was reached; we
+    # don't care about its return value here.
+    from clawrium.core.lifecycle_canonical import CanonicalSyncResult
+
+    canonical_calls: list[dict] = []
+
+    def fake_sync(name: str, **kwargs) -> CanonicalSyncResult:
+        canonical_calls.append({"name": name, **kwargs})
+        return CanonicalSyncResult(
+            success=True,
+            agent=name,
+            host="h",
+            files_written=(),
+            files_unchanged=(),
+            diffs=(),
+            error=None,
+            workspace_files_pushed=(),
+            workspace_files_excluded=(),
+        )
+
+    monkeypatch.setattr(
+        "clawrium.core.lifecycle_canonical.sync_agent_canonical",
+        fake_sync,
+    )
+
     result = runner.invoke(app, ["agent", "sync", "wise-hypatia", flag])
-    assert result.exit_code == 2, (
-        f"{flag} on zeroclaw must exit 2 with a clear error; got "
+    assert result.exit_code == 0, (
+        f"{flag} on zeroclaw must reach the canonical sync layer; got "
         f"exit_code={result.exit_code}, output:\n{result.output}"
     )
-    # Pin the canonical error-fragment string, not just a substring of
-    # the agent type (W4 iter-3 tightening).
-    assert "not supported for zeroclaw" in result.output
-    assert "Phase 2" in result.output
+    assert "not supported for zeroclaw" not in result.output
+    assert len(canonical_calls) == 1
+    if flag == "--workspace-only":
+        assert canonical_calls[0]["workspace_only"] is True
+    else:
+        assert canonical_calls[0]["restart"] is False
+        assert canonical_calls[0]["verify"] is False

--- a/tests/test_manifest_workspace_overlay.py
+++ b/tests/test_manifest_workspace_overlay.py
@@ -33,6 +33,22 @@ def test_openclaw_workspace_overlay_has_no_excludes() -> None:
     assert overlay.get("excludes", []) == []
 
 
+def test_zeroclaw_workspace_overlay_destination_root_pinned() -> None:
+    """U2 (zeroclaw subset, #768): destination_root sourced from manifest,
+    matches the on-host workspace path zeroclaw itself uses for memory."""
+    manifest = load_manifest("zeroclaw")
+    overlay = manifest["features"]["workspace_overlay"]
+    assert overlay["destination_root"] == "~/.zeroclaw/workspace"
+
+
+def test_zeroclaw_workspace_overlay_has_no_excludes() -> None:
+    """U4 (zeroclaw subset, #768): zeroclaw renders no canonical config
+    or auth artifacts under the workspace root, so excludes are empty."""
+    manifest = load_manifest("zeroclaw")
+    overlay = manifest["features"]["workspace_overlay"]
+    assert overlay.get("excludes", []) == []
+
+
 def test_workspace_overlay_parser_accepts_minimal_block() -> None:
     spec = _validate_workspace_overlay(
         {"destination_root": "/home/agent/.x/workspace"}, "openclaw"

--- a/tests/test_workspace_sync.py
+++ b/tests/test_workspace_sync.py
@@ -38,6 +38,16 @@ def test_openclaw_spec_from_manifest_has_no_excludes() -> None:
     assert spec.excludes_dirs == ()
 
 
+def test_zeroclaw_spec_from_manifest_has_no_excludes() -> None:
+    """U4 (zeroclaw subset, #768) — zeroclaw mirrors openclaw's
+    empty-excludes contract."""
+    spec = WorkspaceOverlaySpec.from_manifest("zeroclaw")
+    assert spec is not None
+    assert spec.destination_root == "~/.zeroclaw/workspace"
+    assert spec.excludes_files == frozenset()
+    assert spec.excludes_dirs == ()
+
+
 def test_unknown_agent_type_raises_from_manifest() -> None:
     from clawrium.core.registry import ManifestNotFoundError
 
@@ -323,23 +333,48 @@ def test_resolver_returns_correct_path_per_os() -> None:
     assert darwin_path.name == "workspace_macos.yaml"
 
 
+def test_resolver_returns_zeroclaw_workspace_playbooks() -> None:
+    """U12 (zeroclaw subset, #768) — both linux and darwin variants
+    exist on disk for zeroclaw, mirroring the openclaw pair."""
+    from clawrium.core.playbook_resolver import resolve_agent_playbook
+
+    linux_path = resolve_agent_playbook("zeroclaw", "workspace", "linux")
+    assert linux_path.name == "workspace.yaml"
+    assert linux_path.parent.name == "playbooks"
+    assert linux_path.parent.parent.name == "zeroclaw"
+    assert linux_path.exists()
+
+    darwin_path = resolve_agent_playbook("zeroclaw", "workspace", "darwin")
+    assert darwin_path.name == "workspace_macos.yaml"
+    assert darwin_path.exists()
+
+
 # ---------------------------------------------------------------------------
 # playbook body invariants (U22, U23) — AST-grep on YAML
 # ---------------------------------------------------------------------------
 
 
-def _openclaw_workspace_yaml_body() -> str:
+def _workspace_yaml_body(agent_type: str) -> str:
     from clawrium.core.playbook_resolver import resolve_agent_playbook
 
-    return resolve_agent_playbook("openclaw", "workspace", "linux").read_text()
+    return resolve_agent_playbook(agent_type, "workspace", "linux").read_text()
 
 
-def test_workspace_playbook_does_not_reference_ansible_user_dir() -> None:
+def _openclaw_workspace_yaml_body() -> str:
+    return _workspace_yaml_body("openclaw")
+
+
+# Parametrized over both Ubuntu-shipping agent types so the U22 / U23
+# invariants are enforced uniformly. Hermes joins this matrix in Phase 3.
+@pytest.mark.parametrize("agent_type", ["openclaw", "zeroclaw"])
+def test_workspace_playbook_does_not_reference_ansible_user_dir(
+    agent_type: str,
+) -> None:
     """U22 — B1 iter-3: `ansible_user_dir` resolves to SSH user, not
     agent user. The playbook MUST NOT reference it in any task body.
     Comments explaining the rationale are allowed.
     """
-    body = _openclaw_workspace_yaml_body()
+    body = _workspace_yaml_body(agent_type)
     non_comment_lines: list[str] = []
     for line in body.splitlines():
         stripped = line.split("#", 1)[0]
@@ -347,16 +382,30 @@ def test_workspace_playbook_does_not_reference_ansible_user_dir() -> None:
     assert "ansible_user_dir" not in "\n".join(non_comment_lines)
 
 
-def test_workspace_playbook_uses_copy_with_follow_no() -> None:
+@pytest.mark.parametrize("agent_type", ["openclaw", "zeroclaw"])
+def test_workspace_playbook_uses_copy_with_follow_no(agent_type: str) -> None:
     """U23 — symlink defense at the playbook copy boundary."""
-    body = _openclaw_workspace_yaml_body()
+    body = _workspace_yaml_body(agent_type)
     assert "ansible.builtin.copy" in body
     # The copy task carries `follow: no`. Loose match — YAML whitespace
     # may vary.
     assert "follow: no" in body or "follow: false" in body.lower()
 
 
-def test_workspace_playbook_asserts_home_agent_name_prefix() -> None:
+@pytest.mark.parametrize("agent_type", ["openclaw", "zeroclaw"])
+def test_workspace_playbook_asserts_home_agent_name_prefix(
+    agent_type: str,
+) -> None:
     """U22 — the assert task pins rendered dest under /home/{{ agent_name }}/."""
-    body = _openclaw_workspace_yaml_body()
+    body = _workspace_yaml_body(agent_type)
     assert "workspace_dest_root.startswith('/home/' ~ agent_name ~ '/')" in body
+
+
+def test_zeroclaw_workspace_playbook_uses_agent_name_as_become_user() -> None:
+    """U22 (zeroclaw subset, #768): playbook becomes the agent unix user
+    (`become_user: {{ agent_name }}`), matching openclaw's contract. The
+    SSH user (xclm) writing into ~/.zeroclaw/workspace/ would leave the
+    files owned by xclm, breaking the daemon's reads."""
+    body = _workspace_yaml_body("zeroclaw")
+    assert 'become_user: "{{ agent_name }}"' in body
+    assert "become: yes" in body

--- a/tests/test_workspace_zeroclaw_bearer_rotation.py
+++ b/tests/test_workspace_zeroclaw_bearer_rotation.py
@@ -210,11 +210,13 @@ def test_zeroclaw_workspace_only_sync_calls_repair_with_exact_args(
 
     assert result.success is True
     assert result.workspace_files_pushed == ("MARKER.md",)
+    # iter-1 lifecycle-core S5: reason is distinct per entry point so
+    # `gateway_token_rotated` events are greppable by source.
     repair_mock.assert_called_once_with(
         "h.example",
         agent_name="alice",
         on_event=None,
-        reason="sync",
+        reason="workspace-only-sync",
     )
 
 
@@ -328,8 +330,13 @@ def test_zeroclaw_workspace_only_does_not_transition_state(
 ) -> None:
     """W5 iter-3 / I17: `--workspace-only` preserves the current
     lifecycle state. An operator may overlay onto a STOPPED zeroclaw
-    agent without silently flipping it to READY."""
-    make_canonical_stubs("zeroclaw")
+    agent without silently flipping it to READY.
+
+    iter-1 test-coverage W2/W3: tighten to (a) exact-argument repair
+    assertion (loose assert_called_once() would mask wrong-reason
+    regressions), (b) explicit assertion that restart/verify did not
+    fire on the workspace-only path."""
+    calls = make_canonical_stubs("zeroclaw")
 
     transition_mock = MagicMock()
     monkeypatch.setattr(
@@ -355,10 +362,22 @@ def test_zeroclaw_workspace_only_does_not_transition_state(
             verify=False,
         )
 
-    # Bearer DID rotate (workspace-only is bound by the #437 invariant)
-    repair_mock.assert_called_once()
+    # Bearer DID rotate (workspace-only is bound by the #437 invariant);
+    # pin reason="workspace-only-sync" so the entry-point distinction
+    # in operator logs cannot regress to the default `reason="sync"`.
+    repair_mock.assert_called_once_with(
+        "h.example",
+        agent_name="alice",
+        on_event=None,
+        reason="workspace-only-sync",
+    )
     # But the state-READY transition is NOT attempted.
     transition_mock.assert_not_called()
+    # And neither restart nor verify ran (workspace-only short-circuits
+    # before the canonical write loop).
+    assert not any(c[0] in {"restart", "verify"} for c in calls), (
+        f"workspace-only path should not call restart/verify, got: {calls}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -388,16 +407,20 @@ def test_zeroclaw_workspace_only_repair_failure_raises(
             repair_mock,
         ),
     ):
-        with pytest.raises(
-            CanonicalSyncError,
-            match=r"workspace-only sync wrote overlay for 'alice'",
-        ):
+        with pytest.raises(CanonicalSyncError) as excinfo:
             sync_agent_canonical(
                 "alice",
                 workspace_only=True,
                 restart=False,
                 verify=False,
             )
+    # iter-1 test-coverage W4: pin both the agent-name fragment AND the
+    # upstream `repair_err` so a regression that drops `{repair_err}`
+    # from the raise message (silently stripping the operator's only
+    # diagnostic) is caught.
+    err_msg = str(excinfo.value)
+    assert "workspace-only sync wrote overlay for 'alice'" in err_msg
+    assert "gateway hung" in err_msg
 
 
 # ---------------------------------------------------------------------------
@@ -410,10 +433,15 @@ def test_zeroclaw_workspace_only_dry_run_skips_bearer_rotation(
 ) -> None:
     """W6 iter-3 defense-in-depth: even if a programmatic caller passes
     `dry_run=True` alongside `workspace_only=True`, the bearer MUST NOT
-    be minted and no `gateway_token_rotated` event MAY be emitted."""
+    be minted and no `gateway_token_rotated` event MAY be emitted.
+
+    iter-1 test-coverage W7: also pin that `push_workspace_phase` is
+    invoked with `dry_run=True` — a regression that forwarded
+    `dry_run=False` would cause the dry-run to actually write files."""
     make_canonical_stubs("zeroclaw")
 
     repair_mock = MagicMock()
+    push_mock = MagicMock(return_value=_fake_push_success())
     events: list[tuple[str, str]] = []
 
     def on_event(stage: str, message: str) -> None:
@@ -422,7 +450,7 @@ def test_zeroclaw_workspace_only_dry_run_skips_bearer_rotation(
     with (
         patch(
             "clawrium.core.workspace_sync.push_workspace_phase",
-            return_value=_fake_push_success(),
+            push_mock,
         ),
         patch(
             "clawrium.core.lifecycle._zeroclaw_repair_after_start",
@@ -439,6 +467,10 @@ def test_zeroclaw_workspace_only_dry_run_skips_bearer_rotation(
         )
 
     repair_mock.assert_not_called()
+    # push_workspace_phase MUST receive dry_run=True so it short-circuits
+    # before any host write.
+    push_mock.assert_called_once()
+    assert push_mock.call_args.kwargs.get("dry_run") is True
     # No gateway_token_rotated / gateway_auth_stale events permitted.
     assert all(
         stage not in {"gateway_token_rotated", "gateway_auth_stale"}

--- a/tests/test_workspace_zeroclaw_bearer_rotation.py
+++ b/tests/test_workspace_zeroclaw_bearer_rotation.py
@@ -1,0 +1,589 @@
+"""Bearer-rotation invariant for the canonical workspace phase
+(issue #760 Phase 2 / #768, hot-path regression backstop for #437).
+
+The contract being pinned, per AGENTS.md "Gateway Token Lifecycle
+(zeroclaw)":
+
+  `clawctl agent configure`, `clawctl agent sync`, and
+  `clawctl agent restart` all mint a fresh bearer and overwrite
+  `hosts.json.gateway.auth` atomically.  There is no idempotent-skip
+  path.
+
+The Phase 2 wiring (issue #768) extends the same invariant across all
+three sync entry shapes:
+
+  - default `clawctl agent sync <name>`
+  - `clawctl agent sync <name> --no-restart`
+  - `clawctl agent sync <name> --workspace-only`
+
+These tests stub the dependencies of `sync_agent_canonical` at the
+import sites so the canonical function's own bearer-rotation logic is
+exercised without SSH / Ansible / network. The hook-review S
+requirement makes every assertion `assert_called_once_with(...)` style
+— loose `assert_called()` masks regressions where the repair fires
+with the wrong agent / wrong reason / wrong hostname.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clawrium.core import lifecycle_canonical
+from clawrium.core.lifecycle_canonical import (
+    CanonicalSyncError,
+    sync_agent_canonical,
+)
+from clawrium.core.workspace_sync import WorkspacePhaseResult
+
+
+@pytest.fixture
+def make_canonical_stubs(monkeypatch: pytest.MonkeyPatch):
+    """Factory: returns a stubs builder parametrized on `agent_type`
+    so the same scaffolding drives the openclaw-negative and
+    zeroclaw-positive cases."""
+
+    def _build(agent_type: str):
+        calls: list[str] = []
+
+        inputs = MagicMock()
+        inputs.agent_type = agent_type
+        inputs.integrations = []
+
+        def fake_build_render_inputs(_agent_name: str):
+            return inputs
+
+        def fake_renderer(_inputs):
+            return MagicMock(files={})
+
+        def fake_get_agent_by_name(agent_name: str):
+            host = {
+                "hostname": "h.example",
+                "key_id": "h.example",
+                "user": "xclm",
+                "os_family": "linux",
+            }
+            return (host, agent_name, {"type": agent_type})
+
+        def fake_diff_files(**_kwargs):
+            return []
+
+        fake_client = MagicMock()
+        fake_client.close = lambda: None
+
+        def fake_open_ssh(_host, *, timeout=15):
+            return fake_client
+
+        def fake_restart_unit(_client, *, agent_type, agent_name):
+            calls.append(("restart", agent_type, agent_name))
+
+        def fake_verify_health(_client, *, agent_type, agent_name):
+            calls.append(("verify", agent_type, agent_name))
+
+        monkeypatch.setattr(
+            lifecycle_canonical,
+            "build_render_inputs",
+            fake_build_render_inputs,
+        )
+        monkeypatch.setitem(
+            lifecycle_canonical._RENDERERS, agent_type, fake_renderer
+        )
+        monkeypatch.setattr(
+            lifecycle_canonical, "get_agent_by_name", fake_get_agent_by_name
+        )
+        monkeypatch.setattr(
+            lifecycle_canonical, "diff_files", fake_diff_files
+        )
+        monkeypatch.setattr(lifecycle_canonical, "_open_ssh", fake_open_ssh)
+        monkeypatch.setattr(
+            lifecycle_canonical, "_restart_unit", fake_restart_unit
+        )
+        monkeypatch.setattr(
+            lifecycle_canonical, "_verify_health", fake_verify_health
+        )
+
+        # Suppress onboarding state transition — unrelated to bearer
+        # rotation. Tests that explicitly want to assert the state
+        # transition override this within the test body.
+        monkeypatch.setattr(
+            "clawrium.core.onboarding.transition_state",
+            lambda *_a, **_k: None,
+        )
+
+        return calls
+
+    return _build
+
+
+def _fake_push_success(rel_files: tuple[str, ...] = ()) -> WorkspacePhaseResult:
+    return WorkspacePhaseResult(
+        success=True, files_pushed=rel_files, files_excluded=()
+    )
+
+
+# ---------------------------------------------------------------------------
+# I-pair-A — default sync rotates bearer (zeroclaw)
+# ---------------------------------------------------------------------------
+
+
+def test_zeroclaw_default_sync_calls_repair_with_exact_args(
+    make_canonical_stubs,
+) -> None:
+    """I-pair-A: full-flow rotation. After restart+verify, the
+    canonical pipeline MUST call `_zeroclaw_repair_after_start` exactly
+    once with the host, agent_name, callback, and reason=sync.
+
+    Hook-review S — exact-argument `assert_called_once_with(...)`. The
+    looser `assert_called()` would silently accept a regression that
+    invoked the repair with the wrong agent or the wrong reason."""
+    make_canonical_stubs("zeroclaw")
+
+    repair_mock = MagicMock(return_value=(True, None))
+
+    written_diff = MagicMock()
+    written_diff.unified_diff = "--- a\n+++ b\n"
+    written_diff.path = ".zeroclaw/config.toml"
+    written_diff.remote_path = "/home/alice/.zeroclaw/config.toml"
+    written_diff.rendered_body = "[]"
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            return_value=_fake_push_success(),
+        ),
+        patch.object(
+            lifecycle_canonical, "diff_files", return_value=[written_diff]
+        ),
+        patch.object(lifecycle_canonical, "_atomic_write", return_value=None),
+        patch(
+            "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+            repair_mock,
+        ),
+    ):
+        result = sync_agent_canonical(
+            "alice", force=False, restart=True, verify=True
+        )
+
+    assert result.success is True
+    repair_mock.assert_called_once_with(
+        "h.example",
+        agent_name="alice",
+        on_event=None,
+        reason="sync",
+    )
+
+
+# ---------------------------------------------------------------------------
+# I-pair-B — workspace-only sync rotates bearer (zeroclaw)
+# ---------------------------------------------------------------------------
+
+
+def test_zeroclaw_workspace_only_sync_calls_repair_with_exact_args(
+    make_canonical_stubs,
+) -> None:
+    """I-pair-B + U28: `--workspace-only` MUST also rotate the bearer.
+    Skipping rotation here was the regression class iter-2 protected
+    (B2-NEW) and the original #437 bug shape: any sync entry point that
+    skips re-pair leaves `hosts.json.gateway.auth` permanently stale on
+    the next external daemon restart."""
+    make_canonical_stubs("zeroclaw")
+
+    repair_mock = MagicMock(return_value=(True, None))
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            return_value=_fake_push_success(rel_files=("MARKER.md",)),
+        ),
+        patch(
+            "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+            repair_mock,
+        ),
+    ):
+        result = sync_agent_canonical(
+            "alice",
+            workspace_only=True,
+            restart=False,
+            verify=False,
+        )
+
+    assert result.success is True
+    assert result.workspace_files_pushed == ("MARKER.md",)
+    repair_mock.assert_called_once_with(
+        "h.example",
+        agent_name="alice",
+        on_event=None,
+        reason="sync",
+    )
+
+
+# ---------------------------------------------------------------------------
+# I-pair-C — no-restart sync still rotates bearer (zeroclaw)
+# ---------------------------------------------------------------------------
+
+
+def test_zeroclaw_no_restart_sync_still_calls_repair(
+    make_canonical_stubs,
+) -> None:
+    """I-pair-C: `--no-restart` skips `_restart_unit` but the bearer
+    re-pair still runs unconditionally. AGENTS.md: an externally-driven
+    daemon restart (host reboot, ops systemctl) would otherwise leave
+    hosts.json stale."""
+    calls = make_canonical_stubs("zeroclaw")
+
+    repair_mock = MagicMock(return_value=(True, None))
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            return_value=_fake_push_success(),
+        ),
+        patch(
+            "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+            repair_mock,
+        ),
+    ):
+        sync_agent_canonical(
+            "alice", force=False, restart=False, verify=False
+        )
+
+    # No restart unit ran (operator asked to skip it).
+    restart_calls = [c for c in calls if c[0] == "restart"]
+    assert restart_calls == []
+
+    repair_mock.assert_called_once_with(
+        "h.example",
+        agent_name="alice",
+        on_event=None,
+        reason="sync",
+    )
+
+
+# ---------------------------------------------------------------------------
+# I-pair-D — negative: openclaw NEVER calls repair
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sync_kwargs",
+    [
+        pytest.param(
+            {"restart": True, "verify": True}, id="default"
+        ),
+        pytest.param(
+            {"restart": False, "verify": False}, id="no-restart"
+        ),
+        pytest.param(
+            {"workspace_only": True, "restart": False, "verify": False},
+            id="workspace-only",
+        ),
+    ],
+)
+def test_openclaw_never_calls_zeroclaw_repair(
+    make_canonical_stubs, sync_kwargs: dict
+) -> None:
+    """I-pair-D (openclaw cell): bearer rotation is zeroclaw-specific.
+    Openclaw's gateway uses a flat bearer in
+    `hosts.json.gateway.auth` but it is NOT rotated by clawctl; the
+    repair playbook does not exist for openclaw. Pinning this prevents
+    a regression where the `agent_type == "zeroclaw"` guard is dropped
+    or inverted. Hermes cell joins this parametrization in Phase 3."""
+    make_canonical_stubs("openclaw")
+
+    repair_mock = MagicMock(return_value=(True, None))
+
+    written_diff = MagicMock()
+    written_diff.unified_diff = "--- a\n+++ b\n"
+    written_diff.path = ".openclaw/openclaw.json"
+    written_diff.remote_path = "/home/alice/.openclaw/openclaw.json"
+    written_diff.rendered_body = "{}"
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            return_value=_fake_push_success(),
+        ),
+        patch.object(
+            lifecycle_canonical, "diff_files", return_value=[written_diff]
+        ),
+        patch.object(lifecycle_canonical, "_atomic_write", return_value=None),
+        patch(
+            "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+            repair_mock,
+        ),
+    ):
+        sync_agent_canonical("alice", **sync_kwargs)
+
+    repair_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# I-pair-state / I17 — workspace-only does NOT transition state
+# ---------------------------------------------------------------------------
+
+
+def test_zeroclaw_workspace_only_does_not_transition_state(
+    make_canonical_stubs, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """W5 iter-3 / I17: `--workspace-only` preserves the current
+    lifecycle state. An operator may overlay onto a STOPPED zeroclaw
+    agent without silently flipping it to READY."""
+    make_canonical_stubs("zeroclaw")
+
+    transition_mock = MagicMock()
+    monkeypatch.setattr(
+        "clawrium.core.onboarding.transition_state", transition_mock
+    )
+
+    repair_mock = MagicMock(return_value=(True, None))
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            return_value=_fake_push_success(),
+        ),
+        patch(
+            "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+            repair_mock,
+        ),
+    ):
+        sync_agent_canonical(
+            "alice",
+            workspace_only=True,
+            restart=False,
+            verify=False,
+        )
+
+    # Bearer DID rotate (workspace-only is bound by the #437 invariant)
+    repair_mock.assert_called_once()
+    # But the state-READY transition is NOT attempted.
+    transition_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# I-pair-state — failed repair on workspace-only short-circuits
+# ---------------------------------------------------------------------------
+
+
+def test_zeroclaw_workspace_only_repair_failure_raises(
+    make_canonical_stubs,
+) -> None:
+    """I-pair-state (workspace-only branch): when re-pair fails after
+    workspace push, the canonical sync MUST raise CanonicalSyncError so
+    the CLI's `except` clause routes it to exit code 1."""
+    make_canonical_stubs("zeroclaw")
+
+    repair_mock = MagicMock(
+        return_value=(False, "/pair returned 500: gateway hung")
+    )
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            return_value=_fake_push_success(),
+        ),
+        patch(
+            "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+            repair_mock,
+        ),
+    ):
+        with pytest.raises(
+            CanonicalSyncError,
+            match=r"workspace-only sync wrote overlay for 'alice'",
+        ):
+            sync_agent_canonical(
+                "alice",
+                workspace_only=True,
+                restart=False,
+                verify=False,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Dry-run gate (W6 iter-3) — no bearer mint, no event emission
+# ---------------------------------------------------------------------------
+
+
+def test_zeroclaw_workspace_only_dry_run_skips_bearer_rotation(
+    make_canonical_stubs,
+) -> None:
+    """W6 iter-3 defense-in-depth: even if a programmatic caller passes
+    `dry_run=True` alongside `workspace_only=True`, the bearer MUST NOT
+    be minted and no `gateway_token_rotated` event MAY be emitted."""
+    make_canonical_stubs("zeroclaw")
+
+    repair_mock = MagicMock()
+    events: list[tuple[str, str]] = []
+
+    def on_event(stage: str, message: str) -> None:
+        events.append((stage, message))
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            return_value=_fake_push_success(),
+        ),
+        patch(
+            "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+            repair_mock,
+        ),
+    ):
+        sync_agent_canonical(
+            "alice",
+            workspace_only=True,
+            restart=False,
+            verify=False,
+            dry_run=True,
+            on_event=on_event,
+        )
+
+    repair_mock.assert_not_called()
+    # No gateway_token_rotated / gateway_auth_stale events permitted.
+    assert all(
+        stage not in {"gateway_token_rotated", "gateway_auth_stale"}
+        for stage, _ in events
+    )
+
+
+def test_zeroclaw_default_sync_dry_run_skips_bearer_rotation(
+    make_canonical_stubs,
+) -> None:
+    """W6 iter-3 (main-path branch): `dry_run=True` on the default sync
+    also bypasses re-pair."""
+    make_canonical_stubs("zeroclaw")
+
+    repair_mock = MagicMock()
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            return_value=_fake_push_success(),
+        ),
+        patch(
+            "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+            repair_mock,
+        ),
+    ):
+        sync_agent_canonical(
+            "alice",
+            force=False,
+            restart=True,
+            verify=True,
+            dry_run=True,
+        )
+
+    repair_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# I18 — stale-bearer banner (W11)
+# ---------------------------------------------------------------------------
+
+
+def test_zeroclaw_repair_failure_emits_stale_bearer_event_default_path(
+    make_canonical_stubs,
+) -> None:
+    """I18 / W11 iter-3: when re-pair fails after a successful restart +
+    verify, the canonical sync MUST emit a `gateway_auth_stale` NDJSON
+    event before raising. Without this banner an operator sees a generic
+    CanonicalSyncError and has no signal that the on-disk bearer is now
+    out of sync with the daemon's enforced bearer."""
+    make_canonical_stubs("zeroclaw")
+
+    repair_mock = MagicMock(
+        return_value=(False, "/pair returned 500: gateway hung")
+    )
+
+    events: list[tuple[str, str]] = []
+
+    def on_event(stage: str, message: str) -> None:
+        events.append((stage, message))
+
+    written_diff = MagicMock()
+    written_diff.unified_diff = "--- a\n+++ b\n"
+    written_diff.path = ".zeroclaw/config.toml"
+    written_diff.remote_path = "/home/alice/.zeroclaw/config.toml"
+    written_diff.rendered_body = "[]"
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            return_value=_fake_push_success(),
+        ),
+        patch.object(
+            lifecycle_canonical, "diff_files", return_value=[written_diff]
+        ),
+        patch.object(lifecycle_canonical, "_atomic_write", return_value=None),
+        patch(
+            "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+            repair_mock,
+        ),
+    ):
+        with pytest.raises(CanonicalSyncError):
+            sync_agent_canonical(
+                "alice",
+                force=False,
+                restart=True,
+                verify=True,
+                on_event=on_event,
+            )
+
+    stale_events = [(s, m) for (s, m) in events if s == "gateway_auth_stale"]
+    assert len(stale_events) == 1, (
+        f"expected exactly one gateway_auth_stale event, got: {events}"
+    )
+
+    import json as _json
+
+    payload = _json.loads(stale_events[0][1])
+    assert payload["agent_key"] == "alice"
+    assert payload["reason"] == "sync re-pair failed"
+    # The repair detail surfaces in the structured event so the CLI
+    # banner has a concrete starting point for the operator.
+    assert "gateway hung" in payload["detail"]
+
+
+def test_zeroclaw_workspace_only_repair_failure_emits_stale_bearer_event(
+    make_canonical_stubs,
+) -> None:
+    """I18 (workspace-only branch): stale-bearer banner also fires on
+    the `--workspace-only` re-pair failure path. Without this the
+    operator running `clawctl agent sync --workspace-only` would see a
+    bare exit-1 with no diagnostic on bearer state."""
+    make_canonical_stubs("zeroclaw")
+
+    repair_mock = MagicMock(
+        return_value=(False, "/pair/code returned 401")
+    )
+    events: list[tuple[str, str]] = []
+
+    def on_event(stage: str, message: str) -> None:
+        events.append((stage, message))
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            return_value=_fake_push_success(),
+        ),
+        patch(
+            "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+            repair_mock,
+        ),
+    ):
+        with pytest.raises(CanonicalSyncError):
+            sync_agent_canonical(
+                "alice",
+                workspace_only=True,
+                restart=False,
+                verify=False,
+                on_event=on_event,
+            )
+
+    stale_events = [(s, m) for (s, m) in events if s == "gateway_auth_stale"]
+    assert len(stale_events) == 1
+    import json as _json
+
+    payload = _json.loads(stale_events[0][1])
+    assert payload["agent_key"] == "alice"
+    assert payload["reason"] == "workspace-only re-pair failed"

--- a/tests/test_workspace_zeroclaw_bearer_rotation.py
+++ b/tests/test_workspace_zeroclaw_bearer_rotation.py
@@ -385,6 +385,140 @@ def test_zeroclaw_workspace_only_does_not_transition_state(
 # ---------------------------------------------------------------------------
 
 
+def test_zeroclaw_workspace_only_push_failure_skips_repair(
+    make_canonical_stubs,
+) -> None:
+    """iter-2 test-coverage W4: when the workspace push itself fails on
+    the `--workspace-only` path, the bearer-rotation block MUST be
+    skipped. Reordering the push-failure raise to land after bearer
+    rotation would silently rotate the bearer on a half-applied
+    overlay — the exact regression class the AGENTS.md short-circuit
+    contract forbids.
+    """
+    make_canonical_stubs("zeroclaw")
+
+    repair_mock = MagicMock()
+    events: list[tuple[str, str]] = []
+
+    def on_event(stage: str, message: str) -> None:
+        events.append((stage, message))
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            return_value=WorkspacePhaseResult(
+                success=False,
+                files_pushed=(),
+                files_excluded=(),
+                error="forced workspace_only push failure",
+            ),
+        ),
+        patch(
+            "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+            repair_mock,
+        ),
+    ):
+        with pytest.raises(
+            CanonicalSyncError, match=r"workspace overlay push failed"
+        ):
+            sync_agent_canonical(
+                "alice",
+                workspace_only=True,
+                restart=False,
+                verify=False,
+                on_event=on_event,
+            )
+
+    # The push raised — repair MUST NOT have run.
+    repair_mock.assert_not_called()
+    # And no bearer-related events should have been emitted on the
+    # short-circuited path.
+    assert all(
+        stage not in {"gateway_token_rotated", "gateway_auth_stale"}
+        for stage, _ in events
+    )
+
+
+def test_zeroclaw_no_restart_repair_failure_says_restart_skipped(
+    make_canonical_stubs,
+) -> None:
+    """iter-2 lifecycle-core W3: the user-facing CanonicalSyncError
+    preamble on the main-branch re-pair-failure path must branch on
+    `restart`. In --no-restart mode the preamble must NOT claim a
+    restart that did not happen — operators would otherwise look for
+    systemctl evidence that never existed.
+    """
+    make_canonical_stubs("zeroclaw")
+
+    repair_mock = MagicMock(return_value=(False, "/pair returned 503"))
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            return_value=_fake_push_success(),
+        ),
+        patch(
+            "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+            repair_mock,
+        ),
+    ):
+        with pytest.raises(CanonicalSyncError) as excinfo:
+            sync_agent_canonical(
+                "alice",
+                force=False,
+                restart=False,
+                verify=False,
+            )
+
+    err = str(excinfo.value)
+    assert "restart skipped" in err
+    # The preamble MUST NOT claim a restart that never ran.
+    assert "wrote and restarted" not in err
+
+
+def test_zeroclaw_repair_failure_default_path_says_restarted(
+    make_canonical_stubs,
+) -> None:
+    """iter-2 lifecycle-core W3 (positive pin): in default mode the
+    preamble correctly claims the restart that did happen.
+    """
+    make_canonical_stubs("zeroclaw")
+
+    repair_mock = MagicMock(return_value=(False, "/pair returned 503"))
+
+    written_diff = MagicMock()
+    written_diff.unified_diff = "--- a\n+++ b\n"
+    written_diff.path = ".zeroclaw/config.toml"
+    written_diff.remote_path = "/home/alice/.zeroclaw/config.toml"
+    written_diff.rendered_body = "[]"
+
+    with (
+        patch(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            return_value=_fake_push_success(),
+        ),
+        patch.object(
+            lifecycle_canonical, "diff_files", return_value=[written_diff]
+        ),
+        patch.object(lifecycle_canonical, "_atomic_write", return_value=None),
+        patch(
+            "clawrium.core.lifecycle._zeroclaw_repair_after_start",
+            repair_mock,
+        ),
+    ):
+        with pytest.raises(CanonicalSyncError) as excinfo:
+            sync_agent_canonical(
+                "alice",
+                force=False,
+                restart=True,
+                verify=True,
+            )
+
+    err = str(excinfo.value)
+    assert "wrote and restarted 'alice'" in err
+    assert "restart skipped" not in err
+
+
 def test_zeroclaw_workspace_only_repair_failure_raises(
     make_canonical_stubs,
 ) -> None:
@@ -420,7 +554,10 @@ def test_zeroclaw_workspace_only_repair_failure_raises(
     # diagnostic) is caught.
     err_msg = str(excinfo.value)
     assert "workspace-only sync wrote overlay for 'alice'" in err_msg
-    assert "gateway hung" in err_msg
+    # iter-2 test-coverage S4: pin the FULL repair_err string so a
+    # regression that truncates the detail to its last token still
+    # fails. The literal must match the stub's return value above.
+    assert "/pair returned 500: gateway hung" in err_msg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #768. Phase 2 of #760.

Stacked on top of issue-767-openclaw-workspace-overlay (PR #773).

## Summary

- Adds **zeroclaw workspace overlay** end-to-end on Ubuntu (manifest + Linux playbook + macOS stub).
- Wires the **bearer-rotation invariant** (#437) across all three sync entry points: default, `--no-restart`, and `--workspace-only`. Drops the Phase 1 zeroclaw flag-gate.
- Adds the **stale-bearer banner** (`gateway_auth_stale` NDJSON + yellow stderr) for the case where re-pair fails and `hosts.json.gateway.auth` no longer matches the daemon-enforced bearer.

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 3739 passed, 8 skipped
- [x] 15 new tests in `tests/test_workspace_zeroclaw_bearer_rotation.py` covering I-pair-A/B/C/D, I17, I18, W6 dry-run gates, W11 stale-bearer banner, and the W4 push-failure short-circuit
- [x] CLI tests in `tests/cli/clawctl/agent/test_sync_workspace_flags.py` covering the lifted Phase 1 gate (zeroclaw + `--workspace-only`/`--no-restart` now reach the canonical layer) and the new stale-bearer banner (stderr-only, bidi/ANSI-safe, JSON-tolerant)
- [x] Zeroclaw playbook structural tests parametrized alongside openclaw (no `ansible_user_dir`, `follow: no`, `/home/{{ agent_name }}/` prefix assertion)
- [ ] **Real-host E2E on `wolf-i`** — captured separately under `.itx/760/03_E2E_zeroclaw_wolf-i.md`; this PR ships the unit + integration coverage that gates the E2E

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $13.31 | Total Time: 24m 30s | 3 iterations**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 4/5 (cli-ux 2/5 with B1) | B1 (Phase 1 zeroclaw gate unreachable) | All fixed in c58cfd3 | $4.97 | 7m12s | leader, cli-ux, lifecycle-core, test-coverage, security-reviewer, platform-playbooks |
| 2 | 4/5 | None (leader flagged W1–W4 as must-fix-before-merge) | All fixed in 8c1e54c | $5.05 | 8m51s | leader, cli-ux, lifecycle-core, test-coverage, security-reviewer |
| 3 | 4/5 | None | Merge — lifecycle-core 5/5, cli-ux 4/5, test-coverage 4/5, security 4/5 | $3.30 | 7m48s | leader, cli-ux, lifecycle-core, test-coverage, security-reviewer |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 4/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 (cli-ux) | `cli/clawctl/agent/sync.py:320-340` | Phase 1 zeroclaw gate still rejects `--workspace-only`/`--no-restart` with exit 2 — but this PR is exactly what makes those flags safe. Phase 2 features unreachable from the CLI. | Fixed in c58cfd3: gate dropped, help-text updated, inverted CLI test pins the new contract |

**Warnings (fixed inline):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W2 (cli-ux) | `cli/clawctl/agent/sync.py` help text | Help advertises Phase 1 restriction | Updated both flag help-strings |
| W3 (cli-ux) | `cli/clawctl/agent/sync.py:484-528` | gateway_auth_stale banner bypasses sanitize_passthrough — bidi/zero-width spoof vector | Added sanitize_passthrough on agent_label + detail_text before rich_escape |
| W6 (cli-ux) | `cli/clawctl/agent/sync.py:518` | U+26A0 emoji renders as ? on non-UTF terminals | Replaced with WARN: prefix |
| W1 (lifecycle-core) | `core/lifecycle_canonical.py:1096-1102` | Comment "restart + verify succeeded above" inaccurate for --no-restart case | Corrected comment |
| W2 (lifecycle-core) | `core/lifecycle_canonical.py:861-867,1117` | Recovery hint suggests `clawctl agent sync` which would fail with same error | Tightened to `restart` first then `doctor` |
| S5 (lifecycle-core) | `core/lifecycle_canonical.py:828-832` | workspace-only re-pair passes same `reason="sync"` as main path — events indistinguishable | Pass `reason="workspace-only-sync"` |
| W1 (test-coverage) | `cli/clawctl/agent/sync.py:484-528` | gateway_auth_stale banner has zero CLI tests | Added 2 new CLI tests (stderr + bidi + JSON-tolerant) |
| W2 (test-coverage) | `tests/test_workspace_zeroclaw_bearer_rotation.py:359` | Loose `assert_called_once()` — could mask wrong-reason regressions | Switched to `assert_called_once_with(...)` full kwargs + asserted restart/verify NOT called |
| W4 (test-coverage) | `tests/test_workspace_zeroclaw_bearer_rotation.py:369-400` | `repair_err` preservation not pinned in raised exception | Now asserts both agent-name fragment AND `"gateway hung"` |
| W7 (test-coverage) | `tests/test_workspace_zeroclaw_bearer_rotation.py:408-446` | Doesn't verify push_workspace_phase receives dry_run=True | Now pins `push_mock.call_args.kwargs.get("dry_run") is True` |

**Suggestions (deferred as Callouts below):**
S1 cross-module helper coupling, S2 import-json hoist, S3 bearer_rotated field, security bearer-string redaction, platform staging_dir prefix-match, test-coverage parametrize, platform memory_path collision.

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**No blocking issues. Leader flagged W1–W4 as must-fix-before-merge.**

**Warnings (fixed inline in 8c1e54c):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 (cli-ux) | `cli/clawctl/agent/sync.py:443-449` | iter-1 W3 left the sibling `gateway_token_rotated` handler still using bare `rich_escape` on agent_key — asymmetric bidi exposure | Applied `sanitize(...)` to agent_label in rotation handler too |
| W2 (cli-ux) | `cli/clawctl/agent/sync.py:503,517` | `sanitize_passthrough` strips bidi/zero-width but not C0/C1 controls or ANSI escapes; `detail_text` is raw ansible-runner output | Switched both banners to strict `sanitize(...)` |
| W3 (lifecycle-core) | `core/lifecycle_canonical.py:1133-1138` | Main-branch CanonicalSyncError preamble says "sync wrote and restarted" in --no-restart mode where no restart ran | Branched preamble on `restart` kwarg: "sync of {name} (restart skipped)" vs "sync wrote and restarted {name}" |
| W4 (test-coverage) | `tests/test_workspace_zeroclaw_bearer_rotation.py` | Missing push-failure-skips-repair test on workspace-only path; structurally safe today but no regression backstop | Added `test_zeroclaw_workspace_only_push_failure_skips_repair` + 2 supporting W3 preamble tests |

**Suggestions also folded in:**

| # | File | Suggestion | Action |
|---|------|------------|--------|
| S1 (cli-ux) | `cli/clawctl/agent/sync.py:510` | Malformed-payload fallback embeds 'zeroclaw agent' (with space) in restart command — unrunnable | Use `<agent-name>` placeholder on fallback branch |
| S4 (test-coverage) | iter-1 W4 substring match could pass on truncation | Tightened to full `/pair returned 500: gateway hung` literal |

**Suggestions deferred as Callouts:** S2 cosmetic narrative, S3 pre-existing fragile pattern from Phase 1, S5 premature abstraction (single-member set), S6 emit-side sanitisation (broader convention change).

</details>

<details>
<summary>Review 3 Details (Rating 4/5) — Final</summary>

**No blocking issues. Verdict: MERGE.**

| Agent | Rating | Verdict |
|---|---|---|
| lifecycle-core | **5/5** | "Ship. W3 is a targeted, correct fix with positive and negative test pins; no further iteration warranted under the 3-iter ceiling." |
| cli-ux | 4/5 | "Ship as-is. Three suggestions in a future polish pass; none block merge." |
| test-coverage | 4/5 | "Merge as-is. The three new tests correctly pin the iter-2 W3 and W4 contracts; S4 is appropriately tightened." |
| security-reviewer | 4/5 | "Merge — no blocking findings." |

**Iter-3 suggestions (deferred — see Callouts):** main-branch zeroclaw push-failure short-circuit symmetry gap (regression-resilience only — structurally safe today), `sanitize()` comment overstates ANSI behaviour (cosmetic), nested vs two-step binding style asymmetry (cosmetic), `_AGENT_NAME_RE` re-validation before shell-snippet embedding (defense-in-depth — daemon already trusted), emit-side NDJSON sanitisation (same as iter-2 S6).

</details>

## Callouts

- **[DECISION] `install.py` scaffold extension not needed.**
  - Why: Phase 1's `create_agent` already keys on `WorkspaceOverlaySpec.from_manifest(claw_name)` — adding the manifest entry above is sufficient to enable `~/.config/clawrium/agents/zeroclaw/<name>/workspace/` scaffolding without touching install.py.
  - Reviewer: confirm this is the intended design.

- **[DECISION] Zeroclaw `destination_root` ≡ `workspace.memory_path`.**
  - Why: zeroclaw's workspace dir already holds the personality MD files surfaced via `clawctl agent memory`. Operator drops under `workspace/` will overwrite those files on every sync — this is the documented contract (matches the manifest comment). Adding `memory/` to excludes would silently break that workflow.
  - Reviewer: push back if zeroclaw memory should stay agent-managed.

- **[DECISION] Helper `_zeroclaw_repair_after_start` stays private.**
  - Why: ATX iter-1 lifecycle-core flagged the cross-module private-helper import as a code smell. Phase 1 already imports it inside `configure_agent`; promoting to a public symbol is a broader refactor touching `lifecycle.py` callsites and is out of scope for this stacked PR.
  - Tracking: deferred follow-up.

- **[TODO-FOLLOWUP] ATX deferrals across all 3 iterations.**
  - Tracking: to be filed.
  - Items: hoist `import json` to module top-level (multiple unrelated handlers); `bearer_rotated` field on `CanonicalSyncResult` (caller-coupling); bearer-string redaction from `repair_err` (low-risk, depends on pair-playbook future); `staging_dir` prefix-match hardening (applies equally to Phase 1 openclaw playbook — consistency fix); emit-side NDJSON sanitisation (broader convention change); main-branch zeroclaw push-failure symmetry test (regression-resilience — structurally safe today); `_AGENT_NAME_RE` re-validation before shell-snippet embedding (defense-in-depth).

- **[ENVIRONMENT] ATX reviews ran via CLI (`atx review request`), not MCP.**
  - The orchestrator passed `--no-restart` semantics via the prompt; full session state at `.itx/768/atx-session.json`.

- **[ENVIRONMENT] `make lint` failed on a missing GUI frontend build artifact; ran `uv run ruff check src tests` directly. Stub `src/clawrium/gui/frontend/.gitkeep` created locally but NOT committed (build-artifact issue, not in scope here).**

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
