### PR TITLE
blog: v26.6.5 release notes

### DIFF
--- a/website/blog/2026-06-22-v26.6.5-release.md
+++ b/website/blog/2026-06-22-v26.6.5-release.md
@@ -8,31 +8,29 @@ date: 2026-06-22
 
 ## What changed
 
-A new /create-playwright skill has been added for recording browser-session demos with Playwright, mirroring the /create-vhs workflow. The first demo is a 75-second walkthrough of the clawctl gui dashboard, embedded in the README and on the website's Web Dashboard guide and Introduction page.
+### New /create-playwright skill for browser-session demos
 
-A new agent-scoped audit trail has been introduced with the `clawctl agent audit <name>` command, which filters audit output to a specific agent's entries. Legacy rows (without the `agent_name` field) are only visible via the `--all` flag in the unscoped global view.
+A new /create-playwright skill has been added for recording browser-session demos with Playwright, mirroring the /create-vhs workflow. The first demo is a 75-second walkthrough of the clawctl gui dashboard, embedded in the README and on the website's Web Dashboard guide and Introduction page. This enables users to create high-fidelity browser-based demos for training, documentation, and quality assurance, improving the user experience and reducing the need for manual video recording.
 
-Workspace overlay sync has been implemented for openclaw, zeroclaw, and hermes agents on Ubuntu. Files in `~/.config/clawrium/agents/<type>/<name>/workspace/` are now mirrored to the agent host on every `clawctl agent sync` and `clawctl agent configure` with per-type destination roots and exclude lists to prevent overwriting daemon-managed files.
+### Agent-scoped audit trail
 
-The Brave Search API integration has been added as a new `brave` integration type, with automatic plugin installation and version preflight checks. The `clawctl integration registry create` command now supports `--type brave` to register API keys, and `clawctl integration rotate` can rotate credentials and re-sync bound agents.
+A new agent-scoped audit trail has been introduced with the `clawctl agent audit <name>` command, which filters audit output to a specific agent's entries. Legacy rows (without the `agent_name` field) are only visible via the `--all` flag in the unscoped global view. This provides better security and compliance by allowing operators to focus on a specific agent's activity without being overwhelmed by global audit data, while still maintaining the ability to view all historical data with the `--all` flag.
 
-OpenCode inference provider support has been added with new `--type opencode` and `--type opencode-go` options for `clawctl provider registry create` to support both hosted gateways and renderer wiring for hermes, zeroclaw, and openclaw agents.
+### Workspace overlay sync
 
-The `clawctl agent shell <name> -- <cmd>` command has been added to run arbitrary commands on the host as the agent user in a full login shell with all environment variables loaded, including `~/.bash_profile`, `~/.profile`, and `~/.bashrc`.
+Workspace overlay sync has been implemented for openclaw, zeroclaw, and hermes agents on Ubuntu. Files in `~/.config/clawrium/agents/<type>/<name>/workspace/` are now mirrored to the agent host on every `clawctl agent sync` and `clawctl agent configure` with per-type destination roots and exclude lists to prevent overwriting daemon-managed files. This enables operators to manage agent configuration and state more effectively by allowing them to push custom files to agent hosts without requiring a full agent reinstallation, while the exclude lists prevent conflicts with daemon-managed files.
 
-## Why
+### Brave Search API integration
 
-The new /create-playwright skill enables users to create high-fidelity browser-based demos for training, documentation, and quality assurance, improving the user experience and reducing the need for manual video recording.
+The Brave Search API integration has been added as a new `brave` integration type, with automatic plugin installation and version preflight checks. The `clawctl integration registry create` command now supports `--type brave` to register API keys, and `clawctl integration rotate` can rotate credentials and re-sync bound agents. This provides a more accurate and up-to-date search experience for agents, with better support for current web content compared to the default DuckDuckGo provider.
 
-The agent-scoped audit trail provides better security and compliance by allowing operators to focus on a specific agent's activity without being overwhelmed by global audit data, while still maintaining the ability to view all historical data with the `--all` flag.
+### OpenCode inference provider support
 
-Workspace overlay sync enables operators to manage agent configuration and state more effectively by allowing them to push custom files to agent hosts without requiring a full agent reinstallation, while the exclude lists prevent conflicts with daemon-managed files.
+OpenCode inference provider support has been added with new `--type opencode` and `--type opencode-go` options for `clawctl provider registry create` to support both hosted gateways and renderer wiring for hermes, zeroclaw, and openclaw agents. This expands the range of available LLMs for agents, giving users more choice in their inference providers and enabling better performance and cost optimization.
 
-The Brave Search API integration provides a more accurate and up-to-date search experience for agents, with better support for current web content compared to the default DuckDuckGo provider.
+### Agent shell command
 
-OpenCode inference provider support expands the range of available LLMs for agents, giving users more choice in their inference providers and enabling better performance and cost optimization.
-
-The agent shell command provides a powerful tool for debugging and maintenance, allowing operators to run arbitrary commands on agent hosts with full access to the agent's environment, which is essential for troubleshooting and system administration.
+The `clawctl agent shell <name> -- <cmd>` command has been added to run arbitrary commands on the host as the agent user in a full login shell with all environment variables loaded, including `~/.bash_profile`, `~/.profile`, and `~/.bashrc`. This provides a powerful tool for debugging and maintenance, allowing operators to run arbitrary commands on agent hosts with full access to the agent's environment, which is essential for troubleshooting and system administration.
 
 ## Try it
 

--- a/website/blog/2026-06-22-v26.6.5-release.md
+++ b/website/blog/2026-06-22-v26.6.5-release.md
@@ -1,0 +1,48 @@
+---
+slug: v26.6.5-release
+title: "What's new in clawrium v26.6.5"
+authors: [maurice]
+tags: [release-notes]
+date: 2026-06-22
+---
+
+## What changed
+
+A new /create-playwright skill has been added for recording browser-session demos with Playwright, mirroring the /create-vhs workflow. The first demo is a 75-second walkthrough of the clawctl gui dashboard, embedded in the README and on the website's Web Dashboard guide and Introduction page.
+
+A new agent-scoped audit trail has been introduced with the `clawctl agent audit <name>` command, which filters audit output to a specific agent's entries. Legacy rows (without the `agent_name` field) are only visible via the `--all` flag in the unscoped global view.
+
+Workspace overlay sync has been implemented for openclaw, zeroclaw, and hermes agents on Ubuntu. Files in `~/.config/clawrium/agents/<type>/<name>/workspace/` are now mirrored to the agent host on every `clawctl agent sync` and `clawctl agent configure` with per-type destination roots and exclude lists to prevent overwriting daemon-managed files.
+
+The Brave Search API integration has been added as a new `brave` integration type, with automatic plugin installation and version preflight checks. The `clawctl integration registry create` command now supports `--type brave` to register API keys, and `clawctl integration rotate` can rotate credentials and re-sync bound agents.
+
+OpenCode inference provider support has been added with new `--type opencode` and `--type opencode-go` options for `clawctl provider registry create` to support both hosted gateways and renderer wiring for hermes, zeroclaw, and openclaw agents.
+
+The `clawctl agent shell <name> -- <cmd>` command has been added to run arbitrary commands on the host as the agent user in a full login shell with all environment variables loaded, including `~/.bash_profile`, `~/.profile`, and `~/.bashrc`.
+
+## Why
+
+The new /create-playwright skill enables users to create high-fidelity browser-based demos for training, documentation, and quality assurance, improving the user experience and reducing the need for manual video recording.
+
+The agent-scoped audit trail provides better security and compliance by allowing operators to focus on a specific agent's activity without being overwhelmed by global audit data, while still maintaining the ability to view all historical data with the `--all` flag.
+
+Workspace overlay sync enables operators to manage agent configuration and state more effectively by allowing them to push custom files to agent hosts without requiring a full agent reinstallation, while the exclude lists prevent conflicts with daemon-managed files.
+
+The Brave Search API integration provides a more accurate and up-to-date search experience for agents, with better support for current web content compared to the default DuckDuckGo provider.
+
+OpenCode inference provider support expands the range of available LLMs for agents, giving users more choice in their inference providers and enabling better performance and cost optimization.
+
+The agent shell command provides a powerful tool for debugging and maintenance, allowing operators to run arbitrary commands on agent hosts with full access to the agent's environment, which is essential for troubleshooting and system administration.
+
+## Try it
+
+Upgrade to v26.6.5:
+
+```bash
+uv tool install clawrium@26.6.5
+```
+
+## Links
+
+- [GitHub Release](https://github.com/ric03uec/clawrium/releases/tag/v26.6.5)
+- [Full Changelog](https://github.com/ric03uec/clawrium/blob/main/docs/releases/26.6.5/CHANGELOG.md)


### PR DESCRIPTION
What's new in clawrium v26.6.5: New Playwright skill, agent-scoped audit trail, workspace overlay sync, Brave Search API integration, OpenCode inference provider support, and agent shell command.\n\nOpen for review — please do not auto-merge. GTM will address review comments on a 1-hour cadence.