### PR TITLE
feat(shell): macOS support for `clawctl agent shell` (#808)

### DIFF
--- a/.itx/808/00_PLAN.md
+++ b/.itx/808/00_PLAN.md
@@ -1,0 +1,202 @@
+# Plan — #808: macOS support for `clawctl agent shell`
+
+## Overview
+
+Follow the dispatcher-only OS-fork convention already established for workspace overlay and lifecycle. Add `shell_macos.yaml` as a parallel playbook, route via a new `resolve_shell_playbook(os_family)` helper in `core/playbook_resolver.py`, and replace the darwin short-circuit at `agent_shell.py:232` with a runtime resolver call. Make the rc-file prepend OS-aware (`.bash_profile` first on macOS, then `.bashrc`).
+
+No `if ansible_os_family == "Darwin"` branches inside `shell.yaml` — the dispatcher is the single source of truth (`core/playbook_resolver.py`).
+
+## Files
+
+### New
+
+| Path | Purpose |
+|---|---|
+| `src/clawrium/platform/shell/shell_macos.yaml` | Parallel playbook — same task shape, BSD-friendly timeout |
+| `tests/platform/test_shell_playbook_macos.py` | Static YAML invariants, mirroring `test_shell_playbook.py` |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `src/clawrium/core/playbook_resolver.py` | Add `resolve_shell_playbook(os_family) -> Path` |
+| `src/clawrium/core/agent_shell.py` | Drop module-level `_PLAYBOOK`; resolve per-call; delete darwin preflight at L229–239; OS-aware rc-file prepend |
+| `tests/core/test_agent_shell.py` | Replace `test_K20_macos_host_preflight_error` with `test_K20_macos_host_uses_macos_playbook`; add darwin rc-prepend test |
+| `tests/core/test_playbook_resolver.py` | Add unit tests for `resolve_shell_playbook` (linux/darwin/unknown) |
+| `CHANGELOG.md` | `### Added` entry under `[Unreleased]` |
+
+## Steps
+
+### Step 1 — Resolver helper
+
+Add to `src/clawrium/core/playbook_resolver.py`:
+
+```python
+def resolve_shell_playbook(os_family: str) -> Path:
+    """Return the path to the `clawctl agent shell` playbook for this OS family."""
+    suffix = _suffix_for(os_family)
+    path = _PLATFORM_ROOT / "shell" / f"shell{suffix}.yaml"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"shell playbook for os_family={os_family!r} not found at {path}. "
+            f"This OS family is not yet supported by this clawrium build."
+        )
+    return path
+```
+
+### Step 2 — `shell_macos.yaml`
+
+Mirror `shell.yaml` task-for-task, with the following differences only:
+
+- **Timeout discovery** (new pre-task, run as agent user):
+
+  ```yaml
+  - name: Discover gtimeout (coreutils)
+    ansible.builtin.shell: |
+      PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin which gtimeout || true
+    args:
+      executable: /bin/bash
+    become: true
+    become_user: "{{ agent_name }}"
+    register: gtimeout_which
+    changed_when: false
+    failed_when: false
+  ```
+
+- **Run task** branches by whether `gtimeout` was found:
+  - Found → `argv: [<resolved_gtimeout>, --kill-after=5, "{{ shell_timeout | int }}", /bin/bash, -lc, "{{ cmd_b64 | b64decode }}"]`
+  - Missing → `argv: [/bin/bash, -lc, "{{ cmd_b64 | b64decode }}"]`. The `effective + _RUNNER_GRACE_S` runner-level timeout in `agent_shell.py` is the kill backstop; runner status `timeout` already maps to `rc=124` at L319–320, so the user-facing contract is unchanged. Cost: +25s kill window vs the gtimeout path.
+- **Same** `become: true` / `become_user: "{{ agent_name }}"` / `no_log: true` / `failed_when: false` / `changed_when: false` / `SHELL_STDOUT=`, `SHELL_STDERR=`, `SHELL_RC=` emit tasks.
+- **Same** defense-in-depth fail tasks for `agent_name`, `cmd_b64`, `shell_timeout` (#761 iter-3 W3 + B2).
+- **No** `when: ansible_os_family == "Darwin"` guards — `gather_facts: false`, same comment as `exec_macos.yaml`.
+
+### Step 3 — `agent_shell.py` dispatcher
+
+- Delete L229–239 darwin short-circuit.
+- Delete `_PLAYBOOK = Path(...)` module constant.
+- After `host = get_host(hostname)` resolves, branch playbook per-call:
+
+  ```python
+  os_family = (host.get("os_family") or "linux").lower()
+  try:
+      playbook = playbook_resolver.resolve_shell_playbook(os_family)
+  except (FileNotFoundError, ValueError) as e:
+      return "", str(e), 255
+  ```
+
+- Replace the rc-file prepend at L268 with OS-aware logic:
+
+  ```python
+  if os_family == "darwin":
+      rc_prepend = (
+          '[ -f "$HOME/.bash_profile" ] && . "$HOME/.bash_profile";'
+          ' [ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc";'
+      )
+  else:
+      rc_prepend = '[ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc";'
+  cmd_str = f"{rc_prepend} {user_cmd}"
+  ```
+
+- Pass `playbook=str(playbook)` to `ansible_runner.run` instead of the module constant.
+
+### Step 4 — Tests
+
+**`tests/platform/test_shell_playbook_macos.py`** — mirror every Linux playbook invariant:
+
+- P1 `no_log: true` on each run-command task
+- P2 `become_user == "{{ agent_name }}"`
+- P3 each run task argv contains `/bin/bash -lc`
+- P4 gtimeout-present run task uses the discovered `gtimeout` path as argv0
+- W3 `cmd_b64` defined-and-non-empty guard task present
+- B2 `shell_timeout >= 1` guard task present
+- Both run branches emit `SHELL_STDOUT=`/`SHELL_STDERR=`/`SHELL_RC=` debug events
+
+**`tests/core/test_agent_shell.py`**:
+
+- Replace K20 with `test_K20_macos_host_uses_macos_playbook`:
+
+  ```python
+  captured = {}
+  def fake_run(**kw):
+      captured.update(kw)
+      return _RUNNER_SUCCESS  # fixture mirroring the linux test
+  monkeypatch get_host → os_family=darwin
+  monkeypatch ansible_runner.run → fake_run
+  agent_shell.run_agent_shell("wolf-i", "wolf-i", ["ls"])
+  assert captured["playbook"].endswith("shell_macos.yaml")
+  ```
+
+- Add `test_darwin_rc_prepend_sources_bash_profile`: capture `inventory` extravars, base64-decode `cmd_b64`, assert it starts with the `.bash_profile`-then-`.bashrc` prepend on darwin.
+- Add `test_linux_rc_prepend_unchanged`: same shape, asserts the linux prepend is unchanged.
+
+**`tests/core/test_playbook_resolver.py`**:
+
+- `test_resolve_shell_playbook_linux_returns_shell_yaml`
+- `test_resolve_shell_playbook_darwin_returns_shell_macos_yaml`
+- `test_resolve_shell_playbook_unknown_os_raises`
+
+### Step 5 — CHANGELOG
+
+Under `[Unreleased]` → `### Added`:
+
+```
+- `clawctl agent shell <name> -- <cmd>` now works against macOS hosts (#808).
+  Discovers `gtimeout` (coreutils) when present; without it the
+  ansible-runner outer timeout is the kill backstop.
+```
+
+### Step 6 — Real-host verification on `mac-test`
+
+From the local clawrium worktree (`uv run clawctl …`):
+
+| # | Command | Expected |
+|---|---|---|
+| 1 | `uv run clawctl agent shell <mac-agent> -- ls -la ~/` | listing of `/Users/<agent_name>`, rc=0 |
+| 2 | `uv run clawctl agent shell <mac-agent> -- 'echo $HOME'` | `/Users/<agent_name>`, rc=0 |
+| 3 | `uv run clawctl agent shell <mac-agent> -- 'echo $PATH'` | shims if `.bash_profile` exports them |
+| 4 | `uv run clawctl agent shell <mac-agent> --timeout 2 -- sleep 5` | rc=124, stderr non-empty |
+| 5 | `uv run clawctl agent shell <mac-agent> -- 'echo {{ lookup("env","HOME") }}'` | literal echo, no Jinja expansion |
+| 6 | `uv run clawctl agent shell <mac-agent> -- false` | rc=1 |
+
+## Test Strategy
+
+- `make test` green (full suite)
+- `make lint` green
+- Real-host smoke list above on `mac-test` (100.120.88.97, darwin/arm64)
+- No CI hardware for macOS — playbook tests use static YAML inspection; runtime tests use monkeypatched `ansible_runner`. Same envelope as the workspace-overlay macOS work (#770/#771/#772).
+
+## Risks
+
+- **`gtimeout` not installed** → wider kill window (+25s). Documented; suggest `brew install coreutils` in `--help`.
+- **zsh-default operators** → `bash -lc` does not source `~/.zshrc`. Matches the Linux contract; documented as out of scope for v1.
+- **Non-UTF-8 child output** → still lossy (Ansible decodes with `errors='replace'` before we see it). Matches Linux contract.
+
+## Out of Scope
+
+- zsh login-shell support
+- Auto-installing coreutils on the host
+- launchctl-based binary discovery
+
+## Subtasks
+
+None — single concern; 2 new files + 4 modified files.
+
+---
+
+<details>
+<summary>Prompt Log</summary>
+
+## Plan
+
+**Stage**: plan
+**Skill**: /itx-plan-create
+**Timestamp**: 2026-06-24T15:50:21Z
+**Model**: claude-opus-4-7
+
+```prompt
+808 in a worktree. dont commit anything. just show me the plan
+```
+
+**Output**: `.itx/808/00_PLAN.md` — high-level implementation plan for adding macOS support to `clawctl agent shell`, following the dispatcher-only OS-fork convention. No commits, no GitHub comment, no label change.
+
+</details>

--- a/.itx/808/01_EXECUTION.md
+++ b/.itx/808/01_EXECUTION.md
@@ -1,0 +1,123 @@
+# Execution — #808: macOS support for `clawctl agent shell`
+
+## Stage Outputs
+
+- New file: `src/clawrium/platform/shell/shell_macos.yaml` — macOS
+  counterpart to `shell.yaml`. Discovers `gtimeout` (coreutils) on
+  Homebrew arm64 / Homebrew x86_64 / MacPorts paths and falls back to
+  plain `bash -lc` when absent.
+- New file: `tests/platform/test_shell_playbook_macos.py` — static
+  YAML invariants mirroring `test_shell_playbook.py`, plus assertions
+  on `when:` gating, the `Merge run-task result` set_fact, and the
+  `Discover gtimeout` task's `become_user`.
+- Modified: `src/clawrium/core/playbook_resolver.py` — added
+  `resolve_shell_playbook(os_family)` and `shell_rc_prepend(os_family)`.
+  The rc-prepend helper owns the OS literal for the bash-source
+  prelude so `agent_shell.py` stays OS-agnostic (dispatcher-only
+  OS-fork invariant).
+- Modified: `src/clawrium/core/agent_shell.py` — dropped the
+  module-level `_PLAYBOOK` constant; resolves per-call via
+  `playbook_resolver.resolve_shell_playbook`; deleted the darwin
+  preflight short-circuit; rc-prepend is now
+  `playbook_resolver.shell_rc_prepend(os_family)`; non-string
+  `os_family` values fall back to "linux".
+- Modified: `tests/core/test_agent_shell.py` — replaced
+  `test_K20_macos_host_preflight_error` with
+  `test_K20_macos_host_uses_macos_playbook`; added
+  `test_K20_linux_host_uses_linux_playbook`,
+  `test_unsupported_os_family_returns_255`,
+  `test_non_string_os_family_falls_back_to_linux`,
+  `test_darwin_rc_prepend_sources_login_files_then_bashrc`,
+  `test_linux_rc_prepend_unchanged`; parametrized
+  `test_iter2_B1_reserved_unix_names_rejected` across `os_family`.
+- Modified: `tests/core/test_playbook_resolver.py` — added
+  `TestResolveShellPlaybook` (linux / darwin / unknown OS /
+  FileNotFoundError message-contains-path) and `TestShellRcPrepend`
+  (linux / darwin precedence ordering / unknown OS / trailing
+  semicolon).
+- Modified: `CHANGELOG.md` — `### Added` entry under `[Unreleased]`.
+
+## ATX Review History
+
+| Iter | Rating | Blocking | Cost | Time | Agents |
+|---|---|---|---|---|---|
+| 1 | 3.5/5 | yes (B1) | $3.49 | 9m 55s | leader, cli-ux, test-coverage, platform-playbooks, lifecycle-core, security-reviewer |
+| 2 | 4/5 | no | $3.04 | 5m 2s | leader, cli-ux, test-coverage, platform-playbooks, lifecycle-core, security-reviewer |
+
+**Iter 1 → Iter 2 fixes:**
+
+- B1 (lifecycle-core): inline `if os_family == "darwin":` in
+  `agent_shell.py` violated dispatcher-only invariant. Fixed by
+  introducing `playbook_resolver.shell_rc_prepend(os_family)` and
+  routing the prelude through it.
+- W1: clarified timeout-message semantics in module docstring + on the
+  rc=124 emit site.
+- W2: extended darwin prepend to source `.bash_profile` →
+  `.bash_login` → `.profile` (first-found wins) before always-on
+  `.bashrc` to match bash login-shell precedence.
+- W3: added `test_P4_run_tasks_gated_by_resolved_gtimeout_length` —
+  asserts the gtimeout/fallback `when:` predicates.
+- W4: added `test_P5_merge_run_task_result_present_and_conditional` —
+  asserts the merge set_fact references both registers + the
+  `resolved_gtimeout | length` predicate.
+- W5: added `test_P5_gtimeout_discovery_runs_as_agent_user` — asserts
+  the discovery task's `become_user`.
+- W6: tightened `test_K20_macos_host_uses_macos_playbook` to
+  `endswith("/shell_macos.yaml")`.
+- W7: parametrized `test_iter2_B1_reserved_unix_names_rejected` across
+  `os_family in (None, "linux", "darwin")`.
+- S1: guarded non-string `os_family` in `agent_shell.py`.
+- S2: added `/opt/local/bin` (MacPorts) to the gtimeout discovery PATH.
+- S3: dropped redundant `|| true` from the gtimeout discovery shell.
+- S6 (test-coverage): added
+  `test_unsupported_os_family_returns_255` and
+  `test_file_not_found_message_includes_resolved_path`.
+
+## Verification
+
+- `make lint`: ✅ ruff + ESLint clean
+- `make test`: ✅ 4031 passed, 8 skipped (Python) + 305 passed (frontend)
+- Real-host: ⚠ `mac-test` (100.120.88.97) offline at run-time — not
+  in `tailscale status`, SSH connect timeouts. Operator approved
+  substituting `esper-mac-oc` on `esper-macmini`
+  (espers-mac-mini.tailf7742d.ts.net, darwin/arm64).
+
+### Smoke list on `esper-mac-oc` (espers-mac-mini, darwin/arm64)
+
+| # | Command | Expected | Observed |
+|---|---|---|---|
+| 1 | `agent shell esper-mac-oc -- ls -la ~/` | listing of `/Users/esper-mac-oc`, rc=0 | ✅ listing rendered, rc=0 |
+| 2 | `agent shell esper-mac-oc -- 'echo $HOME'` | `/Users/esper-mac-oc`, rc=0 | ✅ `/Users/esper-mac-oc`, rc=0 |
+| 3 | `agent shell esper-mac-oc -- 'echo $PATH'` | shims if `.bash_profile` exports them | ✅ `/usr/bin:/bin:/usr/sbin:/sbin` (no operator shims on host) |
+| 4 | `agent shell esper-mac-oc --timeout 2 -- 'sleep 60; echo neverreached'` | rc=124, stderr non-empty | ✅ rc=124, stderr `remote command timed out after 2s` (fallback path: host has no gtimeout, runner kill backstop fired at ~32s) |
+| 5 | `agent shell esper-mac-oc -- 'echo "{{ lookup(env,HOME) }}"'` | literal echo, no Jinja expansion | ✅ `{{ lookup(env,HOME) }}` literal, rc=0 |
+| 6 | `agent shell esper-mac-oc -- false` | rc=1 | ✅ rc=1 |
+
+Note for #4: the substitute host has no `gtimeout`. Smoke #4 with
+`sleep 5` returned rc=0 because the inner `bash -lc` finished before
+the runner-level backstop at `2 + 30 = 32s` fired — exactly the
+documented "wider kill window" behavior. The smoke was re-run with
+`sleep 60`, which exceeds the backstop and exits via the rc=124 path.
+On hosts with coreutils installed (`brew install coreutils`), the
+inner `gtimeout` fires at the exact `effective`s mark.
+
+## Prompt Log
+
+### Execution
+
+**Stage**: execution
+**Skill**: /itx-execute
+**Timestamp**: 2026-06-24T16:25:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+808 - macOS support for `clawctl agent shell`. Execute plan at
+.itx/808/00_PLAN.md end-to-end with operator overrides: atx CLI
+review (not MCP), no git push / no PR, mac-test smoke list,
+TaskCreate-driven progress, dispatcher-only OS-fork, new commits
+never amends.
+```
+
+**Output**: Implementation merged into `worktree-issue-808`; two ATX
+review iterations (3.5/5 → 4/5, no blockers); smoke list verified on
+substitute mac host (`esper-mac-oc`, espers-mac-mini, darwin/arm64).

--- a/.itx/808/exec-prompt.txt
+++ b/.itx/808/exec-prompt.txt
@@ -1,0 +1,27 @@
+You are continuing work on issue #808 in the clawrium repo. You are already inside the git worktree at `.claude/worktrees/issue-808` on branch `worktree-issue-808`. Do NOT enter a new worktree.
+
+Read `.itx/808/00_PLAN.md` and execute it end-to-end via the `/itx-execute` skill. Pass `808` as the issue number. Do NOT use any worktree-creation flag — you are already inside the worktree.
+
+OPERATOR OVERRIDES — these supersede the skill defaults:
+
+1. REVIEW TOOL: use the `atx` CLI, NOT `mcp__atx__request_review`. After each meaningful batch of edits (one logical step from the plan), run:
+     atx review --message "iter <N>: <one-line focus>"
+   Parse the JSON output. Iterate until rating > 3/5 AND no blocking issues remain. Capture rating / cost / time / agents for each round in the ATX Review Summary block of the eventual commit message and PR body (format per AGENTS.md `<commit-format-atx>` and `<pr-format-atx>`).
+
+2. ALWAYS run `make lint && make test` BEFORE each `atx review` call. CI runs ruff before pytest; a lint failure surfaces as "all tests failing".
+
+3. DO NOT git push. DO NOT open a PR. Local commits only. The operator will push when ready. (Per project memory `feedback_no_push_without_ask`.)
+
+4. REAL-HOST VERIFICATION: Step 6 of the plan runs against `mac-test` (100.120.88.97, darwin/arm64) using `uv run clawctl agent shell <mac-agent> -- <cmd>` from THIS worktree. Before running, list the mac-test agents with `uv run clawctl agent get` and pick the openclaw/hermes/zeroclaw agent on mac-test. If none are usable, STOP and ask the operator which agent to target — do not invent one.
+
+5. TASK TRACKING: use `TaskCreate` to break the plan into tasks before you start editing. Mark each `in_progress` when starting, `completed` when done. This prevents drift across the review iterations.
+
+6. COMMIT DISCIPLINE: create NEW commits, never amend. One commit per logical step; the final commit carries the ATX Review Summary block. Include `Co-Authored-By: Claude <noreply@anthropic.com>` AND `Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>` per the project ATX commit format.
+
+7. FOLLOW THE DISPATCHER-ONLY OS-FORK CONVENTION: no `if ansible_os_family == "Darwin"` branches inside the existing `shell.yaml`. The new `shell_macos.yaml` is a parallel file; the resolver in `core/playbook_resolver.py` is the single routing seam.
+
+8. EVERY EDIT: prefer Edit over Write; respect existing comment style; do NOT add boilerplate docstrings or what-comments.
+
+When the plan is fully executed, ATX-reviewed clean (>3/5, no blockers), tests green, lint green, and verified on mac-test, STOP and print a status summary. Do not push. Do not open a PR. Do not exit the tmux pane — leave it open so the operator can attach and see the final state.
+
+Start now: invoke `/itx-execute 808` and proceed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,14 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Added
 
+- `clawctl agent shell <name> -- <cmd>` now works against macOS hosts
+  (#808). The new `shell_macos.yaml` playbook is selected per-OS via
+  `core.playbook_resolver.resolve_shell_playbook`; the kill window is
+  enforced via Homebrew's `gtimeout` (coreutils) when available, and
+  the ansible-runner outer timeout is the kill backstop when it is
+  not (`brew install coreutils` is suggested for the tighter window).
+  The rc-file prepend sources `~/.bash_profile` first on darwin to
+  match macOS login-shell convention before `~/.bashrc`.
 - `tape.output_format` key in `docs/demos/<demo>/scenes.yaml` — set to
   `gif` to emit `recording.gif` from `vhs`; defaults to `mp4` (existing
   behavior). GIF outputs skip the `narrate.py` step since GIF has no

--- a/src/clawrium/core/agent_shell.py
+++ b/src/clawrium/core/agent_shell.py
@@ -4,12 +4,14 @@ Self-contained: does NOT import from `agent_exec`. Keeps the shell flow
 free to evolve without contaminating exec's hardened code path.
 
 `run_agent_shell(hostname, agent_name, cmd_argv, timeout)` invokes the
-single `shell.yaml` playbook against the host that owns the agent. The
-playbook runs `/usr/bin/timeout <effective> /bin/bash -lc '<cmd>'` as
-the agent's unix user, captures stdout/stderr/rc, and emits them as
-three base64-tagged debug events (`SHELL_STDOUT=`, `SHELL_STDERR=`,
-`SHELL_RC=`). This module parses those events and returns
-`(stdout, stderr, rc)`.
+shell playbook against the host that owns the agent. The playbook is
+selected per-OS by `core.playbook_resolver.resolve_shell_playbook` —
+Linux runs `shell.yaml` (`/usr/bin/timeout` enforces the kill window);
+macOS runs `shell_macos.yaml` (Homebrew `gtimeout` when present, plain
+`bash -lc` otherwise). Both shapes run as the agent's unix user,
+capture stdout/stderr/rc, and emit them as three base64-tagged debug
+events (`SHELL_STDOUT=`, `SHELL_STDERR=`, `SHELL_RC=`). This module
+parses those events and returns `(stdout, stderr, rc)`.
 
 Timeout handling — all clamping lives here, not at the CLI seam:
 
@@ -17,9 +19,13 @@ Timeout handling — all clamping lives here, not at the CLI seam:
   30-min ceiling still applies).
 - positive → ``min(int(timeout), 1800)``.
 
-The runner-level timeout is ``effective + 30`` so the inner
-``timeout(1)`` is always the kill path under normal operation; the
-+30s buffer gives the playbook time to clean up.
+The runner-level timeout is ``effective + 30`` so the inner kill
+binary (`timeout(1)` on Linux, `gtimeout` on macOS when present) is
+the canonical kill path under normal operation; the +30s buffer gives
+the playbook time to clean up. On macOS hosts without `gtimeout`, the
+runner-level timeout itself becomes the kill backstop — runner status
+`timeout` already maps to rc=124 below, so the user-facing contract
+is unchanged.
 
 Failure modes:
     - Unknown host → ``("", err, 255)``.
@@ -52,14 +58,13 @@ from pathlib import Path
 import ansible_runner
 
 from clawrium.core import keys as core_keys
+from clawrium.core import playbook_resolver
 from clawrium.core.config import get_config_dir
 from clawrium.core.names import RESERVED_UNIX_NAMES
 
 logger = logging.getLogger(__name__)
 
 __all__ = ["AgentShellError", "run_agent_shell"]
-
-_PLAYBOOK = Path(__file__).parent.parent / "platform" / "shell" / "shell.yaml"
 
 # Hard 30-min ceiling. Hardcoded per plan §1 — overrides user input
 # unconditionally so a runaway remote process cannot pin the local CLI.
@@ -217,26 +222,21 @@ def run_agent_shell(
             f"refusing to run shell as reserved system user: {agent_name!r}"
         )
 
-    if not _PLAYBOOK.exists():
-        return "", f"Playbook not found: {_PLAYBOOK}", 255
-
     from clawrium.core.hosts import get_host
 
     host = get_host(hostname)
     if not host:
         return "", f"host {hostname!r} not found", 255
 
-    # v1 is Linux-only; macOS support is tracked separately. Short-circuit
-    # with a clear error so operators don't hit a cryptic ansible failure
-    # when /usr/bin/timeout is missing on macOS hosts (iter-1 B2).
-    if (host.get("os_family") or "linux").lower() == "darwin":
-        return (
-            "",
-            f"`clawctl agent shell` does not support macOS hosts in v1 "
-            f"(host {hostname!r}). Linux-only; macOS support is tracked in a "
-            f"separate issue.",
-            255,
-        )
+    # A tampered hosts.json could carry a non-string os_family (int,
+    # dict, list). Guard the .lower() so the caller gets the controlled
+    # ("", err, 255) shape rather than an uncaught AttributeError.
+    raw_os = host.get("os_family")
+    os_family = raw_os.lower() if isinstance(raw_os, str) and raw_os else "linux"
+    try:
+        playbook = playbook_resolver.resolve_shell_playbook(os_family)
+    except (FileNotFoundError, ValueError) as e:
+        return "", str(e), 255
 
     key_id = host.get("key_id") or host["hostname"]
     ssh_key = core_keys.get_host_private_key(key_id)
@@ -257,15 +257,16 @@ def run_agent_shell(
     # Multi-token argv (`['echo', 'a b']`) is passed through without
     # extra quoting — documented in --help.
     user_cmd = " ".join(cmd_argv)
-    # Explicitly source `~/.bashrc` from a login (non-interactive) shell
-    # so PATH shims set up there (pyenv, nvm, asdf, virtualenv
-    # activations) are loaded before the command runs. Plain `bash -lc`
-    # skips `~/.bashrc`; `bash -lic` sources it but also enables job-
-    # control noise on stderr and appends history (#761 iter-3 W1).
-    # The `[ -f ~/.bashrc ]` guard keeps the wrapper inert when the user
-    # has no .bashrc and prevents a `source` failure from masking the
-    # user command's exit code.
-    cmd_str = f"[ -f \"$HOME/.bashrc\" ] && . \"$HOME/.bashrc\"; {user_cmd}"
+    # Explicitly source rc files from a login (non-interactive) shell so
+    # PATH shims set up there (pyenv, nvm, asdf, virtualenv activations)
+    # are loaded before the command runs. Plain `bash -lc` skips
+    # `~/.bashrc`; `bash -lic` sources it but also enables job-control
+    # noise on stderr and appends history (#761 iter-3 W1). The per-OS
+    # prelude is owned by `playbook_resolver.shell_rc_prepend` so this
+    # module stays free of OS literals (dispatcher-only OS-fork
+    # invariant — `playbook_resolver.py` docstring).
+    rc_prepend = playbook_resolver.shell_rc_prepend(os_family)
+    cmd_str = f"{rc_prepend} {user_cmd}"
     # The command runs through ansible's templating layer, so a user
     # command of `echo {{ lookup('env','SECRET') }}` would otherwise
     # expand the lookup on the controller and ship the secret to the
@@ -307,7 +308,7 @@ def run_agent_shell(
         result = ansible_runner.run(
             private_data_dir=str(log_dir),
             inventory=inventory,
-            playbook=str(_PLAYBOOK),
+            playbook=str(playbook),
             quiet=True,
             timeout=effective + _RUNNER_GRACE_S,
         )
@@ -317,6 +318,12 @@ def run_agent_shell(
 
     try:
         if result.status == "timeout":
+            # Message reports the user-configured kill window. On Linux
+            # and macOS-with-gtimeout this matches the actual wall-clock
+            # spend (inner timeout fires at `effective`s). On macOS
+            # without gtimeout the runner-level timeout fires up to
+            # +_RUNNER_GRACE_S later, so the wall-clock spend can
+            # exceed `effective`s by ~30s — documented at module level.
             return "", f"remote command timed out after {effective}s", 124
         if result.status != "successful":
             err = _extract_failure_message(result, f"playbook {result.status}")

--- a/src/clawrium/core/playbook_resolver.py
+++ b/src/clawrium/core/playbook_resolver.py
@@ -90,6 +90,59 @@ def resolve_agent_playbook(agent_type: str, op: str, os_family: str) -> Path:
     return path
 
 
+def resolve_shell_playbook(os_family: str) -> Path:
+    """Return the path to the `clawctl agent shell` playbook for this OS family."""
+    suffix = _suffix_for(os_family)
+    path = _PLATFORM_ROOT / "shell" / f"shell{suffix}.yaml"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"shell playbook for os_family={os_family!r} not found at {path}. "
+            f"This OS family is not yet supported by this clawrium build."
+        )
+    return path
+
+
+# Per-OS bash rc-file prepend strings for the shell playbook. Keeping
+# this here instead of inside agent_shell.py preserves the
+# dispatcher-only OS-fork invariant: `core.playbook_resolver` owns the
+# OS literal, everywhere else just calls the resolver. Both strings
+# end with a trailing semicolon so the caller can concatenate with a
+# single space before the user's command.
+#
+# macOS bash login-shell precedence is `.bash_profile` → `.bash_login`
+# → `.profile` (first found wins). We mirror that with elif chains so
+# operators with a `.profile`-only POSIX-compat dotfile setup still
+# get their PATH shims. `.bashrc` is always sourced last because
+# operators commonly chain it from `.bash_profile` — we want it to
+# load even when the chain isn't set up.
+_SHELL_RC_PREPEND_BY_OS: dict[str, str] = {
+    "linux": '[ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc";',
+    "darwin": (
+        'if [ -f "$HOME/.bash_profile" ]; then . "$HOME/.bash_profile";'
+        ' elif [ -f "$HOME/.bash_login" ]; then . "$HOME/.bash_login";'
+        ' elif [ -f "$HOME/.profile" ]; then . "$HOME/.profile"; fi;'
+        ' [ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc";'
+    ),
+}
+
+
+def shell_rc_prepend(os_family: str) -> str:
+    """Return the bash rc-file source prelude for `clawctl agent shell`.
+
+    The string is concatenated by `core.agent_shell` ahead of the
+    user's command, then base64-encoded together with it for the
+    `bash -lc` decode-hop in the shell playbook. Keeping the OS branch
+    here keeps `agent_shell` OS-agnostic and preserves the
+    dispatcher-only OS-fork invariant declared at the top of this
+    module.
+    """
+    if os_family not in SUPPORTED_OS:
+        raise ValueError(
+            f"unsupported os_family: {os_family!r} (expected one of {sorted(SUPPORTED_OS)})"
+        )
+    return _SHELL_RC_PREPEND_BY_OS[os_family]
+
+
 def resolve_lifecycle_backend(os_family: str):
     """Return the lifecycle module appropriate for this OS family.
 

--- a/src/clawrium/platform/shell/shell_macos.yaml
+++ b/src/clawrium/platform/shell/shell_macos.yaml
@@ -1,0 +1,119 @@
+---
+# macOS counterpart to shell.yaml. Same shape: run an arbitrary command
+# on the host as the agent's unix user in a login bash shell
+# (`/bin/bash -lc '<cmd>'`), capturing stdout/stderr/rc via three
+# base64-tagged debug events (SHELL_STDOUT=, SHELL_STDERR=, SHELL_RC=).
+#
+# Kill window is enforced via Homebrew's `gtimeout` (coreutils) when
+# available. macOS ships no `/usr/bin/timeout`; without `gtimeout` we
+# fall back to running `bash -lc` directly and rely on the
+# ansible-runner outer timeout (`effective + _RUNNER_GRACE_S` in
+# core/agent_shell.py) as the kill backstop. The cost of the fallback
+# is a wider kill window (+25s); the user-facing rc=124 contract is
+# unchanged because runner status `timeout` already maps to rc=124 in
+# core.
+- hosts: all
+  gather_facts: false
+  tasks:
+    # No OS-family guard here: gather_facts is off (latency matters),
+    # so `ansible_os_family` would be undefined. The dispatcher in
+    # core/playbook_resolver.py is the routing source of truth.
+
+    - name: Validate agent_name (defense-in-depth)
+      ansible.builtin.fail:
+        msg: "Invalid agent_name"
+      when:
+        - agent_name is not match('^[a-z][a-z0-9_-]{0,31}$')
+
+    - name: Validate cmd_b64 is defined and non-empty
+      # If `cmd_b64` is missing or empty the inline `b64decode` filter
+      # in the command task would emit a confusing Jinja error
+      # silenced by `no_log: true` (mirrors shell.yaml #761 iter-3 W3).
+      ansible.builtin.fail:
+        msg: "cmd_b64 must be a non-empty base64 string"
+      when:
+        - (cmd_b64 is not defined) or (cmd_b64 | length == 0)
+
+    - name: Validate shell_timeout is a positive integer
+      # Without this guard, `{{ shell_timeout | int }}` silently
+      # becomes `0`, which `gtimeout` interprets as "no kill window".
+      ansible.builtin.fail:
+        msg: "shell_timeout must be a positive integer (got {{ shell_timeout | default('undefined') }})"
+      when:
+        - (shell_timeout is not defined) or (shell_timeout | int < 1)
+
+    - name: Discover gtimeout (coreutils) as agent user
+      # Include `/opt/local/bin` so MacPorts installs are picked up
+      # alongside Homebrew arm64 (`/opt/homebrew/bin`) and x86_64
+      # (`/usr/local/bin`). `failed_when: false` (idiomatic Ansible)
+      # is the no-fail mechanism; `|| true` would be redundant.
+      ansible.builtin.shell: |
+        PATH=/opt/homebrew/bin:/usr/local/bin:/opt/local/bin:/usr/bin:/bin which gtimeout
+      args:
+        executable: /bin/bash
+      become: true
+      become_user: "{{ agent_name }}"
+      register: gtimeout_which
+      changed_when: false
+      failed_when: false
+
+    - name: Resolve gtimeout binary
+      ansible.builtin.set_fact:
+        resolved_gtimeout: "{{ gtimeout_which.stdout | default('') | trim }}"
+
+    - name: Run command in login shell as agent user (with gtimeout)
+      # gtimeout enforces the kill window so the remote process is
+      # reaped even if ansible-runner is killed. `--kill-after=5`
+      # follows SIGTERM with SIGKILL 5s later if the process ignores
+      # TERM. Same `bash -lc` semantics + `cmd_b64 | b64decode` hop as
+      # shell.yaml so the user-supplied command never passes through
+      # Ansible's recursive Jinja templater.
+      ansible.builtin.command:
+        argv:
+          - "{{ resolved_gtimeout }}"
+          - "--kill-after=5"
+          - "{{ shell_timeout | int }}"
+          - /bin/bash
+          - -lc
+          - "{{ cmd_b64 | b64decode }}"
+      become: true
+      become_user: "{{ agent_name }}"
+      register: shell_result
+      failed_when: false
+      changed_when: false
+      no_log: true
+      when: (resolved_gtimeout | length) > 0
+
+    - name: Run command in login shell as agent user (no gtimeout)
+      # Fallback when coreutils is not installed on the macOS host.
+      # ansible-runner's outer timeout (`effective + _RUNNER_GRACE_S`)
+      # is the kill backstop; status `timeout` already maps to rc=124
+      # in core/agent_shell.py.
+      ansible.builtin.command:
+        argv:
+          - /bin/bash
+          - -lc
+          - "{{ cmd_b64 | b64decode }}"
+      become: true
+      become_user: "{{ agent_name }}"
+      register: shell_result_fallback
+      failed_when: false
+      changed_when: false
+      no_log: true
+      when: (resolved_gtimeout | length) == 0
+
+    - name: Merge run-task result
+      ansible.builtin.set_fact:
+        shell_result: "{{ shell_result_fallback if ((resolved_gtimeout | length) == 0) else shell_result }}"
+
+    - name: Emit stdout
+      ansible.builtin.debug:
+        msg: "SHELL_STDOUT={{ shell_result.stdout | default('') | b64encode }}"
+
+    - name: Emit stderr
+      ansible.builtin.debug:
+        msg: "SHELL_STDERR={{ shell_result.stderr | default('') | b64encode }}"
+
+    - name: Emit rc
+      ansible.builtin.debug:
+        msg: "SHELL_RC={{ shell_result.rc | default(255) }}"

--- a/tests/core/test_agent_shell.py
+++ b/tests/core/test_agent_shell.py
@@ -48,10 +48,6 @@ def patched_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         lambda key_id: tmp_path / "fake-key",
     )
     (tmp_path / "fake-key").write_text("KEY")
-    # Make the shell playbook path exist for tests that don't override it.
-    if not agent_shell._PLAYBOOK.exists():  # pragma: no cover — real playbook exists
-        agent_shell._PLAYBOOK.parent.mkdir(parents=True, exist_ok=True)
-        agent_shell._PLAYBOOK.write_text("dummy")
     # Stub get_host
     from clawrium.core import hosts as hosts_module
 
@@ -248,8 +244,13 @@ def test_K9_invalid_agent_name_raises(patched_env):
 
 
 def test_K10_playbook_missing(monkeypatch, patched_env):
+    def fake_resolve(os_family):
+        raise FileNotFoundError(
+            f"shell playbook for os_family={os_family!r} not found at /nonexistent/path/shell.yaml."
+        )
+
     monkeypatch.setattr(
-        agent_shell, "_PLAYBOOK", Path("/nonexistent/path/shell.yaml")
+        agent_shell.playbook_resolver, "resolve_shell_playbook", fake_resolve
     )
 
     called = {"hit": False}
@@ -263,7 +264,8 @@ def test_K10_playbook_missing(monkeypatch, patched_env):
         "wolf-i", "wolf-i", ["x"]
     )
     assert rc == 255
-    assert "Playbook not found" in stderr
+    assert "shell playbook" in stderr
+    assert "not found" in stderr
     assert called["hit"] is False
 
 
@@ -589,9 +591,25 @@ def test_rc_124_propagates_verbatim(monkeypatch, patched_env):
     "reserved",
     ["root", "daemon", "bin", "nobody"],
 )
-def test_iter2_B1_reserved_unix_names_rejected(patched_env, reserved):
+@pytest.mark.parametrize(
+    "os_family",
+    [None, "linux", "darwin"],
+)
+def test_iter2_B1_reserved_unix_names_rejected(
+    monkeypatch, patched_env, reserved, os_family
+):
     """Even if a regex-match name slips through, the denylist must
-    refuse to `become_user` a privileged or system account."""
+    refuse to `become_user` a privileged or system account — equally
+    on Linux and macOS hosts. A future refactor that moves the check
+    below the os_family branch would otherwise break darwin silently
+    (W7 iter-1)."""
+    from clawrium.core import hosts as hosts_module
+
+    host = {**HOST_FIXTURE}
+    if os_family is not None:
+        host["os_family"] = os_family
+    monkeypatch.setattr(hosts_module, "get_host", lambda h: dict(host))
+
     with pytest.raises(agent_shell.AgentShellError, match=r"reserved system user"):
         agent_shell.run_agent_shell("wolf-i", reserved, ["ls"])
 
@@ -625,10 +643,10 @@ def test_iter2_B3_full_workdir_rmtree_on_cleanup(monkeypatch, patched_env):
     assert not Path(captured["pd"]).exists()
 
 
-# ----- K20 (B2): macOS host returns clear preflight error -----------
+# ----- K20 (#808): macOS host routes to shell_macos.yaml ------------
 
 
-def test_K20_macos_host_preflight_error(monkeypatch, patched_env):
+def test_K20_macos_host_uses_macos_playbook(monkeypatch, patched_env):
     from clawrium.core import hosts as hosts_module
 
     monkeypatch.setattr(
@@ -637,20 +655,150 @@ def test_K20_macos_host_preflight_error(monkeypatch, patched_env):
         lambda h: {**HOST_FIXTURE, "os_family": "darwin"},
     )
 
+    captured = {}
+
+    def fake_run(**kw):
+        captured["playbook"] = kw["playbook"]
+        return _make_result(_ok_events_for(stdout=b"hi"))
+
+    monkeypatch.setattr(agent_shell.ansible_runner, "run", fake_run)
+    stdout, stderr, rc = agent_shell.run_agent_shell(
+        "wolf-i", "wolf-i", ["ls"]
+    )
+    assert (stdout, stderr, rc) == ("hi", "", 0)
+    # Anchor on the leading `/` so a stray rename like
+    # `legacy_shell_macos.yaml` cannot satisfy the assertion (W6 iter-1).
+    assert captured["playbook"].endswith("/shell_macos.yaml")
+
+
+def test_K20_linux_host_uses_linux_playbook(monkeypatch, patched_env):
+    captured = {}
+
+    def fake_run(**kw):
+        captured["playbook"] = kw["playbook"]
+        return _make_result(_ok_events_for(stdout=b"hi"))
+
+    monkeypatch.setattr(agent_shell.ansible_runner, "run", fake_run)
+    agent_shell.run_agent_shell("wolf-i", "wolf-i", ["ls"])
+    # Linux uses the no-suffix shell.yaml — assert end-of-path is exactly
+    # `/shell.yaml` so a future `_linux` rename can't slip past.
+    assert captured["playbook"].endswith("/shell.yaml")
+    assert not captured["playbook"].endswith("shell_macos.yaml")
+
+
+def test_unsupported_os_family_returns_255(monkeypatch, patched_env):
+    """A malformed hosts.json with `os_family: 'windows'` must round-
+    trip to rc=255 with an actionable stderr — not crash with a
+    ValueError up the call stack (iter-1 S6 / lifecycle-core S4)."""
+    from clawrium.core import hosts as hosts_module
+
+    monkeypatch.setattr(
+        hosts_module,
+        "get_host",
+        lambda h: {**HOST_FIXTURE, "os_family": "windows"},
+    )
+
     called = {"hit": False}
 
     def boom_run(**kw):
         called["hit"] = True
-        raise AssertionError("ansible_runner.run must not be called on macOS")
+        raise AssertionError("ansible_runner.run must not be called")
 
     monkeypatch.setattr(agent_shell.ansible_runner, "run", boom_run)
-    stdout, stderr, rc = agent_shell.run_agent_shell(
-        "wolf-i", "wolf-i", ["ls"]
-    )
+    stdout, stderr, rc = agent_shell.run_agent_shell("wolf-i", "wolf-i", ["ls"])
     assert (stdout, rc) == ("", 255)
-    assert "macOS" in stderr or "darwin" in stderr.lower()
-    assert "does not support" in stderr
+    assert "unsupported os_family" in stderr
     assert called["hit"] is False
+
+
+@pytest.mark.parametrize(
+    "raw_os_family",
+    [42, {"x": 1}, ["darwin"], True],
+)
+def test_non_string_os_family_falls_back_to_linux(
+    monkeypatch, patched_env, raw_os_family
+):
+    """A tampered hosts.json record with a non-string `os_family` must
+    not raise AttributeError on `.lower()` — Python normalizes to the
+    default ("linux") and the playbook resolves cleanly (iter-1 S1).
+
+    `True` is a sentinel: bool is a subclass of int, exercising the
+    isinstance-string guard explicitly."""
+    from clawrium.core import hosts as hosts_module
+
+    monkeypatch.setattr(
+        hosts_module,
+        "get_host",
+        lambda h: {**HOST_FIXTURE, "os_family": raw_os_family},
+    )
+
+    captured = {}
+
+    def fake_run(**kw):
+        captured["playbook"] = kw["playbook"]
+        return _make_result(_ok_events_for(stdout=b"ok"))
+
+    monkeypatch.setattr(agent_shell.ansible_runner, "run", fake_run)
+    stdout, stderr, rc = agent_shell.run_agent_shell("wolf-i", "wolf-i", ["ls"])
+    assert (stdout, stderr, rc) == ("ok", "", 0)
+    assert captured["playbook"].endswith("/shell.yaml")
+
+
+# ----- #808: OS-aware rc-file prepend -------------------------------
+
+
+def test_darwin_rc_prepend_sources_login_files_then_bashrc(
+    monkeypatch, patched_env
+):
+    """The macOS prepend must follow bash login-shell precedence
+    (`.bash_profile` → `.bash_login` → `.profile`) followed by an
+    always-on `.bashrc` source. Operators with a `.profile`-only
+    POSIX-compat dotfile setup must still get PATH shims (iter-1 W2)."""
+    from clawrium.core import hosts as hosts_module
+
+    monkeypatch.setattr(
+        hosts_module,
+        "get_host",
+        lambda h: {**HOST_FIXTURE, "os_family": "darwin"},
+    )
+
+    captured = {}
+
+    def fake_run(**kw):
+        captured["vars"] = kw["inventory"]["all"]["vars"]
+        return _make_result(_ok_events_for())
+
+    monkeypatch.setattr(agent_shell.ansible_runner, "run", fake_run)
+    agent_shell.run_agent_shell("wolf-i", "wolf-i", ["echo", "hi"])
+
+    decoded = base64.b64decode(captured["vars"]["cmd_b64"]).decode("utf-8")
+    # All three login-file legs and the always-on bashrc must appear,
+    # in precedence order, followed by exactly the user command.
+    expected_prefix = (
+        'if [ -f "$HOME/.bash_profile" ]; then . "$HOME/.bash_profile";'
+        ' elif [ -f "$HOME/.bash_login" ]; then . "$HOME/.bash_login";'
+        ' elif [ -f "$HOME/.profile" ]; then . "$HOME/.profile"; fi;'
+        ' [ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc"; '
+    )
+    assert decoded.startswith(expected_prefix), decoded
+    assert decoded[len(expected_prefix) :] == "echo hi"
+
+
+def test_linux_rc_prepend_unchanged(monkeypatch, patched_env):
+    """Belt-and-suspenders: the Linux prepend remains bashrc-only."""
+    captured = {}
+
+    def fake_run(**kw):
+        captured["vars"] = kw["inventory"]["all"]["vars"]
+        return _make_result(_ok_events_for())
+
+    monkeypatch.setattr(agent_shell.ansible_runner, "run", fake_run)
+    agent_shell.run_agent_shell("wolf-i", "wolf-i", ["echo", "hi"])
+
+    decoded = base64.b64decode(captured["vars"]["cmd_b64"]).decode("utf-8")
+    assert decoded.startswith(_BASHRC_PREFIX), decoded
+    # Must NOT contain the darwin-specific .bash_profile leg.
+    assert ".bash_profile" not in decoded
 
 
 # ----- W1: Ansible Jinja sub-injection blocked by base64 hop --------

--- a/tests/core/test_playbook_resolver.py
+++ b/tests/core/test_playbook_resolver.py
@@ -7,6 +7,8 @@ import pytest
 from clawrium.core.playbook_resolver import (
     resolve_agent_playbook,
     resolve_base_playbook,
+    resolve_shell_playbook,
+    shell_rc_prepend,
 )
 
 
@@ -53,3 +55,73 @@ class TestResolveAgentPlaybook:
     def test_unknown_os_family_raises_value_error(self):
         with pytest.raises(ValueError, match="unsupported os_family"):
             resolve_agent_playbook("hermes", "install", "windows")
+
+
+class TestResolveShellPlaybook:
+    def test_linux_returns_shell_yaml(self):
+        path = resolve_shell_playbook("linux")
+        assert path.name == "shell.yaml"
+        assert path.exists()
+
+    def test_darwin_returns_shell_macos_yaml(self):
+        path = resolve_shell_playbook("darwin")
+        assert path.name == "shell_macos.yaml"
+        assert path.exists()
+
+    def test_unknown_os_family_raises_value_error(self):
+        with pytest.raises(ValueError, match="unsupported os_family"):
+            resolve_shell_playbook("windows")
+
+    def test_file_not_found_message_includes_resolved_path(
+        self, monkeypatch, tmp_path
+    ):
+        """If the per-OS file is missing (build artifact missing or
+        bad install), the resolver must raise FileNotFoundError with a
+        message that includes the resolved path so the operator can
+        diagnose where it looked (iter-1 lifecycle-core S5)."""
+        from clawrium.core import playbook_resolver as resolver
+
+        monkeypatch.setattr(resolver, "_PLATFORM_ROOT", tmp_path)
+        with pytest.raises(FileNotFoundError) as excinfo:
+            resolve_shell_playbook("linux")
+        assert str(tmp_path) in str(excinfo.value)
+        assert "shell.yaml" in str(excinfo.value)
+
+
+class TestShellRcPrepend:
+    """OS-aware rc-file prelude for `clawctl agent shell`. The OS
+    literal lives here (dispatcher-only OS-fork invariant); agent_shell
+    just concatenates the returned string."""
+
+    def test_linux_sources_bashrc_only(self):
+        prelude = shell_rc_prepend("linux")
+        assert ".bashrc" in prelude
+        # Linux must not source darwin-specific login files.
+        assert ".bash_profile" not in prelude
+        assert ".bash_login" not in prelude
+        assert ".profile" not in prelude.replace(".bash_profile", "").replace(
+            ".bashrc", ""
+        )
+
+    def test_darwin_sources_all_login_legs_then_bashrc(self):
+        """bash login-shell precedence: `.bash_profile` → `.bash_login`
+        → `.profile` (first found wins). Then `.bashrc` is sourced
+        unconditionally so `.bashrc`-only setups still load PATH shims."""
+        prelude = shell_rc_prepend("darwin")
+        for leg in (".bash_profile", ".bash_login", ".profile", ".bashrc"):
+            assert leg in prelude, f"darwin prelude missing {leg!r}: {prelude}"
+        # Precedence: bash_profile comes before bash_login comes before
+        # profile in the source.
+        assert prelude.index(".bash_profile") < prelude.index(".bash_login")
+        assert prelude.index(".bash_login") < prelude.index(".profile")
+
+    def test_unknown_os_family_raises_value_error(self):
+        with pytest.raises(ValueError, match="unsupported os_family"):
+            shell_rc_prepend("windows")
+
+    def test_both_preludes_end_with_semicolon_for_safe_concat(self):
+        """The caller concatenates with ` <user_cmd>` — the prelude
+        must end with `;` so a missing user_cmd doesn't accidentally
+        glue the source statement to whatever follows."""
+        for os_family in ("linux", "darwin"):
+            assert shell_rc_prepend(os_family).rstrip().endswith(";"), os_family

--- a/tests/platform/test_shell_playbook_macos.py
+++ b/tests/platform/test_shell_playbook_macos.py
@@ -1,0 +1,243 @@
+"""YAML-parse invariants on `src/clawrium/platform/shell/shell_macos.yaml`.
+
+Pure static inspection — no ansible-runner invocation. Mirrors the
+Linux invariants in `test_shell_playbook.py` for the macOS playbook so
+a future edit cannot drop `no_log`, the SHELL_*= prefixes, the
+`bash -lc` inner shell, or the gtimeout discovery / fallback branch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+_PLAYBOOK_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "clawrium"
+    / "platform"
+    / "shell"
+    / "shell_macos.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def play() -> dict:
+    text = _PLAYBOOK_PATH.read_text()
+    docs = list(yaml.safe_load_all(text))
+    play_doc = docs[0]
+    assert isinstance(play_doc, list)
+    return play_doc[0]
+
+
+def _tasks_by_name_prefix(play: dict, prefix: str) -> list[dict]:
+    return [t for t in play["tasks"] if t.get("name", "").startswith(prefix)]
+
+
+def _run_tasks(play: dict) -> list[dict]:
+    tasks = _tasks_by_name_prefix(play, "Run command")
+    assert len(tasks) == 2, (
+        f"Expected exactly two `Run command ...` tasks (gtimeout / fallback), "
+        f"got {len(tasks)}: {[t.get('name') for t in tasks]}"
+    )
+    return tasks
+
+
+def test_P1_no_log_true_on_both_run_tasks(play):
+    for task in _run_tasks(play):
+        assert task["no_log"] is True, task.get("name")
+
+
+def test_P2_become_user_is_agent_name_template(play):
+    for task in _run_tasks(play):
+        assert task["become"] is True, task.get("name")
+        assert task["become_user"] == "{{ agent_name }}", task.get("name")
+
+
+def test_P3_bash_lc_is_inner_shell_on_both_run_tasks(play):
+    """Inner shell is `bash -lc` (login, NOT interactive) on both
+    branches. The Python caller prepends `[ -f ~/.bash_profile ] && . ...;`
+    + `[ -f ~/.bashrc ] && . ...;` so PATH shims still load."""
+    for task in _run_tasks(play):
+        argv = task["ansible.builtin.command"]["argv"]
+        found = any(
+            argv[i] == "/bin/bash" and argv[i + 1] == "-lc"
+            for i in range(len(argv) - 1)
+        )
+        assert found, f"argv missing '/bin/bash -lc' sequence: {argv!r}"
+
+
+def test_P4_gtimeout_branch_uses_resolved_gtimeout_as_argv0(play):
+    """The gtimeout branch must use the discovered `resolved_gtimeout`
+    path as argv[0] so the kill window is enforced server-side. The
+    fallback branch starts directly with `/bin/bash` — the runner-level
+    timeout is the kill backstop there."""
+    run_tasks = _run_tasks(play)
+    gtimeout_branch = [
+        t
+        for t in run_tasks
+        if t["ansible.builtin.command"]["argv"][0] == "{{ resolved_gtimeout }}"
+    ]
+    fallback_branch = [
+        t
+        for t in run_tasks
+        if t["ansible.builtin.command"]["argv"][0] == "/bin/bash"
+    ]
+    assert len(gtimeout_branch) == 1, (
+        "Expected exactly one Run command task with resolved_gtimeout as argv0"
+    )
+    assert len(fallback_branch) == 1, (
+        "Expected exactly one fallback Run command task starting with /bin/bash"
+    )
+    # gtimeout branch must include --kill-after=5 between argv[0] and argv[2].
+    assert "--kill-after=5" in gtimeout_branch[0]["ansible.builtin.command"]["argv"]
+
+
+def test_P4_run_tasks_gated_by_resolved_gtimeout_length(play):
+    """The two Run command tasks must be mutually exclusive: gtimeout
+    branch fires when `resolved_gtimeout` is non-empty, fallback fires
+    when it is empty. Without the `when:` gating both tasks would run
+    on every host (resolved_gtimeout=='' case), causing duplicate side
+    effects and indeterminate SHELL_RC capture (W3 iter-1)."""
+    run_tasks = _run_tasks(play)
+    gtimeout_branch = next(
+        t
+        for t in run_tasks
+        if t["ansible.builtin.command"]["argv"][0] == "{{ resolved_gtimeout }}"
+    )
+    fallback_branch = next(
+        t
+        for t in run_tasks
+        if t["ansible.builtin.command"]["argv"][0] == "/bin/bash"
+    )
+
+    gtimeout_when = str(gtimeout_branch.get("when", ""))
+    fallback_when = str(fallback_branch.get("when", ""))
+
+    assert "resolved_gtimeout" in gtimeout_when
+    assert "> 0" in gtimeout_when
+    assert "resolved_gtimeout" in fallback_when
+    assert "== 0" in fallback_when
+
+
+def test_P5_merge_run_task_result_present_and_conditional(play):
+    """The 'Merge run-task result' set_fact stitches the fallback
+    register back to `shell_result` so the downstream emit tasks see
+    one variable name. Its ternary must reference both registers AND
+    the `resolved_gtimeout | length` predicate so the gating cannot
+    drift undetected (W4 iter-1)."""
+    merge_tasks = [
+        t for t in play["tasks"] if "set_fact" in t.get("name", "").lower()
+        or "merge" in t.get("name", "").lower()
+    ]
+    candidates = [
+        t
+        for t in merge_tasks
+        if "ansible.builtin.set_fact" in t
+        and "shell_result" in str(t["ansible.builtin.set_fact"])
+    ]
+    assert len(candidates) >= 1, (
+        f"No `shell_result` merge set_fact task found. Tasks: "
+        f"{[t.get('name') for t in play['tasks']]}"
+    )
+    merge = candidates[0]
+    expr = str(merge["ansible.builtin.set_fact"])
+    assert "shell_result_fallback" in expr
+    assert "resolved_gtimeout" in expr
+    assert "length" in expr
+
+
+def test_P5_gtimeout_discovery_runs_as_agent_user(play):
+    """Homebrew/MacPorts shims live on the agent user's $PATH (and
+    `/opt/homebrew/bin` is readable to that user). Discovery must
+    `become_user` the agent so the same shims are visible during the
+    `which` lookup; otherwise a refactor would silently widen the
+    kill window on every host (W5 iter-1)."""
+    discovery = next(
+        (t for t in play["tasks"] if t.get("name", "").startswith("Discover gtimeout")),
+        None,
+    )
+    assert discovery is not None, (
+        "No `Discover gtimeout` task found in shell_macos.yaml"
+    )
+    assert discovery["become"] is True
+    assert discovery["become_user"] == "{{ agent_name }}"
+
+
+def test_iter3_W3_cmd_b64_validation_task_present(play):
+    for task in play["tasks"]:
+        if "ansible.builtin.fail" not in task:
+            continue
+        when = task.get("when")
+        when_str = " ".join(when) if isinstance(when, list) else (when or "")
+        if "cmd_b64" in when_str and "not defined" in when_str:
+            return
+    raise AssertionError("No `cmd_b64 is not defined` guard task found")
+
+
+def test_iter3_B2_shell_timeout_validation_task_present(play):
+    for task in play["tasks"]:
+        if "ansible.builtin.fail" not in task:
+            continue
+        when = task.get("when")
+        when_str = " ".join(when) if isinstance(when, list) else (when or "")
+        if "shell_timeout" in when_str:
+            return
+    raise AssertionError("No `shell_timeout` guard task found")
+
+
+def test_P5_agent_name_regex_validation_task_present(play):
+    for task in play["tasks"]:
+        if "ansible.builtin.fail" not in task:
+            continue
+        when = task.get("when")
+        when_str = " ".join(when) if isinstance(when, list) else (when or "")
+        if "agent_name is not match" in when_str:
+            return
+    raise AssertionError("No agent_name regex-validation fail task found")
+
+
+def test_P6_failed_when_and_changed_when_false_on_both_run_tasks(play):
+    for task in _run_tasks(play):
+        assert task["failed_when"] is False, task.get("name")
+        assert task["changed_when"] is False, task.get("name")
+
+
+def test_W8_emit_prefix_contracts(play):
+    """The three debug tasks emit SHELL_STDOUT=/SHELL_STDERR=/SHELL_RC=.
+    Core's parser hard-codes these prefixes; flipping any of them
+    silently breaks the round-trip."""
+    expected_prefixes = {
+        "SHELL_STDOUT=": False,
+        "SHELL_STDERR=": False,
+        "SHELL_RC=": False,
+    }
+    for task in play["tasks"]:
+        if "ansible.builtin.debug" not in task:
+            continue
+        msg = task["ansible.builtin.debug"].get("msg", "")
+        for prefix in expected_prefixes:
+            if msg.startswith(prefix):
+                expected_prefixes[prefix] = True
+    missing = [p for p, hit in expected_prefixes.items() if not hit]
+    assert not missing, f"Missing emit prefixes: {missing}"
+
+
+def test_no_darwin_os_family_guard_in_when_clauses(play):
+    """Dispatcher-only OS-fork: the macOS playbook must not branch on
+    `ansible_os_family` itself — `core/playbook_resolver.py` is the
+    routing source of truth. We inspect each task's `when:` clause
+    rather than the raw text so explanatory comments can still mention
+    the fact name."""
+    for task in play["tasks"]:
+        when = task.get("when")
+        if when is None:
+            continue
+        clauses = when if isinstance(when, list) else [when]
+        for clause in clauses:
+            assert "ansible_os_family" not in str(clause), (
+                f"task {task.get('name')!r} branches on ansible_os_family: {clause!r}"
+            )


### PR DESCRIPTION
## Summary

- Adds macOS support to `clawctl agent shell <name> -- <cmd>`.
- New `shell_macos.yaml` parallel playbook discovers Homebrew/MacPorts `gtimeout` (coreutils) and falls back to plain `bash -lc` with the ansible-runner outer timeout as the kill backstop — the user-facing `rc=124` contract is preserved on both paths.
- Per-OS routing lives in `core.playbook_resolver` (`resolve_shell_playbook` + `shell_rc_prepend`), keeping the dispatcher-only OS-fork invariant: no OS literal anywhere in `agent_shell.py`. Darwin login-shell rc-prelude follows bash precedence (`.bash_profile` → `.bash_login` → `.profile`, then `.bashrc`).

Closes #808

## Testing

### Test Results
- [x] All existing tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New tests added for new functionality

### Test Coverage
- Files changed: `src/clawrium/core/playbook_resolver.py`, `src/clawrium/core/agent_shell.py`, `src/clawrium/platform/shell/shell_macos.yaml` (new), `tests/core/test_playbook_resolver.py`, `tests/core/test_agent_shell.py`, `tests/platform/test_shell_playbook_macos.py` (new), `CHANGELOG.md`, `.itx/808/`
- New tests: `tests/platform/test_shell_playbook_macos.py` (12 static-YAML invariants), `TestResolveShellPlaybook` + `TestShellRcPrepend` in `tests/core/test_playbook_resolver.py`, six new cases in `tests/core/test_agent_shell.py` (macOS-playbook routing, linux-playbook anchor, unsupported-OS rc=255, non-string `os_family` fallback, darwin rc-prepend precedence, linux rc-prepend unchanged), and the reserved-unix-name test parametrized across `os_family`.
- Coverage impact: increased — every new code path has an asserting test (playbook resolver, rc-prepend helper, OS-aware dispatch, gtimeout discovery `become_user`, `when:`-gated run-task branches, merge set_fact wiring).

### Manual Testing

Real-host smoke list per plan §6, against `esper-mac-oc` on `esper-macmini` (darwin/arm64). Original target `mac-test` (100.120.88.97) was offline at run-time (not in `tailscale status`, SSH connect timeouts); operator approved the substitution.

| # | Command | Expected | Observed |
|---|---|---|---|
| 1 | `agent shell esper-mac-oc -- ls -la ~/` | listing of `/Users/esper-mac-oc`, rc=0 | ✅ listing rendered, rc=0 |
| 2 | `agent shell esper-mac-oc -- 'echo $HOME'` | `/Users/esper-mac-oc`, rc=0 | ✅ `/Users/esper-mac-oc`, rc=0 |
| 3 | `agent shell esper-mac-oc -- 'echo $PATH'` | shims if `.bash_profile` exports them | ✅ `/usr/bin:/bin:/usr/sbin:/sbin` (no operator shims on host) |
| 4 | `agent shell esper-mac-oc --timeout 2 -- 'sleep 60; echo neverreached'` | rc=124, stderr non-empty | ✅ rc=124, stderr `remote command timed out after 2s`, wall-clock ~32s (fallback path: host has no gtimeout, runner backstop fired) |
| 5 | `agent shell esper-mac-oc -- 'echo "{{ lookup(env,HOME) }}"'` | literal echo, no Jinja expansion | ✅ `{{ lookup(env,HOME) }}` literal, rc=0 |
| 6 | `agent shell esper-mac-oc -- false` | rc=1 | ✅ rc=1 |

Note for #4: the substitute host has no `gtimeout`. Smoke #4 with `sleep 5` returned rc=0 because the inner `bash -lc` finished before the runner-level backstop at `2 + 30 = 32s` fired — exactly the documented "wider kill window" behavior. Re-running with `sleep 60` exercises the rc=124 path. On hosts with coreutils installed (`brew install coreutils`), the inner `gtimeout` fires at the exact `effective`s mark.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (`agent_name` regex; `cmd_b64` defined-and-non-empty guard; `shell_timeout` positive-integer guard; non-string `os_family` fallback)
- [x] No SQL injection, XSS, or command injection risks — the base64 hop from Python to the playbook's `{{ cmd_b64 | b64decode }}` blocks Jinja injection on both OS paths (verified by security-reviewer)
- [x] Dependencies are from trusted sources

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $6.53 | Total Time: 14m 57s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3.5/5 | B1 | Fixed | $3.49 | 9m 55s | leader, cli-ux, test-coverage, platform-playbooks, lifecycle-core, security-reviewer |
| 2 | 4/5 | None | Ready | $3.04 | 5m 2s | leader, cli-ux, test-coverage, platform-playbooks, lifecycle-core, security-reviewer |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 3.5/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `src/clawrium/core/agent_shell.py:270-276` | Inline `if os_family == "darwin":` branch for the rc-source list re-introduced the anti-pattern `playbook_resolver.py` explicitly forbids ("no other code is allowed to branch on OS family"). | **Fixed** — introduced `playbook_resolver.shell_rc_prepend(os_family)`. The OS literal now lives only in the module that owns the OS-fork; `agent_shell.py` just concatenates the returned string. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `src/clawrium/core/agent_shell.py:321-329` | Timeout message misreports kill latency on macOS-without-gtimeout (`effective`s vs `effective + 30s` wall-clock spend) | **Fixed** — clarified semantics in module docstring and at the rc=124 emit site. |
| W2 | `src/clawrium/core/agent_shell.py:270-274` | Missing `.bash_login` / `.profile` fallback in darwin rc-prepend; operators with `.profile`-only POSIX dotfiles silently lose PATH shims | **Fixed** — `shell_rc_prepend("darwin")` now follows bash login-shell precedence: `.bash_profile` → `.bash_login` → `.profile` (first found wins), then always-on `.bashrc`. |
| W3 | `tests/platform/test_shell_playbook_macos.py:73-96` | `test_P4` did not assert the `when:` clauses gating the gtimeout/fallback branches | **Fixed** — added `test_P4_run_tasks_gated_by_resolved_gtimeout_length` asserting both predicates. |
| W4 | `tests/platform/test_shell_playbook_macos.py` | "Merge run-task result" set_fact task was unasserted | **Fixed** — added `test_P5_merge_run_task_result_present_and_conditional` asserting the ternary references both registers and the `resolved_gtimeout | length` predicate. |
| W5 | `tests/platform/test_shell_playbook_macos.py:54-58` | `become_user` not asserted on the "Discover gtimeout" task | **Fixed** — added `test_P5_gtimeout_discovery_runs_as_agent_user`. |
| W6 | `tests/core/test_agent_shell.py:647` | `endswith("shell_macos.yaml")` looser than the Linux mirror (`endswith("/shell.yaml")`) — a stray `legacy_shell_macos.yaml` would have slipped through | **Fixed** — tightened to `endswith("/shell_macos.yaml")`. |
| W7 | `tests/core/test_agent_shell.py:590-598` | Reserved-unix-name rejection test not parametrized for darwin | **Fixed** — parametrized `os_family in (None, "linux", "darwin")` over the existing `reserved` parametrize. |

**Suggestions (applied):**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Guard non-string `os_family` so a tampered hosts.json doesn't raise `AttributeError` on `.lower()` | Applied — `raw.lower() if isinstance(raw, str) and raw else "linux"`. Parametrized test covers `int / dict / list / bool` inputs. |
| S2 | Add MacPorts `/opt/local/bin` to the gtimeout discovery PATH | Applied. |
| S3 | Drop redundant `\|\| true` from gtimeout discovery (keep `failed_when: false`) | Applied. |
| S4 | Add a Python-level test for the gtimeout-absent fallback's rc=124 contract | Partially applied — covered by smoke #4 on a gtimeout-absent host (`esper-macmini`). Module-level test deferred. |
| S5 | Add a direct test of `resolve_shell_playbook`'s `FileNotFoundError` branch | Applied — `test_file_not_found_message_includes_resolved_path` monkeypatches `_PLATFORM_ROOT`. |
| S6 | Lock in the `os_family: "windows"` round-trip | Applied — `test_unsupported_os_family_returns_255`. |

**Confirmed-Good (iter 1, retained in iter 2):**

- Dispatcher-only OS fork: no `when: ansible_os_family` guards inside `shell_macos.yaml`.
- `ansible_user_dir` ban: playbook does not reference the fact; `become_user` only.
- Base64 hop / Jinja injection: `cmd_b64` envelope applied identically on both paths.
- SSH key resolution: `core_keys.get_host_private_key` path identical for both OS paths.
- `RESERVED_UNIX_NAMES` check: executes before any os_family branching.
- SHELL_STDOUT/SHELL_STDERR/SHELL_RC emit prefixes match `shell.yaml` byte-for-byte.

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**Blocking Issues:** None — `blocking: false` on the leader's review summary.

Specialist agent ratings (iter 2): test-coverage 4/5, platform-playbooks 4/5, lifecycle-core 4/5, security-reviewer 4/5. Two non-blocking warnings remained from lifecycle-core and platform-playbooks; per the operator's iteration ceiling (rating > 3/5 AND no blockers), iter 2 cleared and no iter 3 was run.

</details>

## Callouts

- [ENVIRONMENT] Real-host verification target `mac-test` (100.120.88.97) was offline at run-time — not in `tailscale status` and SSH connect timeouts. The operator selected `esper-mac-oc` on `esper-macmini` (espers-mac-mini.tailf7742d.ts.net, darwin/arm64) as the substitute. Same `os_family=darwin`, same `arm64` architecture, same `clawctl agent shell` code path. Smoke list passed; details in `.itx/808/01_EXECUTION.md`.
- [ENVIRONMENT] `esper-macmini` has no `gtimeout` (coreutils) installed, so the smoke list exercises the fallback path. Smoke #4 was re-run with `sleep 60` (vs the plan's `sleep 5`) to exceed the runner-level kill backstop at `effective + 30 = 32s` — confirms the rc=124 contract on the wider-kill-window branch. On a host with `brew install coreutils`, the inner `gtimeout` fires at exactly `effective`s and the original `sleep 5` smoke would succeed.
- [DECISION] Moved the per-OS rc-prelude into `playbook_resolver.shell_rc_prepend(os_family)` rather than into the playbooks themselves (the other option ATX iter 1 suggested for B1).
  - Why: keeps `cmd_b64` semantically "the user's command plus a controller-known prelude" — both shells already share this contract from the Linux-only version. Moving the prelude into the playbooks would have required restructuring the `bash -lc {{ cmd_b64 | b64decode }}` shape on both Linux and macOS, expanding the diff and risking a regression on the Linux path. The helper approach is surgical: one new function, one call-site change.
  - Alternatives considered: in-playbook prelude (cleaner separation but bigger blast radius).
  - Reviewer: confirm or push back.
- [TODO-FOLLOWUP] Suggest documenting `brew install coreutils` in `clawctl agent shell --help` so operators understand the wider-kill-window trade-off without reading the module docstring.
  - Tracking: to be filed (separate issue, out of scope for #808).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
