### PR TITLE
fix(openclaw): add litellm branch to verify_config.py

### DIFF
--- a/.itx/819/01_EXECUTION.md
+++ b/.itx/819/01_EXECUTION.md
@@ -1,0 +1,52 @@
+# Issue #819 — Execution log
+
+## Summary
+
+Single-file fix: add `litellm` branch to
+`src/clawrium/platform/registry/openclaw/templates/verify_config.py:_expected_model_id`.
+
+The canonical renderer (post-#756) emits `<provider-name>/<model>` for
+litellm providers; the verify script fell through and expected the
+raw `default_model`, so every `clawctl agent configure --stage
+providers --provider <litellm>` failed at the `Verify openclaw.json
+configuration` Ansible task with `no_log: true` masking the cause.
+
+Provider overlay already includes `name`
+(`src/clawrium/core/lifecycle.py:605`), so the verify script needed
+no extravar plumbing changes — the expected JSON dumped to
+`/tmp/clawrium_expected_config_<name>.json` already carries
+`provider.name` for every attached provider.
+
+## Changes
+
+- `src/clawrium/platform/registry/openclaw/templates/verify_config.py`
+  — add `provider_type == "litellm"` branch, prefix with
+  `provider.get("name")`. Defensive fall-through when `name` is
+  missing.
+- `tests/test_verify_config_script.py` — four new tests covering:
+  normalize unprefixed → prefixed, already-prefixed not double-
+  prefixed, on-host unprefixed fails verify, missing `name` falls
+  through.
+- `CHANGELOG.md` — `### Fixed` entry referencing #819.
+
+## Verification
+
+- `make lint-py` → All checks passed.
+- `make test-py` → 4037 passed, 8 skipped (pre-existing wheel
+  skips; unrelated).
+
+## Stage execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-06-24T00:00:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx:execute 819
+
+The issue #819 body already has the full root cause + fix plan...
+Single-file fix in src/clawrium/platform/registry/openclaw/templates/verify_config.py (S-sized).
+```
+
+**Output**: 1 file fix + 4 tests + changelog entry; full suite green.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,15 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Fixed
 
+- `clawctl agent configure <name> --stage providers --provider <litellm>`
+  no longer fails at the `Verify openclaw.json configuration`
+  Ansible task for litellm providers. `verify_config.py`
+  (`_expected_model_id`) was missing a litellm branch and fell
+  through to the raw `default_model`, so the verify step mismatched
+  the correctly-rendered `<provider-name>/<model>` on disk. The
+  script now mirrors `clawrium.core.render`'s litellm prefix rule
+  (#819). Direct follow-up to #756 / PR #818 — the canonical render
+  was right; the downstream verifier was stale.
 - openclaw with a litellm provider now correctly emits
   `agents.defaults.model.primary` as `<provider-name>/<model>` on
   `clawctl agent configure`. Previously the configure path used the

--- a/src/clawrium/platform/registry/openclaw/templates/verify_config.py
+++ b/src/clawrium/platform/registry/openclaw/templates/verify_config.py
@@ -72,6 +72,19 @@ def main():
             return f"ollama/{default_model}"
         if provider_type == "bedrock" and not default_model.startswith("amazon-bedrock/"):
             return f"amazon-bedrock/{default_model}"
+        if provider_type == "litellm":
+            # Mirror clawrium.core.render's litellm rule (#756): the prefix
+            # is the clawctl provider name, not a static type-keyed string,
+            # because every litellm proxy is its own custom provider in
+            # `models.providers.<name>`. Without this branch the verify task
+            # always fails for litellm providers (#819) because the
+            # canonical render emits `<provider-name>/<model>` while this
+            # function would otherwise return the raw `default_model`.
+            provider_name = provider.get("name")
+            if isinstance(provider_name, str) and provider_name:
+                prefix = f"{provider_name}/"
+                if not default_model.startswith(prefix):
+                    return f"{prefix}{default_model}"
         return default_model
 
     # Verify model is set if provider configured

--- a/tests/test_verify_config_script.py
+++ b/tests/test_verify_config_script.py
@@ -174,6 +174,7 @@ def test_verify_config_bedrock_already_prefixed_not_double_prefixed(tmp_path: Pa
     assert result.returncode == 0, (
         f"verify failed: stdout={result.stdout!r} stderr={result.stderr!r}"
     )
+    assert "Configuration verified successfully" in result.stdout
 
 
 def test_verify_config_rejects_legacy_bedrock_prefix_on_host(tmp_path: Path):

--- a/tests/test_verify_config_script.py
+++ b/tests/test_verify_config_script.py
@@ -201,6 +201,137 @@ def test_verify_config_rejects_legacy_bedrock_prefix_on_host(tmp_path: Path):
 
 
 # ---------------------------------------------------------------------------
+# Litellm prefix (issue #819) — the canonical renderer in
+# `clawrium.core.render` prefixes litellm models with the *provider's
+# clawctl name* (not a static type-keyed string), because each litellm
+# proxy is its own custom provider in `models.providers.<name>`. The
+# verify script was missing this branch, so every `clawctl agent
+# configure --stage providers --provider <litellm>` failed at the
+# `Verify openclaw.json configuration` task with a mismatch between the
+# correctly-rendered file on disk and the raw `default_model` this
+# script expected. These tests pin the new branch end-to-end against
+# the script — a future regression would surface in CI.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "provider_name, raw_model, rendered_model",
+    [
+        # The production case: hyphenated provider name, single-segment model.
+        ("clawrium-gtm-litellm", "writer", "clawrium-gtm-litellm/writer"),
+        # Provider name with underscores + dots; model with a hyphen. Pins
+        # that the prefix is treated as a literal string, not a regex.
+        ("my_lit.proxy", "model-id", "my_lit.proxy/model-id"),
+        # Multi-segment model (litellm proxies routinely fan out to
+        # `<subdir>/<model>` shapes). Exercises the `startswith` guard
+        # against false-positive idempotency on the wrong prefix.
+        ("myproxy", "subdir/model", "myproxy/subdir/model"),
+    ],
+)
+def test_verify_config_normalizes_litellm_prefix(
+    tmp_path: Path, provider_name: str, raw_model: str, rendered_model: str
+):
+    config = {
+        "agents": {"defaults": {"model": {"primary": rendered_model}}},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    expected = {
+        "provider": {
+            "type": "litellm",
+            "name": provider_name,
+            "default_model": raw_model,
+        },
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    result = _run_verify_script(tmp_path, config, expected)
+    assert result.returncode == 0, (
+        f"verify failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "Configuration verified successfully" in result.stdout
+
+
+def test_verify_config_litellm_already_prefixed_not_double_prefixed(tmp_path: Path):
+    """If `provider.default_model` already starts with `<name>/`, do not
+    double-prefix to `<name>/<name>/<model>` — that's a value the
+    gateway would reject."""
+    model_id = "clawrium-gtm-litellm/writer"
+    config = {
+        "agents": {"defaults": {"model": {"primary": model_id}}},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    expected = {
+        "provider": {
+            "type": "litellm",
+            "name": "clawrium-gtm-litellm",
+            "default_model": model_id,
+        },
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    result = _run_verify_script(tmp_path, config, expected)
+    assert result.returncode == 0, (
+        f"verify failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "Configuration verified successfully" in result.stdout
+
+
+def test_verify_config_rejects_litellm_unprefixed_on_host(tmp_path: Path):
+    """Negative case: if the on-host `openclaw.json` carries the raw
+    model id without the provider-name prefix, verify must mismatch."""
+    config = {
+        "agents": {"defaults": {"model": {"primary": "writer"}}},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    expected = {
+        "provider": {
+            "type": "litellm",
+            "name": "clawrium-gtm-litellm",
+            "default_model": "writer",
+        },
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    result = _run_verify_script(tmp_path, config, expected)
+    assert result.returncode == 1
+    assert "Model mismatch" in result.stderr
+    assert "clawrium-gtm-litellm/writer" in result.stderr  # expected (rendered)
+    # Anchor the assertion to the `got '<actual>'` half of the mismatch
+    # message so a future format-string change surfaces here instead of
+    # silently degrading the assertion to a one-sided check.
+    assert "got 'writer'" in result.stderr
+
+
+@pytest.mark.parametrize("name_value", [None, ""])
+def test_verify_config_litellm_without_name_falls_through(
+    tmp_path: Path, name_value
+):
+    """Defensive: if the provider overlay somehow lacks `name` (a bug
+    upstream of this script), the litellm branch must fall through to
+    the raw default_model rather than crashing or returning a malformed
+    `'/<model>'`. The on-host renderer would have failed earlier, but
+    this script must still produce a usable comparison.
+
+    Parametrized over `None` (missing key) and `""` (empty string) —
+    `lifecycle.py:605` uses `provider_record.get("name", "")`, so the
+    empty-string branch is the realistic case if a provider was
+    registered without a name."""
+    config = {
+        "agents": {"defaults": {"model": {"primary": "writer"}}},
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    provider = {"type": "litellm", "default_model": "writer"}
+    if name_value is not None:
+        provider["name"] = name_value
+    expected = {
+        "provider": provider,
+        "gateway": {"port": 40198, "bind": "lan"},
+    }
+    result = _run_verify_script(tmp_path, config, expected)
+    assert result.returncode == 0, (
+        f"verify failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "Configuration verified successfully" in result.stdout
+
+
+# ---------------------------------------------------------------------------
 # Python 3.9 compat guard — see .itx/719/01_EXECUTION.md
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `clawctl agent configure <name> --stage providers --provider <litellm>` was always failing at the `Verify openclaw.json configuration` Ansible task (with `no_log: true` masking the cause). The canonical render was correct; the verify script was stale.
- `verify_config.py:_expected_model_id` had branches for `openrouter`, `ollama`, and `bedrock` but fell through to the raw `default_model` for any other provider type — including `litellm`. The canonical renderer (post-#756 / PR #818) emits `<provider-name>/<model>` for litellm, so the comparison mismatched and the task failed.
- Fix mirrors `clawrium.core.render`'s litellm prefix rule: prefix with the **clawctl provider name** (every litellm proxy is its own custom provider in `models.providers.<name>`). Provider overlay already includes `name` at `src/clawrium/core/lifecycle.py:605`, so no extravar plumbing was needed.

Direct follow-up to #756 / PR #818. Surfaced during real-host UAT on wolf-i against the merged b90a3c5.

Closes #819

## Real-host UAT (wolf-i, openclaw, clawrium-gtm-litellm)

Verified end-to-end against the live wolf-i openclaw agent (tailscale `wolf.tailf7742d.ts.net`, attached provider `clawrium-gtm-litellm`).

**Before (PyPI clawctl 26.6.5, no litellm branch):**

```
$ clawctl agent configure wolf-i --stage providers --provider clawrium-gtm-litellm
agent/wolf-i: configure stage=providers on wolf.tailf7742d.ts.net
agent/wolf-i: [sync] Syncing wolf-i on wolf.tailf7742d.ts.net...
agent/wolf-i: [sync] Configuring wolf-i...
agent/wolf-i: [configure] Configuring wolf-i on wolf.tailf7742d.ts.net...
agent/wolf-i: [configure] Loaded provider API key from secrets
agent/wolf-i: [configure] Running Ansible playbook...
Error: configure stage failed: Configure failed: task 'Verify openclaw.json configuration'
failed but output was suppressed by `no_log: true`.
Re-run with ANSIBLE_NO_LOG=False in the environment, or temporarily set `no_log: false`
on the task, to see the underlying error.
```

This reproduces the exact failure mode described in #819.

**After (`uv tool install --reinstall --force` from this branch):**

```
$ clawctl agent configure wolf-i --stage providers --provider clawrium-gtm-litellm
agent/wolf-i: configure stage=providers on wolf.tailf7742d.ts.net
agent/wolf-i: [sync] Syncing wolf-i on wolf.tailf7742d.ts.net...
agent/wolf-i: [sync] Configuring wolf-i...
agent/wolf-i: [configure] Configuring wolf-i on wolf.tailf7742d.ts.net...
agent/wolf-i: [configure] Loaded provider API key from secrets
agent/wolf-i: [configure] Running Ansible playbook...
agent/wolf-i: [configure] Saving configuration to hosts.json...
agent/wolf-i: [push_workspace] {"state": "complete", "files_pushed": [], "files_excluded": []}
agent/wolf-i: [configure] Successfully configured wolf-i
agent/wolf-i: [sync] Sync complete for wolf-i
agent/wolf-i: stage providers complete
```

Verify step now passes; configure completes successfully.

## ATX Review Summary

**Final Review: Rating 4.5/5**
**Total Cost: $3.52 | Total Time: 12m25s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3.5/5 | None | Warnings W1/W2 cleared | $1.51 | 4m50s | leader, test-coverage, platform-playbooks |
| 2 | 4.5/5 | None | Warning W1 cleared; ready | $2.01 | 7m35s | leader, test-coverage, platform-playbooks |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 3.5/5)</summary>

No blocking issues. Two warnings:

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `tests/test_verify_config_script.py` | Fallthrough test asserted only `returncode == 0` — could silently pass on a different exit-0 path. | Fixed — added `assert "Configuration verified successfully" in result.stdout`. |
| W2 | `tests/test_verify_config_script.py` | Litellm positive test lacked `@pytest.mark.parametrize` parity with the bedrock test set (no multi-segment model, no non-alphanumeric provider name). | Fixed — parametrized with 3 variants: production case, name with underscores+dots, multi-segment model. |

Suggestions:

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Fallthrough test covers `name=None` but not `name=""` (the realistic case given `lifecycle.py:605` uses `.get("name", "")`). | Fixed — parametrized over both. |
| S2 | Negative test asserts `"'writer'"` — fragile if mismatch format string changes. | Fixed — anchored to `"got 'writer'"`. |
| S3 | No prefix-collision test (provider_name='foo' against default_model='foobar/model'). | Out-of-scope — hypothetical scenario the production overlay does not produce. |
| S4 | `verify_config.py` falls through silently on empty `name`, while `render.py` would emit `/<model>`. | Out-of-scope — see Callouts. |
| S5 | Tighten or harden `render.py` to reject empty/whitespace litellm `provider.name`. | Out-of-scope — see Callouts. |

</details>

<details>
<summary>Review 2 Details (Rating 4.5/5)</summary>

All iter-1 warnings + S1/S2 confirmed cleared. One new warning, addressed before commit:

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `tests/test_verify_config_script.py:test_verify_config_litellm_already_prefixed_not_double_prefixed` | Missing stdout success assertion (parallel to the iter-1 W1 pattern). | Fixed — appended `assert "Configuration verified successfully" in result.stdout`. |

Suggestions:

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Extend fallthrough parametrize with non-string type (e.g. `42`) to specifically exercise the `isinstance(provider_name, str)` guard. | Deferred — guard is correct; covered by `None` (also non-truthy via `isinstance` check) functionally. |
| S2 | Centralize prefix-derivation table to prevent renderer/verifier drift. | Out-of-scope — see Callouts. |

Specialist ratings: platform-playbooks 5/5, test-coverage 4/5. Leader verdict: "Ready to merge."

</details>

## Testing

- `make lint-py` — All checks passed.
- `make test-py` — 4040 passed, 8 skipped (pre-existing wheel skips, unrelated).
- New tests added (18 total in `test_verify_config_script.py`, up from 11): litellm positive (parametrized x3), already-prefixed not double-prefixed, on-host unprefixed mismatch, fallthrough on missing/empty `name` (parametrized x2).
- Real-host UAT on wolf-i: before/after evidence above.

## Callouts

- [ENVIRONMENT] During UAT, an unrelated upstream bug surfaced on the first `configure` attempt against the PyPI install: `Openclaw render failed (internal): 'dict' object has no attribute 'replace'` (originating at `core/render.py:104` in `_clean_secret`, called from `build_render_inputs` for `gateway.auth` when the dict shape `{"mode": "token", "token": "..."}` is encountered). This is tracked separately in #820 / PR #823 (`fix(openclaw): normalize gateway.auth dict/string shape in build_render_inputs`) and is **not** in scope for this PR. The before-state UAT capture above proceeded after the auth field was normalized to a flat string (which happened automatically via the daemon's bearer-rotation path on the next attempt). With the bug worked around, the #819 verify-step failure reproduced cleanly with `no_log: true` masking the underlying mismatch — exactly as the issue describes.

- [DECISION] Did not centralize the openclaw model-id prefix table (ATX iter-2 S2 / platform-playbooks recommendation).
  - Why: scope creep — this PR is S-sized and the prefix logic is currently duplicated only across two surfaces (`render.py` and `verify_config.py`) for four provider types. Refactoring touches the canonical renderer and would expand to M/L.
  - Alternatives considered: extract a shared module under `src/clawrium/platform/registry/openclaw/`; deferred.
  - Reviewer: confirm or file a follow-up issue.

- [DECISION] Did not harden `render.py:1463` to raise `AgentConfigError` on empty/whitespace `provider.name` for litellm (ATX iter-1 S4/S5).
  - Why: separate file, separate concern; mirrors of the existing `default_model` guard at `render.py:1452`. The current PR's defensive fallthrough in `verify_config.py` is a redundant guard against an unreachable production state (overlay always sets `name` at `lifecycle.py:605`, even to `""`).
  - Alternatives considered: harden render in this PR; rejected to keep scope S.
  - Reviewer: a follow-up issue would be appropriate if you want belt-and-suspenders symmetry.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
