### PR TITLE
feat(gui): #758 split agent detail into static + health endpoints

### DIFF
--- a/.itx/758/00_PLAN.md
+++ b/.itx/758/00_PLAN.md
@@ -1,0 +1,199 @@
+# Implementation Plan — Issue #758
+
+Make the agent detail page render its shell instantly and load each
+section's data progressively, instead of blocking the entire route on a
+single slow remote health probe.
+
+## Diagnosis (the actual blocker)
+
+Tracing the click → render path:
+
+- `gui/src/app/agents/page.tsx:58-69` — `AgentDetailView` is gated
+  entirely on `useAgent(agentKey).isLoading`. While that one query is
+  in flight, the page shows three pulsing skeleton blocks. **No shell
+  content, no header, no name** until `useAgent` resolves.
+- `useAgent` → `GET /fleet/agents/:key` →
+  `src/clawrium/gui/routes/fleet.py:211 agent_detail()` →
+  `src/clawrium/cli/tui/data.py:428 get_agent_detail()`.
+- Inside `get_agent_detail`, line 443:
+  `check_claw_health_safe(agent_key, h)`. That's a remote SSH-driven
+  health probe — seconds on a slow/unreachable host. Compounded by a
+  synchronous `latest_supported_version` lookup right after
+  (`fleet.py:238`).
+- Everything *else* the page needs (`agent_name`, `agent_type`, `host`,
+  `version`, `provider`, `gateway_url`, `device_id`) is read straight
+  out of `hosts.json` and would resolve in milliseconds if the health
+  probe weren't on the critical path.
+
+The other tabs (skills, web-ui, memory, etc.) already own their own
+hooks and don't gate the shell — they're not the bug.
+
+## Solution
+
+Split the slow probe off the critical path:
+
+1. One backend endpoint for **static identity + persisted config**
+   (cheap, local — reads `hosts.json` only).
+2. A second endpoint for **runtime health** (slow, remote — runs
+   `check_claw_health_safe` + `latest_supported_version`).
+3. Two React Query hooks. The shell renders as soon as the static call
+   resolves; status / uptime / version-badge show their own loading
+   state.
+4. Per-section failure isolation: a health-endpoint error surfaces an
+   inline "Status unavailable, retry" in the header instead of blanking
+   the page.
+
+No new caching layer (explicitly out of scope per the issue).
+
+## Files to modify
+
+### Backend
+
+- `src/clawrium/cli/tui/data.py`
+  - Extract `get_agent_static(agent_key, host_identifier) -> AgentViewModel | None`
+    returning the hosts.json-derived fields only — no
+    `check_claw_health_safe`, no `latest_supported_version`. Runtime
+    fields default to `None` / `UNKNOWN`.
+  - Keep `get_agent_detail` as the runtime path (or rename to
+    `get_agent_runtime` and have it return just the runtime delta).
+    Simpler refactor: keep `get_agent_detail` as-is and add the static
+    sibling.
+
+- `src/clawrium/gui/routes/fleet.py`
+  - `GET /fleet/agents/{agent_key}` switches to `get_agent_static`.
+    Removes the `latest_supported_version` lookup from this handler.
+  - Add `GET /fleet/agents/{agent_key}/health` returning
+    `{ status, uptime, process_running, missing_secrets,
+       onboarding_step, cpu_count, memory_total_mb, health_error,
+       latest_supported_version }`. Calls `get_agent_detail` and
+    `latest_supported_version` on the executor.
+
+### Frontend
+
+- `gui/src/lib/types.ts` — mark runtime fields optional on
+  `AgentDetail` (`status?`, `uptime?`, `cpu_count?`, `memory_total_mb?`,
+  `missing_secrets?`, `onboarding_step?`, `health_error?`,
+  `process_running?`, `latest_supported_version?`). Optional add: a
+  thin `AgentHealth` type for the new hook's payload.
+
+- `gui/src/lib/api.ts` — add `getAgentHealth(key)` next to `getAgent`.
+
+- `gui/src/hooks/use-agent.ts`
+  - `useAgent` continues to call `/fleet/agents/:key` (now fast). Drop
+    the 10s `refetchInterval` from `useAgent` — static data doesn't
+    change between mutations.
+  - Add `useAgentHealth(key)` with `refetchInterval: 10_000`.
+  - `useAgentActions` `invalidate()` now invalidates both
+    `["agent", key]` AND `["agent-health", key]` (plus the existing
+    fleet/web-ui keys).
+
+- `gui/src/app/agents/page.tsx`
+  - Remove the page-level `isLoading` early-return that gates the shell.
+  - Render shell (breadcrumb, `AgentHeader`, `AgentMetrics`, `TabNav`,
+    active tab) as soon as `useAgent` resolves. The static call should
+    be sub-100ms; keep a minimal skeleton only as a transitional state
+    while it loads.
+  - Error / not-found state stays the same.
+
+- `gui/src/components/agent-detail/agent-header.tsx`
+  - Name / type / host / OS icon from `useAgent` (static).
+  - Status dot, uptime, action-button enable-state from
+    `useAgentHealth(agent.agent_key)`. While pending: status shows
+    "Checking…" placeholder, action buttons disabled with a tooltip.
+    On error: inline "Status unavailable, retry" without killing the
+    header chrome.
+
+- `gui/src/components/agent-detail/agent-metrics.tsx` — runtime metrics
+  (cpu / mem / uptime) consume `useAgentHealth`; skeleton row until
+  resolved.
+
+- `gui/src/components/agent-detail/overview-tab.tsx` — the Status and
+  Uptime rows in the Agent Identity card read from `useAgentHealth`;
+  Version/Name/Type/Host stay on the static payload. `VersionRow`
+  consumes `latestSupportedVersion` from health (loading: hide the
+  upgrade badge, never show a wrong one).
+
+## Test strategy
+
+### Backend unit (`tests/`)
+
+- `tests/gui/routes/test_fleet.py` (or nearest existing file): mock
+  `check_claw_health` to raise / sleep; assert
+  `/fleet/agents/:key` returns the static fields fast and does not
+  surface the probe error.
+- New test: `/fleet/agents/:key/health` returns the runtime fields and
+  surfaces the health probe via the existing `_HEALTH_ERROR_LABELS`
+  sanitizer.
+- `tests/cli/test_tui_data.py` (or nearest): `get_agent_static`
+  populates identity but leaves runtime fields at defaults; `check_claw_health`
+  is NOT called (mock + `assert_not_called()`).
+
+### Frontend (vitest)
+
+- Update existing `gui/src/components/agent-detail/overview-tab.test.tsx`
+  for the hook split (Status / Uptime rows now sourced from
+  `useAgentHealth`).
+- New page-level test: with `useAgent` resolved and `useAgentHealth`
+  pending, assert the shell renders (`agent_name` text,
+  `TabNav`, OverviewTab Provider card visible) AND the status pill
+  reads "Checking…".
+
+### Manual
+
+On an unreachable host (kevin or any stopped Pi): click into the
+agent; chrome + name must appear within ~100ms; status pill stays
+"Checking…" until the probe times out, then shows an inline retryable
+error in the header only — the rest of the page (provider, skills,
+tabs) remains interactive.
+
+## Risks / things to watch
+
+1. **Consumers of `agent.status`** — `agent-header.tsx` uses
+   `agent.status === "running"` / `"stopped"` for button gating. After
+   the split these read from `useAgentHealth`. Other consumers may
+   exist; `grep` pass before implementation.
+2. **Polling moves from `useAgent` to `useAgentHealth`.** Lifecycle
+   mutations (`start` / `stop` / `restart`) must invalidate both
+   queries so the freshly-flipped status shows up without waiting for
+   the 10s tick.
+3. **`key={agent.agent_key}` reset trick** (`page.tsx:98`) on
+   `AgentHeader` still works — `agent.agent_key` is part of the static
+   payload.
+4. **Fleet list page** (`/agents` no key) also calls a fleet-health
+   probe; that is a separate concern and a separate issue. Out of
+   scope here.
+5. **`AgentDetail` type churn** — making fields optional means every
+   render site needs a `?? "—"` fallback or a guard. Keep changes
+   mechanical and grep-driven.
+
+## Subtasks
+
+None — `complexity:s`, single concern (split one endpoint and its
+consumers), ~6–8 files. One PR.
+
+---
+
+<details>
+<summary>Prompt Log</summary>
+
+**Stage**: planning
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-06-21T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx:plan-create 758. plan only no files creation yet
+```
+
+Followed by:
+
+```prompt
+ok. update plan and fix this in a worktree. commit the plan file in the
+worktree only. create tree off of main. use atx cli for review
+```
+
+**Output**: `.itx/758/00_PLAN.md` (this file) — implementation plan
+committed in worktree `clawrium-issue-758` on branch
+`issue-758-agent-page-progressive`.
+
+</details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,15 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Changed
 
+- GUI agent detail page now renders its shell instantly and loads each
+  runtime section progressively. The single backend route was split
+  into `/api/fleet/agents/{key}` (cheap, local — hosts.json only) and
+  `/api/fleet/agents/{key}/health` (the slow SSH probe plus the
+  registry version lookup). A failed or slow probe no longer blanks
+  the page; the header, tabs, and provider/skills cards stay
+  interactive while the status pill and upgrade badge populate on
+  arrival. `latest_supported_version` moved off the static endpoint
+  onto `/health`. Closes #758.
 - Default openclaw install target bumped from `2026.5.28` to `2026.6.8`.
   `clawctl agent create --type openclaw` and `clawctl agent upgrade`
   now install `2026.6.8` by default; manifest entries added for

--- a/gui/src/app/agents/page.tsx
+++ b/gui/src/app/agents/page.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParams, useRouter } from "next/navigation";
 import { Suspense, useState } from "react";
-import { useAgent } from "@/hooks";
+import { useAgent, useAgentHealth } from "@/hooks";
 import { PageHeader } from "@/components/layout";
 import { AgentTable } from "@/components/dashboard";
 import {
@@ -56,6 +56,11 @@ function AgentDetailView({
   onTabChange: (tab: TabId) => void;
 }) {
   const { data: agent, isLoading, error } = useAgent(agentKey);
+  // #758: health is fetched in parallel and never gates the shell.
+  // Children read runtime fields from `health` when present and fall
+  // back to the static AgentDetail (which carries status="checking"
+  // until the probe lands) so they can render a sensible default.
+  const health = useAgentHealth(agentKey);
   const router = useRouter();
 
   if (isLoading) {
@@ -92,18 +97,27 @@ function AgentDetailView({
         <span className="text-primary-text">{agent.agent_name}</span>
       </div>
 
-      {/* key={agent.agent_key}: local state (revealed token, copied flags,
-          pairing-code mutation result) must not leak across agents when the
-          user switches via the search-param-only route change. */}
-      <AgentHeader key={agent.agent_key} agent={agent} />
+      {/* key={agent.agent_key}: prevent local state (revealed token,
+          copied flags, pairing-code mutation result) from leaking
+          across agents when the user switches via the search-param-only
+          route change. AgentMetrics + OverviewTab are keyed too
+          (#758 S4) — no local state today, but the key keeps the
+          invariant consistent so a future hook inside either component
+          does not silently regress. */}
+      <AgentHeader key={agent.agent_key} agent={agent} health={health.data} />
 
-      <AgentMetrics agent={agent} />
+      <AgentMetrics key={agent.agent_key} agent={agent} health={health.data} />
 
       <div className="bg-white rounded-xl border border-default shadow-sm overflow-hidden">
         <TabNav active={activeTab} onChange={onTabChange} />
         <div className="min-h-[500px]">
           {activeTab === "overview" && (
-            <OverviewTab agent={agent} agentKey={agentKey} />
+            <OverviewTab
+              key={agent.agent_key}
+              agent={agent}
+              agentKey={agentKey}
+              health={health.data}
+            />
           )}
           {activeTab === "chat" && (
             <ChatTab agentKey={agentKey} agentName={agent.agent_name} />

--- a/gui/src/components/agent-detail/agent-header.test.tsx
+++ b/gui/src/components/agent-detail/agent-header.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentDetail, AgentDetailHealth } from "@/lib/types";
+
+const webUIState = { data: undefined, isLoading: false, isError: false };
+const noopMutation = { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
+
+vi.mock("@/hooks", () => ({
+  PAIRING_AGENT_TYPES: new Set(["zeroclaw"]),
+  TOKEN_REVEAL_AGENT_TYPES: new Set(["openclaw"]),
+  useAgentActions: () => ({
+    start: noopMutation,
+    stop: noopMutation,
+    restart: noopMutation,
+  }),
+  useAgentConnectionToken: () => ({ ...noopMutation, data: undefined, isError: false, error: null }),
+  useAgentPairingCode: () => ({ ...noopMutation, data: undefined, isError: false, error: null }),
+  useAgentWebUI: () => webUIState,
+}));
+
+import { AgentHeader } from "./agent-header";
+
+function makeAgent(overrides: Partial<AgentDetail> = {}): AgentDetail {
+  return {
+    agent_key: "demo",
+    agent_name: "demo",
+    agent_type: "hermes",
+    host: "192.168.1.100",
+    host_alias: "box",
+    host_os_family: "linux",
+    status: "checking",
+    model: "-",
+    uptime: "1m",
+    gateway_url: null,
+    provider: "",
+    provider_type: "",
+    addresses: [],
+    version: "2026.4.2",
+    device_id: "",
+    onboarding_step: "ready",
+    gateway_port: null,
+    ...overrides,
+  } as AgentDetail;
+}
+
+function makeHealth(
+  overrides: Partial<AgentDetailHealth> = {},
+): AgentDetailHealth {
+  return {
+    agent_key: "demo",
+    status: "running",
+    process_running: true,
+    health_error: null,
+    cpu_count: 4,
+    memory_total_mb: 8192,
+    missing_secrets: null,
+    onboarding_step: "ready",
+    latest_supported_version: null,
+    ...overrides,
+  };
+}
+
+describe("AgentHeader — health loading fallback (#758 ATX W7)", () => {
+  it("renders agent identity even when health is undefined", () => {
+    render(<AgentHeader agent={makeAgent()} health={undefined} />);
+    expect(screen.getByText("demo")).toBeTruthy();
+    // Type + version chip is one of the few places the header renders
+    // the agent_type — its presence confirms the chrome painted.
+    expect(screen.getByText(/hermes v2026\.4\.2/)).toBeTruthy();
+  });
+
+  it("hides Start/Stop/Restart while health is undefined", () => {
+    // liveStatus falls back to agent.status === "checking" so isRunning
+    // and isStopped are both false — neither branch should render the
+    // lifecycle buttons.
+    render(<AgentHeader agent={makeAgent()} health={undefined} />);
+    expect(screen.queryByText("Start")).toBeNull();
+    expect(screen.queryByText("Stop")).toBeNull();
+    expect(screen.queryByText("Restart")).toBeNull();
+  });
+
+  it("shows Start when health reports stopped", () => {
+    render(
+      <AgentHeader
+        agent={makeAgent()}
+        health={makeHealth({ status: "stopped" })}
+      />,
+    );
+    expect(screen.getByText("Start")).toBeTruthy();
+    expect(screen.queryByText("Stop")).toBeNull();
+  });
+
+  it("shows Stop+Restart when health reports running", () => {
+    render(<AgentHeader agent={makeAgent()} health={makeHealth()} />);
+    expect(screen.getByText("Stop")).toBeTruthy();
+    expect(screen.getByText("Restart")).toBeTruthy();
+    expect(screen.queryByText("Start")).toBeNull();
+  });
+});

--- a/gui/src/components/agent-detail/agent-header.tsx
+++ b/gui/src/components/agent-detail/agent-header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { AgentDetail } from "@/lib/types";
+import { AgentDetail, AgentDetailHealth } from "@/lib/types";
 import { StatusDot } from "@/components/ui/status-dot";
 import { OSIcon } from "@/components/ui/os-icon";
 import { Button } from "@/components/ui/button";
@@ -16,12 +16,20 @@ import {
 
 interface AgentHeaderProps {
   agent: AgentDetail;
+  // #758: live runtime fields. Undefined while the probe is in flight;
+  // header falls back to the static "checking" status and disables the
+  // lifecycle buttons (we don't yet know whether the agent is running).
+  health: AgentDetailHealth | undefined;
 }
 
-export function AgentHeader({ agent }: AgentHeaderProps) {
+export function AgentHeader({ agent, health }: AgentHeaderProps) {
   const { start, stop, restart } = useAgentActions(agent.agent_key);
-  const isRunning = agent.status === "running";
-  const isStopped = agent.status === "stopped";
+  // Health-derived: the SSH probe is the source of truth for the
+  // lifecycle buttons. Until it lands, status is "checking" and both
+  // Start and Restart/Stop are hidden to avoid acting on stale data.
+  const liveStatus = health?.status ?? agent.status;
+  const isRunning = liveStatus === "running";
+  const isStopped = liveStatus === "stopped";
 
   // B2 (#560 / #567): backend `/web-ui` returns `available: false` with
   // a `reason` for any agent type whose manifest does not declare
@@ -37,7 +45,9 @@ export function AgentHeader({ agent }: AgentHeaderProps) {
   //   - permanent no-UI (`reason` says "does not expose") → button is
   //     hidden entirely; rendering a perma-disabled button on every
   //     nemoclaw page was the previous UX regression.
-  const webUI = useAgentWebUI(agent.agent_key, agent.status);
+  // Keyed on the live status so the web-ui query re-resolves after a
+  // status transition (e.g. start → running flips tunnel availability).
+  const webUI = useAgentWebUI(agent.agent_key, liveStatus);
   const webUIPermanentlyUnavailable =
     webUI.data?.available === false &&
     !!webUI.data?.reason &&
@@ -77,7 +87,7 @@ export function AgentHeader({ agent }: AgentHeaderProps) {
     <div className="bg-white rounded-xl border border-default p-6 shadow-sm">
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-4">
-          <StatusDot status={agent.status} size="lg" />
+          <StatusDot status={liveStatus} size="lg" />
           <div>
             <h1 className="text-xl font-semibold text-primary-text">
               {agent.agent_name}

--- a/gui/src/components/agent-detail/agent-metrics.test.tsx
+++ b/gui/src/components/agent-detail/agent-metrics.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentDetail, AgentDetailHealth } from "@/lib/types";
+
+// useUsageByAgent is the only hook the component uses. Return an empty
+// dataset so we can assert the metric-cell content unambiguously.
+vi.mock("@/hooks", () => ({
+  useUsageByAgent: () => ({ data: [] }),
+}));
+
+import { AgentMetrics } from "./agent-metrics";
+
+function makeAgent(overrides: Partial<AgentDetail> = {}): AgentDetail {
+  return {
+    agent_key: "demo",
+    agent_name: "demo",
+    agent_type: "openclaw",
+    host: "192.168.1.100",
+    host_alias: "box",
+    host_os_family: "linux",
+    status: "checking",
+    model: "-",
+    uptime: "2h",
+    gateway_url: null,
+    provider: "",
+    provider_type: "",
+    addresses: [],
+    version: "2026.4.2",
+    device_id: "",
+    onboarding_step: "ready",
+    gateway_port: null,
+    ...overrides,
+  } as AgentDetail;
+}
+
+function makeHealth(
+  overrides: Partial<AgentDetailHealth> = {},
+): AgentDetailHealth {
+  return {
+    agent_key: "demo",
+    status: "running",
+    process_running: true,
+    health_error: null,
+    cpu_count: 4,
+    memory_total_mb: 8192,
+    missing_secrets: null,
+    onboarding_step: "ready",
+    latest_supported_version: "2026.5.28",
+    ...overrides,
+  };
+}
+
+describe("AgentMetrics — health loading fallback (#758 ATX W7)", () => {
+  it("renders 'checking' status from static fallback when health is undefined", () => {
+    render(<AgentMetrics agent={makeAgent()} health={undefined} />);
+    // Status cell text comes from agent.status while health is loading.
+    expect(screen.getByText("checking")).toBeTruthy();
+  });
+
+  it("renders live status from health once the probe resolves", () => {
+    render(<AgentMetrics agent={makeAgent()} health={makeHealth()} />);
+    expect(screen.getByText("running")).toBeTruthy();
+  });
+
+  it("renders uptime from the static endpoint regardless of health state", () => {
+    // #758 S5: uptime is owned by useAgent, never duplicated in /health.
+    render(<AgentMetrics agent={makeAgent()} health={undefined} />);
+    expect(screen.getByText("2h")).toBeTruthy();
+  });
+
+  it("renders '—' for uptime when neither static nor health carry one", () => {
+    render(
+      <AgentMetrics agent={makeAgent({ uptime: "" })} health={undefined} />,
+    );
+    // Multiple "—" cells render (empty uptime + empty usage); the one
+    // we care about is the Uptime label's sibling.
+    const uptimeLabel = screen.getByText("Uptime");
+    const uptimeCell = uptimeLabel.parentElement;
+    expect(uptimeCell?.textContent).toContain("—");
+  });
+});

--- a/gui/src/components/agent-detail/agent-metrics.tsx
+++ b/gui/src/components/agent-detail/agent-metrics.tsx
@@ -1,15 +1,23 @@
 "use client";
 
-import { AgentDetail } from "@/lib/types";
+import { AgentDetail, AgentDetailHealth } from "@/lib/types";
 import { useUsageByAgent } from "@/hooks";
 
 interface AgentMetricsProps {
   agent: AgentDetail;
+  // #758: live runtime fields. Undefined while the SSH probe is in
+  // flight — uptime and status fall back to the static AgentDetail.
+  health: AgentDetailHealth | undefined;
 }
 
-export function AgentMetrics({ agent }: AgentMetricsProps) {
+export function AgentMetrics({ agent, health }: AgentMetricsProps) {
   const { data: perAgent } = useUsageByAgent(30);
   const agentUsage = perAgent?.find((row) => row.agent_key === agent.agent_key);
+  // uptime lives on the static endpoint (#758 S5): it's a pure
+  // function of claw_record.runtime.started_at, has no SSH-derived
+  // component, and the static query polls at 10s.
+  const uptime = agent.uptime;
+  const status = health?.status ?? agent.status;
 
   const tokenLabel = agentUsage
     ? formatNumber(agentUsage.tokens)
@@ -24,10 +32,10 @@ export function AgentMetrics({ agent }: AgentMetricsProps) {
   const unavailableTip = "No usage recorded for this agent in the last 30 days";
 
   const metrics = [
-    { label: "Uptime", value: agent.uptime || "—", title: undefined },
+    { label: "Uptime", value: uptime || "—", title: undefined },
     {
       label: "Status",
-      value: agent.status.replace("_", " "),
+      value: status.replace("_", " "),
       title: undefined,
     },
     {

--- a/gui/src/components/agent-detail/overview-tab.test.tsx
+++ b/gui/src/components/agent-detail/overview-tab.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
-import type { AgentDetail, AgentSkills } from "@/lib/types";
+import type { AgentDetail, AgentDetailHealth, AgentSkills } from "@/lib/types";
 
 const agentSkillsState: {
   data: AgentSkills | undefined;
@@ -35,9 +35,26 @@ function makeAgent(overrides: Partial<AgentDetail> = {}): AgentDetail {
     device_id: "",
     onboarding_step: "ready",
     gateway_port: null,
-    latest_supported_version: "2026.5.28",
     ...overrides,
   } as AgentDetail;
+}
+
+function makeHealth(
+  overrides: Partial<AgentDetailHealth> = {},
+): AgentDetailHealth {
+  return {
+    agent_key: "demo",
+    status: "running",
+    uptime: "1m",
+    process_running: true,
+    health_error: null,
+    cpu_count: 4,
+    memory_total_mb: 8192,
+    missing_secrets: null,
+    onboarding_step: "ready",
+    latest_supported_version: "2026.5.28",
+    ...overrides,
+  };
 }
 
 describe("OverviewTab — upgrade-available badge", () => {
@@ -46,7 +63,9 @@ describe("OverviewTab — upgrade-available badge", () => {
   });
 
   it("renders upgrade-available badge when latest_supported_version > agent.version", () => {
-    render(<OverviewTab agent={makeAgent()} agentKey="demo" />);
+    render(
+      <OverviewTab agent={makeAgent()} agentKey="demo" health={makeHealth()} />,
+    );
     const badge = screen.getByTestId("upgrade-available-badge");
     expect(badge).toBeTruthy();
     expect(badge.textContent).toContain("2026.5.28");
@@ -56,11 +75,9 @@ describe("OverviewTab — upgrade-available badge", () => {
   it("does not render badge when latest_supported_version equals agent.version", () => {
     render(
       <OverviewTab
-        agent={makeAgent({
-          version: "2026.5.28",
-          latest_supported_version: "2026.5.28",
-        })}
+        agent={makeAgent({ version: "2026.5.28" })}
         agentKey="demo"
+        health={makeHealth({ latest_supported_version: "2026.5.28" })}
       />,
     );
     expect(screen.queryByTestId("upgrade-available-badge")).toBeNull();
@@ -69,8 +86,9 @@ describe("OverviewTab — upgrade-available badge", () => {
   it("does not render badge for version '?' sentinel (never-started agent)", () => {
     render(
       <OverviewTab
-        agent={makeAgent({ version: "?", latest_supported_version: "2026.5.28" })}
+        agent={makeAgent({ version: "?" })}
         agentKey="demo"
+        health={makeHealth({ latest_supported_version: "2026.5.28" })}
       />,
     );
     expect(screen.queryByTestId("upgrade-available-badge")).toBeNull();
@@ -79,10 +97,42 @@ describe("OverviewTab — upgrade-available badge", () => {
   it("does not render badge when latest_supported_version is null", () => {
     render(
       <OverviewTab
-        agent={makeAgent({ latest_supported_version: null })}
+        agent={makeAgent()}
         agentKey="demo"
+        health={makeHealth({ latest_supported_version: null })}
       />,
     );
+    expect(screen.queryByTestId("upgrade-available-badge")).toBeNull();
+  });
+
+  it("does not render badge while health is still loading (#758)", () => {
+    // Health undefined → latest_supported_version unknown → never show
+    // an upgrade badge with the wrong version.
+    render(
+      <OverviewTab agent={makeAgent()} agentKey="demo" health={undefined} />,
+    );
+    expect(screen.queryByTestId("upgrade-available-badge")).toBeNull();
+  });
+
+  it("renders 'Checking for upgrades…' while health is loading (#758 W3)", () => {
+    // The loading affordance distinguishes "registry lookup in flight"
+    // from "confirmed no upgrade" — without it, an outdated agent
+    // would silently look up-to-date during the loading window.
+    render(
+      <OverviewTab agent={makeAgent()} agentKey="demo" health={undefined} />,
+    );
+    expect(screen.getByTestId("upgrade-loading-badge")).toBeTruthy();
+  });
+
+  it("hides the loading affordance once health resolves with null", () => {
+    render(
+      <OverviewTab
+        agent={makeAgent()}
+        agentKey="demo"
+        health={makeHealth({ latest_supported_version: null })}
+      />,
+    );
+    expect(screen.queryByTestId("upgrade-loading-badge")).toBeNull();
     expect(screen.queryByTestId("upgrade-available-badge")).toBeNull();
   });
 });

--- a/gui/src/components/agent-detail/overview-tab.tsx
+++ b/gui/src/components/agent-detail/overview-tab.tsx
@@ -1,16 +1,23 @@
 "use client";
 
-import { AgentDetail } from "@/lib/types";
+import { AgentDetail, AgentDetailHealth } from "@/lib/types";
 import { Card } from "@/components/ui/card";
 import { useAgentSkills } from "@/hooks";
 
 interface OverviewTabProps {
   agent: AgentDetail;
   agentKey: string;
+  // #758: live runtime fields (status, uptime, latest_supported_version)
+  // arrive separately from the static identity. Undefined while the
+  // probe + registry lookup are in flight.
+  health: AgentDetailHealth | undefined;
 }
 
-export function OverviewTab({ agent, agentKey }: OverviewTabProps) {
+export function OverviewTab({ agent, agentKey, health }: OverviewTabProps) {
   const { data: skillsData } = useAgentSkills(agentKey);
+  const status = health?.status ?? agent.status;
+  // uptime stays on the static endpoint (#758 S5).
+  const uptime = agent.uptime;
 
   const installedSkills = skillsData?.installed ?? [];
 
@@ -104,11 +111,15 @@ export function OverviewTab({ agent, agentKey }: OverviewTabProps) {
           <InfoRow label="Host" value={agent.host_alias || agent.host} />
           <VersionRow
             version={agent.version}
-            latestSupportedVersion={agent.latest_supported_version}
+            latestSupportedVersion={health?.latest_supported_version ?? null}
+            // #758 W3: distinguish "still loading the registry lookup"
+            // from "confirmed no upgrade available" so we don't silently
+            // present a stale agent as up-to-date.
+            healthLoaded={health !== undefined}
             agentName={agent.agent_name}
           />
-          <InfoRow label="Status" value={agent.status} />
-          <InfoRow label="Uptime" value={agent.uptime || "—"} />
+          <InfoRow label="Status" value={status} />
+          <InfoRow label="Uptime" value={uptime || "—"} />
           {agent.gateway_url && (
             <InfoRow label="Gateway" value={agent.gateway_url} />
           )}
@@ -147,10 +158,12 @@ function isNewerVersion(latest: string, current: string): boolean {
 function VersionRow({
   version,
   latestSupportedVersion,
+  healthLoaded,
   agentName,
 }: {
   version: string;
   latestSupportedVersion: string | null;
+  healthLoaded: boolean;
   agentName: string;
 }) {
   // `version === '?'` is the legacy sentinel from `cli/tui/data.py` for
@@ -159,6 +172,7 @@ function VersionRow({
   // state. ATX W2 (issue #592).
   const versionKnown = !!version && version !== "?";
   const upgradeAvailable =
+    healthLoaded &&
     !!latestSupportedVersion &&
     versionKnown &&
     isNewerVersion(latestSupportedVersion, version);
@@ -169,6 +183,14 @@ function VersionRow({
       <span className="text-primary-text font-mono text-xs">
         {version || "—"}
       </span>
+      {!healthLoaded && versionKnown && (
+        <div
+          data-testid="upgrade-loading-badge"
+          className="mt-1 text-xs text-muted font-mono"
+        >
+          Checking for upgrades…
+        </div>
+      )}
       {upgradeAvailable && (
         <div
           data-testid="upgrade-available-badge"

--- a/gui/src/hooks/index.ts
+++ b/gui/src/hooks/index.ts
@@ -5,6 +5,7 @@ export { useProviders, useProviderTypes, useModelCatalog, useCreateProvider, use
 export { useUsageSummary, useUsageHistory, useUsageByAgent } from "./use-usage";
 export {
   useAgent,
+  useAgentHealth,
   useAgentActions,
   useAgentWebUI,
   useAgentPairingCode,

--- a/gui/src/hooks/use-agent.ts
+++ b/gui/src/hooks/use-agent.ts
@@ -1,10 +1,36 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 
+// Static identity + persisted config from hosts.json. Cheap and local;
+// the page shell renders as soon as this resolves. Runtime fields
+// (status, process counts) come from useAgentHealth below.
+//
+// #758: polling was previously here at 10s, dragging the slow SSH
+// health probe into the foreground every tick. The probe now lives on
+// the /health endpoint and useAgentHealth owns the cadence for those
+// fields. We keep a 10s refetch here too because the data still
+// changes out of band — operator runs `clawctl provider attach` from
+// another terminal, gateway port reallocation on upgrade, onboarding
+// step transitions, and the uptime string is recomputed each fetch.
+// The static endpoint is now just a hosts.json read so the cost is
+// negligible (ATX W2 from initial review).
 export function useAgent(key: string) {
   return useQuery({
     queryKey: ["agent", key],
     queryFn: () => api.getAgent(key),
+    enabled: !!key,
+    refetchInterval: 10_000,
+  });
+}
+
+// Live runtime probe for the agent detail page. Independent loading
+// state lets each section show a skeleton while the SSH probe is in
+// flight, and a failure here surfaces inline without blanking the
+// rest of the page (#758).
+export function useAgentHealth(key: string) {
+  return useQuery({
+    queryKey: ["agent-health", key],
+    queryFn: () => api.getAgentHealth(key),
     enabled: !!key,
     refetchInterval: 10_000,
   });
@@ -92,6 +118,10 @@ export function useAgentActions(key: string) {
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ["agent", key] });
+    // #758: live status / uptime live on the health query now. Without
+    // this invalidation the status pill stays stale until the 10s poll
+    // ticks, masking the result of the user's own action.
+    queryClient.invalidateQueries({ queryKey: ["agent-health", key] });
     queryClient.invalidateQueries({ queryKey: ["fleet"] });
     // After a restart/stop/start the tunnel state file may point at a
     // process that's about to die. Invalidate the web-ui query so the

--- a/gui/src/lib/api.ts
+++ b/gui/src/lib/api.ts
@@ -65,6 +65,8 @@ export const api = {
   getFleetHealth: (signal?: AbortSignal) =>
     request<FleetHealthResponse>("/fleet/health", { signal }),
   getAgent: (key: string) => request<AgentDetail>(`/fleet/agents/${key}`),
+  getAgentHealth: (key: string) =>
+    request<AgentDetailHealth>(`/fleet/agents/${key}/health`),
   getAgentWebUI: (key: string) =>
     request<WebUIResponse>(`/fleet/agents/${key}/web-ui`),
   mintAgentPairingCode: (key: string) =>
@@ -302,6 +304,7 @@ import type {
   FleetResponse,
   FleetHealthResponse,
   AgentDetail,
+  AgentDetailHealth,
   ActionResponse,
   WebUIResponse,
   PairingCodeResponse,

--- a/gui/src/lib/types.ts
+++ b/gui/src/lib/types.ts
@@ -66,6 +66,22 @@ export interface AgentDetail extends AgentSummary {
   device_id: string;
   onboarding_step: string;
   gateway_port: number | null;
+}
+
+// Response from GET /fleet/agents/{key}/health. Companion to the static
+// AgentDetail; the GUI fetches both in parallel and the page shell never
+// waits on this one. status/uptime/process_running come from the live
+// SSH probe; `latest_supported_version` is the registry lookup that was
+// previously bundled into AgentDetail. (#758)
+export interface AgentDetailHealth {
+  agent_key: string;
+  status: AgentStatus;
+  process_running: boolean | null;
+  health_error: string | null;
+  cpu_count: number | null;
+  memory_total_mb: number | null;
+  missing_secrets: string[] | null;
+  onboarding_step: string | null;
   // Max manifest version compatible with this host's hardware. `null`
   // when the host's os/arch has no matching platform entry. Issue #592.
   latest_supported_version: string | null;

--- a/src/clawrium/cli/tui/data.py
+++ b/src/clawrium/cli/tui/data.py
@@ -45,6 +45,16 @@ def _resolve_provider_name(claw_record: dict) -> str | None:
 
 
 class AgentViewModel(TypedDict):
+    # SECURITY NOTE (#758 S6): This view model contains secrets
+    # (`gateway_auth`, `device_private_key`) and is the canonical
+    # internal representation used by both the GUI agent_to_dict
+    # allow-list and the TUI's local renderer. Any new field added
+    # here is silently invisible to the browser only because
+    # `gui/routes/fleet.py:_agent_to_dict` is an explicit allow-list.
+    # If you add a new field, also update that allow-list — adding a
+    # field here without touching the GUI serializer is correct (the
+    # field stays redacted) but is easy to forget when the new field
+    # IS meant to reach the browser. There is no compile-time check.
     agent_key: str
     agent_name: str
     agent_type: str
@@ -425,6 +435,129 @@ def check_claw_health_safe(claw_name: str, host: dict) -> HealthResult:
         )
 
 
+def get_agent_static(agent_key: str, host_identifier: str) -> AgentViewModel | None:
+    """Return an AgentViewModel from hosts.json only — no remote probe.
+
+    Mirrors get_agent_detail but skips check_claw_health entirely so the
+    GUI agent-detail page can render its shell instantly. Runtime fields
+    (cpu_count, memory_total_mb, missing_secrets, process_running,
+    health_error) default to None. status is derived from local
+    onboarding data only — CHECKING for agents past onboarding (their
+    real running/stopped state requires SSH and is served by the
+    separate /health endpoint).
+    """
+    if not AGENT_KEY_PATTERN.match(agent_key):
+        logger.warning("Invalid agent_key format: %s", agent_key)
+        return None
+    hosts = load_hosts_safe()
+    for h in hosts:
+        hostname = h.get("hostname", "")
+        if hostname != host_identifier and h.get("alias") != host_identifier:
+            continue
+        agents = h.get("agents", {})
+        if agent_key not in agents:
+            continue
+        claw_record = agents[agent_key]
+        if not isinstance(claw_record, dict):
+            continue
+
+        identity = _build_agent_identity(agent_key, h, claw_record)
+        onboard_status, onboard_step = get_onboarding_status(claw_record)
+        if onboard_status in (ClawStatus.ONBOARDING, ClawStatus.PENDING_ONBOARD):
+            status = onboard_status
+        else:
+            status = ClawStatus.CHECKING
+
+        return AgentViewModel(
+            **identity,
+            status=status,
+            missing_secrets=None,
+            onboarding_step=onboard_step,
+            process_running=None,
+            health_error=None,
+            cpu_count=None,
+            memory_total_mb=None,
+        )
+    return None
+
+
+def _build_agent_identity(
+    agent_key: str, host: dict, claw_record: dict
+) -> dict:
+    """Extract the static identity fields shared by static + full readers.
+
+    Returned dict is suitable for **-spreading into AgentViewModel
+    alongside the runtime fields (status, missing_secrets, etc.).
+    """
+    hostname = host.get("hostname", "")
+    agent_name = (
+        claw_record.get("agent_name") or claw_record.get("name") or agent_key
+    )
+    agent_type = claw_record.get("type", "unknown")
+    version = claw_record.get("version", "?")
+    config = claw_record.get("config", {})
+    model = "-"
+    provider_name = None
+    provider_type = None
+    gateway_port = None
+    gateway_url = None
+    gateway_auth = None
+    device_id = None
+    device_private_key = None
+    if isinstance(config, dict):
+        provider_cfg = config.get("provider")
+        if isinstance(provider_cfg, dict):
+            model = provider_cfg.get("default_model", "-")
+            provider_type = provider_cfg.get("type")
+        provider_name = _resolve_provider_name(claw_record)
+        if provider_name is None and isinstance(provider_cfg, dict):
+            provider_name = provider_cfg.get("name") or provider_cfg.get("type")
+        gateway_cfg = config.get("gateway")
+        if isinstance(gateway_cfg, dict):
+            port_val = gateway_cfg.get("port")
+            if isinstance(port_val, int):
+                gateway_port = port_val
+            auth_val = gateway_cfg.get("auth")
+            if isinstance(auth_val, str) and auth_val.strip():
+                gateway_auth = auth_val
+            if gateway_port is not None:
+                scheme = _gateway_scheme(gateway_cfg.get("url"))
+                gateway_url = f"{scheme}://{hostname}:{gateway_port}"
+            device_cfg = gateway_cfg.get("device")
+            if isinstance(device_cfg, dict):
+                dev_id = device_cfg.get("id")
+                dev_key = device_cfg.get("privateKey")
+                if isinstance(dev_id, str) and dev_id.strip():
+                    device_id = dev_id
+                if isinstance(dev_key, str) and dev_key.strip():
+                    device_private_key = dev_key
+
+    started_at = None
+    runtime = claw_record.get("runtime", {})
+    if isinstance(runtime, dict):
+        started_at = runtime.get("started_at")
+
+    return {
+        "agent_key": agent_key,
+        "agent_name": agent_name,
+        "agent_type": agent_type,
+        "host": hostname,
+        "host_alias": host.get("alias") or hostname,
+        "host_os_family": host.get("os_family"),
+        "version": version,
+        "model": model,
+        "uptime": calculate_uptime(started_at),
+        "addresses": host.get("addresses", []),
+        "provider": provider_name,
+        "provider_type": provider_type,
+        "gateway_port": gateway_port,
+        "gateway_url": gateway_url,
+        "gateway_auth": gateway_auth,
+        "device_id": device_id,
+        "device_private_key": device_private_key,
+    }
+
+
 def get_agent_detail(agent_key: str, host_identifier: str) -> AgentViewModel | None:
     if not AGENT_KEY_PATTERN.match(agent_key):
         logger.warning("Invalid agent_key format: %s", agent_key)
@@ -441,84 +574,16 @@ def get_agent_detail(agent_key: str, host_identifier: str) -> AgentViewModel | N
         if not isinstance(claw_record, dict):
             continue
         result = check_claw_health_safe(agent_key, h)
-        agent_name = (
-            claw_record.get("agent_name") or claw_record.get("name") or agent_key
-        )
-        agent_type = claw_record.get("type", "unknown")
-        version = claw_record.get("version", "?")
-        config = claw_record.get("config", {})
-        model = "-"
-        provider_name = None
-        provider_type = None
-        gateway_port = None
-        gateway_url = None
-        gateway_auth = None
-        device_id = None
-        device_private_key = None
-        if isinstance(config, dict):
-            provider_cfg = config.get("provider")
-            if isinstance(provider_cfg, dict):
-                model = provider_cfg.get("default_model", "-")
-                provider_type = provider_cfg.get("type")
-            # Tier-1 attachment list is canonical for the provider name;
-            # fall back to the tier-2 render payload only for display.
-            provider_name = _resolve_provider_name(claw_record)
-            if provider_name is None and isinstance(provider_cfg, dict):
-                provider_name = provider_cfg.get("name") or provider_cfg.get("type")
-            gateway_cfg = config.get("gateway")
-            if isinstance(gateway_cfg, dict):
-                port_val = gateway_cfg.get("port")
-                if isinstance(port_val, int):
-                    gateway_port = port_val
-                auth_val = gateway_cfg.get("auth")
-                if isinstance(auth_val, str) and auth_val.strip():
-                    gateway_auth = auth_val
-                # Reconstruct gateway URL using host's current address and port,
-                # preserving the scheme stored at install/configure time.
-                if gateway_port is not None:
-                    scheme = _gateway_scheme(gateway_cfg.get("url"))
-                    gateway_url = f"{scheme}://{hostname}:{gateway_port}"
-                # Extract device credentials for operator.write scope
-                device_cfg = gateway_cfg.get("device")
-                if isinstance(device_cfg, dict):
-                    dev_id = device_cfg.get("id")
-                    dev_key = device_cfg.get("privateKey")
-                    if isinstance(dev_id, str) and dev_id.strip():
-                        device_id = dev_id
-                    if isinstance(dev_key, str) and dev_key.strip():
-                        device_private_key = dev_key
-
-        started_at = None
-        runtime = claw_record.get("runtime", {})
-        if isinstance(runtime, dict):
-            started_at = runtime.get("started_at")
-
+        identity = _build_agent_identity(agent_key, h, claw_record)
         status = result.get("status", ClawStatus.UNKNOWN)
-
         return AgentViewModel(
-            agent_key=agent_key,
-            agent_name=agent_name,
-            agent_type=agent_type,
-            host=hostname,
-            host_alias=h.get("alias") or hostname,
-            host_os_family=h.get("os_family"),
-            version=version,
+            **identity,
             status=status,
-            model=model,
-            uptime=calculate_uptime(started_at),
             missing_secrets=result.get("missing_secrets"),
             onboarding_step=result.get("onboarding_step"),
             process_running=result.get("process_running"),
             health_error=result.get("error"),
-            addresses=h.get("addresses", []),
-            provider=provider_name,
-            provider_type=provider_type,
             cpu_count=result.get("cpu_count"),
             memory_total_mb=result.get("memory_total_mb"),
-            gateway_port=gateway_port,
-            gateway_url=gateway_url,
-            gateway_auth=gateway_auth,
-            device_id=device_id,
-            device_private_key=device_private_key,
         )
     return None

--- a/src/clawrium/gui/routes/fleet.py
+++ b/src/clawrium/gui/routes/fleet.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, HTTPException
 from clawrium.cli.tui.data import (
     AgentViewModel,
     get_agent_detail,
+    get_agent_static,
     get_fleet_data,
     get_fleet_data_local,
 )
@@ -210,10 +211,11 @@ async def fleet_health(host: str | None = None):
 
 @router.get("/fleet/agents/{agent_key}")
 async def agent_detail(agent_key: str, host: str | None = None):
-    """Get detailed info for a single agent.
+    """Return static identity + persisted config for a single agent.
 
-    Searches across all hosts unless host is specified. Uses resolve_agent
-    for consistent HostsFileCorruptedError / ambiguous-name / OSError handling.
+    Reads hosts.json only — no SSH probe, no registry lookup. The GUI
+    uses this to paint the detail-page shell instantly; the slow
+    runtime fields are served by the sibling /health endpoint below.
     """
     resolved = await asyncio.to_thread(resolve_agent, agent_key)
     if resolved is None:
@@ -227,20 +229,96 @@ async def agent_detail(agent_key: str, host: str | None = None):
         )
 
     hostname = host_record.get("hostname", "")
-    detail = await asyncio.to_thread(get_agent_detail, agent_key, hostname)
+    detail = await asyncio.to_thread(get_agent_static, agent_key, hostname)
+    if not detail:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
+    return _agent_to_dict(detail)
+
+
+@router.get("/fleet/agents/{agent_key}/health")
+async def agent_health(agent_key: str, host: str | None = None):
+    """Return live runtime fields for a single agent via SSH probe.
+
+    Companion to /fleet/agents/{key}. Runs check_claw_health and the
+    registry version lookup — the slow work the static endpoint
+    intentionally skips. The frontend fetches this in parallel with
+    the static call so the page shell never blocks on it.
+
+    Routed through the same dedicated executor + semaphore + timeout
+    as `/fleet/health` (#758 ATX B1). `useAgentHealth`'s 10s poll on
+    every open detail tab would otherwise pin Starlette's default
+    threadpool indefinitely on a dead host and starve every other
+    route that shares it.
+    """
+    resolved = await asyncio.to_thread(resolve_agent, agent_key)
+    if resolved is None:
+        raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
+    host_record, _agent_type, _ = resolved
+
+    if host and host_record.get("hostname") != host and host_record.get("alias") != host:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent '{agent_key}' not found on host '{host}'",
+        )
+
+    hostname = host_record.get("hostname", "")
+    loop = asyncio.get_running_loop()
+    async with _get_fleet_health_semaphore():
+        try:
+            detail = await asyncio.wait_for(
+                loop.run_in_executor(
+                    _get_fleet_health_executor(),
+                    get_agent_detail,
+                    agent_key,
+                    hostname,
+                ),
+                timeout=_FLEET_HEALTH_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError as e:
+            raise HTTPException(
+                status_code=504, detail="agent health probe timed out"
+            ) from e
     if not detail:
         raise HTTPException(status_code=404, detail=f"Agent '{agent_key}' not found")
 
-    payload = _agent_to_dict(detail)
     from clawrium.core.registry import latest_supported_version
 
     try:
-        payload["latest_supported_version"] = latest_supported_version(
+        latest_version = latest_supported_version(
             detail["agent_type"], host_record.get("hardware") or {}
         )
-    except Exception:
-        payload["latest_supported_version"] = None
-    return payload
+    except (KeyError, ValueError, FileNotFoundError) as e:
+        # W1: previously a bare `except Exception`. A malformed manifest
+        # or genuine bug would silently render as a missing upgrade
+        # badge — operators think they're on the newest build when
+        # they're not. Narrow the catch and log so the failure is
+        # visible server-side without breaking the rest of the
+        # response payload.
+        logger.warning(
+            "latest_supported_version lookup failed for %s: %s",
+            agent_key,
+            e,
+            exc_info=True,
+        )
+        latest_version = None
+
+    status = detail["status"]
+    # S5: `uptime` is computed from claw_record.runtime.started_at and
+    # has no SSH-derived component — keeping it here would be a second,
+    # unsynchronized source of truth. The static endpoint owns uptime;
+    # the frontend reads it from useAgent which now polls (W2) so the
+    # value still advances.
+    return {
+        "agent_key": detail["agent_key"],
+        "status": status.value if isinstance(status, ClawStatus) else status,
+        "process_running": detail["process_running"],
+        "health_error": _sanitize_health_error(detail["health_error"]),
+        "cpu_count": detail["cpu_count"],
+        "memory_total_mb": detail["memory_total_mb"],
+        "missing_secrets": detail["missing_secrets"],
+        "onboarding_step": detail["onboarding_step"],
+        "latest_supported_version": latest_version,
+    }
 
 
 @router.post("/agents/{agent_key}/start")

--- a/tests/test_gui_agent_detail_latest_version.py
+++ b/tests/test_gui_agent_detail_latest_version.py
@@ -1,4 +1,9 @@
-"""Tests for `latest_supported_version` on the agent-detail API (issue #592)."""
+"""Tests for `latest_supported_version` on the agent-detail API (issue #592).
+
+Moved from /api/fleet/agents/{key} to /api/fleet/agents/{key}/health in
+issue #758, where the registry lookup was peeled off the static-data
+endpoint that gates the GUI page shell.
+"""
 
 from __future__ import annotations
 
@@ -53,7 +58,7 @@ def _seed_hosts(
 def test_agent_detail_includes_latest_supported_version(isolated_config: Path):
     _seed_hosts(isolated_config, agent_type="openclaw", installed_version="2026.4.2")
     with TestClient(app) as client:
-        resp = client.get("/api/fleet/agents/demo")
+        resp = client.get("/api/fleet/agents/demo/health")
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert "latest_supported_version" in body
@@ -71,7 +76,7 @@ def test_agent_detail_latest_supported_version_is_none_for_unmatched_host(
         architecture="aarch64",
     )
     with TestClient(app) as client:
-        resp = client.get("/api/fleet/agents/demo")
+        resp = client.get("/api/fleet/agents/demo/health")
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert "latest_supported_version" in body

--- a/tests/test_gui_agent_detail_split.py
+++ b/tests/test_gui_agent_detail_split.py
@@ -1,0 +1,213 @@
+"""Tests for the static/health split on the agent-detail API (issue #758).
+
+The static endpoint must:
+  - return identity from hosts.json without invoking check_claw_health
+  - succeed even when a remote probe would fail or hang
+
+The /health endpoint must:
+  - run check_claw_health and surface its result
+  - include latest_supported_version (moved from the static endpoint)
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from clawrium.core.health import ClawStatus, HealthResult
+from clawrium.gui.server import app
+
+
+def _seed_hosts(config_dir: Path) -> None:
+    hosts = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "box",
+            "port": 22,
+            "user": "xclm",
+            "hardware": {
+                "architecture": "x86_64",
+                "processor_cores": 4,
+                "memtotal_mb": 8192,
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "gpu": {"present": False},
+            },
+            "agents": {
+                "demo": {
+                    "type": "openclaw",
+                    "agent_name": "demo",
+                    "name": "demo",
+                    "version": "2026.4.2",
+                    "status": "installed",
+                    "onboarding": {"state": "ready", "stages": {}},
+                    "config": {
+                        "provider": {"type": "anthropic", "name": "claude"},
+                        "gateway": {"port": 40000, "url": "ws://x:40000"},
+                    },
+                }
+            },
+        }
+    ]
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "hosts.json").write_text(json.dumps(hosts))
+
+
+def test_static_endpoint_does_not_call_check_claw_health(isolated_config: Path):
+    """The page-shell endpoint must never invoke the SSH probe."""
+    _seed_hosts(isolated_config)
+    with patch(
+        "clawrium.cli.tui.data.check_claw_health",
+        side_effect=AssertionError("probe must not run on static path"),
+    ) as probe:
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo")
+    assert resp.status_code == 200, resp.text
+    probe.assert_not_called()
+    body = resp.json()
+    assert body["agent_name"] == "demo"
+    assert body["agent_type"] == "openclaw"
+    assert body["version"] == "2026.4.2"
+    # latest_supported_version was moved to /health in #758.
+    assert "latest_supported_version" not in body
+
+
+def test_static_endpoint_returns_fast_when_probe_would_hang(isolated_config: Path):
+    """A hanging probe must not bleed into the static-data response."""
+    _seed_hosts(isolated_config)
+
+    def _slow_probe(*_a, **_kw):
+        time.sleep(5)
+        raise RuntimeError("should not be reached — static path skips the probe")
+
+    with patch("clawrium.cli.tui.data.check_claw_health", side_effect=_slow_probe):
+        start = time.monotonic()
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo")
+        elapsed = time.monotonic() - start
+    assert resp.status_code == 200
+    assert elapsed < 2.0, f"static endpoint blocked on probe ({elapsed:.2f}s)"
+
+
+def test_health_endpoint_returns_runtime_fields(isolated_config: Path):
+    _seed_hosts(isolated_config)
+    fake_result = HealthResult(
+        agent="demo",
+        host="192.168.1.100",
+        status=ClawStatus.RUNNING,
+        user="xclm",
+        error=None,
+        missing_secrets=None,
+        onboarding_step=None,
+        process_running=True,
+        onboarding_stages=None,
+        cpu_count=4,
+        memory_total_mb=8192,
+    )
+    with patch(
+        "clawrium.cli.tui.data.check_claw_health", return_value=fake_result
+    ) as probe:
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo/health")
+    assert resp.status_code == 200, resp.text
+    probe.assert_called_once()
+    body = resp.json()
+    assert body["agent_key"] == "demo"
+    assert body["status"] == "running"
+    assert body["process_running"] is True
+    assert body["cpu_count"] == 4
+    assert body["memory_total_mb"] == 8192
+    # latest_supported_version is bundled into the health response now.
+    assert "latest_supported_version" in body
+
+
+def test_health_endpoint_404_for_unknown_agent(isolated_config: Path):
+    _seed_hosts(isolated_config)
+    with TestClient(app) as client:
+        resp = client.get("/api/fleet/agents/nope/health")
+    assert resp.status_code == 404
+
+
+def test_health_endpoint_404_when_host_mismatch(isolated_config: Path):
+    """?host=wronghost on /health must 404 — symmetric to the static route.
+
+    Ensures the host-guard is in place; without this test a regression
+    would let per-host runtime data leak across hosts (ATX W4).
+    """
+    _seed_hosts(isolated_config)
+    with TestClient(app) as client:
+        resp = client.get("/api/fleet/agents/demo/health?host=wronghost")
+    assert resp.status_code == 404
+    assert "demo" in resp.json()["detail"]
+    assert "wronghost" in resp.json()["detail"]
+
+
+def test_health_endpoint_returns_degraded_on_probe_exception(isolated_config: Path):
+    """A probe TimeoutError must surface as a 200 with health_error populated.
+
+    The probe wrapper (`check_claw_health_safe`) catches exceptions and
+    returns a degraded HealthResult; the endpoint must NOT 500 (ATX W5).
+    """
+    _seed_hosts(isolated_config)
+    with patch(
+        "clawrium.cli.tui.data.check_claw_health",
+        side_effect=TimeoutError("ssh probe took too long"),
+    ):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo/health")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["health_error"] == "ssh probe timed out"
+    assert body["process_running"] is None
+    assert body["cpu_count"] is None
+    assert body["memory_total_mb"] is None
+
+
+def test_health_endpoint_response_shape_pinned(isolated_config: Path):
+    """The /health response shape is part of the contract with the GUI.
+
+    A renamed or dropped field would silently degrade to `undefined` in
+    React and break the UX without any backend test failing (ATX W6).
+    """
+    _seed_hosts(isolated_config)
+    fake_result = HealthResult(
+        agent="demo",
+        host="192.168.1.100",
+        status=ClawStatus.RUNNING,
+        user="xclm",
+        error=None,
+        missing_secrets=None,
+        onboarding_step=None,
+        process_running=True,
+        onboarding_stages=None,
+        cpu_count=4,
+        memory_total_mb=8192,
+    )
+    with patch(
+        "clawrium.cli.tui.data.check_claw_health", return_value=fake_result
+    ):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {
+        "agent_key",
+        "status",
+        "process_running",
+        "health_error",
+        "cpu_count",
+        "memory_total_mb",
+        "missing_secrets",
+        "onboarding_step",
+        "latest_supported_version",
+    }
+    assert isinstance(body["agent_key"], str)
+    assert isinstance(body["status"], str)
+    assert body["health_error"] is None
+    # uptime was intentionally dropped from /health (S5) — owned by
+    # the static endpoint where it actually originates.
+    assert "uptime" not in body

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -1143,36 +1143,55 @@ def test_agent_detail_404_for_unknown(isolated_config: Path):
 
 
 def test_agent_detail_success(isolated_config: Path):
+    """The static endpoint serves identity from hosts.json. The sibling
+    /health endpoint is the one that carries latest_supported_version
+    (moved off the static path in #758)."""
     _seed_hosts(isolated_config, "hermes")
     vm = _agent_vm()
     captured: dict = {}
 
-    def _capture_detail(agent_key, hostname):
+    def _capture_static(agent_key, hostname):
         captured["agent_key"] = agent_key
         captured["hostname"] = hostname
         return vm
 
-    with (
-        patch("clawrium.gui.routes.fleet.get_agent_detail", side_effect=_capture_detail),
-        patch(
-            "clawrium.core.registry.latest_supported_version",
-            return_value="2026.6.0",
-        ),
+    with patch(
+        "clawrium.gui.routes.fleet.get_agent_static", side_effect=_capture_static
     ):
         with TestClient(app) as client:
             resp = client.get("/api/fleet/agents/demo")
     assert resp.status_code == 200
     data = resp.json()
     assert data["agent_key"] == "demo"
-    assert data["latest_supported_version"] == "2026.6.0"
+    # latest_supported_version is no longer on the static endpoint.
+    assert "latest_supported_version" not in data
     assert captured["hostname"] == "192.168.1.100"
     assert captured["agent_key"] == "demo"
 
 
-def test_agent_detail_404_when_get_agent_detail_returns_none(isolated_config: Path):
-    """Second 404 path: resolve_agent succeeds but get_agent_detail returns None."""
+def test_agent_health_returns_latest_supported_version(isolated_config: Path):
+    """/health is the single source for latest_supported_version (#758)."""
     _seed_hosts(isolated_config, "hermes")
-    with patch("clawrium.gui.routes.fleet.get_agent_detail", return_value=None):
+    vm = _agent_vm()
+    with (
+        patch("clawrium.gui.routes.fleet.get_agent_detail", return_value=vm),
+        patch(
+            "clawrium.core.registry.latest_supported_version",
+            return_value="2026.6.0",
+        ),
+    ):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["agent_key"] == "demo"
+    assert data["latest_supported_version"] == "2026.6.0"
+
+
+def test_agent_detail_404_when_get_agent_static_returns_none(isolated_config: Path):
+    """Second 404 path: resolve_agent succeeds but get_agent_static returns None."""
+    _seed_hosts(isolated_config, "hermes")
+    with patch("clawrium.gui.routes.fleet.get_agent_static", return_value=None):
         with TestClient(app) as client:
             resp = client.get("/api/fleet/agents/demo")
     assert resp.status_code == 404
@@ -1188,8 +1207,12 @@ def test_agent_detail_404_when_host_mismatch(isolated_config: Path):
     assert "wronghost" in resp.json()["detail"]
 
 
-def test_agent_detail_hardware_null_coercion(isolated_config: Path):
-    """Regression: hardware=null in hosts.json must not raise — `or {}` coerces it."""
+def test_agent_health_hardware_null_coercion(isolated_config: Path):
+    """Regression: hardware=null in hosts.json must not raise — `or {}` coerces it.
+
+    Moved to /health in #758 since latest_supported_version now lives
+    on the runtime endpoint.
+    """
     hosts = [
         {
             "hostname": "192.168.1.100",
@@ -1212,7 +1235,7 @@ def test_agent_detail_hardware_null_coercion(isolated_config: Path):
     vm = _agent_vm()
     with patch("clawrium.gui.routes.fleet.get_agent_detail", return_value=vm):
         with TestClient(app) as client:
-            resp = client.get("/api/fleet/agents/demo")
+            resp = client.get("/api/fleet/agents/demo/health")
     assert resp.status_code == 200
     # latest_supported_version raises on hardware={} with no arch; caught → None
     assert resp.json()["latest_supported_version"] is None
@@ -1222,11 +1245,25 @@ def test_agent_detail_excludes_gateway_auth(isolated_config: Path):
     """gateway_auth must never appear in the agent_detail response body (W3)."""
     _seed_hosts(isolated_config, "hermes")
     vm = _agent_vm()
-    with patch("clawrium.gui.routes.fleet.get_agent_detail", return_value=vm):
+    with patch("clawrium.gui.routes.fleet.get_agent_static", return_value=vm):
         with TestClient(app) as client:
             resp = client.get("/api/fleet/agents/demo")
     assert "secret_bearer_must_not_leak" not in resp.text
     assert "gateway_auth" not in resp.json()
+
+
+def test_agent_detail_excludes_device_private_key(isolated_config: Path):
+    """device_private_key is a secret too — _agent_to_dict's allow-list
+    excludes it, but only the gateway_auth field had a regression test.
+    (#758 ATX S1)."""
+    _seed_hosts(isolated_config, "hermes")
+    vm = _agent_vm(device_private_key="SENTINEL_PRIVKEY_NEVER_LEAK")
+    with patch("clawrium.gui.routes.fleet.get_agent_static", return_value=vm):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo")
+    assert resp.status_code == 200
+    assert "SENTINEL_PRIVKEY_NEVER_LEAK" not in resp.text
+    assert "device_private_key" not in resp.json()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Splits `/api/fleet/agents/{key}` into a fast static endpoint (hosts.json identity only) and a slow `/health` endpoint (SSH probe + registry lookup), routed through the same semaphore + dedicated executor + 60s timeout as `/fleet/health`.
- Frontend gets `useAgentHealth` + `AgentDetailHealth`; `AgentHeader`, `AgentMetrics`, and `OverviewTab` fall back to the static `AgentDetail` when health is undefined, so the page shell renders instantly and each runtime field arrives on its own loading state.
- `latest_supported_version` moved off the static endpoint onto `/health`; `VersionRow` distinguishes "loading" from "confirmed no upgrade" so an outdated agent never silently looks current.

Closes #758

## Testing

- `make lint` clean (ruff + eslint)
- `make test` green: 3793 backend + 289 frontend tests
- New backend tests: `tests/test_gui_agent_detail_split.py` (static path skips probe, returns fast under a hanging probe, /health returns runtime fields, host-mismatch 404, probe-exception degraded response, response shape pinned to exact 9-key set).
- New frontend tests: `agent-header.test.tsx` + `agent-metrics.test.tsx` covering `health=undefined` fallback; `overview-tab.test.tsx` extended for the loading badge.
- Manual: not run against a live unreachable host — owner to verify on kevin/wolf-i.

## ATX Review Summary

**Final Review: Rating 5/5**
**Total Cost: \$4.10 | Total Time: 11m 9s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3/5 | B1 | All fixed | \$2.57 | 7m 59s | leader, gui-routes, security-reviewer, test-coverage |
| 2 | 5/5 | None | Ready | \$1.54 | 3m 10s | leader, gui-routes, security-reviewer, test-coverage |

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `src/clawrium/gui/routes/fleet.py:259` | `/health` dispatched the SSH probe via bare `asyncio.to_thread`, bypassing the `_get_fleet_health_executor` + `_get_fleet_health_semaphore` + `_FLEET_HEALTH_TIMEOUT_S` infrastructure. With `useAgentHealth`'s 10s poll, a dead host would pin Starlette's default threadpool indefinitely and starve every other route. | Wrapped in the same semaphore + executor + `asyncio.wait_for(timeout=_FLEET_HEALTH_TIMEOUT_S)`; 504 on TimeoutError. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `gui/routes/fleet.py` `latest_supported_version` catch | Bare `except Exception` masked real bugs as "no upgrade available" | Narrowed to `(KeyError, ValueError, FileNotFoundError)` + `logger.warning(exc_info=True)` |
| W2 | `gui/src/hooks/use-agent.ts` `useAgent` | Lost its `refetchInterval` — out-of-band `clawctl` changes wouldn't reflect until manual reload | Re-added 10s refetch (cheap now that probe is off-path) |
| W3 | `gui/src/components/agent-detail/overview-tab.tsx` `VersionRow` | `latest_supported_version` collapsed to `null` during load — outdated agent silently looked current | Added `healthLoaded` prop; renders "Checking for upgrades…" badge while undefined |
| W4 | `tests/test_gui_routes_fleet.py` | No host-mismatch 404 test on `/health` (asymmetric with the static path) | Added `test_health_endpoint_404_when_host_mismatch` |
| W5 | `tests/test_gui_agent_detail_split.py` | No probe-exception coverage; refactor could silently break degraded UX | Added `test_health_endpoint_returns_degraded_on_probe_exception` (TimeoutError → 200 + populated `health_error`) |
| W6 | `tests/test_gui_agent_detail_split.py` | `/health` response shape only spot-checked | Added `test_health_endpoint_response_shape_pinned` asserting exact 9-key set; confirmed `uptime` is absent |
| W7 | `gui/src/components/agent-detail/` | `health=undefined` fallback untested in AgentHeader/AgentMetrics | New `agent-header.test.tsx` (4 cases) + `agent-metrics.test.tsx` (4 cases) |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Add `device_private_key` redaction test (only `gateway_auth` was covered) | Added `test_agent_detail_excludes_device_private_key` with sentinel |
| S2 | Rename `_sanitize_health_error` — only redacts paths, not IPs/user@host | Deferred — trust model unchanged for this PR |
| S3 | Double `hosts.json` read / TOCTOU between `resolve_agent` and the data layer | Deferred to focused refactor |
| S4 | Add `key={agent.agent_key}` to AgentMetrics/OverviewTab for consistency with AgentHeader | Added keys + consolidated comment |
| S5 | Drop `uptime` from `/health` — identical to static, no SSH-derived component | Dropped from response + type; single source of truth on static query |
| S6 | Comment on `AgentViewModel` documenting the `_agent_to_dict` allow-list invariant | Added SECURITY NOTE |

</details>

<details>
<summary>Review 2 Details (Rating 5/5)</summary>

> "All five round-1 issues are correctly resolved in iteration 2 … Ready to merge."

- B1 — `/health` uses semaphore + executor + `asyncio.wait_for`, 504 on TimeoutError ✅
- W1 — exception narrowed + `exc_info=True` logging ✅
- W2 — `useAgent` 10s refetch restored ✅
- W3 — `VersionRow.healthLoaded` threads through; `upgrade-loading-badge` renders during load ✅
- All new tests present and correct (host-mismatch, probe-exception, shape pin, device_private_key, AgentHeader/AgentMetrics fallback) ✅

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>