### PR TITLE
fix(openclaw): install plugins on clawctl agent sync, not just configure (#755)

### DIFF
--- a/.itx/755/02_EXECUTE.md
+++ b/.itx/755/02_EXECUTE.md
@@ -1,0 +1,78 @@
+# Execution Log — #755
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx-execute
+**Timestamp**: 2026-06-24T19:55:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+755
+
+Read the issue body first via gh issue view 755. Summary of the bug:
+clawctl agent sync on openclaw does NOT install the
+@openclaw/brave-plugin. That plugin install lives only in
+playbooks/openclaw/configure.yaml:131 (Linux) and
+configure_macos.yaml:153 (macOS). sync_agent_canonical in
+src/clawrium/core/lifecycle_canonical.py:799-1167 does brave-version
+preflight, writes diffs, restarts unit, and (zeroclaw only) re-pairs
+— but never installs the plugin. Attaching a brave integration only
+mutates inputs.integrations (used for preflight + env render); there
+is no host-side action to materialize the plugin.
+
+[Full prompt in conversation log.]
+```
+
+**Output**: PR opened against main, closes #755. Plugin install
+lifted from `configure.yaml` + `configure_macos.yaml` into
+`lifecycle_canonical._openclaw_install_plugins`. Driven by manifest
+`plugins:` block (generalizes beyond brave). Idempotent via
+per-version sentinel `.openclaw/.<plugin>-plugin-installed.<version>`.
+Install via `openclaw plugins install --force --pin <pkg>@<ver>` so
+the daemon's `plugins list` actually discovers the plugin (the
+pre-#755 `npm install --prefix ~/.openclaw` approach was discovered
+during UAT to write files the daemon never scanned). Wired between
+brave preflight and `_restart_unit` — install failure short-circuits
+before restart. Extravars `openclaw_brave_plugin_{package,version}`
+stripped from `lifecycle.py`.
+
+## UAT (esper-mac-oc, darwin/arm64)
+
+1. Attached `wolf-brave` integration to esper-mac-oc.
+2. `uv run clawctl agent sync esper-mac-oc` from this worktree:
+   - First run revealed `sudo -n -u` was preserving SSH user's HOME
+     so npm tried to write `/Users/xclm/.npm` (EACCES). Fixed with
+     `sudo -n -H -u`.
+   - Second run revealed `npm install --prefix ~/.openclaw` writes
+     files but openclaw's `plugins list` doesn't scan that dir.
+     Switched to `openclaw plugins install --force --pin <spec>`.
+   - Third run: success. Plugin installed at
+     `/Users/esper-mac-oc/.openclaw/npm/projects/openclaw-brave-plugin-<hash>/`,
+     `openclaw plugins list --json` reports `brave@2026.6.9` with
+     `status: loaded`, `webSearchProviders: ['brave']`.
+3. Sentinel: `/Users/esper-mac-oc/.openclaw/.brave-plugin-installed.2026.6.9`
+   present with mode 0600.
+4. Idempotent: second sync emitted "already installed (sentinel
+   present)" and skipped the install command.
+5. Detach + sync: plugin remains (uninstall out of scope for #755).
+
+## ATX
+
+| Iter | Rating | Blockers | Cost | Time |
+|---|---|---|---|---|
+| 1 | 3.5/5 | B1, B2 | $4.98 | 9m 9s |
+| 2 | 4/5 | None | $2.90 | 12m 52s |
+
+Iter-1 B1 (vacuous T5) fixed by rewriting `test_t5_install_runs_before_restart_via_sync`
+to drive `sync_agent_canonical` with stubbed IO + spy callbacks
+asserting ordering. Iter-1 B2 (missing stamp-failure coverage) fixed
+by `test_stamp_failure_after_successful_install_raises`.
+
+Iter-2 W1 (paramiko stdout buffer deadlock on verbose npm output)
+addressed by draining `i_out.read() + i_err.read()` before
+`recv_exit_status()` — matches `_run_openclaw_version_probe`'s
+established pattern.
+
+Iter-2 W2, W3, S1-S5 left as follow-ups (hygiene improvements;
+none cause production impact).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,34 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Changed
 
+- `clawctl agent sync <openclaw-agent>` now installs the openclaw
+  plugins required by attached integrations (`@openclaw/brave-plugin`
+  today; generalizes via the `plugins:` block in the openclaw
+  manifest). Previously the plugin install lived in
+  `playbooks/openclaw/configure.yaml` only, so an operator who ran
+  `clawctl agent integration attach <brave> --agent <name>` followed
+  by `clawctl agent sync <name>` got a daemon with `BRAVE_API_KEY` in
+  its env but no plugin to consume it — sync had to be followed by a
+  separate `clawctl agent configure --stage <...>` dance for the
+  plugin to materialize. With #755 the canonical sync pipeline owns
+  plugin install end-to-end: install runs after the brave preflight
+  and BEFORE the systemd restart, fails-loud-and-short-circuits on
+  any install error (the unit is never restarted on a half-installed
+  plugin), and is idempotent via a per-version sentinel
+  (`.<plugin>-plugin-installed.<version>`). Install uses openclaw's
+  own `openclaw plugins install --force --pin <pkg>@<ver>` CLI so
+  `openclaw plugins list` actually discovers the plugin — UAT on
+  esper-mac-oc proved that the pre-#755 `npm install --prefix
+  ~/.openclaw` approach wrote files but did not register the plugin
+  with the daemon. **Operator workflow change:** the canonical
+  sequence is now `attach <integration> → sync`. The
+  `attach → configure → start` path documented in the quickstart
+  no longer installs plugins (configure is scoped to onboarding
+  stages — providers / identity / channels — only); operators on
+  the configure-then-start path must add a `clawctl agent sync` in
+  between to materialize plugins. No automated migration; the next
+  `clawctl agent sync` against any openclaw agent with brave
+  attached will install the plugin in-place.
 - openclaw `~/.openclaw/openclaw.json` is now written through the
   canonical Python renderer (`clawrium.core.render._render_openclaw_json`)
   on every code path: `clawctl agent create` (install) pre-renders a

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -2620,17 +2620,15 @@ def configure_agent(
             # as a clean (False, msg) instead of an unhandled traceback.
             return False, f"Openclaw render failed (internal): {exc}"
 
-    # #734 Openclaw brave plugin pin. Single source of truth lives in
-    # `lifecycle_canonical._load_openclaw_brave_pin()` (W2 ATX iter 1),
-    # which reads `plugins.brave` from the openclaw manifest and
-    # hard-fails if any of (npm_package, version, min_host_version) is
-    # missing — so a typo'd manifest never lets npm install
-    # `@openclaw/brave-plugin@` with an empty version (W3 ATX iter 1).
-    # Default empty strings are used for non-openclaw runs where the
-    # vars are referenced but the install task is skipped by
-    # `integrations | selectattr(...)`.
-    openclaw_brave_plugin_package = ""
-    openclaw_brave_plugin_version = ""
+    # #734 / #755 Openclaw brave plugin preflight on the configure
+    # path. Plugin install itself now lives in
+    # `lifecycle_canonical._openclaw_install_plugins` (lifted out of
+    # the configure playbook by #755) — the configure path keeps only
+    # the minHostVersion preflight so `clawctl agent attach + configure`
+    # against a too-old host still fails loud at the configure boundary
+    # rather than surfacing later as an opaque npm error on the next
+    # sync. Pin loader is the single source of truth for the
+    # manifest read (`lifecycle_canonical._load_openclaw_brave_pin`).
     if resolved_type == "openclaw":
         from clawrium.core.lifecycle_canonical import (
             CanonicalSyncError,
@@ -2638,23 +2636,14 @@ def configure_agent(
             _load_openclaw_brave_pin,
         )
 
-        try:
-            _pin = _load_openclaw_brave_pin()
-        except CanonicalSyncError as exc:
-            return False, str(exc)
-        openclaw_brave_plugin_package = _pin["npm_package"]
-        openclaw_brave_plugin_version = _pin["version"]
-
-        # ATX iter 2 B1: openclaw minHostVersion preflight now runs on
-        # the configure path too. Without it, `clawctl agent attach +
-        # configure` on a host below 2026.4.10 would fire `npm install
-        # @openclaw/brave-plugin@2026.6.8` against a host the plugin's
-        # manifest does not support, and surface as an opaque runtime
-        # failure later. Mirrors the `sync_agent_canonical` preflight.
         if any(
             (entry or {}).get("type") == "brave"
             for entry in integrations_data.values()
         ):
+            try:
+                _pin = _load_openclaw_brave_pin()
+            except CanonicalSyncError as exc:
+                return False, str(exc)
             _min_ver = _pin["min_host_version"]
             _min_str = ".".join(str(p) for p in _min_ver)
             _private_key = get_host_private_key(key_id)
@@ -2716,8 +2705,6 @@ def configure_agent(
         "slack_bot_token": slack_bot_token,
         "slack_app_token": slack_app_token,
         "integrations": integrations_data,
-        "openclaw_brave_plugin_package": openclaw_brave_plugin_package,
-        "openclaw_brave_plugin_version": openclaw_brave_plugin_version,
         "prerendered_zeroclaw_config_toml": prerendered_files.get(
             ".zeroclaw/config.toml", ""
         ),

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -804,6 +804,220 @@ def _verify_health(
         raise CanonicalSyncError(base)
 
 
+# #755: openclaw plugin install on every sync.
+#
+# Before #755 the `@openclaw/brave-plugin` install lived only in
+# `playbooks/openclaw/configure.yaml` (+ the macOS sibling). That made
+# `clawctl agent integration attach <brave>` + `clawctl agent sync`
+# silently incomplete — the env was rendered with `BRAVE_API_KEY` but
+# the plugin manifest the var feeds was never written to host. Lifting
+# the install into the canonical sync pipeline makes sync the single
+# source of truth for declared state, the operator's mental model.
+#
+# Generalizes beyond brave: any entry in the openclaw manifest's
+# `plugins:` block whose key matches an attached integration's `type`
+# is installed at the pinned `npm_package@version`. Future plugin-
+# backed integrations need only a manifest row — no playbook change,
+# no Python wiring.
+def _load_openclaw_plugins() -> dict[str, dict]:
+    """Read the entire `plugins:` block from the openclaw manifest.
+
+    Returns a dict keyed by plugin name (matching integration `type`).
+    Raises `CanonicalSyncError` on a structural problem so the caller
+    cannot proceed with an undefined pin (mirrors
+    `_load_openclaw_brave_pin`'s hard-fail discipline)."""
+    import yaml as _yaml
+
+    manifest_path = (
+        Path(__file__).parent.parent
+        / "platform"
+        / "registry"
+        / "openclaw"
+        / "manifest.yaml"
+    )
+    try:
+        manifest = _yaml.safe_load(manifest_path.read_text())
+    except Exception as exc:
+        raise CanonicalSyncError(
+            f"openclaw plugin install: cannot read manifest: {exc}"
+        ) from exc
+    block = (manifest or {}).get("plugins") or {}
+    if not isinstance(block, dict):
+        raise CanonicalSyncError(
+            "openclaw manifest `plugins:` block is malformed (not a mapping)"
+        )
+    return block
+
+
+def _openclaw_plugin_paths(
+    agent_name: str, *, os_family: str
+) -> tuple[str, str]:
+    """Return `(openclaw_home, openclaw_bin)` for `agent_name` on the
+    given `os_family`. `/home` vs `/Users` is sourced via
+    `home_root_for(os_family)` so the OS→home-root mapping stays in
+    one seam (#770 invariant). `openclaw_bin` is the per-agent
+    `openclaw` shim installed by `install.yaml` — invoked by absolute
+    path so PATH lookup is not load-bearing here."""
+    home = f"{home_root_for(os_family)}/{agent_name}/.openclaw"
+    openclaw_bin = f"{home}/bin/openclaw"
+    return home, openclaw_bin
+
+
+def _openclaw_install_plugins(
+    client: paramiko.SSHClient,
+    agent_name: str,
+    *,
+    os_family: str,
+    inputs,
+    on_event: Callable[[str, str], None] | None = None,
+    install_timeout: int = 180,
+    probe_timeout: int = 15,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Install openclaw plugins required by attached integrations.
+
+    For each entry in the openclaw manifest's `plugins:` block whose
+    key matches an attached integration `type`, run
+    `npm install --prefix ~<agent>/.openclaw <npm_package>@<version>`
+    on the host (as the agent user) when the per-version sentinel file
+    `<openclaw_home>/.<plugin>-plugin-installed.<version>` is missing.
+
+    Idempotency: a sentinel file whose name encodes the version. A pin
+    bump changes the sentinel filename so the install re-fires; a same-
+    version repeat is a no-op (the probe short-circuits before npm
+    runs). This is the same gating shape the configure playbook
+    historically used (`creates:` arg on the `npm install` task at
+    `configure.yaml:133`), lifted intact into Python so the canonical
+    sync pipeline owns it.
+
+    Returns `(installed, skipped)` — tuples of plugin keys (e.g.
+    `("brave",)`) for the caller's event payloads. The `skipped`
+    bucket includes both "sentinel already present" and "no attached
+    integration for this plugin"; the latter is the common-case empty
+    branch.
+
+    Raises `CanonicalSyncError` on any per-host failure (npm missing,
+    install non-zero, sentinel stamp failed) so the caller can
+    short-circuit before `_restart_unit`. The agent is never restarted
+    on a half-installed plugin set."""
+    plugins_block = _load_openclaw_plugins()
+    if not plugins_block:
+        return (), ()
+
+    attached_types = {i.type for i in inputs.integrations}
+    home, openclaw_bin = _openclaw_plugin_paths(
+        agent_name, os_family=os_family
+    )
+    quoted_agent = shlex.quote(agent_name)
+    quoted_bin = shlex.quote(openclaw_bin)
+
+    installed: list[str] = []
+    skipped: list[str] = []
+
+    for plugin_key, spec in plugins_block.items():
+        if plugin_key not in attached_types:
+            skipped.append(plugin_key)
+            continue
+        pkg = (spec or {}).get("npm_package")
+        ver = (spec or {}).get("version")
+        if not pkg or not ver:
+            raise CanonicalSyncError(
+                f"openclaw manifest plugin {plugin_key!r} is missing "
+                f"npm_package or version — clawrium build is corrupt; "
+                f"reinstall via `uv tool install clawrium`."
+            )
+        sentinel = f"{home}/.{plugin_key}-plugin-installed.{ver}"
+        quoted_sentinel = shlex.quote(sentinel)
+
+        # Sentinel probe — cheap fast-path that short-circuits the
+        # ~Node-startup cost of `openclaw plugins install` on every
+        # subsequent sync at the same pin. The sentinel filename
+        # encodes the version, so a pin bump auto-fires reinstall
+        # via the missing-sentinel branch below. Runs as the agent
+        # user because `~<agent>/.openclaw` is mode 0700 and the
+        # SSH user (xclm) cannot stat inside it. `sudo -n -H` resets
+        # HOME to the agent user's home — required for `openclaw
+        # plugins install` downstream which writes plugin state into
+        # `~<agent>/.openclaw/state/` (surfaced live during #755 UAT
+        # on esper-mac-oc, where the install otherwise inherited
+        # `/Users/xclm` as HOME and failed EACCES on the state DB).
+        probe = (
+            f"sudo -n -H -u {quoted_agent} test -f {quoted_sentinel}"
+        )
+        _, p_out, _ = client.exec_command(probe, timeout=probe_timeout)
+        if p_out.channel.recv_exit_status() == 0:
+            if on_event is not None:
+                on_event(
+                    "plugin_install",
+                    f"openclaw plugin {plugin_key}@{ver} already "
+                    f"installed on {agent_name} (sentinel present)",
+                )
+            skipped.append(plugin_key)
+            continue
+
+        if on_event is not None:
+            on_event(
+                "plugin_install",
+                f"installing openclaw plugin {pkg}@{ver} on {agent_name}",
+            )
+
+        # `openclaw plugins install <npm-spec>` is openclaw's own
+        # plugin install path — it writes to the per-agent plugin
+        # store that `openclaw plugins list` scans (`~<agent>/.openclaw/
+        # node_modules/` alone is NOT scanned, surfaced live during
+        # #755 UAT). `--force` overwrites a prior pin so a bumped
+        # version takes effect even if the previous install lingers;
+        # `--pin` records the resolved `<name>@<version>` exactly so a
+        # transitive upgrade cannot smuggle in a new floor.
+        install_cmd = (
+            f"sudo -n -H -u {quoted_agent} {quoted_bin} plugins install "
+            f"--force --pin {shlex.quote(f'{pkg}@{ver}')}"
+        )
+        _, i_out, i_err = client.exec_command(
+            install_cmd, timeout=install_timeout
+        )
+        # ATX iter-2 W1: drain stdout + stderr BEFORE recv_exit_status.
+        # `openclaw plugins install` proxies `npm install` whose output
+        # can exceed the ~64KB SSH pipe buffer on fresh-host installs
+        # (download progress, peer-dep warnings, audit reports). With
+        # the buffer full the remote write blocks before exit-status is
+        # sent, so `recv_exit_status()` hangs indefinitely — surfaced as
+        # an apparent freeze of `clawctl agent sync` with no diagnostic.
+        # Matches the established `_run_openclaw_version_probe` pattern.
+        _ = i_out.read()
+        err_bytes = i_err.read()
+        rc = i_out.channel.recv_exit_status()
+        if rc != 0:
+            err_text = err_bytes.decode("utf-8", errors="replace")
+            raise CanonicalSyncError(
+                f"openclaw plugin {pkg}@{ver} install failed on "
+                f"{agent_name} (exit {rc}): {err_text.strip()}"
+            )
+
+        # Stamp sentinel — touch + chmod in one round-trip. Failure
+        # here means a future sync would re-install (sentinel absent),
+        # but the plugin itself is already present; surface as an
+        # error so the operator can investigate fs / perms now rather
+        # than seeing repeated installs on every subsequent sync.
+        stamp_inner = (
+            f"touch {quoted_sentinel} && chmod 0600 {quoted_sentinel}"
+        )
+        stamp = (
+            f"sudo -n -H -u {quoted_agent} sh -c {shlex.quote(stamp_inner)}"
+        )
+        _, s_out, s_err = client.exec_command(stamp, timeout=probe_timeout)
+        if s_out.channel.recv_exit_status() != 0:
+            err_text = s_err.read().decode("utf-8", errors="replace")
+            raise CanonicalSyncError(
+                f"openclaw plugin {pkg}@{ver} installed on {agent_name} "
+                f"but sentinel stamp at {sentinel!r} failed: "
+                f"{err_text.strip()}. Run `clawctl agent sync "
+                f"{agent_name}` again to retry."
+            )
+        installed.append(plugin_key)
+
+    return tuple(installed), tuple(skipped)
+
+
 def sync_agent_canonical(
     agent_name: str,
     *,
@@ -1063,6 +1277,25 @@ def sync_agent_canonical(
                 "brave_integration_configured",
                 f"openclaw {'.'.join(str(p) for p in version)} on {hostname} "
                 f"satisfies brave plugin min version",
+            )
+
+        # #755: openclaw plugin install — moved out of configure.yaml so
+        # `clawctl agent integration attach <brave>` + `clawctl agent
+        # sync` actually materializes the plugin on host (operator's
+        # mental model: sync flushes EVERYTHING the control plane has
+        # declared). Runs BEFORE the file-write loop so the daemon picks
+        # up both the new plugin AND a freshly-rendered env carrying its
+        # credential in a single restart. A failure here raises
+        # CanonicalSyncError and short-circuits before `_restart_unit`,
+        # mirroring the workspace-overlay phase: never restart the unit
+        # on a half-installed plugin set.
+        if inputs.agent_type == "openclaw":
+            _openclaw_install_plugins(
+                client,
+                agent_name,
+                os_family=host.get("os_family", "linux"),
+                inputs=inputs,
+                on_event=on_event,
             )
 
         for d in diffs:

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -74,69 +74,11 @@
         mode: "0644"
       when: identity_files is defined and identity_files.sync_workspace | default(false)
 
-    # Install the brave web-search plugin BEFORE writing the env file
-    # so that a fresh `BRAVE_API_KEY` lands on a host that already has
-    # the plugin manifest the env var feeds — avoids a one-restart-late
-    # state where the env exists but the plugin doesn't.
-    #
-    # Sentinel-gated by the pinned version: a bump in
-    # `openclaw_brave_plugin_version` automatically re-triggers
-    # install on every host on the next configure.
-    #
-    # `no_log` deliberately NOT set: the install pulls a public npm
-    # package with no secrets in scope, and suppressing output here
-    # hides legitimate failures (network 403, ENOSPC, postinstall
-    # error) which under the previous `no_log: true` masked all
-    # diagnostics. (#734 ATX iter 2 W4)
-    #
-    # PATH is exported so Homebrew/apt/dnf Node hosts can resolve
-    # `npm` without an interactive login shell. nvm-only Node
-    # installs are NOT supported (same caveat as the macOS playbook
-    # — Ansible's PATH-env hand-off cannot glob the version-dynamic
-    # ~/.nvm/versions/node/<v>/bin shim).
-    #
-    # S3 iter-3: brave-related tasks share the same predicate;
-    # wrap in a block so a fifth task can't drift the condition.
-    - name: Brave plugin install
-      when:
-        - integrations is defined
-        - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0
-      become: yes
-      become_user: "{{ agent_name }}"
-      environment:
-        PATH: "/home/{{ agent_name }}/.local/bin:/usr/local/bin:/usr/bin:/bin"
-      block:
-        - name: Probe for npm (brave plugin install prereq)
-          ansible.builtin.command:
-            argv:
-              - which
-              - npm
-          register: _npm_probe
-          changed_when: false
-          failed_when: false
-
-        - name: Fail with actionable hint when npm is missing
-          when: _npm_probe.rc != 0
-          ansible.builtin.fail:
-            msg: >-
-              npm not found on the agent host PATH
-              (/usr/local/bin, /usr/bin, /bin). The brave plugin requires
-              a system Node install (apt/dnf/Homebrew); nvm-only installs
-              are not supported because the playbook cannot glob
-              /home/{{ agent_name }}/.nvm/versions/node/*/bin into PATH.
-
-        - name: Install openclaw brave plugin (idempotent, gated by sentinel)
-          ansible.builtin.command: >-
-            npm install --prefix /home/{{ agent_name }}/.openclaw
-            {{ openclaw_brave_plugin_package }}@{{ openclaw_brave_plugin_version }}
-          args:
-            creates: "/home/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
-
-        - name: Stamp brave plugin install sentinel
-          ansible.builtin.file:
-            path: "/home/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
-            state: touch
-            mode: "0600"
+    # #755: openclaw plugin install lifted into the canonical sync
+    # pipeline (`core/lifecycle_canonical.py:_openclaw_install_plugins`).
+    # Configure stays scoped to onboarding stages (providers / identity
+    # / channels); plugin install fires on every `clawctl agent sync`,
+    # which is the operator's "flush declared state" entry point.
 
     - name: Write openclaw .env from template
       ansible.builtin.template:

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure_macos.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure_macos.yaml
@@ -105,62 +105,9 @@
         mode: "0644"
       when: identity_files is defined and identity_files.sync_workspace | default(false)
 
-    # See configure.yaml (Linux) for the rationale on plugin install
-    # ordering and sentinel gating. `no_log` is intentionally omitted
-    # so npm errors surface; the npm package is public and no secrets
-    # are in scope.
-    #
-    # PATH covers Homebrew (/opt/homebrew/bin on Apple Silicon,
-    # /usr/local/bin on Intel) only. nvm shims live under
-    # /Users/<user>/.nvm/versions/node/<version>/bin where <version>
-    # is dynamic — Ansible's PATH-env hand-off cannot glob, so hosts
-    # whose only Node install is via nvm get an opaque
-    # "npm: command not found" without the probe below (W8).
-    #
-    # S2 iter-3: all brave-related tasks share the same predicate;
-    # wrap in a block so a fifth task doesn't need to remember the
-    # condition. Variables `become` / `become_user` / `environment`
-    # set on the block are inherited by each child task.
-    - name: Brave plugin install
-      when:
-        - integrations is defined
-        - integrations.values() | selectattr('type', 'equalto', 'brave') | list | length > 0
-      become: yes
-      become_user: "{{ agent_name }}"
-      environment:
-        PATH: "/Users/{{ agent_name }}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
-      block:
-        - name: Probe for npm (brave plugin install prereq)
-          ansible.builtin.command:
-            argv:
-              - which
-              - npm
-          register: _npm_probe
-          changed_when: false
-          failed_when: false
-
-        - name: Fail with actionable hint when npm is missing
-          when: _npm_probe.rc != 0
-          ansible.builtin.fail:
-            msg: >-
-              npm not found on the agent host PATH
-              (/opt/homebrew/bin, /usr/local/bin). The brave plugin requires
-              a Homebrew-installed Node (`brew install node`); nvm-only
-              installs are not supported because the playbook cannot glob
-              /Users/{{ agent_name }}/.nvm/versions/node/*/bin into PATH.
-
-        - name: Install openclaw brave plugin (idempotent, gated by sentinel)
-          ansible.builtin.command: >-
-            npm install --prefix /Users/{{ agent_name }}/.openclaw
-            {{ openclaw_brave_plugin_package }}@{{ openclaw_brave_plugin_version }}
-          args:
-            creates: "/Users/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
-
-        - name: Stamp brave plugin install sentinel
-          ansible.builtin.file:
-            path: "/Users/{{ agent_name }}/.openclaw/.brave-plugin-installed.{{ openclaw_brave_plugin_version }}"
-            state: touch
-            mode: "0600"
+    # #755: openclaw plugin install lifted into the canonical sync
+    # pipeline (`core/lifecycle_canonical.py:_openclaw_install_plugins`).
+    # See the Linux configure.yaml header comment.
 
     - name: Write openclaw .env from template
       ansible.builtin.template:

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -1398,6 +1398,12 @@ class TestOpenclawBraveVersionPreflight:
             "_get_host_openclaw_version",
             lambda *_a, **_kw: (host_version, ""),
         )
+        # #755: stub the new plugin-install helper — this test class
+        # targets the preflight specifically; install behavior has its
+        # own coverage in TestOpenclawInstallPlugins.
+        monkeypatch.setattr(
+            lc, "_openclaw_install_plugins", lambda *_a, **_kw: ((), ())
+        )
 
     def test_below_min_version_raises(self, monkeypatch):
         self._setup(monkeypatch, (2026, 3, 13))
@@ -1526,6 +1532,13 @@ class TestOpenclawBraveVersionPreflight:
 
         monkeypatch.setattr(
             lc, "_get_host_openclaw_version", _should_not_be_called
+        )
+        # ATX iter-2 W5: stub `_openclaw_install_plugins` so this test
+        # does not implicitly exercise it (and the disk-bound
+        # `_load_openclaw_plugins` it would call) — the test targets
+        # ONLY the version preflight skip.
+        monkeypatch.setattr(
+            lc, "_openclaw_install_plugins", lambda *_a, **_kw: ((), ())
         )
         sync_agent_canonical("oc", restart=False, verify=False)
         assert called == [], "_get_host_openclaw_version was invoked"
@@ -2137,20 +2150,520 @@ class TestOpenclawConfigureDispatch:
         assert path.name == "configure.yaml"
         assert path.exists()
 
-    def test_both_configure_playbooks_contain_brave_install_task(self):
-        """Symmetric brave plugin install on Linux + macOS. If a future
-        edit removes the install task from one but not the other the
-        dispatch test still passes — pin both files explicitly."""
+    def test_neither_configure_playbook_contains_brave_install_task(self):
+        """#755 (T7): brave plugin install was lifted out of both
+        configure playbooks into `lifecycle_canonical._openclaw_install_plugins`.
+        Configure stays scoped to onboarding stages (providers /
+        identity / channels). A regression that reintroduces the
+        playbook install would double-install on every configure-then-
+        sync cycle and re-create the "sync doesn't install plugins"
+        UX gap #755 fixed."""
         from clawrium.core.playbook_resolver import resolve_agent_playbook
 
         linux = resolve_agent_playbook("openclaw", "configure", "linux")
         darwin = resolve_agent_playbook("openclaw", "configure", "darwin")
         for path in (linux, darwin):
             body = path.read_text()
-            assert "openclaw_brave_plugin_package" in body, path
-            assert "openclaw_brave_plugin_version" in body, path
-            assert "no_log: true" in body, path
+            assert "openclaw_brave_plugin_package" not in body, path
+            assert "openclaw_brave_plugin_version" not in body, path
+            assert "brave-plugin-installed" not in body, path
+            assert "@openclaw/brave-plugin" not in body, path
             # No Darwin-conditional inside either file (dispatcher-only
-            # OS fork — #734 invariant).
+            # OS fork — #734 invariant; #755 keeps it).
             assert "ansible_os_family == 'Darwin'" not in body, path
             assert 'ansible_os_family == "Darwin"' not in body, path
+
+
+# ---------------------------------------------------------------------------
+# Openclaw plugin install on sync (#755).
+# ---------------------------------------------------------------------------
+
+
+class _FakeChannel:
+    """Minimal stand-in for paramiko's channel object — only the bits
+    `_openclaw_install_plugins` reads."""
+
+    def __init__(self, exit_status: int):
+        self._exit_status = exit_status
+
+    def recv_exit_status(self) -> int:
+        return self._exit_status
+
+
+class _FakeStream:
+    def __init__(self, body: bytes = b"", exit_status: int = 0):
+        self._body = body
+        self.channel = _FakeChannel(exit_status)
+
+    def read(self) -> bytes:
+        return self._body
+
+
+class _ScriptedSSHClient:
+    """Records every `exec_command` call and replays a scripted set of
+    `(stdout_body, stderr_body, exit_status)` triples in order. Tests
+    that don't care about ordering can rely on the captured `calls`
+    list.
+
+    ATX iter-2 W4: both stdout and stderr share the same `_FakeChannel`
+    so a future code change that reads `stderr.channel.recv_exit_status()`
+    instead of `stdout.channel.recv_exit_status()` does not spuriously
+    pass at rc=0. Real paramiko returns a single shared channel for
+    both streams."""
+
+    def __init__(self, script: list[tuple[bytes, bytes, int]]):
+        self._script = list(script)
+        self.calls: list[str] = []
+
+    def exec_command(self, cmd: str, timeout: int | None = None):
+        self.calls.append(cmd)
+        if not self._script:
+            raise AssertionError(
+                f"unexpected extra exec_command: {cmd!r}"
+            )
+        stdout_body, stderr_body, rc = self._script.pop(0)
+        shared_channel = _FakeChannel(rc)
+        stdout = _FakeStream(stdout_body, rc)
+        stderr = _FakeStream(stderr_body, rc)
+        stdout.channel = shared_channel
+        stderr.channel = shared_channel
+        return _FakeStream(), stdout, stderr
+
+
+def _inputs_with_integrations(types: list[str]):
+    """Build a minimal `RenderInputs`-like object — only `.integrations`
+    is read by `_openclaw_install_plugins`."""
+    from clawrium.core.render import IntegrationInputs
+
+    integrations = tuple(
+        IntegrationInputs(name=f"my-{t}", type=t) for t in types
+    )
+    inputs = MagicMock()
+    inputs.integrations = integrations
+    return inputs
+
+
+class TestOpenclawInstallPlugins:
+    """#755 T1-T6: lifted plugin install. Drives off the openclaw
+    manifest's `plugins:` block; sentinel-gated for idempotency; raises
+    `CanonicalSyncError` on any per-host failure so the caller can
+    short-circuit before restart."""
+
+    _PIN = {
+        "brave": {
+            "npm_package": "@openclaw/brave-plugin",
+            "version": "2026.6.9",
+            "min_host_version": "2026.6.9",
+        }
+    }
+
+    def _patch_pin(self, monkeypatch, plugins=None):
+        monkeypatch.setattr(
+            lc,
+            "_load_openclaw_plugins",
+            lambda: plugins if plugins is not None else self._PIN,
+        )
+
+    def test_t1_installs_when_attached_and_missing(self, monkeypatch):
+        """T1: brave attached, sentinel absent → `openclaw plugins
+        install` is invoked AND sentinel is stamped, in order. The
+        install command must use openclaw's own CLI (not raw `npm
+        install`) because a raw npm install into `~<agent>/.openclaw/
+        node_modules/` is NOT discovered by `openclaw plugins list` —
+        UAT on esper-mac-oc proved this is the failure mode that masked
+        the pre-#755 playbook approach for the entire #734 lifetime."""
+        self._patch_pin(monkeypatch)
+        client = _ScriptedSSHClient(
+            [
+                (b"", b"", 1),  # sentinel probe: absent (test -f exit 1)
+                (b"installed", b"", 0),  # openclaw plugins install
+                (b"", b"", 0),  # sentinel stamp
+            ]
+        )
+        inputs = _inputs_with_integrations(["brave"])
+        installed, skipped = lc._openclaw_install_plugins(
+            client,
+            "wolf-i",
+            os_family="linux",
+            inputs=inputs,
+        )
+        assert installed == ("brave",)
+        assert skipped == ()
+        install_cmd = client.calls[1]
+        # Must use openclaw's own CLI, NOT raw `npm install --prefix`.
+        assert "openclaw plugins install" in install_cmd
+        assert "npm install --prefix" not in install_cmd
+        # --force lets a pin bump overwrite a prior install; --pin
+        # records the resolved name@version exactly so a transitive
+        # upgrade cannot smuggle in a new floor.
+        assert "--force" in install_cmd
+        assert "--pin" in install_cmd
+        assert "@openclaw/brave-plugin@2026.6.9" in install_cmd
+        assert "/home/wolf-i/.openclaw/bin/openclaw" in install_cmd
+        # Sentinel path encodes the version so a pin bump auto-fires.
+        stamp_cmd = client.calls[2]
+        assert ".brave-plugin-installed.2026.6.9" in stamp_cmd
+
+    def test_t2_skips_install_when_sentinel_present(self, monkeypatch):
+        """T2: pin matches what's already installed → sentinel probe
+        succeeds → no install runs, no further commands."""
+        self._patch_pin(monkeypatch)
+        client = _ScriptedSSHClient([(b"", b"", 0)])  # sentinel probe: ok
+        inputs = _inputs_with_integrations(["brave"])
+        installed, skipped = lc._openclaw_install_plugins(
+            client,
+            "wolf-i",
+            os_family="linux",
+            inputs=inputs,
+        )
+        assert installed == ()
+        assert skipped == ("brave",)
+        # Only the sentinel probe ran — no install, no stamp.
+        assert len(client.calls) == 1
+        assert "test -f" in client.calls[0]
+        assert ".brave-plugin-installed.2026.6.9" in client.calls[0]
+
+    def test_t3_reinstalls_when_pin_version_differs(self, monkeypatch):
+        """T3: a pin bump changes the sentinel filename (which encodes
+        the version), so the prior-version sentinel no longer matches.
+        Probe returns absent → install fires at the new pinned version."""
+        self._patch_pin(
+            monkeypatch,
+            plugins={
+                "brave": {
+                    "npm_package": "@openclaw/brave-plugin",
+                    "version": "2027.1.0",
+                    "min_host_version": "2027.1.0",
+                }
+            },
+        )
+        client = _ScriptedSSHClient(
+            [
+                (b"", b"", 1),  # sentinel for 2027.1.0 absent
+                (b"installed", b"", 0),  # openclaw plugins install
+                (b"", b"", 0),  # sentinel stamp
+            ]
+        )
+        inputs = _inputs_with_integrations(["brave"])
+        installed, _ = lc._openclaw_install_plugins(
+            client,
+            "wolf-i",
+            os_family="linux",
+            inputs=inputs,
+        )
+        assert installed == ("brave",)
+        install_cmd = client.calls[1]
+        assert "@openclaw/brave-plugin@2027.1.0" in install_cmd
+        assert "openclaw plugins install" in install_cmd
+
+    def test_t4_does_not_install_when_brave_not_attached(self, monkeypatch):
+        """T4: no brave integration → no per-plugin SSH commands fire.
+        The helper still consults the manifest but exits with empty
+        installed + the manifest key in skipped (the "not attached"
+        bucket)."""
+        self._patch_pin(monkeypatch)
+        client = _ScriptedSSHClient([])  # zero commands expected
+        inputs = _inputs_with_integrations([])
+        installed, skipped = lc._openclaw_install_plugins(
+            client,
+            "wolf-i",
+            os_family="linux",
+            inputs=inputs,
+        )
+        assert installed == ()
+        assert skipped == ("brave",)
+        assert client.calls == []
+
+    def test_t5_install_runs_before_restart_via_sync(self, monkeypatch):
+        """T5 (ATX iter-2 B1): the install helper MUST run before
+        `_restart_unit` inside `sync_agent_canonical`. Iter-1 had a
+        vacuous variant that called both functions directly from the
+        test body — that proved Python executes consecutive statements
+        in order but said nothing about the wiring inside
+        `sync_agent_canonical`. This rewrite drives the whole pipeline
+        and asserts ordering via spies on the IO surface, so a future
+        edit that moves `_openclaw_install_plugins` below
+        `_restart_unit` actually fails."""
+        from clawrium.core.render import (
+            GatewayInputs,
+            IntegrationInputs,
+            ProviderInputs,
+            RenderInputs,
+            RenderedFiles,
+        )
+
+        order: list[str] = []
+
+        def spy_install(*_a, **_kw):
+            order.append("install_plugins")
+            return ((), ())
+
+        def spy_restart(*_a, **_kw):
+            order.append("restart_unit")
+
+        inputs = RenderInputs(
+            agent_name="wolf-i",
+            agent_type="openclaw",
+            provider=ProviderInputs(
+                name="or",
+                type="openrouter",
+                api_key="sk",
+                default_model="m",
+            ),
+            gateway=GatewayInputs(host="h", port=40000, auth="a"),
+            integrations=(
+                IntegrationInputs(
+                    name="my-brave",
+                    type="brave",
+                    credentials=(("BRAVE_API_KEY", "bsk"),),
+                ),
+            ),
+        )
+        rendered = RenderedFiles(
+            files={
+                ".openclaw/env": "BRAVE_API_KEY='bsk'\n",
+                ".openclaw/openclaw.json": "{}",
+            }
+        )
+
+        # Force a non-empty write path so `_restart_unit` is reached
+        # (sync only restarts when files were written or zeroclaw).
+        fake_diff = MagicMock()
+        fake_diff.unified_diff = "+x"
+        fake_diff.path = ".openclaw/env"
+        fake_diff.remote_path = "/home/wolf-i/.openclaw/env"
+        fake_diff.rendered_body = "BRAVE_API_KEY='bsk'\n"
+        fake_diff.remote_body = ""
+
+        monkeypatch.setattr(lc, "build_render_inputs", lambda _: inputs)
+        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _: rendered)
+        monkeypatch.setattr(
+            lc,
+            "get_agent_by_name",
+            lambda _: ({"hostname": "h"}, "openclaw:wolf-i", {}),
+        )
+        monkeypatch.setattr(lc, "diff_files", lambda **_: [fake_diff])
+        monkeypatch.setattr(lc, "_open_ssh", lambda _h, **__: MagicMock())
+        monkeypatch.setattr(
+            lc,
+            "_get_host_openclaw_version",
+            lambda *_a, **_kw: ((2026, 6, 9), ""),
+        )
+        monkeypatch.setattr(
+            lc, "_diff_removes_secrets", lambda _d: set()
+        )
+        monkeypatch.setattr(lc, "_atomic_write", lambda *_a, **_kw: None)
+        monkeypatch.setattr(lc, "_openclaw_install_plugins", spy_install)
+        monkeypatch.setattr(lc, "_restart_unit", spy_restart)
+        monkeypatch.setattr(lc, "_verify_health", lambda **_: None)
+        # workspace_sync push: stub at import site
+        monkeypatch.setattr(
+            "clawrium.core.workspace_sync.push_workspace_phase",
+            lambda **_kw: MagicMock(
+                success=True, files_pushed=(), files_excluded=(), error=None
+            ),
+        )
+
+        sync_agent_canonical("wolf-i", verify=False)
+        assert order == ["install_plugins", "restart_unit"]
+
+    def test_install_failure_short_circuits_before_restart(
+        self, monkeypatch
+    ):
+        """Companion to T5: when `_openclaw_install_plugins` raises,
+        `_restart_unit` MUST NOT run. The agent is never restarted on
+        a half-installed plugin set — mirrors the workspace-overlay
+        contract."""
+        from clawrium.core.render import (
+            GatewayInputs,
+            IntegrationInputs,
+            ProviderInputs,
+            RenderInputs,
+            RenderedFiles,
+        )
+
+        restart_called: list[bool] = []
+
+        def boom_install(*_a, **_kw):
+            raise CanonicalSyncError("plugin install boom")
+
+        def spy_restart(*_a, **_kw):
+            restart_called.append(True)
+
+        inputs = RenderInputs(
+            agent_name="wolf-i",
+            agent_type="openclaw",
+            provider=ProviderInputs(
+                name="or",
+                type="openrouter",
+                api_key="sk",
+                default_model="m",
+            ),
+            gateway=GatewayInputs(host="h", port=40000, auth="a"),
+            integrations=(
+                IntegrationInputs(
+                    name="my-brave",
+                    type="brave",
+                    credentials=(("BRAVE_API_KEY", "bsk"),),
+                ),
+            ),
+        )
+        rendered = RenderedFiles(
+            files={".openclaw/env": "BRAVE_API_KEY='bsk'\n"}
+        )
+
+        monkeypatch.setattr(lc, "build_render_inputs", lambda _: inputs)
+        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _: rendered)
+        monkeypatch.setattr(
+            lc,
+            "get_agent_by_name",
+            lambda _: ({"hostname": "h"}, "openclaw:wolf-i", {}),
+        )
+        monkeypatch.setattr(lc, "diff_files", lambda **_: [])
+        monkeypatch.setattr(lc, "_open_ssh", lambda _h, **__: MagicMock())
+        monkeypatch.setattr(
+            lc,
+            "_get_host_openclaw_version",
+            lambda *_a, **_kw: ((2026, 6, 9), ""),
+        )
+        monkeypatch.setattr(lc, "_openclaw_install_plugins", boom_install)
+        monkeypatch.setattr(lc, "_restart_unit", spy_restart)
+
+        with pytest.raises(CanonicalSyncError, match=r"plugin install boom"):
+            sync_agent_canonical("wolf-i", verify=False)
+        assert restart_called == []
+
+    def test_stamp_failure_after_successful_install_raises(
+        self, monkeypatch
+    ):
+        """ATX iter-2 B2: the sentinel-stamp failure branch had zero
+        coverage in iter-1. Distinct from install-failure: at this
+        point the plugin IS installed; the only fallout is that a
+        future sync will re-install. Surfacing as
+        `CanonicalSyncError` (vs swallow + warn) is deliberate so the
+        operator investigates the FS / perms regression immediately
+        rather than seeing silent re-installs forever."""
+        self._patch_pin(monkeypatch)
+        client = _ScriptedSSHClient(
+            [
+                (b"", b"", 1),  # sentinel probe: absent
+                (b"installed", b"", 0),  # openclaw install OK
+                (
+                    b"",
+                    b"touch: EACCES /home/wolf-i/.openclaw",
+                    1,
+                ),  # stamp fails
+            ]
+        )
+        inputs = _inputs_with_integrations(["brave"])
+        with pytest.raises(CanonicalSyncError) as excinfo:
+            lc._openclaw_install_plugins(
+                client,
+                "wolf-i",
+                os_family="linux",
+                inputs=inputs,
+            )
+        msg = str(excinfo.value)
+        assert "sentinel stamp" in msg
+        assert ".brave-plugin-installed.2026.6.9" in msg
+        assert "EACCES" in msg
+        # The plugin was installed, so the install command did run
+        # before the stamp step.
+        assert "openclaw plugins install" in client.calls[1]
+
+    def test_t6_propagates_install_failure_with_pkg_and_stderr(
+        self, monkeypatch
+    ):
+        """T6: a non-zero install raises CanonicalSyncError whose
+        message names both the npm package and the captured stderr —
+        the operator's actionable signal."""
+        self._patch_pin(monkeypatch)
+        client = _ScriptedSSHClient(
+            [
+                (b"", b"", 1),  # sentinel absent
+                (b"", b"E403 forbidden", 1),  # openclaw install failure
+            ]
+        )
+        inputs = _inputs_with_integrations(["brave"])
+        with pytest.raises(CanonicalSyncError) as excinfo:
+            lc._openclaw_install_plugins(
+                client,
+                "wolf-i",
+                os_family="linux",
+                inputs=inputs,
+            )
+        msg = str(excinfo.value)
+        assert "@openclaw/brave-plugin@2026.6.9" in msg
+        assert "E403 forbidden" in msg
+
+    def test_macos_uses_users_home_root(self, monkeypatch):
+        """OS-family dispatch: darwin → `/Users/<n>/.openclaw`. The
+        mapping flows through `home_root_for` so the no-OS-literal
+        invariant (#770) holds inside this helper."""
+        self._patch_pin(monkeypatch)
+        client = _ScriptedSSHClient(
+            [
+                (b"", b"", 1),  # sentinel absent
+                (b"installed", b"", 0),  # openclaw install
+                (b"", b"", 0),  # sentinel stamp
+            ]
+        )
+        inputs = _inputs_with_integrations(["brave"])
+        lc._openclaw_install_plugins(
+            client,
+            "wolf-i",
+            os_family="darwin",
+            inputs=inputs,
+        )
+        joined = " ".join(client.calls)
+        assert "/Users/wolf-i/.openclaw/bin/openclaw" in joined
+        assert "/home/wolf-i/.openclaw" not in joined
+
+    def test_manifest_missing_npm_package_raises(self, monkeypatch):
+        """Defensive: a malformed plugin spec must hard fail at the
+        Python boundary, not silently invoke `npm install @<empty>@<v>`
+        on the host."""
+        self._patch_pin(
+            monkeypatch,
+            plugins={"brave": {"version": "2026.6.9"}},
+        )
+        client = _ScriptedSSHClient([])
+        inputs = _inputs_with_integrations(["brave"])
+        with pytest.raises(
+            CanonicalSyncError,
+            match=r"missing npm_package or version",
+        ):
+            lc._openclaw_install_plugins(
+                client,
+                "wolf-i",
+                os_family="linux",
+                inputs=inputs,
+            )
+
+
+class TestLoadOpenclawPlugins:
+    """#755: the full-block loader is the manifest seam for the generic
+    install helper. Mirrors `_load_openclaw_brave_pin`'s hard-fail
+    discipline."""
+
+    def test_loads_full_block(self):
+        plugins = lc._load_openclaw_plugins()
+        assert "brave" in plugins
+        assert plugins["brave"]["npm_package"] == "@openclaw/brave-plugin"
+
+    def test_empty_block_returns_empty_dict(self, monkeypatch):
+        import yaml
+
+        monkeypatch.setattr(yaml, "safe_load", lambda _txt: {})
+        assert lc._load_openclaw_plugins() == {}
+
+    def test_malformed_block_raises(self, monkeypatch):
+        import yaml
+
+        monkeypatch.setattr(
+            yaml, "safe_load", lambda _txt: {"plugins": "not-a-mapping"}
+        )
+        with pytest.raises(
+            CanonicalSyncError, match=r"not a mapping"
+        ):
+            lc._load_openclaw_plugins()


### PR DESCRIPTION
## Summary

- `clawctl agent sync` on openclaw now installs `@openclaw/brave-plugin` (and any future plugin-backed integration) — closes the UX gap where `attach brave → sync` rendered `BRAVE_API_KEY` into the env but the daemon never got the plugin to consume it (operator had to run a separate `configure --stage <…>` dance).
- Plugin install lifted from `playbooks/openclaw/configure.yaml` + `configure_macos.yaml` into `core/lifecycle_canonical._openclaw_install_plugins`. Driven by the openclaw manifest's `plugins:` block (generalizes beyond brave). Idempotent via per-version sentinel. Install uses `openclaw plugins install --force --pin <pkg>@<ver>` so the daemon's `plugins list` actually discovers the plugin (the pre-#755 `npm install --prefix ~/.openclaw` approach wrote files openclaw never scanned — UAT discovery on esper-mac-oc).
- Wired between the brave preflight and `_restart_unit`; failure raises `CanonicalSyncError` and short-circuits before restart (never restart on a half-installed plugin set).
- Configure is now scoped to onboarding stages only (providers / identity / channels). Operator workflow change documented under `### Changed` in `CHANGELOG.md`.

## Testing

- `make lint && make test` — 4076 passed, 8 skipped.
- Unit tests T1-T6 from the issue body + supplementary coverage (`TestOpenclawInstallPlugins`, `TestLoadOpenclawPlugins`).
- Real-host UAT on **esper-mac-oc** (darwin/arm64):
  - First sync installed `@openclaw/brave-plugin@2026.6.9`; `openclaw plugins list --json` reports `status=loaded`, `webSearchProviders=[brave]`.
  - Sentinel `/Users/esper-mac-oc/.openclaw/.brave-plugin-installed.2026.6.9` present with mode 0600.
  - Second sync: \"already installed (sentinel present)\" — install skipped.
  - Detach + sync: plugin remains (uninstall out of scope per issue).

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: \$7.88 | Total Time: 22m 1s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3.5/5 | B1, B2 | All fixed | \$4.98 | 9m 9s | leader, lifecycle-core, platform-playbooks, security-reviewer, test-coverage |
| 2 | 4/5 | None | Ready | \$2.90 | 12m 52s | leader, lifecycle-core, platform-playbooks, security-reviewer (test-coverage timed out) |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 3.5/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | \`tests/core/test_lifecycle_canonical.py\` (T5) | T5 was vacuous: patched \`_openclaw_install_plugins\` + \`_restart_unit\` with spies then called them directly from the test body — only proved Python executes consecutive lines in order. | Rewrote as \`test_t5_install_runs_before_restart_via_sync\` that drives \`sync_agent_canonical\` with stubbed IO surface and spy callbacks asserting ordering via shared list. Also added \`test_install_failure_short_circuits_before_restart\`. |
| B2 | \`src/clawrium/core/lifecycle_canonical.py\` (sentinel stamp) | Sentinel-stamp failure path raised distinct \`CanonicalSyncError\` but had zero coverage. | Added \`test_stamp_failure_after_successful_install_raises\` covering the install-OK + stamp-fail branch. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | \`lifecycle.py\` + \`configure.yaml\` | Configure→start UX regression: previously configure installed brave; now configure writes env without installing. | CHANGELOG \`### Changed\` entry documents the operator workflow change (canonical sequence is now \`attach → sync\`). |
| W2 | \`lifecycle_canonical.py\` | Stamp failure aborts whole sync after successful install. | Acknowledged — deliberate. Surfacing as \`CanonicalSyncError\` (vs warn + continue) is the right design so operators investigate the FS/perms regression now rather than seeing silent re-installs forever. |
| W3 | \`lifecycle_canonical.py\` | \`min_host_version\` preflight is brave-specific; a future plugin with \`min_host_version\` would install on under-minimum hosts. | Acknowledged — follow-up when a second plugin lands. |
| W4 | \`tests/core/test_lifecycle_canonical.py\` | \`_ScriptedSSHClient\` channel mismatch — stdout and stderr had independent channels. | Fixed: \`_ScriptedSSHClient\` now shares one \`_FakeChannel\` between both streams. |
| W5 | \`tests/core/test_lifecycle_canonical.py\` | \`test_preflight_skipped_when_no_brave_integration\` silently widens isolation post-#755 (exercises \`_load_openclaw_plugins\` disk read). | Fixed: added \`monkeypatch.setattr(lc, '_openclaw_install_plugins', ...)\` stub. |
| W6 | \`tests/core/test_lifecycle_canonical.py\` | No test exercises \`on_event\` callback. | Acknowledged — follow-up. |

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**Blocking Issues:** None.

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | \`lifecycle_canonical.py:980-984\` | Paramiko stdout buffer deadlock risk: \`recv_exit_status()\` called before draining stdout on the verbose \`openclaw plugins install\` command. If npm output exceeds ~64KB SSH pipe buffer, the remote write blocks before exit-status is sent. | Fixed: drain \`i_out.read()\` + \`i_err.read()\` before \`recv_exit_status()\` — matches the established \`_run_openclaw_version_probe\` pattern. |
| W2 | \`lifecycle_canonical.py\` | \`install_timeout\` / \`probe_timeout\` semantics misleading (paramiko per-channel blocking-I/O timeout, NOT wall-clock cap). | Acknowledged — follow-up; consider renaming + wall-clock guard. |
| W3 | \`lifecycle_canonical.py\` | Remote stderr embedded into \`CanonicalSyncError\` messages without bidi sanitization. | Acknowledged — sanitization should land at the CLI \`emit_error\` boundary for consistency; follow-up. |

**Suggestions S1-S5:** Type annotation, install stdout drain → on_event telemetry, \`bin/openclaw\` shim probe, openclaw CLI flag capability probe, Linux/macOS env-task notify asymmetry (pre-existing, out of scope).

</details>

## Callouts

- [DECISION] Switched the install command from raw \`npm install --prefix ~/.openclaw <pkg>@<ver>\` (what the configure playbook did) to \`openclaw plugins install --force --pin <pkg>@<ver>\`.
  - Why: UAT on esper-mac-oc proved the npm-install approach writes files to \`~/.openclaw/node_modules/\` but openclaw's own \`plugins list\` does NOT scan that directory (it only scans the bundled \`dist/extensions\` source root). The pre-#755 playbook approach was equally broken — files were written but the daemon never registered the plugin. \`openclaw plugins install\` writes to a path openclaw discovers (\`~/.openclaw/npm/projects/<hash>/\`) and registers it in the plugin registry. Verified post-install via \`openclaw plugins list --json\`.
  - Alternatives considered: keeping raw \`npm install\` (matches playbook history) — rejected because UAT showed the daemon doesn't pick up that location.
  - Reviewer: confirm or push back.

- [DECISION] Used \`sudo -n -H -u <agent>\` (with \`-H\` for HOME reset) instead of plain \`sudo -n -u <agent>\` for the openclaw plugin install commands.
  - Why: Without \`-H\`, \`sudo -u\` preserves the SSH user's HOME (\`/Users/xclm\` on macOS, \`/home/xclm\` on Linux). \`npm\` and \`openclaw plugins install\` then try to write to \`/Users/xclm/.npm\` / \`~xclm/.openclaw/state\` — root-owned or unwritable, EACCES. Discovered live during UAT on esper-mac-oc. The version-probe builder (\`_build_openclaw_version_probe\`) does NOT use \`-H\` because \`--version\` reads no cache and writes no state.
  - Reviewer: confirm.

- [TODO-FOLLOWUP] Iter-2 W2 (timeout-semantics rename + wall-clock guard) and W3 (bidi sanitization at \`emit_error\` boundary).
  - Tracking: to be filed.

- [TODO-FOLLOWUP] Iter-1 W3 (generalize \`min_host_version\` preflight beyond brave) and W6 (\`on_event\` callback spy coverage).
  - Tracking: to be filed when a second plugin lands.

- [ENVIRONMENT] Lint required \`mkdir -p src/clawrium/gui/frontend && touch .gitkeep\` to satisfy the hatchling build's force-include rule; the directory is \`.gitignored\` and not part of this PR.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>