### PR TITLE
fix(lifecycle): stop persisting config.provider/providers/channels mirror (#794)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,5 +104,33 @@ cut. The `itx:release` skill archives this section into a new
   hardware first via `clawctl host create`. Eliminates the
   `npm ETARGET: No matching version found for openclaw@0.1.0`
   class of failure (#720).
+- `clawctl agent sync` and `clawctl agent configure` no longer write
+  `config.provider`, `config.providers`, or `config.channels` mirrors
+  back into `~/.config/clawrium/hosts.json`. The Ansible payload still
+  receives the overlays so templates can render the model and channel
+  hulls, but the canonical stores (`providers.json` + tier-1
+  `agent_record["providers"]` for providers; `channels.json` for
+  channels) are now the single source of truth on disk. Eliminates
+  the stale-mirror class of bugs fixed in the GUI read path by #793
+  (#794, Phase 2 of #790).
+- openclaw and nemoclaw also benefit from the channels strip — the
+  previous bot_token/app_token scrub was guarded by `if resolved_type
+  in ("hermes", "zeroclaw")`, so any accumulated stale
+  `config.channels.discord.bot_token` on those types persisted
+  unscrubbed. The unconditional strip now applies to all agent types
+  and removes the gap on first `clawctl agent configure` after
+  upgrade. No operator action required (#794).
+
+### Changed
+
+- `clm agent configure --stage channels` (the legacy `clm` wizard) now
+  prints a deprecation banner and exits with code 2 on entry. The
+  wizard's prompt + Ansible-push flow no longer worked after the #794
+  hosts.json mirror strip — channels collected interactively would be
+  silently dropped before reaching the host. Operators must use the
+  modern `clawctl channel registry create <name> --type <type>` →
+  `clawctl agent channel attach <name> --agent <agent>` →
+  `clawctl agent sync <agent>` pipeline. The full removal of the
+  wizard module is tracked under Phase 4 of #790.
 
 ### Documentation

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -19,6 +19,7 @@ from rich.panel import Panel
 
 from clawrium.cli.agent_skill import agent_skill_app
 from clawrium.cli.install import install as install_command
+from clawrium.cli.output._sanitize import sanitize_passthrough
 from clawrium.cli.status import status as status_command
 from clawrium.core.config import get_config_dir
 from clawrium.core.hosts import get_host, load_hosts, HostsFileCorruptedError
@@ -374,9 +375,12 @@ def _sync_provider_config(
     # Build complete config data
     config_data = {"gateway": gateway_config, "provider": provider_config}
 
-    # Preserve existing channels config (Discord pairing, etc.)
-    if "channels" in existing_config:
-        config_data["channels"] = existing_config["channels"]
+    # Issue #794: channels mirror is no longer carried through. Channel
+    # state is hydrated from canonical channels.json inside
+    # `configure_agent` via `_hydrate_channels_from_canonical`, and the
+    # configure_agent updater strips `channels` from persisted_config
+    # before write — so merging existing_config["channels"] here would
+    # be discarded anyway.
 
     # Preserve existing api_server block (Hermes loopback gateway auth).
     # configure_agent re-hydrates this from hosts.json too, but carrying it
@@ -728,7 +732,6 @@ def _sync_channel_config(
     agents = host_data.get("agents", {})
     agent = agents.get(agent_name, {})
 
-    # Merge channels into existing config
     existing_config = agent.get("config", {})
 
     # Guard against configuring channels before a provider is attached (B4).
@@ -742,7 +745,14 @@ def _sync_channel_config(
             f"'clawctl agent provider attach <provider> --agent {agent_name}' first."
         )
 
-    existing_config["channels"] = channels_config
+    # Issue #794: the legacy `clm agent configure --stage channels` flow
+    # used to merge channels_config into existing_config so the Ansible
+    # extravar payload received it. That merge is gone — `configure_agent`
+    # now hydrates channels from canonical `channels.json` (hermes /
+    # zeroclaw / ethos via `_hydrate_channels_from_canonical`) and the
+    # updater strips `channels` from persisted_config before write.
+    # The modern channel surface is `clawctl channel attach <channel>
+    # --agent <agent>` + `clawctl agent sync <agent>`.
 
     # Call configure_agent to sync
     success, error = configure_agent(
@@ -804,6 +814,67 @@ def _run_channels_stage(
     Returns:
         True if stage completed successfully
     """
+    # Issue #794 (Phase 2 of #790): the legacy `clm agent configure
+    # --stage channels` wizard used to fold the prompted channel block
+    # into `existing_config["channels"]` before calling
+    # `configure_agent`. Phase 2 stops persisting the channels mirror
+    # in hosts.json (the canonical store is `channels.json`), so any
+    # tokens this wizard would collect would be silently dropped after
+    # the Ansible push (ATX #794 iter-1 W1). Fail loudly with a hint
+    # pointing at the modern `clawctl channel` surface; the rest of
+    # the wizard body is dead and is removed alongside the legacy
+    # `clm` driver in Phase 4.
+    #
+    # WARNING (ATX #794 iter-2 W5): the dead body below contains
+    # unguarded `typer.prompt(hide_input=True)` calls. Demoting the
+    # `raise typer.Exit(code=2)` to conditional (e.g. behind a
+    # feature flag) silently restores an interactive token-prompt
+    # path — keep the raise unconditional until Phase 4 deletes the
+    # body entirely.
+    # Channel-type hint must mirror `_hydrate_channels_from_canonical`
+    # in `core/lifecycle.py` (`if resolved_type in ("hermes", "zeroclaw",
+    # "ethos"):`). Only those three types pull channels from the
+    # canonical store on configure; openclaw and nemoclaw have no
+    # canonical channel hydration today, so directing their operators
+    # at `clawctl channel attach` would silently no-op on sync
+    # (ATX #794 iter-4 W1). zeroclaw has no native Slack channel
+    # (#422), so only discord is listed there. `cli` is an in-process
+    # selector in the dead wizard body, not a registry channel type;
+    # it is intentionally absent.
+    _channel_types_by_agent = {
+        "hermes": "discord, slack",
+        "ethos": "discord, slack",
+        "zeroclaw": "discord",
+    }
+    channel_examples = _channel_types_by_agent.get(claw_type)
+    safe_agent_name = sanitize_passthrough(
+        installed_name or "<agent-name>"
+    )
+    if channel_examples is None:
+        # openclaw / nemoclaw / unknown — no canonical hydration path.
+        console.print(
+            "[yellow]This wizard is deprecated.[/yellow] "
+            f"`{claw_type}` does not currently support attaching "
+            "channels via the canonical store. Channel configuration "
+            "for this agent type is tracked as a follow-up under #790."
+        )
+    else:
+        console.print(
+            "[yellow]This wizard is deprecated.[/yellow] "
+            "Channel state is now managed via `channels.json`.\n"
+            "Use the modern surface instead "
+            f"(supported types: {channel_examples}):\n"
+            "  clawctl channel registry create <channel-name> "
+            "--type <type> --token <bot-token>  "
+            "(stores token in secrets.json)\n"
+            "  clawctl agent channel attach <channel-name> --agent "
+            f"{safe_agent_name}\n"
+            f"  clawctl agent sync {safe_agent_name}"
+        )
+    raise typer.Exit(code=2)
+    # mypy/runtime never reach below — the original wizard body remains
+    # only so the parent state-machine references in `STAGES` and
+    # `STATE_RESUME_IDX` still resolve until Phase 4.
     from clawrium.core.secrets import get_instance_key, set_instance_secret
 
     # Channel menu per agent type. ZeroClaw v0.7.5 has no native Slack

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -549,6 +549,105 @@ def _run_lifecycle_playbook(
         _cleanup_ansible_artifacts(operation_log_dir)
 
 
+def _build_provider_overlays_from_attachments(
+    *,
+    claw_record: dict,
+    agent_type: str,
+    agent_key: str,
+) -> tuple[dict | None, list[dict] | None, str | None]:
+    """Materialize provider overlays from canonical attachments.
+
+    Reads tier-1 `claw_record["providers"]` (the attach list written by
+    `clawctl agent provider attach`) and `providers.json` (the canonical
+    provider registry), and returns the overlays the Ansible templates
+    expect on `config.provider` / `config.providers`. Issue #794 stripped
+    those keys from persisted hosts.json, so any caller that wants
+    Ansible to render a real provider block MUST hydrate via this
+    helper before invoking `configure_agent` — `configure_agent` itself
+    only auto-hydrates `channels` (see `_hydrate_channels_from_canonical`).
+
+    Returns a tuple of `(provider_overlay, provider_overlays,
+    provider_name_for_state)`:
+
+    - `provider_overlay`: the singleton overlay (zeroclaw/openclaw), or
+      the primary slot's overlay (hermes), with `role` stripped. `None`
+      when the agent has no attachments.
+    - `provider_overlays`: the full multi-provider list with `role` +
+      per-attachment `model` (hermes only). `None` for singletons.
+    - `provider_name_for_state`: the canonical provider name, suitable
+      for stamping into the onboarding `providers` stage metadata.
+
+    Raises `LifecycleError` for unregistered providers, invalid
+    attachment shapes, or hermes attachments that fail validation.
+    """
+    raw_attachments = claw_record.get("providers") or []
+    attachments = _pa.normalize(raw_attachments, agent_type)
+    try:
+        _pa.validate(attachments, agent_type)
+    except _pa.AttachmentError as exc:
+        raise LifecycleError(
+            f"agent '{agent_key}' has invalid provider attachments: {exc}. "
+            f"Inspect with 'clawctl agent provider get --agent {agent_key}'."
+        ) from exc
+
+    provider_overlay: dict | None = None
+    provider_overlays: list[dict] | None = None
+    provider_name_for_state: str | None = None
+
+    def _build_overlay(provider_name: str) -> dict:
+        provider_record = _provider_storage.get_provider(provider_name)
+        if provider_record is None:
+            raise LifecycleError(
+                f"attached provider '{provider_name}' not registered. "
+                f"Run 'clawctl provider registry get' to list available providers."
+            )
+        overlay = {
+            "name": provider_record.get("name", ""),
+            "type": provider_record.get("type", "ollama"),
+            "endpoint": provider_record.get("endpoint", ""),
+            "default_model": provider_record.get("default_model", ""),
+        }
+        # `is not None` instead of truthy: max_tokens=0 / context_window=0
+        # are meaningful (no-limit signals on some APIs); a falsy check
+        # would silently drop them (ATX iter-1 S1, preserved across the
+        # #794 extraction).
+        if provider_record.get("context_window") is not None:
+            overlay["context_window"] = provider_record["context_window"]
+        if provider_record.get("max_tokens") is not None:
+            overlay["max_tokens"] = provider_record["max_tokens"]
+        return overlay
+
+    if attachments and _pa.supports_multi_provider(agent_type):
+        provider_overlays = []
+        for entry in attachments:
+            if not isinstance(entry, dict):
+                raise LifecycleError(
+                    f"agent '{agent_key}' has non-dict provider attachment "
+                    f"after normalization: {entry!r}. Inspect with "
+                    f"'clawctl agent provider get --agent {agent_key}'."
+                )
+            overlay = _build_overlay(entry["name"])
+            overlay["role"] = entry.get("role", "")
+            attachment_model = entry.get("model") or overlay.get("default_model", "")
+            overlay["model"] = attachment_model
+            provider_overlays.append(overlay)
+            if entry.get("role") == _pa.PRIMARY_ROLE:
+                provider_overlay = {
+                    k: v for k, v in overlay.items() if k not in ("role",)
+                }
+                provider_name_for_state = entry["name"]
+    elif attachments:
+        provider_name = attachments[0]
+        if not isinstance(provider_name, str):
+            raise LifecycleError(
+                f"agent '{agent_key}' provider attachment shape unexpected"
+            )
+        provider_overlay = _build_overlay(provider_name)
+        provider_name_for_state = provider_name
+
+    return provider_overlay, provider_overlays, provider_name_for_state
+
+
 def _hermes_env_token_matches_secrets(
     host: dict, agent_name: str
 ) -> tuple[bool, str | None]:
@@ -716,10 +815,47 @@ def start_agent(
                 if isinstance(claw_record, dict)
                 else {}
             )
+            persisted_config = (
+                persisted_config if isinstance(persisted_config, dict) else {}
+            )
+            # Issue #794 B1 fix: hosts.json no longer carries
+            # `config.provider` / `config.providers` mirrors, but
+            # the hermes configure playbook's post-render verification
+            # tasks (configure.yaml:208-264) are gated on
+            # `config.provider is defined`. Hydrate the overlay from
+            # canonical attachments + providers.json before invoking
+            # configure_agent so those verifications still fire on
+            # the start-precheck reconfigure path.
+            persisted_config = dict(persisted_config)
+            try:
+                provider_overlay, provider_overlays, _ = (
+                    _build_provider_overlays_from_attachments(
+                        claw_record=claw_record,
+                        agent_type=agent_type,
+                        agent_key=agent_key,
+                    )
+                )
+                if provider_overlay is not None:
+                    persisted_config["provider"] = provider_overlay
+                if provider_overlays is not None:
+                    persisted_config["providers"] = provider_overlays
+            except LifecycleError as exc:
+                # An invalid / unregistered attachment surfaces here as
+                # well, with the same remediation hint sync_agent gives.
+                return {
+                    "success": False,
+                    "agent": agent_key,
+                    "host": hostname,
+                    "operation": "start",
+                    "pid": None,
+                    "started_at": None,
+                    "error": f"Pre-start reconfigure failed: {exc}",
+                }
+
             cfg_success, cfg_error = configure_agent(
                 hostname,
                 claw_name,
-                persisted_config if isinstance(persisted_config, dict) else {},
+                persisted_config,
                 agent_name=agent_key,
                 on_event=on_event,
                 reason="start-precheck",
@@ -1389,95 +1525,20 @@ def sync_agent(
     # Ansible templates render). The Pattern A surface from #509 records
     # attachments as metadata only; sync is the declarative reconcile
     # point that materializes those attachments into the agent's config
-    # before pushing to the remote. `detach` intentionally does NOT strip
-    # `config.provider` — once a provider lands in config it is
-    # last-known-good across subsequent syncs (design decision on #426).
+    # before pushing to the remote. After issue #794 the materialized
+    # overlay is no longer persisted in hosts.json — sync rebuilds it
+    # from canonical attachments + providers.json on every call.
     #
     # Issue #501: hermes alone supports N attachments (primary + 9
     # auxiliary slots); zeroclaw/openclaw keep the singleton invariant.
-    # Normalization handles both legacy list-of-strings and the new
-    # list-of-objects shape transparently.
-    raw_attachments = claw_record.get("providers") or []
-    attachments = _pa.normalize(raw_attachments, agent_type)
-    try:
-        _pa.validate(attachments, agent_type)
-    except _pa.AttachmentError as exc:
-        raise LifecycleError(
-            f"agent '{agent_key}' has invalid provider attachments: {exc}. "
-            f"Inspect with 'clawctl agent provider get --agent {agent_key}'."
-        ) from exc
-
-    provider_overlay: dict | None = None
-    provider_overlays: list[dict] | None = None
-    provider_name_for_state: str | None = None
-
-    def _build_overlay(provider_name: str) -> dict:
-        provider_record = _provider_storage.get_provider(provider_name)
-        if provider_record is None:
-            raise LifecycleError(
-                f"attached provider '{provider_name}' not registered. "
-                f"Run 'clawctl provider registry get' to list available providers."
-            )
-        overlay = {
-            "name": provider_record.get("name", ""),
-            "type": provider_record.get("type", "ollama"),
-            "endpoint": provider_record.get("endpoint", ""),
-            "default_model": provider_record.get("default_model", ""),
-        }
-        # `is not None` instead of truthy: max_tokens=0 / context_window=0
-        # are meaningful (no-limit signals on some APIs); a falsy check
-        # would silently drop them. ATX iter-1 S1.
-        if provider_record.get("context_window") is not None:
-            overlay["context_window"] = provider_record["context_window"]
-        if provider_record.get("max_tokens") is not None:
-            overlay["max_tokens"] = provider_record["max_tokens"]
-        return overlay
-
-    if attachments and _pa.supports_multi_provider(agent_type):
-        # Hermes path: build a config.providers list (one overlay per
-        # attachment, carrying role + per-attachment model) and also
-        # populate config.provider from the primary so the bridge
-        # contract with downstream readers (templates, validators) is
-        # preserved unchanged for back-compat. Phase 1 wires the data
-        # model; template rewrites land in Phase 3.
-        provider_overlays = []
-        for entry in attachments:
-            # ATX W5: validate() above guarantees every hermes entry is
-            # a dict — but if normalize() ever regresses, silently
-            # skipping non-dicts would leave the agent with no primary,
-            # no state-machine walk, and a config rendered with empty
-            # provider fields that Ansible would happily push. Fail loud.
-            if not isinstance(entry, dict):
-                raise LifecycleError(
-                    f"agent '{agent_key}' has non-dict provider attachment "
-                    f"after normalization: {entry!r}. Inspect with "
-                    f"'clawctl agent provider get --agent {agent_key}'."
-                )
-            overlay = _build_overlay(entry["name"])
-            overlay["role"] = entry.get("role", "")
-            # Per-attachment model override; falls back to provider's
-            # default_model when the attachment didn't specify one.
-            # Always set `model` explicitly so template authors can
-            # read a single field regardless of whether the operator
-            # supplied an override.
-            attachment_model = entry.get("model") or overlay.get("default_model", "")
-            overlay["model"] = attachment_model
-            provider_overlays.append(overlay)
-            if entry.get("role") == _pa.PRIMARY_ROLE:
-                provider_overlay = {
-                    k: v for k, v in overlay.items() if k not in ("role",)
-                }
-                provider_name_for_state = entry["name"]
-    elif attachments:
-        # Singleton path (zeroclaw/openclaw). normalize() guarantees
-        # list-of-strings shape here; validate() guarantees len<=1.
-        provider_name = attachments[0]
-        if not isinstance(provider_name, str):
-            raise LifecycleError(
-                f"agent '{agent_key}' provider attachment shape unexpected"
-            )
-        provider_overlay = _build_overlay(provider_name)
-        provider_name_for_state = provider_name
+    # The helper handles both shapes.
+    provider_overlay, provider_overlays, provider_name_for_state = (
+        _build_provider_overlays_from_attachments(
+            claw_record=claw_record,
+            agent_type=agent_type,
+            agent_key=agent_key,
+        )
+    )
 
     onboarding = claw_record.get("onboarding", {})
     state_value = onboarding.get("state", "pending")
@@ -2864,42 +2925,33 @@ def configure_agent(
                     api_server_persisted.pop("key", None)
                     persisted_config["api_server"] = api_server_persisted
 
-            # B3 invariant for Discord: bot_token lives in secrets.json only,
-            # never in hosts.json. Applies to both hermes (DISCORD_BOT_TOKEN
-            # hydrated into .env via .env.j2) and zeroclaw (#422 — token
-            # hydrated into config.toml's [channels.discord]). Without this
-            # strip, the bot_token roundtrips: hydrated → persisted → read
-            # back into existing_config on next configure → re-hydrated, etc.
-            # ATX B1 finding. Slack inclusion is hermes-only in practice but
-            # the pop is idempotent on absent keys so leaving it covers both
-            # agent types in one branch.
-            if resolved_type in ("hermes", "zeroclaw"):
-                if "channels" in persisted_config:
-                    channels_persisted = persisted_config.get("channels")
-                    if isinstance(channels_persisted, dict):
-                        channels_persisted = dict(channels_persisted)
-                        discord_persisted = channels_persisted.get("discord")
-                        if isinstance(discord_persisted, dict):
-                            discord_persisted = dict(discord_persisted)
-                            discord_persisted.pop("bot_token", None)
-                            channels_persisted["discord"] = discord_persisted
-                        slack_persisted = channels_persisted.get("slack")
-                        if isinstance(slack_persisted, dict):
-                            slack_persisted = dict(slack_persisted)
-                            slack_persisted.pop("bot_token", None)
-                            slack_persisted.pop("app_token", None)
-                            channels_persisted["slack"] = slack_persisted
-                        persisted_config["channels"] = channels_persisted
-                    else:
-                        # Unexpected shape (string/list/etc.) — drop rather
-                        # than risk persisting a token via an unknown path.
-                        logger.warning(
-                            "Dropping unexpected channels block (type=%s) for "
-                            "agent %s during persist to avoid B3 violation.",
-                            type(channels_persisted).__name__,
-                            agent_key,
-                        )
-                        persisted_config.pop("channels", None)
+            # Issue #794: `provider` / `providers` are render-only state
+            # (the canonical stores are tier-1 `agent_record["providers"]`
+            # + `providers.json`). Persisting a mirror in hosts.json
+            # caused the tier-2 staleness #790 fixed in the read path.
+            # Strip so a subsequent load_hosts() never sees a stale copy.
+            persisted_config.pop("provider", None)
+            persisted_config.pop("providers", None)
+            # `channels` is render + security state — the configure
+            # playbook hydrates channels.discord.bot_token (B3) /
+            # channels.slack.bot_token / app_token for templating, but
+            # the canonical store is `channels.json` + secrets.json.
+            # Strip unconditionally; the broader strip subsumes the
+            # earlier targeted bot_token/app_token scrubs (ATX #794
+            # iter-1 W3) so the B3 isolation invariant now holds for
+            # every agent type, not just hermes/zeroclaw.
+            #
+            # ATX #794 iter-2 W2: emit a debug crumb when we drop a
+            # populated channels block so an operator chasing
+            # hosts.json corruption from a pre-#794 build can see the
+            # strip happened.
+            stripped_channels = persisted_config.pop("channels", None)
+            if stripped_channels:
+                logger.debug(
+                    "Stripped channels block from persisted_config for %s "
+                    "(canonical store is channels.json).",
+                    agent_key,
+                )
 
             h["agents"][agent_key]["config"] = persisted_config
 

--- a/tests/cli/clawctl/agent/test_sync_hermes_multi_provider.py
+++ b/tests/cli/clawctl/agent/test_sync_hermes_multi_provider.py
@@ -196,3 +196,63 @@ def test_hermes_duplicate_auxiliary_slot_rejected():
             sync_agent("192.168.1.100", "hermes")
 
     assert "already filled" in str(exc_info.value)
+
+
+def test_sync_agent_does_not_persist_providers_overlay_hermes():
+    """Issue #794 (Phase 2 of #790): the hermes multi-provider overlay
+    that `sync_agent` builds at lifecycle.py:1410-1682 MUST reach
+    `configure_agent` via `config_data["providers"]` so Ansible
+    templates can render `auxiliary.<slot>`, but the persistence path
+    inside `configure_agent` strips it before write. Confirm the
+    overlay still flows into configure_agent on the hermes path (the
+    persist-strip itself is covered by
+    `tests/test_lifecycle.py::TestConfigureAgentDoesNotPersistOverlay`).
+    """
+    host = _hermes_host(
+        attachments=[
+            {"name": "anth", "role": "primary", "model": "claude-opus"},
+            {"name": "dgx", "role": "compression", "model": "qwen-coder"},
+        ]
+    )
+    by_name = {
+        "anth": _provider_record("anth", "anthropic"),
+        "dgx": _provider_record("dgx", "ollama"),
+    }
+
+    captured: dict = {}
+
+    def fake_configure(hostname, claw_name, config_data, **kwargs):
+        captured["config_data"] = config_data
+        return (True, None)
+
+    with (
+        patch("clawrium.core.lifecycle.get_host", return_value=host),
+        patch(
+            "clawrium.core.providers.storage.get_provider",
+            side_effect=lambda n: by_name.get(n),
+        ),
+        patch("clawrium.core.onboarding.complete_stage", return_value=True),
+        patch("clawrium.core.onboarding.transition_state", return_value=True),
+        patch("clawrium.core.onboarding.can_skip_stage", return_value=True),
+        patch("clawrium.core.lifecycle.configure_agent", side_effect=fake_configure),
+    ):
+        result = sync_agent("192.168.1.100", "hermes")
+
+    assert result["success"] is True
+    cfg = captured["config_data"]
+    # sync_agent still folds the overlay into config_data (so
+    # configure_agent → Ansible can render templates); the persist
+    # strip happens inside configure_agent's updater, asserted in
+    # tests/test_lifecycle.py::TestConfigureAgentDoesNotPersistOverlay.
+    # ATX #794 iter-1 W2: assert per-entry (name, role) so a regression
+    # that swaps roles or drops a name silently is caught here.
+    assert isinstance(cfg.get("providers"), list)
+    assert len(cfg["providers"]) == 2
+    assert {(p["name"], p["role"]) for p in cfg["providers"]} == {
+        ("anth", "primary"),
+        ("dgx", "compression"),
+    }
+    # The primary overlay is also still surfaced as `provider` on the
+    # singleton path so legacy template authors keep working unchanged.
+    assert cfg["provider"]["name"] == "anth"
+    assert "role" not in cfg["provider"]

--- a/tests/core/test_lifecycle_hermes_prerender.py
+++ b/tests/core/test_lifecycle_hermes_prerender.py
@@ -797,12 +797,15 @@ def test_configure_agent_hydrates_channel_tokens_via_hydrate_helper(
 def test_configure_agent_strips_channel_tokens_from_persisted_hosts_json(
     hermes_configure_env, render_stores, monkeypatch
 ):
-    """W-NEW-4 companion (lifecycle.py:2542-2568). Sibling invariant to
-    W-NEW-3: the B3 secret-isolation block in the updater closure must
-    strip `discord.bot_token`, `slack.bot_token`, and `slack.app_token`
-    before persisting to hosts.json. Without this strip, the tokens
-    roundtrip hydrated→persisted→re-hydrated and defeat the secrets.json
-    isolation contract. (ATX iter-2 test-coverage B1.)
+    """W-NEW-4 companion (lifecycle.py persist closure). Sibling invariant
+    to W-NEW-3: channel state must not land in hosts.json.
+
+    Issue #794 generalized the previous targeted strip (only
+    `discord.bot_token`, `slack.bot_token`, `slack.app_token`) into a
+    broader invariant — the entire `channels` block is removed from
+    persisted_config because `channels.json` is the canonical store
+    for channel state. The B3 secret-isolation contract follows
+    directly: with no channels subtree on disk, no token can roundtrip.
     """
     _seed_single_provider(render_stores, hermes_configure_env)
     # Pre-migrate the bind so _migrate_bind doesn't fire and inflate
@@ -866,24 +869,15 @@ def test_configure_agent_strips_channel_tokens_from_persisted_hosts_json(
     assert len(update_host_calls) == 1
 
     # Apply the captured closure to a synthetic host shape and assert
-    # every token is stripped while non-secret fields survive.
+    # the entire channels block is absent post-#794.
     _hostname, persist_closure = update_host_calls[0]
     sample_host = {"hostname": "host-1", "agents": {"alpha": {"config": {}}}}
     mutated = persist_closure(sample_host)
-    persisted_channels = mutated["agents"]["alpha"]["config"]["channels"]
+    persisted_config = mutated["agents"]["alpha"]["config"]
 
-    # Discord: bot_token stripped, enabled flag preserved.
-    assert "bot_token" not in persisted_channels["discord"], (
-        f"discord bot_token leaked into hosts.json: {persisted_channels['discord']!r}"
+    # Issue #794: channels block stripped wholesale, not just the tokens.
+    assert "channels" not in persisted_config, (
+        f"channels block leaked into hosts.json: {persisted_config!r}"
     )
-    assert persisted_channels["discord"].get("enabled") is True
-    # Slack: bot_token + app_token stripped, enabled flag preserved.
-    assert "bot_token" not in persisted_channels["slack"], (
-        f"slack bot_token leaked into hosts.json: {persisted_channels['slack']!r}"
-    )
-    assert "app_token" not in persisted_channels["slack"], (
-        f"slack app_token leaked into hosts.json: {persisted_channels['slack']!r}"
-    )
-    assert persisted_channels["slack"].get("enabled") is True
     # api_server.key strip continues to hold on the same closure call.
-    assert "key" not in mutated["agents"]["alpha"]["config"]["api_server"]
+    assert "key" not in persisted_config["api_server"]

--- a/tests/test_configure_claw.py
+++ b/tests/test_configure_claw.py
@@ -2829,11 +2829,15 @@ class TestZeroclawDiscordHydration:
     def test_discord_bot_token_stripped_from_hosts_json_zeroclaw(
         self, tmp_path: Path, canonical_channels
     ):
-        """ATX Round 1 B1: zeroclaw must mirror hermes's strip-before-persist
-        behavior so bot_token never lands in hosts.json. Without this, the
-        token roundtrips: hydrated → persisted → read into existing_config →
-        re-hydrated, defeating the B3 invariant that bot_token lives in
-        secrets.json only."""
+        """ATX Round 1 B1: zeroclaw must keep bot_token out of hosts.json.
+
+        Issue #794 generalized the previous targeted strip into a broader
+        invariant — the entire `channels` block is now removed from
+        persisted_config because `channels.json` is the canonical store
+        for channel state. The B3 isolation contract (bot_token never
+        in hosts.json) is therefore subsumed by the absence of the
+        whole key.
+        """
         token = "B" * 64
         cfg = {
             "allowed_users": ["740723459344302120"],
@@ -2896,16 +2900,12 @@ class TestZeroclawDiscordHydration:
 
         assert success is True, error
         persisted = captured_update["host"]["agents"]["zc-test"]["config"]
-        # The Discord block must be persisted (so re-configure can find it)
-        # but bot_token MUST be stripped — only secrets.json holds it.
-        assert "channels" in persisted
-        assert "discord" in persisted["channels"]
-        assert persisted["channels"]["discord"]["enabled"] is True
-        assert "bot_token" not in persisted["channels"]["discord"], (
-            f"bot_token leaked into hosts.json for zeroclaw — "
-            f"persisted shape: {persisted['channels']['discord']}"
+        # Issue #794: the entire `channels` block is stripped from
+        # persisted hosts.json. The B3 isolation contract (bot_token
+        # never in hosts.json) follows directly — there is no channels
+        # subtree where it could land. Re-configure rebuilds the block
+        # from `channels.json` via `_hydrate_channels_from_canonical`.
+        assert "channels" not in persisted, (
+            f"channels block leaked into hosts.json for zeroclaw — "
+            f"persisted shape: {persisted!r}"
         )
-        # Other persisted fields survive the strip (idempotency check).
-        assert persisted["channels"]["discord"]["allowed_users"] == [
-            "740723459344302120"
-        ]

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -3356,3 +3356,614 @@ class TestConfigureAgentBravePreflight:
         )
         # If preflight ran, error would mention 'brave plugin requires'.
         assert "brave plugin requires" not in (error or "")
+
+
+class TestConfigureAgentDoesNotPersistOverlay:
+    """Issue #794 (Phase 2 of #790): the configure_agent updater must
+    strip `provider` / `providers` / `channels` from `persisted_config`
+    before writing to `hosts.json`, even though the same keys MUST still
+    reach the Ansible inventory so templates can render the model and
+    channel hulls. The canonical stores for those three keys live
+    elsewhere (tier-1 `agent_record["providers"]` + `providers.json`
+    for providers; `channels.json` for channels); persisting a mirror
+    is what caused the tier-2 staleness #790 fixed in the read path.
+    """
+
+    def _run_configure_capturing_persist(
+        self,
+        host: dict,
+        config_data: dict,
+        claw_type: str,
+        agent_name: str,
+        tmp_path: Path,
+    ) -> tuple[dict, dict, bool, str | None]:
+        """Run configure_agent end-to-end with ansible_runner + update_host
+        mocked. Returns (ansible_inventory, persisted_hosts_json,
+        success, error).
+        """
+        runner = MagicMock()
+        runner.status = "successful"
+        runner.events = []
+        artifacts_dir = tmp_path / "artifacts"
+        (artifacts_dir / "fact_cache").mkdir(parents=True)
+        runner.config.artifact_dir = str(artifacts_dir)
+
+        captured_inventory: dict = {}
+        captured_persisted: dict = {}
+
+        def capture_run(**kwargs):
+            captured_inventory.update(kwargs.get("inventory") or {})
+            return runner
+
+        def capture_update_host(_hostname: str, updater) -> bool:
+            # Mirror the initial-host shape so the updater sees a
+            # realistic dict to merge into.
+            h = {
+                "hostname": host["hostname"],
+                "agents": {k: dict(v) for k, v in host["agents"].items()},
+            }
+            captured_persisted.update(updater(h))
+            return True
+
+        key_path = tmp_path / "k"
+        key_path.write_text("k")
+        playbook_path = tmp_path / "configure.yaml"
+        playbook_path.write_text("---\n- hosts: all\n")
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle.get_host_private_key",
+                return_value=key_path,
+            ),
+            patch(
+                "clawrium.core.lifecycle._get_lifecycle_playbook_path",
+                return_value=playbook_path,
+            ),
+            patch(
+                "clawrium.core.lifecycle.ansible_runner.run",
+                side_effect=capture_run,
+            ),
+            patch(
+                "clawrium.core.lifecycle.update_host",
+                side_effect=capture_update_host,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_config_dir",
+                return_value=tmp_path,
+            ),
+            patch(
+                "clawrium.core.providers.get_provider_api_key",
+                return_value="",
+            ),
+            patch(
+                "clawrium.core.providers.get_provider_aws_credentials",
+                return_value=("", ""),
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                return_value={},
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_instance_key",
+                return_value="test-key",
+            ),
+            patch(
+                "clawrium.core.integrations.get_agent_integrations",
+                return_value=[],
+            ),
+            patch(
+                "clawrium.core.lifecycle._hydrate_channels_from_canonical",
+                return_value=(True, None),
+            ),
+            patch.object(Path, "exists", return_value=True),
+        ):
+            from clawrium.core.lifecycle import configure_agent
+
+            success, error = configure_agent(
+                host["hostname"],
+                claw_type,
+                config_data,
+                agent_name=agent_name,
+            )
+        return captured_inventory, captured_persisted, success, error
+
+    def _openclaw_host(self) -> dict:
+        return {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "opc-test": {
+                    "type": "openclaw",
+                    "agent_name": "opct",
+                    "onboarding": {"state": "ready"},
+                    "config": {"gateway": {"port": 40000, "bind": "lan"}},
+                    "providers": ["test-provider"],
+                }
+            },
+        }
+
+    def _hermes_host(self) -> dict:
+        return {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "hrm-test": {
+                    "type": "hermes",
+                    "agent_name": "hrmt",
+                    "onboarding": {"state": "ready"},
+                    "config": {
+                        "gateway": {"port": 45000},
+                        "api_server": {
+                            "enabled": True,
+                            "host": "0.0.0.0",
+                            "port": 8642,
+                        },
+                    },
+                    "providers": [
+                        {"name": "anth", "role": "primary"},
+                    ],
+                }
+            },
+        }
+
+    def test_sync_agent_does_not_persist_provider_overlay(self, tmp_path: Path):
+        """Singleton path (openclaw/zeroclaw): config_data carries a
+        `provider` overlay so Ansible can render templates, but the
+        persisted hosts.json record MUST NOT contain
+        `config.provider`."""
+        host = self._openclaw_host()
+        config_data = {
+            "gateway": {"port": 40000, "bind": "lan"},
+            "provider": {
+                "name": "test-provider",
+                "type": "openai",
+                "endpoint": "https://api.openai.example",
+                "default_model": "gpt-4",
+            },
+        }
+
+        inv, persisted, success, error = self._run_configure_capturing_persist(
+            host, config_data, "openclaw", "opc-test", tmp_path
+        )
+        assert success is True, error
+
+        persisted_agent = persisted["agents"]["opc-test"]
+        persisted_config = persisted_agent["config"]
+        assert "provider" not in persisted_config, (
+            f"config.provider must not be persisted after sync; "
+            f"got {persisted_config.get('provider')!r}"
+        )
+        # Group B (gateway) must still be persisted.
+        assert persisted_config["gateway"]["port"] == 40000
+
+    def test_sync_agent_does_not_persist_providers_overlay_hermes(
+        self, tmp_path: Path
+    ):
+        """Multi-provider path (hermes): config_data carries both
+        `provider` (primary) and `providers` (list) overlays. Neither
+        may be persisted in hosts.json."""
+        host = self._hermes_host()
+        config_data = {
+            "gateway": {"port": 45000},
+            "api_server": {
+                "enabled": True,
+                "host": "0.0.0.0",
+                "port": 8642,
+            },
+            "provider": {
+                "name": "anth",
+                "type": "anthropic",
+                "endpoint": "https://api.anthropic.example",
+                "default_model": "claude-opus",
+            },
+            "providers": [
+                {
+                    "name": "anth",
+                    "type": "anthropic",
+                    "endpoint": "https://api.anthropic.example",
+                    "default_model": "claude-opus",
+                    "role": "primary",
+                    "model": "claude-opus",
+                }
+            ],
+        }
+        # Hermes needs a valid API server key in secrets to pass
+        # validation, and `configure_agent` pre-renders the canonical
+        # config via `render_hermes(build_render_inputs(...))` which
+        # reads on-disk hosts.json. Stub all three so the test stays
+        # focused on the persist-strip contract.
+        from clawrium.core.render import RenderedFiles
+
+        fake_rendered = RenderedFiles(
+            files={
+                ".hermes/.env": "stub-env",
+                ".hermes/config.yaml": "stub-yaml",
+            },
+        )
+        with (
+            patch(
+                "clawrium.core.install._is_valid_hermes_api_server_key",
+                return_value=True,
+            ),
+            patch(
+                "clawrium.core.lifecycle.get_instance_secrets",
+                return_value={
+                    "HERMES_API_SERVER_KEY": {
+                        "value": "0" * 64,
+                    }
+                },
+            ),
+            patch(
+                "clawrium.core.render.build_render_inputs",
+                return_value={},
+            ),
+            patch(
+                "clawrium.core.render.render_hermes",
+                return_value=fake_rendered,
+            ),
+        ):
+            inv, persisted, success, error = (
+                self._run_configure_capturing_persist(
+                    host,
+                    config_data,
+                    "hermes",
+                    "hrm-test",
+                    tmp_path,
+                )
+            )
+        assert success is True, error
+
+        persisted_config = persisted["agents"]["hrm-test"]["config"]
+        assert "provider" not in persisted_config, (
+            f"hermes config.provider must not be persisted; "
+            f"got {persisted_config.get('provider')!r}"
+        )
+        assert "providers" not in persisted_config, (
+            f"hermes config.providers must not be persisted; "
+            f"got {persisted_config.get('providers')!r}"
+        )
+
+    def test_sync_agent_does_not_persist_channels(self, tmp_path: Path):
+        """Channels are now sourced from canonical channels.json via
+        `_hydrate_channels_from_canonical`. Even if a caller passes
+        a `channels` block in `config_data` (legacy code path),
+        configure_agent must strip it from persisted hosts.json so
+        a stale mirror cannot accumulate."""
+        host = self._openclaw_host()
+        config_data = {
+            "gateway": {"port": 40000, "bind": "lan"},
+            "provider": {
+                "name": "test-provider",
+                "type": "openai",
+                "endpoint": "https://api.openai.example",
+                "default_model": "gpt-4",
+            },
+            "channels": {
+                "discord": {
+                    "enabled": True,
+                    "guilds": {"123": {"channels": {"456": {}}}},
+                }
+            },
+        }
+        inv, persisted, success, error = self._run_configure_capturing_persist(
+            host, config_data, "openclaw", "opc-test", tmp_path
+        )
+        assert success is True, error
+
+        persisted_config = persisted["agents"]["opc-test"]["config"]
+        assert "channels" not in persisted_config, (
+            f"config.channels must not be persisted after sync; "
+            f"got {persisted_config.get('channels')!r}"
+        )
+        # ATX #794 iter-1 S1: pin all three strips per call. A per-key
+        # regression that only re-introduces one of the three would
+        # otherwise pass this test silently.
+        assert "provider" not in persisted_config
+        assert "providers" not in persisted_config
+
+    def _hermes_host_for_start(
+        self, *, providers: list | None = None
+    ) -> dict:
+        return {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "hrm-test": {
+                    "type": "hermes",
+                    "agent_name": "hrmt",
+                    "onboarding": {"state": "ready"},
+                    "config": {
+                        "gateway": {"port": 45000},
+                        "api_server": {
+                            "enabled": True,
+                            "host": "0.0.0.0",
+                            "port": 8642,
+                        },
+                    },
+                    "providers": (
+                        providers
+                        if providers is not None
+                        else [{"name": "anth", "role": "primary"}]
+                    ),
+                }
+            },
+        }
+
+    def test_start_agent_hermes_unregistered_provider_returns_error(
+        self, tmp_path: Path
+    ):
+        """ATX #794 iter-3 B3 part 1: when the hermes drift path hydrates
+        the overlay and the attached provider is not in providers.json,
+        `_build_provider_overlays_from_attachments` raises
+        `LifecycleError`. The start_agent except branch must convert
+        that into a structured `{success: False, error: '...'}` result
+        with a remediation hint, NOT propagate the exception or return
+        success."""
+        host = self._hermes_host_for_start()
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            # Unregistered provider — get_provider returns None.
+            patch(
+                "clawrium.core.providers.storage.get_provider",
+                return_value=None,
+            ),
+            patch(
+                "clawrium.core.lifecycle._hermes_env_token_matches_secrets",
+                return_value=(False, None),
+            ),
+        ):
+            result = start_agent("192.168.1.100", "hermes")
+
+        assert result["success"] is False
+        assert result["operation"] == "start"
+        assert "Pre-start reconfigure failed" in (result.get("error") or "")
+        assert "not registered" in (result.get("error") or "")
+
+    def test_start_agent_hermes_invalid_attachment_shape_returns_error(
+        self, tmp_path: Path
+    ):
+        """ATX #794 iter-3 B3 part 2: malformed attachment (two primary
+        roles) must surface as success=False through the new
+        LifecycleError branch, not via an uncaught exception."""
+        host = self._hermes_host_for_start(
+            providers=[
+                {"name": "anth", "role": "primary"},
+                {"name": "other", "role": "primary"},  # second primary → invalid
+            ]
+        )
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._hermes_env_token_matches_secrets",
+                return_value=(False, None),
+            ),
+        ):
+            result = start_agent("192.168.1.100", "hermes")
+
+        assert result["success"] is False
+        assert "Pre-start reconfigure failed" in (result.get("error") or "")
+        assert "invalid provider attachments" in (result.get("error") or "")
+
+    def test_start_agent_hermes_empty_attachments_still_runs_configure(
+        self, tmp_path: Path
+    ):
+        """ATX #794 iter-3 B3 part 3: `providers=[]` is a valid (if
+        unusual) shape — the hydration helper returns
+        `(None, None, None)`, neither `config_data['provider']` nor
+        `config_data['providers']` is set, and `configure_agent` still
+        runs (the configure playbook's post-render verifications skip
+        themselves when config.provider is undefined)."""
+        host = self._hermes_host_for_start(providers=[])
+
+        captured: dict = {}
+
+        def fake_configure(hostname, claw_name, config_data, **kwargs):
+            captured["config_data"] = dict(config_data)
+            return (True, None)
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.lifecycle._hermes_env_token_matches_secrets",
+                return_value=(False, None),
+            ),
+            patch(
+                "clawrium.core.lifecycle._run_lifecycle_playbook",
+                return_value=(True, None),
+            ),
+            patch(
+                "clawrium.core.lifecycle._update_agent_runtime",
+                return_value=True,
+            ),
+            patch(
+                "clawrium.core.lifecycle.configure_agent",
+                side_effect=fake_configure,
+            ),
+        ):
+            result = start_agent("192.168.1.100", "hermes")
+
+        assert result["success"] is True, result.get("error")
+        cfg = captured["config_data"]
+        assert "provider" not in cfg
+        assert "providers" not in cfg
+        # Other persisted state still flows through.
+        assert cfg["gateway"]["port"] == 45000
+
+    def test_start_agent_hydrates_provider_before_hermes_reconfigure(
+        self, tmp_path: Path
+    ):
+        """ATX #794 iter-2 B1 regression test: `start_agent`'s hermes
+        pre-start reconfigure (the API_SERVER_KEY drift path at
+        lifecycle.py:703-756) historically passed `claw_record.config`
+        directly to `configure_agent`. After Phase 2 stripped
+        `config.provider` from persisted hosts.json, the playbook's
+        post-render verification tasks (configure.yaml:208-264) were
+        silently skipping because they're gated on
+        `config.provider is defined`. The fix hydrates the overlay
+        from canonical attachments + providers.json before invoking
+        configure_agent — assert the inventory shipped to ansible
+        contains the resolved primary provider.
+        """
+        host = {
+            "hostname": "192.168.1.100",
+            "key_id": "test",
+            "agent_name": "xclm",
+            "port": 22,
+            "agents": {
+                "hrm-test": {
+                    "type": "hermes",
+                    "agent_name": "hrmt",
+                    "onboarding": {"state": "ready"},
+                    # Post-#794 shape: no config.provider mirror.
+                    "config": {
+                        "gateway": {"port": 45000},
+                        "api_server": {
+                            "enabled": True,
+                            "host": "0.0.0.0",
+                            "port": 8642,
+                        },
+                    },
+                    "providers": [
+                        {"name": "anth", "role": "primary"},
+                    ],
+                }
+            },
+        }
+
+        provider_record = {
+            "name": "anth",
+            "type": "anthropic",
+            "endpoint": "https://api.anthropic.example",
+            "default_model": "claude-opus",
+        }
+
+        mock_configure = MagicMock(return_value=(True, None))
+
+        with (
+            patch("clawrium.core.lifecycle.get_host", return_value=host),
+            patch(
+                "clawrium.core.providers.storage.get_provider",
+                return_value=provider_record,
+            ),
+            # Force the env-token drift branch so configure_agent runs.
+            patch(
+                "clawrium.core.lifecycle._hermes_env_token_matches_secrets",
+                return_value=(False, None),
+            ),
+            # Stub the start playbook + runtime update so the test
+            # focuses on the pre-start configure path.
+            patch(
+                "clawrium.core.lifecycle._run_lifecycle_playbook",
+                return_value=(True, None),
+            ),
+            patch(
+                "clawrium.core.lifecycle._update_agent_runtime",
+                return_value=True,
+            ),
+            patch(
+                "clawrium.core.lifecycle.configure_agent",
+                side_effect=mock_configure,
+            ),
+        ):
+            result = start_agent("192.168.1.100", "hermes")
+
+        assert result["success"] is True, result.get("error")
+        # ATX #794 iter-3 W10: pin the call shape so this regression
+        # test cannot pass on any other configure entry point (e.g.,
+        # a refactor that accidentally routes through `reason='configure'`).
+        mock_configure.assert_called_once()
+        call_kwargs = mock_configure.call_args.kwargs
+        assert call_kwargs.get("reason") == "start-precheck"
+        assert call_kwargs.get("agent_name") == "hrm-test"
+
+        # B1 fix: hydrated overlay reached configure_agent.
+        cfg = mock_configure.call_args.args[2]
+        assert cfg.get("provider") is not None, (
+            "start_agent hermes pre-start reconfigure shipped an empty "
+            "config.provider — the playbook's post-render verification "
+            "tasks would silently skip (ATX #794 iter-2 B1)"
+        )
+        assert cfg["provider"]["name"] == "anth"
+        assert cfg["provider"]["type"] == "anthropic"
+        assert cfg["provider"]["default_model"] == "claude-opus"
+        # And the multi-provider list is hydrated too (hermes).
+        assert isinstance(cfg.get("providers"), list)
+        assert cfg["providers"][0]["name"] == "anth"
+        assert cfg["providers"][0]["role"] == "primary"
+
+    def test_configure_agent_passes_channels_extravars(self, tmp_path: Path):
+        """ATX #794 iter-1 W3 (positive half for channels): even though
+        the persisted config strips `channels`, the Ansible inventory
+        MUST still carry the overlay so playbook templates can render
+        the channel hulls. Mirrors
+        `test_configure_agent_passes_provider_extravars` for the
+        channels surface."""
+        host = self._openclaw_host()
+        config_data = {
+            "gateway": {"port": 40000, "bind": "lan"},
+            "provider": {
+                "name": "test-provider",
+                "type": "openai",
+                "endpoint": "https://api.openai.example",
+                "default_model": "gpt-4",
+            },
+            "channels": {
+                "discord": {
+                    "enabled": True,
+                    "guilds": {"123": {"channels": {"456": {}}}},
+                }
+            },
+        }
+        inv, persisted, success, error = self._run_configure_capturing_persist(
+            host, config_data, "openclaw", "opc-test", tmp_path
+        )
+        assert success is True, error
+
+        ansible_channels = inv["all"]["vars"]["config"]["channels"]
+        assert ansible_channels["discord"]["enabled"] is True
+        assert ansible_channels["discord"]["guilds"]["123"]["channels"] == {
+            "456": {}
+        }
+        # Persist-strip still held on the same call.
+        assert "channels" not in persisted["agents"]["opc-test"]["config"]
+
+    def test_configure_agent_passes_provider_extravars(self, tmp_path: Path):
+        """Negative half of the contract: even though the persisted
+        config strips provider/providers, the Ansible inventory MUST
+        still carry the overlay so templates can render the model.
+        Mirrors the scaffold's `test_configure_agent_passes_provider_extravars`
+        — the "extravars" path here is `inventory.all.vars.config.provider`
+        (config_data is forwarded into ansible_vars as `config`).
+        """
+        host = self._openclaw_host()
+        config_data = {
+            "gateway": {"port": 40000, "bind": "lan"},
+            "provider": {
+                "name": "test-provider",
+                "type": "openai",
+                "endpoint": "https://api.openai.example",
+                "default_model": "gpt-4-overlay-marker",
+            },
+        }
+        inv, persisted, success, error = self._run_configure_capturing_persist(
+            host, config_data, "openclaw", "opc-test", tmp_path
+        )
+        assert success is True, error
+
+        ansible_provider = inv["all"]["vars"]["config"]["provider"]
+        assert ansible_provider["name"] == "test-provider"
+        assert ansible_provider["default_model"] == "gpt-4-overlay-marker"
+
+        # And confirm the persist strip still happened on the same run.
+        assert (
+            "provider" not in persisted["agents"]["opc-test"]["config"]
+        )


### PR DESCRIPTION
## Summary

Phase 2 of #790. Stop persisting `config.provider`, `config.providers`,
and `config.channels` mirrors in `~/.config/clawrium/hosts.json`. The
Ansible payload still receives them via `config_data` so the configure
playbook can render the model + channel hulls, but the canonical
stores live elsewhere:

- providers: tier-1 `agent_record["providers"]` + `providers.json`
- channels:  `channels.json` (+ secrets.json for tokens)

Stacked on top of issue-793-fix-gui-read-path (PR #800). Phase 3
(#795) prunes existing pollution from `hosts.json` on load; Phase 4
(#796) deletes the now-unreachable readers + comments.

## What changes

- **`src/clawrium/core/lifecycle.py`**
  - Extracts the overlay-building logic out of `sync_agent` into a
    module-level helper `_build_provider_overlays_from_attachments`.
  - `configure_agent`'s `update_host` updater now strips
    `provider` / `providers` / `channels` from `persisted_config`
    before writing. The previously-targeted Discord/Slack
    bot_token / app_token scrub is subsumed by the broader strip,
    which now applies to **every** agent type (the old guard was
    `if resolved_type in ("hermes", "zeroclaw")`).
  - `start_agent`'s hermes API_SERVER_KEY drift path now hydrates
    `config_data["provider"]` / `["providers"]` from canonical
    attachments before calling `configure_agent` so the hermes
    configure playbook's post-render verification tasks still fire
    (ATX iter-2 B1 — without this, the persisted config carried no
    provider block and the verifications silently skipped).

- **`src/clawrium/cli/agent.py`**
  - Deleted the channels merges at the previous `:379` and `:745`
    (they fed `existing_config["channels"]` that the new strip
    would discard anyway).
  - `_run_channels_stage` (the legacy `clm agent configure --stage
    channels` wizard) prints a deprecation banner pointing at
    `clawctl channel registry create` + `clawctl agent channel
    attach` + `clawctl agent sync` and exits 2. The wizard's
    prompt+push flow was silently dropping tokens after the
    persist strip.

- **`CHANGELOG.md`** — entries under `### Fixed` (mirror strip;
  openclaw/nemoclaw channels-strip gap closure) and `### Changed`
  (legacy wizard exit-2 deprecation).

- **Tests** — 9 new tests in
  `tests/test_lifecycle.py::TestConfigureAgentDoesNotPersistOverlay`
  covering the persist-strip contract, the start_agent hydration
  path, and the three LifecycleError-branches. One sync_agent-level
  test added to
  `tests/cli/clawctl/agent/test_sync_hermes_multi_provider.py`.
  Two existing tests in `test_configure_claw.py` and
  `test_lifecycle_hermes_prerender.py` updated to reflect the
  broader strip (the prior B3 bot_token scrub is now subsumed).

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $20.90 | Total Time: 49m 51s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3/5 | None | 3 warnings → fixed | $4.26 | 11m02s | leader, cli-ux, lifecycle-core, security-reviewer, test-coverage |
| 2 | 2/5 | B1 (start_agent hermes drift) | Fixed | $4.82 | 17m37s | leader, cli-ux, lifecycle-core, security-reviewer, test-coverage |
| 3 | 2/5 | B1, B2, B3 (banner paths + LifecycleError tests) | All fixed | $5.75 | 13m25s | leader, cli-ux, lifecycle-core, security-reviewer, test-coverage |
| 4 | 4/5 | None | Ready | $6.07 | 7m57s | leader, cli-ux, lifecycle-core, security-reviewer, test-coverage |

> **Note**: ATX CLI does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Warnings:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `cli/agent.py:707-766` | `_run_channels_stage` wizard silently discarded tokens after the persist strip | Added deprecation banner + `typer.Exit(code=2)` |
| W2 | `tests/cli/clawctl/agent/test_sync_hermes_multi_provider.py:246-248` | Multi-provider sync test only asserted `len(providers) == 2` — roles/names unchecked | Tightened to per-entry `(name, role)` set |
| W3 | `tests/test_lifecycle.py` | No positive-half asserting channels reach Ansible inventory | Added `test_configure_agent_passes_channels_extravars` |

**Suggestions applied:** S1 (all-three-keys assert in channels strip test) and S5 (CHANGELOG note on openclaw/nemoclaw gap closure).

</details>

<details>
<summary>Review 2 Details (Rating 2/5 → Blocking)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `core/lifecycle.py:711-722` | `start_agent` hermes pre-start reconfigure passed empty `config.provider` post-#794 → playbook verification tasks silently skipped | Extracted `_build_provider_overlays_from_attachments` and hydrate before `configure_agent`; regression test added |

**Warnings:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W2 | `core/lifecycle.py:2867-2877` | Silent removal of `logger.warning` for malformed channel shapes | Re-added `logger.debug` crumb on populated channels strip |
| W3 | `cli/agent.py:753-754` | Comment used positional `clawctl channel attach <channel> <agent>` but actual CLI uses `--agent` | Updated comment |
| W4 | `cli/agent.py:830-831` | Banner hardcoded `--type discord` | Agent-type-appropriate channel types now listed |
| W5 | `cli/agent.py:836-839` | Dead `typer.prompt(hide_input=True)` body behind unconditional `raise` | Added safety warning comment |

</details>

<details>
<summary>Review 3 Details (Rating 2/5 → Blocking)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `cli/agent.py:842` | Banner used non-existent `clawctl channel create` | Corrected to `clawctl channel registry create --token` |
| B2 | `cli/agent.py:844` | Banner used `clawctl channel attach`; attach lives at `clawctl agent channel attach` | Corrected |
| B3 | `core/lifecycle.py:836-846` | Zero tests covered the new `except LifecycleError` branch in `start_agent` | Added 3 tests: unregistered provider, invalid attachment shape, empty attachments |

**Warnings:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `cli/agent.py:833` | `channel_examples` included `cli` (not a registry channel type) | Removed |
| W2 | `CHANGELOG.md` | No entry for the wizard exit-2 deprecation | Added `### Changed` entry |
| W4 | `cli/agent.py:838` | `installed_name` interpolated without sanitization | Now passes through `sanitize_passthrough` |
| W6 | `core/lifecycle.py:829` | `_resolve_agent_type(claw_name)` redundantly re-resolved | Uses existing `agent_type` variable |
| W7 | `core/lifecycle.py:827` | `_ov`, `_ovs` underscore prefix but used immediately | Renamed to `provider_overlay`, `provider_overlays` |
| W10 | `tests/test_lifecycle.py` | B1 regression test didn't pin `reason='start-precheck'` | Switched to `MagicMock` + pinned reason + `agent_name` |

</details>

<details>
<summary>Review 4 Details (Rating 4/5 — Ready)</summary>

**Blocking Issues:** None.

**Warnings fixed in-iteration:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `cli/agent.py:838-842` | `channel_examples` over-promised for openclaw/nemoclaw (no canonical hydration there) | Switched to per-type table; openclaw/nemoclaw get a distinct "no canonical hydration" banner |
| W3 | `core/lifecycle.py:594-599` | Dropped `is not None` rationale comment in extracted helper | Re-attached |

**Warnings acknowledged for follow-up:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W2 | `cli/agent.py:846-855` | Banner uses `console.print` instead of structured `--output json` envelope | Tracked under Phase 4 wizard cleanup |
| W4 | `tests/test_lifecycle.py::test_configure_agent_passes_channels_extravars` | Test uses openclaw but `_hydrate_channels_from_canonical` only runs for hermes/zeroclaw/ethos | Tracked as Phase 3 test additions |
| W5 | `tests/test_lifecycle.py::_run_configure_capturing_persist` | Last-write-wins on `captured_persisted`; multi-call regressions could pass vacuously | Tracked as Phase 3 test additions |

</details>

## Testing

### Test Results
- [x] All existing tests pass (`make test-py`: **3936 passed, 8 skipped**)
- [x] Linter passes (`make lint-py`)
- [x] New tests added for new functionality (9 in
      `TestConfigureAgentDoesNotPersistOverlay`, 1 in
      `test_sync_hermes_multi_provider.py`)

### Test Coverage
- Files changed:
  - `src/clawrium/core/lifecycle.py`
  - `src/clawrium/cli/agent.py`
  - `CHANGELOG.md`
  - `tests/test_lifecycle.py`
  - `tests/cli/clawctl/agent/test_sync_hermes_multi_provider.py`
  - `tests/test_configure_claw.py`
  - `tests/core/test_lifecycle_hermes_prerender.py`
- New tests: 10 (5 persist-strip contract; 3 LifecycleError branches;
  1 hermes hydration; 1 channels positive half).
- Coverage impact: increased.

### Real-Host Verification

Ran `uv run clawctl agent sync clawrium-exec` (hermes on wolf-i) from
this worktree against the live fleet — sync completed cleanly with no
regression (config render landed, restart succeeded, health verified).

Note: `clawctl agent sync` for an already-`ready` agent routes through
`lifecycle_canonical.sync_agent_canonical`, which writes files
directly to the host via SSH and does **not** invoke
`configure_agent`'s updater. So the Phase 2 strip changes are not
observable through `clawctl agent sync` for a steady-state agent —
they take effect on paths that DO call `configure_agent`'s updater
(legacy `clm agent configure`, programmatic `lifecycle.configure_agent`
callers, and the `start_agent` hermes drift path now covered by the
B1 fix). Existing legacy `config.provider/providers/channels` keys
remain in `hosts.json` and will be pruned on read by Phase 3 (#795).

## Callouts

- [DECISION] **Used the persist-strip approach inside the existing
  `update_host` updater closure instead of introducing a new
  `provider_extravars` kwarg on `configure_agent`.**
  - Why: The scaffold's exit criteria says "`configure_agent` accepts
    a `provider_extravars` kwarg (or equivalent)." `configure_agent`
    uses `config_data["provider"]` extensively across validation
    (`lifecycle.py:2222-2245`), credentials lookup
    (`lifecycle.py:2287-2299`), and template rendering — all of which
    would need parallel API kwargs to preserve behavior. The
    persist-strip is equivalent at the persistence boundary and
    mirrors the existing scrub pattern that already strips the hermes
    `api_server.key` from `persisted_config`. Smaller surface area
    change, identical observable contract.
  - Reviewer: confirm or push back.

- [DECISION] **Deleted the channels merge in `_sync_channel_config`
  but left the function itself (and its `channels_config` parameter)
  in place.**
  - Why: The legacy `_run_channels_stage` wizard that called it now
    exits 2 on entry — every reachable callsite is dead. Removing the
    parameter signature would force-update the dead call sites at
    `cli/agent.py:1238` and `:1414` for no functional gain. Phase 4
    of #790 deletes the entire module; that's the right place to
    surgically drop the parameter.
  - Alternatives considered: drop `channels_config: dict` now and
    delete the dead call sites individually; rename to
    `_unused_channels_config` per ATX iter-4 S3.
  - Reviewer: confirm the scope decision.

- [DECISION] **Replaced the previously-targeted Discord/Slack
  `bot_token` / `app_token` scrub with an unconditional `pop` of the
  entire `channels` block.**
  - Why: The previous scrub was guarded by `if resolved_type in
    ("hermes", "zeroclaw")`, leaving openclaw/nemoclaw with a real
    B3 gap (stale `config.channels.discord.bot_token` could persist
    on those types). The broader strip subsumes B3 for every agent
    type, mirrors what Phase 3 will do on load anyway, and removes a
    dead nested-key enumeration path.
  - Reviewer: confirm.

- [UNRESOLVED] **Real-host verification on the legacy
  `clawctl agent configure` path was not exercised.**
  - Best guess applied: `clawctl agent sync clawrium-exec` (hermes on
    wolf-i) ran cleanly through the canonical path. The Phase 2
    strip changes are exercised by the legacy lifecycle
    `sync_agent → configure_agent` path, which `clawctl agent sync`
    does not call. The unit test suite covers the strip directly via
    `TestConfigureAgentDoesNotPersistOverlay`.
  - Reviewer: please run `clawctl agent provider attach <other>
    --agent <name>` followed by `clawctl agent sync <name>` on wolf-i
    against a hermes/openclaw agent, and confirm the persisted
    `hosts.json` agent record contains no fresh
    `config.provider/providers/channels` writes. Existing stale
    entries from before Phase 3 may persist — that's the intended
    contract; Phase 3 prunes them.

- [TODO-FOLLOWUP] **`cli/status.py:176` reads `config.provider.type`
  for the legacy `clm status` table.** After this PR new agents will
  display `-` for provider type. This is a legacy `clm` reader (not
  wired into `clawctl agent get`); per project memory the `clm` CLI
  is being deprecated, and Phase 3 of #790 prunes existing entries
  on load anyway. Tracked as #707 follow-up.

- [TODO-FOLLOWUP] **ATX iter-4 W2** (banner should route through
  `emit_error` for `--output json` callers), **W4** (hermes-variant
  of the channels-extravars test), and **W5** (per-call `update_host`
  capture pattern in `_run_configure_capturing_persist`) are all
  acknowledged and tracked for Phase 3 / Phase 4 work in #790. None
  are release blockers per ATX iter-4 verdict ("rating 4/5, ready to
  merge").

- [ENVIRONMENT] ATX review path was the `atx review request` CLI,
  not the MCP transport, per the user's invocation instructions.
  Four review iterations across ~50 minutes wall time clearing 3
  rounds of blockers before reaching 4/5.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)