### PR TITLE
fix(gui): resolve agent model from tier-1 attachment + providers.json (#793)

### DIFF
--- a/.itx/793/01_EXECUTION.md
+++ b/.itx/793/01_EXECUTION.md
@@ -1,0 +1,64 @@
+# Execution Log — Issue #793
+
+Phase 1 of #790: fix the GUI read path so the agent landing page and
+`clawctl agent get` resolve the model from the tier-1 `providers`
+attachment list + `providers.json`, not from the stale
+`config.provider.default_model` mirror in `hosts.json`.
+
+## Summary of changes
+
+- `src/clawrium/cli/tui/data.py`
+  - Added `_resolve_provider_display(claw_record)` returning
+    `(provider_name, provider_type, model)`. Precedence mirrors
+    `core/render.py:build_render_inputs` lines 644–646.
+  - Replaced the three duplicated inline blocks in
+    `get_fleet_data_local`, `get_fleet_data`, and `_build_agent_identity`
+    with calls to the helper.
+  - Narrowed the IO-error `except` to
+    `(ProvidersFileCorruptedError, OSError)`.
+  - Deleted the now-unused `_resolve_provider_name`.
+- `src/clawrium/cli/clawctl/agent/describe.py:83` — dropped the
+  `config.get("channels")` fallback (intentional Phase 1 scope; see
+  Callouts in PR body).
+- `tests/test_tui/test_tui_data.py` — added unit tests for the helper,
+  the regression test `test_build_agent_identity_ignores_stale_tier2_provider`,
+  IO-error / invalid-name / garbage-entry / missing-type / missing-default-model
+  branch tests; updated the no-attachment test to seed a stale
+  `config.provider` mirror so it doubles as a regression gate.
+- `tests/test_gui_routes_fleet.py` — added
+  `test_fleet_endpoint_returns_tier1_model` and
+  `test_fleet_endpoint_broken_attachment_fails_closed`.
+- `tests/test_gui_fleet_health.py` — migrated `test_local_fields_populated`
+  to the tier-1 + providers.json shape.
+
+## ATX Review
+
+- Iteration 1: rating 3/5, no blockers, 8 warnings, 6 suggestions.
+- Iteration 2: rating 4/5, no blockers, remaining items are suggestions
+  only. Clears the ITX merge bar (rating > 3/5 and zero blockers).
+
+Session metadata in `atx-session.json` next to this file.
+
+## Verification
+
+- `make lint-py` clean.
+- `uv run pytest` — 3926 passed, 8 skipped (no failures).
+- Manual GUI verification deferred to PR review (see Callouts).
+
+---
+
+## Prompt Log
+
+### Execution
+
+**Stage**: execution
+**Skill**: /itx-execute
+**Timestamp**: 2026-06-23T20:30:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 793 — use atx CLI (atx review) for review, NOT MCP. The implementation plan lives in issue #793 and its parent .itx/790/01_SCAFFOLD.md (Phase 1). Open the PR against main when done. Include the Callouts section in the PR body per the skill spec.
+```
+
+**Output**: Phase 1 implementation across 5 files, 2 ATX review iterations
+(3/5 → 4/5), branch `issue-793-fix-gui-read-path` ready to push.

--- a/.itx/793/atx-session.json
+++ b/.itx/793/atx-session.json
@@ -1,0 +1,11 @@
+{
+  "session_id": "8f73062c-ab4f-44b0-956f-ef850657cab1",
+  "transport": "cli",
+  "commit_sha": "pending-commit",
+  "iteration": 2,
+  "last_rating": 4,
+  "last_blockers": [],
+  "started_at": "2026-06-23T20:42:00Z",
+  "updated_at": "2026-06-23T21:05:00Z",
+  "notes": "iter-1: 3/5 no blockers / 8W / 6S. iter-2: 4/5 no blockers / remaining items are suggestions only. Clears merge bar."
+}

--- a/src/clawrium/cli/clawctl/agent/describe.py
+++ b/src/clawrium/cli/clawctl/agent/describe.py
@@ -80,7 +80,7 @@ def describe(
     for integration in integration_names:
         lines.append(f"  {_s(integration)}  (configured)")
 
-    channels = (config.get("channels") or claw_record.get("channels") or []) or []
+    channels = (claw_record.get("channels") or []) or []
     lines.append("")
     if channels:
         lines.append(f"Channels ({len(channels)}):")

--- a/src/clawrium/cli/tui/data.py
+++ b/src/clawrium/cli/tui/data.py
@@ -15,6 +15,10 @@ from clawrium.core.health import (
     get_onboarding_status,
 )
 from clawrium.core.hosts import HostsFileCorruptedError, load_hosts
+from clawrium.core.providers.storage import (
+    ProvidersFileCorruptedError,
+    get_provider,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,24 +28,84 @@ AGENT_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
 _PROVIDER_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 
 
-def _resolve_provider_name(claw_record: dict) -> str | None:
-    """Resolve the attached provider name from tier-1 only.
+def _resolve_provider_display(
+    claw_record: dict,
+) -> tuple[str | None, str | None, str]:
+    """Return ``(provider_name, provider_type, model)`` for display.
 
-    The top-level ``providers`` attachment list is the single source of truth
-    for which provider is attached — the same list ``build_render_inputs`` and
-    ``_first_provider`` read. The tier-2 ``config.provider`` render payload is
-    intentionally NOT consulted here; it is read separately for display-only
-    enrichment (default_model / type) that tier-1 does not carry.
+    Reads exclusively from the tier-1 ``providers`` attachment list plus
+    ``providers.json``. The tier-2 ``config.provider`` / ``config.providers``
+    mirror in ``hosts.json`` (kept in sync only by the lifecycle writer at
+    sync time) is intentionally NOT consulted — see #790. After a provider
+    swap that has not been followed by a sync, tier-2 is stale; reading it
+    surfaces the wrong model to the GUI and ``clawctl agent get``.
+
+    Precedence mirrors ``core/render.py:build_render_inputs`` (lines 644–646):
+
+    - ``model``: tier-1 entry's ``model`` override, else
+      ``providers.json[name].default_model``, else ``"-"``.
+    - ``provider_type``: ``providers.json[name].type``, else ``None``.
+    - ``provider_name``: the tier-1 entry's ``name``, else ``None``.
+
+    A tier-1 attachment whose provider record is missing from
+    ``providers.json`` resolves to ``("-", None, "-")`` with a logged
+    warning, representing "broken attachment" rather than "no
+    attachment" (which resolves to ``(None, None, "-")``).
     """
     attached = claw_record.get("providers")
     if not isinstance(attached, list) or not attached:
-        return None
+        return None, None, "-"
+
     first = attached[0]
+    entry_name: str | None = None
+    entry_model: str | None = None
     if isinstance(first, dict):
-        first = first.get("name")
-    if isinstance(first, str) and first and _PROVIDER_NAME_PATTERN.match(first):
-        return first
-    return None
+        raw_name = first.get("name")
+        if isinstance(raw_name, str):
+            entry_name = raw_name
+        raw_model = first.get("model")
+        if isinstance(raw_model, str) and raw_model:
+            entry_model = raw_model
+    elif isinstance(first, str):
+        entry_name = first
+
+    if not (
+        isinstance(entry_name, str)
+        and entry_name
+        and _PROVIDER_NAME_PATTERN.match(entry_name)
+    ):
+        return None, None, "-"
+
+    try:
+        record = get_provider(entry_name)
+    except (ProvidersFileCorruptedError, OSError) as exc:
+        # Storage IO / corruption — never crash the GUI. Programmer
+        # errors (TypeError, AttributeError) are intentionally NOT
+        # caught so future refactors surface them in test output
+        # rather than silently rendering "-" badges.
+        logger.warning("Failed to look up provider %r: %s", entry_name, exc)
+        return "-", None, "-"
+
+    if record is None:
+        logger.warning(
+            "Tier-1 attachment %r is not registered in providers.json",
+            entry_name,
+        )
+        return "-", None, "-"
+
+    provider_type_raw = record.get("type")
+    provider_type = (
+        provider_type_raw if isinstance(provider_type_raw, str) and provider_type_raw
+        else None
+    )
+    default_model_raw = record.get("default_model")
+    default_model = (
+        default_model_raw
+        if isinstance(default_model_raw, str) and default_model_raw
+        else ""
+    )
+    model = entry_model or default_model or "-"
+    return entry_name, provider_type, model
 
 
 class AgentViewModel(TypedDict):
@@ -171,26 +235,15 @@ def get_fleet_data_local(
             agent_type = claw_record.get("type", "unknown")
             version = claw_record.get("version", "?")
             config = claw_record.get("config", {})
-            model = "-"
-            provider_name = None
-            provider_type = None
+            provider_name, provider_type, model = _resolve_provider_display(
+                claw_record
+            )
             gateway_port = None
             gateway_url = None
             gateway_auth = None
             device_id = None
             device_private_key = None
             if isinstance(config, dict):
-                provider_cfg = config.get("provider")
-                if isinstance(provider_cfg, dict):
-                    model = provider_cfg.get("default_model", "-")
-                    provider_type = provider_cfg.get("type")
-                # Tier-1 attachment list is canonical for the provider name;
-                # fall back to the tier-2 render payload only for display.
-                provider_name = _resolve_provider_name(claw_record)
-                if provider_name is None and isinstance(provider_cfg, dict):
-                    provider_name = provider_cfg.get("name") or provider_cfg.get(
-                        "type"
-                    )
                 gateway_cfg = config.get("gateway")
                 if isinstance(gateway_cfg, dict):
                     port_val = gateway_cfg.get("port")
@@ -303,26 +356,15 @@ def get_fleet_data(
             agent_type = claw_record.get("type", "unknown")
             version = claw_record.get("version", "?")
             config = claw_record.get("config", {})
-            model = "-"
-            provider_name = None
-            provider_type = None
+            provider_name, provider_type, model = _resolve_provider_display(
+                claw_record
+            )
             gateway_port = None
             gateway_url = None
             gateway_auth = None
             device_id = None
             device_private_key = None
             if isinstance(config, dict):
-                provider_cfg = config.get("provider")
-                if isinstance(provider_cfg, dict):
-                    model = provider_cfg.get("default_model", "-")
-                    provider_type = provider_cfg.get("type")
-                # Tier-1 attachment list is canonical for the provider name;
-                # fall back to the tier-2 render payload only for display.
-                provider_name = _resolve_provider_name(claw_record)
-                if provider_name is None and isinstance(provider_cfg, dict):
-                    provider_name = provider_cfg.get("name") or provider_cfg.get(
-                        "type"
-                    )
                 gateway_cfg = config.get("gateway")
                 if isinstance(gateway_cfg, dict):
                     port_val = gateway_cfg.get("port")
@@ -496,22 +538,13 @@ def _build_agent_identity(
     agent_type = claw_record.get("type", "unknown")
     version = claw_record.get("version", "?")
     config = claw_record.get("config", {})
-    model = "-"
-    provider_name = None
-    provider_type = None
+    provider_name, provider_type, model = _resolve_provider_display(claw_record)
     gateway_port = None
     gateway_url = None
     gateway_auth = None
     device_id = None
     device_private_key = None
     if isinstance(config, dict):
-        provider_cfg = config.get("provider")
-        if isinstance(provider_cfg, dict):
-            model = provider_cfg.get("default_model", "-")
-            provider_type = provider_cfg.get("type")
-        provider_name = _resolve_provider_name(claw_record)
-        if provider_name is None and isinstance(provider_cfg, dict):
-            provider_name = provider_cfg.get("name") or provider_cfg.get("type")
         gateway_cfg = config.get("gateway")
         if isinstance(gateway_cfg, dict):
             port_val = gateway_cfg.get("port")

--- a/tests/test_gui_fleet_health.py
+++ b/tests/test_gui_fleet_health.py
@@ -200,7 +200,12 @@ class TestGetFleetDataLocal:
         assert summary["running"] == 0
 
     def test_local_fields_populated(self, isolated_config):
-        """Local fields (model, provider, gateway, uptime) should be present."""
+        """Local fields (model, provider, gateway, uptime) should be present.
+
+        Post-#790 the provider/model are resolved from the tier-1
+        attachment list + providers.json — not from the stale
+        ``config.provider`` mirror — so this fixture seeds both files.
+        """
         isolated_config.mkdir(parents=True, exist_ok=True)
         hosts = [
             {
@@ -211,12 +216,8 @@ class TestGetFleetDataLocal:
                         "type": "openclaw",
                         "version": "2.1.0",
                         "agent_name": "my-agent",
+                        "providers": [{"name": "my-provider"}],
                         "config": {
-                            "provider": {
-                                "name": "my-provider",
-                                "type": "bedrock",
-                                "default_model": "claude-3",
-                            },
                             "gateway": {"port": 8080},
                         },
                         "onboarding": {"state": "ready"},
@@ -225,6 +226,17 @@ class TestGetFleetDataLocal:
             }
         ]
         (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+        (isolated_config / "providers.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "my-provider",
+                        "type": "bedrock",
+                        "default_model": "claude-3",
+                    }
+                ]
+            )
+        )
 
         agents, _ = get_fleet_data_local()
         agent = agents[0]

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -1419,3 +1419,110 @@ def test_restart_agent_generic_exception_uses_safe_message(isolated_config: Path
             resp = client.post("/api/agents/demo/restart")
     assert resp.status_code == 500
     assert resp.json()["detail"] == "Lifecycle operation failed. Check server logs."
+
+
+def test_fleet_endpoint_returns_tier1_model(isolated_config: Path):
+    """End-to-end: `/api/fleet` JSON carries the tier-1 model (#790).
+
+    A stale ``config.provider.default_model`` mirror in ``hosts.json``
+    must NOT bleed into the serialized response — the live tier-1
+    attachment + providers.json record is the source of truth. Keep
+    this test forever; it is the user-visible gate for the original
+    bug.
+    """
+    hosts = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "wolf-i",
+            "agents": {
+                "clawrium-exec": {
+                    "type": "openclaw",
+                    "agent_name": "clawrium-exec",
+                    "version": "1.0.0",
+                    "providers": [{"name": "glm51"}],
+                    "config": {
+                        # Pre-#790 stale mirror — must be ignored.
+                        "provider": {
+                            "name": "openai-prod",
+                            "type": "openai",
+                            "default_model": "openai/gpt-4o",
+                        },
+                    },
+                }
+            },
+        }
+    ]
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+    (isolated_config / "providers.json").write_text(
+        json.dumps(
+            [
+                {
+                    "name": "glm51",
+                    "type": "litellm",
+                    "default_model": "z-ai/glm-5.1",
+                }
+            ]
+        )
+    )
+
+    with TestClient(app) as client:
+        resp = client.get("/api/fleet")
+    assert resp.status_code == 200
+    body = resp.json()
+    agents = body["agents"]
+    assert len(agents) == 1
+    assert agents[0]["agent_key"] == "clawrium-exec"
+    assert agents[0]["provider"] == "glm51"
+    assert agents[0]["provider_type"] == "litellm"
+    assert agents[0]["model"] == "z-ai/glm-5.1"
+    # Explicit negative gates — keep the regression contract
+    # self-documenting if the stale-mirror strings get renamed.
+    assert agents[0]["model"] != "openai/gpt-4o"
+    assert agents[0]["provider"] != "openai-prod"
+    assert agents[0]["provider_type"] != "openai"
+
+
+def test_fleet_endpoint_broken_attachment_fails_closed(isolated_config: Path):
+    """Tier-1 attachment absent from providers.json → "broken" badge (#790).
+
+    The "providers.json drifted from hosts.json" mode is the real-world
+    drift this Phase 1 fix protects against. The serializer must surface
+    "-" rather than silently falling back to any tier-2 mirror.
+    """
+    hosts = [
+        {
+            "hostname": "192.168.1.100",
+            "alias": "wolf-i",
+            "agents": {
+                "clawrium-exec": {
+                    "type": "openclaw",
+                    "agent_name": "clawrium-exec",
+                    "version": "1.0.0",
+                    "providers": [{"name": "missing-prov"}],
+                    "config": {
+                        # Stale mirror present — must NOT be used as a fallback.
+                        "provider": {
+                            "name": "openai-prod",
+                            "type": "openai",
+                            "default_model": "openai/gpt-4o",
+                        },
+                    },
+                }
+            },
+        }
+    ]
+    isolated_config.mkdir(parents=True, exist_ok=True)
+    (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+    # No providers.json — get_provider returns None for any lookup.
+    (isolated_config / "providers.json").write_text("[]")
+
+    with TestClient(app) as client:
+        resp = client.get("/api/fleet")
+    assert resp.status_code == 200
+    agents = resp.json()["agents"]
+    assert len(agents) == 1
+    assert agents[0]["provider"] == "-"
+    assert agents[0]["provider_type"] is None
+    assert agents[0]["model"] == "-"
+    assert agents[0]["model"] != "openai/gpt-4o"

--- a/tests/test_tui/test_tui_data.py
+++ b/tests/test_tui/test_tui_data.py
@@ -3,9 +3,12 @@
 from datetime import datetime, timezone, timedelta
 from unittest.mock import patch
 
+import pytest
 
 from clawrium.cli.tui.data import (
+    _build_agent_identity,
     _gateway_scheme,
+    _resolve_provider_display,
     calculate_uptime,
     get_fleet_data,
     get_agent_detail,
@@ -145,12 +148,23 @@ class TestGetFleetData:
                         "status": "installed",
                         "agent_name": "opc-testhost",
                         "type": "openclaw",
-                        "config": {"provider": {"default_model": "gpt-4o"}},
+                        "providers": [{"name": "my-openai"}],
                     }
                 },
             }
         ]
         (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+        (isolated_config / "providers.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "my-openai",
+                        "type": "openai",
+                        "default_model": "gpt-4o",
+                    }
+                ]
+            )
+        )
 
         mock_result = {
             "agent": "openclaw",
@@ -267,8 +281,8 @@ class TestGetFleetData:
         assert agents[0]["provider"] is None
         assert agents[0]["provider_type"] is None
 
-    def test_provider_type_extracted_from_config(self, isolated_config):
-        """Provider type should be extracted from config.provider.type."""
+    def test_provider_type_extracted_from_providers_json(self, isolated_config):
+        """Provider type is sourced from providers.json (#790)."""
         import json
 
         isolated_config.mkdir(parents=True, exist_ok=True)
@@ -283,18 +297,23 @@ class TestGetFleetData:
                         "status": "installed",
                         "agent_name": "opc-testhost",
                         "type": "openclaw",
-                        "config": {
-                            "provider": {
-                                "name": "my-openai",
-                                "type": "openai",
-                                "default_model": "gpt-4o",
-                            }
-                        },
+                        "providers": [{"name": "my-openai"}],
                     }
                 },
             }
         ]
         (isolated_config / "hosts.json").write_text(json.dumps(hosts))
+        (isolated_config / "providers.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "my-openai",
+                        "type": "openai",
+                        "default_model": "gpt-4o",
+                    }
+                ]
+            )
+        )
 
         mock_result = {
             "agent": "openclaw",
@@ -317,8 +336,14 @@ class TestGetFleetData:
         assert agents[0]["provider_type"] == "openai"
         assert agents[0]["model"] == "gpt-4o"
 
-    def test_provider_name_fallback_to_type(self, isolated_config):
-        """Provider name should fallback to type if name is not set."""
+    def test_no_tier1_attachment_ignores_stale_tier2(self, isolated_config):
+        """No tier-1 attachment + stale tier-2 mirror → all None/"-" (#790).
+
+        The pre-#790 code path fell back to ``config.provider.type`` /
+        ``config.provider.default_model`` when no tier-1 attachment
+        existed. The fixture deliberately seeds a stale ``config.provider``
+        mirror so the assertions fail if that fallback regresses.
+        """
         import json
 
         isolated_config.mkdir(parents=True, exist_ok=True)
@@ -329,7 +354,15 @@ class TestGetFleetData:
                     "zeroclaw": {
                         "type": "zeroclaw",
                         "agent_name": "zc-test",
-                        "config": {"provider": {"type": "anthropic"}},
+                        "config": {
+                            # Stale mirror from before the operator detached
+                            # the provider. The new resolver must ignore it.
+                            "provider": {
+                                "name": "stale-anthropic",
+                                "type": "anthropic",
+                                "default_model": "claude-opus-4",
+                            },
+                        },
                     }
                 },
             }
@@ -353,9 +386,9 @@ class TestGetFleetData:
         with patch("clawrium.cli.tui.data.check_claw_health", return_value=mock_result):
             agents, _ = get_fleet_data()
 
-        # provider fallbacks to type when name is not set
-        assert agents[0]["provider"] == "anthropic"
-        assert agents[0]["provider_type"] == "anthropic"
+        assert agents[0]["provider"] is None
+        assert agents[0]["provider_type"] is None
+        assert agents[0]["model"] == "-"
 
     def test_gateway_port_extracted_from_config(self, isolated_config):
         """Gateway port should be extracted from config.gateway.port."""
@@ -830,3 +863,213 @@ class TestGetAgentDetail:
 
         assert detail is not None
         assert detail["gateway_url"] == "wss://gateway.example.com:443"
+
+
+class TestResolveProviderDisplay:
+    """Unit tests for the tier-1 + providers.json display helper (#790)."""
+
+    def test_resolve_provider_display_attachment_override(self):
+        """Tier-1 entry ``model`` override wins over providers.json default."""
+        claw_record = {
+            "providers": [{"name": "openai-prod", "model": "gpt-4o-mini"}]
+        }
+        with patch(
+            "clawrium.cli.tui.data.get_provider",
+            return_value={
+                "name": "openai-prod",
+                "type": "openai",
+                "default_model": "gpt-4o",
+            },
+        ):
+            name, ptype, model = _resolve_provider_display(claw_record)
+        assert name == "openai-prod"
+        assert ptype == "openai"
+        assert model == "gpt-4o-mini"
+
+    def test_resolve_provider_display_falls_back_to_providers_json(self):
+        """When the attachment lacks ``model``, default_model is used."""
+        claw_record = {"providers": [{"name": "openai-prod"}]}
+        with patch(
+            "clawrium.cli.tui.data.get_provider",
+            return_value={
+                "name": "openai-prod",
+                "type": "openai",
+                "default_model": "gpt-4o",
+            },
+        ):
+            name, ptype, model = _resolve_provider_display(claw_record)
+        assert name == "openai-prod"
+        assert ptype == "openai"
+        assert model == "gpt-4o"
+
+    def test_resolve_provider_display_missing_provider_record(self, caplog):
+        """Unresolved tier-1 attachment → ("-", None, "-") + warning.
+
+        The caplog assertion pins logger, level, and full message so the
+        missing-record branch cannot be confused with the IO-error branch
+        below — they emit distinct warnings.
+        """
+        import logging
+
+        claw_record = {"providers": [{"name": "unregistered"}]}
+        with patch("clawrium.cli.tui.data.get_provider", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="clawrium.cli.tui.data"):
+                name, ptype, model = _resolve_provider_display(claw_record)
+        assert (name, ptype, model) == ("-", None, "-")
+        assert any(
+            rec.name == "clawrium.cli.tui.data"
+            and rec.levelno == logging.WARNING
+            and "is not registered in providers.json" in rec.getMessage()
+            and "unregistered" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    def test_resolve_provider_display_get_provider_raises(self, caplog):
+        """Storage IO error → ("-", None, "-") + distinct warning, no crash."""
+        import logging
+
+        claw_record = {"providers": [{"name": "openai-prod"}]}
+        with patch(
+            "clawrium.cli.tui.data.get_provider",
+            side_effect=OSError("disk error"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="clawrium.cli.tui.data"):
+                name, ptype, model = _resolve_provider_display(claw_record)
+        assert (name, ptype, model) == ("-", None, "-")
+        assert any(
+            rec.name == "clawrium.cli.tui.data"
+            and rec.levelno == logging.WARNING
+            and "Failed to look up provider" in rec.getMessage()
+            and "openai-prod" in rec.getMessage()
+            and "disk error" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    def test_resolve_provider_display_no_attachment(self):
+        """No tier-1 attachment → (None, None, "-")."""
+        claw_record: dict = {}
+        name, ptype, model = _resolve_provider_display(claw_record)
+        assert (name, ptype, model) == (None, None, "-")
+
+    def test_resolve_provider_display_record_missing_type(self):
+        """providers.json entry without ``type`` → provider_type is None."""
+        claw_record = {"providers": [{"name": "p"}]}
+        with patch(
+            "clawrium.cli.tui.data.get_provider",
+            return_value={"name": "p", "default_model": "m"},
+        ):
+            name, ptype, model = _resolve_provider_display(claw_record)
+        assert (name, ptype, model) == ("p", None, "m")
+
+    def test_resolve_provider_display_record_missing_default_model(self):
+        """Attached but no model anywhere → model is "-"."""
+        claw_record = {"providers": [{"name": "p"}]}
+        with patch(
+            "clawrium.cli.tui.data.get_provider",
+            return_value={"name": "p", "type": "openai"},
+        ):
+            name, ptype, model = _resolve_provider_display(claw_record)
+        assert (name, ptype, model) == ("p", "openai", "-")
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        ["1leading", "Bad-Name!", "has space", "", "ALLCAPS"],
+    )
+    def test_resolve_provider_display_invalid_name_rejected(self, bad_name):
+        """Attachment names that fail the regex → silent (None, None, "-").
+
+        get_provider must NOT be called for an invalid name. This branch
+        is distinguishable from the missing-record branch because no
+        warning is logged.
+        """
+        claw_record = {"providers": [{"name": bad_name}]}
+        called = {"value": False}
+
+        def fake_get_provider(_):
+            called["value"] = True
+            return None
+
+        with patch(
+            "clawrium.cli.tui.data.get_provider", side_effect=fake_get_provider
+        ):
+            name, ptype, model = _resolve_provider_display(claw_record)
+        assert (name, ptype, model) == (None, None, "-")
+        assert called["value"] is False
+
+    @pytest.mark.parametrize("garbage", [42, None, ["nested"], 3.14])
+    def test_resolve_provider_display_garbage_entry(self, garbage):
+        """Non-dict / non-str first attachment entry → (None, None, "-")."""
+        claw_record = {"providers": [garbage]}
+        name, ptype, model = _resolve_provider_display(claw_record)
+        assert (name, ptype, model) == (None, None, "-")
+
+    def test_resolve_provider_display_ignores_tier2_provider(self):
+        """A leftover ``config.provider`` mirror is NEVER consulted (#790)."""
+        claw_record = {
+            "providers": [{"name": "glm51"}],
+            "config": {
+                "provider": {
+                    "name": "openai-prod",
+                    "type": "openai",
+                    "default_model": "openai/gpt-4o",
+                }
+            },
+        }
+        with patch(
+            "clawrium.cli.tui.data.get_provider",
+            return_value={
+                "name": "glm51",
+                "type": "litellm",
+                "default_model": "z-ai/glm-5.1",
+            },
+        ):
+            name, ptype, model = _resolve_provider_display(claw_record)
+        assert name == "glm51"
+        assert ptype == "litellm"
+        assert model == "z-ai/glm-5.1"
+
+
+class TestBuildAgentIdentityRegression:
+    """Regression coverage for the original #790 bug.
+
+    The GUI agent landing page (and ``clawctl agent get``) were reading
+    the model from the stale ``config.provider.default_model`` mirror in
+    ``hosts.json`` instead of the live tier-1 attachment + providers.json.
+    After a provider swap that the user had not yet ``sync``'d, the
+    operator saw the old model. Keep this test forever — it is the gate.
+    """
+
+    def test_build_agent_identity_ignores_stale_tier2_provider(self):
+        """Tier-1 = glm51, tier-2 leftover = openai/gpt-4o → glm-5.1 wins."""
+        host = {
+            "hostname": "192.168.1.100",
+            "alias": "wolf-i",
+            "addresses": [],
+        }
+        claw_record = {
+            "type": "openclaw",
+            "agent_name": "clawrium-exec",
+            "version": "1.0.0",
+            "providers": [{"name": "glm51"}],
+            "config": {
+                # Pre-#790 lifecycle.sync_agent mirror — must be ignored.
+                "provider": {
+                    "name": "openai-prod",
+                    "type": "openai",
+                    "default_model": "openai/gpt-4o",
+                },
+            },
+        }
+        with patch(
+            "clawrium.cli.tui.data.get_provider",
+            return_value={
+                "name": "glm51",
+                "type": "litellm",
+                "default_model": "z-ai/glm-5.1",
+            },
+        ):
+            identity = _build_agent_identity("clawrium-exec", host, claw_record)
+
+        assert identity["provider"] == "glm51"
+        assert identity["provider_type"] == "litellm"
+        assert identity["model"] == "z-ai/glm-5.1"


### PR DESCRIPTION
## Summary

Phase 1 of #790. The GUI agent landing page and `clawctl agent get` were
reading the agent's model from the stale `config.provider.default_model`
mirror in `hosts.json` — a field that only refreshes when
`clawctl agent sync` runs. After a provider swap that the operator had
not yet `sync`'d, the UI showed the previous provider's model.

This PR centralizes the read path through a new
`_resolve_provider_display(claw_record)` helper in
`src/clawrium/cli/tui/data.py` that consults the tier-1 `providers`
attachment list and `providers.json` only. The stale tier-2
`config.provider` / `config.providers` mirror is intentionally NOT
consulted; precedence mirrors
`core/render.py:build_render_inputs` lines 644–646.

The three duplicated inline provider-resolution blocks in
`get_fleet_data_local`, `get_fleet_data`, and `_build_agent_identity`
collapse onto the helper. `cli/clawctl/agent/describe.py:83` drops its
`config.get("channels")` fallback (scaffold-defined Phase 1 scope —
Phase 2 retires the writers, Phase 3 prunes existing entries).

Cross-references: #790 (parent), `.itx/790/01_SCAFFOLD.md` Phase 1.

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $6.63 | Total Time: 18m40s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3/5 | None | 8 warnings → 6 fixed, 2 deferred | $3.22 | 8m08s | leader, cli-ux, test-coverage, gui-routes |
| 2 | 4/5 | None | Coverage suggestions only | $3.41 | 10m32s | leader, cli-ux, test-coverage, gui-routes |

> **Note**: ATX CLI does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking Issues:** None.

**Warnings:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `cli/clawctl/agent/describe.py:83` | Channels narrowing drops `config.channels` dict shape | **Out-of-scope** — scaffold-defined Phase 1 scope. See [DECISION] callout. |
| W2 | `cli/tui/data.py:96` | N providers.json reads per fleet refresh | **Acknowledged** — performance, not correctness. See [TODO-FOLLOWUP] callout. |
| W3 | `cli/tui/data.py:95-99` | `except Exception` too broad | **Fixed** — narrowed to `(ProvidersFileCorruptedError, OSError)`. |
| W4 | `tests/test_tui/test_tui_data.py` | IO-error branch untested | **Fixed** — added `test_resolve_provider_display_get_provider_raises`. |
| W5 | `test_no_tier1_attachment_yields_none` | Weak regression gate | **Fixed** — renamed `test_no_tier1_attachment_ignores_stale_tier2` and seeded stale `config.provider`. |
| W6 | `test_resolve_provider_display_missing_provider_record` | Caplog assertion too loose | **Fixed** — pinned logger name, level, and full message. |
| W7 | `TestResolveProviderDisplay` | Regex rejection branch untested | **Fixed** — parametrized over `['1leading','Bad-Name!','has space','','ALLCAPS']`. |
| W8 | `TestResolveProviderDisplay` | Garbage attachment entry untested | **Fixed** — parametrized over `[42, None, ['nested'], 3.14]`. |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Broken-attachment HTTP variant | **Added** — `test_fleet_endpoint_broken_attachment_fails_closed`. |
| S2 | Explicit negative asserts on fleet endpoint test | **Added** — `model != 'openai/gpt-4o'`, `provider != 'openai-prod'`, etc. |
| S3 | Delete dead `_resolve_provider_name` | **Done** — function removed entirely. |
| S4 | Cover providers.json record missing `type` / `default_model` | **Added** — two new tests. |
| S5 | Stale-mirror in `test_local_fields_populated` | **Deferred** — already gated by fleet-endpoint test. |
| S6 | Sanitize at AgentViewModel boundary | **Deferred** — security follow-up; not #793 scope. |

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**Blocking Issues:** None.

Remaining items are all coverage suggestions (parametrize the raises
test over both error types; add a no-attachment HTTP variant; assert
the `summary` block; parametrize the fleet-endpoint test over
agent_type; cover the `?host=` query-string filter). All non-blocking
and recorded as follow-ups in Callouts below.

</details>

## Testing

### Test Results
- [x] All existing tests pass (`uv run pytest`: 3926 passed, 8 skipped)
- [x] Linter passes (`make lint-py`)
- [x] New tests added for new functionality (helper + HTTP boundary +
      regression gate)

### Test Coverage
- Files changed:
  - `src/clawrium/cli/tui/data.py`
  - `src/clawrium/cli/clawctl/agent/describe.py`
  - `tests/test_tui/test_tui_data.py`
  - `tests/test_gui_routes_fleet.py`
  - `tests/test_gui_fleet_health.py`
- New tests: 11 in `TestResolveProviderDisplay`,
  `TestBuildAgentIdentityRegression`,
  plus 2 HTTP-boundary tests in `test_gui_routes_fleet.py`.
- Coverage impact: increased.

### Manual Testing

Not performed on a live GUI in this iteration — the scaffold also
requests a real-host check against `http://127.0.0.1:36000/agents?key=clawrium-exec`
matching `clawctl agent get clawrium-exec`. Recording as an
`[UNRESOLVED]` callout for the reviewer.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data — provider name regex
      preserved
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources

## Callouts

- [DECISION] **Deleted `_resolve_provider_name` entirely** rather than
  keeping a stub with an updated docstring.
  - Why: After this refactor, no callsite in `src/` references it. Per
    CLAUDE.md guidance ("avoid backwards-compatibility hacks like
    renaming unused _vars… delete it completely") and the iter-1
    cli-ux finding S3, the function is dead code. Keeping a stub
    invites accidental re-import that would bypass the new helper's
    broken-attachment signaling.
  - Alternatives considered: keep the function with an updated
    docstring per the scaffold's literal wording; add a TODO comment
    for Phase 4 deletion.
  - Reviewer: confirm or push back.

- [DECISION] **Kept `describe.py:83` change as a narrow tier-1 read**
  even though iter-1 flagged it as a potential silent regression for
  legacy agents whose channels live under `config.channels`.
  - Why: The scaffold (`.itx/790/01_SCAFFOLD.md`, Phase 1 exit
    criteria) explicitly directs dropping the `config.get("channels")`
    fallback. Phase 2 retires the writers; Phase 3 prunes existing
    `hosts.json` entries on load. Reverting here would conflict with
    the scaffold's stated exit criteria and would mask the cleanup
    Phase 2 then has to redo.
  - Alternatives considered: restore the fallback and request a
    scaffold amendment; normalize both shapes (list-of-strings AND
    dict-of-type→config) into a single rendering pass.
  - Reviewer: confirm the scope decision, or merge with a tracked
    follow-up to add a smoke test against `claw_record.channels` to
    lock in the new precedence before Phase 2 ships.

- [UNRESOLVED] **Manual GUI verification not performed.**
  - Best guess applied: the HTTP-boundary tests
    (`test_fleet_endpoint_returns_tier1_model`,
    `test_fleet_endpoint_broken_attachment_fails_closed`) prove the
    serializer returns the tier-1 model end-to-end through
    `TestClient`. The frontend reads the same JSON shape with no
    intermediate transformation on the `model`/`provider`/`provider_type`
    fields (verified by `_agent_to_dict` in
    `gui/routes/fleet.py:112`).
  - Reviewer: please run the scaffold's verification step against
    `http://127.0.0.1:36000/agents?key=clawrium-exec` and confirm the
    displayed model matches `clawctl agent get clawrium-exec`.

- [TODO-FOLLOWUP] **`get_provider()` is invoked once per agent**, so a
  fleet of N agents costs N `providers.json` reads per refresh
  (iter-1 W2). Performance only — not a correctness issue.
  - Tracking: to be filed alongside Phase 2 of #790, which adds
    additional per-agent storage reads and is the right surface for
    introducing a per-call provider cache.

- [TODO-FOLLOWUP] **Iter-2 suggestions not addressed** (all
  non-blocking, rating already 4/5):
  - Parametrize `test_resolve_provider_display_get_provider_raises`
    over both `ProvidersFileCorruptedError` and `OSError`.
  - Add a no-attachment-at-all HTTP variant (`providers` key absent,
    expect `provider is None`, `model == "-"`).
  - Assert `summary` block in the new fleet-endpoint tests.
  - Parametrize fleet-endpoint test over `('openclaw','hermes','zeroclaw')`.
  - Cover `?host=` query-string filter at the HTTP boundary.
  - Tracking: to be folded into Phase 2 / Phase 3 PRs which already
    touch these tests.

- [ENVIRONMENT] ATX review path was the `atx` CLI, not the MCP
  transport, per the user's invocation instructions.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
