### PR TITLE
feat(workspace): hermes workspace overlay GA on macOS (#772)

### DIFF
--- a/.itx/760/07_E2E_hermes_esper-macmini.md
+++ b/.itx/760/07_E2E_hermes_esper-macmini.md
@@ -1,0 +1,419 @@
+# Issue #772 — E2E: hermes workspace overlay playbook on `esper-macmini`
+
+**Phase**: 6 (hermes / macOS)
+**Host**: `esper-macmini` (espers-mac-mini.tailf7742d.ts.net, darwin/arm64, macOS 26.5.1)
+**Date**: 2026-06-24
+**Branch**: `issue-772-hermes-workspace-macos`
+
+## Scope of this E2E (and what it cannot cover)
+
+The standard `clawctl agent sync ws-hermes-mac --workspace-only`
+end-to-end flow that Phase 3 (#769) ran on `wolf-i` is **not
+achievable for hermes on `esper-macmini` today** without standing up
+a full hermes upstream install. The hermes manifest does declare a
+macOS arm64 platform entry, but the upstream installer chain (clones
+the repo, builds the ui-tui Node bundle, installs the `[web,pty]`
+extras via uv) is heavy enough that running it against
+`esper-macmini` purely to exercise the workspace-overlay phase would
+trade a 10-second narrow test for a 5+ minute end-to-end run that
+also pulls in dashboard prerequisites, the venv reconciler, the
+launchd plist, and the bearer-auth handshake — none of which Phase 6
+introduces.
+
+So this E2E follows the same shape Phase 4 (#770) and Phase 5 (#771)
+used on this host: direct invocation of
+`src/clawrium/platform/registry/hermes/playbooks/workspace_macos.yaml`
+against `esper-macmini` via `ansible-playbook`, asserting every
+security boundary the playbook enforces — including the
+hermes-specific exclude-payload boundary that the openclaw/zeroclaw
+variants do not have.
+
+### What this E2E does cover
+
+1. Happy path: nested good files land at `/Users/<agent>/.hermes/`
+   with `agent:staff` ownership and the operator-supplied mode.
+2. **Full hostile-file set** — every one of the 10 manifest exclude
+   entries (`config.yaml`, `.env`, `auth.json`, `state.db` + 3 WAL
+   companions, `sessions/`, `logs/`, `skills/clawrium/`) is filtered
+   by the per-file `workspace_excluded` Jinja `when:` clause and does
+   NOT land on host. Pre/post diff of `~/.hermes/` shows zero leak.
+3. Tampered `workspace_dest_root` outside `/Users/<agent>/` is
+   rejected at the assert task (B1 iter-3 backstop, macOS variant).
+4. Path traversal (`..`) in `workspace_dest_root` is rejected at the
+   assert task (ATX iter-1 W1).
+5. Invalid `item.mode` (non-octal regex) is rejected at the assert
+   task (ATX iter-1 W6).
+6. Path traversal (`..`) in `item.rel` is rejected at the assert task
+   (W12 iter-2 belt-and-suspenders).
+7. `item.src` outside `staging_dir` is rejected at the assert task
+   (ATX iter-2 S_NEW_1 — carried forward from Linux hermes).
+8. Malformed `workspace_excludes_files` (string instead of list) is
+   rejected at the assert task — the hermes-specific gate that
+   openclaw and zeroclaw don't need.
+
+### What this E2E does NOT cover
+
+- `clawctl agent doctor` health on macOS — requires a live hermes
+  daemon, which in turn requires the upstream `[web,pty]` install +
+  launchd plist + ui-tui build. Documented as a **Callout** on the
+  PR (B5 from cross-issue ATX findings).
+- `clawctl agent stop` / `clawctl agent remove` on macOS — same
+  prerequisite gap (the lifecycle paths in `core/lifecycle_macos.py`
+  use `launchctl kickstart -k` / `launchctl bootout`, validated for
+  openclaw by #770; the contract is identical for hermes once the
+  upstream install actually runs to completion on this host).
+- `clawctl agent delete --yes ws-hermes-mac` cleanup — no agent
+  was created (we use the SSH proxy user `xclm`); the synthetic
+  `/Users/xclm/.hermes/` tree is wiped via `rm -rf` at the end (see
+  Cleanup below).
+
+The proxy agent identity for the E2E is `xclm` — the SSH user, which
+is the only unprivileged user already provisioned on the host. The
+slug matches the playbook's `^[a-z][a-z0-9_-]{0,31}$` allowlist;
+`workspace_dest_root` expands to `/Users/xclm/.hermes` (no
+`workspace/` suffix — hermes overlays directly under `~/.hermes/`
+because it shares the destination root with canonical render output).
+
+## Setup
+
+```
+$ ssh xclm@espers-mac-mini.tailf7742d.ts.net \
+    'rm -rf /Users/xclm/.hermes; mkdir -p /Users/xclm/.hermes; \
+     stat -f "%Su:%Sg %Sp %N" /Users/xclm/.hermes'
+xclm:staff drwxr-xr-x /Users/xclm/.hermes
+
+$ TS_DIR=/tmp/clawrium/staging/workspace/ws-hermes-mac-$(date +%s)
+$ mkdir -p "$TS_DIR/profiles/coder" "$TS_DIR/memories"
+$ echo "phase-6 e2e SOUL"  > "$TS_DIR/profiles/coder/SOUL.md"
+$ echo "phase-6 e2e NOTES" > "$TS_DIR/memories/NOTES.md"
+
+$ cat > /tmp/ws_hermes_inv.yaml <<'EOF'
+all:
+  hosts:
+    esper-macmini:
+      ansible_host: espers-mac-mini.tailf7742d.ts.net
+      ansible_user: xclm
+      ansible_ssh_private_key_file: ~/.config/clawrium/keys/espers-mac-mini.tailf7742d.ts.net/xclm_ed25519
+      ansible_python_interpreter: /usr/bin/python3
+      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+EOF
+```
+
+## 1. Happy path
+
+```
+$ uv run ansible-playbook -i /tmp/ws_hermes_inv.yaml \
+    src/clawrium/platform/registry/hermes/playbooks/workspace_macos.yaml \
+    -e 'agent_name=xclm' \
+    -e 'workspace_dest_root=/Users/xclm/.hermes' \
+    -e "staging_dir=$TS_DIR" \
+    -e "{\"workspace_files\":[
+          {\"rel\":\"profiles/coder/SOUL.md\",
+           \"src\":\"$TS_DIR/profiles/coder/SOUL.md\",\"mode\":\"0644\"},
+          {\"rel\":\"memories/NOTES.md\",
+           \"src\":\"$TS_DIR/memories/NOTES.md\",\"mode\":\"0644\"}
+        ]}" \
+    -e '{"workspace_excludes_files":["config.yaml",".env","auth.json","state.db","state.db-journal","state.db-wal","state.db-shm"]}' \
+    -e '{"workspace_excludes_dirs":["sessions","logs","skills/clawrium"]}'
+
+PLAY [all] *****
+TASK [Assert agent_name matches the safe slug pattern] *****  ok
+TASK [Assert workspace_dest_root is under /Users/xclm/] *****  ok
+TASK [Assert staging_dir is a non-empty absolute path under the clawrium staging tree] *****  ok
+TASK [Assert workspace_files is a list] *****  ok
+TASK [Assert workspace_excludes_files is a list] *****  ok
+TASK [Assert workspace_excludes_dirs is a list] *****  ok
+TASK [Assert each workspace file entry is a relative path and well-formed mode] *****
+  ok: (item=profiles/coder/SOUL.md)
+  ok: (item=memories/NOTES.md)
+TASK [Assert each workspace file entry's src lives under staging_dir] *****
+  ok: (item=profiles/coder/SOUL.md)
+  ok: (item=memories/NOTES.md)
+TASK [Ensure workspace destination root exists] *****  ok
+TASK [Ensure parent directories exist for each non-excluded workspace file] *****
+  changed: (item=profiles/coder/SOUL.md)
+  changed: (item=memories/NOTES.md)
+TASK [Push each non-excluded workspace file onto the host] *****
+  changed: (item=profiles/coder/SOUL.md)
+  changed: (item=memories/NOTES.md)
+
+PLAY RECAP *****
+esper-macmini  : ok=11  changed=2  unreachable=0  failed=0  skipped=0
+```
+
+Verify on host:
+
+```
+$ ssh xclm@espers-mac-mini.tailf7742d.ts.net \
+    'stat -f "%Su:%Sg %Sp %z %N" /Users/xclm/.hermes/profiles/coder/SOUL.md \
+                                   /Users/xclm/.hermes/memories/NOTES.md'
+xclm:staff -rw-r--r-- 17 /Users/xclm/.hermes/profiles/coder/SOUL.md
+xclm:staff -rw-r--r-- 18 /Users/xclm/.hermes/memories/NOTES.md
+```
+
+- Owner: `xclm` (the agent user).
+- Group: `staff` (gid 20, macOS convention — confirms the playbook's
+  `group: staff` literal applied; using `{{ agent_name }}` would have
+  failed since no `xclm` group exists on macOS).
+- Mode: `0644` (operator-supplied, threaded through the playbook).
+- Paths: under `/Users/xclm/.hermes/` — confirms macOS prefix
+  expansion fired and the dispatcher routed to the macOS playbook
+  variant.
+- Nested rel (`profiles/coder/SOUL.md`) lands correctly — exercises
+  the `when: dirname | length > 0` gate on parent-dir creation.
+
+## 2. Hostile file set — all 10 manifest excludes filtered on macOS
+
+Staged every exclude entry with hostile bytes:
+
+```
+$ TS_DIR=/tmp/clawrium/staging/workspace/ws-hermes-mac-hostile-$(date +%s)
+$ mkdir -p "$TS_DIR/sessions" "$TS_DIR/logs" "$TS_DIR/skills/clawrium/tdd"
+$ echo "MALICIOUS: overwrites canonical"        > "$TS_DIR/config.yaml"
+$ echo "MALICIOUS_KEY=stolen"                    > "$TS_DIR/.env"
+$ echo '{"malicious":true}'                      > "$TS_DIR/auth.json"
+$ echo "MALICIOUS-DB"                            > "$TS_DIR/state.db"
+$ echo "MALICIOUS-JOURNAL"                       > "$TS_DIR/state.db-journal"
+$ echo "MALICIOUS-WAL"                           > "$TS_DIR/state.db-wal"
+$ echo "MALICIOUS-SHM"                           > "$TS_DIR/state.db-shm"
+$ echo '{"malicious_session":true}'              > "$TS_DIR/sessions/123.json"
+$ echo "MALICIOUS-LOG"                           > "$TS_DIR/logs/gateway.log"
+$ echo "MALICIOUS-SKILL"                         > "$TS_DIR/skills/clawrium/tdd/SKILL.md"
+```
+
+Baseline before run:
+
+```
+$ ssh xclm@espers-mac-mini.tailf7742d.ts.net 'ls -la /Users/xclm/.hermes/'
+drwxr-xr-x  xclm staff  memories
+drwxr-xr-x  xclm staff  profiles
+```
+
+Invoke with all 10 hostile entries in `workspace_files` + the full
+hermes exclude payload as extravars (matches what
+`core.workspace_sync.push_workspace_phase` would send):
+
+```
+$ uv run ansible-playbook -i /tmp/ws_hermes_inv.yaml \
+    src/clawrium/platform/registry/hermes/playbooks/workspace_macos.yaml \
+    -e 'agent_name=xclm' \
+    -e 'workspace_dest_root=/Users/xclm/.hermes' \
+    -e "staging_dir=$TS_DIR" \
+    -e "{\"workspace_files\":[<all 10 hostile entries>]}" \
+    -e '{"workspace_excludes_files":["config.yaml",".env","auth.json","state.db","state.db-journal","state.db-wal","state.db-shm"]}' \
+    -e '{"workspace_excludes_dirs":["sessions","logs","skills/clawrium"]}'
+
+TASK [Ensure parent directories exist for each non-excluded workspace file] *****
+  skipping: (item=config.yaml)
+  skipping: (item=.env)
+  skipping: (item=auth.json)
+  skipping: (item=state.db)
+  skipping: (item=state.db-journal)
+  skipping: (item=state.db-wal)
+  skipping: (item=state.db-shm)
+  skipping: (item=sessions/123.json)
+  skipping: (item=logs/gateway.log)
+  skipping: (item=skills/clawrium/tdd/SKILL.md)
+
+TASK [Push each non-excluded workspace file onto the host] *****
+  skipping: (item=config.yaml)
+  skipping: (item=.env)
+  skipping: (item=auth.json)
+  skipping: (item=state.db)
+  skipping: (item=state.db-journal)
+  skipping: (item=state.db-wal)
+  skipping: (item=state.db-shm)
+  skipping: (item=sessions/123.json)
+  skipping: (item=logs/gateway.log)
+  skipping: (item=skills/clawrium/tdd/SKILL.md)
+
+PLAY RECAP: esper-macmini : ok=9  changed=0  unreachable=0  failed=0  skipped=2
+```
+
+Verify zero leak on host:
+
+```
+$ ssh xclm@espers-mac-mini.tailf7742d.ts.net 'ls -la /Users/xclm/.hermes/'
+drwxr-xr-x  xclm staff  memories       # unchanged
+drwxr-xr-x  xclm staff  profiles       # unchanged
+
+$ ssh xclm@espers-mac-mini.tailf7742d.ts.net '
+    for f in config.yaml .env auth.json state.db state.db-{journal,wal,shm}; do
+      [ -e /Users/xclm/.hermes/$f ] && echo "LEAK: $f" || echo "ok-absent: $f"
+    done
+    for d in sessions logs skills; do
+      [ -e /Users/xclm/.hermes/$d ] && echo "LEAK-DIR: $d" || echo "ok-absent: $d"
+    done'
+ok-absent: config.yaml
+ok-absent: .env
+ok-absent: auth.json
+ok-absent: state.db
+ok-absent: state.db-journal
+ok-absent: state.db-wal
+ok-absent: state.db-shm
+ok-absent: sessions
+ok-absent: logs
+ok-absent: skills
+```
+
+**All 10 manifest exclude entries — including all three SQLite WAL
+companion files (`state.db-journal`, `state.db-wal`, `state.db-shm`)
+and the `skills/clawrium/` dir-prefix — are filtered by the per-file
+`workspace_excluded` Jinja `when:` clause and never reach the host.**
+
+> **Daemon state during Test 2** (ATX iter-1 S4 note): NO live hermes
+> daemon was running on `esper-macmini` during this E2E. The host
+> `/Users/xclm/.hermes/` tree was freshly created by the Setup step
+> with only the operator-good `memories/` and `profiles/` dirs from
+> Test 1; there is no SQLite WAL to corrupt under load here. The W13
+> iter-2 invariant (overlaying any WAL companion while the daemon
+> holds the WAL open corrupts the database silently) is structurally
+> proven by this test — the filter prevents the overlay from ever
+> reaching the host — but the live-corruption case under daemon load
+> remains exercised only by the Phase 3 Ubuntu E2E (#769,
+> `.itx/760/04_E2E_hermes_wolf-i.md`), which ran the full
+> `clawctl agent sync` flow against an actively serving hermes
+> daemon. Standing up a live hermes daemon on this Mac would have
+> required the upstream installer + ui-tui Node build + launchd
+> plist drop — out of scope for the workspace-overlay phase.
+The control-machine-side `workspace_excluded` filter loads from the
+adjacent `filter_plugins/clawrium_filters.py` (Ansible auto-discovers
+filter_plugins/ alongside the playbook), which is the same plugin
+file the Linux hermes/workspace.yaml uses — so the filter logic is
+provably identical across Linux and macOS dispatch paths.
+
+## 3. Tampered `workspace_dest_root` outside `/Users/<agent>/`
+
+```
+$ uv run ansible-playbook ... -e 'workspace_dest_root=/etc/hermes' ...
+TASK [Assert workspace_dest_root is under /Users/xclm/] *****
+fatal: [esper-macmini]: FAILED! => {
+  "assertion": "workspace_dest_root.startswith('/Users/' ~ agent_name ~ '/')",
+  "msg": "workspace_dest_root must start with `/Users/xclm/` and contain no
+          `..` segments (got '/etc/hermes')"
+}
+PLAY RECAP: failed=1
+```
+
+B1 iter-3 backstop holds (macOS variant) — the assert bails before
+any `copy` task runs.
+
+## 4. Path traversal (`..`) in `workspace_dest_root`
+
+```
+$ uv run ansible-playbook ... -e 'workspace_dest_root=/Users/xclm/../../etc/hermes' ...
+TASK [Assert workspace_dest_root is under /Users/xclm/] *****
+fatal: [esper-macmini]: FAILED! => {
+  "assertion": "'..' not in workspace_dest_root.split('/')",
+  "msg": "workspace_dest_root must start with `/Users/xclm/` and contain no
+          `..` segments (got '/Users/xclm/../../etc/hermes')"
+}
+PLAY RECAP: failed=1
+```
+
+ATX iter-1 W1 hardening (mirrored from openclaw + zeroclaw macOS)
+holds on a real darwin host. The Python-side
+`_expand_destination_root` does string concatenation only (no
+`os.path.normpath`), so this assert is the live backstop.
+
+## 5. Invalid `item.mode` (non-octal regex)
+
+```
+$ uv run ansible-playbook ... \
+    -e "{\"workspace_files\":[{\"rel\":\"SOUL.md\",\"src\":\"$TS_DIR/SOUL.md\",\"mode\":\"a644\"}]}" ...
+TASK [Assert each workspace file entry is a relative path and well-formed mode] *****
+failed: [esper-macmini] (item=SOUL.md) => {
+  "assertion": "item.mode is match('^0[0-7]{3,4}$')",
+  "msg": "workspace file entry has unsafe rel or mode: rel='SOUL.md', mode='a644'"
+}
+PLAY RECAP: failed=1
+```
+
+ATX iter-1 W6 (security-reviewer) hardening — a hostile extravar
+injecting a malformed mode string is rejected before any `copy` task.
+
+## 6. Path traversal (`..`) in `item.rel`
+
+```
+$ uv run ansible-playbook ... \
+    -e "{\"workspace_files\":[{\"rel\":\"../escaped.md\",\"src\":\"$TS_DIR/SOUL.md\",\"mode\":\"0644\"}]}" ...
+TASK [Assert each workspace file entry is a relative path and well-formed mode] *****
+failed: [esper-macmini] (item=../escaped.md) => {
+  "assertion": "'..' not in (item.rel.split('/'))",
+  "msg": "workspace file entry has unsafe rel or mode: rel='../escaped.md', mode='0644'"
+}
+PLAY RECAP: failed=1
+```
+
+W12 iter-2 belt-and-suspenders holds on macOS.
+
+## 7. `item.src` outside `staging_dir`
+
+```
+$ uv run ansible-playbook ... \
+    -e "{\"workspace_files\":[{\"rel\":\"stolen.md\",\"src\":\"/etc/passwd\",\"mode\":\"0644\"}]}" ...
+TASK [Assert each workspace file entry's src lives under staging_dir] *****
+failed: [esper-macmini] (item=stolen.md) => {
+  "assertion": "item.src.startswith(staging_dir ~ '/')",
+  "msg": "workspace file entry has unsafe src: '/etc/passwd' (must start with
+          '/tmp/clawrium/staging/workspace/ws-hermes-mac-safety-.../')"
+}
+PLAY RECAP: failed=1
+```
+
+ATX iter-2 S_NEW_1 (carried forward from Linux hermes/workspace.yaml)
+holds — a regression in `_stage_files` or any caller injecting
+`workspace_files` extravars cannot smuggle an arbitrary absolute path
+through.
+
+## 8. Malformed `workspace_excludes_files` (string, not list)
+
+```
+$ uv run ansible-playbook ... \
+    -e '{"workspace_excludes_files":"not-a-list"}' ...
+TASK [Assert workspace_excludes_files is a list] *****
+fatal: [esper-macmini]: FAILED! => {
+  "assertion": "workspace_excludes_files is not string",
+  "msg": "workspace_excludes_files must be a list"
+}
+PLAY RECAP: failed=1
+```
+
+Hermes-specific gate (openclaw + zeroclaw ship empty exclude lists
+and their playbooks don't inspect the payload) — pins that a missing
+or malformed exclude payload cannot silently degrade to "let every
+file through".
+
+## Cleanup
+
+```
+$ ssh xclm@espers-mac-mini.tailf7742d.ts.net 'rm -rf /Users/xclm/.hermes; ls /Users/xclm/.hermes 2>&1'
+ls: /Users/xclm/.hermes: No such file or directory
+```
+
+Host left in starting state. All local `/tmp/clawrium/staging/workspace/ws-hermes-*`
+staging dirs removed.
+
+## Gaps documented (Callouts on the PR)
+
+- **Live hermes daemon lifecycle on macOS** — `clawctl agent doctor`,
+  `clawctl agent stop`, `clawctl agent remove` cannot be exercised
+  here without running the full `clawctl agent create ws-hermes-mac
+  --type hermes --host esper-macmini` flow, which pulls in the upstream
+  hermes installer, the `[web,pty]` extras, the ui-tui Node bundle,
+  the launchd plist, and the bearer-auth handshake. None of those
+  layers are touched by this PR. The lifecycle-verb completeness
+  invariant (cross-issue ATX finding **B5**) is pinned for openclaw
+  by #770 on this same host; the contract is identical for hermes
+  once the upstream install actually runs to completion. Documented
+  here so reviewers can decide whether to track a follow-up to
+  smoke-test the full lifecycle on this Mac.
+- **`clawctl agent delete --yes ws-hermes-mac`** — not run because no
+  agent was created (this E2E uses the SSH proxy user `xclm`). The
+  synthetic `/Users/xclm/.hermes/` tree was wiped via `rm -rf` at the
+  end (see Cleanup).
+- **Workspace overlay sync from a real install** — the Phase 3 (#769)
+  Ubuntu E2E ran the full `clawctl agent sync ws-hermes --workspace-only`
+  flow against a freshly installed hermes daemon. The macOS counterpart
+  of that integration test would require the same upstream-install
+  prerequisites as above and is similarly deferred.

--- a/.itx/772/01_EXECUTION.md
+++ b/.itx/772/01_EXECUTION.md
@@ -1,0 +1,32 @@
+# Issue #772 — Execution Log
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-06-24T06:43:27Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx:execute 772 --pr-base=issue-771-zeroclaw-workspace-macos
+
+Operator directives (orchestrate parent #760, Phase 6 — final):
+- Use ATX via CLI only (`atx review --format json ...`). NOT MCP.
+- Real-host E2E target is `esper-macmini`
+  (espers-mac-mini.tailf7742d.ts.net, darwin/arm64).
+- This is Phase 6 (final). PR base =
+  `issue-771-zeroclaw-workspace-macos`.
+- Phase 4 (#799) and Phase 5 (#801) PRs are open but not yet merged;
+  expect their commits in your branch history.
+- This phase closes out the workspace-overlay macOS matrix; update
+  AGENTS.md hermes row to GA and add a CHANGELOG `[Unreleased]`
+  entry covering the macOS landing.
+
+Cross-issue ATX findings to incorporate (W3, W4, B5, W11/S5,
+hermes-specific full hostile-file set on darwin).
+```
+
+**Output**: Phase 6 playbook (real copy pipeline replacing the Phase-3
+`ansible.builtin.fail` stub) + unit/integration tests + AGENTS.md
+hermes row → GA + CHANGELOG `[Unreleased]` entry + E2E run log on
+esper-macmini.

--- a/.itx/772/atx-session.json
+++ b/.itx/772/atx-session.json
@@ -1,0 +1,14 @@
+{
+  "session_id": "858f3245-2e66-4138-a900-bc92b66eea2f",
+  "transport": "cli",
+  "commit_sha": "pending-iter-2-amend",
+  "iteration": 1,
+  "last_rating": 4,
+  "last_blockers": [],
+  "last_warnings": ["W1", "W2", "W3", "W4"],
+  "started_at": "2026-06-24T06:48:00Z",
+  "updated_at": "2026-06-24T06:58:10Z",
+  "duration_seconds": 546,
+  "cost_usd": 2.52,
+  "notes": "Iter-1: rating 4/5 — Approve with follow-up hardening. 0 blockers, 4 warnings, 8 suggestions. Recommended action: merge as-is. Addressing W1/W2/W3 in iter-2 amendment; W4 (mode regex setuid bits) + S1/S2/S3/S5/S6/S7/S8 captured as PR Callouts (parity ticket for openclaw/zeroclaw, documentation polish)."
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,7 +230,7 @@ Per-type destinations:
 |---|---|---|---|---|
 | openclaw | `~/.openclaw/workspace` | `/home/<name>/.openclaw/workspace` | `/Users/<name>/.openclaw/workspace` (#770) | No excludes — workspace zone is operator-owned. macOS GA via #770. |
 | zeroclaw | `~/.zeroclaw/workspace` | `/home/<name>/.zeroclaw/workspace` | `/Users/<name>/.zeroclaw/workspace` (#771) | No excludes — workspace dir holds operator memory files; canonical render writes elsewhere. Every sync also rotates the gateway bearer (#437); macOS GA via #771. |
-| hermes   | `~/.hermes` | `/home/<name>/.hermes` | macOS deferred (Phase 6) | Renderer-output paths excluded. Shares destination root with `core/render.py` output, `skills_apply.yaml` writes, and daemon state (SQLite + WAL companions). |
+| hermes   | `~/.hermes` | `/home/<name>/.hermes` | `/Users/<name>/.hermes` (#772) | Renderer-output paths excluded. Shares destination root with `core/render.py` output, `skills_apply.yaml` writes, and daemon state (SQLite + WAL companions). macOS GA via #772 — the per-file `workspace_excluded` Jinja filter applies identically on darwin and Linux. |
 
 Hermes excludes (manifest source of truth):
 
@@ -267,8 +267,9 @@ CLI flags on `clawctl agent sync`:
 
 Host-write path is **Ansible only** — per-agent
 `playbooks/workspace.yaml` (Linux) and `playbooks/workspace_macos.yaml`
-(macOS; openclaw is GA via #770, zeroclaw is GA via #771, hermes
-ships a deferred stub awaiting Phase 6). The Python side stages files into a
+(macOS; openclaw GA via #770, zeroclaw GA via #771, hermes GA via
+#772 — the workspace-overlay macOS matrix is complete). The Python
+side stages files into a
 managed `tempfile.TemporaryDirectory` under
 `${clawrium_config}/staging/workspace/<name>/` and passes the file
 list as the `workspace_files` extravar; ansible-runner reads the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,21 @@ cut. The `itx:release` skill archives this section into a new
   (`default`, `--workspace-only`, `--no-restart`) mints a fresh
   bearer and emits exactly one `gateway_token_rotated` event. The
   hermes macOS variant remains deferred to Phase 6.
+- hermes workspace overlay end-to-end on macOS (#772, Phase 6 of
+  #760 — final phase). The hermes `workspace_macos.yaml` playbook is
+  now a real copy pipeline rather than the Phase-3 deferral stub.
+  Files dropped under `~/.config/clawrium/agents/hermes/<name>/workspace/`
+  mirror onto darwin hosts at `/Users/<name>/.hermes/` on every
+  `clawctl agent sync` and `clawctl agent configure`. The full
+  hermes exclude list (`config.yaml`, `.env`, `auth.json`, `state.db`
+  + all three SQLite WAL companion files, `sessions/`, `logs/`,
+  `skills/clawrium/`) is enforced on darwin via the same per-file
+  `workspace_excluded` Jinja filter the Linux variant uses — the
+  adjacent `filter_plugins/clawrium_filters.py` is auto-discovered by
+  Ansible for both playbook variants, so the filter logic cannot
+  drift between Linux and macOS. This closes out the workspace-overlay
+  macOS matrix; all three GA agent types (openclaw, zeroclaw, hermes)
+  now support darwin hosts end-to-end.
 
 ### Changed
 

--- a/src/clawrium/platform/registry/hermes/playbooks/workspace_macos.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/workspace_macos.yaml
@@ -1,14 +1,252 @@
 ---
-# Stub playbook — hermes workspace overlay on macOS is deferred to
-# Phase 6 of parent #760 (issue #772). Single source of error surface:
-# the Ansible `fail:` task here. Python side does NOT short-circuit
-# darwin (W8/W9 iter-3); the dispatcher routes via
-# `core/playbook_resolver.resolve_agent_playbook` and the non-zero rc
-# surfaces as a `WorkspaceSyncError` in `core/workspace_sync.py` with
-# this `fail.msg` propagated.
+# Hermes workspace overlay — macOS variant (issue #772, Phase 6 of #760).
+# Mirrors operator-supplied files from the control-plane staging tree
+# onto the agent host under `workspace_dest_root` (declared in
+# hermes/manifest.yaml).
+#
+# The macOS playbook mirrors workspace.yaml's task structure with two
+# OS-specific deltas:
+#   (a) home-dir root is `/Users/<agent_name>/`, not `/home/<agent_name>/`
+#       (macOS user homes live under `/Users`).
+#   (b) `group: staff` is hardcoded instead of `group: "{{ agent_name }}"`
+#       (macOS does NOT create a per-user primary group like Linux does;
+#       every user's primary group is `staff` (gid 20) by default).
+# Reverting either delta to match Linux will fail at apply time on a
+# darwin host, so do not treat them as drift.
+#
+# Hermes is the only agent type with a non-empty exclude list. The
+# destination root `~/.hermes/` is shared with canonical-render output
+# (`.env`, `config.yaml`), reconciled skills under
+# `skills/clawrium/`, and the daemon's own SQLite state (`state.db`
+# + WAL companions). The exclude list reserves every one of those
+# paths. The Python enumerator already filters these before staging,
+# but this playbook re-filters per file against the exclude payload
+# as belt-and-suspenders so a bypass at the Python boundary cannot
+# overwrite renderer / daemon-managed files (hook-review S, plan U5).
+#
+# Per-file filtering is enforced via the `workspace_excluded` Jinja
+# filter (filter_plugins/clawrium_filters.py) — NOT via a directory-
+# level `find … exclude:` pattern. A directory-level pattern would let
+# `skills/clawrium/<sub>/SKILL.md` slip through via tree-walk shortcuts.
+# Ansible auto-discovers the adjacent `filter_plugins/` directory, so
+# the same plugin file serves both `workspace.yaml` (Linux) and this
+# macOS variant — no separate plugin copy required.
+#
+# The dispatcher in `core/playbook_resolver.resolve_agent_playbook`
+# routes to this file when `host.os_family == "darwin"` (#772).
+#
+# Inputs (extravars): same shape as workspace.yaml — see that file for
+# the contract. The Python side at `core/workspace_sync.py` expands
+# `destination_root` against `/Users/<agent_name>` for darwin hosts so
+# the rendered `workspace_dest_root` already begins with `/Users/...`.
+#
+# Why no `ansible_user_dir` (B1 iter-3): `become_user` does NOT re-run
+# the `setup` module, so `ansible_user_dir` keeps the SSH-connecting
+# user's home (`/Users/xclm`), not the agent user's. The literal
+# `/Users/{{ agent_name }}/...` pattern mirrors what
+# `openclaw/playbooks/workspace_macos.yaml` and
+# `zeroclaw/playbooks/workspace_macos.yaml` already use.
 - hosts: all
+  become: yes
+  become_user: "{{ agent_name }}"
   gather_facts: false
   tasks:
-    - name: hermes workspace overlay deferred to macOS subtask
-      ansible.builtin.fail:
-        msg: "hermes workspace overlay deferred to macOS subtask (#772)"
+    - name: Assert agent_name matches the safe slug pattern
+      ansible.builtin.assert:
+        that:
+          - agent_name is string
+          - agent_name is match('^[a-z][a-z0-9_-]{0,31}$')
+        fail_msg: "Invalid agent_name: {{ agent_name | default('<unset>') }}"
+        quiet: true
+
+    - name: Assert workspace_dest_root is under /Users/{{ agent_name }}/
+      # B1 iter-3 backstop, macOS variant: the manifest is the source of
+      # truth, but a tampered extravar pointing at e.g. `/etc/hermes`
+      # must bail before any copy task runs. The `..` rejection (mirrors
+      # openclaw + zeroclaw macOS ATX iter-1 W1) blocks
+      # `/Users/<name>/../../etc/hermes` from passing the prefix check
+      # via path traversal — Python-side `_expand_destination_root` does
+      # string concatenation only and does not call `os.path.normpath`.
+      ansible.builtin.assert:
+        that:
+          - workspace_dest_root is string
+          - workspace_dest_root | length > 0
+          - workspace_dest_root.startswith('/Users/' ~ agent_name ~ '/')
+          - "'..' not in workspace_dest_root.split('/')"
+        fail_msg: >-
+          workspace_dest_root must start with `/Users/{{ agent_name }}/`
+          and contain no `..` segments
+          (got '{{ workspace_dest_root | default('<unset>') }}')
+        quiet: true
+
+    - name: Assert staging_dir is a non-empty absolute path under the clawrium staging tree
+      # ATX iter-2 S_NEW_4 (carried forward from Linux hermes/workspace.yaml):
+      # after S6 switched the copy task to read `item.src` (the absolute
+      # staged path computed Python-side), `staging_dir` is no longer
+      # consumed by the copy task. This assert remains the structural
+      # anchor: the per-file `item.src` assert below pins each entry's
+      # source to live under `staging_dir + '/'`. Dropping this assert
+      # without also dropping the per-file pin would weaken the
+      # defense-in-depth posture — keep both or remove both, do not
+      # split them.
+      ansible.builtin.assert:
+        that:
+          - staging_dir is string
+          - staging_dir | length > 0
+          - staging_dir.startswith('/')
+          - "'/clawrium/staging/workspace/' in staging_dir"
+        fail_msg: >-
+          staging_dir must be an absolute path under
+          `${clawrium_config}/staging/workspace/` (got '{{ staging_dir }}')
+        quiet: true
+
+    - name: Assert workspace_files is a list
+      ansible.builtin.assert:
+        that:
+          - workspace_files is iterable
+          - workspace_files is not string
+          - workspace_files is not mapping
+        fail_msg: "workspace_files must be a list"
+        quiet: true
+
+    - name: Assert workspace_excludes_files is a list
+      # Hermes-specific: the per-file exclude filter below depends on
+      # this var being present and shaped as a list. A missing or
+      # malformed exclude payload would silently let every file through.
+      ansible.builtin.assert:
+        that:
+          - workspace_excludes_files is iterable
+          - workspace_excludes_files is not string
+          - workspace_excludes_files is not mapping
+        fail_msg: "workspace_excludes_files must be a list"
+        quiet: true
+
+    - name: Assert workspace_excludes_dirs is a list
+      ansible.builtin.assert:
+        that:
+          - workspace_excludes_dirs is iterable
+          - workspace_excludes_dirs is not string
+          - workspace_excludes_dirs is not mapping
+        fail_msg: "workspace_excludes_dirs must be a list"
+        quiet: true
+
+    - name: Assert each workspace file entry is a relative path and well-formed mode
+      # W12 iter-2 belt-and-suspenders: even if Python enumeration filters
+      # symlinks/traversal, this re-asserts inside the playbook so a future
+      # bypass cannot land hostile paths on host.
+      # Mirrors openclaw/zeroclaw macOS ATX iter-1 W6 (security-reviewer):
+      # pin `item.mode` to the octal string shape `_floor_mode_for` emits
+      # — if that helper regresses or a hostile extravar is injected, the
+      # playbook would otherwise write whatever string it's given to `mode:`.
+      ansible.builtin.assert:
+        that:
+          - item.rel is string
+          - item.rel | length > 0
+          - not item.rel.startswith('/')
+          - "'..' not in (item.rel.split('/'))"
+          - item.mode is string
+          - item.mode is match('^0[0-7]{3,4}$')
+        fail_msg: >-
+          workspace file entry has unsafe rel or mode: rel='{{ item.rel | default('<unset>') }}',
+          mode='{{ item.mode | default('<unset>') }}'
+        quiet: true
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel | default('<unset>') }}"
+
+    - name: Assert each workspace file entry's src lives under staging_dir
+      # ATX iter-2 S_NEW_1 (carried forward from Linux hermes/workspace.yaml):
+      # after S6 switched the copy task to read `item.src` (the absolute
+      # staged path computed Python-side), the implicit containment binding
+      # that `{{ staging_dir }}/{{ item.rel }}` carried was lost. Without
+      # this per-file assert, a future regression in `_stage_files` — or
+      # any caller injecting `workspace_files` extravars — could set
+      # `item.src` to an arbitrary absolute path (e.g.
+      # `/Users/<ssh_user>/.ssh/id_rsa`) and Ansible would copy it without
+      # complaint. This re-anchors the playbook-side guarantee that the
+      # staged source lives under the asserted `staging_dir`, regardless
+      # of how Python computes `entry.src` in the future.
+      ansible.builtin.assert:
+        that:
+          - item.src is string
+          - item.src | length > 0
+          - item.src.startswith(staging_dir ~ '/')
+          - "'..' not in (item.src.split('/'))"
+        fail_msg: >-
+          workspace file entry has unsafe src: '{{ item.src | default('<unset>') }}'
+          (must start with '{{ staging_dir }}/')
+        quiet: true
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel | default('<unset>') }}"
+
+    - name: Ensure workspace destination root exists
+      # `follow: no` so a pre-existing symlink at `workspace_dest_root`
+      # (pointing at e.g. `~/.ssh`) is not followed when `chown`/`chmod`
+      # apply. Same-user blast radius (become_user is agent_name) but
+      # inverts the documented defense-in-depth posture for symlink
+      # handling. Mirrors openclaw/zeroclaw macOS ATX iter-1 W2.
+      ansible.builtin.file:
+        path: "{{ workspace_dest_root }}"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: staff
+        mode: "0755"
+        follow: no
+
+    - name: Ensure parent directories exist for each non-excluded workspace file
+      # The `workspace_excluded` filter mirrors
+      # `clawrium.core.workspace_sync._is_excluded`. Mirroring this filter
+      # on parent-dir creation avoids spawning empty `sessions/` or
+      # `logs/` shells for files that will subsequently be filtered out
+      # by the copy task. `follow: no` for the same reason as the
+      # dest-root task above.
+      ansible.builtin.file:
+        path: "{{ workspace_dest_root }}/{{ item.rel | dirname }}"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: staff
+        mode: "0755"
+        follow: no
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel }}"
+      when:
+        - item.rel | dirname | length > 0
+        - not (item.rel | workspace_excluded(workspace_excludes_files, workspace_excludes_dirs))
+
+    - name: Push each non-excluded workspace file onto the host
+      # `copy` writes to a tempfile in the dest dir and renames atomically.
+      # `follow: no` is the W12 iter-2 / W18 iter-2 symlink defense: even
+      # though Python enumerates with `os.path.islink` filtering and stages
+      # via `shutil.copy2` into a managed `tempfile.TemporaryDirectory`,
+      # the playbook re-asserts the no-symlink invariant at the copy boundary.
+      #
+      # The `when` clause is the per-file exclude filter described above —
+      # a tampered enumeration that smuggled `state.db` through Python
+      # still bails here. A `WorkspaceExcluded` NDJSON event is emitted
+      # Python-side at enumeration; the playbook itself silently drops
+      # late arrivals (TOCTOU bound) so the operator-facing event log
+      # is the canonical record.
+      ansible.builtin.copy:
+        # ATX iter-1 S6 (carried forward from Linux hermes/workspace.yaml):
+        # use `item.src` (absolute staged path computed by
+        # `core/workspace_sync.py:_stage_files`) rather than reconstructing
+        # `{{ staging_dir }}/{{ item.rel }}` inline. Today both expressions
+        # are byte-equivalent because `_stage_files` writes to exactly
+        # `staging_dir / entry.rel`, but a future refactor (e.g. flattening
+        # or hashing staged names to dodge case-insensitive collisions on
+        # macOS) would silently desync these two paths if the playbook kept
+        # recomputing. The Python side stays the single source of truth
+        # for the staged source path.
+        src: "{{ item.src }}"
+        dest: "{{ workspace_dest_root }}/{{ item.rel }}"
+        owner: "{{ agent_name }}"
+        group: staff
+        mode: "{{ item.mode }}"
+        follow: no
+      loop: "{{ workspace_files }}"
+      loop_control:
+        label: "{{ item.rel }}"
+      when:
+        - not (item.rel | workspace_excluded(workspace_excludes_files, workspace_excludes_dirs))

--- a/tests/test_workspace_sync.py
+++ b/tests/test_workspace_sync.py
@@ -393,8 +393,9 @@ def _macos_playbook_non_comment_body(agent_type: str = "openclaw") -> str:
 
     #771 (Phase 5): `agent_type` parameter added so the same
     invariants below are pinned for both openclaw and zeroclaw on
-    macOS. Hermes is intentionally excluded — its macOS variant is
-    still a deferred stub (Phase 6).
+    macOS. #772 (Phase 6): hermes joined the GA matrix once its
+    `workspace_macos.yaml` stub was replaced with the real copy
+    pipeline.
     """
     from clawrium.core.playbook_resolver import resolve_agent_playbook
 
@@ -402,10 +403,10 @@ def _macos_playbook_non_comment_body(agent_type: str = "openclaw") -> str:
     return "\n".join(line.split("#", 1)[0] for line in body.splitlines())
 
 
-# Parametrized over both agent types whose macOS workspace overlay is
-# GA: openclaw (#770) and zeroclaw (#771). Hermes joins this matrix in
-# Phase 6 (#772).
-_MACOS_GA_AGENT_TYPES = ("openclaw", "zeroclaw")
+# Parametrized over every agent type whose macOS workspace overlay is
+# GA: openclaw (#770), zeroclaw (#771), and hermes (#772, Phase 6 of
+# #760 — closes out the macOS row of the matrix).
+_MACOS_GA_AGENT_TYPES = ("openclaw", "zeroclaw", "hermes")
 
 
 @pytest.mark.parametrize("agent_type", _MACOS_GA_AGENT_TYPES)
@@ -769,6 +770,245 @@ def test_push_workspace_phase_threads_os_family_to_darwin_zeroclaw(
     assert extravars["staging_dir"].startswith(str(tmp_path))
 
 
+def test_push_workspace_phase_threads_os_family_to_darwin_hermes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#772 (Phase 6) — hermes on macOS mirror of the
+    `test_push_workspace_phase_threads_os_family_to_darwin_zeroclaw`
+    test. `push_workspace_phase` MUST:
+
+      1. Route to `hermes/playbooks/workspace_macos.yaml`.
+      2. Expand the rendered destination under `/Users/<agent>/.hermes`
+         (NO `workspace/` suffix — hermes overlays directly under
+         `~/.hermes/` because it shares the destination with canonical
+         render output).
+      3. Thread the FULL hermes excludes payload through to the
+         playbook extravars. Mixing in openclaw / zeroclaw excludes
+         (both empty) or dropping any hermes entry would silently let
+         hostile drops reach the daemon's SQLite WAL or the renderer's
+         `.env` / `config.yaml` outputs.
+
+    Stages a nested-rel file as well (`subdir/NESTED.md`) to exercise
+    the `when: dirname | length > 0` gate on the parent-directory task
+    in `workspace_macos.yaml` (mirrors ATX iter-1 S3 from #771).
+    """
+    monkeypatch.setattr(
+        "clawrium.core.workspace_sync.get_config_dir", lambda: tmp_path
+    )
+    fake_key = tmp_path / "fake.pem"
+    fake_key.write_text("")
+    monkeypatch.setattr(
+        "clawrium.core.keys.get_host_private_key",
+        lambda _key_id: str(fake_key),
+    )
+
+    ws = tmp_path / "agents" / "hermes" / "alice" / "workspace"
+    ws.mkdir(parents=True)
+    (ws / "profiles" / "coder").mkdir(parents=True)
+    (ws / "profiles" / "coder" / "SOUL.md").write_text("you are senior staff")
+    (ws / "memories").mkdir()
+    (ws / "memories" / "NOTES.md").write_text("dad joke")
+
+    captured: dict[str, Any] = {}
+
+    class _StubResult:
+        status = "successful"
+        rc = 0
+
+    class _StubRunner:
+        def run(self, **kwargs: Any) -> _StubResult:
+            captured["playbook"] = kwargs.get("playbook")
+            captured["extravars"] = kwargs.get("extravars")
+            return _StubResult()
+
+    monkeypatch.setitem(
+        __import__("sys").modules, "ansible_runner", _StubRunner()
+    )
+
+    from clawrium.core.workspace_sync import push_workspace_phase
+
+    result = push_workspace_phase(
+        host={
+            "hostname": "esper-macmini.example",
+            "key_id": "esper-macmini.example",
+            "os_family": "darwin",
+        },
+        agent_type="hermes",
+        agent_name="alice",
+    )
+    assert result.success is True, result.error
+    assert set(result.files_pushed) == {
+        "memories/NOTES.md",
+        "profiles/coder/SOUL.md",
+    }
+
+    # Dispatcher routed to the hermes macOS playbook (not openclaw /
+    # zeroclaw, and not the Linux variant).
+    assert captured["playbook"].endswith("workspace_macos.yaml"), captured[
+        "playbook"
+    ]
+    assert "/hermes/playbooks/" in captured["playbook"], captured["playbook"]
+
+    extravars = captured["extravars"]
+    # Expansion used the darwin home root AND the hermes destination
+    # (no `workspace/` suffix — overlay sits directly under `~/.hermes`).
+    assert extravars["workspace_dest_root"] == "/Users/alice/.hermes"
+    files = extravars["workspace_files"]
+    assert len(files) == 2
+    rels = {f["rel"] for f in files}
+    assert rels == {"memories/NOTES.md", "profiles/coder/SOUL.md"}
+    # ATX iter-2 W4 mirror: pin every extravar the downstream playbook
+    # consumes. Critically for hermes: the FULL excludes payload — a
+    # regression that dropped any single entry (or mixed in openclaw's
+    # empty list) opens an exfiltration / corruption channel.
+    assert extravars["agent_name"] == "alice"
+    assert extravars["agent_type"] == "hermes"
+    assert extravars["staging_dir"].startswith(str(tmp_path))
+    assert set(extravars["workspace_excludes_files"]) == {
+        "config.yaml",
+        ".env",
+        "auth.json",
+        "state.db",
+        "state.db-journal",
+        "state.db-wal",
+        "state.db-shm",
+    }
+    assert set(extravars["workspace_excludes_dirs"]) == {
+        "sessions",
+        "logs",
+        "skills/clawrium",
+    }
+
+
+def test_push_workspace_phase_hermes_darwin_filters_full_hostile_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ATX iter-1 W2 fix: companion to
+    `test_push_workspace_phase_threads_os_family_to_darwin_hermes` —
+    stage the FULL hostile-file set (every entry in the hermes manifest
+    exclude list, including all three SQLite WAL companions and the
+    `skills/clawrium/` dir-prefix) into the hermes/<agent> workspace
+    slot under a darwin host record, and assert NONE of them surface
+    in `result.files_pushed` or `extravars['workspace_files']`.
+
+    The Python-side `_is_excluded` filter is shared with the Linux
+    path and covered by `test_workspace_hermes_excludes.py::test_i3_...`
+    at the enumerator layer. This test extends the coverage one layer
+    up — through `push_workspace_phase` on a darwin host — so a
+    regression that smuggled an exclude bypass into a darwin-only
+    enumerator branch would fail here, not just on a live mac.
+
+    A good file (`profiles/coder/SOUL.md`) is staged alongside the
+    hostile set so we can also assert positive landing on the same
+    darwin path in the same run (catches the inverse regression:
+    over-eager filter that drops legitimate drops on macOS too).
+    """
+    monkeypatch.setattr(
+        "clawrium.core.workspace_sync.get_config_dir", lambda: tmp_path
+    )
+    fake_key = tmp_path / "fake.pem"
+    fake_key.write_text("")
+    monkeypatch.setattr(
+        "clawrium.core.keys.get_host_private_key",
+        lambda _key_id: str(fake_key),
+    )
+
+    ws = tmp_path / "agents" / "hermes" / "alice" / "workspace"
+    ws.mkdir(parents=True)
+    # Good file (positive control).
+    (ws / "profiles" / "coder").mkdir(parents=True)
+    (ws / "profiles" / "coder" / "SOUL.md").write_text("you are senior staff")
+    # Full hostile set — every entry from
+    # `WorkspaceOverlaySpec.from_manifest('hermes')`.
+    (ws / "config.yaml").write_text("MALICIOUS: overwrites canonical render")
+    (ws / ".env").write_text("MALICIOUS_KEY=stolen")
+    (ws / "auth.json").write_text('{"malicious": true}')
+    (ws / "state.db").write_text("MALICIOUS-DB")
+    (ws / "state.db-journal").write_text("MALICIOUS-JOURNAL")
+    (ws / "state.db-wal").write_text("MALICIOUS-WAL")
+    (ws / "state.db-shm").write_text("MALICIOUS-SHM")
+    (ws / "sessions").mkdir()
+    (ws / "sessions" / "123.json").write_text('{"malicious_session": true}')
+    (ws / "logs").mkdir()
+    (ws / "logs" / "gateway.log").write_text("MALICIOUS-LOG")
+    (ws / "skills" / "clawrium" / "tdd").mkdir(parents=True)
+    (ws / "skills" / "clawrium" / "tdd" / "SKILL.md").write_text(
+        "MALICIOUS-SKILL"
+    )
+
+    captured: dict[str, Any] = {}
+
+    class _StubResult:
+        status = "successful"
+        rc = 0
+
+    class _StubRunner:
+        def run(self, **kwargs: Any) -> _StubResult:
+            captured["playbook"] = kwargs.get("playbook")
+            captured["extravars"] = kwargs.get("extravars")
+            return _StubResult()
+
+    monkeypatch.setitem(
+        __import__("sys").modules, "ansible_runner", _StubRunner()
+    )
+
+    from clawrium.core.workspace_sync import push_workspace_phase
+
+    result = push_workspace_phase(
+        host={
+            "hostname": "esper-macmini.example",
+            "key_id": "esper-macmini.example",
+            "os_family": "darwin",
+        },
+        agent_type="hermes",
+        agent_name="alice",
+    )
+    assert result.success is True, result.error
+
+    # Positive control: the good file lands.
+    assert result.files_pushed == ("profiles/coder/SOUL.md",)
+
+    # Every hostile entry is in `excluded`, NOT in `files_pushed`.
+    expected_excluded = {
+        "config.yaml",
+        ".env",
+        "auth.json",
+        "state.db",
+        "state.db-journal",
+        "state.db-wal",
+        "state.db-shm",
+        "sessions/123.json",
+        "logs/gateway.log",
+        "skills/clawrium/tdd/SKILL.md",
+    }
+    assert expected_excluded.issubset(set(result.files_excluded)), (
+        f"hermes/darwin exclude leak: {expected_excluded - set(result.files_excluded)}"
+    )
+    assert not (expected_excluded & set(result.files_pushed)), (
+        f"hermes/darwin push leak: hostile file(s) reached files_pushed: "
+        f"{expected_excluded & set(result.files_pushed)}"
+    )
+
+    # Same property at the extravar payload layer — the playbook never
+    # sees the hostile rels at all (defense-in-depth: even if a future
+    # regression let them through Python's exclude check, the playbook's
+    # per-file `workspace_excluded` `when:` clause is the second gate;
+    # we want to know the FIRST gate is holding here).
+    extravar_rels = {f["rel"] for f in captured["extravars"]["workspace_files"]}
+    assert extravar_rels == {"profiles/coder/SOUL.md"}, (
+        f"hermes/darwin extravar leak: hostile rel(s) reached the playbook: "
+        f"{extravar_rels - {'profiles/coder/SOUL.md'}}"
+    )
+
+    # Dispatcher and home-root expansion still correct (smoke-pin in
+    # case the hostile-fixture branch silently routed somewhere else).
+    assert captured["playbook"].endswith("workspace_macos.yaml")
+    assert "/hermes/playbooks/" in captured["playbook"]
+    assert (
+        captured["extravars"]["workspace_dest_root"] == "/Users/alice/.hermes"
+    )
+
+
 def test_push_workspace_phase_empty_zeroclaw_overlay_darwin_noop(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -931,10 +1171,12 @@ def test_hermes_workspace_playbook_filters_excludes_per_file() -> None:
     assert "ansible.builtin.find" not in non_comment_body
 
 
-def test_hermes_workspace_macos_stub_present() -> None:
-    """U12 / U22 (hermes subset, #769) — both Linux and macOS variants
-    exist on disk for hermes, mirroring the openclaw and zeroclaw pair.
-    The darwin variant is a deferred-to-Phase-6 stub that fails loudly."""
+def test_hermes_workspace_macos_playbook_present_and_real() -> None:
+    """U12 / U22 (hermes subset, #769 + #772 Phase 6) — both Linux and
+    macOS variants exist on disk for hermes, mirroring the openclaw and
+    zeroclaw pair. After #772 the darwin variant is a real copy pipeline
+    (not the Phase-3 `ansible.builtin.fail` stub).
+    """
     from clawrium.core.playbook_resolver import resolve_agent_playbook
 
     linux_path = resolve_agent_playbook("hermes", "workspace", "linux")
@@ -945,10 +1187,66 @@ def test_hermes_workspace_macos_stub_present() -> None:
     darwin_path = resolve_agent_playbook("hermes", "workspace", "darwin")
     assert darwin_path.name == "workspace_macos.yaml"
     assert darwin_path.exists()
-    # Stub body: ansible.builtin.fail with a deferral message.
     body = darwin_path.read_text()
-    assert "ansible.builtin.fail" in body
-    assert "deferred" in body.lower()
+    non_comment = "\n".join(line.split("#", 1)[0] for line in body.splitlines())
+    # Real playbook — no `ansible.builtin.fail`-as-stub anymore. The
+    # stub deferral message is gone.
+    assert "deferred to macOS subtask" not in body
+    # Copy task is the real channel, not a `fail:` placeholder.
+    assert "ansible.builtin.copy" in non_comment
+    assert "follow: no" in non_comment
+    # ATX iter-1 W3 fix: the renamed test dropped the previous
+    # `"ansible.builtin.fail" in body` stub-detection assertion. Replace
+    # it with the inverse: a half-stub regression (real `copy` task PLUS
+    # a leftover `ansible.builtin.fail` with a different message) would
+    # have passed every other assertion above without this guard. The
+    # real playbook has zero `fail:` tasks, so this assertion is safe.
+    assert "ansible.builtin.fail" not in non_comment
+
+
+def test_hermes_workspace_macos_playbook_filters_excludes_per_file() -> None:
+    """#772 (Phase 6) — the hermes macOS playbook MUST re-apply exclude
+    semantics per file via the same `workspace_excluded` Jinja filter
+    used by the Linux variant. A directory-level `find … exclude:`
+    pattern would let `skills/clawrium/<sub>/SKILL.md` slip through
+    tree-walk shortcuts (hook-review S — platform-playbooks).
+
+    Without this per-file `when:` guard, a tampered Python enumeration
+    that smuggled `state.db` (or any other exclude entry) into
+    `workspace_files` would land it on the darwin host's `~/.hermes/`
+    and corrupt the SQLite WAL silently.
+    """
+    body = _macos_playbook_non_comment_body("hermes")
+    # ATX iter-1 W1 fix: the filter MUST appear in BOTH `when:` clauses
+    # — the parent-dir creation task AND the copy task. A regression
+    # that dropped the filter from only the parent-dir task (leaving
+    # it on the copy task) would silently create empty `sessions/`,
+    # `logs/`, `skills/clawrium/` shell dirs on the host before
+    # skipping the file copy, leaking the directory structure of
+    # excluded paths even when the file content stays filtered.
+    occurrences = body.count(
+        "workspace_excluded(workspace_excludes_files, workspace_excludes_dirs)"
+    )
+    assert occurrences >= 2, (
+        f"hermes macOS playbook must call workspace_excluded(...) in BOTH "
+        f"`when:` clauses (parent-dir creation + copy task); found "
+        f"{occurrences} occurrence(s). Dropping the filter from either "
+        f"`when:` clause is a release blocker."
+    )
+    assert "ansible.builtin.find" not in body
+
+
+def test_hermes_workspace_macos_playbook_asserts_excludes_payload_is_list() -> None:
+    """#772 (Phase 6) — the hermes-specific exclude-payload assert tasks
+    MUST appear in the macOS variant too. A missing or malformed
+    `workspace_excludes_files` / `workspace_excludes_dirs` extravar
+    would silently let every file through the per-file filter (the
+    filter's `(excludes_files or [])` fallback evaluates a non-list to
+    the empty list).
+    """
+    body = _macos_playbook_non_comment_body("hermes")
+    assert "workspace_excludes_files must be a list" in body
+    assert "workspace_excludes_dirs must be a list" in body
 
 
 def test_hermes_workspace_filter_plugin_mirrors_core_is_excluded() -> None:


### PR DESCRIPTION
## Summary

Phase 6 (final) of #760 — ships hermes workspace overlay end-to-end on macOS and closes out the workspace-overlay macOS matrix (openclaw #770, zeroclaw #771, hermes #772).

- Replaces the Phase-3 `ansible.builtin.fail` stub in `src/clawrium/platform/registry/hermes/playbooks/workspace_macos.yaml` with a real copy pipeline mirroring `hermes/workspace.yaml` (Linux) + the macOS deltas from `zeroclaw/playbooks/workspace_macos.yaml` (`/Users/<agent_name>/` prefix, `group: staff`, `..` rejection, mode regex pinning, `follow: no` on all `file`/`copy` tasks).
- Hermes-specific (no openclaw/zeroclaw counterpart): the per-file `workspace_excluded` Jinja `when:` clause is wired into BOTH the parent-dir creation task AND the copy task, exclude-payload list-shape asserts are present, and per-file `item.src` containment under `staging_dir` is enforced (ATX iter-2 S_NEW_1 carry-over from Linux hermes). The adjacent `playbooks/filter_plugins/clawrium_filters.py` is auto-discovered by Ansible for both Linux and macOS variants, so the filter logic cannot drift between dispatch paths.
- AGENTS.md hermes row updated to GA via #772; matrix marked complete. CHANGELOG `[Unreleased] / ### Added` entry covering the macOS landing.

Stacked on top of `issue-771-zeroclaw-workspace-macos` (#801 — Phase 5). Merging is bottom-up.

## Testing

### Test Results
- [x] All existing tests pass (`make test`): **3948 passed, 8 skipped**.
- [x] Linter passes (`make lint-py`): `All checks passed!`.
- [x] New tests added for new functionality (5 new + 1 renamed):
  - `test_hermes_workspace_macos_playbook_present_and_real` (renamed from `_stub_present`, asserts real copy pipeline)
  - `test_hermes_workspace_macos_playbook_filters_excludes_per_file` (per-file filter present in BOTH `when:` clauses — ATX iter-1 W1 fix)
  - `test_hermes_workspace_macos_playbook_asserts_excludes_payload_is_list` (hermes-specific list-shape asserts)
  - `test_push_workspace_phase_threads_os_family_to_darwin_hermes` (darwin-routing integration test with full hermes excludes payload)
  - `test_push_workspace_phase_hermes_darwin_filters_full_hostile_set` (full hostile-set integration — ATX iter-1 W2 fix)
  - Plus: hermes added to `_MACOS_GA_AGENT_TYPES` so all 4 parametrized macOS structural tests now run against hermes too.

### Test Coverage
- Files changed: see `git diff --stat` below.
- New tests: in `tests/test_workspace_sync.py` (no new test files).
- Coverage impact: increased (hermes/darwin path was previously stub-only).

### Manual Testing — E2E on `esper-macmini`

Full transcript: [`.itx/760/07_E2E_hermes_esper-macmini.md`](.itx/760/07_E2E_hermes_esper-macmini.md).

Eight scenarios run against `espers-mac-mini.tailf7742d.ts.net` (darwin/arm64, macOS 26.5.1), all green:

1. **Happy path** — nested good files land at `/Users/xclm/.hermes/profiles/coder/SOUL.md` and `/Users/xclm/.hermes/memories/NOTES.md` with `xclm:staff` ownership and `0644` mode.
2. **Full 10-entry hostile-file set** — `config.yaml`, `.env`, `auth.json`, `state.db` + 3 WAL companions, `sessions/123.json`, `logs/gateway.log`, `skills/clawrium/tdd/SKILL.md` all filtered by the per-file `when:` clause; zero leak on host (verified via post-run `ls -la /Users/xclm/.hermes/`).
3. **Tampered `workspace_dest_root` outside `/Users/<agent>/`** — assert task rejects (B1 iter-3 backstop, macOS variant).
4. **Path traversal in `workspace_dest_root`** — assert task rejects (`..` segment check).
5. **Invalid `item.mode`** — assert task rejects non-octal mode strings.
6. **Path traversal in `item.rel`** — assert task rejects.
7. **`item.src` outside `staging_dir`** — assert task rejects (ATX iter-2 S_NEW_1 carry-over).
8. **Malformed `workspace_excludes_files`** (string instead of list) — hermes-specific gate rejects.

### Security Checklist
- [x] No hardcoded secrets or credentials.
- [x] Input validation: `agent_name` slug regex, `workspace_dest_root` prefix + `..` rejection, `item.rel` traversal rejection, `item.src` staging-dir containment, `item.mode` octal regex pinning, exclude-payload list-shape asserts.
- [x] No SQL injection, XSS, or command injection risks (Ansible's `copy`/`file` modules do not invoke a shell — see Callout [DECISION] below on the slug regex threat-model framing).
- [x] Dependencies are from trusted sources (no new deps).

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $2.52 | Total Time: 9m 6s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 4/5 | None | Approved | $2.52 | 9m6s | platform-playbooks (5/5), security-reviewer (4/5), test-coverage (4/5) |

> Recommendation from reviewer: **"Merge as-is for Phase 6 close-out. No blockers."** W1/W2/W3 addressed inline in this same PR (test-only changes; tightened invariants without changing production behavior). W4 + suggestions captured as Callouts below.

<details>
<summary>Review 1 Details (Rating 4/5)</summary>

**Blocking Issues:** None.

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `tests/test_workspace_sync.py` | Per-file filter structural test asserts substring exists "anywhere" but the filter MUST appear in both `when:` clauses (parent-dir + copy). A regression dropping it from only the parent-dir task would silently create empty `sessions/` / `logs/` / `skills/clawrium/` shell dirs on host. | **Fixed inline** — assertion now `body.count(...) >= 2` with a release-blocker comment. |
| W2 | `tests/test_workspace_sync.py` | `test_push_workspace_phase_threads_os_family_to_darwin_hermes` stages only benign files; Python-side `_is_excluded` filter not exercised for hermes-on-darwin at the integration layer. | **Fixed inline** — added `test_push_workspace_phase_hermes_darwin_filters_full_hostile_set` that stages all 10 hostile entries + 1 positive control under `agents/hermes/alice/workspace/` and asserts `expected_excluded ⊆ result.files_excluded` AND `expected_excluded ∩ result.files_pushed == ∅` AND zero hostile rels reach `extravars['workspace_files']`. |
| W3 | `tests/test_workspace_sync.py` | Renamed `_stub_present` → `_present_and_real` test dropped the previous `"ansible.builtin.fail" in body` assertion without replacement. A half-stub (real `copy` task + leftover `fail:` with a different message) would pass every other assertion. | **Fixed inline** — added `assert "ansible.builtin.fail" not in non_comment`. |
| W4 | `workspace_macos.yaml: per-file rel/mode assert` | Mode regex `^0[0-7]{3,4}$` accepts 5-char strings (`04755`, `02755`) permitting s-bits on workspace files. No legitimate use case for setuid/setgid on overlay files. | **Captured as Callout [TODO-FOLLOWUP]** — tightening to `^0[0-7]{3}$` is a parity cleanup spanning all three agents' Linux + macOS playbooks (6 files + matching unit tests). Filed separately to avoid scope creep onto openclaw/zeroclaw within Phase 6. |

**Suggestions (all captured as Callouts):**

| # | Domain | Suggestion |
|---|--------|------------|
| S1 | platform-playbooks | Backport macOS hardenings (`..` rejection, `item.mode` regex pin, `follow: no`) to Linux `workspace.yaml`. |
| S2 | security-reviewer | Add symlink-in-staging comment to `item.src` containment assert. |
| S3 | security-reviewer | Document parent-dir `mode: 0755` widening behavior or clarify intent. |
| S4 | security-reviewer | Confirm E2E Test 2 daemon state. **Addressed inline** — added explicit "no live daemon" note to `.itx/760/07_E2E_hermes_esper-macmini.md` Test 2 section. |
| S5 | test-coverage | Add explicit `test_workspace_overlay_specs_per_type_are_distinct` test. |
| S6 | test-coverage | Stage a flat-file (`dirname == 0`) in the hermes darwin integration test. |
| S7 | platform-playbooks | Align task names across Linux and macOS playbooks. |
| S8 | security-reviewer | Fix threat-model framing on slug regex (no shell invocation in `copy`/`file`). |

</details>

## Reviewer Notes

This is the **final phase** of #760. After merge, the workspace-overlay macOS matrix is complete:

| Agent | Linux | macOS |
|---|---|---|
| openclaw | GA (Phase 1) | GA (#770) |
| zeroclaw | GA (#768) | GA (#771) |
| hermes | GA (#769) | **GA (this PR, #772)** |

## Callouts

- **[DECISION] Skipped the live `clawctl agent create ws-hermes-mac --type hermes --host esper-macmini` flow on macOS.**
  - **Why:** The hermes manifest declares a macOS arm64 platform entry, but the upstream installer chain (clones repo, builds the ui-tui Node bundle, installs `[web,pty]` extras via uv, drops the launchd plist, runs the bearer-auth handshake) is heavy enough that running it purely to exercise the workspace-overlay phase trades a 10-second narrow test for a 5+ minute end-to-end run that also pulls in dashboard prerequisites, the venv reconciler, and the plist. None of those layers are touched by this PR.
  - **Alternatives considered:** Phase 4 (#770) and Phase 5 (#771) on this same host used the same approach (direct `ansible-playbook` against the workspace playbook with proxy user `xclm`). Matching their shape keeps the E2E surface comparable across phases.
  - **Reviewer:** confirm or push back.

- **[UNRESOLVED — captured as ATX W4 follow-up] Mode regex `^0[0-7]{3,4}$` permits setuid/setgid bits.**
  - **Best guess applied:** Kept the existing regex shape (carried forward from zeroclaw_macos in #771) to avoid changing openclaw/zeroclaw behavior inside a hermes phase. The tightening to `^0[0-7]{3}$` is a parity cleanup across 6 files (3 agents × 2 OS variants) plus matching unit tests.
  - **Reviewer:** please file a follow-up issue to land the regex tightening as a single parity ticket (#760 isn't the right home now that all 6 phases are merged).

- **[UNRESOLVED — captured as ATX B5 follow-up] Lifecycle verbs (`stop`, `remove`) on macOS not exercised live.**
  - **Best guess applied:** No live hermes daemon was provisioned on `esper-macmini`, so `clawctl agent doctor`, `clawctl agent stop`, `clawctl agent remove` are not in the E2E matrix. The lifecycle-verb completeness invariant is pinned for openclaw on this same host by #770; the contract is identical for hermes once the upstream install actually runs to completion.
  - **Reviewer:** decide whether to track a follow-up to smoke-test the full hermes lifecycle on this Mac.

- **[ENVIRONMENT] Real-host E2E target swapped from `mac-test` to `esper-macmini`.**
  - Operator decision documented in issue #772 body comment (2026-06-24T03:29Z); applies to Phases 4–6.

- **[ENVIRONMENT] ATX run via CLI (`atx review request --format json`), not MCP.**
  - Per operator directive at execution time. `.claude/itx-config.json` still declares `mcp.review_enabled: true`; the CLI path was used here because the operator wanted CLI-only for this phase.

- **[TODO-FOLLOWUP] ATX suggestions S1–S3, S5–S8.**
  - **Tracking:** to be filed.
  - S1: backport macOS hardenings to Linux `workspace.yaml` for all three agents.
  - S2: add symlink-in-staging comment to the `item.src` containment assert across all 6 playbook files.
  - S3: document parent-dir `mode: 0755` widening as intended invariant (or tighten if a tighter mode is the actual intent).
  - S5: add explicit per-type exclude distinctness test (`hermes.excludes ⊃ openclaw.excludes == zeroclaw.excludes == frozenset()`).
  - S6: stage a flat-file in the hermes darwin integration test for direct `when: dirname | length > 0` skip-branch coverage.
  - S7: align playbook task names across Linux and macOS variants for grep-friendly cross-OS log comparison.
  - S8: fix threat-model framing in the slug-regex comment (filesystem-path-shape integrity + dispatcher parity, not "shell injection" — `ansible.builtin.copy`/`file` do not invoke a shell).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
