### PR TITLE
feat(hermes): expose context_length in litellm-rendered config.yaml

### DIFF
--- a/.itx/831/00_PLAN.md
+++ b/.itx/831/00_PLAN.md
@@ -1,0 +1,119 @@
+# Issue #831 — Hermes litellm `context_length` rendering
+
+## Customer outcome
+
+Operators who attach a litellm-typed provider to a hermes agent and set a
+`context_window` on the provider record see the rendered
+`~/.hermes/config.yaml` emit `model.context_length: <window>` so the
+hermes daemon uses the proxy's actual context capacity instead of a
+silent ~65k fallback.
+
+## Why now
+
+`clawrium-gtm` on `wolf-i` is attached to a litellm proxy fronting
+Qwen3-Next-80B (`max_input_tokens=131072`) but hermes is operating with
+a ~65k window. Upstream hermes docs document `model.context_length` as
+the supported override for `provider: custom`, but clawrium's renderer
+does not emit it today.
+
+## Scope
+
+### In
+- `ProviderInputs.context_window` already exists; reuse — no new field.
+- `AttachedProviderInputs` gains `context_window: int = 0` for aux slots.
+- `build_render_inputs` populates aux `context_window` from each aux
+  litellm provider's `providers.json` record.
+- `render_hermes` passes `provider.context_window` + aux attachments
+  through to template context (no new template var beyond existing
+  attachment list).
+- Template `hermes-config.canonical.yaml.j2`: litellm branch (primary
+  + aux-loop litellm path) emits `context_length` conditionally on
+  truthy value; omitted entirely otherwise.
+- CLI: `clawctl provider registry create --type litellm
+  --context-window N` and `clawctl provider registry edit … --context-window
+  N` write `providers.json.<name>.context_window`. Flag is rejected for
+  non-litellm types (parity with `--litellm-url`).
+- Tests: byte-locked render tests (4 cases) + CLI roundtrip (create +
+  edit).
+- Changelog: `### Added` entry under `[Unreleased]`.
+
+### Out (explicit non-goals)
+- `max_tokens` (output cap) — separate knob, tracked separately if
+  needed.
+- openclaw / zeroclaw render paths and templates.
+- workspace overlay (hermes excludes `config.yaml` by design).
+- gateway bearer rotation (sync on hermes does not rotate; rotation is
+  zeroclaw-only per memory note).
+
+## Product output
+
+```yaml
+# .hermes/config.yaml (litellm primary, context_window=131072)
+model:
+  provider: "custom"
+  base_url: "http://192.168.1.17:4000/v1"
+  api_key: 'sk-…'
+  default: 'writer'
+  context_length: 131072
+```
+
+When `context_window` is unset on the provider record, the
+`context_length` line is absent — no `null`, no `0`.
+
+## Technical details
+
+### Files modified
+- `src/clawrium/core/render.py`
+  - `AttachedProviderInputs`: add `context_window: int = 0` (frozen
+    dataclass field).
+  - `build_render_inputs` (hermes branch): when assembling
+    `AttachedProviderInputs`, pull `context_window` from each entry's
+    `providers.json` record (`int(entry_record.get("context_window") or
+    0)`).
+- `src/clawrium/platform/registry/hermes/templates/hermes-config.canonical.yaml.j2`
+  - Litellm branch (lines 132-159): emit `context_length: …` after
+    `default:` when truthy. Mirror in aux loop where `entry.type ==
+    'litellm'`.
+- `src/clawrium/cli/clawctl/provider.py`
+  - `create`: add `--context-window` int option; persist to record when
+    type is litellm; reject for other types.
+  - `edit`: add `--context-window` int option; reject for non-litellm.
+- `CHANGELOG.md`: one `### Added` line.
+
+### Tests added (`tests/core/test_render.py`)
+1. `test_hermes_litellm_primary_no_context_window_omits_context_length`
+2. `test_hermes_litellm_primary_with_context_window_emits_context_length`
+3. `test_hermes_litellm_aux_with_context_window_emits_context_length`
+4. `test_hermes_openrouter_with_litellm_aux_only_aux_emits_context_length`
+   (regression guard that openrouter primary stays clean)
+
+### CLI tests (`tests/cli/clawctl/test_provider.py` or equivalent)
+- Create roundtrip: `--context-window 131072` persisted to
+  providers.json.
+- Edit roundtrip: starts unset → edit `--context-window 131072` → stored.
+- Reject on non-litellm: `--context-window` on `--type anthropic` exits
+  non-zero.
+
+### Risks / contracts
+- `provider.context_window` is `int = 0` (zero means renderer default).
+  Template branches on truthiness, so `0` is treated as "unset". This
+  matches the openclaw render path semantics already in tree.
+- No changes to env file rendering — `context_length` is YAML-only.
+- Aux `AttachedProviderInputs.context_window` defaults to 0 for any
+  caller that builds the struct by hand (preserves existing tests'
+  byte locks for non-litellm cases).
+
+## Verification
+
+- `make lint && make test`
+- Real-host UAT on `clawrium-gtm` (wolf-i):
+  1. `clawctl provider registry edit clawrium-gtm-litellm --context-window 131072`
+  2. `clawctl agent sync clawrium-gtm`
+  3. Verify rendered YAML on host contains `context_length: 131072`
+  4. `clawctl agent doctor clawrium-gtm` → Status: ok
+  5. `clawctl agent restart clawrium-gtm` → dashboard back up
+
+## ATX review
+
+`.claude/itx-config.json` has `mcp.review_enabled: true`. Request ATX
+review iterations after first commit, document each round in PR body.

--- a/.itx/831/01_SCAFFOLD.md
+++ b/.itx/831/01_SCAFFOLD.md
@@ -1,0 +1,74 @@
+# Issue #831 — Phased execution
+
+## Phase 1: Render plumbing
+
+**Entry**: branch checked out, plan written.
+
+**Tasks**:
+- Add `context_window: int = 0` to `AttachedProviderInputs` dataclass
+  in `src/clawrium/core/render.py`.
+- In `build_render_inputs` (hermes branch), populate
+  `context_window=int(entry_record.get("context_window") or 0)` when
+  constructing each `AttachedProviderInputs`.
+
+**Exit**: existing tests still pass (no behavior change yet — template
+ignores the new field). `make lint` clean.
+
+## Phase 2: Template
+
+**Tasks**:
+- Edit `hermes-config.canonical.yaml.j2` litellm branch:
+  - Primary `model:` block: after `default:`, conditionally emit
+    `  context_length: {{ provider.context_window }}` when
+    `provider.context_window`.
+  - Aux loop (litellm path): after `model:`, conditionally emit
+    `    context_length: {{ entry.context_window }}` when
+    `entry.context_window`.
+- Do NOT touch any other branch.
+
+**Exit**: visual diff inspection of template output for litellm cases
+matches expected shape.
+
+## Phase 3: Render tests
+
+**Tasks**: add 4 render tests in `tests/core/test_render.py`:
+- `test_hermes_litellm_primary_no_context_window_omits_context_length`
+- `test_hermes_litellm_primary_with_context_window_emits_context_length`
+  (check `context_length: 131072` appears, positioned after `default:`)
+- `test_hermes_litellm_aux_with_context_window_emits_context_length`
+- `test_hermes_openrouter_with_litellm_aux_only_aux_emits_context_length`
+
+**Exit**: `make test` green (4 new tests pass + no regressions).
+
+## Phase 4: CLI flag
+
+**Tasks**:
+- `clawctl provider registry create`: add `--context-window` Option;
+  if provided, persist to the litellm record. Reject if used with a
+  non-litellm `--type`.
+- `clawctl provider registry edit`: add `--context-window` Option;
+  reject if record type is not litellm; persist to record on update.
+
+**Exit**: `make test` covers CLI roundtrip.
+
+## Phase 5: CLI tests + changelog
+
+**Tasks**:
+- Add CLI tests for create + edit with `--context-window` flag.
+- Add `### Added` entry to `CHANGELOG.md` `[Unreleased]`.
+
+**Exit**: `make lint && make test` all green.
+
+## Phase 6: Real-host UAT
+
+Run UAT steps from 00_PLAN.md against `clawrium-gtm` on `wolf-i`.
+Capture evidence: rendered YAML snippet, doctor status, dashboard
+status. Stop on first failure and report.
+
+## Phase 7: Commit + PR
+
+- Commit all changes incl. `.itx/831/` files.
+- Push branch.
+- `gh pr create` with ATX review section template (request first
+  review round; iterate until rating > 3 and no blockers).
+- DO NOT merge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Added
 
+- `clawctl provider registry create/edit --type litellm --context-window N`
+  pins the hermes / openclaw rendered `context_length` so litellm proxies
+  fronting large-context models (e.g. Qwen3-Next-80B at 131072) no longer
+  silently truncate to hermes' built-in ~65k default (#831).
+
 - `clawctl agent shell <name> -- <cmd>` now works against macOS hosts
   (#808). The new `shell_macos.yaml` playbook is selected per-OS via
   `core.playbook_resolver.resolve_shell_playbook`; the kill window is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,10 +50,15 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Added
 
-- `clawctl provider registry create/edit --type litellm --context-window N`
-  pins the hermes / openclaw rendered `context_length` so litellm proxies
-  fronting large-context models (e.g. Qwen3-Next-80B at 131072) no longer
-  silently truncate to hermes' built-in ~65k default (#831).
+- Hermes: render `model.context_length` (and the same key on each litellm
+  auxiliary slot) in `~/.hermes/config.yaml` for litellm providers when
+  `context_window` is set on the provider record — proxies fronting
+  large-context models (e.g. Qwen3-Next-80B at 131072) no longer silently
+  truncate to hermes' built-in ~65k default (#831).
+- `clawctl provider registry create|edit --context-window N` (litellm only)
+  to persist the value on a provider record — consumed by both the hermes
+  YAML renderer (`context_length`) and the pre-existing openclaw JSON
+  renderer (`contextWindow`, available since #723) (#831).
 
 - `clawctl agent shell <name> -- <cmd>` now works against macOS hosts
   (#808). The new `shell_macos.yaml` playbook is selected per-OS via

--- a/src/clawrium/cli/clawctl/provider.py
+++ b/src/clawrium/cli/clawctl/provider.py
@@ -239,11 +239,9 @@ def create(
         None,
         "--context-window",
         help=(
-            "Override the model's context window (tokens). LiteLLM only. "
-            "Honoured by both the hermes and openclaw renderers — without "
-            "it each renderer falls back to its built-in default (hermes "
-            "~65k; openclaw's per-provider default). Pin to match your "
-            "upstream model (e.g. 131072 for Qwen3-Next-80B)."
+            "Model context window in tokens (LiteLLM only). Honoured by "
+            "hermes and openclaw renderers; both fall back to ~65k (65536) "
+            "when unset."
         ),
     ),
 ) -> None:
@@ -624,11 +622,9 @@ def edit(
         None,
         "--context-window",
         help=(
-            "Override the model's context window (tokens). LiteLLM only. "
-            "Honoured by both the hermes and openclaw renderers; re-render "
-            "with `clawctl agent sync` to push the new value to the agent "
-            "host's config (hermes `~/.hermes/config.yaml`, openclaw "
-            "`~/.openclaw/openclaw.json`)."
+            "Model context window in tokens (LiteLLM only). Honoured by "
+            "hermes and openclaw renderers; re-render with `clawctl agent "
+            "sync` to push the new value to the agent host."
         ),
     ),
 ) -> None:

--- a/src/clawrium/cli/clawctl/provider.py
+++ b/src/clawrium/cli/clawctl/provider.py
@@ -235,6 +235,16 @@ def create(
         "--litellm-url",
         help="LiteLLM (OpenAI-compatible) proxy URL (LiteLLM).",
     ),
+    context_window: Optional[int] = typer.Option(
+        None,
+        "--context-window",
+        help=(
+            "Override the model's context window (tokens). LiteLLM only. "
+            "Without this, hermes' custom provider falls back to a built-in "
+            "default (~65k). Pin to match your upstream model "
+            "(e.g. 131072 for Qwen3-Next-80B)."
+        ),
+    ),
 ) -> None:
     """Register a provider non-interactively when flags are supplied."""
     try:
@@ -245,6 +255,21 @@ def create(
         validate_provider_type(provider_type)
     except InvalidProviderTypeError as exc:
         emit_error(str(exc))
+
+    # #831: --context-window is litellm-only (same pattern as
+    # --litellm-url / --ollama-url). Reject upfront so the operator
+    # doesn't silently get an ignored value persisted on, e.g., a
+    # bedrock record.
+    if context_window is not None and provider_type != "litellm":
+        emit_error(
+            "--context-window only valid for litellm providers",
+            hint="omit --context-window for this provider type",
+        )
+    if context_window is not None and context_window <= 0:
+        emit_error(
+            "--context-window must be a positive integer",
+            hint="pin to the model's actual context window (e.g. 131072)",
+        )
 
     try:
         if get_provider(name):
@@ -321,6 +346,11 @@ def create(
             "created_at": now,
             "updated_at": now,
         }
+        # #831: persist operator-supplied context_window so render_hermes
+        # / render_openclaw emit it on the next configure / sync. Same
+        # field is shared by both render paths.
+        if context_window is not None:
+            record["context_window"] = context_window
         try:
             add_provider(record)
         except DuplicateProviderError as exc:
@@ -589,6 +619,15 @@ def edit(
         "--litellm-url",
         help="New LiteLLM proxy URL (LiteLLM).",
     ),
+    context_window: Optional[int] = typer.Option(
+        None,
+        "--context-window",
+        help=(
+            "Override the model's context window (tokens). LiteLLM only. "
+            "Re-render with `clawctl agent sync` to push the new value to "
+            "the hermes config.yaml on the agent host."
+        ),
+    ),
 ) -> None:
     """Edit an existing provider record."""
     record = _safe_get_provider(name)
@@ -604,15 +643,30 @@ def edit(
             region,
             ollama_url,
             litellm_url,
+            context_window is not None,
         ]
     ):
         emit_error(
             "no changes specified",
             hint=(
                 "pass --model / --api-key / --access-key / --secret-key / "
-                "--region / --ollama-url / --litellm-url"
+                "--region / --ollama-url / --litellm-url / --context-window"
             ),
         )
+
+    # #831: --context-window is litellm-only. Reject upfront on the
+    # existing record's type (mirrors --litellm-url gating below).
+    if context_window is not None:
+        if ptype != "litellm":
+            emit_error(
+                "--context-window only valid for litellm providers",
+                hint=f"provider {name!r} is type {ptype!r}",
+            )
+        if context_window <= 0:
+            emit_error(
+                "--context-window must be a positive integer",
+                hint="pin to the model's actual context window (e.g. 131072)",
+            )
 
     available: Optional[list[str]] = None
     if ollama_url is not None:
@@ -680,6 +734,11 @@ def edit(
                 p["available_models"] = available
         if region:
             p["region"] = region
+        # #831: persist litellm context_window override. The next
+        # `clawctl agent sync` for any hermes/openclaw agent attached
+        # to this provider will re-render with the new value.
+        if context_window is not None:
+            p["context_window"] = context_window
         p["updated_at"] = _now_iso()
         return p
 

--- a/src/clawrium/cli/clawctl/provider.py
+++ b/src/clawrium/cli/clawctl/provider.py
@@ -240,9 +240,10 @@ def create(
         "--context-window",
         help=(
             "Override the model's context window (tokens). LiteLLM only. "
-            "Without this, hermes' custom provider falls back to a built-in "
-            "default (~65k). Pin to match your upstream model "
-            "(e.g. 131072 for Qwen3-Next-80B)."
+            "Honoured by both the hermes and openclaw renderers — without "
+            "it each renderer falls back to its built-in default (hermes "
+            "~65k; openclaw's per-provider default). Pin to match your "
+            "upstream model (e.g. 131072 for Qwen3-Next-80B)."
         ),
     ),
 ) -> None:
@@ -624,8 +625,10 @@ def edit(
         "--context-window",
         help=(
             "Override the model's context window (tokens). LiteLLM only. "
-            "Re-render with `clawctl agent sync` to push the new value to "
-            "the hermes config.yaml on the agent host."
+            "Honoured by both the hermes and openclaw renderers; re-render "
+            "with `clawctl agent sync` to push the new value to the agent "
+            "host's config (hermes `~/.hermes/config.yaml`, openclaw "
+            "`~/.openclaw/openclaw.json`)."
         ),
     ),
 ) -> None:

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -168,6 +168,13 @@ class AttachedProviderInputs:
     # See ProviderInputs.api_key — same repr-leak rationale.
     api_key: str = field(default="", repr=False)
     base_url: str = ""
+    # Optional context-window override for litellm aux attachments
+    # (#831). Mirrors `ProviderInputs.context_window` semantics: 0
+    # means "renderer omits the key entirely" (the hermes template
+    # only emits `context_length:` when this is truthy). Stays 0 for
+    # every non-litellm aux type — the template only reads it inside
+    # the `entry.type == 'litellm'` branch of the aux loop.
+    context_window: int = 0
 
 
 @dataclass(frozen=True)
@@ -743,6 +750,18 @@ def build_render_inputs(agent_name: str) -> RenderInputs:
                     f"is declared supported for agent {agent_type} but has "
                     f"no credential fetch wired in build_render_inputs"
                 )
+            # #831: pull the operator-set context_window override off
+            # the providers.json record for litellm aux slots. Mirrors
+            # the same field that ProviderInputs.context_window reads
+            # for the primary slot — single source of truth on the
+            # provider record. Stays 0 for every non-litellm type;
+            # the hermes template only reads it inside the litellm
+            # branch of the aux loop.
+            entry_context_window = (
+                int(entry_record.get("context_window") or 0)
+                if entry_type == "litellm"
+                else 0
+            )
             attached.append(
                 AttachedProviderInputs(
                     name=entry_name,
@@ -753,6 +772,7 @@ def build_render_inputs(agent_name: str) -> RenderInputs:
                     region=entry_region,
                     api_key=entry_api_key,
                     base_url=entry_base_url,
+                    context_window=entry_context_window,
                 )
             )
         hermes_bundle = HermesProviderBundle(

--- a/src/clawrium/platform/registry/hermes/templates/hermes-config.canonical.yaml.j2
+++ b/src/clawrium/platform/registry/hermes/templates/hermes-config.canonical.yaml.j2
@@ -136,12 +136,24 @@ auxiliary:
    in `.env` (verified against the upstream docs:
    https://hermes-agent.nousresearch.com/docs/integrations/providers#litellm-proxy--multi-provider-gateway).
    No auxiliary.title_generation pin — like ollama, the proxy may front
-   local models; pinning to a remote default would defeat that use case. #}
+   local models; pinning to a remote default would defeat that use case.
+
+   #831: `context_length:` is emitted only when the operator set a
+   non-zero `context_window` on the providers.json record. Hermes'
+   custom provider falls back to an internal default (~65k) when the
+   key is absent — for proxies fronting larger-context models
+   (Qwen3-Next 131072, Llama-3.1 128k, etc.) operators must pin the
+   value explicitly. We omit the key when 0/unset so the daemon's
+   default still applies and the renderer doesn't lie about the
+   number. Mirrored inside the aux loop below. #}
 model:
   provider: "custom"
   base_url: {{ litellm_base_url | yq }}
   api_key: {{ provider.api_key | yq }}
   default: {{ provider.default_model | yq }}
+{% if provider.context_window %}
+  context_length: {{ provider.context_window }}
+{% endif %}
 {% if aux_attachments %}
 auxiliary:
 {% for entry in aux_attachments %}
@@ -151,6 +163,9 @@ auxiliary:
     base_url: {{ entry.base_url | yq }}
     api_key: {{ entry.api_key | yq }}
     model: {{ entry.model | yq }}
+{% if entry.context_window %}
+    context_length: {{ entry.context_window }}
+{% endif %}
 {% else %}
     provider: "{{ entry.type }}"
     model: {{ entry.model | yq }}

--- a/src/clawrium/platform/registry/hermes/templates/hermes-config.canonical.yaml.j2
+++ b/src/clawrium/platform/registry/hermes/templates/hermes-config.canonical.yaml.j2
@@ -21,6 +21,10 @@ auxiliary:
     base_url: {{ entry.base_url | yq }}
     api_key: {{ entry.api_key | yq }}
     model: {{ entry.model | yq }}
+{# #831 B1: litellm aux context_length — see anthropic branch below. #}
+{% if entry.context_window %}
+    context_length: {{ entry.context_window }}
+{% endif %}
 {% else %}
     provider: "{{ entry.type }}"
     model: {{ entry.model | yq }}
@@ -44,6 +48,14 @@ auxiliary:
     base_url: {{ entry.base_url | yq }}
     api_key: {{ entry.api_key | yq }}
     model: {{ entry.model | yq }}
+{# #831: bare int is valid YAML — emit context_length unquoted so the
+   daemon parses it as a number, not a string. Mirrors the primary
+   litellm branch below. Must be emitted in every primary-type aux
+   sub-branch (B1) so litellm aux slots fronting large-context models
+   pin the right window regardless of primary type. #}
+{% if entry.context_window %}
+    context_length: {{ entry.context_window }}
+{% endif %}
 {% else %}
     provider: "{{ entry.type }}"
     model: {{ entry.model | yq }}
@@ -67,6 +79,10 @@ auxiliary:
     base_url: {{ entry.base_url | yq }}
     api_key: {{ entry.api_key | yq }}
     model: {{ entry.model | yq }}
+{# #831 B1: litellm aux context_length — see anthropic branch above. #}
+{% if entry.context_window %}
+    context_length: {{ entry.context_window }}
+{% endif %}
 {% else %}
     provider: "{{ entry.type }}"
     model: {{ entry.model | yq }}
@@ -93,6 +109,10 @@ auxiliary:
     base_url: {{ entry.base_url | yq }}
     api_key: {{ entry.api_key | yq }}
     model: {{ entry.model | yq }}
+{# #831 B1: litellm aux context_length — see anthropic branch above. #}
+{% if entry.context_window %}
+    context_length: {{ entry.context_window }}
+{% endif %}
 {% else %}
     provider: "{{ entry.type }}"
     model: {{ entry.model | yq }}
@@ -123,6 +143,10 @@ auxiliary:
     base_url: {{ entry.base_url | yq }}
     api_key: {{ entry.api_key | yq }}
     model: {{ entry.model | yq }}
+{# #831 B1: litellm aux context_length — see anthropic branch above. #}
+{% if entry.context_window %}
+    context_length: {{ entry.context_window }}
+{% endif %}
 {% else %}
     provider: "{{ entry.type }}"
     model: {{ entry.model | yq }}
@@ -190,6 +214,10 @@ auxiliary:
     base_url: {{ entry.base_url | yq }}
     api_key: {{ entry.api_key | yq }}
     model: {{ entry.model | yq }}
+{# #831 B1: litellm aux context_length — see anthropic branch above. #}
+{% if entry.context_window %}
+    context_length: {{ entry.context_window }}
+{% endif %}
 {% else %}
     provider: "{{ entry.type }}"
     model: {{ entry.model | yq }}

--- a/tests/cli/clawctl/provider/test_registry.py
+++ b/tests/cli/clawctl/provider/test_registry.py
@@ -7,13 +7,27 @@ secrets.json, and hosts.json live inside a tmp directory.
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
 from clawrium.cli import app
+from clawrium.core.providers.storage import get_provider
 from clawrium.core.render import build_render_inputs, render_hermes, render_openclaw
 
 runner = CliRunner()
+
+
+def _mock_litellm_probe():
+    """Patch `fetch_litellm_models` so create/edit don't hit the network.
+
+    Returns a `with`-context patch. The mock returns a single fake model
+    id so the `available_models` field gets populated like a real probe.
+    """
+    return patch(
+        "clawrium.cli.clawctl.provider.fetch_litellm_models",
+        return_value=["writer"],
+    )
 
 
 def test_create_anthropic_with_api_key(fleet_dir, stdin_not_tty) -> None:
@@ -428,3 +442,191 @@ def test_create_opencode_end_to_end_renders_openclaw(fleet_dir, stdin_not_tty) -
     assert "OPENCODE_API_KEY='sk-test'" in env
     assert "OPENAI_BASE_URL='https://opencode.ai/zen/go/v1'" in env
     assert "OPENCLAW_DEFAULT_MODEL='deepseek-v4-flash'" in env
+
+
+# ---------------------------------------------------------------------------
+# #831: `--context-window` CLI flag (litellm only)
+#
+# Pins the operator-supplied context_length used by render_hermes /
+# render_openclaw. The flag is litellm-only — non-litellm types are
+# rejected upfront so the operator doesn't silently set an unused value.
+# ---------------------------------------------------------------------------
+
+
+def test_create_litellm_with_context_window_persists_field(
+    fleet_dir, stdin_not_tty
+) -> None:
+    """`provider registry create --type litellm --context-window 131072` writes the field."""
+    with _mock_litellm_probe():
+        result = runner.invoke(
+            app,
+            [
+                "provider",
+                "registry",
+                "create",
+                "clawrium-gtm-litellm",
+                "--type",
+                "litellm",
+                "--litellm-url",
+                "http://192.168.1.17:4000",
+                "--model",
+                "writer",
+                "--api-key",
+                "sk-master-1",
+                "--context-window",
+                "131072",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    record = get_provider("clawrium-gtm-litellm")
+    assert record is not None
+    assert record.get("context_window") == 131072
+
+
+def test_create_litellm_without_context_window_omits_field(
+    fleet_dir, stdin_not_tty
+) -> None:
+    """Default (no flag) does not set `context_window` on the record at all."""
+    with _mock_litellm_probe():
+        result = runner.invoke(
+            app,
+            [
+                "provider",
+                "registry",
+                "create",
+                "lt-no-ctx",
+                "--type",
+                "litellm",
+                "--litellm-url",
+                "http://10.0.0.5:4000",
+                "--model",
+                "writer",
+                "--api-key",
+                "sk-master-2",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    record = get_provider("lt-no-ctx")
+    assert record is not None
+    # The key is omitted entirely (renderer falls through to default).
+    assert "context_window" not in record
+
+
+def test_create_context_window_rejected_for_non_litellm(
+    fleet_dir, stdin_not_tty
+) -> None:
+    """`--context-window` on a non-litellm `--type` exits non-zero."""
+    result = runner.invoke(
+        app,
+        [
+            "provider",
+            "registry",
+            "create",
+            "anth",
+            "--type",
+            "anthropic",
+            "--api-key",
+            "sk-x",
+            "--context-window",
+            "200000",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--context-window only valid for litellm" in result.output
+
+
+def test_create_context_window_rejects_non_positive(
+    fleet_dir, stdin_not_tty
+) -> None:
+    """`--context-window 0` or negative exits non-zero."""
+    result = runner.invoke(
+        app,
+        [
+            "provider",
+            "registry",
+            "create",
+            "lt-bad",
+            "--type",
+            "litellm",
+            "--litellm-url",
+            "http://10.0.0.5:4000",
+            "--model",
+            "writer",
+            "--api-key",
+            "sk-x",
+            "--context-window",
+            "0",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--context-window must be a positive integer" in result.output
+
+
+def test_edit_litellm_adds_context_window(fleet_dir, stdin_not_tty) -> None:
+    """`edit --context-window N` on an existing litellm record persists the value."""
+    with _mock_litellm_probe():
+        runner.invoke(
+            app,
+            [
+                "provider",
+                "registry",
+                "create",
+                "lt-edit",
+                "--type",
+                "litellm",
+                "--litellm-url",
+                "http://10.0.0.5:4000",
+                "--model",
+                "writer",
+                "--api-key",
+                "sk-y",
+            ],
+        )
+    # Sanity: field absent before edit.
+    assert "context_window" not in (get_provider("lt-edit") or {})
+
+    result = runner.invoke(
+        app,
+        [
+            "provider",
+            "registry",
+            "edit",
+            "lt-edit",
+            "--context-window",
+            "131072",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert get_provider("lt-edit").get("context_window") == 131072
+
+
+def test_edit_context_window_rejected_for_non_litellm(
+    fleet_dir, stdin_not_tty
+) -> None:
+    """`edit --context-window` on a non-litellm provider exits non-zero."""
+    runner.invoke(
+        app,
+        [
+            "provider",
+            "registry",
+            "create",
+            "edit-anth",
+            "--type",
+            "anthropic",
+            "--api-key",
+            "k",
+        ],
+    )
+    result = runner.invoke(
+        app,
+        [
+            "provider",
+            "registry",
+            "edit",
+            "edit-anth",
+            "--context-window",
+            "131072",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--context-window only valid for litellm" in result.output

--- a/tests/cli/clawctl/provider/test_registry.py
+++ b/tests/cli/clawctl/provider/test_registry.py
@@ -565,7 +565,7 @@ def test_create_context_window_rejects_non_positive(
 def test_edit_litellm_adds_context_window(fleet_dir, stdin_not_tty) -> None:
     """`edit --context-window N` on an existing litellm record persists the value."""
     with _mock_litellm_probe():
-        runner.invoke(
+        create_result = runner.invoke(
             app,
             [
                 "provider",
@@ -582,6 +582,9 @@ def test_edit_litellm_adds_context_window(fleet_dir, stdin_not_tty) -> None:
                 "sk-y",
             ],
         )
+    # S4 (ATX round 1): assert the setup `create` actually succeeded.
+    # Otherwise the assertions below would mask a CLI regression.
+    assert create_result.exit_code == 0, create_result.output
     # Sanity: field absent before edit.
     assert "context_window" not in (get_provider("lt-edit") or {})
 
@@ -604,7 +607,7 @@ def test_edit_context_window_rejected_for_non_litellm(
     fleet_dir, stdin_not_tty
 ) -> None:
     """`edit --context-window` on a non-litellm provider exits non-zero."""
-    runner.invoke(
+    create_result = runner.invoke(
         app,
         [
             "provider",
@@ -617,6 +620,8 @@ def test_edit_context_window_rejected_for_non_litellm(
             "k",
         ],
     )
+    # S4 (ATX round 1): verify setup succeeded before exercising edit.
+    assert create_result.exit_code == 0, create_result.output
     result = runner.invoke(
         app,
         [
@@ -630,3 +635,48 @@ def test_edit_context_window_rejected_for_non_litellm(
     )
     assert result.exit_code != 0
     assert "--context-window only valid for litellm" in result.output
+
+
+def test_edit_context_window_rejects_non_positive(
+    fleet_dir, stdin_not_tty
+) -> None:
+    """S5 (ATX round 1): `edit --context-window 0` (or negative) on an existing
+    litellm record exits non-zero. Mirrors `test_create_context_window_rejects_non_positive`
+    to exercise the guard at `provider.py:665`.
+    """
+    with _mock_litellm_probe():
+        create_result = runner.invoke(
+            app,
+            [
+                "provider",
+                "registry",
+                "create",
+                "lt-edit-bad",
+                "--type",
+                "litellm",
+                "--litellm-url",
+                "http://10.0.0.5:4000",
+                "--model",
+                "writer",
+                "--api-key",
+                "sk-z",
+            ],
+        )
+    assert create_result.exit_code == 0, create_result.output
+
+    result = runner.invoke(
+        app,
+        [
+            "provider",
+            "registry",
+            "edit",
+            "lt-edit-bad",
+            "--context-window",
+            "0",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--context-window must be a positive integer" in result.output
+
+    # Record must NOT have been mutated.
+    assert "context_window" not in (get_provider("lt-edit-bad") or {})

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -999,6 +999,125 @@ def test_hermes_litellm_primary_with_openrouter_aux_does_not_emit_aux_context_le
     # Exactly one `context_length:` line in the entire YAML — the primary's.
     assert yaml.count("context_length:") == 1
     assert "context_length: 131072" in yaml
+    # ATX r2 S3: also pin the indentation so a regression that emitted
+    # the primary at four-space indent (under aux) wouldn't slip through
+    # just because the count stayed 1.
+    assert "\n  context_length: 131072\n" in yaml
+
+
+# ATX r2 W1: parametrize the litellm-aux context_length emission across
+# all 5 primary-type branches that received the B1 patch but weren't
+# individually covered (anthropic, openai, bedrock, ollama, opencode).
+# A typo or indentation regression in any branch is now caught — same
+# class of bug B1 itself was. openrouter+litellm-aux is exercised by
+# the dedicated test above; litellm+litellm-aux by the existing
+# `test_hermes_litellm_aux_with_context_window_emits_context_length`.
+@pytest.mark.parametrize(
+    "primary_ptype,api_keys",
+    [
+        ("anthropic", (("anthropic", "sk-ant-p"),)),
+        ("openai", (("openai", "sk-oa-p"),)),
+        ("bedrock", ()),  # bedrock primary uses AWS creds, not bearer
+        ("ollama", ()),  # ollama primary needs no env credential
+        ("opencode", ()),  # opencode reads bearer inline in YAML
+    ],
+)
+def test_hermes_non_litellm_primary_with_litellm_aux_emits_aux_context_length(
+    primary_ptype, api_keys
+):
+    """ATX r2 W1: every non-litellm primary-type aux loop emits
+    `context_length:` for a litellm aux carrying `context_window=131072`.
+    Locks the duplicated B1 emission pattern in all 6 aux sub-branches.
+    """
+    base = _baseline_inputs(ptype=primary_ptype)
+    aws_credentials: tuple = ()
+    if primary_ptype == "bedrock":
+        # Bedrock primary credentials live on the bundle's aws_credentials
+        # — name keyed to the provider name from _baseline_inputs.
+        aws_credentials = ((base.provider.name, ("AKIA-1", "secret-1", "us-east-1")),)
+    bundle = HermesProviderBundle(
+        attachments=(
+            AttachedProviderInputs(
+                name=base.provider.name,
+                type=primary_ptype,
+                role="primary",
+                model=base.provider.default_model,
+            ),
+            AttachedProviderInputs(
+                name="inx-litellm-aux",
+                type="litellm",
+                role="curator",
+                model="writer",
+                endpoint="http://192.168.1.17:4000",
+                api_key="sk-litellm-aux",
+                base_url="http://192.168.1.17:4000/v1",
+                context_window=131072,
+            ),
+        ),
+        api_keys=api_keys,
+        aws_credentials=aws_credentials,
+    )
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        channels=base.channels,
+        integrations=base.integrations,
+        api_server=base.api_server,
+        gateway=base.gateway,
+        hermes=bundle,
+    )
+    yaml = render_hermes(inputs).files[".hermes/config.yaml"]
+    # Exactly one `context_length:` — the aux's. Primary-type
+    # ProviderInputs in `_baseline_inputs` does not set context_window,
+    # so the primary block never emits the key.
+    assert yaml.count("context_length:") == 1, (
+        f"{primary_ptype}: expected exactly one context_length emission, "
+        f"got:\n{yaml}"
+    )
+    # Four-space indent under the aux block.
+    assert "\n    context_length: 131072\n" in yaml, (
+        f"{primary_ptype}: aux context_length missing or wrongly indented:\n{yaml}"
+    )
+
+
+# ATX r2 W2: end-to-end build_render_inputs coverage for the litellm-aux
+# context_window derivation. Every existing #831 render test constructs
+# AttachedProviderInputs directly, bypassing the providers.json →
+# AttachedProviderInputs path at render.py:760-764. A bug in the field
+# name (e.g. "context_length" vs "context_window") or the int() cast
+# would be silent without this.
+def test_831_build_render_inputs_threads_litellm_aux_context_window(stores):
+    """`providers.json.<aux>.context_window` flows into the
+    `AttachedProviderInputs.context_window` field via `build_render_inputs`.
+    """
+    stores.agent = _hermes_multi_agent_record(
+        [
+            {"name": "anthropic-prod", "role": "primary", "model": ""},
+            {"name": "litellm-aux", "role": "compression", "model": "writer"},
+        ]
+    )
+    _seed_provider(stores, name="anthropic-prod", ptype="anthropic")
+    # Seed the litellm aux record with the operator-set context_window.
+    stores.providers["litellm-aux"] = {
+        "name": "litellm-aux",
+        "type": "litellm",
+        "default_model": "writer",
+        "endpoint": "http://192.168.1.17:4000",
+        "context_window": 131072,
+    }
+    stores.provider_api_keys["anthropic-prod"] = "sk-ant"
+    stores.provider_api_keys["litellm-aux"] = "sk-litellm"
+
+    inputs = build_render_inputs("wolf")
+    assert inputs.hermes is not None
+    by_name = {a.name: a for a in inputs.hermes.attachments}
+    # The operator's pin survives the providers.json → RenderInputs
+    # transform with the correct int type.
+    assert by_name["litellm-aux"].context_window == 131072
+    assert isinstance(by_name["litellm-aux"].context_window, int)
+    # Non-litellm aux never carries the field (defense: stays 0).
+    assert by_name["anthropic-prod"].context_window == 0
 
 
 def test_hermes_renders_integrations_in_input_order_and_bare_github_token():

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -739,6 +739,158 @@ def test_hermes_litellm_missing_endpoint_raises():
     assert out.files[".hermes/config.yaml"]
 
 
+# ---------------------------------------------------------------------------
+# #831: hermes litellm context_length emission
+#
+# Operators with litellm proxies fronting large-context models (e.g.
+# Qwen3-Next-80B at 131072) must be able to pin hermes' context window
+# through the canonical render path. The contract:
+#   - `context_window=0` (default) → `context_length:` omitted entirely
+#   - `context_window=N` → `context_length: N` emitted after `default:`
+# Tested for primary (`model:`) and aux (`auxiliary.<role>:`) litellm
+# slots; non-litellm aux types never emit the key.
+# ---------------------------------------------------------------------------
+
+
+def test_hermes_litellm_primary_no_context_window_omits_context_length():
+    """LiteLLM primary with default (0) context_window omits the YAML key entirely."""
+    inputs = _baseline_inputs(ptype="litellm")
+    # _baseline_inputs builds ProviderInputs without setting
+    # context_window, so it defaults to 0.
+    assert inputs.provider.context_window == 0
+    yaml = render_hermes(inputs).files[".hermes/config.yaml"]
+    # No `context_length` key — neither populated, nor null, nor zero.
+    assert "context_length" not in yaml
+
+
+def test_hermes_litellm_primary_with_context_window_emits_context_length():
+    """LiteLLM primary with `context_window=131072` emits `context_length: 131072` after `default:`."""
+    base = _baseline_inputs(ptype="litellm")
+    provider = ProviderInputs(
+        name=base.provider.name,
+        type=base.provider.type,
+        default_model=base.provider.default_model,
+        endpoint=base.provider.endpoint,
+        api_key=base.provider.api_key,
+        context_window=131072,
+    )
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=provider,
+        channels=base.channels,
+        integrations=base.integrations,
+        api_server=base.api_server,
+        gateway=base.gateway,
+    )
+    yaml = render_hermes(inputs).files[".hermes/config.yaml"]
+    assert "context_length: 131072" in yaml
+    # Position: must be after `default:` inside the `model:` block so the
+    # daemon's YAML deep-merge places it under the right parent.
+    default_pos = yaml.index("default:")
+    ctx_pos = yaml.index("context_length: 131072")
+    assert default_pos < ctx_pos
+    # And the key is indented exactly two spaces (sits under `model:`).
+    assert "\n  context_length: 131072\n" in yaml
+
+
+def test_hermes_litellm_aux_with_context_window_emits_context_length():
+    """LiteLLM primary + litellm aux, both with `context_window`, both emit the YAML key."""
+    base = _baseline_inputs(ptype="litellm")
+    # Primary: context_window=200000.
+    provider = ProviderInputs(
+        name=base.provider.name,
+        type=base.provider.type,
+        default_model=base.provider.default_model,
+        endpoint=base.provider.endpoint,
+        api_key=base.provider.api_key,
+        context_window=200000,
+    )
+    # Aux: separate litellm proxy with context_window=131072.
+    bundle = HermesProviderBundle(
+        attachments=(
+            AttachedProviderInputs(
+                name=base.provider.name,
+                type="litellm",
+                role="primary",
+                model=base.provider.default_model,
+            ),
+            AttachedProviderInputs(
+                name="inx-litellm",
+                type="litellm",
+                role="curator",
+                model="gemma4:31b",
+                endpoint="http://192.168.1.17:4000",
+                api_key="sk-litellm-aux",
+                base_url="http://192.168.1.17:4000/v1",
+                context_window=131072,
+            ),
+        ),
+        api_keys=(),
+        aws_credentials=(),
+    )
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=provider,
+        channels=base.channels,
+        integrations=base.integrations,
+        api_server=base.api_server,
+        gateway=base.gateway,
+        hermes=bundle,
+    )
+    yaml = render_hermes(inputs).files[".hermes/config.yaml"]
+    # Primary emits 200000 at two-space indent (under `model:`).
+    assert "\n  context_length: 200000\n" in yaml
+    # Aux emits 131072 at four-space indent (under `auxiliary.curator:`).
+    assert "\n    context_length: 131072\n" in yaml
+
+
+def test_hermes_litellm_primary_with_openrouter_aux_does_not_emit_aux_context_length():
+    """Regression guard: openrouter aux never emits `context_length` even when primary does."""
+    base = _baseline_inputs(ptype="litellm")
+    provider = ProviderInputs(
+        name=base.provider.name,
+        type=base.provider.type,
+        default_model=base.provider.default_model,
+        endpoint=base.provider.endpoint,
+        api_key=base.provider.api_key,
+        context_window=131072,
+    )
+    bundle = HermesProviderBundle(
+        attachments=(
+            AttachedProviderInputs(
+                name=base.provider.name,
+                type="litellm",
+                role="primary",
+                model=base.provider.default_model,
+            ),
+            AttachedProviderInputs(
+                name="or-aux",
+                type="openrouter",
+                role="curator",
+                model="anthropic/claude-haiku-4.5",
+            ),
+        ),
+        api_keys=(("openrouter", "sk-or-aux"),),
+        aws_credentials=(),
+    )
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=provider,
+        channels=base.channels,
+        integrations=base.integrations,
+        api_server=base.api_server,
+        gateway=base.gateway,
+        hermes=bundle,
+    )
+    yaml = render_hermes(inputs).files[".hermes/config.yaml"]
+    # Exactly one `context_length:` line in the entire YAML — the primary's.
+    assert yaml.count("context_length:") == 1
+    assert "context_length: 131072" in yaml
+
+
 def test_hermes_renders_integrations_in_input_order_and_bare_github_token():
     """Renderer iterates input order; sorting is `build_render_inputs`' job."""
     base = _baseline_inputs(ptype="openrouter")

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -844,6 +844,116 @@ def test_hermes_litellm_aux_with_context_window_emits_context_length():
     assert "\n  context_length: 200000\n" in yaml
     # Aux emits 131072 at four-space indent (under `auxiliary.curator:`).
     assert "\n    context_length: 131072\n" in yaml
+    # Count discipline: exactly two `context_length:` lines (primary + aux).
+    # Catches a future regression that double-emits via a buggy macro
+    # refactor or template duplication.
+    assert yaml.count("context_length:") == 2
+
+
+def test_hermes_litellm_aux_unset_context_window_omits_context_length():
+    """LiteLLM primary set + litellm aux with `context_window=0` → only primary emits.
+
+    Exercises the falsy branch of `{% if entry.context_window %}` on the
+    aux loop, which round-1 ATX flagged as untested. A regression that
+    emitted `context_length: 0` (or `context_length: null`) for default
+    aux slots would silently break operator setups.
+    """
+    base = _baseline_inputs(ptype="litellm")
+    provider = ProviderInputs(
+        name=base.provider.name,
+        type=base.provider.type,
+        default_model=base.provider.default_model,
+        endpoint=base.provider.endpoint,
+        api_key=base.provider.api_key,
+        context_window=131072,
+    )
+    bundle = HermesProviderBundle(
+        attachments=(
+            AttachedProviderInputs(
+                name=base.provider.name,
+                type="litellm",
+                role="primary",
+                model=base.provider.default_model,
+            ),
+            AttachedProviderInputs(
+                name="inx-litellm",
+                type="litellm",
+                role="curator",
+                model="gemma4:31b",
+                endpoint="http://192.168.1.17:4000",
+                api_key="sk-litellm-aux",
+                base_url="http://192.168.1.17:4000/v1",
+                # context_window left at default (0).
+            ),
+        ),
+        api_keys=(),
+        aws_credentials=(),
+    )
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=provider,
+        channels=base.channels,
+        integrations=base.integrations,
+        api_server=base.api_server,
+        gateway=base.gateway,
+        hermes=bundle,
+    )
+    yaml = render_hermes(inputs).files[".hermes/config.yaml"]
+    # Exactly one `context_length:` — primary only.
+    assert yaml.count("context_length:") == 1
+    assert "\n  context_length: 131072\n" in yaml
+    # No four-space-indented (aux-level) emission. Catches a regression
+    # that emitted `context_length: 0` or `context_length: null` for
+    # default aux slots.
+    assert "    context_length:" not in yaml
+
+
+def test_hermes_openrouter_primary_with_litellm_aux_emits_aux_context_length():
+    """#831 B1 regression guard: openrouter primary + litellm aux with
+    `context_window` set on the aux emits `context_length:` inside the
+    aux block. Before B1's fix, only the litellm-primary branch carried
+    the emission, so this case silently dropped the operator's pin.
+    """
+    base = _baseline_inputs(ptype="openrouter")
+    bundle = HermesProviderBundle(
+        attachments=(
+            AttachedProviderInputs(
+                name=base.provider.name,
+                type="openrouter",
+                role="primary",
+                model=base.provider.default_model,
+            ),
+            AttachedProviderInputs(
+                name="inx-litellm",
+                type="litellm",
+                role="curator",
+                model="writer",
+                endpoint="http://192.168.1.17:4000",
+                api_key="sk-litellm-aux",
+                base_url="http://192.168.1.17:4000/v1",
+                context_window=131072,
+            ),
+        ),
+        api_keys=(("openrouter", "sk-or"),),
+        aws_credentials=(),
+    )
+    inputs = RenderInputs(
+        agent_name=base.agent_name,
+        agent_type=base.agent_type,
+        provider=base.provider,
+        channels=base.channels,
+        integrations=base.integrations,
+        api_server=base.api_server,
+        gateway=base.gateway,
+        hermes=bundle,
+    )
+    yaml = render_hermes(inputs).files[".hermes/config.yaml"]
+    # Exactly one `context_length:` line — the aux's. Openrouter primary
+    # never emits the key (no context_window on its ProviderInputs).
+    assert yaml.count("context_length:") == 1
+    # Indented four spaces under the aux block.
+    assert "\n    context_length: 131072\n" in yaml
 
 
 def test_hermes_litellm_primary_with_openrouter_aux_does_not_emit_aux_context_length():


### PR DESCRIPTION
## Summary

- Adds `--context-window N` flag to `clawctl provider registry create/edit` for litellm-type providers. Persists to `providers.json.<name>.context_window` (reusing the field openclaw already reads since #723).
- `render_hermes` now passes `provider.context_window` (primary) and per-aux `context_window` (aux loop) into the litellm branch of `hermes-config.canonical.yaml.j2`.
- Template emits `model.context_length: <value>` after `default:` when set; key is omitted entirely when 0/unset so hermes' built-in default still applies for legacy records.
- **Round 2 (B1)**: emission now lives in all 7 litellm branches (1 primary + 6 aux sub-branches). Originally only the litellm-primary branch carried the emission, so e.g. openrouter primary + litellm aux silently dropped operator pins.
- Litellm only — non-litellm types reject the flag at the CLI.

Why: hermes' `provider: custom` falls back to a ~65k context window when `context_length` is unset. Litellm proxies fronting larger-context models (e.g. Qwen3-Next-80B at 131072) silently get truncated. Upstream hermes ([cli-config.yaml.example](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example), [Configuration page](https://hermes-agent.nousresearch.com/docs/user-guide/configuration)) documents `context_length` as the supported knob.

Closes #831

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — 4130 passed, 2 skipped (Python) + 305 passed (GUI)
- [x] Linter passes (`make lint`) — ruff + ESLint both clean
- [x] New tests added for new functionality

### Test Coverage
- Files changed: `src/clawrium/cli/clawctl/provider.py`, `src/clawrium/core/render.py`, `src/clawrium/platform/registry/hermes/templates/hermes-config.canonical.yaml.j2`, `CHANGELOG.md`
- New tests (Python: +12 over round 1):
  - `tests/core/test_render.py` — primary unset (key absent), primary set (`context_length: 131072` emitted after `default:`), primary + litellm aux both set (count = 2 + indent pins), primary + openrouter aux (only primary emits, with indent pin), aux unset omits, openrouter primary + litellm aux emits at aux level, **parametrized across 5 non-litellm primary types** (anthropic/openai/bedrock/ollama/opencode) all paired with a litellm aux, and `build_render_inputs` end-to-end threading of `providers.json.<aux>.context_window` → `AttachedProviderInputs.context_window`.
  - `tests/cli/clawctl/provider/test_registry.py` — CLI roundtrip for `--context-window` on create + edit, rejection cases (non-litellm type, non-positive int on both create and edit).
- Coverage impact: increased

### Manual Testing — Real-host UAT
Target: agent `clawrium-gtm` on host `wolf-i`, attached to provider `clawrium-gtm-litellm` (litellm proxy at `http://192.168.1.17:4000`, model `writer` advertising 131072).

1. **Round 1 (provider edit + sync)** — `clawctl provider registry edit clawrium-gtm-litellm --context-window 131072` persisted to `providers.json`; `clawctl agent sync clawrium-gtm` completed without error.
2. **Round 2 UAT lite** — `clawctl agent sync clawrium-gtm` after template changes: `0 written, 2 unchanged`. Rendered `.hermes/config.yaml` byte-identical (bytes=284, sha256=`4e1fc94123626482`) — confirms 6 aux-branch additions don't disturb the litellm-primary path.
3. **Rendered YAML on host**:
   ```yaml
   # Managed by clawrium (clawctl). Re-render with `clawctl agent configure clawrium-gtm`.
   model:
     provider: "custom"
     base_url: 'http://192.168.1.17:4000/v1'
     api_key: 'sk-99f...6308'
     default: 'writer'
     context_length: 131072
   ```
4. **Doctor** (all rounds) — `clawctl agent doctor clawrium-gtm` → `Status: ok`.
5. **Dashboard** — `clawctl agent exec clawrium-gtm -- dashboard --status` lists gtm dashboard running on `127.0.0.1:46281`.
6. **Omission semantics** — verified separately that clearing `context_window` from the record + re-syncing produces a config.yaml with no `context_length` key (hermes' default applies).

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (`--context-window` rejects non-positive ints and non-litellm provider types at the CLI; renderer treats 0/unset as omit-key, never writes `null` or `0`)
- [x] No SQL injection, XSS, or command injection risks (renderer-only change; `context_length:` value is a Python int interpolated into YAML, guaranteed by `int()` coercion at the build_render_inputs boundary)
- [x] Dependencies are from trusted sources (no new dependencies)

## ATX Review Summary

**Final Review: Rating 4/5** (no blockers, 4 warnings — 3 addressed in r3, 1 deferred)
**Total Cost: $5.51 | Total Time: ~14m | Specialists used: leader, cli-ux, platform-playbooks, render-engine, security-reviewer, test-coverage**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3/5 | B1 | All fixed in r2 | ~$2.29 | ~7m | leader, render-engine, platform-playbooks, cli-ux, test-coverage |
| 2 | 4/5 | None | W1/W2/W3 fixed in r3, W4 deferred | $3.22 | 7m | leader, cli-ux, platform-playbooks, render-engine, security-reviewer, test-coverage |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `hermes-config.canonical.yaml.j2` | `context_length` emission existed only in litellm-primary branch; 6 other primary-type aux sub-branches dropped operator pins for litellm aux slots | Fixed in r2 commit `eeaf282` — added the conditional emission inside all 6 aux sub-branches at 4-space indent |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `provider.py` (create + edit) | Help text mentioned only hermes; openclaw also reads `provider.context_window` since #723 | Fixed in r2 — both help strings name both renderers |
| W2 | `tests/core/test_render.py` | Falsy aux-context_window branch untested; missing positive aux-emission test | Fixed in r2 — added `test_hermes_litellm_aux_unset_context_window_omits_context_length`, `test_hermes_openrouter_primary_with_litellm_aux_emits_aux_context_length`, plus S3/S4/S5 polish |
| W3 | `CHANGELOG.md` | Entry wrongly said openclaw renders `context_length` and that this PR added openclaw consumption | Fixed in r2 — split into two accurate lines under `### Added` |

**Suggestions addressed:** S3 (count discipline), S4 (assert setup `create` succeeded in two edit-side tests), S5 (`test_edit_context_window_rejects_non_positive`), S6 (inline reference comments near new template emissions).

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**Blocking Issues:** None.

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `tests/core/test_render.py` | 5 of 7 modified aux branches (anthropic/openai/bedrock/ollama/opencode) untested for `context_length` emission — same class of regression B1 caught | Fixed in r3 commit `f9d77c5` — added `test_hermes_non_litellm_primary_with_litellm_aux_emits_aux_context_length` parametrized across all 5 |
| W2 | `src/clawrium/core/render.py:760-775` | `build_render_inputs` aux-slot derivation never exercised end-to-end | Fixed in r3 — added `test_831_build_render_inputs_threads_litellm_aux_context_window` |
| W3 | `src/clawrium/cli/clawctl/provider.py:244-245` | `create` help text said "openclaw's per-provider default" but `render.py:1723` hardcodes 65536 | Fixed in r3 — both help strings now say "both fall back to ~65k (65536)"; also condensed verbosity (S5) |
| W4 | `src/clawrium/cli/clawctl/provider.py:124-145` | `_provider_to_row` omits `context_window` → no CLI verification path | **Deferred** — same as round-1 S2; kept out of scope, will land as follow-up |

**Suggestions addressed in r3:** S3 (indent pin on openrouter-aux test). Others (S1/S2/S4/S6/S7/S8) deferred as defense-in-depth/cosmetic polish — providers.json is operator-trust-boundary by convention; CLI guards `> 0`.

</details>

## Reviewer Notes

- **Scope deliberately narrow**: `max_tokens` (output cap) is the related-but-different knob that the upstream hermes example pairs with `context_length`. Intentionally deferred — file a follow-up if needed.
- **Field reuse**: `context_window` already existed on `ProviderInputs` (read by the openclaw render path at `src/clawrium/core/render.py:1723`, renders as JSON `contextWindow`). This PR extends `AttachedProviderInputs` with the same field for hermes aux slots and wires the hermes template/CLI through the same record key. Single source of truth.
- **No gateway-bearer rotation impact**: hermes sync does not rotate the bearer (rotation is zeroclaw-only per `AGENTS.md` "Gateway Token Lifecycle"). No effect on remote `clawctl agent chat` sessions.
- **Workspace overlay unaffected**: hermes excludes `config.yaml` from the overlay by design. This change flows through the renderer (`render_hermes`), which is the documented path.
- **Template duplication**: B1's fix introduced 6 nearly-identical 3-line emissions. Considered a Jinja macro but kept inline per round-2 platform-playbooks confirmation — 6 inline copies are easier to audit than a macro indirection. If a 7th primary type ever arrives, reconsider.

---

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>