### PR TITLE
fix(macos): openclaw E2E support + #720 fail-fast + bedrock prefix rename

### DIFF
--- a/.itx/719/00_PLAN.md
+++ b/.itx/719/00_PLAN.md
@@ -55,12 +55,21 @@ verification on `clawdmin03@espers-mac-mini.tailf7742d.ts.net`.
 - [x] `make test` green (3867 Python + 305 vitest).
 - [x] ATX review iter-1 captured in `.itx/openclaw-macos-bundle/atx-review-1.txt`.
 
-## Pending — ATX Review Iter-2
+## ATX Review History
 
-- [ ] Re-run `atx review request` on the post-fix branch to confirm
-  all 13 iter-1 blockers resolved + capture any new findings on the
-  two follow-up fixes (verify_config.py 3.9 compat, `nc -z` health
-  probe).
+- [x] Iter 1 — 1.5/5, 13 blockers; all resolved (transcript:
+  `.itx/openclaw-macos-bundle/atx-review-1.txt`)
+- [x] Iter 2 — 3/5, 1 blocker + 4 strongly-recommended warnings;
+  all resolved
+- [x] Iter 3 — 3/5, 3 blockers + 6 warnings + 7 suggestions;
+  16/17 resolved (S4 sentinel-env-var skipped)
+- [x] Iter 4 — 2/5, 2 blockers + 4 warnings + 4 suggestions;
+  9/10 resolved (S2 Node test infra skipped)
+- [x] Iter 5 — **4/5, blocking=false** (transcript:
+  `.itx/openclaw-macos-bundle/atx-review-5.txt`). No merge gate
+  remains. Specialists: platform-playbooks 5/5, security 4/5,
+  lifecycle-core 4/5, cli-ux 4/5, test-coverage 3/5, gui-routes
+  2/5, render-engine skipped.
 
 ## End-to-end verification on a real macOS host
 

--- a/.itx/719/00_PLAN.md
+++ b/.itx/719/00_PLAN.md
@@ -1,0 +1,174 @@
+# Issue #719 — openclaw on macOS, end-to-end
+
+Tracking: https://github.com/ric03uec/clawrium/issues/719
+Branch: `fix/openclaw-macos-bundle-20260623`
+
+## Summary
+
+Issue #719 reports that `clawctl agent create` cannot install openclaw
+on a macOS host. The original symptom in the bug report (`xcode-select`
+missing, `ansible.legacy.setup` deserialization failure) is host-setup
+hygiene, but the broader install-on-macOS path has multiple latent gaps
+the bundle from `~/Dropbox/clawrium/clawrium-openclaw-macos-fixes-20260623.zip`
+fixes. This plan tracks both the code fixes and the end-to-end host
+verification on `clawdmin03@espers-mac-mini.tailf7742d.ts.net`.
+
+## Code Fixes (this branch)
+
+- [x] **#720 fallback bug** — `clawctl agent create` no longer picks
+  `platforms[0]` (oldest version) when host hardware is unknown. Fails
+  fast with `InstallationError` and tells the operator to run
+  `clawctl host create` first.
+- [x] **macOS `install -g {agent_name}` failure** — `_atomic_write`
+  on macOS now uses `-g staff` (macOS agent users have PrimaryGroupID
+  20 = `staff`; no per-user group is created).
+- [x] **macOS `systemctl restart` failure** — `_restart_unit` on macOS
+  now goes through `launchctl kickstart -k` via
+  `lifecycle_macos.restart_unit_macos`, which handles hermes's
+  dual-label (gateway + dashboard) and bootstrap-fallback for stopped
+  units.
+- [x] **macOS `systemctl is-active` failure** — `_verify_health` on
+  macOS now polls `lsof -i :<port> -P -sTCP:LISTEN` via
+  `lifecycle_macos.verify_health_macos`; emits `verify_skipped` when no
+  port is persisted; rejects non-int ports.
+- [x] **Dispatcher-only OS fork** — macOS branches live in
+  `lifecycle_macos.py`; `lifecycle_canonical.py` only routes. Matches
+  the project invariant (AGENTS.md memory:
+  `feedback_dispatcher_only_os_fork`).
+- [x] **Bedrock model prefix** — renderer + 3 openclaw templates +
+  `verify_config.py` emit `amazon-bedrock/<id>` instead of
+  `bedrock/<id>`. Operators with the old prefix must update
+  `hosts.json` manually before next sync — documented in `CHANGELOG.md`
+  `### BREAKING`. No automated migration.
+- [x] **openclaw v2026.6.9 manifest entries** — added for Ubuntu
+  24.04/22.04 x86_64 and macOS ≥14 arm64; brave plugin pin and
+  `min_host_version` bumped to 2026.6.9 (`### BREAKING` entry covers
+  the preflight tightening).
+- [x] **Tests** — workspace test stubs accept `**kwargs`; 5 bedrock
+  fixtures updated; idempotency test rewritten for the new prefix and
+  exact-line match; macOS dispatch coverage added
+  (`tests/core/test_lifecycle_canonical_macos_dispatch.py`, 12 tests);
+  hardware-unknown override test strengthened to assert the branch
+  actually ran; preflight/registry version expectations bumped to
+  2026.6.9.
+- [x] `make lint` clean (ruff + next-lint).
+- [x] `make test` green (3867 Python + 305 vitest).
+- [x] ATX review iter-1 captured in `.itx/openclaw-macos-bundle/atx-review-1.txt`.
+
+## Pending — ATX Review Iter-2
+
+- [ ] Re-run `atx review request` on the post-fix branch to confirm
+  all 13 iter-1 blockers resolved + capture any new findings on the
+  two follow-up fixes (verify_config.py 3.9 compat, `nc -z` health
+  probe).
+
+## End-to-end verification on a real macOS host
+
+Target host: **`espers-mac-mini.tailf7742d.ts.net`**, alias
+`esper-macmini` (controller account: `clawdmin03` for initial xclm
+setup; subsequent ops as `xclm`).
+
+Run from the operator machine on this branch
+(`fix/openclaw-macos-bundle-20260623`) using **`uv run clawctl …`**
+so the new code path is exercised (the installed `clawctl 26.6.5` on
+disk does NOT have the bundle fixes yet).
+
+Full step-by-step results are in `01_EXECUTION.md`.
+
+### Host setup
+
+- [x] xcode-select tools confirmed present
+  (`/Library/Developer/CommandLineTools`).
+- [x] xclm user created with NOPASSWD sudo + authorized_key via
+  one-shot script over `ssh clawdmin03@…` (stale prior xclm pubkey
+  overwritten).
+- [x] `clawctl host create … --user xclm --alias esper-macmini`
+  succeeded.
+- [x] Hardware backfilled via direct `gather_hardware` call
+  (canonical `host create` doesn't gather hardware — gap to be filed
+  as a separate issue; not blocking #719).
+  Result: `{os: macos, os_version: 26.5.1, architecture: arm64,
+  processor_cores: 10, memtotal_mb: 16384}`.
+
+### Openclaw install
+
+- [x] **`agent create` fail-fast verified** before hardware backfill:
+  refused to guess `platforms[0]` (the #720 bug from the bundle).
+- [x] After hardware backfill,
+  `clawctl agent create esper-mac-oc --type openclaw --host esper-macmini`
+  succeeded; installed **v2026.6.9** (matches the macOS arm64 manifest
+  entry added in this branch).
+- [x] Agent status: `ready`.
+
+### Provider attach (reused existing openrouter)
+
+- [x] Reused `clm-openrouter` (openrouter/openai/gpt-4o) — already in
+  registry, no new provider record created.
+- [x] `clawctl agent provider attach clm-openrouter --agent esper-mac-oc`
+  → `attached provider 'clm-openrouter'`.
+
+### Configure + lifecycle on macOS
+
+- [x] `configure --stage identity` complete.
+- [x] `configure --stage providers` — initially failed at
+  `Verify openclaw.json configuration`; root cause was
+  `verify_config.py` using PEP 604 `str | None` syntax against macOS
+  Python 3.9.6. **Fixed in this branch** by adding
+  `from __future__ import annotations` to `verify_config.py`. Re-ran
+  clean.
+- [x] `configure --stage validate` complete.
+- [x] Restart used `launchctl kickstart -k system/ai.clawrium.openclaw.esper-mac-oc`
+  (new `restart_unit_macos` dispatcher path from this branch — not
+  systemctl).
+- [x] `clawctl agent sync` — initially errored with `gateway port
+  41091 not listening after 30s` even though the daemon was healthy.
+  Root cause: macOS `lsof -i :<port>` only shows listeners owned by
+  the running user; sync runs as `xclm` but daemon runs as
+  `esper-mac-oc`. **Fixed in this branch** by switching
+  `verify_health_macos` from `lsof` to `nc -z -w 1 127.0.0.1 <port>`
+  (TCP-connect probe; no sudo needed, ships with macOS). Tests +
+  CHANGELOG updated to match.
+
+### Gateway functional check
+
+- [x] `curl http://espers-mac-mini.tailf7742d.ts.net:41091/health` →
+  `{"ok":true,"status":"live"}`.
+- [x] Daemon log confirms:
+  - `openrouter/openai/gpt-4o model configured, enabled automatically`
+  - `agent model: openrouter/openai/gpt-4o (thinking=medium, fast=off)`
+  - `http server listening (9 plugins: bonjour, browser, canvas,
+    device-pair, file-transfer, memory-core, openrouter,
+    phone-control, talk-voice)`
+  - `[gateway] ready`
+  - No `Unknown model: …` errors.
+- [ ] `clawctl agent chat` round-trip — `--once` not implemented;
+  interactive mode hits `Protocol error: protocol mismatch` (separate
+  clawctl-openclaw chat-client skew, NOT a sync/install bug — to be
+  filed as a follow-up). Daemon-level evidence above is sufficient
+  proof for #719.
+
+### Documentation outcome
+
+- [x] Execution log written to `01_EXECUTION.md` with the two new
+  fixes (verify_config 3.9 compat, nc-based health probe) called out.
+- [ ] Mark #719 closed in the PR description when this branch is
+  merged.
+
+## Prompt Log
+
+**Stage**: plan
+**Skill**: (none — written manually based on bundle README + ATX
+review feedback)
+**Timestamp**: 2026-06-23T22:30:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+after fixng this, add a checklist item to setup this machine
+clawdmin03@espers-mac-mini.tailf7742d.ts.net as a new macos host,
+install openclaw on it and testing it end to end using one openrouter
+integration(reuse any one already configured). all of these changes
+and fixes are linked to issue 719 https://github.com/ric03uec/clawrium/issues/719
+```
+
+**Output**: This plan file with the fix checklist (already complete)
+plus the end-to-end verification checklist for the Mac mini host.

--- a/.itx/719/01_EXECUTION.md
+++ b/.itx/719/01_EXECUTION.md
@@ -1,0 +1,267 @@
+# Issue #719 — Execution log
+
+End-to-end verification run on `clawdmin03@espers-mac-mini.tailf7742d.ts.net`
+using the branch `fix/openclaw-macos-bundle-20260623` (i.e. the branch
+code, not the released `clawctl` on the management machine).
+
+Date: 2026-06-23
+Host: macOS 26.5.1, arm64 (Mac mini, 10 cores, 16GB)
+Management user: `xclm`
+Agent: `esper-mac-oc` (openclaw v2026.6.9)
+Provider: `clm-openrouter` (openrouter/openai/gpt-4o) — reused, not
+re-created
+Gateway port: 41091
+
+## Summary
+
+End-to-end is **functional**. The bundle's openclaw-on-macOS fixes
+land correctly. **Two additional bugs were uncovered during live
+verification and fixed in this same branch:**
+
+1. `verify_config.py` used PEP 604 `str | None` syntax (Python 3.10+);
+   macOS ships Python 3.9.6 in `/usr/bin/python3` (Xcode CLI tools),
+   so the verify step crashed with `TypeError: unsupported operand
+   type(s) for |: 'type' and 'NoneType'`. Fixed with
+   `from __future__ import annotations`.
+2. `verify_health_macos` used `lsof -i :<port> -P -sTCP:LISTEN`, which
+   only shows listeners owned by the running user on macOS. The
+   canonical sync runs as `xclm` while the daemon runs as
+   `<agent_name>` (different uid), so `lsof` returned rc=1 and the
+   sync errored with `gateway port 41091 not listening after 30s` —
+   even though the daemon was healthy and accepting connections.
+   Switched to `nc -z -w 1 127.0.0.1 <port>` (TCP connect probe; no
+   sudo required, ships in macOS by default). Tests + CHANGELOG
+   updated to match.
+
+## Steps Executed
+
+### 1. SSH preflight — `clawdmin03`
+
+```
+ssh clawdmin03@espers-mac-mini.tailf7742d.ts.net 'sw_vers && uname -m && xcode-select -p'
+→ macOS 26.5.1, arm64, /Library/Developer/CommandLineTools
+```
+
+Xcode CLI tools already installed → the original symptom in #719
+(`xcode-select: error: No developer tools were found`) does not apply
+to this host.
+
+### 2. xclm management user
+
+`clawctl host create … --user xclm` requires the `xclm` user with
+NOPASSWD sudo and an authorized key. `clawdmin03` was used to set
+this up (single interactive sudo over SSH; one-shot script per
+`docs/host-preparation.md` macOS block).
+
+**Quirk on this host:** an older xclm setup had stale
+`/Users/xclm/.ssh/authorized_keys` (different pubkey from a prior
+bundle owner's setup). Had to overwrite with our branch's
+freshly-generated pubkey. Also, `com.apple.access_ssh` group
+"not found" on this macOS version — irrelevant because Remote Login
+is configured for "All Users".
+
+### 3. `clawctl host create esper-macmini`
+
+Succeeded immediately on the re-run (xclm key auth + NOPASSWD sudo
+both working). Stored at `~/.config/clawrium/hosts.json` with
+`hardware: {}`.
+
+### 4. Hardware gathering — gap surfaced
+
+The canonical `clawctl host create` (under
+`src/clawrium/cli/clawctl/host/create.py`) **does not call
+`gather_hardware`**. Only the legacy `clawctl host add` and `host
+ps --refresh` do. So `hardware == {}` was the persisted state after
+step 3.
+
+Worked around by calling `gather_hardware` directly:
+
+```python
+from clawrium.core.hardware import gather_hardware
+from clawrium.core.hosts import update_host
+hw = gather_hardware(hostname='…', user='xclm', port=22, ssh_key='…')
+update_host('…', lambda h: dict(h, hardware=hw, …))
+```
+
+Result: `hardware = {os: macos, os_version: 26.5.1, architecture: arm64, …}`.
+
+**Follow-up issue worth filing**: canonical `clawctl host create`
+should gather hardware (or call out the next-step) so operators don't
+hit the #720 fail-fast on first install. Out of scope for this
+branch.
+
+### 5. `clawctl agent create … --type openclaw` — #720 fail-fast verified
+
+First run with empty hardware:
+
+```
+agent/esper-mac-oc: [validate] Checking compatibility...
+Error: installation failed: Cannot determine compatible version for
+'openclaw': host hardware information is not available. Run 'clawctl
+host create' with SSH access first to gather hardware facts, then
+retry the install.
+```
+
+This is the #720 fix from the bundle. Confirms the dispatcher refuses
+to guess `platforms[0]` (the v0.1.0 case from the bug report).
+
+After backfilling hardware (step 4) and re-running:
+
+```
+agent/esper-mac-oc: installed (2026.6.9)
+agent/esper-mac-oc: ready
+```
+
+Picks **v2026.6.9** — the macOS arm64 entry added to the manifest in
+this branch.
+
+### 6. Provider attach (reused existing openrouter)
+
+```
+clawctl agent provider attach clm-openrouter --agent esper-mac-oc
+→ agent/esper-mac-oc: attached provider 'clm-openrouter'
+```
+
+### 7. `clawctl agent configure --stage providers` — verify_config bug
+
+Failed at the `Verify openclaw.json configuration` task. `no_log:
+true` masked the error. Temporarily flipped to `no_log: false` +
+added `debug` + `fail` tasks to surface the real error:
+
+```
+verify rc=1 stderr=Traceback (most recent call last):
+  File "/tmp/clawrium_verify_config_esper-mac-oc.py", line 50, in main
+    def _expected_model_id(expected: dict) -> str | None:
+TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
+```
+
+Root cause: macOS host's `python3` is 3.9.6 (Xcode CLI tools); PEP
+604 union types (`X | Y`) require 3.10+. Fixed in
+`src/clawrium/platform/registry/openclaw/templates/verify_config.py`
+by adding `from __future__ import annotations` (defers all annotation
+evaluation; compat back to Python 3.7+).
+
+Reverted the playbook debug changes; configure re-ran clean:
+
+```
+agent/esper-mac-oc: [configure] Successfully configured esper-mac-oc
+agent/esper-mac-oc: [restart] launchctl kickstart -k esper-mac-oc (gateway)
+agent/esper-mac-oc: stage providers complete
+```
+
+That `launchctl kickstart -k` line is the new
+`lifecycle_macos.restart_unit_macos` dispatcher path from this
+branch.
+
+### 8. `clawctl agent sync` — lsof-needs-sudo bug
+
+First sync run:
+
+```
+agent/esper-mac-oc: restart: launchctl kickstart -k system/ai.clawrium.openclaw.esper-mac-oc
+agent/esper-mac-oc: verify: checking unit is active
+Error: sync failed: gateway port 41091 not listening after 30s
+```
+
+But the daemon WAS healthy: `sudo lsof -i :41091 -P -sTCP:LISTEN` on
+the host showed `node 15672 esper-mac-oc … TCP *:41091 (LISTEN)`.
+
+Root cause: `lsof` on macOS only shows listeners owned by the
+running user. Sync runs `lsof` over SSH as `xclm`; the daemon runs
+as `esper-mac-oc`. Different uid → empty result → rc=1 → false
+"not listening" verdict.
+
+Fixed by replacing the lsof probe with `nc -z -w 1 127.0.0.1
+<port>` — a TCP connect that succeeds when the daemon is
+`accept()`-ing, regardless of which uid owns the socket. `nc` ships
+in macOS by default; no sudo needed.
+
+Updates:
+- `src/clawrium/core/lifecycle_macos.py:verify_health_macos`
+- `tests/core/test_lifecycle_canonical_macos_dispatch.py`
+  (test_nc_connect_returns_immediately + timeout-message regex)
+- `CHANGELOG.md` Added entry: `nc -z` (with rationale comment about
+  the `lsof` uid restriction)
+
+Re-ran `clawctl agent restart` to exercise the verify path:
+
+```
+agent/esper-mac-oc: [restart] launchctl kickstart -k esper-mac-oc (gateway)
+agent/esper-mac-oc: [restart] Restarted esper-mac-oc successfully
+agent/esper-mac-oc: restarted
+```
+
+### 9. Functional gateway check
+
+```
+curl http://espers-mac-mini.tailf7742d.ts.net:41091/health
+→ {"ok":true,"status":"live"}
+```
+
+Daemon log shows openrouter provider loaded successfully:
+
+```
+[gateway] auto-enabled plugins for this runtime without writing config:
+  - openrouter/openai/gpt-4o model configured, enabled automatically.
+[gateway] http server listening (9 plugins: bonjour, browser, canvas,
+  device-pair, file-transfer, memory-core, openrouter, phone-control,
+  talk-voice; 0.4s)
+[gateway] agent model: openrouter/openai/gpt-4o (thinking=medium, fast=off)
+[gateway] ready
+[gateway] provider auth state pre-warmed in 466ms
+```
+
+No `Unknown model: …` errors. Openrouter plugin loaded, model
+resolved, gateway healthy.
+
+### 10. `clawctl agent chat --once`
+
+`--once` flag is marked "Not implemented". Interactive mode connects
+but fails with `Protocol error: protocol mismatch` — appears to be a
+separate clawctl-openclaw chat-client skew, not related to the
+sync/install path this issue is about. Out of scope for #719.
+
+The daemon-level evidence (openrouter loaded, model configured,
+`/health` 200) is sufficient proof that the install + configure +
+sync path works end-to-end on macOS.
+
+## Test + Lint Status (post-fixes)
+
+- `make lint` clean.
+- `make test`: **3867 Python passed, 2 skipped, 0 failed; 305 vitest
+  passed**.
+
+## Files Touched (additions to the bundle work)
+
+| File | Change |
+|---|---|
+| `src/clawrium/core/lifecycle_macos.py` | `verify_health_macos`: lsof → `nc -z` |
+| `src/clawrium/platform/registry/openclaw/templates/verify_config.py` | Added `from __future__ import annotations` |
+| `tests/core/test_lifecycle_canonical_macos_dispatch.py` | nc command + new error message in 2 tests |
+| `CHANGELOG.md` | Added entry updated to mention `nc -z` rationale |
+
+## Outstanding (for separate follow-ups, NOT blocking #719 close)
+
+- Canonical `clawctl host create` should gather hardware (or print
+  clear next-step). Today operators hit the #720 fail-fast on first
+  `agent create` and have no documented way to backfill except the
+  legacy `clawctl host add`/`host ps --refresh` paths or the Python
+  workaround above.
+- `clawctl agent chat` protocol mismatch with openclaw v2026.6.9 —
+  worth filing as a separate bug.
+
+## Prompt Log
+
+**Stage**: execution
+**Skill**: (none — direct E2E)
+**Timestamp**: 2026-06-23T23:45:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+run the end to end test now on the host
+```
+
+**Output**: This execution log documenting the full E2E walkthrough,
+two additional bugs found + fixed in the same branch, and the proof
+that the install/configure/sync/health path on macOS works end-to-end
+with an openrouter provider.

--- a/.itx/786/00_PLAN.md
+++ b/.itx/786/00_PLAN.md
@@ -1,0 +1,12 @@
+## Issue Creation
+
+**Stage**: issue-creation
+**Skill**: /itx:issue-new
+**Timestamp**: 2026-06-22T23:34:22Z
+**Model**: claude-opus-4-7
+
+```prompt
+Change the integration page. every integration should show the icon, cehck al the integrations, they don't show the icons right now. Pull those official icons and show them when my integration is configured. Add integration button should be just above the configured integration list and not by the top panel. dont create plan, jsust add issue with these requirements
+```
+
+**Output**: Created issue #786 — "User can identify configured integrations via official icons and add new ones from the list area"

--- a/.itx/openclaw-macos-bundle/atx-review-1.txt
+++ b/.itx/openclaw-macos-bundle/atx-review-1.txt
@@ -1,0 +1,330 @@
+Requesting review for /home/devashish/workspace/ric03uec/clawrium...
+{"time":"2026-06-23T14:55:01.583108991-07:00","level":"INFO","msg":"request_review: starting","project_root":"/home/devashish/workspace/ric03uec/clawrium"}
+{"time":"2026-06-23T14:55:01.610133012-07:00","level":"INFO","msg":"request_review: task created","task_id":"49093e0e-76e5-4298-8b11-5e5805edc150","project_port":30011}
+ATX review in progress. Using high effort (per-call-override) — leader may invoke up to 6 of 7 specialists.
+Task created (id: 49093e0e-76e5-4298-8b11-5e5805edc150), polling for completion...
+Waiting for review... (0s elapsed)
+Waiting for review... (1s elapsed)
+Waiting for review... (3s elapsed)
+Waiting for review... (7s elapsed)
+Waiting for review... (15s elapsed)
+Waiting for review... (25s elapsed)
+Waiting for review... (35s elapsed)
+Waiting for review... (45s elapsed)
+Waiting for review... (55s elapsed)
+Waiting for review... (1m5s elapsed)
+Waiting for review... (1m15s elapsed)
+Waiting for review... (1m25s elapsed)
+Waiting for review... (1m35s elapsed)
+Waiting for review... (1m45s elapsed)
+Waiting for review... (1m55s elapsed)
+Waiting for review... (2m5s elapsed)
+Waiting for review... (2m15s elapsed)
+Waiting for review... (2m25s elapsed)
+Waiting for review... (2m35s elapsed)
+Waiting for review... (2m45s elapsed)
+Waiting for review... (2m55s elapsed)
+Waiting for review... (3m5s elapsed)
+Waiting for review... (3m15s elapsed)
+Waiting for review... (3m25s elapsed)
+Waiting for review... (3m35s elapsed)
+Waiting for review... (3m45s elapsed)
+Waiting for review... (3m55s elapsed)
+Waiting for review... (4m5s elapsed)
+Waiting for review... (4m15s elapsed)
+Waiting for review... (4m25s elapsed)
+Waiting for review... (4m35s elapsed)
+Waiting for review... (4m45s elapsed)
+Waiting for review... (4m55s elapsed)
+Waiting for review... (5m5s elapsed)
+Waiting for review... (5m15s elapsed)
+Waiting for review... (5m25s elapsed)
+Waiting for review... (5m35s elapsed)
+Waiting for review... (5m45s elapsed)
+Waiting for review... (5m55s elapsed)
+Waiting for review... (6m5s elapsed)
+Waiting for review... (6m15s elapsed)
+Waiting for review... (6m25s elapsed)
+Waiting for review... (6m35s elapsed)
+Waiting for review... (6m45s elapsed)
+Waiting for review... (6m55s elapsed)
+Waiting for review... (7m5s elapsed)
+Waiting for review... (7m15s elapsed)
+Waiting for review... (7m25s elapsed)
+Waiting for review... (7m35s elapsed)
+Waiting for review... (7m45s elapsed)
+Waiting for review... (7m55s elapsed)
+Waiting for review... (8m5s elapsed)
+Waiting for review... (8m15s elapsed)
+Waiting for review... (8m25s elapsed)
+Waiting for review... (8m35s elapsed)
+Waiting for review... (8m45s elapsed)
+Waiting for review... (8m55s elapsed)
+Waiting for review... (9m5s elapsed)
+Waiting for review... (9m15s elapsed)
+Waiting for review... (9m25s elapsed)
+Waiting for review... (9m35s elapsed)
+Waiting for review... (9m46s elapsed)
+Waiting for review... (9m56s elapsed)
+Waiting for review... (10m6s elapsed)
+Waiting for review... (10m16s elapsed)
+Waiting for review... (10m26s elapsed)
+Waiting for review... (10m36s elapsed)
+Waiting for review... (10m46s elapsed)
+Waiting for review... (10m56s elapsed)
+Waiting for review... (11m6s elapsed)
+Waiting for review... (11m16s elapsed)
+Waiting for review... (11m26s elapsed)
+Waiting for review... (11m36s elapsed)
+Waiting for review... (11m46s elapsed)
+Waiting for review... (11m56s elapsed)
+Waiting for review... (12m6s elapsed)
+Waiting for review... (12m16s elapsed)
+Waiting for review... (12m26s elapsed)
+Waiting for review... (12m36s elapsed)
+Waiting for review... (12m46s elapsed)
+Waiting for review... (12m56s elapsed)
+Waiting for review... (13m6s elapsed)
+Waiting for review... (13m16s elapsed)
+Waiting for review... (13m26s elapsed)
+Waiting for review... (13m36s elapsed)
+Waiting for review... (13m46s elapsed)
+Waiting for review... (13m56s elapsed)
+Waiting for review... (14m6s elapsed)
+Waiting for review... (14m16s elapsed)
+Waiting for review... (14m26s elapsed)
+Waiting for review... (14m36s elapsed)
+Waiting for review... (14m46s elapsed)
+Waiting for review... (14m56s elapsed)
+Waiting for review... (15m6s elapsed)
+Waiting for review... (15m16s elapsed)
+Waiting for review... (15m26s elapsed)
+Waiting for review... (15m36s elapsed)
+Waiting for review... (15m46s elapsed)
+Waiting for review... (15m56s elapsed)
+Waiting for review... (16m6s elapsed)
+Waiting for review... (16m16s elapsed)
+Waiting for review... (16m26s elapsed)
+Waiting for review... (16m36s elapsed)
+Waiting for review... (16m46s elapsed)
+Waiting for review... (16m56s elapsed)
+Waiting for review... (17m6s elapsed)
+{"time":"2026-06-23T15:12:17.56754668-07:00","level":"INFO","msg":"review: task completed","task_id":"49093e0e-76e5-4298-8b11-5e5805edc150","status":"completed","duration_ms":1027919}
+{"time":"2026-06-23T15:12:17.567784647-07:00","level":"INFO","msg":"request_review: completed","status":"completed","blocking":true,"files_reviewed":0,"cost_usd":8.56233115,"task_id":"49093e0e-76e5-4298-8b11-5e5805edc150"}
+Status: reviewed
+Blocking: YES
+Summary: ## ATX Review — fix/openclaw-macos-bundle-20260623
+
+**Overall rating: 1.5 / 5 — DO NOT MERGE**
+
+13 blocking issues, 14 warnings. Three categories own the blockers: `make test` is currently broken in a...
+Cost: $8.5623
+Time: 17m 7s
+Rating: 2.5/5
+Models: claude-opus-4-7, claude-sonnet-4-6
+
+Agent Feedback:
+  [completed] leader (-) — ## ATX Review — fix/openclaw-macos-bundle-20260623
+
+**Overall rating: 1.5 / 5 — DO NOT MERGE**
+
+13 blocking issues, 14 w...
+  [completed] security-reviewer (3/5) — <output>
+{
+  "rating": 3,
+  "summary": "No exploitable command injection given current upstream validation, but the new ...
+  [completed] test-coverage (2/5) — <output>
+{
+  "rating": 2,
+  "summary": "The patch fixes ONE stub signature but leaves four other identical stubs broken ...
+  [completed] lifecycle-core (2/5) — <output>
+{
+  "rating": 2,
+  "summary": "The label format `ai.clawrium.<agent_type>.<agent_name>` and `group='staff'` cho...
+  [completed] cli-ux (3/5) — <output>
+{
+  "rating": 3,
+  "summary": "The guard is functionally necessary (without it the next line would crash with T...
+  [completed] platform-playbooks (3/5) — <output>{
+  "rating": 3,
+  "summary": "The manifest additions are structurally correct and the `>=14` matcher works as a...
+  [completed] render-engine (1/5) — <output>
+{
+  "rating": 1,
+  "summary": "The bedrock prefix change is incomplete: three test files still assert the legac...
+  [skipped] gui-routes (-) — 
+
+Full Feedback:
+## ATX Review — fix/openclaw-macos-bundle-20260623
+
+**Overall rating: 1.5 / 5 — DO NOT MERGE**
+
+13 blocking issues, 14 warnings. Three categories own the blockers: `make test` is currently broken in at least 11 places, the macOS lifecycle architecture violates a documented project invariant, and the bedrock prefix rename has no migration guard and will corrupt existing operator configs on next sync.
+
+---
+
+## Blocking Issues
+
+### B1–B2 · test stub signatures broken — `test_workspace_phase_ordering.py` + `test_workspace_zeroclaw_bearer_rotation.py`
+*Specialist: test-coverage*
+
+The patch applied `**kwargs` to one stub (`test_sync.py`) but missed two other files with identical stubs:
+
+- `tests/test_workspace_phase_ordering.py:71,74` — `fake_restart_unit(_client, *, agent_type, agent_name)` and `fake_verify_health(...)` lack `**kwargs`. Every test that reaches the restart phase will `TypeError`.
+- `tests/test_workspace_zeroclaw_bearer_rotation.py:78,81` — same `fake_restart_unit` / `fake_verify_health` inside `make_canonical_stubs`; at least 4 tests call `sync_agent_canonical(restart=True)` and will fail.
+
+**Fix:** Add `, **kwargs` to both stub signatures in both files. Optionally capture `host_os` in the call recorder to assert the #437 bearer-rotation path propagates correctly on macOS.
+
+---
+
+### B3 · Five failing assertions on old `bedrock/` prefix — `test_configure_claw.py` + `test_render.py`
+*Specialist: test-coverage, render-engine*
+
+Tests NOT updated by this patch:
+
+| File | Location | Assertion |
+|------|----------|-----------|
+| `tests/test_configure_claw.py` | :2269, :2310, :2336 | `OPENCLAW_DEFAULT_MODEL='bedrock/anthropic.claude-3-7-sonnet-...'` — now renders `amazon-bedrock/` |
+| `tests/core/test_render.py` | :2420 `_OPENCLAW_ENV_BEDROCK` | fixture still contains `bedrock/anthropic.claude-opus-4-1-v1:0` |
+| `tests/core/test_render.py` | :3079 `test_openclaw_model_prefix_idempotent` | passes `bedrock/<id>` model → new code double-prefixes to `amazon-bedrock/bedrock/<id>`, breaking the assertion at :3104 |
+
+**Fix:** Update all five string literals to `amazon-bedrock/...`. The idempotency test at :3079 also needs to be rewritten for the new prefix scheme — see B12 below.
+
+---
+
+### B4 · Zero test coverage for all three new macOS code paths
+*Specialist: test-coverage, lifecycle-core*
+
+`_atomic_write(host_os='macos')` (group=staff), `_restart_unit(host_os='macos')` (launchctl kickstart), and `_verify_health(host_os='macos', gateway_port=N)` (lsof poll) have no tests at all. The command strings, label formats, and timeout behavior are entirely unasserted.
+
+**Fix:** Add `_FakeSSHClient`-scripted tests asserting exact command strings, e.g.:
+- `sudo -n install -m 0600 -o alpha -g staff /tmp/... /path/...`
+- `sudo -n launchctl kickstart -k system/ai.clawrium.openclaw.alpha`
+- `lsof -i :40000 -P -sTCP:LISTEN`
+
+Cover: success, port-poll timeout raise, and `gateway_port=None` silent-return.
+
+---
+
+### B5 · `test_install_hardware_unknown_with_version_override_bypasses_check` — weak-assertion anti-pattern
+*Specialist: test-coverage*
+
+```python
+with pytest.raises(Exception) as exc_info:
+    run_installation("openclaw", "test-host", version_override="2026.6.8")
+assert "hardware information is not available" not in str(exc_info.value)
+```
+
+This passes whenever ANY exception is raised for any reason. It does not prove the `version_override` branch was entered. A future regression (different `InstallationError`, `KeyError`, missing SSH key) still passes.
+
+**Fix:** Capture on_event callbacks and assert `('validate', 'Version override: openclaw v2026.6.8') in events`. Narrow `pytest.raises` to the specific downstream exception type, not `Exception`.
+
+---
+
+### B6 · In-file `if host_os == 'macos'` branching violates dispatcher-only OS fork invariant
+*Specialist: lifecycle-core*
+
+`_restart_unit`, `_atomic_write`, and `_verify_health` in `lifecycle_canonical.py` now contain `if host_os == 'macos':` branches. This violates the explicit project rule (MEMORY.md `feedback_dispatcher_only_os_fork`, AGENTS.md):
+
+> *Dispatcher-only OS fork: Mac/Linux split via parallel \*\_macos.yaml playbooks, never `if Darwin` guards inside existing files*
+
+A parallel implementation already exists in `lifecycle_macos.py` (`restart_agent_macos`, `_kickstart`, `install_service`, `_bootstrap_with_tolerance`). The canonical sync should route to those helpers via a dispatcher, not re-implement them inline.
+
+**Fix:** Add a thin dispatcher (e.g. `_restart_unit_for_host(host, ...)`) that selects between the Linux path in `lifecycle_canonical.py` and the existing helpers in `lifecycle_macos.py`. Apply the same pattern to `_atomic_write` and `_verify_health`.
+
+---
+
+### B7 · Hermes macOS sync restarts only the gateway label — dashboard label never restarted
+*Specialist: lifecycle-core*
+
+The new `_restart_unit` constructs only `ai.clawrium.hermes.<name>` (gateway label). Hermes on macOS runs a SECOND launchd unit `ai.clawrium.hermes.<name>.dashboard` (see `core/launchd.py:91`, `hermes/templates/dashboard.plist.j2:18`, `lifecycle_macos.restart_agent_macos:368-370`). On Linux, `PartOf=` propagates the restart automatically; on macOS, only the gateway is kicked. After `sync_agent_canonical` rewrites `hermes-config.canonical.yaml` on macOS, the dashboard continues serving stale config.
+
+**Fix:** Enumerate both labels for hermes on macOS, mirroring `restart_agent_macos`. Reuse `lifecycle_macos._kickstart` rather than constructing labels inline.
+
+---
+
+### B8 · `launchctl kickstart -k` hard-fails on stopped/unbootstrapped agents — no bootstrap fallback
+*Specialist: lifecycle-core*
+
+`kickstart -k` returns non-zero with "Could not find service" when the unit was never bootstrapped or was booted-out (e.g. after `clawctl agent stop` or partial install). The new code unconditionally raises `CanonicalSyncError`. The existing `restart_agent_macos:382-416` detects exactly this stderr and falls back to `install_service` + `bootstrap` + `kickstart`. Canonical sync on a stopped macOS agent will hard-fail where both the Linux path and the existing macOS helper recover cleanly.
+
+**Fix:** Route through `restart_agent_macos` (preferred) or replicate the not-loaded → bootstrap-fallback branch.
+
+---
+
+### B9–B11 · Bedrock prefix rename has no legacy-prefix migration — will corrupt existing configs
+*Specialist: render-engine, platform-playbooks*
+
+The idempotency guards now check `not startswith('amazon-bedrock/')`. Any operator whose `hosts.json.agents.<name>.config.provider.default_model` already stores `bedrock/<id>` (persisted by previous install or hand-edited) will be silently rewritten to `amazon-bedrock/bedrock/<id>` on the next `clawctl agent sync`. The daemon then routes to a non-existent model and fails at runtime.
+
+This is the same double-prefix class the idempotency test at `test_render.py:3079` was written to prevent — and that test is now also broken because it exercises exactly this path with the old prefix form.
+
+Affected locations: `render.py:1455`, `.env.j2:23-24`, `openclaw.json.j2:21-22`, `verify_config.py:63-64`.
+
+**Fix:**
+1. Add legacy-prefix stripping before the new-prefix prepend in all four locations: `if model_id.startswith('bedrock/'): model_id = model_id[len('bedrock/'):]` before the `amazon-bedrock/` prepend.
+2. Update `test_openclaw_model_prefix_idempotent` to: (a) use `amazon-bedrock/<id>` as the idempotent case, (b) add a migration case that asserts `bedrock/<id>` → `amazon-bedrock/<id>` (single prefix, not double).
+3. Add a `### BREAKING` entry in `CHANGELOG.md [Unreleased]` documenting the rename and auto-migration behavior. Required per AGENTS.md changelog rules.
+
+---
+
+## Warnings
+
+| # | Location | Issue |
+|---|----------|-------|
+| W1 | `lifecycle_canonical.py:1030,1105,1113` | `host.get('hardware', {}).get('os', 'linux')` — default 'linux' is not a value `hardware.py` ever writes (writes 'ubuntu', 'debian', etc.). Safe today (only compared with `== 'macos'`) but misleads future code. Change to `is_macos = host.get('hardware', {}).get('os') == 'macos'` and pass bool. |
+| W2 | `lifecycle_canonical.py:1114` | 5-level `.get()` chain for gateway_port — if any intermediate value is explicitly `null` in hosts.json, `None.get('port')` raises `AttributeError`. Use `(host.get('agents') or {})` guard or extract a helper. |
+| W3 | `lifecycle_canonical.py:704-723` | `_verify_health` silently returns when `gateway_port is None` on macOS — a broken agent passes health check. At minimum emit a `verify_skipped` event so the operator sees nothing was verified. |
+| W4 | `lifecycle_canonical.py:519-524` | Error message regression: removed unit/label name from restart error string. Include the label and command in the `CanonicalSyncError` message. |
+| W5 | `cli/install.py:250` | `selected_claw` interpolated raw into Rich message — every other `[red]Error:[/red]` in this file wraps it with `escape(selected_claw)`. Bidi/Rich injection risk. |
+| W6 | `cli/install.py:251-252` | Remediation hint is wrong: `clawctl host create` registers a host with `hardware: {}` and never calls `gather_hardware`. No `clawctl` command currently re-gathers hardware. Either point at the real command or file a gap issue and say so explicitly in the hint. |
+| W7 | `cli/install.py:248-253` vs `core/install.py:329-334` | Same message text duplicated in two layers — will drift. Extract to a shared constant in `core/install.py` and import in the CLI guard. Also: CLI guard prints `[red]Error:[/red]` while the `except InstallationError` handler at line 357 prints `[red]Installation failed:[/red]` — inconsistent prefix. |
+| W8 | `hermes-config.canonical.yaml.j2:83` | `api_key: "aws-sdk"` is an undocumented magic-string sentinel. Add a Jinja comment citing the upstream hermes schema requirement (LiteLLM boto3 credential chain sentinel). Cross-reference in AGENTS.md hermes section. |
+| W9 | `test_render.py:3101` | `f"OPENCLAW_DEFAULT_MODEL='{model_id}'" in env` substring check passes even when model_id is a substring of a double-prefixed string. Use exact-line match: `any(line == f"..." for line in env.splitlines())`. |
+| W10 | `manifest.yaml:12-13` | `brave min_host_version` bumped to 2026.6.9 with no CHANGELOG entry. Hard-fails preflight on hosts running openclaw <2026.6.9 with brave attached. Needs `### BREAKING` entry or keep floor at 2026.6.8. Also: `openclaw/playbooks/install.yaml:7` default still references v2026.6.8. |
+| W11 | `manifest.yaml + install.yaml` | `requirements.dependencies.nodejs` is declarative-only — `check_compatibility()` never reads it, and install.yaml does not check node version before npm install. Ubuntu 22.04 ships node 12.x; `>=18.0.0` claim is unenforced. |
+| W12 | `lifecycle_canonical.py:516` | `agent_type` and `agent_name` interpolated into launchctl label without calling `_validate_agent_name()`. `launchd.py` explicitly enforces this at every public entry point as defense-in-depth. Reuse `launchd.label_for(agent_name, kind='gateway', agent_type=agent_type)` — it also errors explicitly on unsupported combos (e.g. zeroclaw on macOS). |
+| W13 | `lifecycle_canonical.py:720` | `gateway_port` not validated as `int` before f-string interpolation into `lsof` command. Type annotation says `int | None` but hosts.json is hand-editable. Add `isinstance(gateway_port, int) and 0 < gateway_port < 65536` guard before the f-string. |
+| W14 | `tests/ (missing)` | No test pins that `host_os='macos'` zeroclaw bearer-rotation (#437 invariant) still runs. A macOS sync that silently skips rotation is the exact regression class #437 fixed. |
+
+---
+
+## Suggestions
+
+| # | Issue |
+|---|-------|
+| S1 | Parametrize `test_install_hardware_unknown_raises` + `test_install_hardware_unknown_with_version_override_bypasses_check` into one `@pytest.mark.parametrize` per project convention (see `test_render.py:1994`). |
+| S2 | `import time as _time` inside `_verify_health` body — hoist to module level so tests can monkeypatch `lifecycle_canonical.time.sleep` cleanly. |
+| S3 | `openclaw/playbooks/install.yaml:7` version default should track manifest (`v2026.6.8` → `v2026.6.9`). |
+| S4 | CLI guard in `cli/install.py` only fires through the legacy `cli/agent.py:install` shim (not the canonical `clawctl agent create` path per issue #707 split). Consider deleting the guard as part of #707 cleanup rather than maintaining parallel error text. |
+
+---
+
+## What the ~21 Pre-existing Failures Look Like vs. Patch-Introduced
+
+| Category | Count | Nature |
+|----------|-------|--------|
+| `fake_restart_unit` / `fake_verify_health` `**kwargs` missing in `test_workspace_*` | ~11 | **Introduced by this patch** — new `host_os` kwarg not plumbed in |
+| `bedrock/` → `amazon-bedrock/` assertion string drift | ~5 | **Introduced by this patch** — test fixtures not updated |
+| macOS branch coverage failures | 0 now, risk later | **Introduced by this patch** — net-new untested code |
+| Other pre-existing failures (unrelated to patch) | ~5 | Pre-existing — not caused by this patch |
+
+The 5 "cosmetic" pre-existing failures should be documented but don't block this PR. The ~16 patch-introduced failures are blockers.
+
+---
+
+## Required Before Merge (Summary)
+
+1. Add `**kwargs` to stubs in `test_workspace_phase_ordering.py` and `test_workspace_zeroclaw_bearer_rotation.py` (B1–B2)
+2. Update 5 test fixtures from `bedrock/` → `amazon-bedrock/` (B3)
+3. Add macOS unit tests for `_atomic_write`, `_restart_unit`, `_verify_health` (B4)
+4. Strengthen `test_install_hardware_unknown_with_version_override_bypasses_check` assertion (B5)
+5. Extract macOS branches from `lifecycle_canonical.py` to `lifecycle_macos.py` via dispatcher (B6)
+6. Fix hermes dual-label restart on macOS (B7)
+7. Add not-loaded bootstrap fallback for launchctl (B8)
+8. Add legacy `bedrock/` → `amazon-bedrock/` migration stripping in all four render locations (B9–B11)
+9. Add `### BREAKING` CHANGELOG entry for bedrock prefix rename (B9–B11)
+10. Fix `escape(selected_claw)` in CLI error message (W5)
+11. Fix remediation hint to point at a real hardware-gathering command (W6)
+12. Add `isinstance(gateway_port, int)` guard before lsof f-string (W13)
+

--- a/.itx/openclaw-macos-bundle/atx-review-5.txt
+++ b/.itx/openclaw-macos-bundle/atx-review-5.txt
@@ -1,0 +1,76 @@
+Requesting review for /home/devashish/workspace/ric03uec/clawrium...
+{"time":"2026-06-23T20:07:48.895960403-07:00","level":"INFO","msg":"request_review: starting","project_root":"/home/devashish/workspace/ric03uec/clawrium"}
+{"time":"2026-06-23T20:07:48.921259698-07:00","level":"INFO","msg":"request_review: task created","task_id":"cea21dcd-5da5-4b4e-b9a5-11c2e20dedac","project_port":30011}
+ATX review in progress. Using high effort (per-call-override) — leader may invoke up to 6 of 7 specialists.
+Task created (id: cea21dcd-5da5-4b4e-b9a5-11c2e20dedac), polling for completion...
+Waiting for review... (0s elapsed)
+Waiting for review... (1s elapsed)
+Waiting for review... (3s elapsed)
+Waiting for review... (7s elapsed)
+Waiting for review... (15s elapsed)
+Waiting for review... (25s elapsed)
+Waiting for review... (35s elapsed)
+Waiting for review... (45s elapsed)
+Waiting for review... (55s elapsed)
+Waiting for review... (1m5s elapsed)
+Waiting for review... (1m15s elapsed)
+Waiting for review... (1m25s elapsed)
+Waiting for review... (1m35s elapsed)
+Waiting for review... (1m45s elapsed)
+Waiting for review... (1m55s elapsed)
+Waiting for review... (2m5s elapsed)
+Waiting for review... (2m15s elapsed)
+Waiting for review... (2m25s elapsed)
+Waiting for review... (2m35s elapsed)
+Waiting for review... (2m45s elapsed)
+Waiting for review... (2m55s elapsed)
+Waiting for review... (3m5s elapsed)
+Waiting for review... (3m15s elapsed)
+Waiting for review... (3m25s elapsed)
+Waiting for review... (3m35s elapsed)
+Waiting for review... (3m45s elapsed)
+Waiting for review... (3m55s elapsed)
+Waiting for review... (4m5s elapsed)
+Waiting for review... (4m15s elapsed)
+Waiting for review... (4m25s elapsed)
+Waiting for review... (4m35s elapsed)
+Waiting for review... (4m45s elapsed)
+Waiting for review... (4m55s elapsed)
+Waiting for review... (5m5s elapsed)
+Waiting for review... (5m15s elapsed)
+Waiting for review... (5m25s elapsed)
+Waiting for review... (5m35s elapsed)
+Waiting for review... (5m45s elapsed)
+Waiting for review... (5m55s elapsed)
+{"time":"2026-06-23T20:13:54.224024543-07:00","level":"INFO","msg":"review: task completed","task_id":"cea21dcd-5da5-4b4e-b9a5-11c2e20dedac","status":"completed","duration_ms":364959}
+{"time":"2026-06-23T20:13:54.224046925-07:00","level":"INFO","msg":"request_review: completed","status":"completed","blocking":false,"files_reviewed":0,"cost_usd":3.9884192499999997,"task_id":"cea21dcd-5da5-4b4e-b9a5-11c2e20dedac"}
+Status: reviewed
+Summary: Synthesizing iter-5 findings from six specialists.
+Cost: $3.9884
+Time: 6m 4s
+Rating: 4/5
+Models: claude-opus-4-7, claude-sonnet-4-6
+
+Agent Feedback:
+  [completed] leader (-) — Synthesizing iter-5 findings from six specialists.
+  [completed] gui-routes (2/5) — <output>
+{
+  "rating": 2,
+  "summary": "Guard runs in the correct place and uses an allowlist as required, but drifts fr...
+  [completed] platform-playbooks (5/5) — <output>
+{
+  "rating": 5,
+  "summary": "ATX iter-5 W3 verification on the operator_platform extravar guard. Both opencla...
+  [completed] cli-ux (4/5) — <output>{"rating": 4, "summary": "Both targeted concerns (S1 sys import, S3 CHANGELOG structure) are satisfied. chat.py ...
+  [completed] test-coverage (3/5) — <output>
+{
+  "rating": 3,
+  "summary": "B1 install parametrize is complete and correctly inspects the inventory extravar...
+  [completed] lifecycle-core (4/5) — <output>
+{
+  "rating": 4,
+  "summary": "The `_operator_platform` module is well-designed: regex-based version stripping ...
+  [completed] security-reviewer (4/5) — <output>{
+  "rating": 4,
+  "summary": "The operator_platform threading is implemented defensively across all three bound...
+  [skipped] render-engine (-) — 

--- a/.itx/openclaw-macos-bundle/bundle-README.md
+++ b/.itx/openclaw-macos-bundle/bundle-README.md
@@ -1,0 +1,125 @@
+# Clawrium Fixes — 2026-06-23
+
+Bundle of fixes from setting up `macmini-openclaw` agent on `espers-mac-mini.tailf7742d.ts.net`.
+
+## Issues Fixed
+
+### 1. Issue #720 — openclaw install fails with `npm ETARGET` when hardware unknown
+
+**Symptom**: `clawctl agent create` picks `openclaw@0.1.0` (first entry in manifest platforms list) instead of the latest CalVer version. That version doesn't exist on npm.
+
+**Root cause**: `src/clawrium/core/install.py:327-331` — when `check_compatibility()` returns `matched_entry=None` (hardware facts not gathered), the fallback was `manifest["platforms"][0]["version"]` which is the oldest entry.
+
+**Fix**: Deterministic fail-fast. If hardware is unknown, raise `InstallationError` with a message telling the operator to ensure `clawctl host create` gathered hardware facts first. No guessing.
+
+**Files**:
+- `src/clawrium/core/install.py` — `InstallationError` when `matched_entry` is None
+- `src/clawrium/cli/install.py` — null-check before accessing `compat["matched_entry"]["version"]` (would crash with TypeError)
+- `tests/test_install.py` — 2 new tests: `test_install_hardware_unknown_raises`, `test_install_hardware_unknown_with_version_override_bypasses_check`
+
+**Error log (before fix)**:
+```
+agent/macmini-openclaw: [validate] Hardware unknown, using latest: openclaw v0.1.0
+...
+npm error notarget No matching version found for openclaw@0.1.0.
+npm error A complete log of this run can be found in: /Users/macmini-openclaw/.npm/_logs/2026-06-23T04_36_01_529Z-debug-0.log
+```
+
+---
+
+### 2. macOS sync — `install -g {owner}` fails (no per-user group on Darwin)
+
+**Symptom**: `clawctl agent sync` fails on macOS with `install: illegal option -- g` or group-not-found because macOS doesn't create a per-user primary group matching the username.
+
+**Root cause**: `_atomic_write()` in `lifecycle_canonical.py` passed `-g {agent_name}` unconditionally. macOS primary group is `staff`.
+
+**Fix**: Added `host_os` parameter; group resolves to `"staff"` on macOS.
+
+**File**: `src/clawrium/core/lifecycle_canonical.py`
+
+---
+
+### 3. macOS sync — `systemctl restart` doesn't exist
+
+**Symptom**: `clawctl agent sync` calls `systemctl restart` which doesn't exist on macOS.
+
+**Fix**: `_restart_unit()` now branches on `host_os`:
+- macOS: `sudo -n launchctl kickstart -k system/ai.clawrium.{agent_type}.{agent_name}`
+- Linux: `sudo -n systemctl restart` (unchanged)
+
+**File**: `src/clawrium/core/lifecycle_canonical.py`
+
+---
+
+### 4. macOS sync — `systemctl is-active` verify doesn't exist
+
+**Symptom**: `_verify_health()` calls `systemctl is-active` on macOS — fails.
+
+**Fix**: macOS branch polls `lsof -i :{port} -P -sTCP:LISTEN` every 1s, up to 30s. Returns on first listen. Requires `gateway_port` parameter (from hosts.json).
+
+**File**: `src/clawrium/core/lifecycle_canonical.py`
+
+---
+
+### 5. Bedrock model prefix — openclaw expects `amazon-bedrock/` not `bedrock/`
+
+**Symptom**: After sync, openclaw logs `Unknown model: bedrock/zai.glm-5`. The agent can't use the provider.
+
+**Root cause**: `_OPENCLAW_MODEL_PREFIX` in `render.py` mapped `"bedrock"` → `"bedrock/"`. OpenClaw's Bedrock provider is named `amazon-bedrock` and expects the prefix `amazon-bedrock/`.
+
+**Fix**: Changed prefix mapping and all templates.
+
+**Files**:
+- `src/clawrium/core/render.py:1369` — `"bedrock"` → `"amazon-bedrock/"`
+- `src/clawrium/platform/registry/openclaw/templates/.env.j2` — prefix fix
+- `src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2` — prefix fix
+- `src/clawrium/platform/registry/openclaw/templates/verify_config.py` — prefix fix
+
+**Error log (before fix)**:
+```
+[gateway] Unknown model: bedrock/zai.glm-5
+[gateway] Falling back to default model selection
+```
+
+---
+
+### 6. Manifest registry update — v2026.6.9
+
+OpenClaw published v2026.6.9. Added platform entries to manifest.
+
+**File**: `src/clawrium/platform/registry/openclaw/manifest.yaml`
+- Ubuntu 24.04 x86_64: v2026.6.9
+- Ubuntu 22.04 x86_64: v2026.6.9
+- macOS >=14 arm64: v2026.6.9
+- Plugin pin bumped: `brave.version` → `"2026.6.9"`
+
+---
+
+## Test Adjustments
+
+- `tests/cli/clawctl/agent/test_sync.py` — mock `fake_restart()` updated to accept `**kwargs` (for new `host_os` param)
+- `tests/cli/test_agent_upgrade.py` — `test_upgrade_no_op_when_already_at_max` updated expected version from `2026.6.8` → `2026.6.9`
+- `tests/core/test_render.py` — render tests updated for `amazon-bedrock/` prefix
+
+## Known Remaining Issues
+
+1. `test_below_min_version_raises` may need version update (manifest now has 2026.6.9)
+2. `plugins.allow` warning on gateway startup (cosmetic, upstream openclaw issue)
+3. macOS verify timeout (30s) can be tight on cold start with bedrock plugin
+
+## How to Apply
+
+```bash
+cd /path/to/clawrium
+git apply changes.patch
+```
+
+Or copy individual files from this bundle (directory structure matches repo layout).
+
+## Host Setup Completed
+
+- **Host**: `esper-macmini` @ `espers-mac-mini.tailf7742d.ts.net`
+- **Agent**: `macmini-openclaw` (openclaw v2026.6.9)
+- **Provider**: `keith-bedrock` → `amazon-bedrock/zai.glm-5`
+- **Port**: 40510
+- **Status**: Running, healthy, gateway responding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,40 @@ cut. The `itx:release` skill archives this section into a new
 
 ### BREAKING
 
+- **openclaw bedrock model prefix renamed `bedrock/` → `amazon-bedrock/`.**
+  The openclaw gateway's Bedrock provider is registered as
+  `amazon-bedrock` upstream; the previous `bedrock/<id>` prefix caused
+  `Unknown model: bedrock/<id>` errors at request time. The renderer,
+  `.env.j2`, `openclaw.json.j2`, and `verify_config.py` all emit
+  `amazon-bedrock/<id>` going forward.
+
+  **No automated migration.** Operators with a previously-installed
+  openclaw agent whose `hosts.json.agents.<name>.config.provider.default_model`
+  starts with `bedrock/` must update it manually before the next
+  `clawctl agent sync` — either edit `~/.config/clawrium/hosts.json`
+  directly to replace the `bedrock/` prefix with `amazon-bedrock/`, or
+  reattach the provider via `clawctl agent provider attach <agent>
+  --provider <provider> --model <id-without-prefix>`. Syncing without
+  the manual update will continue to write the old prefix, and the
+  gateway will continue to fail with `Unknown model`.
+
+- **openclaw brave plugin pin bumped to `2026.6.9` and
+  `min_host_version` raised to `2026.6.9`.** The
+  `clawctl agent sync` brave preflight now rejects hosts running
+  openclaw `< 2026.6.9` when the brave integration is attached, with
+  a `clawctl agent upgrade <name>` remediation hint. Operators on
+  older openclaw versions who use brave must upgrade openclaw before
+  the next sync.
+
+  **Heads-up before upgrading:** `clawctl agent upgrade` on openclaw
+  is known to strip provider and channel attachments (see issue tracker
+  and operator notes from the wolf-i upgrade on 2026-06-18 — systemd
+  reports the unit ready but `clawctl agent doctor` will show the
+  attachments gone). Recommended flow: capture `clawctl agent doctor
+  <name>` output BEFORE the upgrade, run the upgrade, then re-attach
+  the provider + channels and run `clawctl agent sync <name>` to
+  re-materialize them on the host.
+
 ### Added
 
 - `tape.output_format` key in `docs/demos/<demo>/scenes.yaml` — set to
@@ -21,6 +55,21 @@ cut. The `itx:release` skill archives this section into a new
   behavior). GIF outputs skip the `narrate.py` step since GIF has no
   audio container. The `/create-vhs` skill documents this in its
   scenes.yaml template and Step 6 (narration).
+- openclaw macOS support in `clawctl agent sync`: the canonical pipeline
+  now dispatches per-OS for atomic file replace (`install -g staff` on
+  macOS vs per-user group on Linux), unit restart (launchctl kickstart
+  with dual-label and bootstrap fallback for hermes, vs systemctl
+  restart on Linux), and health verification (`nc -z 127.0.0.1 <port>`
+  TCP-connect poll on macOS — chosen over `lsof -i :<port>` because
+  macOS `lsof` only shows ports owned by the running user, and the
+  sync runs as `xclm` while the daemon runs as `<agent_name>`; vs
+  `systemctl is-active` on Linux). The macOS branches live in
+  `lifecycle_macos.py` and are routed via a thin dispatcher in
+  `lifecycle_canonical.py`; no `if Darwin` guards inside the canonical
+  business logic. Per-instance gateway port pulled from
+  `hosts.json.agents.<name>.config.gateway.port`.
+- openclaw v2026.6.9 platform entries in the openclaw manifest
+  (Ubuntu 24.04 x86_64, Ubuntu 22.04 x86_64, macOS ≥14 arm64).
 
 ### Changed
 
@@ -33,5 +82,12 @@ cut. The `itx:release` skill archives this section into a new
   (#786).
 
 ### Fixed
+
+- `clawctl agent create` no longer guesses `platforms[0]` (the oldest
+  manifest entry) when host hardware facts are missing. It now fails
+  fast with `InstallationError` and tells the operator to populate
+  hardware first via `clawctl host create`. Eliminates the
+  `npm ETARGET: No matching version found for openclaw@0.1.0`
+  class of failure (#720).
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,21 @@ cut. The `itx:release` skill archives this section into a new
   was moved out of the page header and now sits directly above the
   configured integrations list, co-located with the list it mutates
   (#786).
+- openclaw WebSocket chat protocol negotiation now spans
+  `minProtocol=3, maxProtocol=4`. openclaw v2026.6.9+ requires
+  protocol 4 (the daemon rejects min=3/max=3 handshakes with
+  `expected=4 probeMin=4`); the 3..4 range keeps `clawctl agent
+  chat` compatible with both older daemons still on protocol 3 and
+  v2026.6.9+ (#719).
+- openclaw install now threads the OPERATOR'S `sys.platform`
+  (normalized to the bare family name — `freebsd13` → `freebsd`,
+  etc.) through to the pair script as the `operator_platform`
+  inventory extravar. The daemon stores this on the paired device
+  entry; `clawctl agent chat` sends the same value on subsequent
+  connects. Previously the pair script recorded the AGENT HOST's
+  OS (Mac mini → `darwin`) while the chat client hardcoded
+  `"linux"` — every cross-platform install required UI re-approval
+  to chat. Same-platform installs are unaffected (#719).
 
 ### Fixed
 

--- a/src/clawrium/cli/install.py
+++ b/src/clawrium/cli/install.py
@@ -244,6 +244,15 @@ def install(
             console.print(f"  - {reason}")
         raise typer.Exit(code=1)
 
+    if compat["matched_entry"] is None:
+        console.print(
+            f"[red]Error:[/red] Cannot determine compatible version for "
+            f"'{selected_claw}': host hardware information is not available.\n"
+            f"Run 'clawctl host create' with SSH access first to gather "
+            f"hardware facts, then retry the install."
+        )
+        raise typer.Exit(code=1)
+
     matched_version = compat["matched_entry"]["version"]
     display_host = host_record.get("alias") or host_record["hostname"]
 

--- a/src/clawrium/core/_operator_platform.py
+++ b/src/clawrium/core/_operator_platform.py
@@ -1,0 +1,71 @@
+"""Normalize the operator's `sys.platform` value for openclaw pairing.
+
+Python `sys.platform` returns versioned strings on some POSIX flavors:
+
+- Linux         → `linux`
+- macOS         → `darwin`
+- Windows       → `win32`
+- FreeBSD 13.x  → `freebsd13`   (versioned!)
+- FreeBSD 14.x  → `freebsd14`   (versioned!)
+- AIX 7.x       → `aix7`        (versioned!)
+- OpenBSD       → `openbsd6.9`  (versioned!)
+
+Node's `process.platform` returns BARE family names on the same OSes
+(`freebsd`, `aix`, `openbsd`). The openclaw daemon stores whatever
+string the pair script (Node) sends on the device record and rejects
+any subsequent connect that reports a different `platform` value as
+"device identity changed".
+
+Without normalization, a Python interpreter upgrade on a FreeBSD
+operator (3.11 on freebsd13 → 3.12 on freebsd14, both perfectly fine)
+would trigger the exact "device identity changed" rejection the
+operator-platform threading was written to prevent.
+
+`normalize()` strips trailing version digits and the optional `.minor`
+suffix so Python's value matches Node's bare family name. The known
+safe set (`linux`, `darwin`, `win32`) passes through unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+# Strip trailing major[.minor[.patch]] version suffix off platform
+# names like "freebsd13", "aix7", "openbsd6.9". Anchored at the end
+# so a legitimate `linux` or `darwin` is left alone.
+_VERSION_SUFFIX_RE = re.compile(r"\d+(\.\d+)*$")
+
+# Values that must pass through verbatim — either already bare-family
+# (linux/darwin) OR a special name where the trailing digit is part of
+# the identifier itself (win32: the "32" is the Win32 API family, not
+# a version). Node's `process.platform` also returns `win32`, so the
+# two sides agree.
+_PASSTHROUGH = frozenset({"linux", "darwin", "win32", "cygwin"})
+
+
+def normalize(value: str | None = None) -> str:
+    """Return the bare platform family for `value` (default `sys.platform`).
+
+    Examples:
+        >>> normalize("linux")        # passes through
+        'linux'
+        >>> normalize("darwin")       # passes through
+        'darwin'
+        >>> normalize("win32")        # passes through (Node also returns 'win32')
+        'win32'
+        >>> normalize("freebsd13")    # strip version
+        'freebsd'
+        >>> normalize("openbsd6.9")   # strip version
+        'openbsd'
+
+    A non-string `value` falls back to `sys.platform` so callers can
+    pass `os.environ.get(...)` results without an extra guard.
+    """
+    raw = value if isinstance(value, str) and value else sys.platform
+    if raw in _PASSTHROUGH:
+        return raw
+    return _VERSION_SUFFIX_RE.sub("", raw)
+
+
+__all__ = ["normalize"]

--- a/src/clawrium/core/chat.py
+++ b/src/clawrium/core/chat.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import sys
 import time
 import uuid
 from collections import deque
@@ -15,6 +16,7 @@ import websockets
 from websockets.exceptions import WebSocketException
 
 from clawrium import __version__
+from clawrium.core._operator_platform import normalize as _normalize_operator_platform
 
 __all__ = [
     "ChatError",
@@ -228,13 +230,38 @@ class OpenClawChatClient:
             role = "operator"
             scopes = ["operator.read", "operator.write"]
 
+            # openclaw stores the `platform` field on the paired
+            # device record. A subsequent connect that reports a
+            # different platform is treated as "device identity
+            # changed" and rejected pending UI re-approval — even when
+            # the deviceId + publicKey + signature all match. The
+            # install pair script runs the pairing handshake from the
+            # AGENT HOST via localhost (a Mac mini → `darwin`), but
+            # the operator's clawctl that drives chat actually lives
+            # on a different machine (Linux/macOS workstation). Send
+            # the OPERATOR's platform, not a hardcoded value, so the
+            # pair-time and chat-time `platform` strings agree.
+            #
+            # `_normalize_operator_platform` strips Python's
+            # versioned-platform suffix (`freebsd13` → `freebsd`) so
+            # the value matches Node's `process.platform` shape that
+            # `pair_device.mjs` records on the daemon side — without
+            # this a Python 3.11→3.12 bump on a FreeBSD operator
+            # would trigger the exact "device identity changed"
+            # rejection this code was written to prevent.
             connect_params: dict[str, Any] = {
+                # openclaw v2026.6.9 dropped protocol 3 — the daemon
+                # rejects min=3/max=3 handshakes with "expected=4
+                # probeMin=4" (verified live against esper-mac-oc,
+                # see .itx/719/01_EXECUTION.md). Negotiate 3..4 so
+                # the client stays compatible with both older daemons
+                # still on proto 3 and v2026.6.9+ on proto 4.
                 "minProtocol": 3,
-                "maxProtocol": 3,
+                "maxProtocol": 4,
                 "client": {
                     "id": client_id,
                     "version": __version__,
-                    "platform": "linux",
+                    "platform": _normalize_operator_platform(sys.platform),
                     "mode": client_mode,
                 },
                 "role": role,

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -25,12 +25,14 @@ Host record schema (extended):
 import hashlib
 import logging
 import os
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, NotRequired, TypedDict
 
 import ansible_runner
 
+from clawrium.core._operator_platform import normalize as _normalize_operator_platform
 from clawrium.core.config import get_config_dir
 from clawrium.core.hosts import get_host, update_host
 from clawrium.core.keys import get_host_private_key
@@ -926,6 +928,24 @@ def run_installation(
                 "config": config,
                 "template_path": str(template_path),
                 "force_install": force,
+                # The OPERATOR's platform (`linux`/`darwin`/`win32`/
+                # `freebsd`/...). The openclaw pair script records
+                # this on the daemon's paired device entry; the chat
+                # client sends the same value on subsequent connects.
+                # If the two disagree, openclaw treats the connect as
+                # "device identity changed" and demands UI re-approval.
+                # Setting it here from clawctl's own process platform
+                # — the install pair script runs on the agent host but
+                # is paired ON BEHALF OF this clawctl install, so the
+                # operator platform is what matters, not the agent
+                # host's OS.
+                #
+                # `_normalize_operator_platform` strips Python's
+                # versioned-platform suffix (`freebsd13` → `freebsd`)
+                # so the install-time and chat-time values match
+                # across Python interpreter upgrades on the same
+                # operator machine.
+                "operator_platform": _normalize_operator_platform(sys.platform),
                 # ATX W2: scope dashboard_port to hermes only. Unconditional
                 # injection puts `dashboard_port: null` in non-hermes
                 # inventories where `when: dashboard_port is defined`

--- a/src/clawrium/core/install.py
+++ b/src/clawrium/core/install.py
@@ -325,10 +325,15 @@ def run_installation(
         matched_version = compat["matched_entry"]["version"]
         emit("validate", f"Compatible with {claw_name} v{matched_version}")
     else:
-        # Hardware not yet gathered — fall back to latest manifest version.
-        manifest = load_manifest(claw_name)
-        matched_version = manifest["platforms"][0]["version"]
-        emit("validate", f"Hardware unknown, using latest: {claw_name} v{matched_version}")
+        # Hardware not yet gathered — cannot determine correct version.
+        # Refuse to proceed: guessing a version risks installing an
+        # incompatible or non-existent package (see issue #720).
+        raise InstallationError(
+            f"Cannot determine compatible version for '{claw_name}': "
+            f"host hardware information is not available. "
+            f"Run 'clawctl host create' with SSH access first to gather "
+            f"hardware facts, then retry the install."
+        )
 
     # Step 4: Validate custom name if provided (format only, uniqueness checked in updater)
     if name is not None:

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -444,7 +444,12 @@ def _open_ssh(host: dict, *, timeout: int = 15) -> paramiko.SSHClient:
     return client
 
 
-def _atomic_write(
+def _host_is_macos(host: dict) -> bool:
+    """Single OS-detection helper for the canonical pipeline dispatchers."""
+    return host.get("hardware", {}).get("os") == "macos"
+
+
+def _atomic_write_linux(
     client: paramiko.SSHClient,
     *,
     agent_name: str,
@@ -452,17 +457,8 @@ def _atomic_write(
     body: str,
     timeout: int = 30,
 ) -> None:
-    """Atomically replace `remote_path` with `body`, mode 0600, owned by agent.
-
-    Uses `sudo -n` to write a tmpfile under `/tmp` (xclm-writable) and
-    then `sudo -n install` to atomically move it into place with the
-    correct mode / owner. `install` is preferred over `mv` because it
-    sets mode + owner in one syscall and is universally available on
-    Linux hosts.
-    """
+    """Linux implementation: agent_name doubles as the primary group name."""
     quoted_path = shlex.quote(remote_path)
-    # mktemp -p /tmp: deterministic, world-writable location for the
-    # xclm user before sudo takes over for the final placement.
     _, stdout, _ = client.exec_command("mktemp /tmp/clawrium-sync.XXXXXX")
     if stdout.channel.recv_exit_status() != 0:
         raise CanonicalSyncError("mktemp failed on host")
@@ -476,9 +472,6 @@ def _atomic_write(
                 fh.write(body.encode("utf-8"))
         finally:
             sftp.close()
-        # `install -m 0600 -o <name> -g <name>` requires sudo (target
-        # dirs are root- or agent-owned). `install` is atomic w.r.t.
-        # the destination so a partial write is never visible.
         owner = shlex.quote(agent_name)
         cmd = (
             f"sudo -n install -m 0600 -o {owner} -g {owner} "
@@ -495,7 +488,42 @@ def _atomic_write(
         client.exec_command(f"rm -f {shlex.quote(tmp_path)}")
 
 
-def _restart_unit(
+def _atomic_write(
+    client: paramiko.SSHClient,
+    *,
+    agent_name: str,
+    remote_path: str,
+    body: str,
+    host: dict | None = None,
+    timeout: int = 30,
+) -> None:
+    """Dispatcher — routes to the Linux or macOS atomic-write impl by host OS.
+
+    `install` is atomic w.r.t. the destination on both platforms, so a
+    partial write is never visible. The OS split is purely about the
+    primary-group name passed to `install -g`: Linux uses a per-user
+    group matching `agent_name`; macOS uses the shared `staff` group.
+    """
+    if host is not None and _host_is_macos(host):
+        from clawrium.core.lifecycle_macos import atomic_write_macos
+
+        return atomic_write_macos(
+            client,
+            agent_name=agent_name,
+            remote_path=remote_path,
+            body=body,
+            timeout=timeout,
+        )
+    _atomic_write_linux(
+        client,
+        agent_name=agent_name,
+        remote_path=remote_path,
+        body=body,
+        timeout=timeout,
+    )
+
+
+def _restart_unit_linux(
     client: paramiko.SSHClient,
     *,
     agent_type: str,
@@ -509,8 +537,43 @@ def _restart_unit(
     if rc != 0:
         stderr_text = err.read().decode("utf-8", errors="replace")
         raise CanonicalSyncError(
-            f"systemctl restart {unit} failed (exit {rc}): {stderr_text.strip()}"
+            f"restart {unit} failed (exit {rc}): {stderr_text.strip()}"
         )
+
+
+def _restart_unit(
+    client: paramiko.SSHClient,
+    *,
+    agent_type: str,
+    agent_name: str,
+    host: dict | None = None,
+    on_event: Callable[[str, str], None] | None = None,
+    timeout: int = 30,
+) -> None:
+    """Dispatcher — routes to systemctl (Linux) or launchctl helpers (macOS).
+
+    macOS routes through `lifecycle_macos.restart_unit_macos` which
+    handles dual-label (gateway + dashboard for hermes), validates the
+    agent name via `label_for`, and falls back to a fresh bootstrap if
+    the unit was never loaded.
+    """
+    if host is not None and _host_is_macos(host):
+        from clawrium.core.lifecycle_macos import restart_unit_macos
+
+        return restart_unit_macos(
+            client,
+            host=host,
+            agent_name=agent_name,
+            agent_type=agent_type,
+            on_event=on_event,
+            timeout=timeout,
+        )
+    _restart_unit_linux(
+        client,
+        agent_type=agent_type,
+        agent_name=agent_name,
+        timeout=timeout,
+    )
 
 
 # #575: when a unit fails to come active after restart, capture the
@@ -683,8 +746,25 @@ def _verify_health(
     *,
     agent_type: str,
     agent_name: str,
+    host: dict | None = None,
+    gateway_port: int | None = None,
+    on_event: Callable[[str, str], None] | None = None,
     timeout: int = 15,
 ) -> None:
+    """Dispatcher — systemctl is-active (Linux) or lsof port-listen (macOS)."""
+    if host is not None and _host_is_macos(host):
+        from clawrium.core.lifecycle_macos import verify_health_macos
+
+        # macOS launchd needs longer than systemctl to stabilize after
+        # kickstart, especially if the daemon crash-looped previously.
+        return verify_health_macos(
+            client,
+            agent_name=agent_name,
+            gateway_port=gateway_port,
+            on_event=on_event,
+            timeout=max(timeout, 30),
+        )
+
     unit = f"{agent_type}-{agent_name}.service"
     cmd = f"systemctl is-active {shlex.quote(unit)}"
     _, out, _ = client.exec_command(cmd, timeout=timeout)
@@ -987,6 +1067,7 @@ def sync_agent_canonical(
                 agent_name=agent_name,
                 remote_path=d.remote_path,
                 body=d.rendered_body,
+                host=host,
             )
             files_written.append(d.path)
 
@@ -1061,13 +1142,24 @@ def sync_agent_canonical(
                 client,
                 agent_type=inputs.agent_type,
                 agent_name=agent_name,
+                host=host,
+                on_event=on_event,
             )
             if verify:
                 emit("verify", "checking unit is active")
+                gateway_port = (
+                    ((host.get("agents") or {}).get(agent_name) or {})
+                    .get("config", {})
+                    .get("gateway", {})
+                    .get("port")
+                )
                 _verify_health(
                     client,
                     agent_type=inputs.agent_type,
                     agent_name=agent_name,
+                    host=host,
+                    gateway_port=gateway_port,
+                    on_event=on_event,
                 )
         elif restart and not files_written:
             emit("restart", "skipped (no files changed)")

--- a/src/clawrium/core/lifecycle_macos.py
+++ b/src/clawrium/core/lifecycle_macos.py
@@ -75,8 +75,13 @@ def _ssh(host: dict) -> paramiko.SSHClient:
     return client
 
 
-def _run(client: paramiko.SSHClient, cmd: str) -> tuple[int, str, str]:
-    _, stdout, stderr = client.exec_command(cmd)
+def _run(
+    client: paramiko.SSHClient,
+    cmd: str,
+    *,
+    timeout: int | None = None,
+) -> tuple[int, str, str]:
+    _, stdout, stderr = client.exec_command(cmd, timeout=timeout)
     out = stdout.read().decode()
     err = stderr.read().decode()
     rc = stdout.channel.recv_exit_status()
@@ -89,6 +94,7 @@ def install_service(
     *,
     dashboard_port: int | None = None,
     agent_type: str = "hermes",
+    timeout: int | None = None,
 ) -> str:
     """Render and write the gateway plist (and dashboard plist if `dashboard_port`)
     for `agent_name`. Returns the gateway plist path.
@@ -96,6 +102,10 @@ def install_service(
     Idempotent: re-writing the same content is a no-op. Does NOT bootstrap
     the units — that's start_agent. Always ensures the agent's logs dir
     exists so StandardOutPath / StandardErrorPath in the plists resolve.
+
+    `timeout` (default None = no bound) is honored on the `sudo mkdir
+    -p / chown` command so callers from the canonical sync path can
+    bound every sudo call in the fallback leg (B2).
     """
     if agent_type == "openclaw":
         template_name = "openclaw.plist.j2"
@@ -125,6 +135,7 @@ def install_service(
         client,
         f"sudo mkdir -p {shlex.quote(logs_dir)} "
         f"&& sudo chown {shlex.quote(agent_name)}:staff {shlex.quote(logs_dir)}",
+        timeout=timeout,
     )
     if rc != 0:
         raise RuntimeError(
@@ -140,6 +151,7 @@ def _bootstrap(
     *,
     kind: str = "gateway",
     agent_type: str = "hermes",
+    timeout: int | None = None,
 ) -> tuple[int, str, str]:
     """`launchctl bootstrap system <plist>`. Idempotent-ish.
 
@@ -147,7 +159,11 @@ def _bootstrap(
     caller treats that case as success. Other non-zero results bubble up.
     """
     path = plist_path_for(agent_name, kind=kind, agent_type=agent_type)
-    return _run(client, f"sudo launchctl bootstrap system {shlex.quote(path)}")
+    return _run(
+        client,
+        f"sudo launchctl bootstrap system {shlex.quote(path)}",
+        timeout=timeout,
+    )
 
 
 def _bootout(
@@ -156,10 +172,15 @@ def _bootout(
     *,
     kind: str = "gateway",
     agent_type: str = "hermes",
+    timeout: int | None = None,
 ) -> tuple[int, str, str]:
     """`launchctl bootout system/<label>`. Tolerates "not loaded"."""
     label = label_for(agent_name, kind=kind, agent_type=agent_type)
-    return _run(client, f"sudo launchctl bootout system/{shlex.quote(label)}")
+    return _run(
+        client,
+        f"sudo launchctl bootout system/{shlex.quote(label)}",
+        timeout=timeout,
+    )
 
 
 def _kickstart(
@@ -169,11 +190,16 @@ def _kickstart(
     kill: bool = False,
     kind: str = "gateway",
     agent_type: str = "hermes",
+    timeout: int | None = None,
 ) -> tuple[int, str, str]:
     """`launchctl kickstart [-k] system/<label>` — restart in place."""
     label = label_for(agent_name, kind=kind, agent_type=agent_type)
     flag = "-k " if kill else ""
-    return _run(client, f"sudo launchctl kickstart {flag}system/{shlex.quote(label)}")
+    return _run(
+        client,
+        f"sudo launchctl kickstart {flag}system/{shlex.quote(label)}",
+        timeout=timeout,
+    )
 
 
 def _dashboard_port_from_host(host: dict, agent_name: str) -> int | None:
@@ -199,6 +225,7 @@ def _bootstrap_with_tolerance(
     *,
     kind: str,
     agent_type: str = "hermes",
+    timeout: int | None = None,
 ) -> tuple[bool, str | None]:
     """`launchctl bootstrap`, treating any "already loaded" signal as success.
 
@@ -213,7 +240,9 @@ def _bootstrap_with_tolerance(
     The follow-up kickstart confirms whether the daemon is actually
     running.
     """
-    rc, out, err = _bootstrap(client, agent_name, kind=kind, agent_type=agent_type)
+    rc, out, err = _bootstrap(
+        client, agent_name, kind=kind, agent_type=agent_type, timeout=timeout
+    )
     if rc == 0:
         return True, None
     combined = (out + err).lower()
@@ -804,17 +833,350 @@ def sync_agent(
     return result
 
 
+# --- Canonical-sync dispatch helpers (called from lifecycle_canonical.py) ----
+#
+# These wrap launchctl in the same shape the Linux path uses in
+# lifecycle_canonical.py (atomic_write / restart_unit / verify_health) so
+# the canonical sync pipeline can route to macOS via a thin dispatcher
+# rather than `if host_os == 'macos':` branches inside the canonical file.
+# Dispatcher-only OS fork — see AGENTS.md feedback memory.
+
+
+def atomic_write_macos(
+    client: paramiko.SSHClient,
+    *,
+    agent_name: str,
+    remote_path: str,
+    body: str,
+    timeout: int = 30,
+) -> None:
+    """Atomic file replace on macOS via `install -g staff`.
+
+    macOS agent users are created with PrimaryGroupID 20 (`staff`); there
+    is no per-user group matching the agent name like on Linux. Raises
+    `clawrium.core.lifecycle_canonical.CanonicalSyncError` on failure so
+    the canonical sync surface stays uniform.
+
+    `agent_name` is validated up-front (defense-in-depth W1) — every
+    public entry point in `launchd.py` does the same; the `shlex.quote`
+    on the f-string interpolation alone is current-safe but an explicit
+    regex guard survives future refactors to argv form.
+    """
+    from clawrium.core.launchd import _validate_agent_name
+    from clawrium.core.lifecycle_canonical import CanonicalSyncError
+
+    _validate_agent_name(agent_name)
+
+    quoted_path = shlex.quote(remote_path)
+    tmp_path: str | None = None
+    try:
+        # `/tmp` is mode 1777 (sticky bit) on every supported macOS /
+        # Linux host, so only root or the owner can unlink files in
+        # it — the mktemp→sftp→install window is safe against a
+        # same-host attacker racing to swap the tmpfile contents (S3).
+        # The mktemp template ends in XXXXXX → mode 0600 on creation
+        # per POSIX. mktemp is inside the try (W3) so the empty-stdout
+        # / unsafe-path branches below still hit the cleanup leg if
+        # mktemp managed to land a file before reporting back.
+        _, mktemp_out, mktemp_err = client.exec_command(
+            "mktemp /tmp/clawrium-sync.XXXXXX", timeout=timeout
+        )
+        # S1: drain stderr first (W2 deadlock guard), then exit
+        # status — surfaces sudo/disk-full/permissions errors instead
+        # of a bare "mktemp failed".
+        mktemp_stdout_text = mktemp_out.read().decode("utf-8", errors="replace")
+        mktemp_stderr_text = mktemp_err.read().decode("utf-8", errors="replace")
+        mktemp_rc = mktemp_out.channel.recv_exit_status()
+        if mktemp_rc != 0:
+            detail = mktemp_stderr_text.strip() or mktemp_stdout_text.strip()
+            raise CanonicalSyncError(
+                f"mktemp failed on host (exit {mktemp_rc}): {detail}"
+            )
+        candidate = mktemp_stdout_text.strip()
+        if not candidate:
+            raise CanonicalSyncError(
+                "mktemp returned empty path (transient SSH glitch?); "
+                "refusing to write body to an empty target"
+            )
+        # B1: validate the path actually lives under our /tmp prefix.
+        # A hostile/malfunctioning host returning
+        # `/Users/<agent>/.openclaw/openclaw.json` from mktemp would
+        # otherwise let the sudo install below overwrite that path
+        # with `body`. Same defense-in-depth register as
+        # _validate_agent_name.
+        if not candidate.startswith("/tmp/clawrium-sync."):
+            raise CanonicalSyncError(
+                f"mktemp returned unsafe path {candidate!r}; expected "
+                f"prefix '/tmp/clawrium-sync.'"
+            )
+        tmp_path = candidate
+
+        sftp = client.open_sftp()
+        try:
+            with sftp.file(tmp_path, "wb") as fh:
+                fh.write(body.encode("utf-8"))
+        finally:
+            sftp.close()
+        owner = shlex.quote(agent_name)
+        cmd = (
+            f"sudo -n install -m 0600 -o {owner} -g staff "
+            f"{shlex.quote(tmp_path)} {quoted_path}"
+        )
+        _, install_out, install_err = client.exec_command(cmd, timeout=timeout)
+        # W2: drain stderr (and stdout) BEFORE `recv_exit_status`. If
+        # the remote process is buffered on a full stderr (≥64KB) it
+        # blocks on write and recv_exit_status waits forever. read()
+        # drains the buffer as bytes arrive, unblocking the write.
+        stdout_text = install_out.read().decode("utf-8", errors="replace")
+        stderr_text = install_err.read().decode("utf-8", errors="replace")
+        rc = install_out.channel.recv_exit_status()
+        if rc != 0:
+            detail = stderr_text.strip() or stdout_text.strip()
+            raise CanonicalSyncError(
+                f"install {remote_path!r} failed (exit {rc}): {detail}"
+            )
+    finally:
+        # S2: drain the cleanup channel deterministically — without
+        # `recv_exit_status` the SSH channel lingers until GC and can
+        # tie up server-side resources on long-lived sync sessions.
+        # Skip when `tmp_path` is None (mktemp itself failed before
+        # returning a path); skip when path is unsafe (we never
+        # accepted it). The `rm -f` is bounded by the same timeout.
+        if tmp_path is not None:
+            _, cleanup_out, _ = client.exec_command(
+                f"rm -f {shlex.quote(tmp_path)}", timeout=timeout
+            )
+            cleanup_out.channel.recv_exit_status()
+
+
+def restart_unit_macos(
+    client: paramiko.SSHClient,
+    *,
+    host: dict,
+    agent_name: str,
+    agent_type: str,
+    on_event: Callable[[str, str], None] | None = None,
+    timeout: int = 30,
+) -> None:
+    """Restart agent via launchctl using existing macOS helpers.
+
+    Mirrors `restart_agent_macos` but takes a pre-opened client (so the
+    canonical sync can reuse its connection): enumerates dashboard +
+    gateway labels for hermes; falls back to a fresh
+    install_service + bootstrap when kickstart reports "not loaded".
+
+    `agent_name` is validated up-front so a shell metacharacter cannot
+    reach `sudo launchctl` through the label f-string in `_kickstart`.
+    `label_for` raises `ValueError` for unsupported (agent_type, kind)
+    combinations (e.g. zeroclaw on macOS) — wrapped here as
+    `CanonicalSyncError` so the canonical sync's error surface stays
+    uniform (W4).
+
+    `timeout` (default 30s) is propagated into every `launchctl …` call
+    so a wedged sudo cannot hang the canonical sync indefinitely (W3).
+    """
+    from clawrium.core.launchd import _validate_agent_name
+    from clawrium.core.lifecycle_canonical import CanonicalSyncError
+
+    _validate_agent_name(agent_name)
+
+    def _emit(stage: str, msg: str) -> None:
+        if on_event is not None:
+            on_event(stage, msg)
+
+    dashboard_port = (
+        _dashboard_port_from_host(host, agent_name) if agent_type == "hermes" else None
+    )
+    kinds: tuple[str, ...] = (
+        ("dashboard", "gateway") if dashboard_port is not None else ("gateway",)
+    )
+
+    # W4: resolve labels up-front so a `label_for` ValueError
+    # (unsupported agent_type/kind combo, e.g. zeroclaw on macOS)
+    # surfaces as CanonicalSyncError before any wire call, not as an
+    # unhandled traceback past sync_agent_canonical.
+    #
+    # S1 iter-3: the resolved values feed only the `_emit` log lines
+    # below — `_kickstart` recomputes its own label internally via
+    # `label_for`. The eager resolve is for FAIL-FAST + LOG-DISPLAY,
+    # not to share state with the launchctl helpers.
+    try:
+        labels = {
+            kind: label_for(agent_name, kind=kind, agent_type=agent_type)
+            for kind in kinds
+        }
+    except ValueError as exc:
+        raise CanonicalSyncError(
+            f"restart_unit_macos: unsupported launchd label for "
+            f"agent_type={agent_type!r}: {exc}"
+        ) from exc
+
+    any_not_loaded = False
+    for kind in kinds:
+        _emit("restart", f"launchctl kickstart -k system/{labels[kind]}")
+        rc, out, err = _kickstart(
+            client,
+            agent_name,
+            kill=True,
+            kind=kind,
+            agent_type=agent_type,
+            timeout=timeout,
+        )
+        if rc == 0:
+            continue
+        combined = (out + err).lower()
+        if "could not find service" in combined or "no such process" in combined:
+            any_not_loaded = True
+            break
+        raise CanonicalSyncError(
+            f"launchctl kickstart -k ({kind}) failed (rc={rc}): "
+            f"{(err or out).strip()}"
+        )
+
+    if not any_not_loaded:
+        return
+
+    _emit("restart", f"installing plists for {agent_name} (fallback)")
+    install_service(
+        client,
+        agent_name,
+        dashboard_port=dashboard_port,
+        agent_type=agent_type,
+        timeout=timeout,
+    )
+    for kind in kinds:
+        _emit("restart", f"launchctl bootstrap {agent_name} (fallback {kind})")
+        ok, err = _bootstrap_with_tolerance(
+            client,
+            agent_name,
+            kind=kind,
+            agent_type=agent_type,
+            timeout=timeout,
+        )
+        if not ok:
+            raise CanonicalSyncError(err)
+        _emit("restart", f"launchctl kickstart {agent_name} (fallback {kind})")
+        rc, out, err = _kickstart(
+            client,
+            agent_name,
+            kind=kind,
+            agent_type=agent_type,
+            timeout=timeout,
+        )
+        if rc != 0:
+            raise CanonicalSyncError(
+                f"launchctl kickstart fallback ({kind}) failed (rc={rc}): "
+                f"{(err or out).strip()}"
+            )
+
+
+def verify_health_macos(
+    client: paramiko.SSHClient,
+    *,
+    agent_name: str,
+    gateway_port: int | None,
+    on_event: Callable[[str, str], None] | None = None,
+    timeout: int = 30,
+) -> None:
+    """Poll the gateway port with `nc -z` until accept, or raise on timeout.
+
+    macOS launchd has no `systemctl is-active` equivalent. We probe the
+    loopback gateway port with `nc -z -w 1 127.0.0.1 <port>` — a TCP
+    connect that succeeds when the daemon is `accept()`-ing. `nc` ships
+    in macOS by default and (unlike `lsof -i :<port>`) does not require
+    `sudo` to see a listener owned by a different user (the canonical
+    sync runs as `xclm` while the daemon runs as `<agent_name>`; macOS
+    `lsof` only shows your own ports).
+
+    A missing port is treated as `CanonicalSyncError` rather than a
+    skip (W2 iter-3): all agent types reaching this dispatcher on
+    macOS (openclaw, hermes) declare gateways in their manifests, so
+    `gateway_port is None` means install.py never allocated one — the
+    agent was never properly installed, and a skip would let
+    canonical sync write `state=READY` for a never-verified daemon.
+    """
+    from clawrium.core.launchd import _validate_agent_name
+    from clawrium.core.lifecycle_canonical import CanonicalSyncError
+    import re as _re
+    import time as _time
+
+    # W4: parity with atomic_write_macos / restart_unit_macos. The
+    # name currently only appears in error strings, but a future
+    # refactor adding e.g. `lsof -u <name>` for richer diagnostics
+    # would silently lose the guard without this call.
+    _validate_agent_name(agent_name)
+
+    if gateway_port is None:
+        raise CanonicalSyncError(
+            f"verify_health_macos: no gateway port persisted for "
+            f"{agent_name!r}. install.py never allocated one — the "
+            f"agent install is incomplete. Re-run "
+            f"`clawctl agent create` or inspect "
+            f"hosts.json.agents.{agent_name}.config.gateway.port."
+        )
+    # `type(...) is int` (not `isinstance`) so `True`/`False` are
+    # rejected — bool is a subclass of int and a JSON parser that
+    # round-trips `true` through `int` would otherwise sail through.
+    if (
+        type(gateway_port) is not int
+        or not 0 < gateway_port < 65536
+    ):
+        raise CanonicalSyncError(
+            f"verify_health_macos: invalid gateway_port {gateway_port!r}"
+        )
+
+    deadline = _time.monotonic() + timeout
+    while _time.monotonic() < deadline:
+        cmd = f"nc -z -w 1 127.0.0.1 {gateway_port}"
+        _, out, err = client.exec_command(cmd, timeout=5)
+        # W2 ordering: drain both streams before exit status.
+        _ = out.read()
+        stderr_text = err.read().decode("utf-8", errors="replace")
+        rc = out.channel.recv_exit_status()
+        if rc == 0:
+            return
+        # W5: if `nc` itself is missing (PATH-broken, stripped image,
+        # etc.) every poll fails with a "command not found"-shaped
+        # stderr. Break early with a diagnostic that points at the
+        # tool, not at the daemon — otherwise the operator chases a
+        # 30s "port not accepting" red herring.
+        #
+        # W1 iter-3: regex-match the precise "nc … not found" shape.
+        # The previous boolean had an unparenthesized `or … and …`
+        # that risked matching a stray "nc:" prefix on BSD
+        # `connection refused` stderr from a not-yet-listening daemon
+        # and prematurely aborting the wait window.
+        _NC_MISSING_RE = _re.compile(r"\bnc\b[^\n]*not found", _re.IGNORECASE)
+        if (
+            "command not found" in stderr_text.lower()
+            or _NC_MISSING_RE.search(stderr_text)
+        ):
+            raise CanonicalSyncError(
+                f"verify_health_macos: `nc` is not available on the agent "
+                f"host (stderr: {stderr_text.strip()}). nc ships with "
+                f"macOS by default — investigate PATH / image stripping."
+            )
+        _time.sleep(1)
+    raise CanonicalSyncError(
+        f"gateway port {gateway_port} not accepting connections after "
+        f"{timeout}s (agent={agent_name})"
+    )
+
+
 __all__ = [
     "LifecycleError",
     "LifecycleResult",
+    "atomic_write_macos",
     "configure_agent",
     "install_service",
     "remove_service_macos",
     "restart_agent",
     "restart_agent_macos",
+    "restart_unit_macos",
     "start_agent",
     "start_agent_macos",
     "stop_agent",
     "stop_agent_macos",
     "sync_agent",
+    "verify_health_macos",
 ]

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -1368,7 +1368,7 @@ _OPENCLAW_SUPPORTED_INTEGRATIONS = frozenset(
 )
 _OPENCLAW_MODEL_PREFIX = {
     "openrouter": "openrouter/",
-    "bedrock": "bedrock/",
+    "bedrock": "amazon-bedrock/",
 }
 
 # Single source of truth for the openclaw gateway port fallback. Used by

--- a/src/clawrium/platform/registry/hermes/templates/hermes-config.canonical.yaml.j2
+++ b/src/clawrium/platform/registry/hermes/templates/hermes-config.canonical.yaml.j2
@@ -80,6 +80,7 @@ auxiliary:
 {% elif provider.type == 'bedrock' %}
 model:
   provider: "bedrock"
+  api_key: "aws-sdk"
   default: {{ provider.default_model | yq }}
 bedrock:
   region: {{ (provider.region or 'us-east-1') | yq }}

--- a/src/clawrium/platform/registry/openclaw/manifest.yaml
+++ b/src/clawrium/platform/registry/openclaw/manifest.yaml
@@ -9,8 +9,8 @@ agent:
 plugins:
   brave:
     npm_package: "@openclaw/brave-plugin"
-    version: "2026.6.8"
-    min_host_version: "2026.6.8"
+    version: "2026.6.9"
+    min_host_version: "2026.6.9"
 
 # Workspace metadata consumed by cross-claw subsystems (memory CLI, etc.).
 # Path matches the location previously hard-coded in core/memory.py so the
@@ -210,6 +210,33 @@ platforms:
       dependencies:
         nodejs: ">=18.0.0"
   - version: "2026.6.8"
+    os: macos
+    os_version: ">=14"
+    arch: arm64
+    requirements:
+      min_memory_mb: 2048
+      gpu_required: false
+      dependencies:
+        nodejs: ">=20.0.0"
+  - version: "2026.6.9"
+    os: ubuntu
+    os_version: "24.04"
+    arch: x86_64
+    requirements:
+      min_memory_mb: 2048
+      gpu_required: false
+      dependencies:
+        nodejs: ">=20.0.0"
+  - version: "2026.6.9"
+    os: ubuntu
+    os_version: "22.04"
+    arch: x86_64
+    requirements:
+      min_memory_mb: 2048
+      gpu_required: false
+      dependencies:
+        nodejs: ">=18.0.0"
+  - version: "2026.6.9"
     os: macos
     os_version: ">=14"
     arch: arm64

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -89,32 +89,54 @@
     # error) which under the previous `no_log: true` masked all
     # diagnostics. (#734 ATX iter 2 W4)
     #
-    # PATH is exported so nvm/Homebrew Node hosts can resolve `npm`
-    # without an interactive login shell. (ATX iter 2 W3)
-    - name: Install openclaw brave plugin (idempotent, gated by sentinel)
+    # PATH is exported so Homebrew/apt/dnf Node hosts can resolve
+    # `npm` without an interactive login shell. nvm-only Node
+    # installs are NOT supported (same caveat as the macOS playbook
+    # — Ansible's PATH-env hand-off cannot glob the version-dynamic
+    # ~/.nvm/versions/node/<v>/bin shim).
+    #
+    # S3 iter-3: brave-related tasks share the same predicate;
+    # wrap in a block so a fifth task can't drift the condition.
+    - name: Brave plugin install
+      when:
+        - integrations is defined
+        - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0
       become: yes
       become_user: "{{ agent_name }}"
       environment:
         PATH: "/home/{{ agent_name }}/.local/bin:/usr/local/bin:/usr/bin:/bin"
-      ansible.builtin.command: >-
-        npm install --prefix /home/{{ agent_name }}/.openclaw
-        {{ openclaw_brave_plugin_package }}@{{ openclaw_brave_plugin_version }}
-      args:
-        creates: "/home/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
-      when:
-        - integrations is defined
-        - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0
+      block:
+        - name: Probe for npm (brave plugin install prereq)
+          ansible.builtin.command:
+            argv:
+              - which
+              - npm
+          register: _npm_probe
+          changed_when: false
+          failed_when: false
 
-    - name: Stamp brave plugin install sentinel
-      become: yes
-      become_user: "{{ agent_name }}"
-      ansible.builtin.file:
-        path: "/home/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
-        state: touch
-        mode: "0600"
-      when:
-        - integrations is defined
-        - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0
+        - name: Fail with actionable hint when npm is missing
+          when: _npm_probe.rc != 0
+          ansible.builtin.fail:
+            msg: >-
+              npm not found on the agent host PATH
+              (/usr/local/bin, /usr/bin, /bin). The brave plugin requires
+              a system Node install (apt/dnf/Homebrew); nvm-only installs
+              are not supported because the playbook cannot glob
+              /home/{{ agent_name }}/.nvm/versions/node/*/bin into PATH.
+
+        - name: Install openclaw brave plugin (idempotent, gated by sentinel)
+          ansible.builtin.command: >-
+            npm install --prefix /home/{{ agent_name }}/.openclaw
+            {{ openclaw_brave_plugin_package }}@{{ openclaw_brave_plugin_version }}
+          args:
+            creates: "/home/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
+
+        - name: Stamp brave plugin install sentinel
+          ansible.builtin.file:
+            path: "/home/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
+            state: touch
+            mode: "0600"
 
     - name: Write openclaw .env from template
       ansible.builtin.template:
@@ -201,7 +223,10 @@
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
         mode: "0600"
-        backup: yes
+        # W6: `backup: yes` accumulates `exec-approvals.json.NNNN~`
+        # siblings on every reconfigure with no rotation; on
+        # hot-iterating agents this grows unbounded. The previous
+        # value is recoverable via git (template-rendered) anyway.
       no_log: true
       notify: Restart openclaw service
 

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure_macos.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure_macos.yaml
@@ -4,6 +4,14 @@
 # /Users/<agent>/.openclaw/ instead of /home/<agent>/.openclaw/, and
 # DOES NOT touch launchctl — lifecycle_macos.configure_agent triggers
 # a launchctl restart after this playbook returns.
+#
+# IMPORTANT: This playbook is NOT safe to invoke directly via
+# `ansible-playbook`. Direct invocation will write the rendered config
+# but leave the launchd daemon running the previous version of
+# `openclaw.json`. The supported entry point is
+# `clawctl agent configure` / `clawctl agent sync`, which routes
+# through `lifecycle_macos.configure_agent` and fires
+# `launchctl kickstart -k` after this playbook returns (W7).
 - hosts: all
   become: yes
   tasks:
@@ -25,7 +33,15 @@
       tags: [never, strict]
 
     - name: Check that agent user exists via dscl
-      ansible.builtin.command: "dscl . -read /Users/{{ agent_name | quote }} UniqueID"
+      ansible.builtin.command:
+        # argv form — no shell, no need for `| quote`. `agent_name`
+        # is already regex-validated above (S4).
+        argv:
+          - dscl
+          - "."
+          - -read
+          - "/Users/{{ agent_name }}"
+          - UniqueID
       register: agent_user_check
       changed_when: false
       failed_when: false
@@ -90,33 +106,59 @@
     # See configure.yaml (Linux) for the rationale on plugin install
     # ordering and sentinel gating. `no_log` is intentionally omitted
     # so npm errors surface; the npm package is public and no secrets
-    # are in scope. macOS PATH covers Homebrew (/opt/homebrew/bin on
-    # Apple Silicon, /usr/local/bin on Intel) plus nvm's default shim
-    # under /Users/<user>/.nvm. (#734 ATX iter 2 W3, W4)
-    - name: Install openclaw brave plugin (idempotent, gated by sentinel)
+    # are in scope.
+    #
+    # PATH covers Homebrew (/opt/homebrew/bin on Apple Silicon,
+    # /usr/local/bin on Intel) only. nvm shims live under
+    # /Users/<user>/.nvm/versions/node/<version>/bin where <version>
+    # is dynamic — Ansible's PATH-env hand-off cannot glob, so hosts
+    # whose only Node install is via nvm get an opaque
+    # "npm: command not found" without the probe below (W8).
+    #
+    # S2 iter-3: all brave-related tasks share the same predicate;
+    # wrap in a block so a fifth task doesn't need to remember the
+    # condition. Variables `become` / `become_user` / `environment`
+    # set on the block are inherited by each child task.
+    - name: Brave plugin install
+      when:
+        - integrations is defined
+        - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0
       become: yes
       become_user: "{{ agent_name }}"
       environment:
         PATH: "/Users/{{ agent_name }}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
-      ansible.builtin.command: >-
-        npm install --prefix /Users/{{ agent_name }}/.openclaw
-        {{ openclaw_brave_plugin_package }}@{{ openclaw_brave_plugin_version }}
-      args:
-        creates: "/Users/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
-      when:
-        - integrations is defined
-        - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0
+      block:
+        - name: Probe for npm (brave plugin install prereq)
+          ansible.builtin.command:
+            argv:
+              - which
+              - npm
+          register: _npm_probe
+          changed_when: false
+          failed_when: false
 
-    - name: Stamp brave plugin install sentinel
-      become: yes
-      become_user: "{{ agent_name }}"
-      ansible.builtin.file:
-        path: "/Users/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
-        state: touch
-        mode: "0600"
-      when:
-        - integrations is defined
-        - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0
+        - name: Fail with actionable hint when npm is missing
+          when: _npm_probe.rc != 0
+          ansible.builtin.fail:
+            msg: >-
+              npm not found on the agent host PATH
+              (/opt/homebrew/bin, /usr/local/bin). The brave plugin requires
+              a Homebrew-installed Node (`brew install node`); nvm-only
+              installs are not supported because the playbook cannot glob
+              /Users/{{ agent_name }}/.nvm/versions/node/*/bin into PATH.
+
+        - name: Install openclaw brave plugin (idempotent, gated by sentinel)
+          ansible.builtin.command: >-
+            npm install --prefix /Users/{{ agent_name }}/.openclaw
+            {{ openclaw_brave_plugin_package }}@{{ openclaw_brave_plugin_version }}
+          args:
+            creates: "/Users/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
+
+        - name: Stamp brave plugin install sentinel
+          ansible.builtin.file:
+            path: "/Users/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
+            state: touch
+            mode: "0600"
 
     - name: Write openclaw .env from template
       ansible.builtin.template:
@@ -197,7 +239,9 @@
         owner: "{{ agent_name }}"
         group: staff
         mode: "0600"
-        backup: yes
+        # W6: `backup: yes` accumulates `exec-approvals.json.NNNN~`
+        # siblings on every reconfigure; the previous value is
+        # recoverable from the template anyway.
       no_log: true
 
     - name: Verify exec approvals JSON is valid

--- a/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
@@ -2,6 +2,24 @@
 - hosts: all
   become: yes
   tasks:
+    # W3 (ATX iter-4): a direct `ansible-playbook install.yaml` run
+    # (no `operator_platform` extravar) would otherwise pass these
+    # tasks and crash deep in the pair step with an opaque
+    # `AnsibleUndefinedVariable`. Fail early with a hint pointing at
+    # `clawctl agent create`, which is the only supported entry.
+    - name: Assert operator_platform is provided (set by core/install.py)
+      ansible.builtin.assert:
+        that:
+          - operator_platform is defined
+          - operator_platform | length > 0
+        fail_msg: >-
+          `operator_platform` extravar is required; the openclaw
+          pair script records it on the daemon's device entry. This
+          playbook is invoked by `clawctl agent create`
+          (core/install.py), which sets it from the operator
+          machine's `sys.platform`. A direct `ansible-playbook
+          install.yaml` invocation is not supported.
+
     - name: Normalize target OpenClaw version
       ansible.builtin.set_fact:
         openclaw_target_version: "{{ (claw_version | default('v2026.6.8')) | regex_replace('^v', '') }}"
@@ -295,8 +313,19 @@
       when: not openclaw_already_installed
 
     - name: Run device pairing via localhost
+      # Pass the OPERATOR's platform (the clawctl machine that drove
+      # this install) as the 3rd arg so the daemon's paired record
+      # carries the same `platform` value the chat client will send
+      # on subsequent connects. Without this the daemon flags
+      # later connects as "device identity changed" and demands UI
+      # re-approval.
       ansible.builtin.command:
-        cmd: "node pair_device.mjs ws://127.0.0.1:{{ openclaw_port }} {{ gateway_token_result_stdout }}"
+        argv:
+          - node
+          - pair_device.mjs
+          - "ws://127.0.0.1:{{ openclaw_port }}"
+          - "{{ gateway_token_result_stdout }}"
+          - "{{ operator_platform }}"
         chdir: "/home/{{ agent_name }}"
       become_user: "{{ agent_name }}"
       register: pairing_result

--- a/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/install.yaml
@@ -177,7 +177,10 @@
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
         mode: "0600"
-        backup: yes
+        # W6 (ATX iter-2): `backup: yes` accumulates
+        # `exec-approvals.json.NNNN~` siblings on every install/reconfigure
+        # with no rotation; the previous value is recoverable from the
+        # template anyway.
       no_log: true
 
     - name: Verify exec approvals JSON is valid

--- a/src/clawrium/platform/registry/openclaw/playbooks/install_macos.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/install_macos.yaml
@@ -28,6 +28,23 @@
         msg: "Invalid agent_name"
       when: agent_name is not match('^[a-z][a-z0-9_-]{0,31}$')
 
+    # W3 (ATX iter-4): paired with the Linux install.yaml guard. A
+    # direct `ansible-playbook install_macos.yaml` invocation lacks
+    # `operator_platform` and would crash deep in the pair step with
+    # `AnsibleUndefinedVariable`. Fail early with a hint.
+    - name: Assert operator_platform is provided (set by core/install.py)
+      ansible.builtin.assert:
+        that:
+          - operator_platform is defined
+          - operator_platform | length > 0
+        fail_msg: >-
+          `operator_platform` extravar is required; the openclaw
+          pair script records it on the daemon's device entry. This
+          playbook is invoked by `clawctl agent create`
+          (core/install.py), which sets it from the operator
+          machine's `sys.platform`. A direct `ansible-playbook
+          install_macos.yaml` invocation is not supported.
+
     - name: Normalize target OpenClaw version
       ansible.builtin.set_fact:
         openclaw_target_version: "{{ (claw_version | default('v2026.6.8')) | regex_replace('^v', '') }}"
@@ -362,12 +379,17 @@
       when: not openclaw_already_installed
 
     - name: Run device pairing via localhost
+      # 5th argv element is the OPERATOR's platform (the clawctl
+      # machine that drove this install). Daemon stores it on the
+      # paired record; chat client sends the same value via
+      # `sys.platform`. Mismatch → "device identity changed" rejects.
       ansible.builtin.command:
         argv:
           - /opt/homebrew/bin/node
           - pair_device.mjs
           - "ws://127.0.0.1:{{ openclaw_port }}"
           - "{{ gateway_token_result_stdout }}"
+          - "{{ operator_platform }}"
         chdir: "/Users/{{ agent_name }}"
       become_user: "{{ agent_name }}"
       environment:

--- a/src/clawrium/platform/registry/openclaw/scripts/pair_device.mjs
+++ b/src/clawrium/platform/registry/openclaw/scripts/pair_device.mjs
@@ -11,25 +11,73 @@
  * then falls back to v2). Bumping to a v3-payload default is a follow-up
  * once v3-only daemons exist in the field.
  *
- * Usage: node pair_device.mjs <gateway_url> <bootstrap_token>
+ * Usage: node pair_device.mjs <gateway_url> <bootstrap_token> [<platform>]
+ *
+ * <platform> is the OPERATOR's platform (the machine where clawctl
+ * lives), NOT the agent host's platform. The daemon stores this on
+ * the paired device record and rejects subsequent connects from a
+ * different platform as "device identity changed". The chat client
+ * (`clawrium.core.chat`) sends `sys.platform` from the operator's
+ * machine, so the pair-time value MUST match. Default falls back to
+ * `process.platform` for the legacy 2-arg invocation, but the install
+ * playbooks pass the operator's platform explicitly.
+ *
  * Output: JSON with deviceId, deviceToken, privateKeyPem
  */
 
 import WebSocket from 'ws';
 import crypto from 'crypto';
 
-const [,, gatewayUrl, bootstrapToken] = process.argv;
+const [,, gatewayUrl, bootstrapToken, platformArg] = process.argv;
 
 const MIN_SUPPORTED_PROTOCOL = 3;
 const MAX_SUPPORTED_PROTOCOL = 4;
 const DEFAULT_PAYLOAD_VERSION = 'v2';
 
+// Accept only the well-known bare-family shapes the operator side
+// (clawrium.core._operator_platform.normalize) emits. Anything else
+// is either a misrendered Jinja extravar or an unsupported OS; in
+// both cases falling back to `process.platform` would silently
+// reinstate the #719 cross-platform pairing mismatch (W2 ATX iter-4).
+const ALLOWED_PLATFORMS = new Set([
+  'linux', 'darwin', 'win32', 'freebsd', 'openbsd', 'netbsd', 'aix', 'sunos',
+]);
+
 if (!gatewayUrl || !bootstrapToken) {
   console.error(JSON.stringify({
     error: 'Missing required arguments',
-    usage: 'node pair_device.mjs <gateway_url> <bootstrap_token>'
+    usage: 'node pair_device.mjs <gateway_url> <bootstrap_token> [<platform>]'
   }));
   process.exit(1);
+}
+
+// W2: if the caller passed a platformArg, require a non-empty,
+// well-known value. Empty string from Jinja `default('')` would
+// otherwise silently fall back to `process.platform` (= the AGENT
+// HOST's OS) and reinstate the exact identity-changed mismatch this
+// arg was added to prevent. The legacy 2-arg invocation (no
+// platformArg at all) still falls back to `process.platform` — only
+// the unsupported case is the explicit empty 3rd arg.
+let clientPlatform;
+if (platformArg === undefined) {
+  clientPlatform = process.platform;
+} else if (typeof platformArg !== 'string' || platformArg.length === 0) {
+  console.error(JSON.stringify({
+    error: 'platformArg present but empty/non-string',
+    received: platformArg,
+    fix: 'install playbook must set operator_platform from the inventory'
+  }));
+  process.exit(1);
+} else if (!ALLOWED_PLATFORMS.has(platformArg)) {
+  console.error(JSON.stringify({
+    error: 'platformArg is not a known platform family',
+    received: platformArg,
+    allowed: Array.from(ALLOWED_PLATFORMS),
+    fix: 'normalize via clawrium.core._operator_platform.normalize before passing'
+  }));
+  process.exit(1);
+} else {
+  clientPlatform = platformArg;
 }
 
 function generateDeviceKeypair() {
@@ -150,7 +198,7 @@ async function pairDevice() {
               client: {
                 id: clientId,
                 version: '1.0.0',
-                platform: process.platform,
+                platform: clientPlatform,
                 mode: clientMode
               },
               role: role,

--- a/src/clawrium/platform/registry/openclaw/templates/.env.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/.env.j2
@@ -20,8 +20,8 @@ OPENCLAW_GATEWAY_AUTH_TOKEN={{ shell_quote(config.gateway.auth) }}
 {% if config.provider.default_model %}
 {% if config.provider.type == "openrouter" and not config.provider.default_model.startswith("openrouter/") %}
 OPENCLAW_DEFAULT_MODEL={{ shell_quote("openrouter/" ~ config.provider.default_model) }}
-{% elif config.provider.type == "bedrock" and not config.provider.default_model.startswith("bedrock/") %}
-OPENCLAW_DEFAULT_MODEL={{ shell_quote("bedrock/" ~ config.provider.default_model) }}
+{% elif config.provider.type == "bedrock" and not config.provider.default_model.startswith("amazon-bedrock/") %}
+OPENCLAW_DEFAULT_MODEL={{ shell_quote("amazon-bedrock/" ~ config.provider.default_model) }}
 {% else %}
 OPENCLAW_DEFAULT_MODEL={{ shell_quote(config.provider.default_model) }}
 {% endif %}

--- a/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
+++ b/src/clawrium/platform/registry/openclaw/templates/openclaw.json.j2
@@ -18,8 +18,8 @@
       "model": { "primary": {{ ("openrouter/" ~ config.provider.default_model) | tojson }} },
 {% elif config.provider.type == "ollama" and not config.provider.default_model.startswith("ollama/") %}
       "model": { "primary": {{ ("ollama/" ~ config.provider.default_model) | tojson }} },
-{% elif config.provider.type == "bedrock" and not config.provider.default_model.startswith("bedrock/") %}
-      "model": { "primary": {{ ("bedrock/" ~ config.provider.default_model) | tojson }} },
+{% elif config.provider.type == "bedrock" and not config.provider.default_model.startswith("amazon-bedrock/") %}
+      "model": { "primary": {{ ("amazon-bedrock/" ~ config.provider.default_model) | tojson }} },
 {% else %}
       "model": { "primary": {{ config.provider.default_model | tojson }} },
 {% endif %}

--- a/src/clawrium/platform/registry/openclaw/templates/verify_config.py
+++ b/src/clawrium/platform/registry/openclaw/templates/verify_config.py
@@ -4,7 +4,17 @@
 This script is called by Ansible to verify the configuration file
 was rendered correctly. It reads the actual and expected config files
 and validates critical fields match.
+
+Runs on the agent host with whatever `python3` ships there. PEP 604
+union syntax (`X | Y`) became a legal *runtime* annotation in Python
+3.10; on Python 3.9 (which Apple/Xcode CLI tools ship as
+`/usr/bin/python3`) the same syntax raises `TypeError` when the
+function definition is evaluated. `from __future__ import annotations`
+defers all annotation evaluation to string form, keeping this script
+compatible back to Python 3.7.
 """
+
+from __future__ import annotations
 
 import json
 import sys
@@ -60,8 +70,8 @@ def main():
             return f"openrouter/{default_model}"
         if provider_type == "ollama" and not default_model.startswith("ollama/"):
             return f"ollama/{default_model}"
-        if provider_type == "bedrock" and not default_model.startswith("bedrock/"):
-            return f"bedrock/{default_model}"
+        if provider_type == "bedrock" and not default_model.startswith("amazon-bedrock/"):
+            return f"amazon-bedrock/{default_model}"
         return default_model
 
     # Verify model is set if provider configured
@@ -83,19 +93,21 @@ def main():
                     f"Model mismatch: expected '{expected_model}', got '{actual_model}'"
                 )
 
-    # Verify gateway port
-    if expected_config.get("gateway", {}).get("port"):
+    # Verify gateway port. Use `is not None` rather than truthy: a
+    # misconfigured `port: 0` (or `bind: ""`) would otherwise silently
+    # skip verification and let a broken render through (S7).
+    expected_port = expected_config.get("gateway", {}).get("port")
+    if expected_port is not None:
         gateway_port = config.get("gateway", {}).get("port")
-        expected_port = expected_config["gateway"]["port"]
         if gateway_port != expected_port:
             errors.append(
                 f"Gateway port mismatch: expected {expected_port}, got {gateway_port}"
             )
 
     # Verify gateway bind
-    if expected_config.get("gateway", {}).get("bind"):
+    expected_bind = expected_config.get("gateway", {}).get("bind")
+    if expected_bind is not None:
         gateway_bind = config.get("gateway", {}).get("bind")
-        expected_bind = expected_config["gateway"]["bind"]
         if gateway_bind != expected_bind:
             errors.append(
                 f"Gateway bind mismatch: expected {expected_bind}, got {gateway_bind}"

--- a/tests/cli/clawctl/agent/test_sync.py
+++ b/tests/cli/clawctl/agent/test_sync.py
@@ -398,7 +398,7 @@ def test_canonical_sync_repairs_zeroclaw_even_with_no_drift(
 
     restart_calls: list[str] = []
 
-    def fake_restart(client, *, agent_type, agent_name):
+    def fake_restart(client, *, agent_type, agent_name, **kwargs):
         restart_calls.append(agent_name)
 
     monkeypatch.setattr(lifecycle_canonical, "_restart_unit", fake_restart)

--- a/tests/cli/test_agent_upgrade.py
+++ b/tests/cli/test_agent_upgrade.py
@@ -90,7 +90,7 @@ def _patch_drift_clean():
 
 def test_upgrade_no_op_when_already_at_max(isolated_config: Path):
     """Already at manifest max → exit 0, no install, no version mutation."""
-    _write_host(isolated_config, "openclaw", "2026.6.8")
+    _write_host(isolated_config, "openclaw", "2026.6.9")
     with patch("clawrium.core.install.run_installation") as mock_install:
         result = runner.invoke(
             app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
@@ -98,7 +98,7 @@ def test_upgrade_no_op_when_already_at_max(isolated_config: Path):
     assert result.exit_code == 0, result.output
     assert "already at latest" in result.output.lower()
     mock_install.assert_not_called()
-    assert _read_version(isolated_config) == "2026.6.8"
+    assert _read_version(isolated_config) == "2026.6.9"
 
 
 def test_upgrade_nochange_zeroclaw_exits_zero(isolated_config: Path):

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -1403,29 +1403,29 @@ class TestOpenclawBraveVersionPreflight:
         self._setup(monkeypatch, (2026, 3, 13))
         with pytest.raises(
             CanonicalSyncError,
-            match=r"openclaw on 'h' is 2026\.3\.13; brave plugin requires >= 2026\.6\.8",
+            match=r"openclaw on 'h' is 2026\.3\.13; brave plugin requires >= 2026\.6\.9",
         ):
             sync_agent_canonical("oc", restart=False, verify=False)
 
     def test_one_below_floor_raises(self, monkeypatch):
-        """Off-by-one boundary: 2026.6.7 must be rejected. The far-below
-        case (2026.3.13) wouldn't catch a comparator regression that
-        treated the floor as `< min` instead of `<= min`. (W3 ATX iter 2)"""
-        self._setup(monkeypatch, (2026, 6, 7))
+        """Off-by-one boundary: pin-floor minus one must be rejected. The
+        far-below case wouldn't catch a comparator regression that treated
+        the floor as `< min` instead of `<= min`. (W3 ATX iter 2)"""
+        self._setup(monkeypatch, (2026, 6, 8))
         with pytest.raises(
             CanonicalSyncError,
-            match=r"openclaw on 'h' is 2026\.6\.7; brave plugin requires >= 2026\.6\.8",
+            match=r"openclaw on 'h' is 2026\.6\.8; brave plugin requires >= 2026\.6\.9",
         ):
             sync_agent_canonical("oc", restart=False, verify=False)
 
     def test_exact_min_version_passes(self, monkeypatch):
-        self._setup(monkeypatch, (2026, 6, 8))
+        self._setup(monkeypatch, (2026, 6, 9))
         # Should not raise on the preflight; diffs are empty so the rest
         # of the pipeline is a no-op.
         sync_agent_canonical("oc", restart=False, verify=False)
 
     def test_newer_than_min_version_passes(self, monkeypatch):
-        self._setup(monkeypatch, (2026, 6, 9))
+        self._setup(monkeypatch, (2026, 6, 10))
         sync_agent_canonical("oc", restart=False, verify=False)
 
     def test_unknown_version_raises(self, monkeypatch):
@@ -1462,7 +1462,7 @@ class TestOpenclawBraveVersionPreflight:
         through to `_get_host_openclaw_version` — otherwise a Darwin
         host falls back to the Linux variant and the macOS home-path
         fork is dead code."""
-        self._setup(monkeypatch, (2026, 6, 8))
+        self._setup(monkeypatch, (2026, 6, 9))
         monkeypatch.setattr(
             lc,
             "get_agent_by_name",
@@ -1476,7 +1476,7 @@ class TestOpenclawBraveVersionPreflight:
 
         def _spy(_client, _agent_name, *, os_family, timeout=10):
             captured["os_family"] = os_family
-            return (2026, 6, 8), ""
+            return (2026, 6, 9), ""
 
         monkeypatch.setattr(lc, "_get_host_openclaw_version", _spy)
         sync_agent_canonical("oc", restart=False, verify=False)
@@ -1989,8 +1989,8 @@ class TestLoadOpenclawBravePin:
     def test_loads_pin_from_manifest(self):
         pin = lc._load_openclaw_brave_pin()
         assert pin["npm_package"] == "@openclaw/brave-plugin"
-        assert pin["version"] == "2026.6.8"
-        assert pin["min_host_version"] == (2026, 6, 8)
+        assert pin["version"] == "2026.6.9"
+        assert pin["min_host_version"] == (2026, 6, 9)
 
     def test_raises_when_pin_block_missing(self, monkeypatch):
         """Manifest with no `plugins.brave` block → hard fail. Never

--- a/tests/core/test_lifecycle_canonical_macos_dispatch.py
+++ b/tests/core/test_lifecycle_canonical_macos_dispatch.py
@@ -1,0 +1,818 @@
+"""Tests for the macOS dispatch path in `core/lifecycle_canonical.py`.
+
+The canonical sync pipeline branches on `host['hardware']['os'] == 'macos'`
+at three points (atomic file replace, unit restart, health verify) and
+routes to helpers in `lifecycle_macos.py` rather than running the Linux
+systemctl/`-g {agent_name}` path. This module asserts the exact wire
+commands issued on the macOS branch, the dual-label restart for hermes,
+the bootstrap-fallback on a not-loaded unit, and the nc-probe behavior
+for verify_health.
+
+The Linux path is already covered by tests in `test_lifecycle_canonical.py`
+and `test_workspace_*.py`; this file pins the macOS leg so the
+dispatcher-only OS fork invariant (AGENTS.md) cannot regress silently.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+from clawrium.core import lifecycle_canonical as lc
+from clawrium.core import lifecycle_macos as lm
+from clawrium.core.launchd import label_for
+
+
+class _Stream:
+    def __init__(self, payload: bytes = b"", exit_status: int = 0) -> None:
+        self._payload = payload
+
+        class _Ch:
+            def __init__(self, rc):
+                self._rc = rc
+
+            def recv_exit_status(self):
+                return self._rc
+
+        self.channel = _Ch(exit_status)
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+class _SftpFile:
+    def __init__(self, written: dict[str, bytes], path: str) -> None:
+        self._written = written
+        self._path = path
+        self._buf: list[bytes] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        self._written[self._path] = b"".join(self._buf)
+        return False
+
+    def write(self, data: bytes) -> None:
+        self._buf.append(data)
+
+
+class _Sftp:
+    def __init__(self, written: dict[str, bytes]) -> None:
+        self._written = written
+        self.closed = False
+
+    def file(self, path: str, mode: str):
+        return _SftpFile(self._written, path)
+
+    def close(self):
+        self.closed = True
+
+
+class _Client:
+    """Fake paramiko SSHClient. Each entry in `script` is
+    (substring, exit_status, stdout_bytes, stderr_bytes). First match
+    is consumed. Unmatched commands raise so a typo fails loudly."""
+
+    def __init__(
+        self,
+        script: list[tuple[str, int, bytes, bytes]] | None = None,
+    ) -> None:
+        self.calls: list[str] = []
+        self._script = list(script or [])
+        self.sftp_writes: dict[str, bytes] = {}
+
+    def exec_command(self, cmd: str, timeout: int | None = None):
+        self.calls.append(cmd)
+        for i, (needle, rc, out, err) in enumerate(self._script):
+            if needle in cmd:
+                self._script.pop(i)
+                return StringIO(), _Stream(out, rc), _Stream(err, rc)
+        raise AssertionError(f"unscripted command: {cmd!r}")
+
+    def open_sftp(self):
+        return _Sftp(self.sftp_writes)
+
+
+class _FailingSftp:
+    """Sftp stub whose `file()` raises — exercises the SFTP-failure
+    branch in atomic_write_macos (W9)."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+        self.closed = False
+
+    def file(self, path: str, mode: str):
+        raise self._exc
+
+    def close(self):
+        self.closed = True
+
+
+# ---------------------------------------------------------------------------
+# _atomic_write: macOS uses group="staff" (not per-user group)
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWriteMacosDispatch:
+    @pytest.mark.parametrize(
+        "os_value, expected_group_flag, expected_dir_root, pass_host",
+        [
+            # ATX W12: parametrize the OS branch so a regression that
+            # drops one side of the dispatch is caught by the same test.
+            ("macos", "-g staff", "/Users/", True),
+            ("ubuntu", "-g alpha", "/home/", True),
+            ("debian", "-g alpha", "/home/", True),
+            # S5 iter-3: when `host=None` the dispatcher must fall
+            # through to the Linux path (per-user group). A regression
+            # that defaulted to macOS would corrupt Linux hosts.
+            (None, "-g alpha", "/home/", False),
+        ],
+    )
+    def test_install_command_group_flag_per_os(
+        self, os_value, expected_group_flag, expected_dir_root, pass_host
+    ):
+        client = _Client(
+            [
+                ("mktemp", 0, b"/tmp/clawrium-sync.XYZ\n", b""),
+                ("install", 0, b"", b""),
+                ("rm -f", 0, b"", b""),
+            ]
+        )
+        host = (
+            {"hostname": "h", "hardware": {"os": os_value}} if pass_host else None
+        )
+        lc._atomic_write(
+            client,
+            agent_name="alpha",
+            remote_path=f"{expected_dir_root}alpha/.openclaw/env",
+            body="X=1\n",
+            host=host,
+        )
+        install_call = next(c for c in client.calls if "install" in c)
+        assert "-o alpha" in install_call
+        assert expected_group_flag in install_call
+        # Body must have been pushed via SFTP to the mktemp path on
+        # both branches.
+        assert client.sftp_writes == {"/tmp/clawrium-sync.XYZ": b"X=1\n"}
+
+    def test_install_failure_raises_canonical_error_on_macos(self):
+        client = _Client(
+            [
+                ("mktemp", 0, b"/tmp/clawrium-sync.X\n", b""),
+                ("install", 1, b"", b"chown: invalid group: 'staff'\n"),
+                ("rm -f", 0, b"", b""),
+            ]
+        )
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        with pytest.raises(lc.CanonicalSyncError, match=r"install .* failed"):
+            lc._atomic_write(
+                client,
+                agent_name="alpha",
+                remote_path="/Users/alpha/.openclaw/env",
+                body="x",
+                host=host,
+            )
+
+    def test_install_failure_includes_stderr_detail_after_drain(self):
+        """W2 ordering test — error surface must include stderr text
+        AFTER `recv_exit_status`, proving the drain ordering didn't
+        accidentally drop the diagnostic body."""
+        client = _Client(
+            [
+                ("mktemp", 0, b"/tmp/clawrium-sync.X\n", b""),
+                ("install", 1, b"", b"sudo: a password is required\n"),
+                ("rm -f", 0, b"", b""),
+            ]
+        )
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        with pytest.raises(
+            lc.CanonicalSyncError,
+            match=r"sudo: a password is required",
+        ):
+            lc._atomic_write(
+                client,
+                agent_name="alpha",
+                remote_path="/Users/alpha/.openclaw/env",
+                body="x",
+                host=host,
+            )
+
+    # W9: failure branches that previously had zero coverage.
+
+    def test_mktemp_nonzero_exit_includes_stderr(self):
+        """mktemp rc != 0 → CanonicalSyncError with stderr text."""
+        client = _Client([("mktemp", 1, b"", b"mktemp: too many templates\n")])
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        with pytest.raises(
+            lc.CanonicalSyncError,
+            match=r"mktemp failed on host.*too many templates",
+        ):
+            lc._atomic_write(
+                client,
+                agent_name="alpha",
+                remote_path="/Users/alpha/.openclaw/env",
+                body="x",
+                host=host,
+            )
+
+    def test_mktemp_empty_stdout_is_rejected(self):
+        """A transient SSH glitch returning `b''` from mktemp would
+        pass an rc==0 guard naively, then `install` would write the
+        body to `""`. The empty-path guard rejects this case loudly."""
+        client = _Client([("mktemp", 0, b"\n", b"")])
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        with pytest.raises(
+            lc.CanonicalSyncError,
+            match=r"mktemp returned empty path",
+        ):
+            lc._atomic_write(
+                client,
+                agent_name="alpha",
+                remote_path="/Users/alpha/.openclaw/env",
+                body="x",
+                host=host,
+            )
+
+    def test_invalid_agent_name_rejected_before_any_ssh_command(self):
+        """B3 (ATX iter-3): `atomic_write_macos` must call
+        `_validate_agent_name` at function entry, refusing shell
+        metacharacters BEFORE any SSH command runs. A regression that
+        dropped the call would let `a;rm -rf /` reach the install
+        command's `-o` argument. Asserts both the ValueError raise and
+        zero SSH calls executed (no mktemp leak, no install attempt)."""
+        client = _Client()  # empty script — any exec_command would fail
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        with pytest.raises(ValueError, match=r"invalid agent_name"):
+            lc._atomic_write(
+                client,
+                agent_name="a;rm -rf /",
+                remote_path="/Users/alpha/.openclaw/env",
+                body="x",
+                host=host,
+            )
+        assert client.calls == [], (
+            "validation must happen before any SSH command"
+        )
+
+    def test_mktemp_returns_unsafe_path_rejected(self):
+        """B1 (ATX iter-3): defense-in-depth against a hostile or
+        malfunctioning host returning a path OUTSIDE
+        `/tmp/clawrium-sync.*` from mktemp. Without the prefix guard
+        the subsequent `sudo -n install` would overwrite that path
+        with `body` — e.g. clobbering the operator's
+        ~/.openclaw/openclaw.json with the rendered .env."""
+        client = _Client(
+            [
+                ("mktemp", 0, b"/Users/alpha/.openclaw/openclaw.json\n", b""),
+            ]
+        )
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        with pytest.raises(
+            lc.CanonicalSyncError,
+            match=r"unsafe path.*expected prefix '/tmp/clawrium-sync.'",
+        ):
+            lc._atomic_write(
+                client,
+                agent_name="alpha",
+                remote_path="/Users/alpha/.openclaw/env",
+                body="x",
+                host=host,
+            )
+        # The install command must NOT have run.
+        assert not any("install" in c for c in client.calls), client.calls
+
+    def test_sftp_open_failure_surfaces_and_cleans_up(self, monkeypatch):
+        """If SFTP `file()` raises (channel torn down mid-handshake,
+        quota exceeded, etc.) the exception must propagate AND the
+        mktemp tmpfile must still be cleaned up via the finally
+        block."""
+
+        class _ClientWithFailingSftp(_Client):
+            def open_sftp(self):
+                return _FailingSftp(IOError("sftp channel closed"))
+
+        client = _ClientWithFailingSftp(
+            [
+                ("mktemp", 0, b"/tmp/clawrium-sync.X\n", b""),
+                ("rm -f /tmp/clawrium-sync.X", 0, b"", b""),
+            ]
+        )
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        with pytest.raises(IOError, match=r"sftp channel closed"):
+            lc._atomic_write(
+                client,
+                agent_name="alpha",
+                remote_path="/Users/alpha/.openclaw/env",
+                body="x",
+                host=host,
+            )
+        # Finally block must have fired the rm.
+        assert any("rm -f /tmp/clawrium-sync.X" in c for c in client.calls)
+
+
+# ---------------------------------------------------------------------------
+# _restart_unit: launchctl kickstart with dual-label (hermes) + fallback
+# ---------------------------------------------------------------------------
+
+
+class TestRestartUnitMacosDispatch:
+    def test_openclaw_macos_kickstarts_gateway_label_only(self):
+        client = _Client(
+            [("launchctl kickstart -k", 0, b"", b"")]
+        )
+        host = {"hostname": "h", "hardware": {"os": "macos"}, "agents": {}}
+        lc._restart_unit(
+            client,
+            agent_type="openclaw",
+            agent_name="alpha",
+            host=host,
+        )
+        expected_label = label_for("alpha", kind="gateway", agent_type="openclaw")
+        assert any(
+            f"system/{expected_label}" in c and "kickstart -k" in c
+            for c in client.calls
+        ), client.calls
+
+    def test_hermes_macos_kickstarts_dashboard_then_gateway_in_order(self):
+        """Hermes runs two launchd units on macOS; sync must restart
+        both. Order matters: `dashboard` before `gateway` mirrors the
+        existing `restart_agent_macos` invariant, and a flipped order
+        reopens a window where the gateway runs ahead of the dashboard
+        with mismatched config (S11)."""
+        client = _Client(
+            [
+                ("launchctl kickstart -k", 0, b"", b""),
+                ("launchctl kickstart -k", 0, b"", b""),
+            ]
+        )
+        host = {
+            "hostname": "h",
+            "hardware": {"os": "macos"},
+            "agents": {
+                "alpha": {
+                    "type": "hermes",
+                    "config": {"dashboard": {"port": 45123}},
+                }
+            },
+        }
+        lc._restart_unit(
+            client,
+            agent_type="hermes",
+            agent_name="alpha",
+            host=host,
+        )
+        gateway_label = label_for("alpha", kind="gateway", agent_type="hermes")
+        dashboard_label = label_for("alpha", kind="dashboard", agent_type="hermes")
+        kick_calls = [c for c in client.calls if "kickstart -k" in c]
+        assert len(kick_calls) == 2
+        # S11: pin the order, not just "both appeared".
+        assert dashboard_label in kick_calls[0], (
+            f"dashboard must be first; got order: {kick_calls}"
+        )
+        assert gateway_label in kick_calls[1]
+
+    def test_kickstart_not_loaded_triggers_bootstrap_then_kickstart(
+        self, monkeypatch
+    ):
+        """W10: assert the fallback path actually fires `bootstrap` AND
+        `kickstart` on the wire, not just that `install_service` was
+        called. A regression that called install_service but skipped
+        the bootstrap+kickstart pair would leave the unit installed-
+        but-not-running and pass the earlier weaker assertion."""
+        client = _Client(
+            [
+                ("launchctl kickstart -k", 113, b"", b"Could not find service\n"),
+                ("launchctl bootstrap", 0, b"", b""),
+                ("launchctl kickstart", 0, b"", b""),
+            ]
+        )
+        host = {"hostname": "h", "hardware": {"os": "macos"}, "agents": {}}
+
+        install_calls: list[tuple] = []
+
+        def _fake_install_service(
+            c, name, *, dashboard_port=None, agent_type="hermes", timeout=None
+        ):
+            install_calls.append((name, dashboard_port, agent_type))
+            return "/Library/LaunchDaemons/ai.clawrium.openclaw.alpha.plist"
+
+        monkeypatch.setattr(lm, "install_service", _fake_install_service)
+
+        lc._restart_unit(
+            client,
+            agent_type="openclaw",
+            agent_name="alpha",
+            host=host,
+        )
+        # install_service called once.
+        assert install_calls == [("alpha", None, "openclaw")]
+        # Bootstrap fired AFTER the install_service step.
+        assert any("launchctl bootstrap" in c for c in client.calls), client.calls
+        # And the recovery kickstart (without -k) fired AFTER bootstrap.
+        recovery_kicks = [
+            c for c in client.calls
+            if "launchctl kickstart" in c and "kickstart -k" not in c
+        ]
+        assert len(recovery_kicks) == 1, recovery_kicks
+
+    def test_hermes_dual_label_bootstrap_fallback_covers_both_kinds(
+        self, monkeypatch
+    ):
+        """W10: hermes' two-label fallback must bootstrap+kickstart
+        BOTH dashboard and gateway. A regression that only fell back on
+        one label would silently leave the other absent."""
+        client = _Client(
+            [
+                # First kickstart -k (dashboard) reports not-loaded
+                # → fallback kicks in for both labels.
+                ("launchctl kickstart -k", 113, b"", b"Could not find service\n"),
+                # Two bootstrap + kickstart pairs (dashboard, gateway).
+                ("launchctl bootstrap", 0, b"", b""),
+                ("launchctl kickstart", 0, b"", b""),
+                ("launchctl bootstrap", 0, b"", b""),
+                ("launchctl kickstart", 0, b"", b""),
+            ]
+        )
+        host = {
+            "hostname": "h",
+            "hardware": {"os": "macos"},
+            "agents": {
+                "alpha": {
+                    "type": "hermes",
+                    "config": {"dashboard": {"port": 45123}},
+                }
+            },
+        }
+        monkeypatch.setattr(
+            lm,
+            "install_service",
+            lambda c, name, *, dashboard_port=None, agent_type="hermes", timeout=None: "/L/H.plist",
+        )
+        lc._restart_unit(
+            client,
+            agent_type="hermes",
+            agent_name="alpha",
+            host=host,
+        )
+        bootstrap_calls = [c for c in client.calls if "launchctl bootstrap" in c]
+        recovery_kicks = [
+            c for c in client.calls
+            if "launchctl kickstart" in c and "kickstart -k" not in c
+        ]
+        assert len(bootstrap_calls) == 2, bootstrap_calls
+        assert len(recovery_kicks) == 2, recovery_kicks
+
+    def test_bootstrap_with_tolerance_failure_during_fallback_raises(
+        self, monkeypatch
+    ):
+        """W10: the fallback's `_bootstrap_with_tolerance` can still
+        fail hard (e.g. malformed plist, rc=5 + 'configuration
+        invalid'). That failure must surface as CanonicalSyncError,
+        not be swallowed."""
+        client = _Client(
+            [
+                ("launchctl kickstart -k", 113, b"", b"Could not find service\n"),
+                ("launchctl bootstrap", 78, b"", b"Bootstrap failed: invalid plist\n"),
+            ]
+        )
+        host = {"hostname": "h", "hardware": {"os": "macos"}, "agents": {}}
+        monkeypatch.setattr(
+            lm,
+            "install_service",
+            lambda c, name, *, dashboard_port=None, agent_type="hermes", timeout=None: "/L/O.plist",
+        )
+        with pytest.raises(
+            lc.CanonicalSyncError,
+            match=r"launchctl bootstrap.*failed.*invalid plist",
+        ):
+            lc._restart_unit(
+                client,
+                agent_type="openclaw",
+                agent_name="alpha",
+                host=host,
+            )
+
+    def test_kickstart_real_failure_raises_canonical_error(self):
+        """An error that is NOT 'not loaded' must surface — operator
+        needs to know the daemon refused to start."""
+        client = _Client(
+            [("launchctl kickstart -k", 1, b"", b"permission denied\n")]
+        )
+        host = {"hostname": "h", "hardware": {"os": "macos"}, "agents": {}}
+        with pytest.raises(lc.CanonicalSyncError, match=r"kickstart.*permission denied"):
+            lc._restart_unit(
+                client,
+                agent_type="openclaw",
+                agent_name="alpha",
+                host=host,
+            )
+
+    def test_invalid_agent_name_rejected_via_validate(self):
+        """Defense-in-depth (W1/W12): both atomic_write_macos AND
+        restart_unit_macos must call `_validate_agent_name` up-front.
+        Tested for the restart path here; atomic_write coverage is
+        below."""
+        client = _Client()
+        host = {"hostname": "h", "hardware": {"os": "macos"}, "agents": {}}
+        with pytest.raises(ValueError, match=r"invalid agent_name"):
+            lc._restart_unit(
+                client,
+                agent_type="openclaw",
+                agent_name="a;rm -rf /",
+                host=host,
+            )
+
+    def test_unsupported_agent_type_for_macos_raises_canonical_error(
+        self, monkeypatch
+    ):
+        """W4: `label_for` raises `ValueError` for unsupported
+        (agent_type, kind) combos (e.g. zeroclaw on macOS — no
+        launchd backend). The dispatcher must catch and re-raise as
+        CanonicalSyncError so sync_agent_canonical's error path
+        handles it uniformly."""
+        client = _Client()
+        host = {"hostname": "h", "hardware": {"os": "macos"}, "agents": {}}
+        with pytest.raises(
+            lc.CanonicalSyncError,
+            match=r"unsupported launchd label.*zeroclaw",
+        ):
+            lc._restart_unit(
+                client,
+                agent_type="zeroclaw",
+                agent_name="alpha",
+                host=host,
+            )
+
+
+# ---------------------------------------------------------------------------
+# _verify_health: nc -z port poll on macOS
+# ---------------------------------------------------------------------------
+
+
+def _stub_monotonic(monkeypatch, ticks: list[float]) -> list[float]:
+    """W11: replace the brittle 3-element-iterator + dead hasattr
+    pattern with a single counted stub. Pops one value per call;
+    `StopIteration` here means the test under-fed ticks (bug in the
+    test), so raising loudly is correct.
+
+    S7 (ATX iter-3): this stub assumes `verify_health_macos` calls
+    `time.monotonic` via the module-level `time` import (which it does
+    via the local alias `import time as _time` resolved per-call).
+    A refactor that rebinds with `from time import monotonic` at
+    module load would bypass this patch, and timeout tests would
+    silently no-op (the wall clock would advance instead). If
+    `verify_health_macos` is ever changed to a from-import,
+    `monkeypatch.setattr` here must be re-pointed at the function-local
+    reference too."""
+    import time as time_mod
+
+    feed = list(ticks)
+
+    def _next_tick() -> float:
+        if not feed:
+            raise AssertionError(
+                "test under-fed monotonic ticks — extend the list"
+            )
+        return feed.pop(0)
+
+    monkeypatch.setattr(time_mod, "monotonic", _next_tick)
+    monkeypatch.setattr(time_mod, "sleep", lambda _s: None)
+    return feed
+
+
+class TestVerifyHealthMacosDispatch:
+    def test_nc_connect_returns_immediately_on_first_poll(self, monkeypatch):
+        client = _Client([("nc -z -w 1 127.0.0.1 40510", 0, b"", b"")])
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        lc._verify_health(
+            client,
+            agent_type="openclaw",
+            agent_name="alpha",
+            host=host,
+            gateway_port=40510,
+        )
+        assert any("nc -z -w 1 127.0.0.1 40510" in c for c in client.calls)
+        # Exactly one probe — happy path is one round trip.
+        assert sum(1 for c in client.calls if "nc -z" in c) == 1
+
+    def test_nc_delayed_success_exercises_polling_loop(self, monkeypatch):
+        """S10: a regression that short-circuited on the first non-zero
+        rc would pass `test_nc_connect_returns_immediately` (no nc
+        failure there) but break here. This delayed-success case fails
+        nc twice, then succeeds, and asserts the loop kept polling."""
+        client = _Client(
+            [
+                ("nc -z -w 1 127.0.0.1 40510", 1, b"", b""),
+                ("nc -z -w 1 127.0.0.1 40510", 1, b"", b""),
+                ("nc -z -w 1 127.0.0.1 40510", 0, b"", b""),
+            ]
+        )
+        # Feed: initial deadline calc + 3 loop-head checks (well under
+        # deadline) + headroom. We never miss the deadline before nc
+        # returns 0.
+        _stub_monotonic(monkeypatch, [0.0] + [1.0, 2.0, 3.0])
+
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        lc._verify_health(
+            client,
+            agent_type="openclaw",
+            agent_name="alpha",
+            host=host,
+            gateway_port=40510,
+            timeout=30,
+        )
+        nc_calls = [c for c in client.calls if "nc -z" in c]
+        assert len(nc_calls) == 3, nc_calls
+
+    def test_timeout_raises_canonical_error(self, monkeypatch):
+        """Port never opens → operator gets a precise error naming the
+        port rather than a stuck sync. W11: uses the new counted stub
+        instead of the fragile shared iterator pattern."""
+        client = _Client(
+            [("nc -z -w 1 127.0.0.1 40510", 1, b"", b"")]
+        )
+        # Feed: initial deadline calc returns 0.0 (deadline = 1.0),
+        # then the loop check returns 999.0 (past deadline → exit).
+        _stub_monotonic(monkeypatch, [0.0, 999.0])
+
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        with pytest.raises(
+            lc.CanonicalSyncError,
+            match=r"gateway port 40510 not accepting connections",
+        ):
+            lc._verify_health(
+                client,
+                agent_type="openclaw",
+                agent_name="alpha",
+                host=host,
+                gateway_port=40510,
+                timeout=1,
+            )
+
+    @pytest.mark.parametrize(
+        "stderr_text",
+        [
+            # bash / zsh shape
+            b"bash: nc: command not found\n",
+            # BusyBox / dash / sh shape — `nc: not found`
+            b"sh: nc: not found\n",
+            # macOS shape (rare, but matches the precise regex)
+            b"-bash: nc: command not found\n",
+        ],
+    )
+    def test_nc_missing_breaks_early_with_diagnostic(
+        self, monkeypatch, stderr_text
+    ):
+        """W5 + W6 iter-3: if `nc` is not on PATH the stderr text
+        matches one of several shell-prelude shapes. The helper must
+        break early with a diagnostic pointing at the tool — not
+        retry until the 30s deadline and then misdirect the operator
+        at the daemon. Parametrized across both `command not found`
+        (bash/zsh) and `not found` (BusyBox/dash) variants."""
+        client = _Client(
+            [
+                (
+                    "nc -z -w 1 127.0.0.1 40510",
+                    127,
+                    b"",
+                    stderr_text,
+                )
+            ]
+        )
+        _stub_monotonic(monkeypatch, [0.0, 0.5])
+
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        with pytest.raises(
+            lc.CanonicalSyncError,
+            match=r"`nc` is not available",
+        ):
+            lc._verify_health(
+                client,
+                agent_type="openclaw",
+                agent_name="alpha",
+                host=host,
+                gateway_port=40510,
+                timeout=30,
+            )
+        # MUST break on the first probe — not retry until the deadline.
+        assert sum(1 for c in client.calls if "nc -z" in c) == 1
+
+    def test_nc_connection_refused_does_not_match_missing_diagnostic(
+        self, monkeypatch
+    ):
+        """W1 iter-3: the regex must NOT match BSD `nc: connect to
+        127.0.0.1 port N (tcp) failed: Connection refused` — that is
+        the expected "daemon not yet listening" stderr and the loop
+        must keep retrying until the deadline, not bail early."""
+        client = _Client(
+            [
+                (
+                    "nc -z -w 1 127.0.0.1 40510",
+                    1,
+                    b"",
+                    b"nc: connect to 127.0.0.1 port 40510 (tcp) failed: "
+                    b"Connection refused\n",
+                ),
+                (
+                    "nc -z -w 1 127.0.0.1 40510",
+                    0,
+                    b"",
+                    b"",
+                ),
+            ]
+        )
+        _stub_monotonic(monkeypatch, [0.0, 1.0, 2.0])
+
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        # Must NOT raise — must keep polling and then succeed.
+        lc._verify_health(
+            client,
+            agent_type="openclaw",
+            agent_name="alpha",
+            host=host,
+            gateway_port=40510,
+            timeout=30,
+        )
+        assert sum(1 for c in client.calls if "nc -z" in c) == 2
+
+    def test_missing_gateway_port_raises_canonical_error(self):
+        """W2 iter-3: a missing persisted port on macOS for openclaw /
+        hermes means install.py never allocated one — the agent is not
+        properly installed. The previous behavior (emit
+        `verify_skipped` and return) let canonical sync write
+        `state=READY` for a never-verified daemon. Now treated as a
+        hard CanonicalSyncError pointing the operator at the cause."""
+        client = _Client()
+
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        with pytest.raises(
+            lc.CanonicalSyncError,
+            match=r"no gateway port persisted.*install\.py never allocated",
+        ):
+            lc._verify_health(
+                client,
+                agent_type="openclaw",
+                agent_name="alpha",
+                host=host,
+                gateway_port=None,
+            )
+        # No port-probe attempted — we raise before any SSH.
+        assert client.calls == []
+
+    @pytest.mark.parametrize(
+        "invalid_port",
+        [
+            "40510",  # string-typed (hand-edited hosts.json)
+            0,        # zero — POSIX reserved, never a real listener
+            -1,       # negative
+            65536,    # exact upper-bound off-by-one (W5 iter-3)
+            70000,    # above 65535
+            3.14,     # float
+            True,     # bool (subclass of int but semantically wrong)
+            False,    # also a bool subclass of int (S6 iter-3)
+        ],
+    )
+    def test_invalid_port_rejected(self, invalid_port):
+        """W12: parametrized matrix of invalid port values. A
+        hand-edited hosts.json could put any of these in the port
+        field; refuse to interpolate them into a shell command.
+
+        W5 iter-3: includes the exact upper-bound 65536 to pin the
+        `< 65536` strict-less-than guard (off-by-one regression
+        would let port 65536 through).
+        S6 iter-3: both True AND False to lock the `type(...) is int`
+        idiom — `isinstance(False, int)` is True, so a switch back to
+        isinstance would let bools through."""
+        client = _Client()
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        with pytest.raises(
+            lc.CanonicalSyncError,
+            match=r"invalid gateway_port",
+        ):
+            lc._verify_health(
+                client,
+                agent_type="openclaw",
+                agent_name="alpha",
+                host=host,
+                gateway_port=invalid_port,  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.parametrize("valid_port", [1, 1024, 41091, 65535])
+    def test_valid_port_boundary_values_accepted(self, monkeypatch, valid_port):
+        """W5 iter-3: the highest legal port (65535) must succeed
+        through the validator. Combined with the 65536 case above,
+        this pins the exact `0 < port < 65536` invariant."""
+        client = _Client(
+            [(f"nc -z -w 1 127.0.0.1 {valid_port}", 0, b"", b"")]
+        )
+        host = {"hostname": "h", "hardware": {"os": "macos"}}
+        lc._verify_health(
+            client,
+            agent_type="openclaw",
+            agent_name="alpha",
+            host=host,
+            gateway_port=valid_port,
+        )
+        assert any(f"nc -z -w 1 127.0.0.1 {valid_port}" in c for c in client.calls)

--- a/tests/core/test_lifecycle_macos.py
+++ b/tests/core/test_lifecycle_macos.py
@@ -43,7 +43,7 @@ class _FakeClient:
         self.commands: list[str] = []
         self._responses = list(responses or [])
 
-    def exec_command(self, cmd):  # noqa: ANN001
+    def exec_command(self, cmd, **_kwargs):  # noqa: ANN001
         self.commands.append(cmd)
         if self._responses:
             rc, out, err = self._responses.pop(0)

--- a/tests/core/test_lifecycle_macos_openclaw.py
+++ b/tests/core/test_lifecycle_macos_openclaw.py
@@ -33,7 +33,7 @@ class _FakeClient:
         self.commands = []
         self._responses = list(responses or [])
 
-    def exec_command(self, cmd):
+    def exec_command(self, cmd, **_kwargs):
         self.commands.append(cmd)
         rc, out, err = self._responses.pop(0) if self._responses else (0, "", "")
         return StringIO(), _Out(out, rc), _Out(err, rc)

--- a/tests/core/test_registry_latest_supported.py
+++ b/tests/core/test_registry_latest_supported.py
@@ -10,8 +10,8 @@ from clawrium.core.registry import latest_supported_version
 @pytest.mark.parametrize(
     "claw_name,os_,os_version,arch,expected",
     [
-        ("openclaw", "ubuntu", "24.04", "x86_64", "2026.6.8"),
-        ("openclaw", "ubuntu", "22.04", "x86_64", "2026.6.8"),
+        ("openclaw", "ubuntu", "24.04", "x86_64", "2026.6.9"),
+        ("openclaw", "ubuntu", "22.04", "x86_64", "2026.6.9"),
         ("hermes", "ubuntu", "24.04", "x86_64", "2026.5.29.2"),
         ("hermes", "ubuntu", "22.04", "x86_64", "2026.5.29.2"),
         ("hermes", "macos", "14.5", "arm64", "2026.5.29.2"),

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -1976,6 +1976,7 @@ _HERMES_BEDROCK_YAML = (
     "# Managed by clawrium (clawctl). Re-render with `clawctl agent configure alpha`.\n"
     "model:\n"
     "  provider: \"bedrock\"\n"
+    "  api_key: \"aws-sdk\"\n"
     "  default: 'anthropic.claude-opus-4-1-v1:0'\n"
     "bedrock:\n"
     "  region: 'us-east-1'\n"
@@ -2416,7 +2417,7 @@ _OPENCLAW_ENV_BEDROCK = (
     "OPENCLAW_GATEWAY_PORT=40000\n"
     "OPENCLAW_GATEWAY_AUTH_MODE=token\n"
     "OPENCLAW_GATEWAY_AUTH_TOKEN='tkn'\n"
-    "OPENCLAW_DEFAULT_MODEL='bedrock/anthropic.claude-opus-4-1-v1:0'\n"
+    "OPENCLAW_DEFAULT_MODEL='amazon-bedrock/anthropic.claude-opus-4-1-v1:0'\n"
     "AWS_ACCESS_KEY_ID='AKIA-1'\n"
     "AWS_SECRET_ACCESS_KEY='secret-1'\n"
     "AWS_DEFAULT_REGION='us-east-1'\n"
@@ -3072,11 +3073,17 @@ def test_openclaw_git_integration_skipped():
 
 def test_openclaw_model_prefix_idempotent():
     """Round 2 S3: pre-prefixed model id must NOT double up.
-    (`openrouter/m` stays `openrouter/m`, not `openrouter/openrouter/m`.)"""
-    for ptype, model_id in [
-        ("openrouter", "openrouter/anthropic/claude-opus-4.7"),
-        ("bedrock", "bedrock/anthropic.claude-opus-4-1-v1:0"),
-    ]:
+    (`openrouter/m` stays `openrouter/m`; `amazon-bedrock/m` stays
+    `amazon-bedrock/m`, not `amazon-bedrock/amazon-bedrock/m`.)"""
+    cases = [
+        ("openrouter", "openrouter/", "openrouter/anthropic/claude-opus-4.7"),
+        (
+            "bedrock",
+            "amazon-bedrock/",
+            "amazon-bedrock/anthropic.claude-opus-4-1-v1:0",
+        ),
+    ]
+    for ptype, prefix, model_id in cases:
         if ptype == "openrouter":
             p = ProviderInputs(
                 name="or", type=ptype, default_model=model_id, api_key="sk-1"
@@ -3097,9 +3104,12 @@ def test_openclaw_model_prefix_idempotent():
             gateway=GatewayInputs(host="0.0.0.0", port=40000, bind="lan"),
         )
         env = render_openclaw(inputs).files[".openclaw/env"]
-        assert f"OPENCLAW_DEFAULT_MODEL='{model_id}'" in env
-        # Critical: prefix must not appear twice.
-        prefix = f"{ptype}/"
+        expected_line = f"OPENCLAW_DEFAULT_MODEL='{model_id}'"
+        # Exact-line match — substring would pass for a double-prefixed
+        # value that happens to contain the model id as a tail.
+        assert any(line == expected_line for line in env.splitlines()), (
+            f"expected exact line {expected_line!r} in:\n{env}"
+        )
         assert env.count(prefix + prefix) == 0
 
 

--- a/tests/integration/test_macos_e2e_mocked.py
+++ b/tests/integration/test_macos_e2e_mocked.py
@@ -89,7 +89,7 @@ class _Client:
         self.commands: list[str] = []
         self._sftp = _SFTP()
 
-    def exec_command(self, cmd: str):
+    def exec_command(self, cmd: str, **_kwargs):
         self.commands.append(cmd)
         return StringIO(), _Stream("", rc=0), _Stream("", rc=0)
 

--- a/tests/test_configure_claw.py
+++ b/tests/test_configure_claw.py
@@ -2263,10 +2263,10 @@ class TestEnvTemplate:
             in rendered
         )
         env_map = self._parse_env(rendered)
-        # Bedrock models get prefixed with bedrock/
+        # Bedrock models get prefixed with amazon-bedrock/
         assert (
             env_map["OPENCLAW_DEFAULT_MODEL"]
-            == "bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0"
+            == "amazon-bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0"
         )
 
     def test_env_bedrock_credentials_with_special_chars(self):
@@ -2304,10 +2304,10 @@ class TestEnvTemplate:
         # No AWS credentials should be in output when not provided
         assert "AWS_ACCESS_KEY_ID" not in env_map
         assert "AWS_SECRET_ACCESS_KEY" not in env_map
-        # Bedrock models get prefixed with bedrock/
+        # Bedrock models get prefixed with amazon-bedrock/
         assert (
             env_map["OPENCLAW_DEFAULT_MODEL"]
-            == "bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0"
+            == "amazon-bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0"
         )
 
     def test_env_bedrock_provider_with_empty_string_credentials(self):
@@ -2333,7 +2333,7 @@ class TestEnvTemplate:
         # Model should still be prefixed correctly
         assert (
             env_map["OPENCLAW_DEFAULT_MODEL"]
-            == "bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0"
+            == "amazon-bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0"
         )
 
     def test_env_vertex_provider(self):

--- a/tests/test_core_chat.py
+++ b/tests/test_core_chat.py
@@ -74,6 +74,108 @@ def test_connect_success(monkeypatch):
     assert req["params"]["auth"]["token"] == "secret-token"
 
 
+# ---------------------------------------------------------------------------
+# B2 + W1 (ATX iter-4 #719): pin the cross-platform pairing invariant
+# and the protocol-3..4 negotiation on the wire. A regression that
+# reverts `platform` back to a hardcoded string OR drops the
+# `maxProtocol` bump from 4 to 3 would otherwise pass every other
+# chat test silently and only surface live against openclaw v2026.6.9
+# (protocol-4-only) or on a cross-platform operator/agent install.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sys_platform_value, expected_normalized",
+    [
+        ("linux", "linux"),
+        ("darwin", "darwin"),
+        ("win32", "win32"),
+        # Versioned POSIX shapes must be stripped so the value matches
+        # what Node's `process.platform` (= bare family) records on
+        # the daemon side at pair time.
+        ("freebsd13", "freebsd"),
+        ("openbsd6.9", "openbsd"),
+    ],
+)
+def test_connect_sends_normalized_operator_platform(
+    monkeypatch, sys_platform_value, expected_normalized
+):
+    """The `client.platform` field on the wire MUST be the normalized
+    operator platform (matching the value the install pair script
+    persisted). The openclaw daemon rejects any subsequent connect
+    with a different `platform` as 'device identity changed'."""
+    import sys as _sys
+
+    monkeypatch.setattr(_sys, "platform", sys_platform_value)
+
+    frames = [
+        {
+            "type": "event",
+            "event": "connect.challenge",
+            "payload": {"nonce": "abc123", "ts": 1234},
+        },
+        {
+            "type": "res",
+            "id": "1",
+            "ok": True,
+            "payload": {"type": "hello-ok", "protocol": 4},
+        },
+    ]
+    fake_ws = FakeWebSocket(frames)
+
+    async def fake_connect(*args, **kwargs):
+        return fake_ws
+
+    monkeypatch.setattr("clawrium.core.chat.websockets.connect", fake_connect)
+
+    client = OpenClawChatClient("ws://test-host:40123", "secret-token")
+    asyncio.run(client.connect())
+
+    req = fake_ws.sent[0]
+    assert req["params"]["client"]["platform"] == expected_normalized, (
+        f"client.platform must match Node's process.platform shape "
+        f"(install pair side); sys.platform={sys_platform_value!r} "
+        f"normalized → {expected_normalized!r}, got "
+        f"{req['params']['client']['platform']!r}"
+    )
+
+
+def test_connect_negotiates_protocol_3_to_4(monkeypatch):
+    """W1 (ATX iter-4): openclaw v2026.6.9 dropped protocol 3 — the
+    daemon rejects min=3/max=3 handshakes with 'expected=4 probeMin=4'
+    (verified live against esper-mac-oc, see
+    .itx/719/01_EXECUTION.md). The client must advertise minProtocol=3
+    (compat with older daemons still on proto 3) AND maxProtocol=4
+    (compat with v2026.6.9+). A revert to max=3 would silently break
+    every chat session against a v2026.6.9+ host."""
+    frames = [
+        {
+            "type": "event",
+            "event": "connect.challenge",
+            "payload": {"nonce": "abc123", "ts": 1234},
+        },
+        {
+            "type": "res",
+            "id": "1",
+            "ok": True,
+            "payload": {"type": "hello-ok", "protocol": 4},
+        },
+    ]
+    fake_ws = FakeWebSocket(frames)
+
+    async def fake_connect(*args, **kwargs):
+        return fake_ws
+
+    monkeypatch.setattr("clawrium.core.chat.websockets.connect", fake_connect)
+
+    client = OpenClawChatClient("ws://test-host:40123", "secret-token")
+    asyncio.run(client.connect())
+
+    req = fake_ws.sent[0]
+    assert req["params"]["minProtocol"] == 3
+    assert req["params"]["maxProtocol"] == 4
+
+
 def test_secret_str_masks_repr():
     secret = SecretStr("very-secret")
     assert repr(secret) == "***"

--- a/tests/test_gui_agent_detail_latest_version.py
+++ b/tests/test_gui_agent_detail_latest_version.py
@@ -62,7 +62,7 @@ def test_agent_detail_includes_latest_supported_version(isolated_config: Path):
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert "latest_supported_version" in body
-    assert body["latest_supported_version"] == "2026.6.8"
+    assert body["latest_supported_version"] == "2026.6.9"
 
 
 def test_agent_detail_latest_supported_version_is_none_for_unmatched_host(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2631,3 +2631,124 @@ def test_install_hardware_unknown_with_version_override_bypasses_check(monkeypat
         "validate",
         "Version override: openclaw v2026.6.8",
     ) in events
+
+
+# ---------------------------------------------------------------------------
+# B1 (ATX iter-4 #719): `operator_platform` extravar must be threaded
+# from `sys.platform` (normalized) into the ansible inventory so the
+# openclaw pair script records the OPERATOR's platform on the daemon's
+# paired device entry — not the agent host's OS. A regression that
+# drops/renames this key would only surface on a live host at pair
+# time as `AnsibleUndefinedVariable`, reinstating the #719 bug
+# silently. Asserts the value via `mock_run.call_args` introspection
+# on the same fixture pattern as `test_install_success` above.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sys_platform_value, expected_normalized",
+    [
+        ("linux", "linux"),
+        ("darwin", "darwin"),
+        ("win32", "win32"),
+        # FreeBSD: Python returns versioned `freebsd13`; the normalizer
+        # must strip the version so the value matches what Node's
+        # `process.platform` (= bare `freebsd`) records on the daemon.
+        ("freebsd13", "freebsd"),
+        ("freebsd14", "freebsd"),
+        ("openbsd6.9", "openbsd"),
+    ],
+)
+def test_install_inventory_threads_normalized_operator_platform(
+    monkeypatch, tmp_path, sys_platform_value, expected_normalized
+):
+    """`run_installation` must inject `operator_platform` into the
+    ansible inventory vars dict, normalized to the bare family name
+    that matches Node's `process.platform` shape (see
+    clawrium.core._operator_platform)."""
+    import sys as _sys
+
+    monkeypatch.setattr(_sys, "platform", sys_platform_value)
+
+    from clawrium.core.install import run_installation
+    import clawrium.core.install
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mock_manifest = {
+        "name": "openclaw",
+        "entries": [
+            {
+                "version": "0.1.0",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "arch": "x86_64",
+                "sha256": "abc123",
+                "requirements": {
+                    "min_memory_mb": 2048,
+                    "gpu_required": False,
+                    "dependencies": {"python": ">=3.9"},
+                },
+            }
+        ],
+    }
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+
+    key_file = tmp_path / "test_key"
+    key_file.write_text("fake key")
+
+    compatible_host = {
+        "hostname": "test-host",
+        "agent_name": "xclm",
+        "port": 22,
+        "key_id": "test-host",
+        "hardware": {
+            "architecture": "x86_64",
+            "os": "ubuntu",
+            "os_version": "24.04",
+            "memtotal_mb": 4096,
+        },
+    }
+    monkeypatch.setattr(clawrium.core.install, "get_host", lambda x: compatible_host)
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *args, **kwargs: {
+            "compatible": True,
+            "matched_entry": mock_manifest["entries"][0],
+            "reasons": [],
+        },
+    )
+    monkeypatch.setattr(
+        clawrium.core.install, "get_host_private_key", lambda x: key_file
+    )
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "update_host",
+        lambda h, u: u(clawrium.core.install.get_host(h)),
+    )
+    monkeypatch.setattr(
+        clawrium.core.install, "initialize_onboarding", lambda h, c: True
+    )
+
+    class SuccessfulResult:
+        status = "successful"
+
+    mock_run = Mock(return_value=SuccessfulResult())
+    import ansible_runner
+    monkeypatch.setattr(ansible_runner, "run", mock_run)
+
+    run_installation("openclaw", "test-host")
+
+    # Inspect the CLAW playbook call (second invocation; first is base).
+    assert mock_run.call_count == 2
+    claw_call_kwargs = mock_run.call_args_list[1].kwargs
+    inv_vars = claw_call_kwargs["inventory"]["all"]["vars"]
+    assert "operator_platform" in inv_vars, (
+        f"missing operator_platform; got keys: {sorted(inv_vars.keys())}"
+    )
+    assert inv_vars["operator_platform"] == expected_normalized, (
+        f"expected {expected_normalized!r} (normalized from "
+        f"sys.platform={sys_platform_value!r}); got "
+        f"{inv_vars['operator_platform']!r}"
+    )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2498,3 +2498,136 @@ def test_install_hermes_dashboard_port_pool_exhausted(monkeypatch, tmp_path):
 
     with pytest.raises(InstallationError, match="[Pp]ool exhausted"):
         run_installation("hermes", "test-host", name="hermes-new")
+
+
+def test_install_hardware_unknown_raises(monkeypatch, tmp_path):
+    """Issue #720: install MUST fail when host hardware is unknown.
+
+    When check_compatibility returns matched_entry=None (no hardware facts
+    gathered), the install must refuse to proceed rather than guessing a
+    version. Guessing caused npm ETARGET errors with non-existent versions.
+    """
+    from clawrium.core.install import run_installation, InstallationError
+
+    # Mock load_manifest
+    mock_manifest = {
+        "name": "openclaw",
+        "platforms": [
+            {
+                "version": "2026.6.8",
+                "os": "macos",
+                "os_version": ">=14",
+                "arch": "arm64",
+            }
+        ],
+    }
+
+    import clawrium.core.install
+
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+
+    # Host exists but has empty hardware (not yet gathered)
+    host_no_hardware = {
+        "hostname": "test-host.local",
+        "agent_name": "xclm",
+        "port": 22,
+        "hardware": {},
+        "agents": {},
+    }
+    monkeypatch.setattr(clawrium.core.install, "get_host", lambda x: host_no_hardware)
+
+    # check_compatibility with empty hardware returns compatible=True, matched_entry=None
+    compat_result = {
+        "compatible": True,
+        "matched_entry": None,
+        "reasons": [],
+    }
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *args, **kwargs: compat_result,
+    )
+
+    with pytest.raises(InstallationError, match="hardware information is not available"):
+        run_installation("openclaw", "test-host")
+
+
+def test_install_hardware_unknown_with_version_override_bypasses_check(monkeypatch, tmp_path):
+    """When --version is explicitly provided, hardware-unknown gate is skipped.
+
+    An explicit version override means the operator knows what they want —
+    the hardware check gate should not block them. We verify the code
+    proceeds past the hardware gate (it may fail later for other reasons,
+    but NOT with the 'hardware information is not available' error).
+    """
+    from clawrium.core.install import run_installation
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    mock_manifest = {
+        "name": "openclaw",
+        "platforms": [
+            {
+                "version": "2026.6.8",
+                "os": "macos",
+                "os_version": ">=14",
+                "arch": "arm64",
+            }
+        ],
+    }
+
+    import clawrium.core.install
+
+    monkeypatch.setattr(clawrium.core.install, "load_manifest", lambda x: mock_manifest)
+
+    host_no_hardware = {
+        "hostname": "test-host.local",
+        "agent_name": "xclm",
+        "port": 22,
+        "hardware": {},
+        "agents": {},
+    }
+    monkeypatch.setattr(clawrium.core.install, "get_host", lambda x: host_no_hardware)
+
+    # compatible=True, matched_entry=None (hardware unknown)
+    compat_result = {
+        "compatible": True,
+        "matched_entry": None,
+        "reasons": [],
+    }
+    monkeypatch.setattr(
+        clawrium.core.install,
+        "check_compatibility",
+        lambda *args, **kwargs: compat_result,
+    )
+
+    # Capture events so we can prove the version-override branch ran
+    # (rather than just observing "no hardware-unknown error" — which
+    # would also pass if some unrelated exception fired before the gate).
+    events: list[tuple[str, str]] = []
+
+    def _on_event(stage: str, message: str) -> None:
+        events.append((stage, message))
+
+    # We expect the code to proceed past the hardware gate. It will fail
+    # later (e.g. missing SSH key), but NOT with InstallationError about
+    # missing hardware.
+    from clawrium.core.install import InstallationError
+
+    with pytest.raises(InstallationError) as exc_info:
+        run_installation(
+            "openclaw",
+            "test-host",
+            on_event=_on_event,
+            version_override="2026.6.8",
+        )
+
+    # The error must NOT be about hardware being unavailable.
+    assert "hardware information is not available" not in str(exc_info.value)
+    # The version-override branch must have fired before the failure —
+    # this pins the branch entry so the assertion above can't pass
+    # vacuously on an unrelated early exit.
+    assert (
+        "validate",
+        "Version override: openclaw v2026.6.8",
+    ) in events

--- a/tests/test_playbooks.py
+++ b/tests/test_playbooks.py
@@ -124,7 +124,11 @@ def test_openclaw_install_playbook_structure():
     assert (
         template_cfg["dest"] == "/home/{{ agent_name }}/.openclaw/exec-approvals.json"
     )
-    assert template_cfg["backup"] is True
+    # W6 (ATX iter-2): `backup: yes` was removed because it accumulates
+    # `exec-approvals.json.NNNN~` siblings on every reconfigure with no
+    # rotation; the previous value is recoverable from the template.
+    # Pin its absence so a re-add is caught.
+    assert "backup" not in template_cfg
     assert exec_approvals_task["no_log"] is True
     assert any(t.get("name") == "Verify exec approvals JSON is valid" for t in tasks), (
         "Should validate exec-approvals JSON after rendering"
@@ -174,7 +178,11 @@ def test_openclaw_configure_playbook_structure():
     assert (
         template_cfg["dest"] == "/home/{{ agent_name }}/.openclaw/exec-approvals.json"
     )
-    assert template_cfg["backup"] is True
+    # W6 (ATX iter-2): `backup: yes` was removed because it accumulates
+    # `exec-approvals.json.NNNN~` siblings on every reconfigure with no
+    # rotation; the previous value is recoverable from the template.
+    # Pin its absence so a re-add is caught.
+    assert "backup" not in template_cfg
     assert exec_approvals_task["no_log"] is True
     assert any(t.get("name") == "Verify exec approvals JSON is valid" for t in tasks), (
         "Should validate exec-approvals JSON after rendering"

--- a/tests/test_verify_config_script.py
+++ b/tests/test_verify_config_script.py
@@ -1,9 +1,12 @@
 """Tests for openclaw verify_config.py model schema checks."""
 
+import ast
 import json
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 
 def _run_verify_script(
@@ -104,3 +107,129 @@ def test_verify_config_normalizes_openrouter_prefix(tmp_path: Path):
 
     result = _run_verify_script(tmp_path, config, expected)
     assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Bedrock prefix (ATX iter-2 B1) — the prefix this branch introduced.
+# Previously the script used `bedrock/`; the openclaw gateway actually
+# registers its Bedrock provider as `amazon-bedrock`, so an
+# `Unknown model: bedrock/<id>` was the production symptom that led to
+# the bundle. These tests pin the new prefix end-to-end against the
+# script — a future typo or revert would fail loudly in CI instead of
+# shipping silently to a real agent. Bedrock model ids contain colons
+# and dots, which makes mis-normalization especially hard to spot at
+# runtime.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw_model, rendered_model",
+    [
+        (
+            "anthropic.claude-3-7-sonnet-20250219-v1:0",
+            "amazon-bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0",
+        ),
+        ("zai.glm-5", "amazon-bedrock/zai.glm-5"),
+        ("anthropic.claude-opus-4-1-v1:0", "amazon-bedrock/anthropic.claude-opus-4-1-v1:0"),
+    ],
+)
+def test_verify_config_normalizes_bedrock_prefix(
+    tmp_path: Path, raw_model: str, rendered_model: str
+):
+    """Operator stores a bare model id; renderer must prepend
+    `amazon-bedrock/`; verify passes when actual on-host config carries
+    the prefixed form."""
+    config = {
+        "agents": {"defaults": {"model": {"primary": rendered_model}}},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    expected = {
+        "provider": {"type": "bedrock", "default_model": raw_model},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    result = _run_verify_script(tmp_path, config, expected)
+    assert result.returncode == 0, (
+        f"verify failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "Configuration verified successfully" in result.stdout
+
+
+def test_verify_config_bedrock_already_prefixed_not_double_prefixed(tmp_path: Path):
+    """If `provider.default_model` already starts with `amazon-bedrock/`
+    (operator hand-typed the prefix, or this is a re-render of an
+    already-normalized value), the script must not double-prefix it to
+    `amazon-bedrock/amazon-bedrock/<id>` — that's a value the gateway
+    would reject at request time. The `startswith` guard inside
+    `_expected_model_id` is the protection; pin its behavior here."""
+    model_id = "amazon-bedrock/anthropic.claude-opus-4-1-v1:0"
+    config = {
+        "agents": {"defaults": {"model": {"primary": model_id}}},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    expected = {
+        "provider": {"type": "bedrock", "default_model": model_id},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    result = _run_verify_script(tmp_path, config, expected)
+    assert result.returncode == 0, (
+        f"verify failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_verify_config_rejects_legacy_bedrock_prefix_on_host(tmp_path: Path):
+    """Negative case: if the on-host `openclaw.json` still carries the
+    legacy `bedrock/<id>` form (operator hand-edited, or an old render
+    was never re-synced), verify must mismatch. The fix in this branch
+    deliberately does NOT auto-migrate operator data
+    (CHANGELOG.md ### BREAKING), so the surfaced error is the only
+    signal the operator gets that they need to update `hosts.json`."""
+    config = {
+        "agents": {"defaults": {"model": {"primary": "bedrock/zai.glm-5"}}},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    expected = {
+        "provider": {"type": "bedrock", "default_model": "zai.glm-5"},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    result = _run_verify_script(tmp_path, config, expected)
+    assert result.returncode == 1
+    # Pin the message body — both expected and actual values must
+    # surface so the operator can diff them.
+    assert "Model mismatch" in result.stderr
+    assert "amazon-bedrock/zai.glm-5" in result.stderr  # expected (rendered)
+    assert "bedrock/zai.glm-5" in result.stderr  # actual (on host)
+
+
+# ---------------------------------------------------------------------------
+# Python 3.9 compat guard — see .itx/719/01_EXECUTION.md
+# ---------------------------------------------------------------------------
+
+
+def test_verify_config_requires_future_annotations_import():
+    """The script runs on agent hosts with whatever `python3` is on
+    PATH. macOS Xcode CLI tools ship Python 3.9.6, which predates PEP
+    604 union types (`X | Y`) being legal as runtime annotations. The
+    `from __future__ import annotations` import in `verify_config.py`
+    defers all annotation evaluation, making the file compatible with
+    Python 3.7+.
+
+    A future contributor removing that import would not fail any test
+    on the developer machine (CPython 3.10+ accepts the syntax
+    natively), but would crash at the first openclaw sync on macOS
+    with `TypeError: unsupported operand type(s) for |: 'type' and
+    'NoneType'`. This guard makes the regression a CI failure instead."""
+    from importlib.resources import files
+
+    script_path = files("clawrium.platform.registry.openclaw") / "templates" / "verify_config.py"
+    source = Path(str(script_path)).read_text()
+    tree = ast.parse(source)
+    has_future_annotations = any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "__future__"
+        and any(alias.name == "annotations" for alias in node.names)
+        for node in tree.body
+    )
+    assert has_future_annotations, (
+        "verify_config.py MUST `from __future__ import annotations` for "
+        "Python 3.9 compatibility on macOS hosts. See .itx/719/01_EXECUTION.md."
+    )

--- a/tests/test_workspace_phase_ordering.py
+++ b/tests/test_workspace_phase_ordering.py
@@ -68,10 +68,10 @@ def canonical_stubs(monkeypatch: pytest.MonkeyPatch):
     def fake_open_ssh(_host, *, timeout=15):
         return fake_client
 
-    def fake_restart_unit(_client, *, agent_type, agent_name):
+    def fake_restart_unit(_client, *, agent_type, agent_name, **_kwargs):
         calls.append("restart")
 
-    def fake_verify_health(_client, *, agent_type, agent_name):
+    def fake_verify_health(_client, *, agent_type, agent_name, **_kwargs):
         calls.append("verify")
 
     monkeypatch.setattr(

--- a/tests/test_workspace_zeroclaw_bearer_rotation.py
+++ b/tests/test_workspace_zeroclaw_bearer_rotation.py
@@ -75,10 +75,10 @@ def make_canonical_stubs(monkeypatch: pytest.MonkeyPatch):
         def fake_open_ssh(_host, *, timeout=15):
             return fake_client
 
-        def fake_restart_unit(_client, *, agent_type, agent_name):
+        def fake_restart_unit(_client, *, agent_type, agent_name, **_kwargs):
             calls.append(("restart", agent_type, agent_name))
 
-        def fake_verify_health(_client, *, agent_type, agent_name):
+        def fake_verify_health(_client, *, agent_type, agent_name, **_kwargs):
             calls.append(("verify", agent_type, agent_name))
 
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- Lands openclaw on macOS end-to-end via dispatcher-only OS fork in `lifecycle_canonical.py` → new helpers in `lifecycle_macos.py` (`atomic_write_macos`, `restart_unit_macos`, `verify_health_macos`).
- Fixes #720: `clawctl agent create` fail-fasts when host hardware facts are missing instead of silently picking `platforms[0]` = openclaw@0.1.0 (npm ETARGET).
- Renames the openclaw bedrock model prefix `bedrock/` → `amazon-bedrock/` to match the upstream gateway provider name. **BREAKING**: no automated migration — operators with the legacy prefix in `hosts.json` must update manually (steps in CHANGELOG).
- Bumps openclaw manifest to v2026.6.9 (Ubuntu 24.04/22.04 x86_64 + macOS ≥14 arm64); brave plugin pin + `min_host_version` → 2026.6.9.
- **Threads operator platform through the openclaw pair handshake** so `clawctl agent chat` works end-to-end on cross-platform installs (linux clawctl → darwin agent) without needing UI re-approval (commit `9e123d8`, iter-4 follow-up).
- Bumps openclaw WS chat protocol to `min=3 max=4` so `clawctl agent chat` works against v2026.6.9+ daemons (which dropped protocol 3).

Closes #719, #720.

## E2E Test Summary

Run live on `clawdmin03@espers-mac-mini.tailf7742d.ts.net` (Mac mini, macOS 26.5.1 arm64) using **this branch's `uv run clawctl`** (the installed 26.6.5 does not have the fixes). Reused the existing `clm-openrouter` provider (openrouter/openai/gpt-4o) so no new credentials. Full walkthrough captured in `.itx/719/01_EXECUTION.md`.

| # | Step | Result |
|---|---|---|
| 1 | SSH preflight (`xcode-select -p` already populated) | ✓ |
| 2 | `xclm` user setup over `ssh clawdmin03@…` (NOPASSWD sudo + authorized_key) | ✓ |
| 3 | `clawctl host create esper-macmini` | ✓ |
| 4 | Hardware backfill via `gather_hardware` | ✓ macos arm64 26.5.1 |
| 5 | `clawctl agent create … --type openclaw` BEFORE backfill | ✓ Fails fast per #720 |
| 6 | `clawctl agent create … --type openclaw` AFTER backfill | ✓ Picks v2026.6.9 |
| 7 | `clawctl agent provider attach clm-openrouter` | ✓ |
| 8–10 | `clawctl agent configure --stage {identity,providers,validate}` | ✓ |
| 11 | `clawctl agent sync` | ✓ Used new dispatchers (`install -g staff`, `launchctl kickstart -k`, `nc -z`) |
| 12 | `curl /health` | ✓ `{"ok":true,"status":"live"}` |
| 13 | Daemon log confirms openrouter plugin loaded | ✓ |
| 14 | **`clawctl agent chat` round-trip (post iter-4 fix)** | ✓ Real openrouter response, **zero UI approval, fresh install** |

### Bugs Found & Fixed Live During E2E

1. **`verify_config.py` used PEP 604 `str \| None`** → crashed on macOS Python 3.9.6 (`/usr/bin/python3`, Xcode CLI tools). Fixed with `from __future__ import annotations`.
2. **`verify_health_macos` used `lsof -i :<port>`** → macOS `lsof` only shows ports owned by the running user; sync runs as `xclm` but daemon runs as `<agent_name>`. Switched to `nc -z -w 1 127.0.0.1 <port>` (TCP connect, no sudo needed).
3. **Port validator accepted Python bools** (`True`/`False` are `isinstance(int)`) → would interpolate `nc -z … True` into the shell. Strengthened to `type(...) is int`.
4. **openclaw v2026.6.9 dropped WS protocol 3** → `clawctl agent chat` advertised `min=3 max=3`, daemon rejected with `expected=4 probeMin=4`. Bumped `maxProtocol` to 4 in `chat.py`.
5. **Install pair script recorded `platform: <agent-host-os>` instead of `platform: <operator-os>`** → `clawctl agent chat` from a Linux clawctl connecting to a paired-as-`darwin` device was rejected as "device identity changed". Fixed by threading operator's normalized `sys.platform` through inventory → playbook → `pair_device.mjs` → daemon, and sending the same normalized value from `chat.py`. New shared helper `clawrium.core._operator_platform.normalize()` strips Python's versioned-platform suffix (`freebsd13` → `freebsd`) so the value matches Node's bare-family `process.platform` shape on the pair side.

### Follow-ups (separate issues — NOT blocking this PR)

- Canonical `clawctl host create` doesn't gather hardware → operators hit the #720 fail-fast on first `agent create` with no documented backfill path. Worth filing.

## Testing

- [x] `make lint` clean (ruff + ESLint).
- [x] `make test`: **3912 Python pass + 305 vitest pass** (+45 net new in this PR, including parametrized macOS dispatch suite, `atomic_write_macos` failure branches, `nc -z` polling, port boundary matrix, bedrock prefix normalization on `verify_config.py`, and the iter-4 `operator_platform` extravar + `client.platform` on-the-wire + protocol 3..4 assertions).
- [x] **Live host verification on real macOS hardware** (see E2E table above). This is the load-bearing artifact for #719.

## ATX Review Summary

Five review iterations completed. Final iteration (iter-5) against the current branch state (commit `158dbad`) returns **rating 4/5 with `blocking=false`** — no merge gate remains.

| Review | Rating | Blocking | Status | Notes |
|---|---|---|---|---|
| 1 | 1.5/5 | 13 | All resolved | initial bundle apply |
| 2 | 3/5 | 1 (B1) + W1–W4 strongly recommended | All resolved | macOS dispatcher hardening |
| 3 | 3/5 | 3 (B1, B2, B3) + 6 warnings + 7 suggestions | **16/17 resolved** | S4 sentinel-env-var skipped (multi-entry plumbing) |
| 4 | 2/5 | 2 (B1, B2) + 4 warnings + 4 suggestions | **9/10 resolved** | rating on submission state; S2 Node test infra skipped |
| **5** | **4/5** | **`false`** (no blockers) | _re-review against post-iter-4-fix state_ | platform-playbooks 5/5, security/lifecycle/cli-ux 4/5, test-coverage 3/5, gui-routes 2/5 (refinement, not blocking) |

Transcripts are committed under `.itx/openclaw-macos-bundle/`.

### Iter-4 disposition (what `9e123d8` actually does)

| # | What it asked | Fix in `9e123d8` |
|---|---|---|
| B1 | `operator_platform` extravar unasserted in test_install.py | 6-case parametrized `test_install_inventory_threads_normalized_operator_platform` (`linux`/`darwin`/`win32`/`freebsd13`/`freebsd14`/`openbsd6.9`) via `monkeypatch.setattr(sys, "platform", ...)`, inspects `mock_run.call_args_list[1].kwargs["inventory"]["all"]["vars"]["operator_platform"]` |
| B2 | `client.platform` field unasserted in test_core_chat.py | 5-case parametrized `test_connect_sends_normalized_operator_platform` reads `fake_ws.sent[0]["params"]["client"]["platform"]` on the same matrix |
| W1 | `maxProtocol` 3→4 unasserted on the wire | `test_connect_negotiates_protocol_3_to_4` pins both `minProtocol=3` and `maxProtocol=4` on the sent frame |
| W2 | `pair_device.mjs` `\|\|` silently falls back on empty string | Explicit empty-string + non-string + unknown-family rejection with structured JSON error and `process.exit(1)`; legacy 2-arg invocation still falls back to `process.platform` (no behavior change for old callers) |
| W3 | `{{ operator_platform }}` has no default; direct playbook runs crash opaquely | Both `install.yaml` and `install_macos.yaml` get an early `ansible.builtin.assert` with `fail_msg` pointing at `clawctl agent create` |
| W4 | `sys.platform` and `process.platform` shapes diverge on BSD/AIX | New `clawrium.core._operator_platform.normalize()` strips trailing version digits (`freebsd13` → `freebsd`, `openbsd6.9` → `openbsd`); `linux`/`darwin`/`win32`/`cygwin` pass through unchanged. Both `install.py` and `chat.py` call through it |
| S1 | `import sys as _sys` inline in chat.py | Moved to module-top `import sys`; removed alias |
| S2 | Node-side test for `pair_device.mjs` platform forwarding | **Skipped** — no JS test infrastructure in this repo; the Python-side parametrize tests pin the same invariant from the caller, and `pair_device.mjs` itself has new validation that `process.exit(1)`s on mismatch |
| S3 | CHANGELOG entry for protocol bump + operator-platform mismatch behavior | Two `### Changed` bullets added |
| S4 | `cmd:` → `argv:` conversion noted as intentional hardening | Called out here in PR body: the Linux `install.yaml` pair task was switched from `cmd:` string to `argv:` list at the same time as adding the 5th platform argument. This is intentional hardening (no shell parsing, no escaping needed for the new argv elements). Not unrelated drift. |

<details>
<summary>Earlier iterations (iter 1–3) — collapsed</summary>

**Iter 1** (Rating 1.5/5, 13 blockers, all fixed):
- B1–B2: workspace test stubs broken by new `host_os` kwarg
- B3: 5 bedrock fixture strings still on legacy prefix
- B4: zero coverage for 3 new macOS code paths
- B5: weak `pytest.raises(Exception)` in hardware-unknown override test
- B6: `if host_os == 'macos':` violated dispatcher-only invariant — refactored into `lifecycle_macos.py`
- B7: hermes macOS sync only restarted gateway, not dashboard — fixed via dual-label kickstart
- B8: kickstart hard-failed on stopped units — added bootstrap fallback
- B9–B11: bedrock prefix rename — `### BREAKING` CHANGELOG entry (no auto-migration per user direction)

**Iter 2** (Rating 3/5, 1 blocker + 4 strongly-recommended warnings, all fixed):
- B1: zero test coverage for `amazon-bedrock/` prefix normalization in `verify_config.py` — added 6 parametrized cases + double-prefix guard + future-annotations AST guard
- W1: `atomic_write_macos` missing `_validate_agent_name`
- W2: stderr-deadlock risk in `recv_exit_status` ordering — drain stderr first
- W3: missing `timeout` in `restart_unit_macos` — threaded through `_kickstart`/`_bootstrap`/`_run`
- W4: `label_for` ValueError leak past `sync_agent_canonical` — wrapped as `CanonicalSyncError`

**Iter 3** (Rating 3/5, 3 blockers + 6 warnings + 7 suggestions, 16/17 fixed):
- B1: hostile mktemp path could clobber arbitrary files — added `/tmp/clawrium-sync.` prefix validation
- B2: `install_service` had no timeout — threaded `timeout` through `install_service` + `_bootout`
- B3: comment promised atomic_write_macos invalid-name test that didn't exist — added it
- W1–W6: tightened nc-missing regex, raise on missing gateway_port, mktemp inside try, `_validate_agent_name` in verify_health, port boundary tests, both nc-missing stderr shapes
- S1–S7 (minus S4): doc the labels dict purpose, brave-task block wrapping, Linux npm probe mirror, host=None Linux fall-through test, False in invalid-port, `_stub_monotonic` doc

**Not implemented** (per direction):
- Iter-1 S5: legacy bedrock prefix auto-migration — would be the auto-migration explicitly rejected; BREAKING CHANGELOG + new negative test makes the failure mode loud
- Iter-2 S8: cross-file prefix table refactor — out-of-scope; worth a separate issue
- Iter-3 S4: env-var sentinel for direct-invocation guard — multi-entry plumbing more invasive than value justifies; file-header comment documents it
- Iter-4 S2: Node test infra for `pair_device.mjs` — see W disposition above
</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
