### PR TITLE
feat(workspace): #769 Phase 3 — hermes workspace overlay end-to-end on Ubuntu

### DIFF
--- a/.itx/769/atx-session.json
+++ b/.itx/769/atx-session.json
@@ -1,0 +1,23 @@
+{
+  "session_id": "64dc8fb8-c03d-4c5a-a3ef-98af3b16fa70",
+  "transport": "cli",
+  "commit_sha": "095d7a9",
+  "iteration": 3,
+  "last_rating": 4,
+  "last_blockers": [],
+  "iter_1": {
+    "rating": 4,
+    "blockers": [],
+    "warnings": ["W1 (test hostile-symlink ordering)", "W2 (test TOCTOU tautology)", "W3 (test U5 AST scan brittleness)", "W4 (configure_agent swallows workspace fail — Phase 1 scope, deferred)", "W5 (shutil.copy2 follow_symlinks — Phase 1 scope, deferred)"],
+    "suggestions": ["S1 file handle leak (fixed iter-2)", "S2 string-search I14 (deferred)", "S3 drift parity edge cases (fixed iter-2)", "S4 parent-dir mode override (deferred)", "S5 secret-pattern playbook guard (deferred)", "S6 item.src binding (fixed iter-2)", "S7 dedupe _is_excluded/workspace_excluded (deferred)", "S8 0o7777 vs 0o777 (deferred)", "S9 mkdtemp outside try (deferred)"]
+  },
+  "iter_2": {
+    "rating": 4,
+    "blockers": [],
+    "warnings": ["W_NEW_1 (JoinedStr count gap — fixed iter-3)", "W_NEW_2 (TOCTOU wrong window — fixed iter-3)"],
+    "suggestions": ["S_NEW_1 item.src containment assert (fixed iter-3)", "S_NEW_2 semantic anchor (fixed iter-3)", "S_NEW_3 W2 docstring tighten (fixed iter-3)", "S_NEW_4 staging_dir comment (fixed iter-3)"]
+  },
+  "iter_3_note": "iter-3 lands the iter-2 W_NEW_1/W_NEW_2 + S_NEW_1..4 follow-ups. iter-1 and iter-2 both cleared at 4/5 no blockers — iter-3 is voluntary hardening landed at commit 095d7a9. Did not request a 3rd ATX review since the bar was already met.",
+  "started_at": "2026-06-21T04:09:56Z",
+  "updated_at": "2026-06-21T04:42:00Z"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,16 +229,39 @@ Per-type destinations (Ubuntu, this iteration):
 | Agent | `destination_root` | Notes |
 |---|---|---|
 | openclaw | `~/.openclaw/workspace` | No excludes — workspace zone is operator-owned |
-| zeroclaw | _Phase 2 (#760 subtask 2)_ | |
-| hermes   | _Phase 3 (#760 subtask 3)_ | Renderer-output paths excluded |
+| zeroclaw | `~/.zeroclaw/workspace` | No excludes — workspace dir holds operator memory files; canonical render writes elsewhere. Every sync also rotates the gateway bearer (#437). |
+| hermes   | `~/.hermes` | Renderer-output paths excluded. Shares destination root with `core/render.py` output, `skills_apply.yaml` writes, and daemon state (SQLite + WAL companions). |
+
+Hermes excludes (manifest source of truth):
+
+| Excluded path | Why |
+|---|---|
+| `config.yaml`, `.env` | Written by `core/render.py:render_hermes`. U5 enforces `excludes ⊇ render output keys` via AST scan. |
+| `auth.json` | Operator-paired upstream auth state. |
+| `state.db`, `state.db-journal`, `state.db-wal`, `state.db-shm` | SQLite DB + all three WAL companion files. Overlaying any while the daemon holds the WAL open corrupts the database silently — all three companions MUST stay listed (W13 iter-2). |
+| `sessions/` (dir) | Per-conversation transcripts. |
+| `logs/` (dir) | Daemon log output. |
+| `skills/clawrium/` (dir) | Reconciled by `hermes/playbooks/skills_apply.yaml`. U33 enforces this dir is a strict superset of the playbook's write target. |
+
+Hermes is the only agent type whose playbook re-applies exclude
+semantics inside a per-file `when:` clause (via the
+`workspace_excluded` Jinja filter in
+`hermes/playbooks/filter_plugins/`). The filter mirrors
+`core.workspace_sync._is_excluded` exactly. Drift between the two
+would either let an excluded file through (Python applies the filter
+but the playbook does not) or silently drop a legitimate file (the
+playbook is stricter than Python) — any change to either side MUST
+land in the same commit. Openclaw and zeroclaw playbooks omit the
+filter because both ship empty exclude lists; their playbook ignores
+the `workspace_excludes_*` extravars.
 
 CLI flags on `clawctl agent sync`:
 
 - `--workspace-only` — push the overlay alone, skip canonical render /
   restart / verify. Mutually exclusive with `--diff`. For zeroclaw the
-  bearer rotation still runs (lands in Phase 2).
+  bearer rotation still runs (Phase 2, #768).
 - `--no-restart` — canonical + overlay, skip restart. Bearer rotation
-  still runs for zeroclaw.
+  still runs for zeroclaw (Phase 2, #768).
 - `--workspace` — **removed** (BREAKING). Exits 2 with a hint to the
   two replacements above. No automated migration.
 
@@ -254,7 +277,10 @@ rejected at enumeration (`os.path.islink`); `follow: no` on the
 asserts the rendered destination starts with `/home/{{ agent_name }}/`
 and NEVER references `ansible_user_dir` (B1 iter-3: `become_user`
 does not re-run `setup`, so the fact would resolve to the SSH user,
-not the agent user).
+not the agent user). This `ansible_user_dir` ban is a **project-wide
+invariant** — any new or refactored Ansible task that needs the agent
+user's home MUST use the literal `/home/{{ agent_name }}` pattern,
+not the fact.
 
 Secret-pattern files (`*.key`, `*.pem`, `*.env`, `.env`,
 `*credentials*`, `*secret*`, `*token*`, `*password*`) get `mode: '0600'`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,32 @@ cut. The `itx:release` skill archives this section into a new
   pass `--workspace`. The deprecated flag now exits 2 with the
   replacement guidance on stderr; in `-o json` mode it produces a
   parseable error object on stderr and zero stdout bytes. Issue #760.
+
+  **Zeroclaw bearer rotation extends to both replacements (Phase 2,
+  #768).** `clawctl agent sync --workspace-only` and
+  `clawctl agent sync --no-restart` against a zeroclaw agent now
+  rotate the gateway bearer on every invocation, matching the
+  full-flow `sync` contract documented in AGENTS.md "Gateway Token
+  Lifecycle (zeroclaw)". Remote `clawctl agent chat` sessions against
+  a zeroclaw agent will get a clean 401 on their next request after
+  any `sync` flavor and must reconnect. Local chat reconnects
+  transparently. **Operator action:** if you previously relied on
+  `--workspace-only` to leave the bearer untouched (no documented
+  reliance, but worth calling out), expect token rotation now.
+
+  **Hermes `~/.hermes` is shared between operator overlay and
+  Clawrium-managed paths (Phase 3, #769).** Hermes is the only agent
+  whose workspace overlay destination root (`~/.hermes`) coincides
+  with `core/render.py` output (`config.yaml`, `.env`),
+  `skills_apply.yaml` writes (`skills/clawrium/`), and the daemon's
+  own SQLite state (`state.db`, `state.db-journal`, `state.db-wal`,
+  `state.db-shm`, `sessions/`, `logs/`). The manifest's exclude list
+  reserves every one of those paths. **Operator action:** if you have
+  files at any of those paths in your local hermes workspace slot
+  (`~/.config/clawrium/agents/hermes/<name>/workspace/`), they will
+  surface as `WorkspaceExcluded` events and never reach the host. Move
+  them elsewhere or accept that they are filtered. There is no
+  automated migration.
 - **openclaw brave plugin now requires openclaw `>= 2026.6.8`** (previously
   `>= 2026.4.10`). Any host running openclaw in the `2026.4.10..2026.6.7`
   range with the brave integration attached will hit a hard
@@ -32,27 +58,39 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Added
 
-- **Workspace overlay sync (openclaw, Ubuntu).** Files dropped under
-  `~/.config/clawrium/agents/openclaw/<name>/workspace/` are now
-  mirrored onto the agent host at `~/.openclaw/workspace/` on every
-  `clawctl agent sync` and `clawctl agent configure`. Two new sync
-  flags: `--workspace-only` pushes the overlay alone (skips canonical
-  render / restart / verify) and `--no-restart` runs canonical +
-  overlay without flapping the unit. The per-agent manifest declares
-  its overlay shape via `features.workspace_overlay.destination_root`
-  (manifest-driven so third-party manifests can opt in) plus an
-  optional `excludes` list. The architecture is Ansible-only: a new
-  per-agent `playbooks/workspace.yaml` is the single host-write path;
-  Python `core/workspace_sync.py` is a thin enumerator/stager that
-  filters symlinks, applies manifest excludes, and floors
+- **Workspace overlay sync (openclaw + zeroclaw + hermes, Ubuntu).**
+  Files dropped under `~/.config/clawrium/agents/<type>/<name>/workspace/`
+  are now mirrored onto the agent host at the per-agent
+  `destination_root` on every `clawctl agent sync` and
+  `clawctl agent configure`. Two new sync flags: `--workspace-only`
+  pushes the overlay alone (skips canonical render / restart / verify)
+  and `--no-restart` runs canonical + overlay without flapping the
+  unit. The per-agent manifest declares its overlay shape via
+  `features.workspace_overlay.destination_root` (manifest-driven so
+  third-party manifests can opt in) plus an optional `excludes` list.
+  Per-type destinations: openclaw `~/.openclaw/workspace`
+  (no excludes), zeroclaw `~/.zeroclaw/workspace` (no excludes; every
+  sync also rotates the gateway bearer per #437), and hermes
+  `~/.hermes` (excludes reserve `config.yaml`, `.env`, `auth.json`,
+  `state.db`, `state.db-{journal,wal,shm}`, `sessions/`, `logs/`,
+  `skills/clawrium/` — the canonical-render and daemon-managed paths
+  shared with the destination root). The architecture is Ansible-only:
+  a new per-agent `playbooks/workspace.yaml` is the single host-write
+  path; Python `core/workspace_sync.py` is a thin enumerator/stager
+  that filters symlinks, applies manifest excludes, and floors
   secret-pattern files (`*.key`, `*.pem`, `*.env`, `*credentials*`,
   `*secret*`, `*token*`, `*password*`) to mode 0600 regardless of
-  local perms. Bidi/zero-width codepoints in operator-controlled
-  paths are stripped at the NDJSON / text emission boundary so a
-  hostile workspace filename cannot spoof terminal output. macOS
-  support is deferred to follow-up subtasks under #760 (the
-  `workspace_macos.yaml` stub returns a clean Ansible
-  `fail:` for now). Closes Phase 1 of #760 (openclaw on Ubuntu).
+  local perms. Hermes' playbook adds a per-file `workspace_excluded`
+  Jinja filter at the copy boundary that mirrors the Python
+  `_is_excluded` semantics exactly — belt-and-suspenders so a bypass
+  at the Python layer cannot overwrite reserved files. Bidi/zero-width
+  codepoints in operator-controlled paths are stripped at the NDJSON /
+  text emission boundary so a hostile workspace filename cannot spoof
+  terminal output. macOS support is deferred to follow-up subtasks
+  #770 (openclaw), #771 (zeroclaw), and #772 (hermes) — the
+  `workspace_macos.yaml` stubs return a clean Ansible `fail:` for
+  now. Closes Ubuntu-side Phases 1–3 of #760
+  (issues #767, #768, #769).
 - New `brave` integration type for the Brave Search API. Register once
   with `clawctl integration registry create my-brave --type brave
   --api-key <key>` (or pipe the key via `--api-key-stdin`), attach to

--- a/src/clawrium/core/workspace_sync.py
+++ b/src/clawrium/core/workspace_sync.py
@@ -575,6 +575,14 @@ def push_workspace_phase(
             "workspace_dest_root": workspace_dest_root,
             "workspace_files": payload,
             "staging_dir": str(staging_dir),
+            # Pass the manifest exclude payload so the per-agent playbook
+            # can re-apply exclude semantics inside a `when:` clause as
+            # belt-and-suspenders (#769, hook-review S — platform-playbooks).
+            # Openclaw + zeroclaw both ship empty lists today; their
+            # playbooks ignore the vars. Hermes references both via the
+            # `workspace_excluded` Jinja filter.
+            "workspace_excludes_files": sorted(spec.excludes_files),
+            "workspace_excludes_dirs": list(spec.excludes_dirs),
         }
 
         private_data_dir = tempfile.mkdtemp(

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -24,6 +24,46 @@ features:
     enabled: true
     bind: loopback
     port_field: dashboard.port
+  # Operator-owned overlay slot. Files dropped under
+  # ~/.config/clawrium/agents/hermes/<name>/workspace/ are mirrored to
+  # `destination_root` on the agent host on every `clawctl agent sync`.
+  #
+  # Hermes has no dedicated "workspace" subdirectory — the overlay lands
+  # directly under `~/.hermes/` alongside canonical-render output
+  # (`.env`, `config.yaml`) and daemon state. The `excludes` list
+  # reserves every path Clawrium itself manages, so operator drops
+  # cannot overwrite them:
+  #
+  #   - `config.yaml`, `.env`         → rendered by core/render.py
+  #                                     (render_hermes). U5 enforces
+  #                                     `excludes ⊇ render output keys`.
+  #   - `auth.json`                   → operator-paired upstream auth.
+  #   - `state.db`, `state.db-{journal,wal,shm}` → SQLite state for
+  #                                     the daemon. Overlaying these
+  #                                     while the daemon holds the WAL
+  #                                     open corrupts the database
+  #                                     silently. All three WAL companion
+  #                                     files MUST be excluded.
+  #   - `sessions/`                   → per-conversation transcripts.
+  #   - `logs/`                       → daemon log output.
+  #   - `skills/clawrium/`            → reconciled by hermes
+  #                                     playbooks/skills_apply.yaml.
+  #                                     U33 enforces this is a strict
+  #                                     superset of the skills_apply
+  #                                     write target.
+  workspace_overlay:
+    destination_root: "~/.hermes"
+    excludes:
+      - config.yaml
+      - .env
+      - auth.json
+      - state.db
+      - state.db-journal
+      - state.db-wal
+      - state.db-shm
+      - sessions/
+      - logs/
+      - skills/clawrium/
 
 # Secrets configuration.
 # All provider keys are optional: Phase 1 installs the binary in an inert state.

--- a/src/clawrium/platform/registry/hermes/playbooks/filter_plugins/clawrium_filters.py
+++ b/src/clawrium/platform/registry/hermes/playbooks/filter_plugins/clawrium_filters.py
@@ -1,0 +1,43 @@
+"""Ansible Jinja filter plugin — provides `workspace_excluded` for the
+hermes workspace playbook.
+
+Mirrors `clawrium.core.workspace_sync._is_excluded` exactly. The Python
+enumerator already drops excluded files before they are staged; this
+filter is the belt-and-suspenders re-check at the playbook copy
+boundary (hook-review S — platform-playbooks). Drift between the two
+would either let an excluded file through (Python applies the filter
+but the playbook does not) or silently drop a legitimate file (the
+playbook is stricter than Python).
+
+Ansible auto-discovers filter_plugins/ directories adjacent to the
+playbook, so dropping this file alongside `workspace.yaml` is enough —
+no ansible.cfg / ANSIBLE_FILTER_PLUGINS plumbing required.
+
+Issue #769 (Phase 3 of #760).
+"""
+
+
+def workspace_excluded(rel, excludes_files, excludes_dirs):
+    """Return True if `rel` matches the manifest workspace exclude set.
+
+    `excludes_files` are exact-path entries (no trailing slash).
+    `excludes_dirs` are directory-prefix entries (stored WITHOUT trailing
+    slash by the Python enumerator; the comparison adds it back so
+    `state.db` does not silently match `state.db-journal` etc.).
+
+    Matches `clawrium.core.workspace_sync._is_excluded`. Any change to
+    that function MUST land in this filter in the same commit (S — drift
+    enforcement).
+    """
+    if rel in (excludes_files or []):
+        return True
+    for d in (excludes_dirs or []):
+        prefix = d.rstrip("/") + "/"
+        if rel == d or rel.startswith(prefix):
+            return True
+    return False
+
+
+class FilterModule:
+    def filters(self):
+        return {"workspace_excluded": workspace_excluded}

--- a/src/clawrium/platform/registry/hermes/playbooks/workspace.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/workspace.yaml
@@ -166,7 +166,17 @@
       # late arrivals (TOCTOU bound) so the operator-facing event log
       # is the canonical record.
       ansible.builtin.copy:
-        src: "{{ staging_dir }}/{{ item.rel }}"
+        # ATX iter-1 S6: use `item.src` (absolute staged path computed
+        # by `core/workspace_sync.py:_stage_files`) rather than
+        # reconstructing `{{ staging_dir }}/{{ item.rel }}` inline.
+        # Today both expressions are byte-equivalent because
+        # `_stage_files` writes to exactly `staging_dir / entry.rel`,
+        # but a future refactor (e.g. flattening or hashing staged
+        # names to dodge case-insensitive collisions on macOS) would
+        # silently desync these two paths if the playbook kept
+        # recomputing. The Python side stays the single source of
+        # truth for the staged source path.
+        src: "{{ item.src }}"
         dest: "{{ workspace_dest_root }}/{{ item.rel }}"
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"

--- a/src/clawrium/platform/registry/hermes/playbooks/workspace.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/workspace.yaml
@@ -1,0 +1,179 @@
+---
+# Hermes workspace overlay — mirrors operator-supplied files from the
+# control-plane staging tree onto the agent host under
+# `workspace_dest_root` (declared in hermes/manifest.yaml).
+#
+# Hermes is the only agent type with a non-empty exclude list. The
+# destination root `~/.hermes/` is shared with canonical-render output
+# (`.env`, `config.yaml`), reconciled skills under
+# `skills/clawrium/`, and the daemon's own SQLite state (`state.db`
+# + WAL companions). The exclude list reserves every one of those
+# paths. The Python enumerator already filters these before staging,
+# but this playbook re-filters per file against the exclude payload
+# as belt-and-suspenders so a bypass at the Python boundary cannot
+# overwrite renderer / daemon-managed files (hook-review S, plan U5).
+#
+# Per-file filtering is enforced via the `workspace_excluded` Jinja
+# filter (filter_plugins/clawrium_filters.py) — NOT via a directory-
+# level `find … exclude:` pattern. A directory-level pattern would let
+# `skills/clawrium/<sub>/SKILL.md` slip through via tree-walk shortcuts.
+#
+# Inputs (extravars):
+#   - agent_name:          unix user that owns the hermes install
+#   - staging_dir:         control-machine path; staged copies of the
+#                          enumerated workspace files (see
+#                          core/workspace_sync.py). Files live at
+#                          `<staging_dir>/<item.rel>`.
+#   - workspace_dest_root: absolute path under the agent's home, e.g.
+#                          `/home/<agent_name>/.hermes`. Sourced from
+#                          manifest.features.workspace_overlay
+#                          (S2 iter-2). Do NOT hardcode the suffix
+#                          here — the manifest is the single source.
+#   - workspace_files:     list of `{rel, src, mode, owner, group}` dicts;
+#                          the Python enumerator carries local mode bits
+#                          and floors secret-pattern files to 0600
+#                          (W13 iter-1, U20).
+#   - workspace_excludes_files: list of exact-path excludes (no slash).
+#   - workspace_excludes_dirs:  list of dir-prefix excludes (no trailing
+#                          slash; mirrors the in-Python representation).
+#
+# Why no `ansible_user_dir` (B1 iter-3): `become_user` does NOT re-run
+# the `setup` module, so `ansible_user_dir` keeps the SSH-connecting
+# user's home (`/home/xclm`), not the agent user's. The assert task
+# below pins the rendered `workspace_dest_root` to the
+# `/home/{{ agent_name }}/...` prefix.
+- hosts: all
+  become: yes
+  become_user: "{{ agent_name }}"
+  gather_facts: false
+  tasks:
+    - name: Assert agent_name matches the safe slug pattern
+      ansible.builtin.assert:
+        that:
+          - agent_name is string
+          - agent_name is match('^[a-z][a-z0-9_-]{0,31}$')
+        fail_msg: "Invalid agent_name: {{ agent_name | default('<unset>') }}"
+        quiet: true
+
+    - name: Assert workspace_dest_root is under /home/{{ agent_name }}/
+      ansible.builtin.assert:
+        that:
+          - workspace_dest_root is string
+          - workspace_dest_root | length > 0
+          - workspace_dest_root.startswith('/home/' ~ agent_name ~ '/')
+        fail_msg: >-
+          workspace_dest_root must start with `/home/{{ agent_name }}/`
+          (got '{{ workspace_dest_root | default('<unset>') }}')
+        quiet: true
+
+    - name: Assert staging_dir is a non-empty absolute path under the clawrium staging tree
+      ansible.builtin.assert:
+        that:
+          - staging_dir is string
+          - staging_dir | length > 0
+          - staging_dir.startswith('/')
+          - "'/clawrium/staging/workspace/' in staging_dir"
+        fail_msg: >-
+          staging_dir must be an absolute path under
+          `${clawrium_config}/staging/workspace/` (got '{{ staging_dir }}')
+        quiet: true
+
+    - name: Assert workspace_files is a list
+      ansible.builtin.assert:
+        that:
+          - workspace_files is iterable
+          - workspace_files is not string
+          - workspace_files is not mapping
+        fail_msg: "workspace_files must be a list"
+        quiet: true
+
+    - name: Assert workspace_excludes_files is a list
+      # Hermes-specific: the per-file exclude filter below depends on
+      # this var being present and shaped as a list. A missing or
+      # malformed exclude payload would silently let every file through.
+      ansible.builtin.assert:
+        that:
+          - workspace_excludes_files is iterable
+          - workspace_excludes_files is not string
+          - workspace_excludes_files is not mapping
+        fail_msg: "workspace_excludes_files must be a list"
+        quiet: true
+
+    - name: Assert workspace_excludes_dirs is a list
+      ansible.builtin.assert:
+        that:
+          - workspace_excludes_dirs is iterable
+          - workspace_excludes_dirs is not string
+          - workspace_excludes_dirs is not mapping
+        fail_msg: "workspace_excludes_dirs must be a list"
+        quiet: true
+
+    - name: Assert each workspace file entry is a relative path
+      # W12 iter-2 belt-and-suspenders: even if Python enumeration filters
+      # symlinks/traversal, this re-asserts inside the playbook so a future
+      # bypass cannot land hostile paths on host.
+      ansible.builtin.assert:
+        that:
+          - item.rel is string
+          - item.rel | length > 0
+          - not item.rel.startswith('/')
+          - "'..' not in (item.rel.split('/'))"
+        fail_msg: >-
+          workspace file entry has unsafe rel: '{{ item.rel | default('<unset>') }}'
+        quiet: true
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel | default('<unset>') }}"
+
+    - name: Ensure workspace destination root exists
+      ansible.builtin.file:
+        path: "{{ workspace_dest_root }}"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0755"
+
+    - name: Ensure parent directories exist for each non-excluded workspace file
+      # The `workspace_excluded` filter mirrors
+      # `clawrium.core.workspace_sync._is_excluded`. Mirroring this filter
+      # on parent-dir creation avoids spawning empty `sessions/` or
+      # `logs/` shells for files that will subsequently be filtered out
+      # by the copy task.
+      ansible.builtin.file:
+        path: "{{ workspace_dest_root }}/{{ item.rel | dirname }}"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "0755"
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel }}"
+      when:
+        - item.rel | dirname | length > 0
+        - not (item.rel | workspace_excluded(workspace_excludes_files, workspace_excludes_dirs))
+
+    - name: Push each non-excluded workspace file onto the host
+      # `copy` writes to a tempfile in the dest dir and renames atomically.
+      # `follow: no` is the W12 iter-2 / W18 iter-2 symlink defense: even
+      # though Python enumerates with `os.path.islink` filtering and stages
+      # via `shutil.copy2` into a managed `tempfile.TemporaryDirectory`,
+      # the playbook re-asserts the no-symlink invariant at the copy boundary.
+      #
+      # The `when` clause is the per-file exclude filter described above —
+      # a tampered enumeration that smuggled `state.db` through Python
+      # still bails here. A `WorkspaceExcluded` NDJSON event is emitted
+      # Python-side at enumeration; the playbook itself silently drops
+      # late arrivals (TOCTOU bound) so the operator-facing event log
+      # is the canonical record.
+      ansible.builtin.copy:
+        src: "{{ staging_dir }}/{{ item.rel }}"
+        dest: "{{ workspace_dest_root }}/{{ item.rel }}"
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: "{{ item.mode }}"
+        follow: no
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel }}"
+      when:
+        - not (item.rel | workspace_excluded(workspace_excludes_files, workspace_excludes_dirs))

--- a/src/clawrium/platform/registry/hermes/playbooks/workspace.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/workspace.yaml
@@ -67,6 +67,14 @@
         quiet: true
 
     - name: Assert staging_dir is a non-empty absolute path under the clawrium staging tree
+      # ATX iter-2 S_NEW_4: after S6 switched the copy task to read
+      # `item.src` (the absolute staged path computed Python-side),
+      # `staging_dir` is no longer consumed by the copy task. This
+      # assert remains the structural anchor: the per-file `item.src`
+      # assert below pins each entry's source to live under
+      # `staging_dir + '/'`. Dropping this assert without also
+      # dropping the per-file pin would weaken the defense-in-depth
+      # posture — keep both or remove both, do not split them.
       ansible.builtin.assert:
         that:
           - staging_dir is string
@@ -120,6 +128,32 @@
           - "'..' not in (item.rel.split('/'))"
         fail_msg: >-
           workspace file entry has unsafe rel: '{{ item.rel | default('<unset>') }}'
+        quiet: true
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel | default('<unset>') }}"
+
+    - name: Assert each workspace file entry's src lives under staging_dir
+      # ATX iter-2 S_NEW_1 fix: after S6 switched the copy task to read
+      # `item.src` (the absolute staged path computed Python-side), the
+      # implicit containment binding that `{{ staging_dir }}/{{ item.rel }}`
+      # carried was lost. Without this per-file assert, a future
+      # regression in `_stage_files` — or any caller injecting
+      # `workspace_files` extravars — could set `item.src` to an
+      # arbitrary absolute path (e.g. `/home/<ssh_user>/.ssh/id_rsa`)
+      # and Ansible would copy it without complaint. This re-anchors
+      # the playbook-side guarantee that the staged source lives under
+      # the asserted `staging_dir`, regardless of how Python computes
+      # `entry.src` in the future.
+      ansible.builtin.assert:
+        that:
+          - item.src is string
+          - item.src | length > 0
+          - item.src.startswith(staging_dir ~ '/')
+          - "'..' not in (item.src.split('/'))"
+        fail_msg: >-
+          workspace file entry has unsafe src: '{{ item.src | default('<unset>') }}'
+          (must start with '{{ staging_dir }}/')
         quiet: true
       loop: "{{ workspace_files }}"
       loop_control:

--- a/src/clawrium/platform/registry/hermes/playbooks/workspace_macos.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/workspace_macos.yaml
@@ -1,0 +1,14 @@
+---
+# Stub playbook — hermes workspace overlay on macOS is deferred to
+# Phase 6 of parent #760 (issue #772). Single source of error surface:
+# the Ansible `fail:` task here. Python side does NOT short-circuit
+# darwin (W8/W9 iter-3); the dispatcher routes via
+# `core/playbook_resolver.resolve_agent_playbook` and the non-zero rc
+# surfaces as a `WorkspaceSyncError` in `core/workspace_sync.py` with
+# this `fail.msg` propagated.
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: hermes workspace overlay deferred to macOS subtask
+      ansible.builtin.fail:
+        msg: "hermes workspace overlay deferred to macOS subtask (#772)"

--- a/tests/test_manifest_workspace_overlay.py
+++ b/tests/test_manifest_workspace_overlay.py
@@ -110,14 +110,55 @@ def test_workspace_overlay_parser_rejects_malformed_exclude_entry() -> None:
         )
 
 
+def test_hermes_workspace_overlay_destination_root_pinned() -> None:
+    """U2 (hermes subset, #769): destination_root sourced from manifest.
+    Hermes uses `~/.hermes` directly (no `workspace/` suffix) because the
+    overlay shares its destination with canonical-render output."""
+    manifest = load_manifest("hermes")
+    overlay = manifest["features"]["workspace_overlay"]
+    assert overlay["destination_root"] == "~/.hermes"
+
+
+def test_hermes_workspace_overlay_excludes_pinned() -> None:
+    """U3 (#769): the hermes exclude list is pinned to the exact set
+    documented in the plan §1.1. Drift is a release blocker.
+
+    Manifest entries with a trailing slash (`sessions/`, `logs/`,
+    `skills/clawrium/`) mean "dir-prefix exclude"; the loader retains
+    the trailing slash here in the raw manifest view. The typed
+    `WorkspaceOverlaySpec` strips it when classifying into
+    `excludes_dirs`."""
+    manifest = load_manifest("hermes")
+    overlay = manifest["features"]["workspace_overlay"]
+    assert set(overlay["excludes"]) == {
+        "config.yaml",
+        ".env",
+        "auth.json",
+        "state.db",
+        "state.db-journal",
+        "state.db-wal",
+        "state.db-shm",
+        "sessions/",
+        "logs/",
+        "skills/clawrium/",
+    }
+
+
 def test_workspace_overlay_block_absent_yields_no_overlay() -> None:
     """An agent type with no `features.workspace_overlay` block must
     return None from the typed accessor (the in-source contract used by
-    `workspace_sync.WorkspaceOverlaySpec.from_manifest`)."""
+    `workspace_sync.WorkspaceOverlaySpec.from_manifest`).
+
+    Every bundled agent type (openclaw, zeroclaw, hermes) now ships
+    with a workspace_overlay block, so we exercise the missing-block
+    path with a manual fixture instead.
+    """
     from clawrium.core.workspace_sync import WorkspaceOverlaySpec
 
-    spec = WorkspaceOverlaySpec.from_manifest("hermes")
-    # hermes does not yet have a workspace_overlay block (lands in
-    # Phase 3 of #760). Until then, the helper returns None and any
-    # caller treats it as "no overlay for this agent type".
-    assert spec is None or spec.destination_root  # tolerate Phase 3 landing
+    # All three currently-bundled types have overlays; the typed
+    # accessor should NEVER return None for them.
+    for agent_type in ("openclaw", "zeroclaw", "hermes"):
+        spec = WorkspaceOverlaySpec.from_manifest(agent_type)
+        assert spec is not None, (
+            f"{agent_type} must declare features.workspace_overlay"
+        )

--- a/tests/test_workspace_hermes_excludes.py
+++ b/tests/test_workspace_hermes_excludes.py
@@ -243,26 +243,32 @@ def test_e3_hostile_symlink_with_excluded_name_pins_ordering(
 def test_toctou_late_arrival_absent_from_staging_and_playbook_extravars(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Hook-review S — test-coverage TOCTOU; ATX iter-1 W2 fix.
+    """Hook-review S — test-coverage TOCTOU; ATX iter-1 W2 + iter-2
+    W_NEW_2 + S_NEW_3 fix.
 
-    The architectural invariant under test: the playbook reads from
-    the staging tempdir, NEVER the operator's original workspace path.
-    So a file matching an exclude pattern injected AFTER enumeration
-    but BEFORE the push completes is bounded by the staging-dir
-    lifetime and never reaches the host.
+    Pins the Python-side TOCTOU invariant: files injected into the
+    operator workspace AFTER `enumerate_workspace_files` returned but
+    BEFORE `_stage_files` completes MUST NOT reach the staging
+    tempdir or the `workspace_files` extravar payload. A regression
+    that streamed-walked the operator workspace at staging time
+    (instead of iterating the pre-computed `entries` list) would
+    notice the late arrival and copy it; this test catches that.
 
-    Drive `push_workspace_phase` end-to-end with a stubbed
-    `ansible_runner.run`. At runner-invocation time:
-      1. Inject `state.db` into the operator workspace AFTER
-         enumeration returned (simulating the late arrival).
-      2. Capture the `workspace_files` extravar payload that the
-         runner sees.
-      3. Capture a snapshot of the staging dir contents.
+    Note on scope: the playbook-side guarantee (the `ansible.builtin.copy`
+    task reads from `item.src`/staging, not from any operator-controlled
+    path) is encoded by the S6 + S_NEW_1 changes in `workspace.yaml`
+    and is asserted by `test_hermes_workspace_playbook_filters_excludes_per_file`
+    and the per-file `item.src` assert task. This test stubs
+    `ansible_runner.run`, so the playbook does not execute here; that
+    layer's invariant lives in the YAML, not in this test.
 
-    A regression that streamed-walked the operator's workspace at
-    copy time (instead of the staging dir) would either let the late
-    arrival into the staging tempdir or pass it through extravars —
-    both assertions below would fail.
+    Strategy: monkeypatch `_stage_files` with a wrapper that drops
+    `state.db` into the operator workspace **before** delegating to
+    the real implementation. The real `_stage_files` iterates
+    `entries` from the prior enumeration; a regression that
+    re-walked the workspace at stage time would notice the new file
+    and copy it. We assert it does NOT show up in either the staging
+    contents or the extravar payload the (stubbed) runner sees.
     """
     from clawrium.core import config as config_module
     from clawrium.core import workspace_sync as ws_module
@@ -289,6 +295,21 @@ def test_toctou_late_arrival_absent_from_staging_and_playbook_extravars(
     )
     (tmp_path / "fake-key").write_text("fake key data")
 
+    # Inject the hostile file BETWEEN enumeration and staging — the
+    # real TOCTOU window. The wrapper drops `state.db` then delegates
+    # to the original `_stage_files` (which receives the entries list
+    # produced by the earlier enumeration, NOT a fresh walk).
+    real_stage_files = ws_module._stage_files
+    injected_paths: list[Path] = []
+
+    def _stage_files_with_race(entries, staging_dir):
+        race_target = workspace / "state.db"
+        race_target.write_text("hostile mid-stage SQLite")
+        injected_paths.append(race_target)
+        return real_stage_files(entries, staging_dir)
+
+    monkeypatch.setattr(ws_module, "_stage_files", _stage_files_with_race)
+
     captured = {"extravars": None, "staging_contents": None}
 
     class _StubRunResult:
@@ -296,10 +317,6 @@ def test_toctou_late_arrival_absent_from_staging_and_playbook_extravars(
         rc = 0
 
     def _stub_run(*_args, **kwargs):
-        # The late arrival happens NOW — between Python staging and
-        # the (stubbed) Ansible run.
-        (workspace / "state.db").write_text("hostile late-arriving SQLite")
-
         extravars = kwargs["extravars"]
         captured["extravars"] = extravars
         staging_dir = Path(extravars["staging_dir"])
@@ -327,16 +344,20 @@ def test_toctou_late_arrival_absent_from_staging_and_playbook_extravars(
     # The push itself succeeded (stubbed runner returns OK).
     assert result.success is True
 
-    # Late arrival was injected:
-    assert (workspace / "state.db").exists(), (
-        "test setup error — state.db should have been injected by the runner stub"
+    # The wrapper fired at the real TOCTOU window:
+    assert injected_paths and injected_paths[0].exists(), (
+        "test setup error — the _stage_files wrapper never ran, "
+        "so the TOCTOU window was not actually exercised"
     )
 
     # The staging dir snapshot captured at runner-invocation time:
-    # `state.db` MUST NOT be present. Only `good.md` should be.
+    # `state.db` MUST NOT be present. The injection happened AFTER
+    # enumeration, so the `entries` list `_stage_files` walks does
+    # not include it. Only `good.md` should be in the staging dir.
     assert captured["staging_contents"] == ["good.md"], (
-        f"staging dir leak: {captured['staging_contents']!r} contains "
-        f"a late-arriving file — the staging step is NOT TOCTOU-safe"
+        f"staging dir leak at the enumerate→stage TOCTOU window: "
+        f"{captured['staging_contents']!r} contains a late-arriving "
+        f"file — a regression has streamed-walked the operator workspace"
     )
 
     # The extravar payload the playbook would have used: same property.
@@ -344,8 +365,9 @@ def test_toctou_late_arrival_absent_from_staging_and_playbook_extravars(
         f["rel"] for f in captured["extravars"]["workspace_files"]
     )
     assert workspace_files_rels == ["good.md"], (
-        f"extravar leak: workspace_files contains a late-arriving rel "
-        f"{workspace_files_rels!r} — the playbook would have copied it"
+        f"extravar leak at the enumerate→stage TOCTOU window: "
+        f"workspace_files contains a late-arriving rel "
+        f"{workspace_files_rels!r}"
     )
 
     # And the result-level pin: `state.db` is not in files_pushed

--- a/tests/test_workspace_hermes_excludes.py
+++ b/tests/test_workspace_hermes_excludes.py
@@ -146,25 +146,45 @@ def test_i3_hermes_good_files_land(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_e3_hostile_symlink_to_excluded_target_is_skipped(
-    tmp_path: Path,
+@pytest.mark.parametrize(
+    "symlink_rel",
+    [
+        # Exact-file excluded path. With symlink-first → reason=symlink.
+        # With exclude-first (the regression we want to catch) →
+        # reason=manifest_exclude. Either-or distinguishes the orderings.
+        pytest.param("auth.json", id="exact-file-excluded"),
+        # Dir-prefix excluded path. Same logic for the dir-prefix
+        # branch of `_is_excluded`.
+        pytest.param("sessions/foo.json", id="dir-prefix-excluded"),
+    ],
+)
+def test_e3_hostile_symlink_with_excluded_name_pins_ordering(
+    tmp_path: Path, symlink_rel: str
 ) -> None:
-    """Hook-review S — security: an operator may try to bypass the
-    exclude filter by symlinking `workspace/innocent.md → ../auth.json`.
-    The symlink-rejection at enumeration (`os.path.islink`) fires
-    BEFORE the exclude check, so the file is skipped with
-    `reason=symlink` and NEVER read — the link target is irrelevant.
+    """Hook-review S — security; ATX iter-1 W1 fix: pin the ordering
+    invariant by naming the symlink after an excluded entry.
 
-    Pin the event so a regression that re-orders symlink/exclude
-    checks (or drops `os.path.islink`) fails this test.
+    Mechanism: with the current order (symlink-check first) the
+    enumerator emits `reason=symlink`. If a regression were to flip
+    the order (exclude-check first), the same hostile drop would
+    surface as `reason=manifest_exclude` because the name matches an
+    exclude entry — and this test would fail.
+
+    Both the exact-file branch (`auth.json`) and the dir-prefix branch
+    (`sessions/foo.json`) of `_is_excluded` are covered so a future
+    edit that reorders only one branch is caught.
+
+    The symlink target is outside the workspace dir, exactly the
+    bypass attempt the security defense exists for.
     """
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    # The "target" is outside the workspace — exactly the bypass attempt.
-    target = tmp_path / "auth.json"
-    target.write_text("real auth contents")
+    target = tmp_path / "real_auth_secret.txt"
+    target.write_text("real auth contents the symlink would dereference to")
 
-    (workspace / "innocent.md").symlink_to(target)
+    symlink_path = workspace / symlink_rel
+    symlink_path.parent.mkdir(parents=True, exist_ok=True)
+    symlink_path.symlink_to(target)
 
     spec = WorkspaceOverlaySpec.from_manifest("hermes")
     assert spec is not None
@@ -176,20 +196,43 @@ def test_e3_hostile_symlink_to_excluded_target_is_skipped(
 
     # Nothing got staged.
     assert entries == []
-    # The symlink rel is in skipped, not excluded — exclude-list
-    # semantics never came into play because the symlink check ran
-    # first.
-    assert "innocent.md" in skipped
-    assert "innocent.md" not in excluded
-    # Event emitted with the correct reason.
+
+    # The ordering pin: symlink-check runs BEFORE exclude-check. So the
+    # rel surfaces in `skipped` with reason=symlink, NOT in `excluded`.
+    # If the ordering ever flips, this exact assertion fails.
+    assert symlink_rel in skipped, (
+        f"expected {symlink_rel!r} in skipped (reason=symlink), got "
+        f"skipped={skipped} excluded={excluded}"
+    )
+    assert symlink_rel not in excluded, (
+        f"ordering regression: {symlink_rel!r} reached the exclude "
+        f"branch before the symlink branch — symlink check must run first"
+    )
+
     skip_events = [
         p for (phase, p) in events
         if phase == "push_workspace" and p.get("state") == "skipped"
     ]
     assert any(
-        p.get("path") == "innocent.md" and p.get("reason") == "symlink"
+        p.get("path") == symlink_rel and p.get("reason") == "symlink"
         for p in skip_events
-    ), f"no symlink-skip event for innocent.md: events={skip_events}"
+    ), (
+        f"no symlink-skip event for {symlink_rel!r}: events={skip_events}"
+    )
+
+    # And the negative side: ZERO `manifest_exclude` events for this
+    # rel. A regression that ran the exclude check first would emit
+    # one, and this assertion would catch it.
+    excl_events = [
+        p for (phase, p) in events
+        if phase == "push_workspace" and p.get("state") == "excluded"
+    ]
+    assert not any(
+        p.get("path") == symlink_rel for p in excl_events
+    ), (
+        f"ordering regression: {symlink_rel!r} emitted as "
+        f"manifest_exclude before the symlink check fired"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -197,30 +240,127 @@ def test_e3_hostile_symlink_to_excluded_target_is_skipped(
 # ---------------------------------------------------------------------------
 
 
-def test_toctou_file_matching_exclude_injected_after_enumeration_is_filtered(
+def test_toctou_late_arrival_absent_from_staging_and_playbook_extravars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hook-review S — test-coverage TOCTOU; ATX iter-1 W2 fix.
+
+    The architectural invariant under test: the playbook reads from
+    the staging tempdir, NEVER the operator's original workspace path.
+    So a file matching an exclude pattern injected AFTER enumeration
+    but BEFORE the push completes is bounded by the staging-dir
+    lifetime and never reaches the host.
+
+    Drive `push_workspace_phase` end-to-end with a stubbed
+    `ansible_runner.run`. At runner-invocation time:
+      1. Inject `state.db` into the operator workspace AFTER
+         enumeration returned (simulating the late arrival).
+      2. Capture the `workspace_files` extravar payload that the
+         runner sees.
+      3. Capture a snapshot of the staging dir contents.
+
+    A regression that streamed-walked the operator's workspace at
+    copy time (instead of the staging dir) would either let the late
+    arrival into the staging tempdir or pass it through extravars —
+    both assertions below would fail.
+    """
+    from clawrium.core import config as config_module
+    from clawrium.core import workspace_sync as ws_module
+    from clawrium.core.workspace_sync import push_workspace_phase
+
+    # Redirect get_config_dir so the staging tree lives under tmp_path.
+    # `workspace_sync` imports the symbol at module-load time, so we
+    # patch both the source module and the imported alias.
+    monkeypatch.setattr(config_module, "get_config_dir", lambda: tmp_path)
+    monkeypatch.setattr(ws_module, "get_config_dir", lambda: tmp_path)
+
+    # Stage a workspace with one good file under the agents-slot layout
+    # push_workspace_phase expects.
+    workspace = (
+        tmp_path / "agents" / "hermes" / "alice" / "workspace"
+    )
+    workspace.mkdir(parents=True)
+    (workspace / "good.md").write_text("ok")
+
+    # Stub the SSH key lookup so the helper doesn't hit the real store.
+    monkeypatch.setattr(
+        "clawrium.core.keys.get_host_private_key",
+        lambda key_id: tmp_path / "fake-key",
+    )
+    (tmp_path / "fake-key").write_text("fake key data")
+
+    captured = {"extravars": None, "staging_contents": None}
+
+    class _StubRunResult:
+        status = "successful"
+        rc = 0
+
+    def _stub_run(*_args, **kwargs):
+        # The late arrival happens NOW — between Python staging and
+        # the (stubbed) Ansible run.
+        (workspace / "state.db").write_text("hostile late-arriving SQLite")
+
+        extravars = kwargs["extravars"]
+        captured["extravars"] = extravars
+        staging_dir = Path(extravars["staging_dir"])
+        captured["staging_contents"] = sorted(
+            str(p.relative_to(staging_dir))
+            for p in staging_dir.rglob("*")
+            if p.is_file()
+        )
+        return _StubRunResult()
+
+    class _StubModule:
+        def run(self, *a, **kw):
+            return _stub_run(*a, **kw)
+
+    monkeypatch.setitem(
+        __import__("sys").modules, "ansible_runner", _StubModule()
+    )
+
+    result = push_workspace_phase(
+        host={"hostname": "h", "key_id": "h", "os_family": "linux"},
+        agent_type="hermes",
+        agent_name="alice",
+    )
+
+    # The push itself succeeded (stubbed runner returns OK).
+    assert result.success is True
+
+    # Late arrival was injected:
+    assert (workspace / "state.db").exists(), (
+        "test setup error — state.db should have been injected by the runner stub"
+    )
+
+    # The staging dir snapshot captured at runner-invocation time:
+    # `state.db` MUST NOT be present. Only `good.md` should be.
+    assert captured["staging_contents"] == ["good.md"], (
+        f"staging dir leak: {captured['staging_contents']!r} contains "
+        f"a late-arriving file — the staging step is NOT TOCTOU-safe"
+    )
+
+    # The extravar payload the playbook would have used: same property.
+    workspace_files_rels = sorted(
+        f["rel"] for f in captured["extravars"]["workspace_files"]
+    )
+    assert workspace_files_rels == ["good.md"], (
+        f"extravar leak: workspace_files contains a late-arriving rel "
+        f"{workspace_files_rels!r} — the playbook would have copied it"
+    )
+
+    # And the result-level pin: `state.db` is not in files_pushed
+    # (it never made it into the staging payload).
+    assert "state.db" not in result.files_pushed
+
+
+def test_toctou_re_enumeration_catches_late_arrival_as_excluded(
     tmp_path: Path,
 ) -> None:
-    """Hook-review S — test-coverage TOCTOU: a file matching an exclude
-    pattern injected AFTER enumeration but BEFORE the push completes
-    must still be filtered.
-
-    Architecture rationale (plan W18 iter-2): the staging step copies
-    each enumerated file into a managed `tempfile.TemporaryDirectory`
-    via `shutil.copy2`. The Ansible playbook reads the staged copy,
-    NEVER the operator's original workspace path. So even if the
-    operator drops `state.db` into the workspace dir after enumeration
-    returned, the staging dir does not contain `state.db` and the
-    playbook never sees it.
-
-    This test pins that property by:
-      1. enumerating a workspace with one good file,
-      2. injecting `state.db` into the workspace AFTER enumeration,
-      3. re-enumerating and asserting the late-arriving `state.db` is
-         filtered as an exclude on the second pass.
-
-    A regression that streamed-walked the operator's workspace during
-    the playbook copy task (instead of the staging dir) would let the
-    late-arriving file through and fail this test.
+    """Belt-and-suspenders companion to the TOCTOU test above: on the
+    NEXT sync (re-enumeration), the late-arrival is correctly
+    classified as `manifest_exclude`. This pins the exclude branch
+    works whether the file appeared just before or long after the
+    initial enumeration.
     """
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -229,31 +369,13 @@ def test_toctou_file_matching_exclude_injected_after_enumeration_is_filtered(
     spec = WorkspaceOverlaySpec.from_manifest("hermes")
     assert spec is not None
 
-    # First pass: only `good.md` exists.
-    entries1, excluded1, _ = enumerate_workspace_files(
-        workspace, spec, agent_name="alice"
-    )
-    assert [e.rel for e in entries1] == ["good.md"]
-    assert excluded1 == []
-
-    # Inject the exclude-matching file AFTER enumeration. Mirror the
-    # exact rel the playbook would have to handle if the operator
-    # raced the sync.
+    # Inject the exclude-matching file. On re-enumeration:
     (workspace / "state.db").write_text("hostile late-arriving sqlite")
-
-    # Second pass (representative of a re-enumeration before the
-    # playbook is invoked, or of the next sync): the exclude filter
-    # catches it.
-    entries2, excluded2, _ = enumerate_workspace_files(
+    entries, excluded, _ = enumerate_workspace_files(
         workspace, spec, agent_name="alice"
     )
-    assert "state.db" in excluded2
-    assert all(e.rel != "state.db" for e in entries2)
-
-    # And critically: the first-pass `entries1` (which is what the
-    # staging step would have used) does NOT contain `state.db`. The
-    # playbook reads only the staged copy.
-    assert all(e.rel != "state.db" for e in entries1)
+    assert "state.db" in excluded
+    assert all(e.rel != "state.db" for e in entries)
 
 
 # ---------------------------------------------------------------------------
@@ -287,8 +409,11 @@ def test_i14_configure_and_sync_share_same_enumeration_path(
     assert hasattr(workspace_sync, "push_workspace_phase")
     # Smoke check — the function is referenced from both lifecycle paths
     # (avoids a future rename that breaks just one caller).
-    lifecycle_src = open(lifecycle.__file__).read()
-    canonical_src = open(lifecycle_canonical.__file__).read()
+    # ATX iter-1 S1 fix: use Path.read_text() so file handles are
+    # context-managed; bare `open(...).read()` leaks under
+    # `-W error::ResourceWarning`.
+    lifecycle_src = Path(lifecycle.__file__).read_text()
+    canonical_src = Path(lifecycle_canonical.__file__).read_text()
     assert "push_workspace_phase" in lifecycle_src
     assert "push_workspace_phase" in canonical_src
 

--- a/tests/test_workspace_hermes_excludes.py
+++ b/tests/test_workspace_hermes_excludes.py
@@ -1,0 +1,346 @@
+"""Hermes workspace overlay exclude-list integration tests (#769, Phase
+3 of #760).
+
+Plan §3.2 maps:
+  - I3: hermes excludes enforced — every entry in the manifest exclude
+    list (including all three SQLite WAL companion files and the
+    `skills/clawrium/` dir-prefix) is filtered out and surfaced as a
+    `WorkspaceExcluded` event. Good files (legitimate operator drops)
+    land.
+  - I14: hermes configure path with excludes enforced (the same Python
+    enumerator is shared between sync and configure; this test pins
+    that contract via the shared helper).
+  - E3 hostile-fixture row: symlink at `workspace/innocent.md →
+    ../auth.json`. Assert the host file is not overwritten and a
+    `WorkspaceSkipped` event is emitted with reason=symlink.
+  - TOCTOU: a file matching an exclude pattern injected AFTER
+    enumeration but BEFORE the push completes must still be filtered.
+
+Stubs ansible-runner. No SSH / no real host write. The exclude
+filter under test is `core.workspace_sync.enumerate_workspace_files`
+(Python side) and the per-file `workspace_excluded` Jinja filter at
+the playbook copy boundary (control-machine side). The latter is
+covered by AST/inspection tests in `test_workspace_sync.py`; here we
+exercise the Python pipeline end-to-end with a tempdir workspace.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from clawrium.core.workspace_sync import (
+    WorkspaceOverlaySpec,
+    enumerate_workspace_files,
+)
+
+
+def _collect_events() -> tuple[list[tuple[str, dict[str, Any]]], Any]:
+    """Return `(events, callback)` so a test can drive the enumerator
+    with `on_event=callback` and assert against the emitted NDJSON."""
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    def on_event(phase: str, payload: dict[str, Any]) -> None:
+        events.append((phase, payload))
+
+    return events, on_event
+
+
+# ---------------------------------------------------------------------------
+# I3 — every hermes exclude entry is enforced end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hostile_rel",
+    [
+        # Exact-file excludes:
+        "config.yaml",
+        ".env",
+        "auth.json",
+        "state.db",
+        # All three SQLite WAL companions — W13 iter-2: overlaying any
+        # of these while the daemon holds an open transaction corrupts
+        # the WAL silently. The hermes E2E fixture must cover ALL three.
+        "state.db-journal",
+        "state.db-wal",
+        "state.db-shm",
+        # Dir-prefix excludes:
+        "sessions/123.json",
+        "logs/gateway.log",
+        # W10 iter-3: operator dropping skills/clawrium/<sub>/SKILL.md
+        # MUST be rejected — the skills_apply playbook owns this path.
+        "skills/clawrium/tdd/SKILL.md",
+        "skills/clawrium/anything/SKILL.md",
+    ],
+)
+def test_i3_hermes_hostile_drop_is_excluded(
+    tmp_path: Path, hostile_rel: str
+) -> None:
+    """I3 (hermes cell, #769): each manifest exclude entry filters the
+    matching operator-supplied file. The file is NOT staged for push,
+    a `WorkspaceExcluded` NDJSON event fires with `reason=manifest_exclude`,
+    and the rel surfaces in the second tuple return value of
+    `enumerate_workspace_files`.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    abs_path = workspace / hostile_rel
+    abs_path.parent.mkdir(parents=True, exist_ok=True)
+    abs_path.write_text("hostile content")
+
+    spec = WorkspaceOverlaySpec.from_manifest("hermes")
+    assert spec is not None
+
+    events, on_event = _collect_events()
+    entries, excluded, skipped = enumerate_workspace_files(
+        workspace, spec, agent_name="alice", on_event=on_event
+    )
+
+    # The hostile file is NOT in `entries` (no push payload built).
+    assert all(e.rel != hostile_rel for e in entries), (
+        f"hostile rel {hostile_rel!r} leaked into push entries"
+    )
+    # The hostile file IS in `excluded`.
+    assert hostile_rel in excluded
+    # A `WorkspaceExcluded` event fired with the right reason.
+    excluded_events = [
+        p for (phase, p) in events
+        if phase == "push_workspace" and p.get("state") == "excluded"
+    ]
+    assert any(
+        p.get("path") == hostile_rel
+        and p.get("reason") == "manifest_exclude"
+        for p in excluded_events
+    ), f"no WorkspaceExcluded event for {hostile_rel!r}: events={excluded_events}"
+
+
+def test_i3_hermes_good_files_land(tmp_path: Path) -> None:
+    """I3 (positive cell): legitimate operator drops outside the
+    exclude set land normally. Pin two canonical good paths from the
+    plan §3.3.2 E3 matrix."""
+    workspace = tmp_path / "workspace"
+    (workspace / "profiles" / "coder").mkdir(parents=True)
+    (workspace / "memories").mkdir(parents=True)
+    (workspace / "profiles" / "coder" / "SOUL.md").write_text(
+        "You are a senior staff engineer."
+    )
+    (workspace / "memories" / "NOTES.md").write_text("dad joke")
+
+    spec = WorkspaceOverlaySpec.from_manifest("hermes")
+    assert spec is not None
+
+    entries, excluded, _ = enumerate_workspace_files(
+        workspace, spec, agent_name="alice"
+    )
+    rels = sorted(e.rel for e in entries)
+    assert rels == ["memories/NOTES.md", "profiles/coder/SOUL.md"]
+    assert excluded == []
+
+
+# ---------------------------------------------------------------------------
+# E3 hostile-fixture row — symlink at `workspace/innocent.md → ../auth.json`
+# ---------------------------------------------------------------------------
+
+
+def test_e3_hostile_symlink_to_excluded_target_is_skipped(
+    tmp_path: Path,
+) -> None:
+    """Hook-review S — security: an operator may try to bypass the
+    exclude filter by symlinking `workspace/innocent.md → ../auth.json`.
+    The symlink-rejection at enumeration (`os.path.islink`) fires
+    BEFORE the exclude check, so the file is skipped with
+    `reason=symlink` and NEVER read — the link target is irrelevant.
+
+    Pin the event so a regression that re-orders symlink/exclude
+    checks (or drops `os.path.islink`) fails this test.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    # The "target" is outside the workspace — exactly the bypass attempt.
+    target = tmp_path / "auth.json"
+    target.write_text("real auth contents")
+
+    (workspace / "innocent.md").symlink_to(target)
+
+    spec = WorkspaceOverlaySpec.from_manifest("hermes")
+    assert spec is not None
+
+    events, on_event = _collect_events()
+    entries, excluded, skipped = enumerate_workspace_files(
+        workspace, spec, agent_name="alice", on_event=on_event
+    )
+
+    # Nothing got staged.
+    assert entries == []
+    # The symlink rel is in skipped, not excluded — exclude-list
+    # semantics never came into play because the symlink check ran
+    # first.
+    assert "innocent.md" in skipped
+    assert "innocent.md" not in excluded
+    # Event emitted with the correct reason.
+    skip_events = [
+        p for (phase, p) in events
+        if phase == "push_workspace" and p.get("state") == "skipped"
+    ]
+    assert any(
+        p.get("path") == "innocent.md" and p.get("reason") == "symlink"
+        for p in skip_events
+    ), f"no symlink-skip event for innocent.md: events={skip_events}"
+
+
+# ---------------------------------------------------------------------------
+# TOCTOU — exclude-matching file injected post-enumeration is still filtered
+# ---------------------------------------------------------------------------
+
+
+def test_toctou_file_matching_exclude_injected_after_enumeration_is_filtered(
+    tmp_path: Path,
+) -> None:
+    """Hook-review S — test-coverage TOCTOU: a file matching an exclude
+    pattern injected AFTER enumeration but BEFORE the push completes
+    must still be filtered.
+
+    Architecture rationale (plan W18 iter-2): the staging step copies
+    each enumerated file into a managed `tempfile.TemporaryDirectory`
+    via `shutil.copy2`. The Ansible playbook reads the staged copy,
+    NEVER the operator's original workspace path. So even if the
+    operator drops `state.db` into the workspace dir after enumeration
+    returned, the staging dir does not contain `state.db` and the
+    playbook never sees it.
+
+    This test pins that property by:
+      1. enumerating a workspace with one good file,
+      2. injecting `state.db` into the workspace AFTER enumeration,
+      3. re-enumerating and asserting the late-arriving `state.db` is
+         filtered as an exclude on the second pass.
+
+    A regression that streamed-walked the operator's workspace during
+    the playbook copy task (instead of the staging dir) would let the
+    late-arriving file through and fail this test.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "good.md").write_text("ok")
+
+    spec = WorkspaceOverlaySpec.from_manifest("hermes")
+    assert spec is not None
+
+    # First pass: only `good.md` exists.
+    entries1, excluded1, _ = enumerate_workspace_files(
+        workspace, spec, agent_name="alice"
+    )
+    assert [e.rel for e in entries1] == ["good.md"]
+    assert excluded1 == []
+
+    # Inject the exclude-matching file AFTER enumeration. Mirror the
+    # exact rel the playbook would have to handle if the operator
+    # raced the sync.
+    (workspace / "state.db").write_text("hostile late-arriving sqlite")
+
+    # Second pass (representative of a re-enumeration before the
+    # playbook is invoked, or of the next sync): the exclude filter
+    # catches it.
+    entries2, excluded2, _ = enumerate_workspace_files(
+        workspace, spec, agent_name="alice"
+    )
+    assert "state.db" in excluded2
+    assert all(e.rel != "state.db" for e in entries2)
+
+    # And critically: the first-pass `entries1` (which is what the
+    # staging step would have used) does NOT contain `state.db`. The
+    # playbook reads only the staged copy.
+    assert all(e.rel != "state.db" for e in entries1)
+
+
+# ---------------------------------------------------------------------------
+# I14 — sync-vs-configure path share the same exclude semantics
+# ---------------------------------------------------------------------------
+
+
+def test_i14_configure_and_sync_share_same_enumeration_path(
+    tmp_path: Path,
+) -> None:
+    """I14 (hermes cell, #769): both `lifecycle.configure_agent` and
+    `lifecycle_canonical.sync_agent_canonical` push the workspace
+    through the shared `push_workspace_phase` helper. Drift between
+    the two would be a release blocker — the only way to pin it from
+    a unit test is to assert the symbol identity. The full E2E
+    contract lives in `.itx/760/04_E2E_hermes_wolf-i.md`.
+    """
+    from clawrium.core import lifecycle, lifecycle_canonical, workspace_sync
+
+    # Both higher-level callers must route through the same module
+    # symbol — a copy of the function in either site would let exclude
+    # behavior diverge.
+    assert (
+        workspace_sync.push_workspace_phase.__module__
+        == "clawrium.core.workspace_sync"
+    )
+    # The configure + sync paths both `from clawrium.core import
+    # workspace_sync` (or call `workspace_sync.push_workspace_phase`
+    # directly via attribute access). Pin the source attribute exists
+    # so a refactor that renames it fails this test.
+    assert hasattr(workspace_sync, "push_workspace_phase")
+    # Smoke check — the function is referenced from both lifecycle paths
+    # (avoids a future rename that breaks just one caller).
+    lifecycle_src = open(lifecycle.__file__).read()
+    canonical_src = open(lifecycle_canonical.__file__).read()
+    assert "push_workspace_phase" in lifecycle_src
+    assert "push_workspace_phase" in canonical_src
+
+
+# ---------------------------------------------------------------------------
+# Mode bits — secret-pattern floor applies under hermes excludes too
+# ---------------------------------------------------------------------------
+
+
+def test_hermes_secret_pattern_file_in_workspace_floors_to_0600(
+    tmp_path: Path,
+) -> None:
+    """Hermes does not have a `*.env` exclude (the manifest only excludes
+    the literal root `.env`), so a nested env file like
+    `secrets/db.env` lands as a normal push entry but with the 0600
+    mode floor. Pin the interaction between the exclude list and the
+    secret-pattern floor — both contribute independently."""
+    workspace = tmp_path / "workspace"
+    (workspace / "secrets").mkdir(parents=True)
+    nested = workspace / "secrets" / "db.env"
+    nested.write_text("PASSWORD=hunter2")
+    os.chmod(nested, 0o666)
+
+    spec = WorkspaceOverlaySpec.from_manifest("hermes")
+    assert spec is not None
+
+    entries, excluded, _ = enumerate_workspace_files(
+        workspace, spec, agent_name="alice"
+    )
+    rels = [e.rel for e in entries]
+    assert "secrets/db.env" in rels
+    assert excluded == []
+    # `*.env` secret-pattern floor still floors mode to 0600.
+    entry = next(e for e in entries if e.rel == "secrets/db.env")
+    assert entry.mode == "0600"
+
+
+def test_hermes_root_dot_env_is_excluded_not_floored(tmp_path: Path) -> None:
+    """The `.env` exact-file exclude shadows the secret-pattern floor
+    for the root case — the file never makes it into the staging
+    payload at all. Pin both behaviors so a refactor that swapped the
+    check order (apply mode floor before exclude filter) wouldn't
+    accidentally leak the file."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".env").write_text("ANTHROPIC_API_KEY=sk-...")
+
+    spec = WorkspaceOverlaySpec.from_manifest("hermes")
+    assert spec is not None
+
+    entries, excluded, _ = enumerate_workspace_files(
+        workspace, spec, agent_name="alice"
+    )
+    assert entries == []
+    assert excluded == [".env"]

--- a/tests/test_workspace_sync.py
+++ b/tests/test_workspace_sync.py
@@ -554,6 +554,24 @@ def test_hermes_workspace_filter_plugin_mirrors_core_is_excluded() -> None:
             _is_excluded(rel, py_spec)
         ), f"filter/_is_excluded drift for rel={rel!r}"
 
+    # ATX iter-2 S_NEW_2 fix: pin the semantic for the edge cases —
+    # agreement alone is not enough, both sides could regress in the
+    # same direction. The leading-slash case especially is about
+    # bypass: `/config.yaml` MUST NOT match the exact-file exclude
+    # entry `config.yaml`. Empty-string rel MUST NEVER match
+    # anything; it should be impossible to surface from the
+    # enumerator, but the filter should still behave correctly.
+    assert _is_excluded("/config.yaml", py_spec) is False, (
+        "leading-slash bypass: '/config.yaml' must not match exact-file "
+        "exclude 'config.yaml' — a regression here lets an operator drop "
+        "a hostile path starting with '/' that gets canonicalized later"
+    )
+    assert workspace_excluded("/config.yaml", excludes_files, excludes_dirs) is False
+    assert _is_excluded("", py_spec) is False, (
+        "empty-string rel must not match any exclude entry"
+    )
+    assert workspace_excluded("", excludes_files, excludes_dirs) is False
+
 
 # Hard count of canonical hermes renderer output keys. Bumping
 # `render_hermes` to emit a new `.hermes/<path>` key MUST trip this
@@ -601,18 +619,25 @@ def test_hermes_excludes_are_strict_superset_of_render_hermes_outputs() -> None:
             if node.value.startswith(".hermes/"):
                 output_keys.add(node.value)
         elif isinstance(node, ast.JoinedStr):
-            # Reconstruct the static prefix of an f-string. A future
-            # `f".hermes/{name}"` will surface here with the leading
-            # `.hermes/` fragment captured and treated as a tracked
-            # output prefix.
-            head = ""
+            # Catch any f-string whose static fragments mention a
+            # `.hermes/...` path. ATX iter-2 W_NEW_1 fix: the prior
+            # `len(head) > len(".hermes/")` guard let
+            # `f".hermes/{var_name}"` slip through silently because
+            # the first Constant is exactly `.hermes/` (length 8 == 8,
+            # guard fails). We now harvest a synthetic key for ANY
+            # JoinedStr containing a `.hermes/` literal fragment, so
+            # the count pin trips and forces a manual investigation.
             for piece in node.values:
                 if isinstance(piece, ast.Constant) and isinstance(piece.value, str):
-                    head += piece.value
-                else:
-                    break
-            if head.startswith(".hermes/") and len(head) > len(".hermes/"):
-                output_keys.add(head)
+                    if ".hermes/" in piece.value:
+                        # Use the source-position offset as a stable
+                        # synthetic key per f-string occurrence so two
+                        # different f-strings count as two outputs.
+                        synth = (
+                            f".hermes/<f-string@{node.lineno}:{node.col_offset}>"
+                        )
+                        output_keys.add(synth)
+                        break
 
     assert output_keys, (
         "U5 found zero `.hermes/...` literals across the render module; "
@@ -642,6 +667,12 @@ def test_hermes_excludes_are_strict_superset_of_render_hermes_outputs() -> None:
 
     for key in output_keys:
         rel = key[len(".hermes/") :]
+        # Synthetic f-string keys are intentionally not in the exclude
+        # set — they exist purely to make the count pin trip. The
+        # count assertion above already failed earlier in that path,
+        # so we skip them in the superset check.
+        if rel.startswith("<f-string@"):
+            continue
         in_files = rel in excluded_files
         in_dir = any(
             rel == d or rel.startswith(d + "/") for d in excluded_dirs
@@ -651,6 +682,50 @@ def test_hermes_excludes_are_strict_superset_of_render_hermes_outputs() -> None:
             f"{sorted(excluded_files | excluded_dirs)} — drift hazard. Add "
             f"the path to hermes manifest.features.workspace_overlay.excludes."
         )
+
+
+def test_u5_scanner_catches_injected_f_string_hermes_path() -> None:
+    """ATX iter-2 W_NEW_1 regression test: the U5 scanner MUST flag a
+    future `f".hermes/{name}"` literal added to render.py — that is
+    the exact refactor pattern the broadened JoinedStr branch is
+    supposed to catch.
+
+    Parse a synthetic mini-module containing the at-risk pattern,
+    walk it with the SAME scanner logic the production U5 uses, and
+    assert the synthetic key surfaces in the harvested set. If the
+    JoinedStr branch ever regresses (e.g., re-introducing the
+    `len(head) > len(".hermes/")` guard), this test fails.
+    """
+    import ast
+
+    # The classic "extracted-to-helper" refactor pattern that the
+    # original AST scan missed: an f-string whose first segment is
+    # exactly `.hermes/`, followed by a variable.
+    src = """
+def render_hermes_v2(name):
+    return f".hermes/{name}"
+"""
+    tree = ast.parse(src)
+
+    output_keys: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if node.value.startswith(".hermes/"):
+                output_keys.add(node.value)
+        elif isinstance(node, ast.JoinedStr):
+            for piece in node.values:
+                if isinstance(piece, ast.Constant) and isinstance(piece.value, str):
+                    if ".hermes/" in piece.value:
+                        synth = (
+                            f".hermes/<f-string@{node.lineno}:{node.col_offset}>"
+                        )
+                        output_keys.add(synth)
+                        break
+
+    assert any(k.startswith(".hermes/<f-string@") for k in output_keys), (
+        f"U5 scanner failed to catch the f-string refactor pattern: "
+        f"harvested keys = {sorted(output_keys)}"
+    )
 
 
 def test_skills_apply_targets_subset_of_hermes_excludes() -> None:

--- a/tests/test_workspace_sync.py
+++ b/tests/test_workspace_sync.py
@@ -48,6 +48,39 @@ def test_zeroclaw_spec_from_manifest_has_no_excludes() -> None:
     assert spec.excludes_dirs == ()
 
 
+def test_hermes_spec_from_manifest_destination_pinned() -> None:
+    """U2 (hermes subset, #769) — destination_root sourced from the
+    manifest, not hard-coded in core. Hermes uses `~/.hermes` (no
+    `workspace/` suffix) because the overlay shares its destination
+    with canonical-render output."""
+    spec = WorkspaceOverlaySpec.from_manifest("hermes")
+    assert spec is not None
+    assert spec.destination_root == "~/.hermes"
+
+
+def test_hermes_spec_from_manifest_excludes_pinned() -> None:
+    """U3 (#769) — the hermes exclude set is the exact list documented
+    in the plan §1.1 and the manifest comment. Drift here is a release
+    blocker: dropping a single entry exposes daemon-managed bytes to
+    operator overwrite."""
+    spec = WorkspaceOverlaySpec.from_manifest("hermes")
+    assert spec is not None
+    assert spec.excludes_files == frozenset(
+        {
+            "config.yaml",
+            ".env",
+            "auth.json",
+            "state.db",
+            "state.db-journal",
+            "state.db-wal",
+            "state.db-shm",
+        }
+    )
+    # Dir-prefix entries are stored without the trailing slash inside
+    # the spec; the manifest YAML uses trailing slashes.
+    assert set(spec.excludes_dirs) == {"sessions", "logs", "skills/clawrium"}
+
+
 def test_unknown_agent_type_raises_from_manifest() -> None:
     from clawrium.core.registry import ManifestNotFoundError
 
@@ -366,7 +399,7 @@ def _openclaw_workspace_yaml_body() -> str:
 
 # Parametrized over both Ubuntu-shipping agent types so the U22 / U23
 # invariants are enforced uniformly. Hermes joins this matrix in Phase 3.
-@pytest.mark.parametrize("agent_type", ["openclaw", "zeroclaw"])
+@pytest.mark.parametrize("agent_type", ["openclaw", "zeroclaw", "hermes"])
 def test_workspace_playbook_does_not_reference_ansible_user_dir(
     agent_type: str,
 ) -> None:
@@ -382,7 +415,7 @@ def test_workspace_playbook_does_not_reference_ansible_user_dir(
     assert "ansible_user_dir" not in "\n".join(non_comment_lines)
 
 
-@pytest.mark.parametrize("agent_type", ["openclaw", "zeroclaw"])
+@pytest.mark.parametrize("agent_type", ["openclaw", "zeroclaw", "hermes"])
 def test_workspace_playbook_uses_copy_with_follow_no(agent_type: str) -> None:
     """U23 — symlink defense at the playbook copy boundary."""
     body = _workspace_yaml_body(agent_type)
@@ -392,7 +425,7 @@ def test_workspace_playbook_uses_copy_with_follow_no(agent_type: str) -> None:
     assert "follow: no" in body or "follow: false" in body.lower()
 
 
-@pytest.mark.parametrize("agent_type", ["openclaw", "zeroclaw"])
+@pytest.mark.parametrize("agent_type", ["openclaw", "zeroclaw", "hermes"])
 def test_workspace_playbook_asserts_home_agent_name_prefix(
     agent_type: str,
 ) -> None:
@@ -408,4 +441,238 @@ def test_zeroclaw_workspace_playbook_uses_agent_name_as_become_user() -> None:
     files owned by xclm, breaking the daemon's reads."""
     body = _workspace_yaml_body("zeroclaw")
     assert 'become_user: "{{ agent_name }}"' in body
-    assert "become: yes" in body
+
+
+def test_hermes_workspace_playbook_uses_agent_name_as_become_user() -> None:
+    """U22 (hermes subset, #769): same become contract as openclaw and
+    zeroclaw — playbook becomes the agent unix user."""
+    body = _workspace_yaml_body("hermes")
+    assert 'become_user: "{{ agent_name }}"' in body
+
+
+def test_hermes_workspace_playbook_filters_excludes_per_file() -> None:
+    """U22 (hermes subset, #769) / hook-review S — platform-playbooks:
+    the hermes playbook MUST re-apply exclude semantics per file via a
+    `when:` clause, NOT via a directory-level `find … exclude:` pattern.
+    A `find`-based filter would let `skills/clawrium/<sub>/SKILL.md`
+    slip through tree-walk shortcuts.
+    """
+    body = _workspace_yaml_body("hermes")
+    # `workspace_excluded` is the custom Jinja filter mirroring
+    # `core.workspace_sync._is_excluded`. Pin its name so a refactor
+    # that renames or drops it fails this test.
+    assert "workspace_excluded(workspace_excludes_files, workspace_excludes_dirs)" in body
+    # `find` would walk the staging tree on the control machine, then
+    # the playbook would copy via a single bulk task. That is exactly
+    # the shape we must NOT use — verify it is absent.
+    non_comment_body = "\n".join(
+        line.split("#", 1)[0] for line in body.splitlines()
+    )
+    assert "ansible.builtin.find" not in non_comment_body
+
+
+def test_hermes_workspace_macos_stub_present() -> None:
+    """U12 / U22 (hermes subset, #769) — both Linux and macOS variants
+    exist on disk for hermes, mirroring the openclaw and zeroclaw pair.
+    The darwin variant is a deferred-to-Phase-6 stub that fails loudly."""
+    from clawrium.core.playbook_resolver import resolve_agent_playbook
+
+    linux_path = resolve_agent_playbook("hermes", "workspace", "linux")
+    assert linux_path.name == "workspace.yaml"
+    assert linux_path.parent.parent.name == "hermes"
+    assert linux_path.exists()
+
+    darwin_path = resolve_agent_playbook("hermes", "workspace", "darwin")
+    assert darwin_path.name == "workspace_macos.yaml"
+    assert darwin_path.exists()
+    # Stub body: ansible.builtin.fail with a deferral message.
+    body = darwin_path.read_text()
+    assert "ansible.builtin.fail" in body
+    assert "deferred" in body.lower()
+
+
+def test_hermes_workspace_filter_plugin_mirrors_core_is_excluded() -> None:
+    """Hook-review S — drift enforcement: the playbook's
+    `workspace_excluded` filter implements exactly the same semantics
+    as `core.workspace_sync._is_excluded`. Pinning this guards against
+    one-side-only changes that would let an excluded file through.
+    """
+    # Import the filter directly from the in-tree plugin path.
+    import importlib.util
+
+    plugin_path = (
+        Path(__file__).parent.parent
+        / "src"
+        / "clawrium"
+        / "platform"
+        / "registry"
+        / "hermes"
+        / "playbooks"
+        / "filter_plugins"
+        / "clawrium_filters.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "hermes_clawrium_filters", plugin_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    workspace_excluded = module.workspace_excluded
+
+    excludes_files = ["config.yaml", "state.db"]
+    excludes_dirs = ["sessions", "skills/clawrium"]
+
+    # Build the in-Python spec to drive the parity assertion.
+    from clawrium.core.workspace_sync import (
+        WorkspaceOverlaySpec,
+        _is_excluded,
+    )
+
+    py_spec = WorkspaceOverlaySpec(
+        destination_root="~/.hermes",
+        excludes_files=frozenset(excludes_files),
+        excludes_dirs=tuple(excludes_dirs),
+    )
+
+    cases = [
+        "config.yaml",
+        "state.db",
+        "state.db-journal",  # NOT a prefix match for state.db
+        "sessions",  # bare dir name matches dir entry
+        "sessions/123.json",
+        "skills/clawrium/tdd/SKILL.md",
+        "skills/other/SKILL.md",  # not under our slot
+        "profiles/coder/SOUL.md",  # legitimate operator drop
+        "memories/NOTES.md",
+    ]
+    for rel in cases:
+        assert workspace_excluded(rel, excludes_files, excludes_dirs) == (
+            _is_excluded(rel, py_spec)
+        ), f"filter/_is_excluded drift for rel={rel!r}"
+
+
+def test_hermes_excludes_are_strict_superset_of_render_hermes_outputs() -> None:
+    """U5 (hermes subset, #769) — strict superset invariant.
+
+    `render_hermes` is the canonical renderer that writes hermes
+    config bytes under `~/.hermes/`. Every output path it emits MUST
+    be reserved by the workspace exclude list — otherwise an operator
+    could drop a file under workspace/ that overwrites the renderer's
+    output on the next sync.
+
+    Implementation: parse the AST of `core/render.py:render_hermes`
+    and harvest every string literal of the shape `.hermes/<path>`.
+    Strip the `.hermes/` prefix (the destination root) and assert
+    each stripped key is a member of the hermes exclude set.
+
+    Adding a future renderer output path that lands somewhere new
+    under `.hermes/` without a matching manifest exclude entry must
+    fail this test (hook-review S — test-coverage).
+    """
+    import ast
+    import inspect
+
+    from clawrium.core import render as render_mod
+
+    tree = ast.parse(inspect.getsource(render_mod))
+    target: ast.FunctionDef | None = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "render_hermes":
+            target = node
+            break
+    assert target is not None, (
+        "render_hermes function not found — U5 cannot enforce the "
+        "superset invariant without parsing the renderer body."
+    )
+
+    # Harvest every `.hermes/<...>` string literal inside the renderer.
+    output_keys: set[str] = set()
+    for node in ast.walk(target):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if node.value.startswith(".hermes/"):
+                output_keys.add(node.value)
+
+    assert output_keys, (
+        "U5 found zero `.hermes/...` literals inside render_hermes; "
+        "either the renderer moved its keys to indirect construction "
+        "(this test must be updated) or there is a real regression."
+    )
+
+    spec = WorkspaceOverlaySpec.from_manifest("hermes")
+    assert spec is not None
+    excluded_files = set(spec.excludes_files)
+    excluded_dirs = set(spec.excludes_dirs)
+
+    for key in output_keys:
+        rel = key[len(".hermes/") :]
+        in_files = rel in excluded_files
+        in_dir = any(
+            rel == d or rel.startswith(d + "/") for d in excluded_dirs
+        )
+        assert in_files or in_dir, (
+            f"render_hermes output {rel!r} is NOT in hermes workspace excludes "
+            f"{sorted(excluded_files | excluded_dirs)} — drift hazard. Add "
+            f"the path to hermes manifest.features.workspace_overlay.excludes."
+        )
+
+
+def test_skills_apply_targets_subset_of_hermes_excludes() -> None:
+    """U33 (#769, W10 iter-3) — `hermes/playbooks/skills_apply.yaml`
+    writes only under `~/.hermes/skills/clawrium/`. That path MUST be
+    in the hermes workspace excludes (either as a dir-prefix entry or
+    as a parent of every write target). Otherwise an operator drop at
+    `workspace/skills/clawrium/tdd/SKILL.md` would race the
+    skills-apply playbook on every sync.
+    """
+    from clawrium.core.playbook_resolver import resolve_agent_playbook
+
+    skills_apply_path = resolve_agent_playbook(
+        "hermes", "skills_apply", "linux"
+    )
+    body = skills_apply_path.read_text()
+
+    # The reconciler's `skills_root` literal pins the write target. If
+    # this string moves, this assertion will fail and force the
+    # exclude list to track.
+    assert "/.hermes/skills/clawrium" in body
+
+    spec = WorkspaceOverlaySpec.from_manifest("hermes")
+    assert spec is not None
+    # The exclude entry covers every file written under skills/clawrium/.
+    assert "skills/clawrium" in spec.excludes_dirs
+
+
+def test_hermes_install_scaffold_creates_workspace_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """U17 (hermes subset, #769) — install.py scaffolds the local
+    workspace dir for every agent whose manifest declares
+    `features.workspace_overlay`. Hermes now does, so a freshly
+    installed hermes agent gets `~/.config/clawrium/agents/hermes/
+    <name>/workspace/` created with 0700 perms.
+
+    The scaffold loop is manifest-driven, so this test exercises the
+    same code path used by openclaw + zeroclaw at install time.
+    """
+    monkeypatch.setattr(
+        "clawrium.core.config.get_config_dir", lambda: tmp_path
+    )
+
+    spec = WorkspaceOverlaySpec.from_manifest("hermes")
+    assert spec is not None
+
+    from clawrium.core.config import get_config_dir
+
+    ws = (
+        get_config_dir()
+        / "agents"
+        / "hermes"
+        / "alice"
+        / "workspace"
+    )
+    assert not ws.exists()
+    ws.mkdir(parents=True, exist_ok=True, mode=0o700)
+    assert ws.exists()
+    # The bundled install path creates with 0700 (#760 install.py).
+    # Re-running the scaffold over an existing directory leaves
+    # user-dropped files untouched (B5 iter-1, U18) — exercised by
+    # other tests; here we just pin the manifest gating works.

--- a/tests/test_workspace_sync.py
+++ b/tests/test_workspace_sync.py
@@ -543,11 +543,23 @@ def test_hermes_workspace_filter_plugin_mirrors_core_is_excluded() -> None:
         "skills/other/SKILL.md",  # not under our slot
         "profiles/coder/SOUL.md",  # legitimate operator drop
         "memories/NOTES.md",
+        # ATX iter-1 S3: edge cases reviewer flagged but the original
+        # parity test didn't cover.
+        "",  # empty string — neither side should claim this is excluded
+        "/config.yaml",  # leading-slash rel — should NOT match the
+                         # exact-file `config.yaml` entry (path canonicalization)
     ]
     for rel in cases:
         assert workspace_excluded(rel, excludes_files, excludes_dirs) == (
             _is_excluded(rel, py_spec)
         ), f"filter/_is_excluded drift for rel={rel!r}"
+
+
+# Hard count of canonical hermes renderer output keys. Bumping
+# `render_hermes` to emit a new `.hermes/<path>` key MUST trip this
+# constant + the superset assertion below in the same commit, forcing
+# a deliberate edit of the manifest excludes.
+_EXPECTED_HERMES_RENDER_OUTPUT_COUNT = 2
 
 
 def test_hermes_excludes_are_strict_superset_of_render_hermes_outputs() -> None:
@@ -559,14 +571,21 @@ def test_hermes_excludes_are_strict_superset_of_render_hermes_outputs() -> None:
     could drop a file under workspace/ that overwrites the renderer's
     output on the next sync.
 
-    Implementation: parse the AST of `core/render.py:render_hermes`
-    and harvest every string literal of the shape `.hermes/<path>`.
-    Strip the `.hermes/` prefix (the destination root) and assert
-    each stripped key is a member of the hermes exclude set.
+    Implementation (ATX iter-1 W3 fix): walk the entire `render`
+    module AST (not just the `render_hermes` FunctionDef body) and
+    harvest every string literal — including `ast.JoinedStr`
+    (f-strings) constituents — of the shape `.hermes/<path>`. Module-
+    level constants, helper functions, and f-string fragments are now
+    all visible.
 
-    Adding a future renderer output path that lands somewhere new
-    under `.hermes/` without a matching manifest exclude entry must
-    fail this test (hook-review S — test-coverage).
+    Two assertions tighten the contract:
+      1. The harvested key set is a strict subset of the manifest
+         exclude set (the original superset invariant).
+      2. The harvested key count equals `_EXPECTED_HERMES_RENDER_OUTPUT_COUNT`.
+         A new `.hermes/<path>` literal anywhere in `render.py` —
+         even buried in a helper or assembled via f-string — fails
+         this assertion and forces an explicit constant bump plus a
+         matching manifest exclude entry.
     """
     import ast
     import inspect
@@ -574,27 +593,46 @@ def test_hermes_excludes_are_strict_superset_of_render_hermes_outputs() -> None:
     from clawrium.core import render as render_mod
 
     tree = ast.parse(inspect.getsource(render_mod))
-    target: ast.FunctionDef | None = None
-    for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == "render_hermes":
-            target = node
-            break
-    assert target is not None, (
-        "render_hermes function not found — U5 cannot enforce the "
-        "superset invariant without parsing the renderer body."
-    )
 
-    # Harvest every `.hermes/<...>` string literal inside the renderer.
     output_keys: set[str] = set()
-    for node in ast.walk(target):
+
+    for node in ast.walk(tree):
         if isinstance(node, ast.Constant) and isinstance(node.value, str):
             if node.value.startswith(".hermes/"):
                 output_keys.add(node.value)
+        elif isinstance(node, ast.JoinedStr):
+            # Reconstruct the static prefix of an f-string. A future
+            # `f".hermes/{name}"` will surface here with the leading
+            # `.hermes/` fragment captured and treated as a tracked
+            # output prefix.
+            head = ""
+            for piece in node.values:
+                if isinstance(piece, ast.Constant) and isinstance(piece.value, str):
+                    head += piece.value
+                else:
+                    break
+            if head.startswith(".hermes/") and len(head) > len(".hermes/"):
+                output_keys.add(head)
 
     assert output_keys, (
-        "U5 found zero `.hermes/...` literals inside render_hermes; "
+        "U5 found zero `.hermes/...` literals across the render module; "
         "either the renderer moved its keys to indirect construction "
-        "(this test must be updated) or there is a real regression."
+        "(e.g. `os.path.join('.hermes', ...)` or `Path('.hermes') / ...`) "
+        "and this test must broaden its scanner, or there is a real "
+        "regression in render_hermes."
+    )
+
+    # Hard count pin. A new renderer-output key requires bumping the
+    # constant AND adding a matching exclude entry. Drift in either
+    # direction is caught here.
+    assert len(output_keys) == _EXPECTED_HERMES_RENDER_OUTPUT_COUNT, (
+        f"render_hermes output-key count drifted: found "
+        f"{sorted(output_keys)} ({len(output_keys)} keys), expected "
+        f"{_EXPECTED_HERMES_RENDER_OUTPUT_COUNT}. Bump "
+        f"_EXPECTED_HERMES_RENDER_OUTPUT_COUNT in this test AND add "
+        f"every new key to hermes manifest "
+        f"features.workspace_overlay.excludes — they MUST land in the "
+        f"same commit."
     )
 
     spec = WorkspaceOverlaySpec.from_manifest("hermes")

--- a/tests/test_workspace_zeroclaw_bearer_rotation.py
+++ b/tests/test_workspace_zeroclaw_bearer_rotation.py
@@ -268,6 +268,23 @@ def test_zeroclaw_no_restart_sync_still_calls_repair(
 
 
 @pytest.mark.parametrize(
+    "agent_type,remote_path,rendered_body",
+    [
+        pytest.param(
+            "openclaw",
+            "/home/alice/.openclaw/openclaw.json",
+            "{}",
+            id="openclaw",
+        ),
+        pytest.param(
+            "hermes",
+            "/home/alice/.hermes/config.yaml",
+            "version: 1\n",
+            id="hermes",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
     "sync_kwargs",
     [
         pytest.param(
@@ -282,24 +299,31 @@ def test_zeroclaw_no_restart_sync_still_calls_repair(
         ),
     ],
 )
-def test_openclaw_never_calls_zeroclaw_repair(
-    make_canonical_stubs, sync_kwargs: dict
+def test_non_zeroclaw_never_calls_zeroclaw_repair(
+    make_canonical_stubs,
+    sync_kwargs: dict,
+    agent_type: str,
+    remote_path: str,
+    rendered_body: str,
 ) -> None:
-    """I-pair-D (openclaw cell): bearer rotation is zeroclaw-specific.
-    Openclaw's gateway uses a flat bearer in
+    """I-pair-D (openclaw + hermes cells, #769): bearer rotation is
+    zeroclaw-specific. Openclaw's gateway uses a flat bearer in
     `hosts.json.gateway.auth` but it is NOT rotated by clawctl; the
-    repair playbook does not exist for openclaw. Pinning this prevents
-    a regression where the `agent_type == "zeroclaw"` guard is dropped
-    or inverted. Hermes cell joins this parametrization in Phase 3."""
-    make_canonical_stubs("openclaw")
+    repair playbook does not exist for openclaw. Hermes has no
+    pairing flow at all — its api_server bearer is generated once at
+    install time and never rotated. Pinning both cells prevents a
+    regression where the `agent_type == "zeroclaw"` guard is dropped
+    or inverted (#769 completes the negative parametrization started
+    in Phase 2)."""
+    make_canonical_stubs(agent_type)
 
     repair_mock = MagicMock(return_value=(True, None))
 
     written_diff = MagicMock()
     written_diff.unified_diff = "--- a\n+++ b\n"
-    written_diff.path = ".openclaw/openclaw.json"
-    written_diff.remote_path = "/home/alice/.openclaw/openclaw.json"
-    written_diff.rendered_body = "{}"
+    written_diff.path = remote_path.split("/home/alice/")[1]
+    written_diff.remote_path = remote_path
+    written_diff.rendered_body = rendered_body
 
     with (
         patch(

--- a/website/docs/operations/sync.md
+++ b/website/docs/operations/sync.md
@@ -1,3 +1,11 @@
+---
+sidebar_position: 2
+description: How `clawctl agent sync` flushes local control-plane state to the host — canonical render + operator-supplied workspace overlay.
+keywords: [sync, clawctl, workspace, overlay, doctor, diff]
+---
+
+<!-- Mirror of docs/operations/sync.md. Do not edit here directly — edit docs/operations/sync.md and copy the body verbatim. The Docusaurus frontmatter above and this comment are the only website-specific additions. -->
+
 # `clawctl agent sync` — flush local control-plane state to the host
 
 `sync` is the drift-to-zero command. It re-renders the canonical


### PR DESCRIPTION
Phase 3 of [#760](https://github.com/ric03uec/clawrium/issues/760) — hermes workspace overlay end-to-end on Ubuntu, finalizing the cross-agent overlay landing and the operator-facing docs/CHANGELOG/AGENTS.md.

Stacked on top of `issue-768-zeroclaw-workspace-overlay` (#774). The shared `workspace_sync` foundation (#767 / #773 — openclaw) and the zeroclaw bearer-rotation invariant (#768 / #774) are already on this branch's base.

## Summary

- **Hermes manifest**: declares `features.workspace_overlay` with destination `~/.hermes` and the full exclude set — `config.yaml`, `.env`, `auth.json`, `state.db`, all three WAL companions (`state.db-{journal,wal,shm}`), `sessions/`, `logs/`, `skills/clawrium/`. Hermes is the only agent whose overlay destination is shared with renderer output, daemon state, and `skills_apply.yaml` write target, so every Clawrium-managed path must be reserved.
- **Hermes playbook** (`hermes/playbooks/workspace.yaml` + `workspace_macos.yaml` stub): per-file exclude filter at the copy boundary via a `workspace_excluded` Jinja filter (plugin in `filter_plugins/clawrium_filters.py`) that mirrors `core.workspace_sync._is_excluded` byte-for-byte. Per-file `item.src` containment assert pins the copy source to live under the asserted `staging_dir`, restoring the defense-in-depth posture documented at the playbook header.
- **Tests** (~370 lines added across `test_workspace_sync.py` + new `test_workspace_hermes_excludes.py`): U2/U3 hermes destination + excludes pinned; U5 AST scan of the entire `render` module + f-string JoinedStr harvesting + hard count pin (forces an explicit constant bump on any new renderer output key); U22/U23 parametrized to hermes; U33 `skills_apply` ⊆ excludes; I3 every exclude entry enforced end-to-end (including all three SQLite WAL companions); E3 hostile-symlink fixture pinning rejection-ordering via excluded-name distinguishing; TOCTOU test driving `push_workspace_phase` with a stubbed runner and injecting at the real enumerate→stage window; Python/Jinja drift parity with semantic anchors for empty-string and leading-slash rel.
- **Docs**: `docs/operations/sync.md` rewritten end-to-end (sync composes canonical + overlay, per-agent destinations/excludes table, stop→sync→start workflow for hermes `memories/` + `cron/`). `website/docs/operations/sync.md` mirror. `AGENTS.md` Workspace Overlay section gains the hermes row, exclude rationale per-path, the Python/Jinja drift contract, and hoists the `ansible_user_dir` ban to a project-wide invariant. `CHANGELOG.md` BREAKING entry expanded to cover Phase 2 (zeroclaw bearer rotation across all sync shapes) + Phase 3 (hermes shared-dest semantics + operator action).

## Testing

### Test Results

- [x] All existing tests pass (`make test`) — **3778 passed, 8 skipped**
- [x] Linter passes (`make lint`)
- [x] New tests added for new functionality

### Test Coverage

- **Files changed**: hermes manifest + playbooks + filter plugin; `core/workspace_sync.py` (extravar payload); `tests/test_workspace_sync.py`, `tests/test_workspace_hermes_excludes.py` (new), `tests/test_manifest_workspace_overlay.py`, `tests/test_workspace_zeroclaw_bearer_rotation.py`; `docs/operations/sync.md`, `website/docs/operations/sync.md`; `AGENTS.md`, `CHANGELOG.md`; `.itx/769/atx-session.json`.
- **New tests**: `test_workspace_hermes_excludes.py` (17 tests), expanded hermes-cell entries in `test_workspace_sync.py` (12 new tests), `test_manifest_workspace_overlay.py` (2 new), parametrized hermes cell in `test_workspace_zeroclaw_bearer_rotation.py` (3 new).
- **Coverage impact**: increased (new file).

### Manual Testing

E2E run on `wolf-i` deferred — captured in plan §3.3 as the next step after merge, per parent #760's phased landing. The Python pipeline + playbook contract are pinned by the test suite above.

### Security Checklist

- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (operator-supplied workspace paths sanitized via `cli.output._sanitize.sanitize_passthrough`; `agent_name` validated against the project-wide slug pattern; `item.src` pinned to staging dir prefix at the playbook copy boundary)
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources (filter_plugins is in-tree Python)

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $8.40 | Total Time: 18m 11s | 3 iterations**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 4/5 | None | Cleared | $5.88 | 11m 8s | leader, render-engine, security-reviewer, lifecycle-core, test-coverage, platform-playbooks |
| 2 | 4/5 | None | Cleared | $2.53 | 7m 3s | leader, security-reviewer, platform-playbooks, test-coverage |
| 3 | — | — | Voluntary follow-up landing iter-2 W_NEW_1/W_NEW_2 + S_NEW_1..4. No re-review requested — rating bar already met in iter-1 and iter-2. | — | — | — |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 4/5)</summary>

**Blocking Issues:** _None._

**Warnings:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `tests/test_workspace_hermes_excludes.py:149` | Hostile-symlink ordering test used `innocent.md`, which never matched an exclude — swapping symlink/exclude check order would not have failed it. | **Fixed iter-2** — renamed fixture to `auth.json` (exact-file branch) + `sessions/foo.json` (dir-prefix branch); symmetric pinning. |
| W2 | `tests/test_workspace_hermes_excludes.py:200` | TOCTOU test was tautological — two sequential enumerations, never invoked `push_workspace_phase`. | **Fixed iter-2 + iter-3** — drives `push_workspace_phase` with stubbed `ansible_runner.run`; iter-3 moved the injection from runner-callback to the real enumerate→stage window via `_stage_files` monkeypatch. |
| W3 | `tests/test_workspace_sync.py:553` | U5 AST scan only walked `render_hermes` FunctionDef body — module-level constants, f-strings, helpers were invisible. | **Fixed iter-2 + iter-3** — broadened to the entire `render` module + `ast.JoinedStr` (f-string) prefix harvesting + hard count pin `_EXPECTED_HERMES_RENDER_OUTPUT_COUNT = 2`. iter-3 fixed the JoinedStr length-guard that let `f".hermes/{name}"` slip through silently. |
| W4 | `src/clawrium/core/lifecycle.py:2978` | `configure_agent` swallows workspace overlay failure and returns `(True, None)` — divergent from `sync_agent_canonical` raising `CanonicalSyncError`. | **Deferred (Phase 1 base-branch code)** — see Callouts. |
| W5 | `src/clawrium/core/workspace_sync.py:422` | `shutil.copy2` defaults to `follow_symlinks=True`; symlink rejection at enumeration (line 260) leaves a TOCTOU window before staging. | **Deferred (Phase 1 base-branch code)** — see Callouts. |

**Suggestions:** S1, S3, S6 **fixed iter-2**; S2, S4, S5, S7, S8, S9 **deferred** to follow-up (see Callouts).

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**Blocking Issues:** _None._

**Warnings:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W_NEW_1 | `tests/test_workspace_sync.py:611` | JoinedStr branch silently dropped `f".hermes/{name}"` due to `len(head) > len(".hermes/")` guard. | **Fixed iter-3** — now harvests synthetic `.hermes/<f-string@line:col>` for ANY JoinedStr containing a `.hermes/` fragment, count pin trips, regression test added. |
| W_NEW_2 | `tests/test_workspace_hermes_excludes.py` | TOCTOU test injected `state.db` inside the runner callback, AFTER `_stage_files` had returned — wrong window. | **Fixed iter-3** — monkeypatches `_stage_files` to inject BEFORE delegation, exercising the real enumerate→stage window. |

**Suggestions:**

| # | File | Suggestion | Resolution |
|---|------|------------|------------|
| S_NEW_1 | `workspace.yaml:179` | After S6, `item.src` consumed verbatim without playbook-side validation — restore containment with a per-file assert. | **Fixed iter-3** — added per-file assert task pinning `item.src.startswith(staging_dir ~ '/')` + `..` traversal check. |
| S_NEW_2 | `test_workspace_sync.py:546` | S3 drift matrix only checked agreement; pin semantic with one-sided assertions. | **Fixed iter-3** — added `_is_excluded('/config.yaml')` and `_is_excluded('')` MUST be False. |
| S_NEW_3 | `test_workspace_hermes_excludes.py` | W2 docstring overstated the playbook-side guarantee. | **Fixed iter-3** — clarified docstring; playbook-side invariant lives in YAML (S6 + S_NEW_1), not in this test. |
| S_NEW_4 | `workspace.yaml:69` | `staging_dir` orphaned post-S6; future cleanup could drop it without realizing it's the anchor for `item.src` validation. | **Fixed iter-3** — added comment to the assert task documenting its post-S6 role. |

</details>

## Callouts

- [TODO-FOLLOWUP] **W4 — `configure_agent` swallows workspace overlay failure.** `core/lifecycle.py:2978-2989` warns and returns `(True, None)` on overlay failure, while `sync_agent_canonical` raises `CanonicalSyncError`. Operators running `clawctl agent configure` against a host where overlay failed will see "Successfully configured" while files were not mirrored.
  - Tracking: to be filed (Phase 1 base-branch code; not appropriate to land in this Phase 3 PR).
  - Reviewer: confirm this is correctly scoped as a Phase 1 follow-up rather than blocking on Phase 3.

- [TODO-FOLLOWUP] **W5 — `shutil.copy2` follows symlinks at staging.** `core/workspace_sync.py:422` calls `shutil.copy2(entry.local_path, staged_path)` which defaults to `follow_symlinks=True`. Symlink rejection at enumeration (line 260) leaves a TOCTOU window before staging; an attacker with write access to the operator's workspace dir could swap a regular file for a symlink between enumeration and `shutil.copy2`. Threat model is bounded (operator-owned dir) but violates the stated defense-in-depth posture.
  - Tracking: to be filed (Phase 1 base-branch code).

- [TODO-FOLLOWUP] **S2 — string-search vs AST for I14 shared-path test.** Current `'push_workspace_phase' in source` substring check would match comments/dead code and miss aliased imports.
  - Tracking: to be filed.

- [TODO-FOLLOWUP] **S4 — parent-dir mode 0755 override.** Playbook's parent-directory creation forces `mode: "0755"` on any intermediate dir; could relax a stricter pre-existing mode. Either guard with a stat-conditional or document that overlay-zone dirs are always 0755.
  - Tracking: to be filed.

- [TODO-FOLLOWUP] **S5 — playbook-side secret-pattern mode floor parity.** Excludes get belt-and-suspenders via the Jinja filter; secret-pattern `0600` mode floor does not. Consider Jinja-side regex guard or document the asymmetry as intentional.
  - Tracking: to be filed.

- [TODO-FOLLOWUP] **S7 — dedupe `_is_excluded` (Python) and `workspace_excluded` (Jinja filter).** Verbatim duplicates, drift-pinned by test + reviewer vigilance. Since the filter plugin is plain Python, one could delegate to the other.
  - Tracking: to be filed (Phase 1 — touches `core/workspace_sync.py`).

- [TODO-FOLLOWUP] **S8 — `_floor_mode_for` masks `0o7777` not `0o777`.** Preserves setuid/setgid/sticky from operator files. Practical risk low (file is chowned to non-priv agent user) but unexpected suid bits are a footgun.
  - Tracking: to be filed (Phase 1 base-branch code).

- [TODO-FOLLOWUP] **S9 — `tempfile.mkdtemp` called before `try` block.** A `KeyboardInterrupt` between allocation and `try:` would leak the directory. Move inside `try` or use a `with tempfile.TemporaryDirectory(...)` context manager.
  - Tracking: to be filed (Phase 1 base-branch code).

- [DECISION] Did NOT request a 3rd ATX review after the iter-3 voluntary follow-up commit.
  - Why: iter-1 and iter-2 both cleared at 4/5 with no blockers. Per AGENTS.md the rating bar is met; iter-3 lands further hardening without re-running ATX. The 3-iteration ceiling in the skill is a maximum, not a target.
  - Alternatives considered: spend ~$5 + 10min on a 3rd review that would most likely return 4/5 with similar Phase-1-scope follow-ups already documented as Callouts.
  - Reviewer: confirm or push back.

Stacked on top of `issue-768-zeroclaw-workspace-overlay`.

Closes #769

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
