### PR TITLE
chore(blog): link features to GitHub issues in v26.6.5 release post

### DIFF
--- a/website/blog/2026-06-22-v26.6.5-release.md
+++ b/website/blog/2026-06-22-v26.6.5-release.md
@@ -10,27 +10,39 @@ date: 2026-06-22
 
 ### New /create-playwright skill for browser-session demos
 
-A new /create-playwright skill has been added for recording browser-session demos with Playwright, mirroring the /create-vhs workflow. The first demo is a 75-second walkthrough of the clawctl gui dashboard, embedded in the README and on the website's Web Dashboard guide and Introduction page. This enables users to create high-fidelity browser-based demos for training, documentation, and quality assurance, improving the user experience and reducing the need for manual video recording.
+### New /create-playwright skill for browser-session demos
+
+A new /create-playwright skill has been added for recording browser-session demos with Playwright, mirroring the /create-vhs workflow. The first demo is a 75-second walkthrough of the clawctl gui dashboard, embedded in the README and on the website's Web Dashboard guide and Introduction page. This enables users to create high-fidelity browser-based demos for training, documentation, and quality assurance, improving the user experience and reducing the need for manual video recording. [See #720](https://github.com/ric03uec/clawrium/issues/720)
 
 ### Agent-scoped audit trail
 
-A new agent-scoped audit trail has been introduced with the `clawctl agent audit <name>` command, which filters audit output to a specific agent's entries. Legacy rows (without the `agent_name` field) are only visible via the `--all` flag in the unscoped global view. This provides better security and compliance by allowing operators to focus on a specific agent's activity without being overwhelmed by global audit data, while still maintaining the ability to view all historical data with the `--all` flag.
+### Agent-scoped audit trail
+
+A new agent-scoped audit trail has been introduced with the `clawctl agent audit <name>` command, which filters audit output to a specific agent's entries. Legacy rows (without the `agent_name` field) are only visible via the `--all` flag in the unscoped global view. This provides better security and compliance by allowing operators to focus on a specific agent's activity without being overwhelmed by global audit data, while still maintaining the ability to view all historical data with the `--all` flag. [See #780](https://github.com/ric03uec/clawrium/issues/780)
 
 ### Workspace overlay sync
 
-Workspace overlay sync has been implemented for openclaw, zeroclaw, and hermes agents on Ubuntu. Files in `~/.config/clawrium/agents/<type>/<name>/workspace/` are now mirrored to the agent host on every `clawctl agent sync` and `clawctl agent configure` with per-type destination roots and exclude lists to prevent overwriting daemon-managed files. This enables operators to manage agent configuration and state more effectively by allowing them to push custom files to agent hosts without requiring a full agent reinstallation, while the exclude lists prevent conflicts with daemon-managed files.
+### Workspace overlay sync
+
+Workspace overlay sync has been implemented for openclaw, zeroclaw, and hermes agents on Ubuntu. Files in `~/.config/clawrium/agents/<type>/<name>/workspace/` are now mirrored to the agent host on every `clawctl agent sync` and `clawctl agent configure` with per-type destination roots and exclude lists to prevent overwriting daemon-managed files. This enables operators to manage agent configuration and state more effectively by allowing them to push custom files to agent hosts without requiring a full agent reinstallation, while the exclude lists prevent conflicts with daemon-managed files. [See #760](https://github.com/ric03uec/clawrium/issues/760)
 
 ### Brave Search API integration
 
-The Brave Search API integration has been added as a new `brave` integration type, with automatic plugin installation and version preflight checks. The `clawctl integration registry create` command now supports `--type brave` to register API keys, and `clawctl integration rotate` can rotate credentials and re-sync bound agents. This provides a more accurate and up-to-date search experience for agents, with better support for current web content compared to the default DuckDuckGo provider.
+### Brave Search API integration
+
+The Brave Search API integration has been added as a new `brave` integration type, with automatic plugin installation and version preflight checks. The `clawctl integration registry create` command now supports `--type brave` to register API keys, and `clawctl integration rotate` can rotate credentials and re-sync bound agents. This provides a more accurate and up-to-date search experience for agents, with better support for current web content compared to the default DuckDuckGo provider. [See #734](https://github.com/ric03uec/clawrium/issues/734)
 
 ### OpenCode inference provider support
 
-OpenCode inference provider support has been added with new `--type opencode` and `--type opencode-go` options for `clawctl provider registry create` to support both hosted gateways and renderer wiring for hermes, zeroclaw, and openclaw agents. This expands the range of available LLMs for agents, giving users more choice in their inference providers and enabling better performance and cost optimization.
+### OpenCode inference provider support
+
+OpenCode inference provider support has been added with new `--type opencode` and `--type opencode-go` options for `clawctl provider registry create` to support both hosted gateways and renderer wiring for hermes, zeroclaw, and openclaw agents. This expands the range of available LLMs for agents, giving users more choice in their inference providers and enabling better performance and cost optimization. [See #722](https://github.com/ric03uec/clawrium/issues/722)
 
 ### Agent shell command
 
-The `clawctl agent shell <name> -- <cmd>` command has been added to run arbitrary commands on the host as the agent user in a full login shell with all environment variables loaded, including `~/.bash_profile`, `~/.profile`, and `~/.bashrc`. This provides a powerful tool for debugging and maintenance, allowing operators to run arbitrary commands on agent hosts with full access to the agent's environment, which is essential for troubleshooting and system administration.
+### Agent shell command
+
+The `clawctl agent shell <name> -- <cmd>` command has been added to run arbitrary commands on the host as the agent user in a full login shell with all environment variables loaded, including `~/.bash_profile`, `~/.profile`, and `~/.bashrc`. This provides a powerful tool for debugging and maintenance, allowing operators to run arbitrary commands on agent hosts with full access to the agent's environment, which is essential for troubleshooting and system administration. [See #761](https://github.com/ric03uec/clawrium/issues/761)
 
 ## Try it
 

--- a/website/blog/2026-06-22-v26.6.5-release.md
+++ b/website/blog/2026-06-22-v26.6.5-release.md
@@ -10,11 +10,7 @@ date: 2026-06-22
 
 ### New /create-playwright skill for browser-session demos
 
-### New /create-playwright skill for browser-session demos
-
 A new /create-playwright skill has been added for recording browser-session demos with Playwright, mirroring the /create-vhs workflow. The first demo is a 75-second walkthrough of the clawctl gui dashboard, embedded in the README and on the website's Web Dashboard guide and Introduction page. This enables users to create high-fidelity browser-based demos for training, documentation, and quality assurance, improving the user experience and reducing the need for manual video recording. [See #720](https://github.com/ric03uec/clawrium/issues/720)
-
-### Agent-scoped audit trail
 
 ### Agent-scoped audit trail
 
@@ -22,11 +18,7 @@ A new agent-scoped audit trail has been introduced with the `clawctl agent audit
 
 ### Workspace overlay sync
 
-### Workspace overlay sync
-
 Workspace overlay sync has been implemented for openclaw, zeroclaw, and hermes agents on Ubuntu. Files in `~/.config/clawrium/agents/<type>/<name>/workspace/` are now mirrored to the agent host on every `clawctl agent sync` and `clawctl agent configure` with per-type destination roots and exclude lists to prevent overwriting daemon-managed files. This enables operators to manage agent configuration and state more effectively by allowing them to push custom files to agent hosts without requiring a full agent reinstallation, while the exclude lists prevent conflicts with daemon-managed files. [See #760](https://github.com/ric03uec/clawrium/issues/760)
-
-### Brave Search API integration
 
 ### Brave Search API integration
 
@@ -34,11 +26,7 @@ The Brave Search API integration has been added as a new `brave` integration typ
 
 ### OpenCode inference provider support
 
-### OpenCode inference provider support
-
 OpenCode inference provider support has been added with new `--type opencode` and `--type opencode-go` options for `clawctl provider registry create` to support both hosted gateways and renderer wiring for hermes, zeroclaw, and openclaw agents. This expands the range of available LLMs for agents, giving users more choice in their inference providers and enabling better performance and cost optimization. [See #722](https://github.com/ric03uec/clawrium/issues/722)
-
-### Agent shell command
 
 ### Agent shell command
 


### PR DESCRIPTION
## Summary

The `blog/v26.6.5-release` branch had two unreleased commits improving the v26.6.5 release blog post:

1. **Add issue links** — each feature section now ends with `[See #NNN](link)` pointing to the corresponding GitHub issue (#720, #780, #760, #734, #722, #761).
2. **Remove duplicate h3 headers** — combines what/why sections under a single h3 per feature.

## Changed

- `website/blog/2026-06-22-v26.6.5-release.md` — 6 insertions, 6 deletions

## Test Plan

- [x] Visual review of diff — only adds `[See #NNN]` links and consolidates h3 headers
- [ ] Verify links resolve on `npm run start` (website dev server)