### PR TITLE
feat(demos): scenes.yaml tape.output_format supports gif

### DIFF
--- a/.claude/skills/create-vhs/SKILL.md
+++ b/.claude/skills/create-vhs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-vhs
-description: Record a CLI demo (GIF or MP4) using VHS via a replay-first compile pipeline. Outputs are captured once on a live host, then a YAML spec drives both the tape and the ElevenLabs voiceover.
-argument-hint: "<scenario-name> [--description 'what to demo']"
+description: Record a clawrium CLI demo (MP4 or GIF) using VHS via the project's replay-first compile pipeline at docs/demos/lib/. Outputs are captured once on a live host, then scenes.yaml drives the tape, the recording, and (for MP4) the ElevenLabs voiceover. In the clawrium repo this skill shadows the global /global-create-vhs and should be used instead.
+argument-hint: "<scenario-slug> [--description 'what to demo']"
 ---
 
 # Demo Recording with VHS — replay-first pipeline
@@ -129,9 +129,14 @@ export PATH="${GOPATH:-$HOME/go}/bin:$PATH"
 vhs docs/demos/YYYYMMDD-<scenario-name>/tape.tape
 ```
 
-Output lands at `docs/demos/YYYYMMDD-<scenario-name>/recording.mp4`. Replay-first tapes run in roughly their on-screen duration (no live waits), so recording time ≈ recording duration.
+Output lands at `docs/demos/YYYYMMDD-<scenario-name>/recording.<ext>` — `.mp4` by default, `.gif` if `tape.output_format: gif` is set in `scenes.yaml`. Replay-first tapes run in roughly their on-screen duration (no live waits), so recording time ≈ recording duration.
 
 ### Step 6 — Layer narration (ElevenLabs)
+
+> **Skip this step for GIF demos.** GIF has no audio container, so the
+> narration beats in `scenes.yaml` are unused at render time. They still
+> drive `hold_seconds` extension during compile so on-screen pacing
+> matches the spoken cadence — keep them written.
 
 **One-time setup per machine:**
 

--- a/.claude/skills/create-vhs/templates/scenes.yaml.template
+++ b/.claude/skills/create-vhs/templates/scenes.yaml.template
@@ -23,6 +23,8 @@ tape:
   height: 900
   theme: Catppuccin Mocha
   typing_speed_ms: 50
+  # output_format: mp4   # mp4 (default) | gif. GIF skips the ElevenLabs
+  #                       narration step — GIFs have no audio container.
 
 # Hidden setup: runs in a VHS Hide block. Does NOT advance the recording's
 # visible timeline. Use for venv activation, source-of-truth state resets,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Added
 
+- `tape.output_format` key in `docs/demos/<demo>/scenes.yaml` — set to
+  `gif` to emit `recording.gif` from `vhs`; defaults to `mp4` (existing
+  behavior). GIF outputs skip the `narrate.py` step since GIF has no
+  audio container. The `/create-vhs` skill documents this in its
+  scenes.yaml template and Step 6 (narration).
+
 ### Changed
 
 ### Fixed

--- a/docs/demos/lib/compile.py
+++ b/docs/demos/lib/compile.py
@@ -217,6 +217,12 @@ def compile_demo(demo_dir: Path) -> tuple[Path, Path]:
     theme = tape_cfg.get("theme", DEFAULT_THEME)
     audio_cps = float(tape_cfg.get("audio_cps", DEFAULT_AUDIO_CPS))
     narration_buffer = float(tape_cfg.get("narration_buffer_seconds", DEFAULT_NARRATION_BUFFER))
+    output_format = str(tape_cfg.get("output_format", "mp4")).lower()
+    if output_format not in ("mp4", "gif"):
+        raise ValueError(
+            f"tape.output_format must be 'mp4' or 'gif', got {output_format!r}"
+        )
+    recording_filename = f"recording.{output_format}"
 
     # Stage 2 refinement: real durations from prior narrate.py run, if any.
     actual_durations = _load_actual_durations(demo_dir)
@@ -261,11 +267,11 @@ def compile_demo(demo_dir: Path) -> tuple[Path, Path]:
         f"#   Edit scenes.yaml then re-run: uv run docs/demos/lib/compile.py {rel_demo}",
         "#",
         "# Records: title card -> checklist -> N scenes (replay) -> outro card.",
-        "# Output : recording.mp4 alongside this tape (gitignored).",
+        f"# Output : {recording_filename} alongside this tape (gitignored).",
         "",
         "Require vhs",
         "",
-        f"Output {rel_demo}/recording.mp4",
+        f"Output {rel_demo}/{recording_filename}",
         "",
         'Set Shell "bash"',
         "Set FontSize 18",

--- a/tests/test_demo_assets.py
+++ b/tests/test_demo_assets.py
@@ -259,6 +259,77 @@ class TestCompilePipeline:
         assert data["narration"][0]["absolute_seconds"] > 0
         assert data["recording_duration_seconds"] > 0
 
+    @pytest.mark.parametrize(
+        "fmt,expected_filename",
+        [
+            (None, "recording.mp4"),  # absent → default to mp4
+            ("mp4", "recording.mp4"),
+            ("gif", "recording.gif"),
+            ("MP4", "recording.mp4"),  # case-insensitive
+            ("GIF", "recording.gif"),
+        ],
+        ids=["default", "mp4", "gif", "mp4-upper", "gif-upper"],
+    )
+    def test_compile_output_format(
+        self, compile_mod, tmp_path: Path, fmt: str | None, expected_filename: str
+    ) -> None:
+        """`tape.output_format` drives the tape's Output line (mp4 default; gif valid)."""
+        demo = tmp_path / "20260101-fmt"
+        (demo / "outputs").mkdir(parents=True)
+        (demo / "outputs" / "01-version.txt").write_text("clawctl 99.99.99\n")
+        tape_block = "tape:\n  framerate: 30\n"
+        if fmt is not None:
+            tape_block += f"  output_format: {fmt}\n"
+        (demo / "scenes.yaml").write_text(
+            "title: Fmt\n"
+            "subtitle: test\n"
+            f"{tape_block}"
+            "outro:\n"
+            "  line_1: x\n"
+            "  line_2: y\n"
+            "scenes:\n"
+            "  - n: 1\n"
+            "    title: version\n"
+            "    command: clawctl --version\n"
+            f"    output_file: docs/demos/{demo.name}/outputs/01-version.txt\n"
+            "    screen_seconds: 3\n"
+            "    narration:\n"
+            "      - text: hello\n"
+        )
+        tape, _manifest, _w, _u = compile_mod.compile_demo(demo)
+        tape_text = tape.read_text()
+        assert f"/{expected_filename}" in tape_text, (
+            f"expected Output line to reference {expected_filename}, "
+            f"got tape:\n{tape_text[:600]}"
+        )
+
+    def test_compile_output_format_rejects_unknown(
+        self, compile_mod, tmp_path: Path
+    ) -> None:
+        """An invalid `tape.output_format` must fail loudly, not silently default."""
+        demo = tmp_path / "20260101-badfmt"
+        (demo / "outputs").mkdir(parents=True)
+        (demo / "outputs" / "01-version.txt").write_text("x\n")
+        (demo / "scenes.yaml").write_text(
+            "title: Bad\n"
+            "subtitle: t\n"
+            "tape:\n"
+            "  output_format: webm\n"
+            "outro:\n"
+            "  line_1: x\n"
+            "  line_2: y\n"
+            "scenes:\n"
+            "  - n: 1\n"
+            "    title: v\n"
+            "    command: clawctl --version\n"
+            f"    output_file: docs/demos/{demo.name}/outputs/01-version.txt\n"
+            "    screen_seconds: 3\n"
+            "    narration:\n"
+            "      - text: hi\n"
+        )
+        with pytest.raises(ValueError, match="output_format"):
+            compile_mod.compile_demo(demo)
+
     # --- W3: every (head, tail) combination for replay dispatch ------------- #
     @pytest.mark.parametrize(
         "head,tail,expect_in_dispatch,not_expect_in_dispatch",


### PR DESCRIPTION
## Summary

- Add optional `tape.output_format` key to `scenes.yaml` — `mp4` (default, existing behavior) or `gif`. `compile.py` branches the tape's `Output` line accordingly.
- Invalid values raise `ValueError` at compile time instead of silently defaulting.
- `/create-vhs` skill: description loosened from "(MP4)" to "(MP4 or GIF)"; scenes.yaml template documents the key; Step 6 calls out that GIF outputs skip the ElevenLabs `narrate.py` step (GIF has no audio container — narration beats still influence `hold_seconds` though, so keep them written).

## Testing

### Test Results
- [x] All existing tests pass (`make test` — 289 passed)
- [x] Linter passes (`make lint` — ruff + eslint clean)
- [x] New tests added covering: default, `mp4`, `gif`, case-insensitive (`MP4` / `GIF`), and rejection of an unknown value (`webm` → `ValueError`)

### Test Coverage
- Files changed: `docs/demos/lib/compile.py`, `tests/test_demo_assets.py`, `.claude/skills/create-vhs/SKILL.md`, `.claude/skills/create-vhs/templates/scenes.yaml.template`, `CHANGELOG.md`
- New tests: 6 (5 parametrized cases + 1 rejection case) in `tests/test_demo_assets.py::TestCompilePipeline`

### Manual Testing
- Re-ran `make lint && make test` locally — both green.
- Did **not** re-record any existing demo since their `scenes.yaml` files don't set `output_format` and the default path is unchanged (`recording.mp4`).

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (`output_format` validated against allow-list)
- [x] No SQL injection, XSS, or command injection risks (string flows into a VHS directive only; no shell interpolation)
- [x] No new dependencies

## Reviewer Notes

- Per author request, **no ATX review** for this change.
- The skill's mandatory up-front output-format question (MP4 vs GIF) was already in place — this PR just makes the pipeline honor the GIF choice instead of producing MP4 either way.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)