### PR TITLE
fix(tests): skip Playwright demos in VHS compile pipeline tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,16 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Fixed
 
+- **`tests/test_demo_assets.py` no longer fails on Playwright demos.**
+  Three `TestCompilePipeline` parametrize blocks unconditionally invoked
+  the VHS-only `docs/demos/lib/compile.py` against every
+  `docs/demos/*/scenes.yaml`, including browser-style specs (e.g.
+  `20260621-clawrium-gui-walkthrough`) that have `actions:` instead of
+  `command:`. Those specs are compiled by `pw_compile.py`; feeding them to
+  `compile.py` raised `KeyError: 'command'`. The parametrize lists now
+  consult a `_committed_vhs_demos()` helper that skips any demo whose
+  `scenes.yaml` declares `tape.base_url` (the Playwright discriminator).
+
 - **`clawctl audit show --grep <pattern>` no longer raises a Python
   traceback** when the pattern is not a valid regex (#780). A
   malformed pattern (e.g. `--grep '['`) now exits 2 with

--- a/tests/test_demo_assets.py
+++ b/tests/test_demo_assets.py
@@ -173,6 +173,25 @@ def _load_module(path: Path, name: str):
         raise
 
 
+def _committed_vhs_demos() -> list[Path]:
+    # Playwright demos (tape.base_url set) are compiled by pw_compile.py and
+    # do not share compile.py's `command:` per-scene contract.
+    import yaml as _yaml
+    demos: list[Path] = []
+    for p in sorted(DEMOS_DIR.glob("*/")):
+        scenes = p / "scenes.yaml"
+        if not scenes.exists():
+            continue
+        try:
+            spec = _yaml.safe_load(scenes.read_text()) or {}
+        except Exception:
+            continue
+        if (spec.get("tape") or {}).get("base_url"):
+            continue
+        demos.append(p)
+    return demos
+
+
 class TestCompilePipeline:
     @pytest.fixture
     def compile_mod(self):
@@ -484,11 +503,7 @@ class TestCompilePipeline:
     # --- timing safety: no narration audio bleeds across boundaries ---------- #
     @pytest.mark.parametrize(
         "demo_dir",
-        [
-            pytest.param(p, id=p.name)
-            for p in sorted(DEMOS_DIR.glob("*/"))
-            if (p / "scenes.yaml").exists()
-        ],
+        [pytest.param(p, id=p.name) for p in _committed_vhs_demos()],
     )
     def test_no_narration_overlap_committed(
         self, compile_mod, demo_dir: Path, tmp_path: Path
@@ -537,11 +552,7 @@ class TestCompilePipeline:
     # --- W6: every committed scenes.yaml's output_file must exist on disk --- #
     @pytest.mark.parametrize(
         "demo_dir",
-        [
-            pytest.param(p, id=p.name)
-            for p in sorted(DEMOS_DIR.glob("*/"))
-            if (p / "scenes.yaml").exists()
-        ],
+        [pytest.param(p, id=p.name) for p in _committed_vhs_demos()],
     )
     def test_committed_demo_output_files_exist(self, demo_dir: Path) -> None:
         """Every `output_file:` referenced in a committed scenes.yaml must
@@ -580,11 +591,7 @@ class TestCompilePipeline:
     # --- W4 round-trip over the real committed demo --------------------------- #
     @pytest.mark.parametrize(
         "demo_dir",
-        [
-            pytest.param(p, id=p.name)
-            for p in sorted(DEMOS_DIR.glob("*/"))
-            if (p / "scenes.yaml").exists()
-        ],
+        [pytest.param(p, id=p.name) for p in _committed_vhs_demos()],
     )
     def test_committed_demos_compile_cleanly(
         self, compile_mod, demo_dir: Path, tmp_path: Path


### PR DESCRIPTION
## Summary
- `make test` on `main` currently fails with `KeyError: 'command'` in three `TestCompilePipeline` parametrize blocks, blocking the next release cut (`/itx-release`).
- Root cause: those tests iterate over every `docs/demos/*/scenes.yaml` and feed them all to the VHS-only `docs/demos/lib/compile.py`. PR #782 committed `docs/demos/20260621-clawrium-gui-walkthrough/`, a browser-style demo whose scenes carry `actions:` (no `command:`) and are compiled by `pw_compile.py`.
- Add `_committed_vhs_demos()` helper that excludes demos whose `scenes.yaml` sets `tape.base_url` (the Playwright discriminator), and route all three parametrize blocks through it. Equivalent coverage for the Playwright pipeline is out of scope here.

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — 3847 py + 289 GUI, 2 skipped
- [x] Linter passes (`make lint`)
- [x] No new tests added (this is a parametrize-filter fix, not new logic)

### Test Coverage
- Files changed: `tests/test_demo_assets.py`, `CHANGELOG.md`
- New tests: N/A
- Coverage impact: maintained

### Manual Testing
Before: `pytest tests/test_demo_assets.py` reported 3 failures, all on the `20260621-clawrium-gui-walkthrough` demo:
- `test_no_narration_overlap_committed`
- `test_committed_demo_output_files_exist`
- `test_committed_demos_compile_cleanly`

After: 43 passed.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — test-only code; reads committed YAML
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources — uses already-imported `pyyaml`

## Reviewer Notes
The Playwright demo pipeline (`docs/demos/lib/pw_compile.py`) currently has no equivalent compile-time regression tests. Adding parallel `TestPwCompilePipeline` coverage is a worthwhile follow-up but intentionally not part of this fix — the goal here is to unblock `main` and the release cut.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)