### PR TITLE
feat(audit): #780 scope clawctl audit to a specific agent

### DIFF
--- a/.itx/760/01_EXECUTION.md
+++ b/.itx/760/01_EXECUTION.md
@@ -84,15 +84,41 @@ manifest and playbook.
   asserts `/home/{{ agent_name }}/` prefix, NEVER references
   `ansible_user_dir` (B1 iter-3).
 - `sync_agent_canonical` runs the workspace phase between canonical
-  write loop and restart per §1.4. `configure_agent` (core) calls
-  `push_workspace_phase` alongside `_do_pair()` (W3 iter-3).
+  write loop and restart per §1.4. `configure_agent` invokes
+  `push_workspace_phase` **before** the existing restart / state-
+  transition block (W2 hook-review fix). The `_do_pair()` dispatch
+  for zeroclaw is unchanged; openclaw is not in `_PAIRING_AGENT_TYPES`
+  and has no pairing handshake.
 - `CanonicalSyncResult` carries `workspace_files_pushed` /
   `workspace_files_excluded`.
 - CLI flags landed: `--workspace-only`, `--no-restart`, `--workspace`
   hard error (hidden=True). `--workspace-only --diff` mutex rejected
   via `cli/output/errors.py`. Help text + short string updated.
+- **Bidi sanitization (W3 hook-review fix)**: workspace-relative
+  paths emitted in NDJSON events AND the human-facing banner pass
+  through the project's bidi sanitizer (see existing
+  `tests/cli/clawctl/test_bidi_safety.py`) before display.
+  Filenames containing U+202E etc. MUST NOT spoof adjacent NDJSON
+  lines on operator terminals.
+- **CHANGELOG `### BREAKING` lands in Phase 1 (W1 hook-review fix)**:
+  `CHANGELOG.md` `[Unreleased]` gets the `### BREAKING` entry for
+  the `--workspace` flag removal in the same PR that lands the
+  hard-error. AGENTS.md: "an undocumented breaking change is a
+  release blocker." Phase 3 may expand the section; Phase 1 must
+  not merge to main without it.
 - `install.py:create_agent` mkdirs the local workspace scaffold for
   openclaw (idempotent on pre-existing).
+- **`agent_name` allowlist (hook-review S — security)**: `workspace_sync.py`
+  rejects `agent_name` values not matching `^[a-z][a-z0-9_-]{0,30}$`
+  before computing the `/home/<agent_name>/` prefix assertion, and
+  the Ansible playbook re-asserts the same regex server-side.
+  Pre-existing `agent_name` validation in `install.py` is the
+  source of truth — `workspace_sync.py` imports the same validator
+  rather than duplicating the regex.
+- **Workspace-phase failure exit code (hook-review S — cli-ux)**:
+  workspace-phase failure surfaces as `typer.Exit(code=1)` so
+  operator scripts (`clawctl agent sync ... || handle_err`) work.
+  Integration assertion pins the non-zero exit code.
 
 *Tests (the openclaw-applicable subset of §3.1 / §3.2):*
 - Unit: U1 (openclaw row), U2 (openclaw destination pinned), U4
@@ -278,8 +304,11 @@ root with canonical-render output).
   mirror document the overlay model end-to-end now that all three
   agents are present. Stop→sync→start workflow recommendation for
   hermes `memories/` and `cron/` overlays (W14 iter-2).
-- `CHANGELOG.md` `[Unreleased]` finalized with `### Added` +
-  `### BREAKING` entries.
+- `CHANGELOG.md` `[Unreleased]` finalizes the `### Added` section
+  for the overall overlay landing AND expands the existing
+  `### BREAKING` entry (landed in Phase 1 for `--workspace`
+  removal) to cover Phase 2/3 deltas. **Do not duplicate or move
+  the Phase 1 BREAKING line** — it already on main.
 - `AGENTS.md` "Workspace Overlay" section landed — destination +
   excludes from manifest; per-agent `playbooks/workspace.yaml` is the
   only host-write path; `--workspace-only` syncs + rotates bearer;

--- a/.itx/780/00_PLAN.md
+++ b/.itx/780/00_PLAN.md
@@ -1,0 +1,18 @@
+# Issue #780 — Scope clawctl audit to an agent
+
+GitHub: https://github.com/ric03uec/clawrium/issues/780
+
+## Issue Creation
+
+**Stage**: issue-creation
+**Skill**: /itx:issue-new
+**Timestamp**: 2026-06-21T20:50:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+update this command (add a new issue first). the audit command needs to be scoped to an agent as part of cli. so the format will also change
+
+[Context: prior turn established that `clawctl audit` has no `agent_name` field in its v1 schema, so `_format_entry` never shows an agent and `--grep <name>` is the only (unreliable) per-agent slice. On follow-up "What should the user be able to do when this is implemented?", user replied: "this should be scoped at agent level. clawctl agent audit <name> or whatever convention".]
+```
+
+**Output**: Created issue #780 — "User can run `clawctl agent audit <name>` to view audit history scoped to an agent". Acceptance criteria cover schema additive change, `audit log --agent`, `audit show --agent`, new `clawctl agent audit <name>` subcommand surface, formatter update, stats "By agent" breakdown, and backward-compat tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ cut. The `itx:release` skill archives this section into a new
 
 ### BREAKING
 
+- **`clawctl audit show`, `clawctl audit tail`, and `clawctl audit
+  stats` now require explicit scope** (#780). Each of these read
+  verbs exits 2 unless invoked with either `--agent <name>` (filter
+  to one agent's entries) or `--all` (the unscoped global view that
+  also surfaces legacy rows written before the `agent_name` schema
+  field existed). The two flags are mutually exclusive. There is no
+  automated migration — operators and any scripts, cron jobs, or
+  skills that ran these commands unscoped MUST update to pass
+  `--all` for the previous behavior, or `--agent <name>` to scope
+  to a single agent. The new `clawctl agent audit <name>` command
+  is the recommended per-agent read surface and is equivalent to
+  `clawctl audit show --agent <name>`. The `--actor`, `--result`,
+  `--session-id`, `--grep`, `--last`, `--date`, and `--json` flags
+  on `show` retain their old semantics and compose with the new
+  scope flag.
+
 - **`clawctl agent sync --workspace` is removed.** Use `--no-restart`
   for canonical render + workspace overlay without a unit restart, or
   `--workspace-only` to push the operator overlay alone. There is no
@@ -57,6 +73,32 @@ cut. The `itx:release` skill archives this section into a new
   automated migration — the upgrade must be initiated explicitly.
 
 ### Added
+
+- **`clawctl agent audit <name>` — agent-scoped audit trail** (#780).
+  A new read-only command that filters `clawctl audit` output to one
+  agent's entries via a positional `<name>`. Composable with
+  `--actor`, `--result`, `--session-id`, `--grep`, `--last`,
+  `--date`, and `--json`. Legacy rows (no `agent_name` field)
+  intentionally do not surface — only the unscoped global view
+  (`clawctl audit show --all`) shows them. Unlike every other
+  `clawctl agent <verb> <name>` surface, this command does NOT
+  reject `<name>` values that are missing from `hosts.json` — the
+  audit trail outlives the agent, so inspecting a deleted agent's
+  history is a first-class use case. When the result is empty AND
+  the name is not currently registered, a one-line stderr notice
+  (`Note: '<name>' is not a registered agent…`) flags likely typos;
+  exit code stays 0.
+
+- **`agent_name` field on the audit-trail schema** (#780).
+  `clawctl audit log` accepts `--agent <name>` to populate the new
+  field; downstream `clawctl audit show / tail / stats` accept
+  `--agent <name>` to filter and `--all` to bypass scoping. The
+  schema version stays at `"1"` because the change is additive and
+  reads are tolerant — pre-#780 rows render as "unscoped" and only
+  appear under `--all`. `audit stats` adds a `By agent:` breakdown.
+  Formatter output gains a fixed-width agent column so scoped and
+  unscoped rows align in mixed listings; agent names are
+  bidi-sanitized before terminal emission.
 
 - **Workspace overlay sync (openclaw + zeroclaw + hermes, Ubuntu).**
   Files dropped under `~/.config/clawrium/agents/<type>/<name>/workspace/`
@@ -145,6 +187,19 @@ cut. The `itx:release` skill archives this section into a new
   silently fallen through to a system-PATH binary on Darwin.
 
 ### Fixed
+
+- **`clawctl audit show --grep <pattern>` no longer raises a Python
+  traceback** when the pattern is not a valid regex (#780). A
+  malformed pattern (e.g. `--grep '['`) now exits 2 with
+  `Error: invalid --grep regex: <details>` and a hint, matching the
+  rest of the audit error surface.
+
+- **`clawctl audit show --date <value>` validates the value as
+  `^[0-9]{8}$`** (#780). A typo like `--date 2026-06-21` previously
+  produced a silently empty result by interpolating a non-existent
+  log filename; it now exits 2 with `Error: --date must be 8 digits
+  (YYYYMMDD); got '2026-06-21'` and an example hint. The same
+  validation applies to `clawctl agent audit <name> --date <value>`.
 
 - openclaw renderer no longer emits `{"allow": true}` for entries in
   `channels.discord.guilds.<id>.channels.<id>`. openclaw 2026.5.28+

--- a/src/clawrium/cli/clawctl/agent/__init__.py
+++ b/src/clawrium/cli/clawctl/agent/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import typer
 
 from clawrium.cli.clawctl.agent import (
+    audit as _audit,
     chat as _chat,
     channel as _channel,
     configure as _configure,
@@ -103,3 +104,7 @@ agent_app.add_typer(_skill.skill_app, name="skill")
 agent_app.add_typer(_secret.secret_app, name="secret")
 agent_app.add_typer(_memory.memory_app, name="memory")
 agent_app.add_typer(_registry.registry_app, name="registry")
+agent_app.command(
+    name="audit",
+    help="Show audit trail entries scoped to one agent.",
+)(_audit.audit)

--- a/src/clawrium/cli/clawctl/agent/audit.py
+++ b/src/clawrium/cli/clawctl/agent/audit.py
@@ -1,0 +1,112 @@
+"""`clawctl agent audit <name>` — agent-scoped audit trail (issue #780).
+
+A single command that shows the audit trail filtered to one agent.
+The positional `<name>` IS the scope — no `--agent` flag, no `--all`
+escape hatch — and legacy entries (no agent_name) never surface
+here by design.
+
+This is a read-only facade over the public audit primitives in
+`src/clawrium/cli/clawctl/audit.py`. For writing, tailing across
+days, or summary stats, use `clawctl audit log --agent <name>`,
+`clawctl audit tail --agent <name>`, or `clawctl audit stats
+--agent <name>` — same data, same filter semantics.
+
+**Permissive name handling** (deliberate departure from the rest of
+`clawctl agent <verb> <name>`): the audit trail outlives the agent.
+Inspecting the history of a deleted agent is a first-class use case,
+so this command does NOT call `safe_resolve_agent`. To still catch
+typos, when the result set is empty AND `<name>` is not currently
+registered in ``hosts.json``, we emit a one-line stderr notice. The
+exit code stays 0 — silent empty results remain valid for genuinely
+empty trails of registered agents.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Optional
+
+import typer
+
+from clawrium.cli.clawctl.audit import (
+    VALID_ACTORS,
+    VALID_RESULTS,
+    filter_entries,
+    format_entry,
+    iter_entries,
+    validate_date,
+)
+from clawrium.cli.output.errors import emit_error
+from clawrium.core.hosts import HostsFileCorruptedError, get_agent_by_name
+
+__all__ = ["audit"]
+
+
+def audit(
+    name: str = typer.Argument(..., help="Agent name to scope the read to."),
+    date: Optional[str] = typer.Option(None, "--date", help="Restrict to a single UTC day (YYYYMMDD)."),
+    actor: Optional[str] = typer.Option(None, "--actor", help="Filter by actor (user|agent)."),
+    result: Optional[str] = typer.Option(None, "--result", help="Filter by result (success|failure|skipped)."),
+    session_id: Optional[str] = typer.Option(None, "--session-id", help="Restrict to one session."),
+    grep: Optional[str] = typer.Option(None, "--grep", help="Regex matched against action + notes."),
+    last: Optional[int] = typer.Option(None, "--last", help="Only the last N matching entries."),
+    as_json: bool = typer.Option(False, "--json", help="Emit raw JSONL instead of formatted lines."),
+) -> None:
+    """Show audit entries for <name>."""
+    if actor is not None and actor not in VALID_ACTORS:
+        emit_error(
+            f"--actor must be one of {VALID_ACTORS}",
+            hint="Valid values: user, agent.",
+            exit_code=2,
+        )
+    if result is not None and result not in VALID_RESULTS:
+        emit_error(
+            f"--result must be one of {VALID_RESULTS}",
+            hint="Valid values: success, failure, skipped.",
+            exit_code=2,
+        )
+    validate_date(date)
+
+    entries = filter_entries(
+        iter_entries(date),
+        actor=actor,
+        result=result,
+        session_id=session_id,
+        agent=name,
+        grep=grep,
+        last=last,
+    )
+    if as_json:
+        # ensure_ascii=True so raw non-ASCII codepoints (including
+        # bidi overrides smuggled into any field) escape to \uXXXX —
+        # safe to pipe to a terminal without a downstream sanitize().
+        emitted = 0
+        for e in entries:
+            typer.echo(json.dumps(e, ensure_ascii=True, separators=(",", ":")))
+            emitted += 1
+    else:
+        emitted = 0
+        for e in entries:
+            typer.echo(format_entry(e))
+            emitted += 1
+
+    if emitted == 0 and not _agent_is_registered(name):
+        # Empty result + unregistered name → likely typo (or the
+        # agent was deleted long ago). Soft notice on stderr; exit
+        # code stays 0 because an empty trail is a valid state.
+        sys.stderr.write(
+            f"Note: {name!r} is not a registered agent "
+            f"(typo, or already deleted).\n"
+        )
+
+
+def _agent_is_registered(name: str) -> bool:
+    """Return True iff ``name`` resolves to an agent currently present
+    in ``hosts.json``. A missing or corrupted hosts file is treated
+    as "unknown" rather than raising — the audit trail must remain
+    usable even if the local hosts file is broken."""
+    try:
+        return get_agent_by_name(name) is not None
+    except HostsFileCorruptedError:
+        return False

--- a/src/clawrium/cli/clawctl/audit.py
+++ b/src/clawrium/cli/clawctl/audit.py
@@ -27,16 +27,32 @@ from typing import Iterator, List, Optional
 import typer
 
 from clawrium import __version__ as _clawctl_version
+from clawrium.cli.output._sanitize import sanitize
+from clawrium.cli.output.errors import emit_error
 
-__all__ = ["audit_app", "audit_session_app"]
+__all__ = [
+    "audit_app",
+    "audit_session_app",
+    # Public API consumed by clawrium.cli.clawctl.agent.audit (the
+    # per-agent read facade for issue #780). Promoted from underscore-
+    # prefixed privates in #780 so the cross-module boundary is
+    # explicit and rename-safe.
+    "VALID_ACTORS",
+    "VALID_RESULTS",
+    "iter_entries",
+    "filter_entries",
+    "format_entry",
+    "action_verb",
+    "validate_date",
+]
 
 
 # ---------------------------------------------------------------------------
 # Schema constants
 # ---------------------------------------------------------------------------
 
-_VALID_ACTORS = ("user", "agent")
-_VALID_RESULTS = ("success", "failure", "skipped")
+VALID_ACTORS = ("user", "agent")
+VALID_RESULTS = ("success", "failure", "skipped")
 _DEFAULT_TYPE = "clawctl_command"
 _SCHEMA_VERSION = "1"
 _SESSION_ENV_VAR = "CLAWCTL_AUDIT_SESSION_ID"
@@ -92,6 +108,7 @@ def _build_entry(
     notes: str = "",
     session_id: Optional[str] = None,
     parent_uuid: Optional[str] = None,
+    agent_name: Optional[str] = None,
     entry_type: str = _DEFAULT_TYPE,
 ) -> dict:
     """Construct a schema-v1 entry.
@@ -101,6 +118,7 @@ def _build_entry(
       uuid        -- uuid4, unique per entry
       parent_uuid -- causal parent's uuid (or None)
       session_id  -- workflow grouping id (or None)
+      agent_name  -- agent this op touched (or None for unscoped)
       timestamp   -- ISO 8601 UTC with ms precision
       cwd         -- captured os.getcwd() at write time
       version     -- {"audit": "<schema>", "clawctl": "<clawctl>"}
@@ -108,12 +126,22 @@ def _build_entry(
       action      -- short description / literal command
       result      -- "success" | "failure" | "skipped"
       notes       -- free text; "" allowed
+
+    Schema-v1 additive boundary (issue #780): ``agent_name`` was
+    introduced after the initial v1 schema. Entries written
+    pre-#780 do NOT contain the ``agent_name`` key at all
+    (distinct from ``"agent_name": null``). Readers MUST treat
+    missing-key and ``None`` as equivalent ("unscoped") and MUST
+    NOT branch on key presence alone. The schema version stays at
+    "1" because reads are tolerant by design; no migration is
+    required.
     """
     return {
         "type": entry_type,
         "uuid": str(uuidlib.uuid4()),
         "parent_uuid": parent_uuid,
         "session_id": session_id,
+        "agent_name": agent_name,
         "timestamp": _utc_now_iso_ms(),
         "cwd": os.getcwd(),
         "version": {
@@ -136,7 +164,7 @@ def _append_entry(entry: dict) -> Path:
     return target
 
 
-def _iter_entries(date: Optional[str] = None) -> Iterator[dict]:
+def iter_entries(date: Optional[str] = None) -> Iterator[dict]:
     """Yield entries from one day's log, or from every log on disk.
 
     Malformed lines are silently skipped so a corrupt write never blocks
@@ -163,20 +191,67 @@ def _iter_entries(date: Optional[str] = None) -> Iterator[dict]:
                     continue
 
 
-def _format_entry(e: dict) -> str:
-    notes = e.get("notes") or ""
+#: Width of the agent_name column when rendered in formatted output.
+#: Chosen to fit common per-instance names (e.g. ``wolf-i``,
+#: ``mybox-openclaw``) without truncation while keeping the
+#: result/action columns vertically aligned across mixed listings of
+#: scoped and legacy (unscoped) rows. Names longer than this are
+#: truncated with an ellipsis.
+AGENT_COL_WIDTH = 18
+
+
+def format_entry(e: dict) -> str:
+    """Render one entry as a single human-readable line.
+
+    Every interpolated field is operator-controlled (the JSONL row
+    is read from disk, where any actor with write access could have
+    smuggled bidi codepoints into ``timestamp``, ``actor``,
+    ``result``, ``session_id``, ``agent_name``, ``action``, or
+    ``notes``). We sanitize the entire rendered line at the output
+    boundary rather than per-field — one call, no missed surface
+    area, and idempotent on already-safe strings.
+
+    All field reads pass through ``str(... or '?')`` so a JSONL row
+    with a non-string typed scalar (``"timestamp": null``,
+    ``"actor": 5``) does NOT raise ``TypeError`` against the
+    ``:24s`` / ``:5s`` / ``:7s`` format specs. A malformed row
+    degrades to ``"?"`` placeholders instead of taking down the
+    entire ``show``/``tail`` invocation.
+    """
+    notes_raw = e.get("notes") or ""
+    notes = str(notes_raw)
     tail = f"  -- {notes}" if notes else ""
     sess = e.get("session_id")
-    sess_tag = f" {sess[:8]}" if sess else ""
-    return (
-        f"{e.get('timestamp', '?'):24s}  "
-        f"[{e.get('actor', '?'):5s}]  "
-        f"{e.get('result', '?'):7s}  "
-        f"{e.get('action', '?')}{sess_tag}{tail}"
+    sess_tag = f" {str(sess)[:8]}" if sess else ""
+    agent = e.get("agent_name")
+    # Fixed-width agent slot so the result/action columns line up
+    # across mixed listings (scoped + legacy). When agent_name is
+    # absent we emit AGENT_COL_WIDTH spaces; when present we render
+    # ``(name)`` padded/truncated to the same width.
+    if agent:
+        inner = str(agent)
+        # Reserve 2 chars for the parens; truncate the body if needed.
+        body_max = AGENT_COL_WIDTH - 2
+        if len(inner) > body_max:
+            inner = inner[: body_max - 1] + "…"
+        agent_slot = f"({inner})".ljust(AGENT_COL_WIDTH)
+    else:
+        agent_slot = " " * AGENT_COL_WIDTH
+    ts = str(e.get("timestamp") or "?")
+    actor = str(e.get("actor") or "?")
+    result = str(e.get("result") or "?")
+    action = str(e.get("action") or "?")
+    line = (
+        f"{ts:24s}  "
+        f"[{actor:5s}]  "
+        f"{agent_slot}  "
+        f"{result:7s}  "
+        f"{action}{sess_tag}{tail}"
     )
+    return sanitize(line)
 
 
-def _action_verb(action: str) -> str:
+def action_verb(action: str) -> str:
     """Coarse grouping for ``stats`` output.
 
     Almost every action will start with ``clawctl``, so the leading token
@@ -192,10 +267,11 @@ def _action_verb(action: str) -> str:
     return tokens[0]
 
 
-def _filter_entries(entries: Iterator[dict], *,
+def filter_entries(entries: Iterator[dict], *,
                     actor: Optional[str],
                     result: Optional[str],
                     session_id: Optional[str],
+                    agent: Optional[str],
                     grep: Optional[str],
                     last: Optional[int]) -> List[dict]:
     out = list(entries)
@@ -205,8 +281,23 @@ def _filter_entries(entries: Iterator[dict], *,
         out = [e for e in out if e.get("result") == result]
     if session_id:
         out = [e for e in out if e.get("session_id") == session_id]
+    if agent:
+        out = [e for e in out if e.get("agent_name") == agent]
     if grep:
-        pat = re.compile(grep)
+        try:
+            pat = re.compile(grep)
+        except re.error as exc:
+            emit_error(
+                f"invalid --grep regex: {exc}",
+                hint="Pass a valid Python regex; escape literal metacharacters.",
+                exit_code=2,
+            )
+            # Defensive: emit_error is annotated NoReturn, but a future
+            # refactor that demoted it to a regular return would leave
+            # `pat` unbound on the line below. Make the exit explicit
+            # so the failure mode at that point is `SystemExit`, not
+            # `NameError`.
+            raise typer.Exit(code=2)
         def matches(e: dict) -> bool:
             haystack = " ".join([
                 str(e.get("action", "")),
@@ -217,6 +308,52 @@ def _filter_entries(entries: Iterator[dict], *,
     if last:
         out = out[-last:]
     return out
+
+
+#: ``[0-9]`` rather than ``\d`` deliberately — ``\d`` matches any
+#: Unicode Nd digit, which is imprecise even though no Nd codepoint
+#: would form a path-traversal sequence here.
+_DATE_FORMAT_RE = re.compile(r"^[0-9]{8}$")
+
+
+def validate_date(date: Optional[str]) -> None:
+    """Reject ``--date`` values that don't match the YYYYMMDD log naming.
+
+    The value is interpolated into the log file path. Even though the
+    audit log directory is operator-local (so path-traversal risk is
+    negligible), a format guard catches typos at entry rather than
+    producing a silently empty result when the file doesn't exist.
+    """
+    if date is None:
+        return
+    if not _DATE_FORMAT_RE.match(date):
+        emit_error(
+            f"--date must be 8 digits (YYYYMMDD); got {date!r}",
+            hint="Example: --date 20260621 for 2026-06-21.",
+            exit_code=2,
+        )
+
+
+def _require_scope(agent: Optional[str], all_flag: bool, *, verb: str) -> None:
+    """Enforce the issue #780 contract: every read verb is agent-scoped by
+    default. The operator must either name an agent (`--agent`) or opt into
+    the unscoped global view (`--all`)."""
+    if agent and all_flag:
+        emit_error(
+            f"audit {verb}: --agent and --all are mutually exclusive",
+            hint="Pass exactly one of --agent <name> or --all.",
+            exit_code=2,
+        )
+    if not agent and not all_flag:
+        emit_error(
+            f"audit {verb}: must pass --agent <name> or --all",
+            hint=(
+                "--all surfaces every entry, including legacy rows that pre-date "
+                "the agent_name field. For one agent, use --agent <name> or run "
+                "'clawctl agent audit <name>'."
+            ),
+            exit_code=2,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -260,6 +397,12 @@ def log(
         "--parent-uuid",
         help="Causal parent entry's uuid (capture with --print-uuid on the previous log).",
     ),
+    agent: Optional[str] = typer.Option(
+        None,
+        "--agent",
+        help="Agent this entry pertains to. Sets the agent_name field so the entry "
+             "is reachable via 'clawctl agent audit <name>'.",
+    ),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress the 'logged -> path' line."),
     print_uuid: bool = typer.Option(
         False,
@@ -267,12 +410,18 @@ def log(
         help="On success print only the new entry's uuid (for chaining via --parent-uuid).",
     ),
 ) -> None:
-    if result not in _VALID_RESULTS:
-        typer.echo(f"--result must be one of {_VALID_RESULTS}", err=True)
-        raise typer.Exit(code=2)
-    if actor not in _VALID_ACTORS:
-        typer.echo(f"--actor must be one of {_VALID_ACTORS}", err=True)
-        raise typer.Exit(code=2)
+    if result not in VALID_RESULTS:
+        emit_error(
+            f"--result must be one of {VALID_RESULTS}",
+            hint="Valid values: success, failure, skipped.",
+            exit_code=2,
+        )
+    if actor not in VALID_ACTORS:
+        emit_error(
+            f"--actor must be one of {VALID_ACTORS}",
+            hint="Valid values: user, agent.",
+            exit_code=2,
+        )
 
     effective_session = session_id or os.environ.get(_SESSION_ENV_VAR) or None
     entry = _build_entry(
@@ -282,6 +431,7 @@ def log(
         notes=notes,
         session_id=effective_session,
         parent_uuid=parent_uuid,
+        agent_name=agent,
     )
     path = _append_entry(entry)
 
@@ -293,65 +443,149 @@ def log(
     typer.echo(f"logged -> {path}  uuid={entry['uuid'][:8]}")
 
 
-@audit_app.command("show", help="Show / filter audit entries.")
+@audit_app.command(
+    "show",
+    help="Show / filter audit entries. Requires --agent <name> or --all.",
+)
 def show(
     date: Optional[str] = typer.Option(None, "--date", help="Restrict to a single UTC day (YYYYMMDD)."),
     actor: Optional[str] = typer.Option(None, "--actor", help="Filter by actor."),
     result: Optional[str] = typer.Option(None, "--result", help="Filter by result."),
     session_id: Optional[str] = typer.Option(None, "--session-id", help="Restrict to one session."),
+    agent: Optional[str] = typer.Option(
+        None,
+        "--agent",
+        help="Restrict to entries whose agent_name matches. Legacy entries that "
+             "pre-date the agent_name field are excluded.",
+    ),
+    all_flag: bool = typer.Option(
+        False,
+        "--all",
+        help="Show every entry, including legacy/unscoped ones with no agent_name. "
+             "Mutually exclusive with --agent.",
+    ),
     grep: Optional[str] = typer.Option(None, "--grep", help="Regex matched against action + notes."),
     last: Optional[int] = typer.Option(None, "--last", help="Only the last N matching entries."),
     as_json: bool = typer.Option(False, "--json", help="Emit raw JSONL instead of formatted lines."),
 ) -> None:
-    if actor is not None and actor not in _VALID_ACTORS:
-        typer.echo(f"--actor must be one of {_VALID_ACTORS}", err=True)
-        raise typer.Exit(code=2)
-    if result is not None and result not in _VALID_RESULTS:
-        typer.echo(f"--result must be one of {_VALID_RESULTS}", err=True)
-        raise typer.Exit(code=2)
+    # _require_scope first: scope is the #780 BREAKING contract and
+    # the primary gate. An operator who forgot --all/--agent should
+    # see that error, not fix a date typo and then discover they
+    # still need a scope flag.
+    _require_scope(agent, all_flag, verb="show")
+    if actor is not None and actor not in VALID_ACTORS:
+        emit_error(
+            f"--actor must be one of {VALID_ACTORS}",
+            hint="Valid values: user, agent.",
+            exit_code=2,
+        )
+    if result is not None and result not in VALID_RESULTS:
+        emit_error(
+            f"--result must be one of {VALID_RESULTS}",
+            hint="Valid values: success, failure, skipped.",
+            exit_code=2,
+        )
+    validate_date(date)
 
-    entries = _filter_entries(
-        _iter_entries(date),
+    entries = filter_entries(
+        iter_entries(date),
         actor=actor,
         result=result,
         session_id=session_id,
+        agent=agent,
         grep=grep,
         last=last,
     )
     if as_json:
+        # ensure_ascii=True per cli/output/_sanitize.py contract — raw
+        # non-ASCII codepoints (including bidi overrides smuggled into
+        # any field) are escaped to \uXXXX so piping to a terminal is
+        # safe even without a downstream sanitize() call.
         for e in entries:
-            typer.echo(json.dumps(e, ensure_ascii=False, separators=(",", ":")))
+            typer.echo(json.dumps(e, ensure_ascii=True, separators=(",", ":")))
     else:
         for e in entries:
-            typer.echo(_format_entry(e))
+            typer.echo(format_entry(e))
 
 
-@audit_app.command("tail", help="Show the last N entries across all days.")
+@audit_app.command(
+    "tail",
+    help="Show the last N entries. Requires --agent <name> or --all.",
+)
 def tail(
     n: int = typer.Option(20, "-n", "--lines", help="Number of entries to show."),
+    agent: Optional[str] = typer.Option(
+        None,
+        "--agent",
+        help="Restrict to entries whose agent_name matches.",
+    ),
+    all_flag: bool = typer.Option(
+        False,
+        "--all",
+        help="Show every entry, including legacy/unscoped ones.",
+    ),
 ) -> None:
-    entries = list(_iter_entries(None))[-n:]
-    for e in entries:
-        typer.echo(_format_entry(e))
+    _require_scope(agent, all_flag, verb="tail")
+    entries = filter_entries(
+        iter_entries(None),
+        actor=None,
+        result=None,
+        session_id=None,
+        agent=agent,
+        grep=None,
+        last=None,
+    )
+    for e in entries[-n:]:
+        typer.echo(format_entry(e))
 
 
-@audit_app.command("stats", help="Summary counts across the full audit history.")
+@audit_app.command(
+    "stats",
+    help="Summary counts. Requires --agent <name> or --all.",
+)
 def stats(
     top: int = typer.Option(10, "--top", help="Top N action groups by frequency."),
+    agent: Optional[str] = typer.Option(
+        None,
+        "--agent",
+        help="Restrict the summary to one agent.",
+    ),
+    all_flag: bool = typer.Option(
+        False,
+        "--all",
+        help="Summarise every entry. Mutually exclusive with --agent.",
+    ),
 ) -> None:
+    _require_scope(agent, all_flag, verb="stats")
     actor_count: Counter = Counter()
     result_count: Counter = Counter()
     verb_count: Counter = Counter()
+    agent_count: Counter = Counter()
     days: set = set()
     sessions: set = set()
     total = 0
-    for e in _iter_entries(None):
+    for e in filter_entries(
+        iter_entries(None),
+        actor=None,
+        result=None,
+        session_id=None,
+        agent=agent,
+        grep=None,
+        last=None,
+    ):
         total += 1
-        actor_count[e.get("actor", "?")] += 1
-        result_count[e.get("result", "?")] += 1
-        verb_count[_action_verb(e.get("action", "") or "")] += 1
-        ts = e.get("timestamp", "")
-        if len(ts) >= 10:
+        # Every Counter key is derived from a disk-read JSONL field
+        # and emitted to the terminal via dict repr (which escapes
+        # some control bytes but is not bidi-safe) or via raw
+        # f-string in the Top-N loop (which is not safe at all).
+        # Sanitize at insertion so the emit sites stay simple and
+        # no path can leak a smuggled codepoint to the user's shell.
+        actor_count[sanitize(str(e.get("actor") or "?"))] += 1
+        result_count[sanitize(str(e.get("result") or "?"))] += 1
+        verb_count[sanitize(action_verb(str(e.get("action") or "")))] += 1
+        agent_count[sanitize(str(e.get("agent_name") or "(unscoped)"))] += 1
+        ts = e.get("timestamp")
+        if isinstance(ts, str) and len(ts) >= 10:
             days.add(ts[:10])
         sid = e.get("session_id")
         if sid:
@@ -362,9 +596,13 @@ def stats(
     typer.echo(f"Distinct sessions: {len(sessions)}")
     typer.echo(f"By actor:          {dict(actor_count)}")
     typer.echo(f"By result:         {dict(result_count)}")
+    typer.echo(f"By agent:          {dict(agent_count)}")
     if top and verb_count:
         typer.echo(f"Top {top} action groups:")
         for verb, n in verb_count.most_common(top):
+            # `verb` is already sanitized at insertion above, but we
+            # also coerce `n` to int formatting only — no extra
+            # surface here.
             typer.echo(f"  {n:5d}  {verb}")
 
 

--- a/tests/cli/clawctl/agent/test_audit.py
+++ b/tests/cli/clawctl/agent/test_audit.py
@@ -1,0 +1,212 @@
+"""Tests for `clawctl agent audit <name>` — issue #780.
+
+The agent-scoped surface is a single read-only command: a thin
+facade over the top-level audit primitives, with the positional
+`<name>` acting as a fixed filter. Legacy entries (no agent_name)
+never surface here — that's enforced by the same `_filter_entries`
+agent check that `clawctl audit show --agent` uses.
+
+Writes go through the top-level `clawctl audit log --agent <name>`;
+this surface is intentionally read-only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def audit_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    config_root = tmp_path / "clawrium"
+    monkeypatch.setenv("CLAWRIUM_CONFIG_HOME", str(config_root))
+    monkeypatch.delenv("CLAWCTL_AUDIT_SESSION_ID", raising=False)
+    # Mark `wolf-i` as a registered agent in hosts.json so the
+    # "permissive + soft notice" path (issue #780 iter 6 W1) only
+    # fires when the test deliberately uses an unregistered name.
+    config_root.mkdir(parents=True, exist_ok=True)
+    (config_root / "hosts.json").write_text(
+        json.dumps([
+            {"hostname": "test-host", "agents": {"wolf-i": {"type": "openclaw"}}},
+        ])
+    )
+    return config_root / "changelog"
+
+
+@pytest.fixture
+def no_registered_agents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    """Like ``audit_home`` but without a hosts.json — every name reads
+    as unregistered, so the soft-notice path is unavoidable."""
+    config_root = tmp_path / "clawrium"
+    monkeypatch.setenv("CLAWRIUM_CONFIG_HOME", str(config_root))
+    monkeypatch.delenv("CLAWCTL_AUDIT_SESSION_ID", raising=False)
+    return config_root / "changelog"
+
+
+def _seed(audit_home: Path, *args: Iterable[str]) -> None:
+    for cmd in args:
+        result = runner.invoke(app, list(cmd))
+        assert result.exit_code == 0, result.output
+
+
+def test_agent_audit_filters_to_positional_only(audit_home: Path) -> None:
+    """Other agents and legacy entries must not appear."""
+    _seed(
+        audit_home,
+        ["audit", "log", "legacy op", "--result", "success"],
+        ["audit", "log", "wolf op", "--result", "success", "--agent", "wolf-i"],
+        ["audit", "log", "kevin op", "--result", "success", "--agent", "kevin"],
+    )
+    result = runner.invoke(app, ["agent", "audit", "wolf-i", "--json"])
+    assert result.exit_code == 0, result.output
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    actions = [json.loads(ln)["action"] for ln in lines]
+    assert actions == ["wolf op"]
+
+
+def test_agent_audit_renders_formatted_output_with_agent_tag(audit_home: Path) -> None:
+    _seed(
+        audit_home,
+        ["audit", "log", "scoped op", "--result", "success", "--agent", "wolf-i"],
+    )
+    result = runner.invoke(app, ["agent", "audit", "wolf-i"])
+    assert result.exit_code == 0
+    assert "(wolf-i)" in result.output
+    assert "scoped op" in result.output
+
+
+def test_agent_audit_no_matches_for_registered_agent_is_silent(audit_home: Path) -> None:
+    """A registered agent (in hosts.json) with no audit history yields
+    a silent empty result — the soft-notice path does NOT fire because
+    the empty trail is a legitimate state, not a typo signal."""
+    _seed(
+        audit_home,
+        ["audit", "log", "kevin op", "--result", "success", "--agent", "kevin"],
+    )
+    result = runner.invoke(app, ["agent", "audit", "wolf-i"])
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+def test_agent_audit_no_matches_for_unregistered_agent_emits_notice(
+    audit_home: Path,
+) -> None:
+    """Iter-6 W1: when an empty result happens AND the name is not in
+    hosts.json, emit a stderr note so typos / deleted agents are
+    visible. Exit 0 — empty trails remain valid."""
+    result = runner.invoke(app, ["agent", "audit", "wol-fi"])
+    assert result.exit_code == 0
+    # The notice must surface (CliRunner mixes stderr into output).
+    assert "Note:" in result.output
+    assert "'wol-fi' is not a registered agent" in result.output
+
+
+def test_agent_audit_notice_does_not_fire_when_rows_match(audit_home: Path) -> None:
+    """If the trail has rows for the name, the notice is suppressed
+    even if the name happens to be unregistered — the rows themselves
+    are the signal that the name was meaningful at some point."""
+    _seed(
+        audit_home,
+        ["audit", "log", "scoped op", "--result", "success", "--agent", "deleted-agent"],
+    )
+    result = runner.invoke(app, ["agent", "audit", "deleted-agent"])
+    assert result.exit_code == 0
+    assert "scoped op" in result.output
+    # The soft notice would be a false positive here — the rows prove
+    # the name has history.
+    assert "is not a registered agent" not in result.output
+
+
+def test_agent_audit_notice_fires_when_hosts_json_missing(
+    no_registered_agents: Path,
+) -> None:
+    """No hosts.json + empty trail: every name reads as unregistered.
+    Notice must surface for every empty result."""
+    result = runner.invoke(app, ["agent", "audit", "any-name"])
+    assert result.exit_code == 0
+    assert "Note:" in result.output
+
+
+def test_agent_audit_composes_with_filters(audit_home: Path) -> None:
+    _seed(
+        audit_home,
+        ["audit", "log", "op1", "--result", "success", "--agent", "wolf-i"],
+        ["audit", "log", "op2", "--result", "failure", "--agent", "wolf-i",
+         "--notes", "broken"],
+        ["audit", "log", "op3", "--result", "success", "--agent", "wolf-i"],
+    )
+    result = runner.invoke(
+        app,
+        ["agent", "audit", "wolf-i", "--result", "failure", "--json"],
+    )
+    assert result.exit_code == 0
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    actions = [json.loads(ln)["action"] for ln in lines]
+    assert actions == ["op2"]
+
+
+def test_agent_audit_last_n(audit_home: Path) -> None:
+    _seed(
+        audit_home,
+        ["audit", "log", "op1", "--result", "success", "--agent", "wolf-i"],
+        ["audit", "log", "op2", "--result", "success", "--agent", "wolf-i"],
+        ["audit", "log", "op3", "--result", "success", "--agent", "wolf-i"],
+        ["audit", "log", "op4", "--result", "success", "--agent", "wolf-i"],
+    )
+    result = runner.invoke(app, ["agent", "audit", "wolf-i", "--last", "2", "--json"])
+    assert result.exit_code == 0
+    actions = [
+        json.loads(ln)["action"] for ln in result.output.splitlines() if ln.strip()
+    ]
+    assert actions == ["op3", "op4"]
+
+
+def test_agent_audit_rejects_invalid_actor(audit_home: Path) -> None:
+    result = runner.invoke(app, ["agent", "audit", "wolf-i", "--actor", "bot"])
+    assert result.exit_code == 2
+    assert "--actor must be one of" in result.output
+
+
+def test_agent_audit_rejects_invalid_result(audit_home: Path) -> None:
+    result = runner.invoke(app, ["agent", "audit", "wolf-i", "--result", "bogus"])
+    assert result.exit_code == 2
+    assert "--result must be one of" in result.output
+
+
+def test_agent_audit_does_not_accept_agent_flag(audit_home: Path) -> None:
+    """W3: the facade has no --agent escape hatch — the positional IS
+    the scope. A future refactor accidentally re-exposing the flag
+    would slip past `test_agent_audit_filters_to_positional_only`."""
+    result = runner.invoke(app, ["agent", "audit", "wolf-i", "--agent", "kevin"])
+    assert result.exit_code != 0
+    assert "no such option" in result.output.lower()
+
+
+def test_agent_audit_does_not_accept_all_flag(audit_home: Path) -> None:
+    """W3: no --all on the facade either. Operators wanting the global
+    view should use `clawctl audit show --all`."""
+    result = runner.invoke(app, ["agent", "audit", "wolf-i", "--all"])
+    assert result.exit_code != 0
+    assert "no such option" in result.output.lower()
+
+
+def test_agent_audit_invalid_grep_regex_exits_with_emit_error(audit_home: Path) -> None:
+    """Iter-5 W3 (test-coverage): the facade and the top-level command
+    share filter_entries, but a regression in the facade (e.g.
+    accidentally swallowing typer.Exit) would not be caught by the
+    top-level test. Lock in the same contract on the per-agent surface."""
+    result = runner.invoke(app, ["agent", "audit", "wolf-i", "--grep", "["])
+    assert result.exit_code == 2
+    assert "invalid --grep regex" in result.output
+    assert "Error:" in result.output
+    assert "Hint:" in result.output

--- a/tests/cli/clawctl/audit/test_audit.py
+++ b/tests/cli/clawctl/audit/test_audit.py
@@ -72,9 +72,22 @@ def test_log_writes_schema_v1_entry(audit_home: Path) -> None:
     assert "clawctl" in e["version"]
     # cwd captured
     assert isinstance(e["cwd"], str) and e["cwd"]
-    # session/parent default to null
+    # session/parent/agent default to null
     assert e["session_id"] is None
     assert e["parent_uuid"] is None
+    assert e["agent_name"] is None
+
+
+def test_log_with_agent_sets_agent_name(audit_home: Path) -> None:
+    """`--agent <name>` populates the new schema field on the row."""
+    result = runner.invoke(
+        app,
+        ["audit", "log", "clawctl agent sync wolf-i", "--result", "success",
+         "--agent", "wolf-i"],
+    )
+    assert result.exit_code == 0, result.output
+    e = _read_jsonl(_single_log_file(audit_home))[0]
+    assert e["agent_name"] == "wolf-i"
 
 
 def test_log_actor_user_is_recorded(audit_home: Path) -> None:
@@ -169,7 +182,7 @@ def test_show_filter_by_result(audit_home: Path) -> None:
         ["audit", "log", "clawctl agent stop a2", "--result", "failure", "--notes", "broken"],
         ["audit", "log", "clawctl agent sync a3", "--result", "success"],
     )
-    result = runner.invoke(app, ["audit", "show", "--result", "failure"])
+    result = runner.invoke(app, ["audit", "show", "--all", "--result", "failure"])
     assert result.exit_code == 0
     assert "clawctl agent stop a2" in result.output
     assert "clawctl agent start a1" not in result.output
@@ -183,7 +196,7 @@ def test_show_filter_by_session_id(audit_home: Path) -> None:
         ["audit", "log", "beta", "--result", "success", "--session-id", "S2"],
         ["audit", "log", "gamma", "--result", "success", "--session-id", "S1"],
     )
-    result = runner.invoke(app, ["audit", "show", "--session-id", "S1", "--json"])
+    result = runner.invoke(app, ["audit", "show", "--all", "--session-id", "S1", "--json"])
     assert result.exit_code == 0
     lines = [ln for ln in result.output.splitlines() if ln.strip()]
     actions = [json.loads(ln)["action"] for ln in lines]
@@ -197,7 +210,7 @@ def test_show_grep_matches_action_and_notes(audit_home: Path) -> None:
         ["audit", "log", "bar", "--result", "success"],
         ["audit", "log", "myassistant boot", "--result", "success"],
     )
-    result = runner.invoke(app, ["audit", "show", "--grep", "myassistant", "--json"])
+    result = runner.invoke(app, ["audit", "show", "--all", "--grep", "myassistant", "--json"])
     assert result.exit_code == 0
     lines = [ln for ln in result.output.splitlines() if ln.strip()]
     assert len(lines) == 2
@@ -213,7 +226,7 @@ def test_show_last_n_returns_tail_after_filters(audit_home: Path) -> None:
         ["audit", "log", "c", "--result", "success"],
         ["audit", "log", "d", "--result", "success"],
     )
-    result = runner.invoke(app, ["audit", "show", "--last", "2", "--json"])
+    result = runner.invoke(app, ["audit", "show", "--all", "--last", "2", "--json"])
     assert result.exit_code == 0
     actions = [json.loads(ln)["action"] for ln in result.output.splitlines() if ln.strip()]
     assert actions == ["c", "d"]
@@ -225,7 +238,7 @@ def test_tail_default_returns_recent(audit_home: Path) -> None:
         ["audit", "log", "first", "--result", "success"],
         ["audit", "log", "second", "--result", "success"],
     )
-    result = runner.invoke(app, ["audit", "tail"])
+    result = runner.invoke(app, ["audit", "tail", "--all"])
     assert result.exit_code == 0
     out = result.output
     assert "first" in out and "second" in out
@@ -240,7 +253,7 @@ def test_stats_summarises_by_actor_result_verb(audit_home: Path) -> None:
         ["audit", "log", "clawctl agent stop a1", "--result", "failure", "--notes", "x"],
         ["audit", "log", "clawctl host create 1.2.3.4", "--actor", "user", "--result", "success"],
     )
-    result = runner.invoke(app, ["audit", "stats", "--top", "5"])
+    result = runner.invoke(app, ["audit", "stats", "--all", "--top", "5"])
     assert result.exit_code == 0
     out = result.output
     assert "Total entries:     3" in out
@@ -251,13 +264,645 @@ def test_stats_summarises_by_actor_result_verb(audit_home: Path) -> None:
 
 
 def test_stats_on_empty_trail_returns_zero(audit_home: Path) -> None:
-    result = runner.invoke(app, ["audit", "stats"])
+    result = runner.invoke(app, ["audit", "stats", "--all"])
     assert result.exit_code == 0
     assert "Total entries:     0" in result.output
 
 
-def test_show_on_empty_trail_prints_nothing(audit_home: Path) -> None:
+def test_show_without_scope_errors(audit_home: Path) -> None:
+    """Issue #780: show requires --agent or --all explicitly."""
     result = runner.invoke(app, ["audit", "show"])
+    assert result.exit_code == 2
+    assert "--agent" in result.output and "--all" in result.output
+
+
+def test_show_agent_and_all_are_mutually_exclusive(audit_home: Path) -> None:
+    result = runner.invoke(app, ["audit", "show", "--agent", "wolf-i", "--all"])
+    assert result.exit_code == 2
+    assert "audit show: --agent and --all are mutually exclusive" in result.output
+
+
+def test_tail_agent_and_all_are_mutually_exclusive(audit_home: Path) -> None:
+    """W1: mutex contract must hold for tail too."""
+    result = runner.invoke(app, ["audit", "tail", "--agent", "wolf-i", "--all"])
+    assert result.exit_code == 2
+    assert "audit tail: --agent and --all are mutually exclusive" in result.output
+    # Iter-2 W5: mutex errors must carry a recovery Hint, same as the
+    # scope-required errors.
+    assert "Hint:" in result.output
+    assert "Pass exactly one of --agent <name> or --all." in result.output
+
+
+def test_stats_agent_and_all_are_mutually_exclusive(audit_home: Path) -> None:
+    """W1: mutex contract must hold for stats too."""
+    result = runner.invoke(app, ["audit", "stats", "--agent", "wolf-i", "--all"])
+    assert result.exit_code == 2
+    assert "audit stats: --agent and --all are mutually exclusive" in result.output
+    assert "Hint:" in result.output
+    assert "Pass exactly one of --agent <name> or --all." in result.output
+
+
+def test_show_mutex_error_carries_hint(audit_home: Path) -> None:
+    """Iter-2 W5: show mutex must also surface the Hint line."""
+    result = runner.invoke(app, ["audit", "show", "--agent", "wolf-i", "--all"])
+    assert result.exit_code == 2
+    assert "Hint:" in result.output
+    assert "Pass exactly one of --agent <name> or --all." in result.output
+
+
+def test_tail_agent_filters_to_named_agent(audit_home: Path) -> None:
+    """W2: `audit tail --agent <name>` actually filters by agent."""
+    _seed(
+        audit_home,
+        ["audit", "log", "legacy op", "--result", "success"],
+        ["audit", "log", "wolf-a", "--result", "success", "--agent", "wolf-i"],
+        ["audit", "log", "kevin-a", "--result", "success", "--agent", "kevin"],
+        ["audit", "log", "wolf-b", "--result", "success", "--agent", "wolf-i"],
+    )
+    result = runner.invoke(app, ["audit", "tail", "--agent", "wolf-i"])
+    assert result.exit_code == 0
+    out = result.output
+    assert "wolf-a" in out and "wolf-b" in out
+    assert "kevin-a" not in out
+    assert "legacy op" not in out
+
+
+def test_scope_required_error_mentions_agent_audit(audit_home: Path) -> None:
+    """W5: scope-required error must surface 'clawctl agent audit <name>'
+    as a discoverable alternative."""
+    result = runner.invoke(app, ["audit", "show"])
+    assert result.exit_code == 2
+    assert "clawctl agent audit" in result.output
+
+
+def test_scope_required_error_uses_emit_error_format(audit_home: Path) -> None:
+    """W4: errors must route through emit_error (Error: <msg> + Hint: ...)."""
+    result = runner.invoke(app, ["audit", "show"])
+    assert result.exit_code == 2
+    assert "Error:" in result.output
+    assert "Hint:" in result.output
+
+
+def test_format_entry_strips_bidi_from_agent_name(audit_home: Path) -> None:
+    """B2: agent_name must be sanitized before terminal emission so a
+    smuggled bidi codepoint cannot reverse-render the row."""
+    audit_home.mkdir(parents=True, exist_ok=True)
+    smuggled = {
+        "type": "clawctl_command",
+        "uuid": "00000000-0000-4000-8000-000000000aaa",
+        "parent_uuid": None,
+        "session_id": None,
+        # U+202E RIGHT-TO-LEFT OVERRIDE smuggled into the agent name.
+        "agent_name": "wolf‮i",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "cwd": "/tmp",
+        "version": {"audit": "1", "clawctl": "0.0.0"},
+        "actor": "agent",
+        "action": "clawctl agent sync wolf-i",
+        "result": "success",
+        "notes": "",
+    }
+    log_file = audit_home / "20260101.jsonl"
+    log_file.write_text(json.dumps(smuggled, ensure_ascii=False) + "\n")
+
+    result = runner.invoke(app, ["audit", "show", "--all"])
+    assert result.exit_code == 0
+    # The raw bidi codepoint must NOT appear in formatted output.
+    assert "‮" not in result.output
+
+
+def test_format_entry_strips_bidi_via_agent_audit_facade(audit_home: Path) -> None:
+    """B2: the `clawctl agent audit <name>` facade must also sanitize."""
+    audit_home.mkdir(parents=True, exist_ok=True)
+    smuggled = {
+        "type": "clawctl_command",
+        "uuid": "00000000-0000-4000-8000-000000000bbb",
+        "parent_uuid": None,
+        "session_id": None,
+        "agent_name": "wolf-i",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "cwd": "/tmp",
+        "version": {"audit": "1", "clawctl": "0.0.0"},
+        "actor": "agent",
+        # Bidi smuggled into the action field instead.
+        "action": "clawctl agent sync wolf‮i",
+        "result": "success",
+        "notes": "trust‮me",
+    }
+    log_file = audit_home / "20260101.jsonl"
+    log_file.write_text(json.dumps(smuggled, ensure_ascii=False) + "\n")
+
+    result = runner.invoke(app, ["agent", "audit", "wolf-i"])
+    assert result.exit_code == 0
+    assert "‮" not in result.output
+
+
+def test_show_agent_filters_out_legacy_entries(audit_home: Path) -> None:
+    """An entry with no agent_name MUST NOT match --agent <name>."""
+    _seed(
+        audit_home,
+        ["audit", "log", "legacy op", "--result", "success"],
+        ["audit", "log", "scoped op", "--result", "success", "--agent", "wolf-i"],
+    )
+    result = runner.invoke(app, ["audit", "show", "--agent", "wolf-i", "--json"])
+    assert result.exit_code == 0
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    actions = [json.loads(ln)["action"] for ln in lines]
+    assert actions == ["scoped op"]
+
+
+def test_show_all_surfaces_legacy_entries(audit_home: Path) -> None:
+    """--all is the only way to see entries that pre-date the agent_name field."""
+    _seed(
+        audit_home,
+        ["audit", "log", "legacy op", "--result", "success"],
+        ["audit", "log", "scoped op", "--result", "success", "--agent", "wolf-i"],
+    )
+    result = runner.invoke(app, ["audit", "show", "--all", "--json"])
+    assert result.exit_code == 0
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    actions = sorted(json.loads(ln)["action"] for ln in lines)
+    assert actions == ["legacy op", "scoped op"]
+
+
+def test_format_includes_agent_column_when_present(audit_home: Path) -> None:
+    _seed(
+        audit_home,
+        ["audit", "log", "scoped op", "--result", "success", "--agent", "wolf-i"],
+    )
+    result = runner.invoke(app, ["audit", "show", "--all"])
+    assert result.exit_code == 0
+    assert "(wolf-i)" in result.output
+
+
+def test_format_omits_agent_column_when_absent(audit_home: Path) -> None:
+    _seed(
+        audit_home,
+        ["audit", "log", "legacy op", "--result", "success"],
+    )
+    result = runner.invoke(app, ["audit", "show", "--all"])
+    assert result.exit_code == 0
+    # No parenthesised agent block should appear in the line — tighter
+    # than the previous "before success" check.
+    assert "(wolf-i)" not in result.output
+    assert "(" not in result.output
+
+
+def test_format_truncates_long_agent_name(audit_home: Path) -> None:
+    """Iter-2 W4 + iter-3 W3: agent names exceeding AGENT_COL_WIDTH-2 must
+    be ellipsis-truncated AND the slot must stay exactly AGENT_COL_WIDTH
+    chars wide so column alignment survives."""
+    from clawrium.cli.clawctl.audit import AGENT_COL_WIDTH
+
+    long_name = "a" * (AGENT_COL_WIDTH * 2)  # well past the slot
+    _seed(
+        audit_home,
+        ["audit", "log", "op-long", "--result", "success", "--agent", long_name],
+        # Seed a short-name row to establish the canonical column offset.
+        ["audit", "log", "op-short", "--result", "success", "--agent", "wolf-i"],
+    )
+    result = runner.invoke(app, ["audit", "show", "--all"])
+    assert result.exit_code == 0
+    # The ellipsis marker is present and the full name is not.
+    assert "…" in result.output
+    assert long_name not in result.output
+    # Iter-3 W3: the result column lands at the same offset for both
+    # rows — locks in the .ljust(AGENT_COL_WIDTH) padding contract.
+    long_line = next(ln for ln in result.output.splitlines() if "op-long" in ln)
+    short_line = next(ln for ln in result.output.splitlines() if "op-short" in ln)
+    assert long_line.index("success") == short_line.index("success")
+
+
+def test_format_mixed_listing_aligns_result_column(audit_home: Path) -> None:
+    """Iter-2 W4: scoped and unscoped rows must place 'success' at the
+    same column offset so listings stay vertically aligned."""
+    _seed(
+        audit_home,
+        ["audit", "log", "legacy op", "--result", "success"],
+        ["audit", "log", "scoped op", "--result", "success", "--agent", "wolf-i"],
+    )
+    result = runner.invoke(app, ["audit", "show", "--all"])
+    assert result.exit_code == 0
+    lines = [ln for ln in result.output.splitlines() if "success" in ln]
+    assert len(lines) == 2
+    # Both lines should have 'success' at the same index — the
+    # AGENT_COL_WIDTH padding contract is what makes this true.
+    offsets = {ln.index("success") for ln in lines}
+    assert len(offsets) == 1, f"misaligned result column: {offsets}"
+
+
+def test_stats_by_agent_breakdown(audit_home: Path) -> None:
+    _seed(
+        audit_home,
+        ["audit", "log", "op1", "--result", "success", "--agent", "wolf-i"],
+        ["audit", "log", "op2", "--result", "success", "--agent", "wolf-i"],
+        ["audit", "log", "op3", "--result", "success", "--agent", "kevin"],
+        ["audit", "log", "op4", "--result", "success"],
+    )
+    result = runner.invoke(app, ["audit", "stats", "--all"])
+    assert result.exit_code == 0
+    out = result.output
+    assert "By agent:" in out
+    assert "'wolf-i': 2" in out
+    assert "'kevin': 1" in out
+    assert "'(unscoped)': 1" in out
+
+
+def test_stats_agent_scopes_counts(audit_home: Path) -> None:
+    _seed(
+        audit_home,
+        ["audit", "log", "op1", "--result", "success", "--agent", "wolf-i"],
+        ["audit", "log", "op2", "--result", "failure", "--agent", "wolf-i"],
+        ["audit", "log", "op3", "--result", "success", "--agent", "kevin"],
+        # Iter-2 W9: include an unscoped entry to confirm it doesn't leak.
+        ["audit", "log", "legacy op", "--result", "success"],
+    )
+    result = runner.invoke(app, ["audit", "stats", "--agent", "wolf-i"])
+    assert result.exit_code == 0
+    out = result.output
+    assert "Total entries:     2" in out
+    assert "'success': 1" in out and "'failure': 1" in out
+    assert "'kevin'" not in out
+    # Iter-2 W9: legacy/unscoped rows must not contaminate scoped stats.
+    assert "(unscoped)" not in out
+
+
+@pytest.mark.parametrize(
+    "field,value,marker",
+    [
+        # Iter-3 W2: every Counter key and Top-N verb must strip bidi
+        # before terminal emission.
+        ("actor", "agent‮x", "‮"),
+        ("result", "success‮x", "‮"),
+        ("action", "clawctl agent sync‮x wolf", "‮"),
+    ],
+)
+def test_stats_sanitizes_all_counter_paths(
+    audit_home: Path, field: str, value: str, marker: str,
+) -> None:
+    """Iter-3 W1+W2: every Counter key (actor/result/verb/agent) and
+    the Top-N verb emission must strip smuggled bidi codepoints."""
+    audit_home.mkdir(parents=True, exist_ok=True)
+    row = {
+        "type": "clawctl_command",
+        "uuid": "00000000-0000-4000-8000-000000000111",
+        "parent_uuid": None,
+        "session_id": None,
+        "agent_name": None,
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "cwd": "/tmp",
+        "version": {"audit": "1", "clawctl": "0.0.0"},
+        "actor": "agent",
+        "action": "op",
+        "result": "success",
+        "notes": "",
+    }
+    row[field] = value
+    log_file = audit_home / "20260101.jsonl"
+    log_file.write_text(json.dumps(row, ensure_ascii=False) + "\n")
+
+    result = runner.invoke(app, ["audit", "stats", "--all"])
+    assert result.exit_code == 0
+    assert marker not in result.output
+
+
+def test_stats_by_agent_sanitizes_smuggled_bidi(audit_home: Path) -> None:
+    """Iter-2 B1: agent_name carries to the stats `By agent:` line via
+    Counter; bidi codepoints must be stripped before terminal emission."""
+    audit_home.mkdir(parents=True, exist_ok=True)
+    smuggled = {
+        "type": "clawctl_command",
+        "uuid": "00000000-0000-4000-8000-000000000ccc",
+        "parent_uuid": None,
+        "session_id": None,
+        # U+202E smuggled into agent_name (\u escape for source hygiene).
+        "agent_name": "wolf‮i",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "cwd": "/tmp",
+        "version": {"audit": "1", "clawctl": "0.0.0"},
+        "actor": "agent",
+        "action": "op",
+        "result": "success",
+        "notes": "",
+    }
+    log_file = audit_home / "20260101.jsonl"
+    log_file.write_text(json.dumps(smuggled, ensure_ascii=False) + "\n")
+
+    result = runner.invoke(app, ["audit", "stats", "--all"])
+    assert result.exit_code == 0
+    assert "By agent:" in result.output
+    # The raw bidi codepoint must NOT appear anywhere in the stats output.
+    assert "‮" not in result.output
+
+
+def test_json_path_escapes_smuggled_bidi(audit_home: Path) -> None:
+    """Iter-2 W3: --json paths must use ensure_ascii=True so bidi codepoints
+    escape to \\uXXXX rather than passing through to the terminal."""
+    audit_home.mkdir(parents=True, exist_ok=True)
+    smuggled = {
+        "type": "clawctl_command",
+        "uuid": "00000000-0000-4000-8000-000000000ddd",
+        "parent_uuid": None,
+        "session_id": None,
+        "agent_name": "wolf-i",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "cwd": "/tmp",
+        "version": {"audit": "1", "clawctl": "0.0.0"},
+        "actor": "agent",
+        "action": "op‮-smuggled",
+        "result": "success",
+        "notes": "",
+    }
+    log_file = audit_home / "20260101.jsonl"
+    log_file.write_text(json.dumps(smuggled, ensure_ascii=False) + "\n")
+
+    result = runner.invoke(app, ["audit", "show", "--all", "--json"])
+    assert result.exit_code == 0
+    # Raw bidi codepoint stripped; \uXXXX escape present instead.
+    assert "‮" not in result.output
+    assert "\\u202e" in result.output
+    # JSON still parses round-trip back to the original codepoint.
+    parsed = json.loads(result.output.strip().splitlines()[0])
+    assert parsed["action"] == "op‮-smuggled"
+
+
+def test_agent_audit_json_path_escapes_smuggled_bidi(audit_home: Path) -> None:
+    """Iter-2 W3: same contract for the per-agent facade's --json output."""
+    audit_home.mkdir(parents=True, exist_ok=True)
+    smuggled = {
+        "type": "clawctl_command",
+        "uuid": "00000000-0000-4000-8000-000000000eee",
+        "parent_uuid": None,
+        "session_id": None,
+        "agent_name": "wolf-i",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "cwd": "/tmp",
+        "version": {"audit": "1", "clawctl": "0.0.0"},
+        "actor": "agent",
+        "action": "op‮-smuggled",
+        "result": "success",
+        "notes": "",
+    }
+    log_file = audit_home / "20260101.jsonl"
+    log_file.write_text(json.dumps(smuggled, ensure_ascii=False) + "\n")
+
+    result = runner.invoke(app, ["agent", "audit", "wolf-i", "--json"])
+    assert result.exit_code == 0
+    assert "‮" not in result.output
+    assert "\\u202e" in result.output
+
+
+@pytest.mark.parametrize("verb", ["show", "tail", "stats"])
+def test_scope_required_error_uses_emit_error_across_all_verbs(
+    audit_home: Path, verb: str,
+) -> None:
+    """Iter-3 W4: every read verb routes scope-required errors through
+    emit_error (Error: + Hint:). A regression bypassing emit_error for
+    tail or stats (reverting to raw typer.echo) is caught here."""
+    result = runner.invoke(app, ["audit", verb])
+    assert result.exit_code == 2
+    assert "Error:" in result.output
+    assert "Hint:" in result.output
+    assert "--agent" in result.output
+    assert "--all" in result.output
+    assert "clawctl agent audit" in result.output
+
+
+def test_tail_requires_scope(audit_home: Path) -> None:
+    result = runner.invoke(app, ["audit", "tail"])
+    assert result.exit_code == 2
+    assert "--agent" in result.output and "--all" in result.output
+
+
+def test_stats_requires_scope(audit_home: Path) -> None:
+    result = runner.invoke(app, ["audit", "stats"])
+    assert result.exit_code == 2
+    assert "--agent" in result.output and "--all" in result.output
+
+
+def test_show_rejects_invalid_actor(audit_home: Path) -> None:
+    """Iter-3 W5: show's --actor validation routes through emit_error."""
+    result = runner.invoke(app, ["audit", "show", "--all", "--actor", "bot"])
+    assert result.exit_code == 2
+    assert "--actor must be one of" in result.output
+    assert "Error:" in result.output
+
+
+def test_show_rejects_invalid_result(audit_home: Path) -> None:
+    """Iter-3 W5: show's --result validation routes through emit_error."""
+    result = runner.invoke(app, ["audit", "show", "--all", "--result", "bogus"])
+    assert result.exit_code == 2
+    assert "--result must be one of" in result.output
+    assert "Error:" in result.output
+
+
+def test_show_invalid_grep_regex_exits_with_emit_error(audit_home: Path) -> None:
+    """Iter-4: a malformed --grep regex must surface a clean error,
+    not a Python traceback. re.error wrapped in emit_error."""
+    result = runner.invoke(app, ["audit", "show", "--all", "--grep", "["])
+    assert result.exit_code == 2
+    assert "invalid --grep regex" in result.output
+    assert "Error:" in result.output
+    assert "Hint:" in result.output
+
+
+def test_show_invalid_date_format_exits_with_emit_error(audit_home: Path) -> None:
+    """Iter-4: --date must match ^\\d{8}$ to prevent typos producing
+    silently-empty results and to keep the interpolated log path bounded."""
+    result = runner.invoke(app, ["audit", "show", "--all", "--date", "2026-06-21"])
+    assert result.exit_code == 2
+    assert "--date must be 8 digits" in result.output
+    assert "Error:" in result.output
+
+
+def test_agent_audit_invalid_date_format_exits_with_emit_error(audit_home: Path) -> None:
+    """Iter-4: same --date validation on the agent-scoped facade.
+    Iter-5: also assert Error:/Hint: format for parity with the
+    top-level test."""
+    result = runner.invoke(app, ["agent", "audit", "wolf-i", "--date", "bad"])
+    assert result.exit_code == 2
+    assert "--date must be 8 digits" in result.output
+    assert "Error:" in result.output
+    assert "Hint:" in result.output
+
+
+def test_show_valid_date_actually_filters_by_day(audit_home: Path) -> None:
+    """Iter-4 introduced --date format validation; iter-5 W1 hardens
+    this test to also prove the date actually filters the result.
+    Seed entries across two days and assert --date selects the right
+    one. (The previous empty-trail variant proved nothing about
+    filter behaviour — only that validation accepted the format.)"""
+    audit_home.mkdir(parents=True, exist_ok=True)
+
+    def _row(uid_suffix: str, action: str) -> dict:
+        return {
+            "type": "clawctl_command",
+            "uuid": f"00000000-0000-4000-8000-00000000{uid_suffix}",
+            "parent_uuid": None,
+            "session_id": None,
+            "agent_name": None,
+            "timestamp": "2026-01-01T00:00:00.000Z",
+            "cwd": "/tmp",
+            "version": {"audit": "1", "clawctl": "0.0.0"},
+            "actor": "user",
+            "action": action,
+            "result": "success",
+            "notes": "",
+        }
+
+    (audit_home / "20260101.jsonl").write_text(
+        json.dumps(_row("0a01", "day-1 op")) + "\n"
+    )
+    (audit_home / "20260202.jsonl").write_text(
+        json.dumps(_row("0a02", "day-2 op")) + "\n"
+    )
+
+    day1 = runner.invoke(
+        app, ["audit", "show", "--all", "--date", "20260101", "--json"]
+    )
+    assert day1.exit_code == 0
+    actions = [
+        json.loads(ln)["action"] for ln in day1.output.splitlines() if ln.strip()
+    ]
+    assert actions == ["day-1 op"]
+
+
+def test_show_valid_date_on_empty_day_returns_nothing(audit_home: Path) -> None:
+    """Iter-4: well-formed --date with no log file for that day is a
+    silent empty result, not an error."""
+    result = runner.invoke(app, ["audit", "show", "--all", "--date", "19990101"])
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+def test_format_tolerates_non_string_field_values(audit_home: Path) -> None:
+    """Iter-3 B2: a row with timestamp/actor/result/action as null or a
+    non-string scalar must NOT crash format_entry — degrade to '?'
+    placeholders and keep the rest of the trail readable."""
+    audit_home.mkdir(parents=True, exist_ok=True)
+    malformed = {
+        "type": "clawctl_command",
+        "uuid": "00000000-0000-4000-8000-000000000222",
+        "parent_uuid": None,
+        "session_id": None,
+        "agent_name": None,
+        # All four format-spec fields hostile to :24s/:5s/:7s/str interp.
+        "timestamp": None,
+        "cwd": "/tmp",
+        "version": {"audit": "1", "clawctl": "0.0.0"},
+        "actor": 5,
+        "action": None,
+        "result": ["nested"],
+        "notes": 42,
+    }
+    well_formed = {
+        "type": "clawctl_command",
+        "uuid": "00000000-0000-4000-8000-000000000333",
+        "parent_uuid": None,
+        "session_id": None,
+        "agent_name": "wolf-i",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "cwd": "/tmp",
+        "version": {"audit": "1", "clawctl": "0.0.0"},
+        "actor": "agent",
+        "action": "survivor",
+        "result": "success",
+        "notes": "",
+    }
+    log_file = audit_home / "20260101.jsonl"
+    log_file.write_text(
+        json.dumps(malformed) + "\n" + json.dumps(well_formed) + "\n"
+    )
+
+    # show must NOT crash on the malformed row — exit 0 and emit the
+    # well-formed row intact.
+    result = runner.invoke(app, ["audit", "show", "--all"])
+    assert result.exit_code == 0, result.output
+    assert "survivor" in result.output
+
+    # stats must not crash either (B2 also affects the date-bucket
+    # `ts[:10]` slice on a non-string timestamp).
+    stats_result = runner.invoke(app, ["audit", "stats", "--all"])
+    assert stats_result.exit_code == 0
+
+
+def test_iter_read_tolerates_missing_agent_field(audit_home: Path) -> None:
+    """Hand-write a pre-#780 row (no agent_name key) and confirm reads work."""
+    audit_home.mkdir(parents=True, exist_ok=True)
+    legacy = {
+        "type": "clawctl_command",
+        "uuid": "00000000-0000-4000-8000-000000000001",
+        "parent_uuid": None,
+        "session_id": None,
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "cwd": "/tmp",
+        "version": {"audit": "1", "clawctl": "0.0.0"},
+        "actor": "user",
+        "action": "legacy hand-written",
+        "result": "success",
+        "notes": "",
+    }
+    log_file = audit_home / "20260101.jsonl"
+    log_file.write_text(json.dumps(legacy) + "\n")
+
+    result = runner.invoke(app, ["audit", "show", "--all", "--json"])
+    assert result.exit_code == 0
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert parsed["action"] == "legacy hand-written"
+    # Round-trip stayed faithful: missing key passed through, not synthesised.
+    assert "agent_name" not in parsed
+
+
+def test_iter_read_tolerates_explicit_null_agent_field(audit_home: Path) -> None:
+    """Iter-2 W7: a row with ``"agent_name": null`` (vs the key being
+    absent) must be treated as unscoped — same filter behavior, same
+    stats bucket. Distinct case from `test_iter_read_tolerates_missing_agent_field`."""
+    audit_home.mkdir(parents=True, exist_ok=True)
+    null_field = {
+        "type": "clawctl_command",
+        "uuid": "00000000-0000-4000-8000-000000000fff",
+        "parent_uuid": None,
+        "session_id": None,
+        "agent_name": None,
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "cwd": "/tmp",
+        "version": {"audit": "1", "clawctl": "0.0.0"},
+        "actor": "user",
+        "action": "explicit-null row",
+        "result": "success",
+        "notes": "",
+    }
+    log_file = audit_home / "20260101.jsonl"
+    log_file.write_text(json.dumps(null_field) + "\n")
+
+    # Filter behaviour: --agent <name> must NOT match an explicit-null row.
+    scoped = runner.invoke(app, ["audit", "show", "--agent", "anyone", "--json"])
+    assert scoped.exit_code == 0
+    assert scoped.output.strip() == ""
+
+    # --all surfaces it.
+    all_view = runner.invoke(app, ["audit", "show", "--all", "--json"])
+    assert all_view.exit_code == 0
+    assert "explicit-null row" in all_view.output
+
+    # Stats: bucketed under the same "(unscoped)" label as missing-key rows.
+    stats_view = runner.invoke(app, ["audit", "stats", "--all"])
+    assert stats_view.exit_code == 0
+    assert "(unscoped)" in stats_view.output
+
+
+def test_show_all_on_empty_trail_prints_nothing(audit_home: Path) -> None:
+    """Iter-2 W8: empty trail under --all is silent success."""
+    result = runner.invoke(app, ["audit", "show", "--all"])
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+def test_show_agent_on_empty_trail_prints_nothing(audit_home: Path) -> None:
+    """Iter-2 W8: empty trail under --agent <name> is silent success."""
+    result = runner.invoke(app, ["audit", "show", "--agent", "wolf-i"])
     assert result.exit_code == 0
     assert result.output.strip() == ""
 
@@ -299,7 +944,7 @@ def test_iter_entries_skips_malformed_lines(audit_home: Path) -> None:
     raw = log_file.read_text().splitlines()
     log_file.write_text(raw[0] + "\n" + "{not-json\n" + raw[1] + "\n")
 
-    result = runner.invoke(app, ["audit", "show", "--json"])
+    result = runner.invoke(app, ["audit", "show", "--all", "--json"])
     assert result.exit_code == 0
     actions = [json.loads(ln)["action"] for ln in result.output.splitlines() if ln.strip()]
     assert actions == ["good1", "good2"]


### PR DESCRIPTION
## Summary

- Adds `clawctl agent audit <name>` — a new read-only command that scopes the audit trail to a single agent. Permissive name handling (the trail outlives the agent); a soft stderr note flags typos when an empty result lands on an unregistered name.
- Adds `agent_name` to the schema-v1 entry as an additive field; `clawctl audit log` accepts `--agent <name>` to populate it. Pre-#780 rows keep parsing — they read as unscoped and only appear under `--all`.
- BREAKING: `clawctl audit show`, `audit tail`, `audit stats` now require either `--agent <name>` or `--all` (mutually exclusive). Exits 2 with `Error:` + `Hint:` otherwise. Migration path documented in `CHANGELOG.md`.
- Hardens the read paths: `format_entry` sanitizes the whole rendered line, coerces non-string fields via `str(... or '?')`; stats Counter keys (`actor`/`result`/`verb`/`agent_name`) sanitize at insertion; `--json` paths use `ensure_ascii=True`; fixed-width agent column keeps mixed listings aligned.
- `--grep` wraps `re.compile` in `try/except re.error` → clean exit 2. `--date` validates `^[0-9]{8}$`.

## Testing

- 73 audit tests (was 37). Coverage includes: schema round-trip with/without agent, `--agent` filter excludes legacy rows, `--all` migration path, scope-required errors across all three verbs, mutex contract, column alignment + ellipsis truncation, bidi sanitization across format_entry / stats counters / `--json`, non-string row tolerance, `--grep` and `--date` validation, soft-notice behavior with registered vs unregistered names.
- ` make lint` clean. \`make test\` shows 3847 passed (3 pre-existing demo-asset failures on this branch are unrelated to #780 — `docs/demos/lib/compile.py` `KeyError: 'command'`).

## ATX Review Summary

**Final Review: Rating 4/5 — Merge-ready, no blockers**
**Total Cost: \$17.21 | Total Time: 38m 26s**

| Review | Rating | Blocking Issues | Status | Cost | Time |
|--------|--------|-----------------|--------|------|------|
| 1 | 2/5 | B1 (CHANGELOG), B2 (bidi sanitize) | All fixed | \$3.80 | 9m 45s |
| 2 | 3/5 | B1 (stats By-agent sanitize) | All fixed | \$2.68 | 5m 40s |
| 3 | 3/5 | B1 (verb_count sanitize), B2 (format_entry non-string) | All fixed | \$2.89 | 8m 11s |
| 4 | 4/5 | None | Ready | \$2.63 | 5m 9s |
| 5 | 4/5 | None | Ready | \$2.44 | 4m 40s |
| 6 | 4/5 | None | Ready | \$2.77 | 5m 1s |

> ATX does not expose model information per agent.

<details>
<summary>Review 1 (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `CHANGELOG.md` | Undocumented breaking change (audit show/tail/stats exit 2) | Fixed — `### BREAKING` entry under `[Unreleased]` covers all three verbs, exit code, both migration paths, no automated migration |
| B2 | `src/clawrium/cli/clawctl/audit.py:format_entry` | `agent_name` rendered without bidi sanitization | Fixed — interpolated through `sanitize()`; two regression tests (`test_format_entry_strips_bidi_from_agent_name`, `test_format_entry_strips_bidi_via_agent_audit_facade`) |

**Warnings (all fixed):** tail/stats mutex test gaps (W1), `audit tail --agent` filter test missing (W2), `clawctl agent audit <name>` flag-rejection tests missing (W3), errors using bare `typer.echo` instead of `emit_error` (W4), scope-required error doesn't mention `clawctl agent audit <name>` (W5), fixed-width agent column for alignment (W6), private symbols cross-imported (W7), schema additive boundary undocumented (W8).
</details>

<details>
<summary>Review 2 (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `src/clawrium/cli/clawctl/audit.py:stats` | `By agent:` Counter inserted unsanitized — bidi gap | Fixed — `agent_count[sanitize(...)]` at insertion; `test_stats_by_agent_sanitizes_smuggled_bidi` |

**Warnings (all fixed):** session_id slice (W1) and timestamp/actor/result (W2) not sanitized in `format_entry`; `--json` used `ensure_ascii=False` (W3); AGENT_COL_WIDTH untested (W4); mutex errors lacked `hint=` (W5); explicit-null vs missing-key untested (W7); empty-trail variants untested under new scope regime (W8); scoped stats didn't assert `(unscoped)` absence (W9).
</details>

<details>
<summary>Review 3 (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `src/clawrium/cli/clawctl/audit.py:stats` | Top-N `verb_count` loop emitted unsanitized | Fixed — `verb_count[sanitize(action_verb(...))] += 1`; parametrized `test_stats_sanitizes_all_counter_paths` covers actor / result / action |
| B2 | `src/clawrium/cli/clawctl/audit.py:format_entry` | `:24s`/`:5s`/`:7s` crashes on non-string disk values | Fixed — every field coerced via `str(... or '?')`; `isinstance(ts, str)` guard on stats date bucket; `test_format_tolerates_non_string_field_values` |

**Warnings (all fixed):** actor/result Counter keys missed in iter-2 sweep (W1); bidi tests didn't cover actor/result/action stats paths (W2); truncation test didn't lock in slot width (W3); tail/stats scope-required tests lacked `Error:`/`Hint:` (W4); `show` `--actor`/`--result` validation untested (W5).
</details>

<details>
<summary>Review 4 (Rating 4/5) — merge-ready</summary>

All iter-3 blockers and warnings cleared. Two non-blocking security warnings flagged for clean 5/5 — both addressed: `--grep re.error` wrapped in `try/except` → `emit_error`; `--date` validated against `^[0-9]{8}$`.
</details>

<details>
<summary>Review 5 (Rating 4/5)</summary>

All iter-4 warnings confirmed cleared. One convention warning (CHANGELOG `### Fixed` entries missing for `--grep` and `--date` changes) plus 6 polish items addressed: `_DATE_FORMAT_RE` tightened to `[0-9]{8}`; defensive `raise typer.Exit(2)` after the `re.error` `emit_error`; `_require_scope` runs before `validate_date` in `show()`; `_validate_date` promoted to public `validate_date` in `__all__`; facade date test asserts `Error:`/`Hint:`; valid-date test now seeds two dated files and asserts bidirectional filter; new `test_agent_audit_invalid_grep_regex_exits_with_emit_error`.
</details>

<details>
<summary>Review 6 (Rating 4/5)</summary>

All iter-5 items cleared. One product-design warning: `clawctl agent audit <name>` skips `safe_resolve_agent`. Deliberate — the audit trail outlives the agent. Resolved by emitting a one-line stderr notice when result is empty AND name is not in `hosts.json`; exit code stays 0. Tests cover registered vs unregistered, hosts.json missing, and notice suppression when rows match. Iter-6 CLI-UX S1 also addressed: `--actor`/`--result` errors carry `hint=` on both surfaces.
</details>

Closes #780

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>