### PR TITLE
fix(blog): add truncate marker to v26.6.5 release post

### DIFF
--- a/website/blog/2026-06-22-v26.6.5-release.md
+++ b/website/blog/2026-06-22-v26.6.5-release.md
@@ -6,6 +6,10 @@ tags: [release-notes]
 date: 2026-06-22
 ---
 
+The v26.6.5 release adds a Playwright demo skill, agent-scoped audit trails, workspace overlay sync, Brave Search integration, OpenCode provider support, and an agent shell command.
+
+<!-- truncate -->
+
 ## What changed
 
 ### New /create-playwright skill for browser-session demos


### PR DESCRIPTION
## Summary

- Adds `<!-- truncate -->` marker and intro summary paragraph to the v26.6.5 release blog post
- Docusaurus requires truncation markers in blog posts for preview generation on paginated blog lists
- Follows the same pattern used by all other release posts (v26.6.0, v26.6.3, etc.)

## Test Results

- [x] `make test-py` passes (3847 passed, 8 skipped)
- [x] `make lint-py` passes
- [x] DoD items verified

## DoD Verification

- Blog post has truncation marker matching other release posts — `website/blog/2026-06-22-v26.6.5-release.md` lines 8–11
- Docusaurus build will pass (Deploy Documentation CI was failing due to missing `<!-- truncate -->`)
- No code changes — only a documentation/blog markdown file

## Closes

Fixes the Deploy Documentation CI failure introduced by PR #791
