### PR TITLE
feat(openclaw): Slack MCP integration (Phase 2 of #499)

### DIFF
--- a/.itx/835/01_EXECUTION.md
+++ b/.itx/835/01_EXECUTION.md
@@ -1,0 +1,96 @@
+# Issue #835 — Execution Log
+
+GitHub: https://github.com/ric03uec/clawrium/issues/835
+
+Phase 2 of the #499 orchestrated chain. Depends on #834 (Phase 1 —
+hermes) via stacked-PR chain: base branch is `issue-834-hermes-slack`.
+
+## Execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-07-01T17:32:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 835 --pr-base=issue-834-hermes-slack.
+
+This is Phase 2 of the #499 orchestrated chain. Your PR MUST target
+issue-834-hermes-slack (not main). Include "Stacked on top of
+issue-834-hermes-slack" in the PR body.
+
+Review-tool override: use the atx CLI (`atx review request --prompt
+"..."`) for all code review iterations. Do NOT use
+mcp__atx__request_review. The repo config (.claude/itx-config.json)
+has MCP review enabled but the orchestrator is overriding it for this
+run. Persist review state in .itx/835/atx-session.json with transport:
+cli. Follow the skill resilient chain: if atx CLI fails, skip ATX and
+record a Callout — never block on ATX. Iteration ceiling 3, then open
+PR with [ITX-STUCK] marker if unresolved blockers remain.
+
+Branch is issue-835-openclaw-slack (already checked out). Do not
+create a new branch.
+
+Real-host UAT target for Phase 2 openclaw: wolf-i (per the plan).
+```
+
+**Output**: Openclaw Slack MCP integration end-to-end:
+
+- `_OPENCLAW_SUPPORTED_INTEGRATIONS` extended to include `slack-user` /
+  `slack-cookie` — attach gate at
+  `cli/clawctl/agent/integration.py:attach` now accepts openclaw+slack.
+- `_render_openclaw_json` takes new `slack_integrations`, `agent_name`,
+  `home_root` parameters; emits `mcp.servers.<slug>` block conditionally.
+  W10 byte-lock guaranteed via unit tests: openclaw agents without slack
+  render byte-identical to pre-#835 output.
+- `render_openclaw` takes `os_family` for per-OS binary path selection
+  (`/home` vs `/Users`).
+- `core/playbook_resolver.py` gains `_MCP_SLACK_VERSION` / arch maps /
+  sha256 maps + `mcp_slack_extravars(os_family)` — single Python source
+  of truth (B9 fix). Both hermes and openclaw configure playbooks (Linux
+  + macOS) removed their inline `vars:` pins.
+- `core/playbook_resolver.normalize_os_family(host)` — single seam for
+  the `os_family` alias normalization (previously triplicated in
+  `configure_agent`).
+- `lifecycle.configure_agent` threads `mcp_slack_extravars` for hermes
+  + openclaw; wraps in `try/ValueError → (False, msg)` so exotic
+  os_family surfaces as a clean assembly-time failure.
+- `lifecycle_canonical.sync_agent_canonical` threads `os_family` into
+  hermes + openclaw renderer calls (closes the darwin+slack silent
+  wrong-path bug ATX iter-1 W1 flagged).
+- openclaw `configure.yaml` / `configure_macos.yaml` install
+  `slack-mcp-server` when a slack integration is attached; `no_log:
+  true` on install tasks matches openclaw.json copy posture.
+- Tests: openclaw slack render goldens, W10 byte-lock, unknown-auth
+  defensive raise, slack-user + slack-cookie coexistence, agent_name
+  validation, `os_family` typo rejection, playbook_resolver extravar
+  matrix, `normalize_os_family` alias parametrize, `mcp_slack_extravars`
+  ValueError → `(False, msg)` lifecycle path, attach-gate acceptance
+  with hosts.json persistence assertion.
+
+## ATX Review Iterations
+
+Three iterations via the atx CLI (`atx review request --prompt ...`)
+per the orchestrator override — MCP review path skipped per Task
+instruction. State persisted at `.itx/835/atx-session.json`.
+
+| Iter | Rating | Cost   | Duration | Blockers | Resolution                                    |
+|------|--------|--------|----------|----------|-----------------------------------------------|
+| 1    | 3.5/5  | $3.63  | 8m22s    | 0 B, 7 W | All 7 warnings fixed in iter-2                |
+| 2    | 4.0/5  | $5.53  | 9m10s    | 3 B, 3 W | 3 blockers + 3 warnings fixed in iter-3       |
+| 3    | 4.0/5  | $6.56  | 10m19s   | 0 B      | Threshold `>3/5` met; iteration ceiling (3)   |
+
+Total review cost: **$15.72**.
+
+## Real-Host UAT
+
+**Target per plan**: wolf-i openclaw. `clawctl agent get` shows the
+only openclaw agent on wolf-i (`wolf-i` itself) is in `failed` state
+(age 0s) and cannot serve as a UAT target. `esper-mac-oc` is a `ready`
+darwin openclaw on `esper-macmini` (not wolf-i) — usable for macOS UAT
+if the operator elects to use it.
+
+**Blocked by pre-existing openclaw install state on wolf-i.** UAT
+recorded in the PR Callouts section for the operator to run manually
+or after remediating the failed install with `clawctl agent create
+<name> --type openclaw --host wolf-i --cleanup-failed`.

--- a/.itx/835/atx-session.json
+++ b/.itx/835/atx-session.json
@@ -1,0 +1,51 @@
+{
+  "session_id": "153b0288-55c5-4a28-a058-13b7edf117ee-iter3",
+  "transport": "cli",
+  "commit_sha": "107bdcf4746c5504fcf0275e1ff832ff20fdf3d0",
+  "iteration": 3,
+  "last_rating": 4,
+  "last_blockers": [],
+  "started_at": "2026-07-01T17:32:00Z",
+  "updated_at": "2026-07-01T18:12:00Z",
+  "review_cost_usd_total": 15.72,
+  "iterations": [
+    {
+      "iteration": 1,
+      "rating": 3.5,
+      "cost_usd": 3.62796075,
+      "duration_ms": 502353,
+      "warnings": [
+        "W1: canonical sync omits os_family for darwin openclaw+slack",
+        "W2: os_family normalization triplicated in lifecycle.configure_agent",
+        "W3: zeroclaw comment misleading",
+        "W4: _render_openclaw_json docstring numbering skip 4→6→5",
+        "W5: no_log missing on slack install tasks in openclaw playbooks",
+        "W6: seen_mcp_slugs scope not documented",
+        "W7: slack integration_views entry is env-template-inert"
+      ]
+    },
+    {
+      "iteration": 2,
+      "rating": 4.0,
+      "cost_usd": 5.532675,
+      "duration_ms": 549699,
+      "blockers": [
+        "B1: normalize_os_family has zero unit tests",
+        "B2: _render_openclaw_json unknown auth-mode raise untested",
+        "B3: lifecycle.py mcp_slack_extravars ValueError→(False,msg) path untested"
+      ],
+      "warnings": [
+        "W1: TypeError shim in lifecycle_canonical unreachable in all stubs",
+        "W2: multi-slack (user+cookie) coexistence render untested",
+        "W3: gate acceptance tests don't assert hosts.json write"
+      ]
+    },
+    {
+      "iteration": 3,
+      "rating": 4.0,
+      "cost_usd": 6.558892305,
+      "duration_ms": 618742,
+      "notes": "All iter-2 blockers closed: 3 new tests added (normalize_os_family parametrize, unknown-auth defensive raise, lifecycle ValueError→(False,msg)). All iter-2 warnings closed: TypeError shim removed + 9+4 test lambdas updated to accept **_kwargs; multi-slack coexistence test added; hosts.json persistence asserted in gate acceptance tests. Iteration ceiling (3) reached with rating > 3/5 threshold met."
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,30 @@ cut. The `itx:release` skill archives this section into a new
   gate rejects `slack-*` on openclaw / zeroclaw agents at CLI time
   (Phase 1 of #499); those agent types will gain support in follow-up
   slices. First MCP subprocess on darwin hermes. (#834, #499)
+- Slack integration for openclaw agents — Phase 2 of #499. The
+  `slack-user` and `slack-cookie` types now attach to openclaw agents
+  and emit an `mcp.servers.<slug>` block in
+  `~/.openclaw/openclaw.json` referencing the same
+  SHA256-pinned korotovsky/slack-mcp-server binary that hermes uses.
+  The `mcp` key is emitted **conditionally**: openclaw agents without
+  a slack integration attached render byte-identical to pre-#835
+  output — no drift on the on-host `openclaw.json` after upgrade.
+  Attach gate now accepts openclaw + slack-* pairs; render-time
+  enforcement remains as defense-in-depth. Zeroclaw slack support
+  lands in Phase 3. GUI attach flow is generic (no per-agent-type
+  card) — server-side gate flip is sufficient. macOS openclaw (GA per
+  #770) covered via `configure_macos.yaml`. (#835, #499)
+- Shared install-task shape for slack-mcp-server across hermes and
+  openclaw playbooks — the pinned version + per-OS SHA256 map moved
+  out of the individual playbooks and into
+  `clawrium.core.playbook_resolver.mcp_slack_extravars(os_family)`.
+  Both hermes and openclaw configure playbooks (Linux + macOS) now
+  consume the same `mcp_slack_*` extravars, threaded by
+  `lifecycle.configure_agent`. A future pin bump lands in one Python
+  location instead of four YAML files — dispatcher-only-OS-fork
+  invariant preserved (no `_shared/tasks/…` file, no `if Darwin`
+  inside existing playbooks). Retrospective refactor of the Phase 1
+  hermes inline install per the #499 B9 blocker fix. (#835, #499)
 - CLI attach-time agent-type / integration-type gate:
   `clawctl agent integration attach <name> --agent <agent>` now rejects
   `(agent-type, integration-type)` pairs that the renderer does not

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -2668,10 +2668,9 @@ def configure_agent(
             # but hosts.json may carry pre-normalization values from
             # older host records or third-party importers. Fold the
             # normalization here rather than reopen B1 by another name.
-            raw_os_family = (host.get("os_family") if host else None) or "linux"
-            os_family = str(raw_os_family).strip().lower()
-            if os_family in ("mac", "macos", "osx"):
-                os_family = "darwin"
+            from clawrium.core.playbook_resolver import normalize_os_family
+
+            os_family = normalize_os_family(host)
             rendered = render_hermes(render_inputs, os_family=os_family)
             prerendered_files[".hermes/.env"] = rendered.files[".hermes/.env"]
             prerendered_files[".hermes/config.yaml"] = (
@@ -2704,7 +2703,14 @@ def configure_agent(
 
         try:
             render_inputs = build_render_inputs(unix_agent_name)
-            rendered = render_openclaw(render_inputs)
+            # #835: pass os_family so the slack-mcp-server command path
+            # under `mcp.servers.<slug>.command` picks the correct home
+            # root. Single normalization helper closes the drift risk
+            # ATX #835 iter-1 W2 flagged.
+            from clawrium.core.playbook_resolver import normalize_os_family
+
+            _of = normalize_os_family(host)
+            rendered = render_openclaw(render_inputs, os_family=_of)
             prerendered_files[".openclaw/openclaw.json"] = (
                 rendered.files[".openclaw/openclaw.json"]
             )
@@ -2823,6 +2829,37 @@ def configure_agent(
     # Issue #437: zeroclaw always re-pairs on configure. No skip path,
     # no existing_gateway_token, no force_repair. The token in hosts.json
     # is overwritten with whatever the playbook's pair handshake mints.
+
+    # #835 (B9): Thread slack-mcp-server pins from playbook_resolver.
+    # Both hermes and openclaw configure playbooks (Linux + macOS)
+    # removed their inline `mcp_slack_version` / `mcp_slack_arch_map` /
+    # `mcp_slack_sha256_map` `vars:` blocks and now consume them as
+    # extravars. Threading here for every configure run keeps the two
+    # OS branches and two agent types in lockstep — a single-file bump
+    # in playbook_resolver.py is the only place a version pin can move.
+    #
+    # Gate: only hermes + openclaw consume these keys today. Any future
+    # agent type (nemoclaw, ethos, third-party) is added to the tuple
+    # ONLY after its playbook actually references the extravars —
+    # threading them into an ignoring playbook would be dead weight
+    # and hide the coupling from readers. (ATX #835 iter-1 W3.)
+    if resolved_type in ("hermes", "openclaw"):
+        from clawrium.core.playbook_resolver import (
+            mcp_slack_extravars,
+            normalize_os_family,
+        )
+
+        # `mcp_slack_extravars` raises on any unknown os_family value.
+        # An exotic os_family on a real host record is a data bug that
+        # should surface loudly, not silently pick a possibly-wrong
+        # arch map. Wrapped in try/except so it maps to the same
+        # `(False, msg)` shape every other assembly-time failure in
+        # this function returns (ATX #835 iter-1 S). Without this the
+        # traceback would leave lifecycle state half-walked.
+        try:
+            ansible_vars.update(mcp_slack_extravars(normalize_os_family(host)))
+        except ValueError as exc:
+            return False, f"{resolved_type} configure failed: {exc}"
 
     # Merge extra_vars (not persisted to hosts.json)
     if extra_vars:

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -1742,7 +1742,21 @@ def sync_agent_canonical(
         )
 
     emit("render", f"rendering canonical config for {inputs.agent_type}")
-    rendered = renderer(inputs)
+    # #835 (ATX iter-1 W1 → iter-2 W1 tightened): thread os_family into
+    # hermes/openclaw renderers so `clawctl agent sync` produces the
+    # same binary paths `configure` does on darwin. Test stubs across
+    # `test_lifecycle_canonical.py`, `test_workspace_*`, and
+    # `test_sync.py` accept `**_kw` — no TypeError shim, so any future
+    # stub that drops kwarg support fails loudly instead of silently
+    # falling back to a linux-only render (the iter-2 reviewer flagged
+    # the shim as silencing a programming-error class).
+    from clawrium.core.playbook_resolver import normalize_os_family
+
+    _os_family = normalize_os_family(host)
+    if inputs.agent_type in ("hermes", "openclaw"):
+        rendered = renderer(inputs, os_family=_os_family)
+    else:
+        rendered = renderer(inputs)
 
     emit("diff", f"reading on-host files from {hostname}")
     diffs = diff_files(

--- a/src/clawrium/core/playbook_resolver.py
+++ b/src/clawrium/core/playbook_resolver.py
@@ -35,6 +35,30 @@ _HOME_ROOT_BY_OS: dict[str, str] = {
 }
 
 
+def normalize_os_family(host: dict | None) -> str:
+    """Return a normalized `os_family` string for a hosts.json record.
+
+    Reads `host.get("os_family")`, strips whitespace + lowercases, and
+    coerces the common `mac` / `macos` / `osx` aliases to `darwin`.
+    Legacy or missing host records fall back to `linux` (mirrors the
+    `load_hosts` migration default at `core/hosts.py:330`).
+
+    Callers pass the normalized value into per-OS APIs
+    (`render_hermes(..., os_family=of)`, `render_openclaw(..., os_family=of)`,
+    `mcp_slack_extravars(of)`) — each raises on any final value outside
+    `{'linux', 'darwin'}` so an exotic input surfaces loudly at the
+    per-API boundary rather than getting silently coerced to `linux`
+    here. Extracted (ATX #835 iter-1 W2) so
+    `lifecycle.configure_agent`'s three previously-duplicated coercion
+    blocks stay in lockstep.
+    """
+    raw = (host.get("os_family") if host else None) or "linux"
+    of = str(raw).strip().lower()
+    if of in ("mac", "macos", "osx"):
+        of = "darwin"
+    return of
+
+
 def home_root_for(os_family: str) -> str:
     """Return the per-OS user home-directory root.
 
@@ -163,6 +187,80 @@ _SHELL_RC_PREPEND_BY_OS: dict[str, str] = {
         ' [ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc";'
     ),
 }
+
+
+# Pinned korotovsky/slack-mcp-server release + per-arch SHA256 hashes.
+# Single Python source of truth for hermes + openclaw Ansible playbooks
+# (#835 B9 fix). Both playbooks removed their inline `mcp_slack_*` vars
+# and now consume these values as extravars threaded through
+# `lifecycle.configure_agent` — closes the drift risk of maintaining
+# the same pins in two YAML files. `render.py` also imports the
+# version constant lazily so the Jinja template comment matches.
+#
+# Bumping the pin: fetch the new `.sha256` sidecar files from
+#   https://github.com/korotovsky/slack-mcp-server/releases/tag/<version>
+# and replace the values below. `_MCP_SLACK_VERSION` and both SHA maps
+# MUST land in the same commit.
+#
+# armv7l is NOT shipped by upstream as of v1.3.0 (linux amd64/arm64 +
+# darwin amd64/arm64 only). Neither map includes it; the playbook's
+# arch-guard task fails fast on armv7l hosts with a pointer at the
+# upstream release page. Tracked as the zeroclaw armv7l coverage gap
+# in #499.
+_MCP_SLACK_VERSION = "v1.3.0"
+_MCP_SLACK_ARCH_MAP_LINUX = {
+    "x86_64": "linux-amd64",
+    "aarch64": "linux-arm64",
+}
+_MCP_SLACK_SHA256_MAP_LINUX = {
+    "x86_64": "d1525962e9b9dbfdd2eaf48d0a81ca1eca7d8f1862b8d34931b812c850b3e568",
+    "aarch64": "a307a48d16c2261346bdc257274cdcdb8b2027c867dc971b41d52cef36472c88",
+}
+_MCP_SLACK_ARCH_MAP_DARWIN = {
+    "arm64": "darwin-arm64",
+    "x86_64": "darwin-amd64",
+}
+_MCP_SLACK_SHA256_MAP_DARWIN = {
+    "arm64": "e839aa5c2e28253438ed704dd862aa4afb75711d688080ce447a3b1167855312",
+    "x86_64": "e38142ee628b2c2ff241f0d021947b96e743540cfb702fc8b01f61a4f7a4a125",
+}
+
+
+def mcp_slack_extravars(os_family: str) -> dict:
+    """Return the Ansible extravars carrying the slack-mcp-server pins.
+
+    The returned dict is merged into `configure.yaml`'s inventory `vars`
+    by `lifecycle.configure_agent` for hermes AND openclaw playbooks
+    (both Linux and macOS variants). Keys:
+
+      - `mcp_slack_version`: git tag string (e.g. ``"v1.3.0"``)
+      - `mcp_slack_arch_map`: ``ansible_architecture`` → release-asset suffix
+      - `mcp_slack_sha256_map`: ``ansible_architecture`` → SHA256 hex
+
+    Playbooks index the two maps by the runtime-discovered
+    ``ansible_architecture`` fact — this is the only viable seam
+    because arch is not persisted in ``hosts.json``. Unmapped arches
+    (notably ``armv7l``) fail the playbook's arch-guard task with a
+    pointer at the upstream release page.
+
+    Raises ``ValueError`` on unsupported ``os_family`` — mirrors
+    ``home_root_for`` / ``resolve_agent_playbook`` symmetric strictness.
+    """
+    if os_family not in SUPPORTED_OS:
+        raise ValueError(
+            f"unsupported os_family: {os_family!r} (expected one of {sorted(SUPPORTED_OS)})"
+        )
+    if os_family == "darwin":
+        return {
+            "mcp_slack_version": _MCP_SLACK_VERSION,
+            "mcp_slack_arch_map": dict(_MCP_SLACK_ARCH_MAP_DARWIN),
+            "mcp_slack_sha256_map": dict(_MCP_SLACK_SHA256_MAP_DARWIN),
+        }
+    return {
+        "mcp_slack_version": _MCP_SLACK_VERSION,
+        "mcp_slack_arch_map": dict(_MCP_SLACK_ARCH_MAP_LINUX),
+        "mcp_slack_sha256_map": dict(_MCP_SLACK_SHA256_MAP_LINUX),
+    }
 
 
 def shell_rc_prepend(os_family: str) -> str:

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -931,14 +931,15 @@ _HERMES_SUPPORTED_INTEGRATIONS = frozenset(
 # installed onto the host, so a fresh tool venv would silently get a
 # different MCP build than the one tested.
 _HERMES_MCP_ATLASSIAN_VERSION = "0.21.1"
-# Lockstep with hermes' configure.yaml `mcp_slack_version` +
-# `mcp_slack_sha256_map`. The korotovsky/slack-mcp-server release
-# ships a single Go binary per (os, arch); the playbook downloads it
-# via `get_url` with a sha256 pin. Bumping this pin MUST land in the
-# same commit as the corresponding sha256 map bumps in configure.yaml
-# and configure_macos.yaml — otherwise the checksum guard fails on
-# the first configure after upgrade. #834 (B6 fix).
-_HERMES_MCP_SLACK_VERSION = "v1.3.0"
+# Slack MCP version pin — lazy-loaded from
+# `clawrium.core.playbook_resolver._MCP_SLACK_VERSION` (single Python
+# source of truth per #835 B9 fix). Kept lazy because a module-level
+# import would reintroduce the render↔playbook_resolver cycle called
+# out at render.py:967. The value is only threaded into the Jinja
+# template as a comment string, so a lazy accessor is cheap here.
+def _hermes_mcp_slack_version() -> str:
+    from clawrium.core.playbook_resolver import _MCP_SLACK_VERSION
+    return _MCP_SLACK_VERSION
 
 
 def render_hermes(
@@ -1219,7 +1220,7 @@ def render_hermes(
         atlassian_integrations=atlassian_views,
         mcp_atlassian_version=_HERMES_MCP_ATLASSIAN_VERSION,
         slack_integrations=slack_views,
-        mcp_slack_version=_HERMES_MCP_SLACK_VERSION,
+        mcp_slack_version=_hermes_mcp_slack_version(),
         home_root=home_root,
     )
 
@@ -1506,7 +1507,17 @@ _OPENCLAW_SUPPORTED_PROVIDERS = frozenset(
 )
 _OPENCLAW_SUPPORTED_CHANNELS = frozenset({"discord", "slack"})
 _OPENCLAW_SUPPORTED_INTEGRATIONS = frozenset(
-    {"github", "atlassian", "linear", "notion", "gitlab", "git", "brave"}
+    {
+        "github",
+        "atlassian",
+        "linear",
+        "notion",
+        "gitlab",
+        "git",
+        "brave",
+        "slack-user",
+        "slack-cookie",
+    }
 )
 _OPENCLAW_MODEL_PREFIX = {
     "openrouter": "openrouter/",
@@ -1522,7 +1533,9 @@ _OPENCLAW_MODEL_PREFIX = {
 _OPENCLAW_DEFAULT_GATEWAY_PORT = 40000
 
 
-def render_openclaw(inputs: RenderInputs) -> RenderedFiles:
+def render_openclaw(
+    inputs: RenderInputs, *, os_family: str = "linux"
+) -> RenderedFiles:
     """Render openclaw's `.openclaw/env` (Jinja) + `.openclaw/openclaw.json`
     (JSON baseline deep-update).
 
@@ -1539,12 +1552,31 @@ def render_openclaw(inputs: RenderInputs) -> RenderedFiles:
       - `models.providers.<provider-name>` — litellm only (#723); writes a
         custom OpenAI-compatible provider block so openclaw routes via the
         operator-supplied proxy (LiteLLM, vLLM, etc.).
+      - `mcp.servers.<slug>` — one entry per attached `slack-user` /
+        `slack-cookie` integration (#835). The `mcp` key is emitted
+        **conditionally**: baseline shape is preserved byte-identical when
+        no slack integrations are attached (W10 byte-lock guard).
 
     Every other key in the baseline is preserved byte-identically (modulo
     `json.dumps` formatting), matching the silent-wipe-prevention contract
     introduced for zeroclaw in #565.
+
+    `os_family` picks the home-root prefix for the slack-mcp-server binary
+    path (`/home/<name>/.local/bin/…` on Linux, `/Users/<name>/…` on
+    darwin). Default `"linux"` keeps every pre-#835 render byte-identical
+    since the path only surfaces inside `mcp.servers.*.command`, and the
+    `mcp` key is dropped entirely when no slack integration is attached.
     """
     _validate_agent_name(inputs.agent_name)
+    # #835: mirror render_hermes' os_family validation (see render.py:967).
+    # Any typo would silently fall through to `/home` — reopening the
+    # class of bug the hermes ATX iter-2 blocker closed.
+    if os_family not in ("linux", "darwin"):
+        raise AgentConfigError(
+            f"render_openclaw: unsupported os_family {os_family!r}. "
+            f"Supported: ['darwin', 'linux']"
+        )
+    home_root = "/Users" if os_family == "darwin" else "/home"
     ptype = inputs.provider.type
     if ptype not in _OPENCLAW_SUPPORTED_PROVIDERS:
         raise AgentConfigError(
@@ -1610,6 +1642,22 @@ def render_openclaw(inputs: RenderInputs) -> RenderedFiles:
 
     # --- Integration views for the env template ---------------------------
     integration_views: list[dict] = []
+    # #835: slack integrations feed a separate view list so
+    # `_render_openclaw_json` can emit `mcp.servers.<slug>` blocks
+    # without leaking into the env-template loop (openclaw's `.env` does
+    # NOT carry SLACK_MCP_XOX* — those live under the mcp subprocess's
+    # own `env` dict inside openclaw.json).
+    slack_views: list[dict] = []
+    # #835 (mirror render_hermes:1028): slug tracker so two slack
+    # integrations cannot collide on the same JSON key inside
+    # `mcp.servers.<slug>`. Scope is intentionally slack-only today —
+    # openclaw's atlassian integration lives in env vars, not in
+    # `mcp.servers`, so there is no cross-type collision surface. If a
+    # future change adds openclaw atlassian-MCP support (parity with
+    # hermes), the atlassian branch above MUST also register its slug
+    # here or an atlassian-vs-slack name collision could silently
+    # last-write-win. (ATX #835 iter-1 W6.)
+    seen_mcp_slugs: set[str] = set()
     last_github_token = ""
     for integration in inputs.integrations:
         if integration.type == "git":
@@ -1639,6 +1687,85 @@ def render_openclaw(inputs: RenderInputs) -> RenderedFiles:
             view["notion_api_key"] = creds.get("NOTION_API_KEY", "")
         elif integration.type == "brave":
             view["brave_api_key"] = creds.get("BRAVE_API_KEY", "")
+        elif integration.type in ("slack-user", "slack-cookie"):
+            # #835 (ATX iter-1 W7): slack integrations feed
+            # `slack_views` only. Openclaw's `.env` (rendered from
+            # `openclaw-env.canonical.j2`) has no slack branch — the
+            # tokens land inside `mcp.servers.<slug>.env` in the JSON
+            # baseline deep-update instead. Skip the
+            # `integration_views` append so the env-template loop
+            # doesn't see a credential-less entry it would silently
+            # drop, and future readers of `integration_views` know
+            # every dict there produces env output.
+            # #835: build a slack MCP subprocess view for
+            # `_render_openclaw_json`. Mirrors the hermes slack view
+            # builder at render.py:1073 line-for-line: same slug
+            # collision + empty-slug + missing-token guards; same
+            # (xoxp_token, xoxc_token, xoxd_token) tuple layout so the
+            # JSON emitter downstream stays symmetric with the hermes
+            # Jinja loop.
+            slug = _integration_slug(integration.name)
+            lo_slug = slug.lower()
+            if not lo_slug:
+                raise AgentConfigError(
+                    f"render_openclaw: integration name {integration.name!r} "
+                    f"slugifies to empty — refusing to emit an unnamed JSON key"
+                )
+            if lo_slug in seen_mcp_slugs:
+                raise AgentConfigError(
+                    f"render_openclaw: mcp.servers integration names collide "
+                    f"on JSON key {lo_slug!r} (slack branch); another "
+                    f"attached integration already claims this slug — "
+                    f"rename one to differentiate after slugification"
+                )
+            seen_mcp_slugs.add(lo_slug)
+            if integration.type == "slack-user":
+                xoxp = _clean_secret(creds.get("SLACK_MCP_XOXP_TOKEN", ""))
+                if not xoxp:
+                    raise AgentConfigError(
+                        f"render_openclaw: slack-user integration "
+                        f"{integration.name!r} is missing "
+                        f"SLACK_MCP_XOXP_TOKEN in its credential store"
+                    )
+                slack_views.append(
+                    {
+                        "slug": lo_slug,
+                        "auth": "user",
+                        "xoxp_token": xoxp,
+                        "xoxc_token": "",
+                        "xoxd_token": "",
+                    }
+                )
+            else:  # slack-cookie
+                xoxc = _clean_secret(creds.get("SLACK_MCP_XOXC_TOKEN", ""))
+                xoxd = _clean_secret(creds.get("SLACK_MCP_XOXD_TOKEN", ""))
+                if not xoxc or not xoxd:
+                    missing = [
+                        k
+                        for k, v in (
+                            ("SLACK_MCP_XOXC_TOKEN", xoxc),
+                            ("SLACK_MCP_XOXD_TOKEN", xoxd),
+                        )
+                        if not v
+                    ]
+                    raise AgentConfigError(
+                        f"render_openclaw: slack-cookie integration "
+                        f"{integration.name!r} is missing "
+                        f"{', '.join(missing)} in its credential store"
+                    )
+                slack_views.append(
+                    {
+                        "slug": lo_slug,
+                        "auth": "cookie",
+                        "xoxp_token": "",
+                        "xoxc_token": xoxc,
+                        "xoxd_token": xoxd,
+                    }
+                )
+            # W7 fix: slack integrations do NOT flow into the env
+            # template. Skip the shared append so `integration_views`
+            # only ever contains entries that produce env output.
+            continue
         integration_views.append(view)
 
     env_body = _render_openclaw_template(
@@ -1659,6 +1786,9 @@ def render_openclaw(inputs: RenderInputs) -> RenderedFiles:
         provider_default_model=model_id,
         gateway=inputs.gateway,
         discord_channel=discord_channel,
+        slack_integrations=slack_views,
+        agent_name=inputs.agent_name,
+        home_root=home_root,
     )
 
     return RenderedFiles(
@@ -1730,15 +1860,15 @@ def _render_openclaw_json(
     provider_default_model: str | None,
     gateway: "GatewayInputs | None",
     discord_channel: "ChannelInputs | None",
+    slack_integrations: list[dict] | tuple[dict, ...] = (),
+    agent_name: str = "",
+    home_root: str = "/home",
 ) -> str:
     """Deep-update the openclaw.json baseline with the clawctl-managed paths.
 
-    Managed paths:
+    Managed paths (listed in the order they are written below):
       1. `agents.defaults.model.primary` (when `provider` is not None)
-      2. `gateway.port`
-      3. `gateway.bind` (+ `gateway.auth` when present)
-      4. `channels.discord.enabled` / `allowFrom` / `guilds`
-      5. (litellm only) `models.providers.<provider-name>` — a custom
+      2. `models.providers.<provider-name>` — litellm only (#723); a custom
          OpenAI-compatible provider block matching upstream openclaw's
          `models.providers` schema (see
          `docs.openclaw.ai/gateway/config-tools#custom-providers-and-base-urls`).
@@ -1748,9 +1878,18 @@ def _render_openclaw_json(
          `default_model`. Non-litellm provider types do NOT write this
          path — for them, model selection flows through `OPENCLAW_DEFAULT_MODEL`
          in `.openclaw/env` only.
+      3. `gateway.port`
+      4. `gateway.bind` (+ `gateway.auth` when present)
+      5. `channels.discord.enabled` / `allowFrom` / `guilds`
+      6. `mcp.servers.<slug>` — one entry per attached `slack-user` /
+         `slack-cookie` integration in `slack_integrations` (#835).
+         When the list is empty the `mcp` key is **dropped entirely**
+         (W10 conditional-emit contract) so pre-#835 rendered bodies
+         stay byte-identical. `home_root` and `agent_name` are only
+         consulted when at least one slack integration is attached.
 
     When `provider is None` (install-time bootstrap), the provider-dependent
-    writes (step 1 + step 5) are skipped — the function returns the static
+    writes (steps 1 + 2) are skipped — the function returns the static
     baseline merged with the gateway / discord overrides only. This is the
     canonical no-provider path used by `clawctl agent create` before any
     `clawctl provider attach` has run; the daemon needs a startable
@@ -1786,7 +1925,7 @@ def _render_openclaw_json(
         model = defaults.setdefault("model", {})
         model["primary"] = provider_default_model
 
-    # 5. models.providers.<provider-name> — litellm only.
+    # 2. models.providers.<provider-name> — litellm only.
     if provider is not None and provider.type == "litellm":
         # W3 (#723 ATX): the provider name is used both as a JSON key in
         # `models.providers.<name>` AND as a routing prefix in
@@ -1868,7 +2007,7 @@ def _render_openclaw_json(
             ],
         }
 
-    # 2. gateway.port + 3. gateway.bind + gateway.auth (managed bearer)
+    # 3. gateway.port + 4. gateway.bind + gateway.auth (managed bearer)
     #
     # Round 3 B1: `gateway.auth` MUST flow into the JSON. The daemon
     # expects the bearer at `gateway.auth.{mode,token}`; if sync ever
@@ -1886,7 +2025,7 @@ def _render_openclaw_json(
             # to keep the state explicit: no auth → no `gateway.auth` key.
             gw.pop("auth", None)
 
-    # 4. channels.discord.enabled + 5. channels.discord.allowFrom + guilds.
+    # 5. channels.discord.enabled + channels.discord.allowFrom + guilds.
     channels = baseline.setdefault("channels", {})
     discord = channels.setdefault(
         "discord", {"enabled": False, "allowFrom": [], "guilds": {}}
@@ -1923,6 +2062,53 @@ def _render_openclaw_json(
         discord["enabled"] = False
         discord["allowFrom"] = []
         discord["guilds"] = {}
+
+    # 6. mcp.servers.<slug> — slack-mcp-server subprocess declarations
+    # for every attached slack integration. Conditional emit: an empty
+    # `slack_integrations` list drops the `mcp` key entirely, keeping
+    # the byte diff for existing openclaw agents at zero (W10 in #499
+    # plan). The block shape mirrors upstream openclaw's mcp.servers
+    # contract used by the daemon's stdio launcher.
+    if slack_integrations:
+        # Both fields become part of every rendered command path, so
+        # a caller that supplies slack integrations MUST also supply
+        # agent_name + home_root. Raise here — a silent `"/{}/.local/…"`
+        # segment would produce a nonexistent path on the daemon and
+        # fail-open the mcp subprocess spawn under `no_log: true`.
+        if not agent_name:
+            raise AgentConfigError(
+                "render_openclaw: slack_integrations supplied without "
+                "agent_name — cannot resolve slack-mcp-server binary path"
+            )
+        servers: dict[str, dict] = {}
+        for entry in slack_integrations:
+            server: dict = {
+                "command": (
+                    f"{home_root}/{agent_name}/.local/bin/slack-mcp-server"
+                ),
+                "args": ["--transport", "stdio"],
+            }
+            if entry["auth"] == "user":
+                server["env"] = {
+                    "SLACK_MCP_XOXP_TOKEN": entry["xoxp_token"],
+                }
+            elif entry["auth"] == "cookie":
+                server["env"] = {
+                    "SLACK_MCP_XOXC_TOKEN": entry["xoxc_token"],
+                    "SLACK_MCP_XOXD_TOKEN": entry["xoxd_token"],
+                }
+            else:
+                # Defensive: view builder is the single source of truth
+                # for `entry.auth`. Any drift lands here loudly instead
+                # of silently spawning the MCP subprocess with no auth
+                # token and 401ing at first API call.
+                raise AgentConfigError(
+                    f"render_openclaw: slack integration "
+                    f"{entry['slug']!r} has unknown auth mode "
+                    f"{entry['auth']!r}"
+                )
+            servers[entry["slug"]] = server
+        baseline["mcp"] = {"servers": servers}
 
     return json.dumps(baseline, indent=2, sort_keys=False) + "\n"
 

--- a/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/configure.yaml
@@ -30,27 +30,21 @@
               | selectattr('value.type', 'equalto', 'atlassian')
               | list | length > 0)
       }}
-    # Pinned korotovsky/slack-mcp-server release + per-arch sha256 map.
-    # The release ships single Go binaries (not tarballs), so no
-    # unarchive step — `get_url` writes the binary directly to
-    # ~/.local/bin/slack-mcp-server with `mode: '0755'`. Bumping this
-    # pin MUST land in the same commit as the corresponding sha256 map
-    # bumps AND the `_HERMES_MCP_SLACK_VERSION` constant in
-    # `clawrium/core/render.py` — otherwise the checksum guard fails
-    # on the first configure after upgrade. #834 (B6 fix).
+    # #835 (B9 fix): `mcp_slack_version`, `mcp_slack_arch_map`, and
+    # `mcp_slack_sha256_map` are threaded in as extravars by
+    # `clawrium.core.lifecycle.configure_agent`. Single Python source of
+    # truth is `clawrium.core.playbook_resolver._MCP_SLACK_VERSION` +
+    # the per-OS sha256 maps in the same module. Both hermes and
+    # openclaw configure playbooks (Linux + macOS) consume the same
+    # extravars — closes the pin-drift risk of maintaining the same
+    # values in four YAML files.
     #
     # armv7l is NOT shipped by upstream as of v1.3.0 (linux amd64/arm64
     # + darwin amd64/arm64 only). This blocks `slack-*` integrations on
     # armv7l hosts — the arch-guard task below fails fast with a clear
     # message pointing at the upstream release page. Tracked as the
     # Phase 3 (zeroclaw armv7l) coverage gap in #499.
-    mcp_slack_version: "v1.3.0"
-    mcp_slack_arch_map:
-      x86_64: "linux-amd64"
-      aarch64: "linux-arm64"
-    mcp_slack_sha256_map:
-      x86_64: "d1525962e9b9dbfdd2eaf48d0a81ca1eca7d8f1862b8d34931b812c850b3e568"
-      aarch64: "a307a48d16c2261346bdc257274cdcdb8b2027c867dc971b41d52cef36472c88"
+    #
     # Precomputed convenience flag — true iff this run has at least one
     # slack integration (slack-user or slack-cookie) assigned.
     slack_integration_assigned: >-

--- a/src/clawrium/platform/registry/hermes/playbooks/configure_macos.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/configure_macos.yaml
@@ -21,17 +21,10 @@
 - hosts: all
   become: yes
   vars:
-    # #834: mirror configure.yaml's pins verbatim. Bumping the version
-    # requires updating _HERMES_MCP_SLACK_VERSION in core/render.py and
-    # the sha256 map in BOTH configure.yaml and this file in the same
-    # commit — otherwise the checksum guard fails on darwin hermes.
-    mcp_slack_version: "v1.3.0"
-    mcp_slack_arch_map:
-      arm64: "darwin-arm64"
-      x86_64: "darwin-amd64"
-    mcp_slack_sha256_map:
-      arm64: "e839aa5c2e28253438ed704dd862aa4afb75711d688080ce447a3b1167855312"
-      x86_64: "e38142ee628b2c2ff241f0d021947b96e743540cfb702fc8b01f61a4f7a4a125"
+    # #835 (B9 fix): `mcp_slack_version`, `mcp_slack_arch_map`,
+    # `mcp_slack_sha256_map` are extravars owned by
+    # `clawrium.core.playbook_resolver.mcp_slack_extravars`. See the
+    # Linux `configure.yaml` header comment for rationale.
     slack_integration_assigned: >-
       {{
         integrations is defined

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure.yaml
@@ -1,6 +1,22 @@
 ---
 - hosts: all
   become: yes
+  vars:
+    # #835: Precomputed convenience flag — true iff this run has at
+    # least one slack-* integration attached. Extravars carrying the
+    # release pin (`mcp_slack_version`, `mcp_slack_arch_map`,
+    # `mcp_slack_sha256_map`) are threaded by
+    # `clawrium.core.lifecycle.configure_agent`; single Python source
+    # of truth is `clawrium.core.playbook_resolver`. The install block
+    # further down is a byte-parity mirror of the hermes counterpart
+    # so a pin bump propagates through the resolver alone.
+    slack_integration_assigned: >-
+      {{
+        integrations is defined
+        and (integrations | dict2items
+              | selectattr('value.type', 'in', ['slack-user', 'slack-cookie'])
+              | list | length > 0)
+      }}
   tasks:
     - name: Verify gateway token exists in config (strict mode only)
       ansible.builtin.fail:
@@ -155,6 +171,61 @@
         group: "{{ agent_name }}"
         mode: "0600"
       no_log: true
+      notify: Restart openclaw service
+
+    # #835: install korotovsky/slack-mcp-server (single Go binary) for
+    # slack-* integrations. Structurally mirrors the hermes install
+    # block at hermes/playbooks/configure.yaml (`mcp_slack_*` extravars
+    # threaded from `clawrium.core.playbook_resolver` — single Python
+    # source of truth). Adds a `notify: Restart openclaw service` on
+    # the get_url task that hermes does NOT have — hermes' restart
+    # trigger fires from the config.yaml render + explicit
+    # `flush_handlers`, whereas openclaw's restart trigger sits on
+    # openclaw.json writes and the notify here is a belt-and-suspenders
+    # nudge in case the operator toggles slack without touching
+    # openclaw.json otherwise. Guarded by `slack_integration_assigned`
+    # so openclaw agents without slack pay no cost.
+    - name: Fail early if host architecture is unsupported by the slack-mcp arch map
+      ansible.builtin.fail:
+        msg: >-
+          slack-mcp-server install: ansible_architecture='{{ ansible_architecture }}'
+          is not mapped to a korotovsky/slack-mcp-server release asset
+          (upstream {{ mcp_slack_version }} ships linux amd64/arm64 + darwin
+          amd64/arm64 only — no armv7l). Supported here: {{ mcp_slack_arch_map.keys() | list | join(', ') }}.
+          See https://github.com/korotovsky/slack-mcp-server/releases/tag/{{ mcp_slack_version }}.
+      when:
+        - slack_integration_assigned | bool
+        - ansible_architecture not in mcp_slack_arch_map
+
+    - name: Ensure ~/.local/bin exists for slack-mcp-server binary
+      ansible.builtin.file:
+        path: "/home/{{ agent_name }}/.local/bin"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: '0755'
+      become: true
+      no_log: true
+      when:
+        - slack_integration_assigned | bool
+
+    - name: Download pinned slack-mcp-server binary
+      ansible.builtin.get_url:
+        url: "https://github.com/korotovsky/slack-mcp-server/releases/download/{{ mcp_slack_version }}/slack-mcp-server-{{ mcp_slack_arch_map[ansible_architecture] }}"
+        dest: "/home/{{ agent_name }}/.local/bin/slack-mcp-server"
+        checksum: "sha256:{{ mcp_slack_sha256_map[ansible_architecture] }}"
+        validate_certs: yes
+        owner: "{{ agent_name }}"
+        group: "{{ agent_name }}"
+        mode: '0755'
+      become: true
+      # #835 (ATX iter-1 W5): parity with the openclaw.json copy task
+      # posture — Ansible's default get_url echo would leak `dest` +
+      # `agent_name` on failure into the CLI stream. no_log matches
+      # the rest of the play.
+      no_log: true
+      when:
+        - slack_integration_assigned | bool
       notify: Restart openclaw service
 
     - name: Write exec approvals policy from template

--- a/src/clawrium/platform/registry/openclaw/playbooks/configure_macos.yaml
+++ b/src/clawrium/platform/registry/openclaw/playbooks/configure_macos.yaml
@@ -16,6 +16,20 @@
 # `launchctl kickstart -k` after this playbook returns (W7).
 - hosts: all
   become: yes
+  vars:
+    # #835: Precomputed convenience flag — true iff this run has at
+    # least one slack-* integration attached. Extravars carrying the
+    # release pin (`mcp_slack_version`, `mcp_slack_arch_map`,
+    # `mcp_slack_sha256_map`) are threaded by
+    # `clawrium.core.lifecycle.configure_agent` from
+    # `clawrium.core.playbook_resolver.mcp_slack_extravars("darwin")`.
+    slack_integration_assigned: >-
+      {{
+        integrations is defined
+        and (integrations | dict2items
+              | selectattr('value.type', 'in', ['slack-user', 'slack-cookie'])
+              | list | length > 0)
+      }}
   tasks:
     - name: Refuse to run on non-Darwin hosts (dispatcher contract)
       ansible.builtin.fail:
@@ -179,6 +193,47 @@
         group: staff
         mode: "0600"
       no_log: true
+
+    # #835: install korotovsky/slack-mcp-server on darwin. Mirror of
+    # the Linux configure.yaml block, path root differs (`/Users`).
+    # Group is `staff` per the AGENTS.md macOS invariant.
+    - name: Fail early if darwin architecture is unsupported by the slack-mcp arch map
+      ansible.builtin.fail:
+        msg: >-
+          slack-mcp-server install: ansible_architecture='{{ ansible_architecture }}'
+          is not mapped to a korotovsky/slack-mcp-server darwin release asset.
+          Supported here: {{ mcp_slack_arch_map.keys() | list | join(', ') }}.
+          See https://github.com/korotovsky/slack-mcp-server/releases/tag/{{ mcp_slack_version }}.
+      when:
+        - slack_integration_assigned | bool
+        - ansible_architecture not in mcp_slack_arch_map
+
+    - name: Ensure ~/.local/bin exists (darwin)
+      ansible.builtin.file:
+        path: "/Users/{{ agent_name }}/.local/bin"
+        state: directory
+        owner: "{{ agent_name }}"
+        group: staff
+        mode: '0755'
+      become: true
+      no_log: true
+      when:
+        - slack_integration_assigned | bool
+
+    - name: Download pinned slack-mcp-server binary (darwin)
+      ansible.builtin.get_url:
+        url: "https://github.com/korotovsky/slack-mcp-server/releases/download/{{ mcp_slack_version }}/slack-mcp-server-{{ mcp_slack_arch_map[ansible_architecture] }}"
+        dest: "/Users/{{ agent_name }}/.local/bin/slack-mcp-server"
+        checksum: "sha256:{{ mcp_slack_sha256_map[ansible_architecture] }}"
+        validate_certs: yes
+        owner: "{{ agent_name }}"
+        group: staff
+        mode: '0755'
+      become: true
+      # #835 (ATX iter-1 W5): mirror the Linux configure.yaml posture.
+      no_log: true
+      when:
+        - slack_integration_assigned | bool
 
     - name: Write exec approvals policy from template
       ansible.builtin.template:

--- a/tests/cli/clawctl/agent/test_integration_gate.py
+++ b/tests/cli/clawctl/agent/test_integration_gate.py
@@ -80,11 +80,30 @@ def _create_integration(name: str, type_: str, credentials: dict[str, str]) -> N
 # ---------------------------------------------------------------------------
 
 
-def test_attach_slack_user_to_openclaw_rejected(fleet_dir, stdin_not_tty) -> None:
-    """openclaw does not (yet) support slack-user in Phase 1. The
-    CLI must reject at attach time with exit 2 and a hint referencing
-    #499. Enforcement at render time alone would still write the
-    attachment to hosts.json — the exact regression #499 targets."""
+def _hosts_json_agent_integrations(fleet_dir, agent_name: str) -> list[str]:
+    """Read back the persisted integration list for an agent so
+    positive-path tests can assert the write actually happened.
+
+    The seed hosts.json keys agents by type (`openclaw`, `hermes`, …)
+    not by `agent_name`, so we walk every agent record and match on
+    `agent_name` to stay symmetric with how the CLI's
+    `safe_resolve_agent` picks the record."""
+    import json
+
+    hosts = json.loads((fleet_dir / "hosts.json").read_text())
+    for host in hosts:
+        for _key, agent in host.get("agents", {}).items():
+            if agent.get("agent_name") == agent_name:
+                return list(agent.get("integrations", []))
+    raise AssertionError(f"agent {agent_name!r} not found in hosts.json")
+
+
+def test_attach_slack_user_to_openclaw_succeeds(fleet_dir, stdin_not_tty) -> None:
+    """#835 (Phase 2): openclaw NOW supports slack-user. The gate must
+    let the attach through AND persist to hosts.json — an exit-0 that
+    silently skipped the write is the exact regression pattern the
+    coming-soon contract in #499 is meant to prevent. (ATX #835 iter-2
+    W6)."""
     _create_integration(
         "slack-work", "slack-user", {"SLACK_MCP_XOXP_TOKEN": "xoxp-1"}
     )
@@ -92,21 +111,15 @@ def test_attach_slack_user_to_openclaw_rejected(fleet_dir, stdin_not_tty) -> Non
         app,
         ["agent", "integration", "attach", "slack-work", "--agent", "wise-hypatia"],
     )
-    assert result.exit_code == 2, result.output
-    combined = result.output + (result.stderr or "")
-    # Pin to the specific gate error string — a loose disjunct with just
-    # `'slack-user' in combined` would pass on unrelated exit-2 paths
-    # (e.g. the integration name echoed in a different error).
-    assert "does not support integration type 'slack-user'" in combined
-    assert "#499" in combined
+    assert result.exit_code == 0, result.output
+    assert "slack-work" in _hosts_json_agent_integrations(
+        fleet_dir, "wise-hypatia"
+    )
 
 
-def test_attach_slack_cookie_to_openclaw_rejected(fleet_dir, stdin_not_tty) -> None:
-    """openclaw also rejects slack-cookie in Phase 1.
-
-    #834 (ATX iter-1 B4): assert on the specific error string, not
-    just exit_code == 2. Any unrelated exit-2 path (e.g. arg parser
-    failure) would silently pass a broken gate otherwise."""
+def test_attach_slack_cookie_to_openclaw_succeeds(fleet_dir, stdin_not_tty) -> None:
+    """#835 (Phase 2): cookie mode is also accepted on openclaw. Also
+    asserts hosts.json persistence per ATX #835 iter-2 W6."""
     _create_integration(
         "slack-legacy",
         "slack-cookie",
@@ -123,10 +136,10 @@ def test_attach_slack_cookie_to_openclaw_rejected(fleet_dir, stdin_not_tty) -> N
             "wise-hypatia",
         ],
     )
-    assert result.exit_code == 2, result.output
-    combined = result.output + (result.stderr or "")
-    assert "does not support integration type 'slack-cookie'" in combined
-    assert "#499" in combined
+    assert result.exit_code == 0, result.output
+    assert "slack-legacy" in _hosts_json_agent_integrations(
+        fleet_dir, "wise-hypatia"
+    )
 
 
 def test_attach_slack_user_to_zeroclaw_rejected(fleet_dir, stdin_not_tty) -> None:

--- a/tests/cli/clawctl/agent/test_sync.py
+++ b/tests/cli/clawctl/agent/test_sync.py
@@ -261,7 +261,7 @@ def test_canonical_sync_advances_state_to_ready(monkeypatch, fleet_dir) -> None:
             ),
         )
 
-    def fake_render(inputs):
+    def fake_render(inputs, **_kw):
         from clawrium.core.render import RenderedFiles
 
         return RenderedFiles(files={".openclaw/.env": "OPENROUTER_API_KEY=k\n"})
@@ -346,7 +346,7 @@ def test_canonical_sync_repairs_zeroclaw_gateway(monkeypatch, fleet_dir) -> None
             ),
         )
 
-    def fake_render(inputs):
+    def fake_render(inputs, **_kw):
         from clawrium.core.render import RenderedFiles
 
         return RenderedFiles(files={".zeroclaw/config.toml": "[gateway]\n"})
@@ -434,7 +434,7 @@ def test_canonical_sync_repairs_zeroclaw_even_with_no_drift(
             ),
         )
 
-    def fake_render(inputs):
+    def fake_render(inputs, **_kw):
         from clawrium.core.render import RenderedFiles
 
         return RenderedFiles(files={".zeroclaw/config.toml": "[gateway]\n"})
@@ -508,7 +508,7 @@ def test_canonical_sync_propagates_repair_failure(monkeypatch, fleet_dir) -> Non
             ),
         )
 
-    def fake_render(inputs):
+    def fake_render(inputs, **_kw):
         from clawrium.core.render import RenderedFiles
 
         return RenderedFiles(files={".zeroclaw/config.toml": "[gateway]\n"})

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -204,7 +204,7 @@ def _stub_sync_environment(monkeypatch, *, agent_type: str = "hermes"):
         )
     else:
         rendered = RenderedFiles(files={".hermes/.env": "FOO=1\n"})
-    monkeypatch.setitem(lc._RENDERERS, agent_type, lambda _: rendered)
+    monkeypatch.setitem(lc._RENDERERS, agent_type, lambda _inputs, **_kw: rendered)
     monkeypatch.setattr(
         lc,
         "get_agent_by_name",
@@ -436,7 +436,7 @@ def test_zeroclaw_sync_repair_failure_raises(monkeypatch):
     rendered = RenderedFiles(
         files={".zeroclaw/config.toml": "x = 1\n", ".zeroclaw/zeroclaw-env.conf": ""}
     )
-    monkeypatch.setitem(lc._RENDERERS, "zeroclaw", lambda _: rendered)
+    monkeypatch.setitem(lc._RENDERERS, "zeroclaw", lambda _inputs, **_kw: rendered)
     monkeypatch.setattr(
         lc,
         "get_agent_by_name",
@@ -571,7 +571,7 @@ def test_sync_force_bypass_writes_through_secret_removal(monkeypatch):
     )
     monkeypatch.setattr(lc, "build_render_inputs", lambda _: inputs)
     rendered = RenderedFiles(files={".hermes/.env": "FOO=1\n"})
-    monkeypatch.setitem(lc._RENDERERS, "hermes", lambda _: rendered)
+    monkeypatch.setitem(lc._RENDERERS, "hermes", lambda _inputs, **_kw: rendered)
     monkeypatch.setattr(
         lc,
         "get_agent_by_name",
@@ -733,7 +733,7 @@ def test_zeroclaw_sync_restart_false_still_repairs_bearer(monkeypatch):
     rendered = RenderedFiles(
         files={".zeroclaw/config.toml": "x = 1\n", ".zeroclaw/zeroclaw-env.conf": ""}
     )
-    monkeypatch.setitem(lc._RENDERERS, "zeroclaw", lambda _: rendered)
+    monkeypatch.setitem(lc._RENDERERS, "zeroclaw", lambda _inputs, **_kw: rendered)
     monkeypatch.setattr(
         lc,
         "get_agent_by_name",
@@ -1892,7 +1892,7 @@ class TestOpenclawBraveVersionPreflight:
                 ".openclaw/openclaw.json": "{}",
             }
         )
-        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _: rendered)
+        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _inputs, **_kw: rendered)
         monkeypatch.setattr(
             lc,
             "get_agent_by_name",
@@ -2021,7 +2021,7 @@ class TestOpenclawBraveVersionPreflight:
         rendered = RenderedFiles(
             files={".openclaw/env": "", ".openclaw/openclaw.json": "{}"}
         )
-        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _: rendered)
+        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _inputs, **_kw: rendered)
         monkeypatch.setattr(
             lc,
             "get_agent_by_name",
@@ -2943,7 +2943,7 @@ class TestOpenclawInstallPlugins:
         fake_diff.remote_body = ""
 
         monkeypatch.setattr(lc, "build_render_inputs", lambda _: inputs)
-        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _: rendered)
+        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _inputs, **_kw: rendered)
         monkeypatch.setattr(
             lc,
             "get_agent_by_name",
@@ -3020,7 +3020,7 @@ class TestOpenclawInstallPlugins:
         )
 
         monkeypatch.setattr(lc, "build_render_inputs", lambda _: inputs)
-        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _: rendered)
+        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _inputs, **_kw: rendered)
         monkeypatch.setattr(
             lc,
             "get_agent_by_name",
@@ -3801,7 +3801,7 @@ class TestSyncRefusesIncompleteInstall:
         )
         monkeypatch.setattr(lc, "build_render_inputs", lambda _: inputs)
         rendered = RenderedFiles(files={".openclaw/openclaw.json": "{}"})
-        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _: rendered)
+        monkeypatch.setitem(lc._RENDERERS, "openclaw", lambda _inputs, **_kw: rendered)
         monkeypatch.setattr(
             lc,
             "get_agent_by_name",

--- a/tests/core/test_lifecycle_openclaw_prerender.py
+++ b/tests/core/test_lifecycle_openclaw_prerender.py
@@ -446,7 +446,10 @@ def test_configure_agent_openclaw_unexpected_render_exception_surfaces_cleanly(
     unhandled traceback that leaves the lifecycle half-walked."""
     _seed_openclaw_openrouter(render_stores, openclaw_configure_env)
 
-    def _boom(_inputs):
+    def _boom(_inputs, **_kwargs):
+        # #835: configure_agent now threads os_family= into render_openclaw.
+        # Accept and ignore so the stub raises via the exception under test
+        # and not via TypeError on the kwarg.
         raise RuntimeError("simulated json baseline IOError")
 
     # configure_agent does `from clawrium.core.render import render_openclaw`
@@ -467,4 +470,42 @@ def test_configure_agent_openclaw_unexpected_render_exception_surfaces_cleanly(
     assert err is not None
     assert "Openclaw render failed" in err
     assert "simulated json baseline IOError" in err
+    assert "inventory" not in openclaw_configure_env.captured
+
+
+def test_configure_agent_openclaw_mcp_slack_extravars_bad_os_family(
+    openclaw_configure_env, render_stores, monkeypatch
+):
+    """#835 iter-2 blocker: `configure_agent` wraps
+    `mcp_slack_extravars(normalize_os_family(host))` in try/ValueError
+    and returns `(False, msg)` on failure. The path fires when a host
+    record's `os_family` normalizes to a value outside {linux, darwin}
+    — e.g. a `windows` alias or a typo the normalizer passes through.
+    Without this test the error return path is dead in the suite,
+    leaving future refactors free to break the (False, msg) contract."""
+    _seed_openclaw_openrouter(render_stores, openclaw_configure_env)
+
+    def _bad(_of):
+        raise ValueError(f"unsupported os_family: {_of!r}")
+
+    monkeypatch.setattr(
+        "clawrium.core.playbook_resolver.mcp_slack_extravars", _bad
+    )
+
+    ok, err = _invoke_configure(
+        openclaw_configure_env,
+        {
+            "provider": {
+                "name": "or",
+                "type": "openrouter",
+                "default_model": "anthropic/claude-opus-4",
+            }
+        },
+    )
+    assert not ok
+    assert err is not None
+    assert "openclaw configure failed" in err
+    assert "unsupported os_family" in err
+    # Ansible-runner.run must not have been invoked — extravars failure
+    # short-circuits before playbook dispatch.
     assert "inventory" not in openclaw_configure_env.captured

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -5502,8 +5502,367 @@ def test_supported_integrations_for_agent_type():
 
     oc = supported_integrations_for_agent_type("openclaw")
     assert oc is not None
-    assert "slack-user" not in oc
-    assert "slack-cookie" not in oc
+    # #835 (Phase 2): openclaw now supports both slack types.
+    assert "slack-user" in oc
+    assert "slack-cookie" in oc
 
     assert supported_integrations_for_agent_type("ethos") is None
     assert supported_integrations_for_agent_type("unknown") is None
+
+
+# ---------------------------------------------------------------------------
+# #835 (Phase 2): Slack MCP integration — openclaw end-to-end.
+# ---------------------------------------------------------------------------
+
+
+def _openclaw_baseline_inputs(*, integrations=(), agent_name="alpha") -> RenderInputs:
+    """Compact factory mirroring the byte-lock test's provider + gateway
+    triple so the Phase 2 golden tests read cleanly."""
+    return RenderInputs(
+        agent_name=agent_name,
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="or",
+            type="openrouter",
+            default_model="anthropic/claude-opus-4.7",
+            api_key="sk-or-1",
+        ),
+        channels=(),
+        integrations=integrations,
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tkn", bind="lan"),
+    )
+
+
+def test_openclaw_json_no_slack_baseline_byte_lock_unchanged():
+    """#835 W10 conditional-emit contract: rendering openclaw.json with
+    no slack integration attached must be byte-identical to the pre-#835
+    output. The `mcp` key MUST be absent — not `mcp: {servers: {}}`.
+    This is the most important test in Phase 2: any drift here means
+    every existing openclaw agent's on-host openclaw.json diffs on the
+    first sync after upgrade."""
+    import json
+
+    inputs = _openclaw_baseline_inputs(integrations=())
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    parsed = json.loads(body)
+    assert "mcp" not in parsed, (
+        "W10 conditional-emit violated: rendering openclaw.json without "
+        "slack integrations must not add the `mcp` key. Byte diff for "
+        "every existing openclaw agent would follow."
+    )
+
+
+def test_openclaw_json_slack_user_mcp_block():
+    """#835 B1 fix: `_render_openclaw_json` emits a well-formed
+    `mcp.servers.<slug>` block for a slack-user integration. Byte-locks
+    the command path, args tuple, and single-XOXP env var so any silent
+    drift in the JSON emitter is caught."""
+    import json
+
+    inputs = _openclaw_baseline_inputs(
+        integrations=(
+            IntegrationInputs(
+                name="slack-work",
+                type="slack-user",
+                credentials=(("SLACK_MCP_XOXP_TOKEN", "xoxp-1"),),
+            ),
+        ),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    parsed = json.loads(body)
+    assert parsed["mcp"] == {
+        "servers": {
+            "slack_work": {
+                "command": "/home/alpha/.local/bin/slack-mcp-server",
+                "args": ["--transport", "stdio"],
+                "env": {"SLACK_MCP_XOXP_TOKEN": "xoxp-1"},
+            }
+        }
+    }
+
+
+def test_openclaw_json_slack_cookie_mcp_block():
+    """#835: same shape as slack-user but with two env vars for xoxc + xoxd.
+    Declared insertion order is contract (matches hermes template)."""
+    import json
+
+    inputs = _openclaw_baseline_inputs(
+        integrations=(
+            IntegrationInputs(
+                name="slack-legacy",
+                type="slack-cookie",
+                credentials=(
+                    ("SLACK_MCP_XOXC_TOKEN", "xoxc-1"),
+                    ("SLACK_MCP_XOXD_TOKEN", "xoxd-1"),
+                ),
+            ),
+        ),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    parsed = json.loads(body)
+    slack = parsed["mcp"]["servers"]["slack_legacy"]
+    assert slack["command"] == "/home/alpha/.local/bin/slack-mcp-server"
+    assert slack["args"] == ["--transport", "stdio"]
+    assert slack["env"] == {
+        "SLACK_MCP_XOXC_TOKEN": "xoxc-1",
+        "SLACK_MCP_XOXD_TOKEN": "xoxd-1",
+    }
+    # Declared env-key order preserved in the JSON emission (dicts in
+    # Python 3.7+ preserve insertion order; json.dumps mirrors it).
+    assert list(slack["env"].keys()) == [
+        "SLACK_MCP_XOXC_TOKEN",
+        "SLACK_MCP_XOXD_TOKEN",
+    ]
+
+
+def test_openclaw_json_slack_command_path_darwin_home_root():
+    """#835: `os_family="darwin"` picks `/Users/…` for the binary path.
+    Mirrors the equivalent hermes test — same lockstep contract with
+    `home_root_for`. A silent fallback to `/home/…` would produce a
+    nonexistent path on darwin openclaw and the MCP subprocess would
+    fail-open."""
+    import json
+
+    from clawrium.core.playbook_resolver import home_root_for
+
+    inputs = _openclaw_baseline_inputs(
+        integrations=(
+            IntegrationInputs(
+                name="slack-work",
+                type="slack-user",
+                credentials=(("SLACK_MCP_XOXP_TOKEN", "x"),),
+            ),
+        ),
+    )
+    for os_family in ("linux", "darwin"):
+        body = render_openclaw(inputs, os_family=os_family).files[
+            ".openclaw/openclaw.json"
+        ]
+        parsed = json.loads(body)
+        expected = f"{home_root_for(os_family)}/alpha/.local/bin/slack-mcp-server"
+        assert parsed["mcp"]["servers"]["slack_work"]["command"] == expected
+
+
+def test_openclaw_json_render_openclaw_json_legacy_kwargs_backward_compat():
+    """#835: `_render_openclaw_json`'s new `slack_integrations` /
+    `agent_name` / `home_root` parameters MUST default to values that
+    keep pre-#835 callers byte-identical. Guard so any future signature
+    tweak fails loud here rather than at the on-host diff."""
+    import json
+
+    from clawrium.core.render import _render_openclaw_json
+
+    body = _render_openclaw_json(
+        provider=None,
+        provider_default_model=None,
+        gateway=None,
+        discord_channel=None,
+    )
+    parsed = json.loads(body)
+    assert "mcp" not in parsed
+
+
+def test_openclaw_json_slack_slug_collision_raises():
+    """#835 (mirror hermes guard): distinct integration names that
+    slug-collide must raise rather than silently drop one entry."""
+    inputs = _openclaw_baseline_inputs(
+        integrations=(
+            IntegrationInputs(
+                name="slack-a",
+                type="slack-user",
+                credentials=(("SLACK_MCP_XOXP_TOKEN", "x1"),),
+            ),
+            IntegrationInputs(
+                name="slack_a",
+                type="slack-user",
+                credentials=(("SLACK_MCP_XOXP_TOKEN", "x2"),),
+            ),
+        ),
+    )
+    with pytest.raises(AgentConfigError, match="collide on JSON key"):
+        render_openclaw(inputs)
+
+
+def test_openclaw_json_slack_empty_slug_raises():
+    """#835 (mirror hermes guard): integration names that slugify to
+    empty must raise rather than emit an unnamed JSON key."""
+    inputs = _openclaw_baseline_inputs(
+        integrations=(
+            IntegrationInputs(
+                name="!!!",
+                type="slack-cookie",
+                credentials=(
+                    ("SLACK_MCP_XOXC_TOKEN", "xc"),
+                    ("SLACK_MCP_XOXD_TOKEN", "xd"),
+                ),
+            ),
+        ),
+    )
+    with pytest.raises(AgentConfigError, match="slugifies to empty"):
+        render_openclaw(inputs)
+
+
+def test_openclaw_json_slack_user_missing_token_raises():
+    """#835 (mirror hermes guard): an empty SLACK_MCP_XOXP_TOKEN would
+    render silently but 401 at first Slack API call. Raise here so the
+    fix surface is the credential store, not the daemon log."""
+    inputs = _openclaw_baseline_inputs(
+        integrations=(
+            IntegrationInputs(
+                name="slack-work",
+                type="slack-user",
+                credentials=(),
+            ),
+        ),
+    )
+    with pytest.raises(AgentConfigError, match="SLACK_MCP_XOXP_TOKEN"):
+        render_openclaw(inputs)
+
+
+def test_openclaw_json_slack_cookie_missing_tokens_raises():
+    """#835: cookie mode requires BOTH XOXC + XOXD — raise if either
+    is empty."""
+    inputs = _openclaw_baseline_inputs(
+        integrations=(
+            IntegrationInputs(
+                name="slack-legacy",
+                type="slack-cookie",
+                credentials=(("SLACK_MCP_XOXC_TOKEN", "xc"),),
+            ),
+        ),
+    )
+    with pytest.raises(AgentConfigError, match="SLACK_MCP_XOXD_TOKEN"):
+        render_openclaw(inputs)
+
+
+def test_openclaw_json_slack_leaves_unmanaged_baseline_keys_intact():
+    """#835: emitting `mcp` MUST preserve every other baseline key
+    byte-for-byte. Otherwise the mere presence of a slack integration
+    could silently drop e.g. `session.threadBindings` on hosts."""
+    import json
+
+    inputs = _openclaw_baseline_inputs(
+        integrations=(
+            IntegrationInputs(
+                name="slack-work",
+                type="slack-user",
+                credentials=(("SLACK_MCP_XOXP_TOKEN", "x"),),
+            ),
+        ),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    parsed = json.loads(body)
+    # Baseline keys still present.
+    for key in (
+        "agents",
+        "gateway",
+        "session",
+        "tools",
+        "channels",
+        "browser",
+        "env",
+        "mcp",
+    ):
+        assert key in parsed, f"key {key!r} missing after slack render"
+    assert parsed["session"]["threadBindings"] == {
+        "enabled": True,
+        "idleHours": 24,
+        "maxAgeHours": 168,
+    }
+    assert parsed["tools"]["deny"] == ["browser"]
+
+
+def test_openclaw_json_slack_integrations_without_agent_name_raises():
+    """#835: the JSON emitter must refuse to write an unresolvable
+    command path. A silent fallback to `/{home_root}//.local/…` would
+    ship a broken path and fail-open under `no_log: true`."""
+    from clawrium.core.render import _render_openclaw_json
+
+    with pytest.raises(AgentConfigError, match="agent_name"):
+        _render_openclaw_json(
+            provider=None,
+            provider_default_model=None,
+            gateway=None,
+            discord_channel=None,
+            slack_integrations=[
+                {
+                    "slug": "slack_work",
+                    "auth": "user",
+                    "xoxp_token": "x",
+                    "xoxc_token": "",
+                    "xoxd_token": "",
+                }
+            ],
+            agent_name="",
+        )
+
+
+def test_openclaw_unsupported_os_family_raises():
+    """#835: unsupported os_family typos on render_openclaw must raise
+    (mirrors the hermes guard at render.py:967)."""
+    inputs = _openclaw_baseline_inputs()
+    with pytest.raises(AgentConfigError, match="unsupported os_family"):
+        render_openclaw(inputs, os_family="Darwin")  # capitalized
+
+
+def test_openclaw_json_slack_unknown_auth_mode_raises():
+    """#835 iter-2: the defensive `else:` branch inside
+    `_render_openclaw_json`'s slack loop is the only guard against a
+    view-builder drift. A future rename or refactor that pushes a third
+    `auth` value through must fail loudly here rather than silently
+    spawn the MCP subprocess with no auth (401 storm)."""
+    from clawrium.core.render import _render_openclaw_json
+
+    with pytest.raises(AgentConfigError, match="unknown auth mode"):
+        _render_openclaw_json(
+            provider=None,
+            provider_default_model=None,
+            gateway=None,
+            discord_channel=None,
+            slack_integrations=[
+                {
+                    "slug": "slack_bogus",
+                    "auth": "bogus",  # neither 'user' nor 'cookie'
+                    "xoxp_token": "",
+                    "xoxc_token": "",
+                    "xoxd_token": "",
+                }
+            ],
+            agent_name="alpha",
+        )
+
+
+def test_openclaw_json_slack_user_and_cookie_coexist():
+    """#835 iter-2: two slack integrations of different types on the
+    same agent must both emit — no short-circuit after the first entry.
+    Guards against a future refactor collapsing the for-loop."""
+    import json
+
+    inputs = _openclaw_baseline_inputs(
+        integrations=(
+            IntegrationInputs(
+                name="slack-work",
+                type="slack-user",
+                credentials=(("SLACK_MCP_XOXP_TOKEN", "xoxp-1"),),
+            ),
+            IntegrationInputs(
+                name="slack-legacy",
+                type="slack-cookie",
+                credentials=(
+                    ("SLACK_MCP_XOXC_TOKEN", "xoxc-1"),
+                    ("SLACK_MCP_XOXD_TOKEN", "xoxd-1"),
+                ),
+            ),
+        ),
+    )
+    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+    parsed = json.loads(body)
+    servers = parsed["mcp"]["servers"]
+    assert set(servers.keys()) == {"slack_work", "slack_legacy"}
+    assert servers["slack_work"]["env"] == {
+        "SLACK_MCP_XOXP_TOKEN": "xoxp-1",
+    }
+    assert servers["slack_legacy"]["env"] == {
+        "SLACK_MCP_XOXC_TOKEN": "xoxc-1",
+        "SLACK_MCP_XOXD_TOKEN": "xoxd-1",
+    }

--- a/tests/platform/test_slack_asset_map.py
+++ b/tests/platform/test_slack_asset_map.py
@@ -1,44 +1,29 @@
-"""Tests for the slack-mcp-server per-arch install matrix on hermes.
+"""Tests for the slack-mcp-server per-arch install matrix.
 
-#834 (B6/W3): the playbook downloads the korotovsky/slack-mcp-server
-binary via `get_url` with an sha256 checksum. The (arch → asset filename)
-and (arch → sha256) maps live in the playbook `vars:` block. A drift
-between the two, or a missing arch that ansible would happily leave
-without a checksum guard, would silently install a mismatched binary
-(or fail loudly at first configure — this test catches the drift up
-front).
+#835 (B9): the (arch → asset filename) and (arch → sha256) maps were
+lifted out of the hermes `configure.yaml` / `configure_macos.yaml`
+`vars:` blocks and now live in
+`clawrium.core.playbook_resolver.mcp_slack_extravars`. The extravars
+are threaded into BOTH hermes and openclaw configure playbooks by
+`lifecycle.configure_agent`, so a single Python location owns the
+pins for four YAML files. This test suite pins the resolver contract
+directly — any drift between hermes and openclaw ships as one
+resolver change or fails these tests.
 
-macOS variants live in `configure_macos.yaml` with a divergent arch
-naming (`arm64` vs Linux's `aarch64`). Both files are covered here.
+macOS variants keep the divergent ansible arch naming (`arm64` vs
+Linux's `aarch64`) — that's a fact about how ansible reports the
+darwin architecture and cannot be normalized away.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
-import yaml
 
-
-def _playbook_vars(name: str) -> dict:
-    path = (
-        Path(__file__).parent.parent.parent
-        / "src"
-        / "clawrium"
-        / "platform"
-        / "registry"
-        / "hermes"
-        / "playbooks"
-        / name
-    )
-    data = yaml.safe_load(path.read_text())
-    # ansible playbooks are top-level lists of plays; `vars:` sits on
-    # the single play we author.
-    return data[0]["vars"]
+from clawrium.core.playbook_resolver import mcp_slack_extravars
 
 
 # ---------------------------------------------------------------------------
-# Linux (configure.yaml)
+# Linux
 # ---------------------------------------------------------------------------
 
 
@@ -53,27 +38,27 @@ LINUX_EXPECTED_SHA256 = {
 }
 
 
-def test_linux_playbook_pins_mcp_slack_version() -> None:
-    vs = _playbook_vars("configure.yaml")
+def test_linux_resolver_pins_mcp_slack_version() -> None:
+    vs = mcp_slack_extravars("linux")
     assert vs["mcp_slack_version"] == "v1.3.0"
 
 
 @pytest.mark.parametrize(("arch", "expected_asset_suffix"), LINUX_ARCH_TARGETS)
 def test_linux_arch_map_covers_arch(arch: str, expected_asset_suffix: str) -> None:
-    vs = _playbook_vars("configure.yaml")
+    vs = mcp_slack_extravars("linux")
     assert vs["mcp_slack_arch_map"][arch] == expected_asset_suffix
 
 
 @pytest.mark.parametrize("arch", ["x86_64", "aarch64"])
 def test_linux_sha256_map_covers_arch(arch: str) -> None:
-    vs = _playbook_vars("configure.yaml")
+    vs = mcp_slack_extravars("linux")
     assert vs["mcp_slack_sha256_map"][arch] == LINUX_EXPECTED_SHA256[arch]
 
 
 def test_linux_maps_have_identical_keys() -> None:
     """The arch and sha256 maps must have the exact same key set —
     a mismatch would let a supported arch slip past the checksum guard."""
-    vs = _playbook_vars("configure.yaml")
+    vs = mcp_slack_extravars("linux")
     assert set(vs["mcp_slack_arch_map"].keys()) == set(
         vs["mcp_slack_sha256_map"].keys()
     )
@@ -84,13 +69,13 @@ def test_linux_armv7l_intentionally_absent() -> None:
     The playbook's arch guard MUST fail-fast rather than silently skip
     slack setup on armv7l zeroclaw hosts. Regression signal so a
     future addition of armv7 shipping upstream also lands here."""
-    vs = _playbook_vars("configure.yaml")
+    vs = mcp_slack_extravars("linux")
     assert "armv7l" not in vs["mcp_slack_arch_map"]
     assert "armv7l" not in vs["mcp_slack_sha256_map"]
 
 
 # ---------------------------------------------------------------------------
-# Darwin (configure_macos.yaml)
+# Darwin
 # ---------------------------------------------------------------------------
 
 
@@ -105,47 +90,111 @@ DARWIN_EXPECTED_SHA256 = {
 }
 
 
-def test_darwin_playbook_pins_mcp_slack_version() -> None:
-    vs = _playbook_vars("configure_macos.yaml")
+def test_darwin_resolver_pins_mcp_slack_version() -> None:
+    vs = mcp_slack_extravars("darwin")
     assert vs["mcp_slack_version"] == "v1.3.0"
 
 
 @pytest.mark.parametrize(("arch", "expected_asset_suffix"), DARWIN_ARCH_TARGETS)
 def test_darwin_arch_map_covers_arch(arch: str, expected_asset_suffix: str) -> None:
-    vs = _playbook_vars("configure_macos.yaml")
+    vs = mcp_slack_extravars("darwin")
     assert vs["mcp_slack_arch_map"][arch] == expected_asset_suffix
 
 
 @pytest.mark.parametrize("arch", ["arm64", "x86_64"])
 def test_darwin_sha256_map_covers_arch(arch: str) -> None:
-    vs = _playbook_vars("configure_macos.yaml")
+    vs = mcp_slack_extravars("darwin")
     assert vs["mcp_slack_sha256_map"][arch] == DARWIN_EXPECTED_SHA256[arch]
 
 
 def test_darwin_maps_have_identical_keys() -> None:
-    vs = _playbook_vars("configure_macos.yaml")
+    vs = mcp_slack_extravars("darwin")
     assert set(vs["mcp_slack_arch_map"].keys()) == set(
         vs["mcp_slack_sha256_map"].keys()
     )
 
 
 # ---------------------------------------------------------------------------
-# Cross-file version lockstep
+# Cross-OS lockstep + guardrails
 # ---------------------------------------------------------------------------
 
 
 def test_linux_and_darwin_pin_same_version() -> None:
-    """Both playbooks must reference the same upstream release, else a
+    """Both OS branches must reference the same upstream release, else a
     partially-migrated pin bump silently ships a mixed fleet."""
-    linux = _playbook_vars("configure.yaml")
-    darwin = _playbook_vars("configure_macos.yaml")
+    linux = mcp_slack_extravars("linux")
+    darwin = mcp_slack_extravars("darwin")
     assert linux["mcp_slack_version"] == darwin["mcp_slack_version"]
 
 
-def test_render_constant_matches_playbook_pin() -> None:
-    """`_HERMES_MCP_SLACK_VERSION` in render.py is a documentation
-    anchor for the same pin — drift silently, hosts silently. Lockstep."""
-    from clawrium.core.render import _HERMES_MCP_SLACK_VERSION
+def test_render_helper_matches_resolver_pin() -> None:
+    """The render.py lazy accessor MUST resolve to the same string the
+    resolver hands to Ansible — drift here would render a Jinja comment
+    that names a version different from the one Ansible actually
+    downloaded (silent, no error surface)."""
+    from clawrium.core.render import _hermes_mcp_slack_version
 
-    linux = _playbook_vars("configure.yaml")
-    assert _HERMES_MCP_SLACK_VERSION == linux["mcp_slack_version"]
+    linux = mcp_slack_extravars("linux")
+    assert _hermes_mcp_slack_version() == linux["mcp_slack_version"]
+
+
+def test_unsupported_os_family_raises() -> None:
+    with pytest.raises(ValueError, match="unsupported os_family"):
+        mcp_slack_extravars("windows")
+
+
+# ---------------------------------------------------------------------------
+# normalize_os_family — the shared normalization seam (#835 iter-1 W2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        (None, "linux"),
+        ({}, "linux"),
+        ({"os_family": "linux"}, "linux"),
+        ({"os_family": "Linux"}, "linux"),
+        ({"os_family": "  linux  "}, "linux"),
+        ({"os_family": "darwin"}, "darwin"),
+        ({"os_family": "Darwin"}, "darwin"),
+        ({"os_family": "mac"}, "darwin"),
+        ({"os_family": "macos"}, "darwin"),
+        ({"os_family": "macOS"}, "darwin"),
+        ({"os_family": "OSX"}, "darwin"),
+        ({"os_family": "osx"}, "darwin"),
+        ({"os_family": None}, "linux"),
+        ({"os_family": ""}, "linux"),
+    ],
+)
+def test_normalize_os_family_covers_documented_aliases(host, expected):
+    """#835 iter-1 W2 (iter-2 blocker): the normalizer is the single
+    seam consumed by `lifecycle.configure_agent`, `lifecycle_canonical`,
+    and `render_openclaw`. Any drift in the alias table would ship a
+    linux-only render on a darwin host, exactly the bug the seam was
+    extracted to prevent."""
+    from clawrium.core.playbook_resolver import normalize_os_family
+
+    assert normalize_os_family(host) == expected
+
+
+def test_normalize_os_family_passes_exotic_values_through_unchanged():
+    """Values outside {linux, darwin} + the mac aliases MUST pass
+    through unchanged so downstream per-API validators (`render_hermes`,
+    `render_openclaw`, `mcp_slack_extravars`) can raise with a useful
+    trace of the original value. Silently coercing to `linux` here
+    would mask the data bug."""
+    from clawrium.core.playbook_resolver import normalize_os_family
+
+    assert normalize_os_family({"os_family": "windows"}) == "windows"
+    assert normalize_os_family({"os_family": "freebsd"}) == "freebsd"
+
+
+def test_returned_dict_is_a_copy_not_shared() -> None:
+    """The resolver must hand back a fresh dict on every call so an
+    unfortunate caller that mutates it (e.g. ansible_vars.update / pop)
+    cannot poison the next configure run's extravars."""
+    a = mcp_slack_extravars("linux")
+    a["mcp_slack_sha256_map"]["x86_64"] = "tampered"
+    b = mcp_slack_extravars("linux")
+    assert b["mcp_slack_sha256_map"]["x86_64"] == LINUX_EXPECTED_SHA256["x86_64"]

--- a/tests/test_workspace_phase_ordering.py
+++ b/tests/test_workspace_phase_ordering.py
@@ -47,7 +47,10 @@ def canonical_stubs(monkeypatch: pytest.MonkeyPatch):
     def fake_build_render_inputs(agent_name: str):
         return inputs
 
-    def fake_renderer(_inputs):
+    def fake_renderer(_inputs, **_kwargs):
+        # #835: hermes / openclaw canonical render accepts `os_family=`
+        # keyword; accept and ignore so this stub stays signature-
+        # agnostic across agent types.
         return MagicMock(files={})
 
     def fake_get_agent_by_name(agent_name: str):

--- a/tests/test_workspace_zeroclaw_bearer_rotation.py
+++ b/tests/test_workspace_zeroclaw_bearer_rotation.py
@@ -60,7 +60,10 @@ def make_canonical_stubs(monkeypatch: pytest.MonkeyPatch):
         def fake_build_render_inputs(_agent_name: str):
             return inputs
 
-        def fake_renderer(_inputs):
+        def fake_renderer(_inputs, **_kwargs):
+            # #835: lifecycle_canonical threads `os_family=` for hermes
+            # and openclaw renderers. Accept and ignore so the stub
+            # stays call-signature agnostic.
             return MagicMock(files={})
 
         def fake_get_agent_by_name(agent_name: str):


### PR DESCRIPTION
Stacked on top of `issue-834-hermes-slack` (Phase 1 of #499). This PR extends the Phase 1 hermes Slack MCP integration to openclaw agents.

## Summary

- Adds `slack-user` + `slack-cookie` to `_OPENCLAW_SUPPORTED_INTEGRATIONS` and wires openclaw's JSON renderer to emit `mcp.servers.<slug>` blocks referencing the same SHA256-pinned `korotovsky/slack-mcp-server` binary hermes already uses. The `mcp` key is emitted **conditionally**: openclaw agents without slack render byte-identical to pre-#835 output (W10 byte-lock guard).
- Consolidates the slack-mcp-server release pin + per-OS SHA256 map into `core/playbook_resolver.mcp_slack_extravars(os_family)` — single Python source of truth (B9 fix). Both hermes and openclaw configure playbooks (Linux + macOS) removed their inline `mcp_slack_*` vars and now consume the extravars threaded by `lifecycle.configure_agent`.
- Extracts `core/playbook_resolver.normalize_os_family(host)` — shared alias-coercion seam replacing three inline blocks in `configure_agent`.
- Threads `os_family` into `render_openclaw` for per-OS binary path selection (`/home/…` vs `/Users/…`), including through `lifecycle_canonical.sync_agent_canonical` so `clawctl agent sync` on darwin openclaw with slack now renders the correct path.
- openclaw `configure.yaml` + `configure_macos.yaml` install slack-mcp-server when a slack integration is attached; `no_log: true` on install tasks matches the openclaw.json copy posture.

## Testing

### Test Results

- [x] All existing tests pass (`make test`) — 4265 passed, 8 skipped
- [x] Linter passes (`make lint`)
- [x] New tests added for new functionality

### Test Coverage

- Openclaw slack render goldens (slack-user, slack-cookie, both together, darwin home_root)
- W10 byte-lock guard (no slack → mcp key absent)
- Unknown auth-mode defensive raise
- Slug-collision + empty-slug + missing-token guards mirroring hermes
- `_render_openclaw_json` legacy-kwargs backward-compat
- `render_openclaw` `os_family` typo rejection
- `playbook_resolver.mcp_slack_extravars` per-OS matrix + version lockstep + returned-dict-is-copy
- `normalize_os_family` alias parametrize (None/`{}`/whitespace/case/mac/macos/OSX/passthrough)
- `lifecycle.configure_agent` `mcp_slack_extravars(ValueError) → (False, msg)` path
- Attach-gate acceptance for openclaw+slack with hosts.json persistence assertion

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $15.72 | Total Time: 27m 51s**

| Review | Rating | Blocking Issues | Status | Cost   | Time    | Agents |
|--------|--------|-----------------|--------|--------|---------|--------|
| 1      | 3.5/5  | None (7 warnings) | All fixed | $3.63  | 8m22s   | platform-playbooks, security-reviewer, lifecycle-core, render-engine |
| 2      | 4/5    | B1, B2, B3        | All fixed | $5.53  | 9m10s   | test-coverage, platform-playbooks, security-reviewer, lifecycle-core, render-engine |
| 3      | 4/5    | None              | Ready     | $6.56  | 10m19s  | test-coverage, platform-playbooks, security-reviewer, lifecycle-core, render-engine |

> **Transport override**: ATX CLI (`atx review request --prompt ...`) used per the orchestrator instruction. Session state persisted at `.itx/835/atx-session.json`.

<details>
<summary>Review 1 Details (Rating 3.5/5)</summary>

No blockers. Seven warnings across four specialists, all fixed in iter-2:

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `lifecycle_canonical.py:1742` | Canonical sync omitted `os_family` for darwin openclaw+slack | Fixed — thread `os_family` via `normalize_os_family(host)` |
| W2 | `lifecycle.py:2671, 2712, 2851` | `os_family` normalization triplicated | Fixed — extracted `normalize_os_family` in playbook_resolver |
| W3 | `lifecycle.py:2844` | Zeroclaw fallback-behavior comment misleading | Rewrote comment |
| W4 | `render.py:1854` | `_render_openclaw_json` docstring numbering skip 4→6→5 | Renumbered 1–6 in execution order |
| W5 | `openclaw/playbooks/configure.yaml`, `configure_macos.yaml` | Missing `no_log: true` on slack install tasks | Added |
| W6 | `render.py:seen_mcp_slugs` | Scope not documented (slack-only) | Added scope comment |
| W7 | `render.py` slack elif branch | Slack integration_views entry env-template-inert | Added `continue` to skip the append |

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/platform/test_slack_asset_map.py` | `normalize_os_family` had zero unit tests | Fixed — added `test_normalize_os_family_covers_documented_aliases` (14-case parametrize) + passthrough test |
| B2 | `tests/core/test_render.py` | `_render_openclaw_json` unknown auth-mode defensive raise untested | Fixed — added `test_openclaw_json_slack_unknown_auth_mode_raises` |
| B3 | `tests/core/test_lifecycle_openclaw_prerender.py` | `mcp_slack_extravars(ValueError) → (False, msg)` untested | Fixed — added `test_configure_agent_openclaw_mcp_slack_extravars_bad_os_family` |

**Warnings:**

| # | File | Warning | Resolution |
|---|------|---------|------------|
| W1 | `lifecycle_canonical.py:1760-1763` | TypeError shim silenced programming errors + unreachable in all stubs | Fixed — removed shim, updated 9 lambdas in `test_lifecycle_canonical.py` + 4 `fake_render` defs in `test_sync.py` to accept `**_kwargs` |
| W2 | `tests/core/test_render.py` | Multi-slack (user+cookie) coexistence render untested | Added `test_openclaw_json_slack_user_and_cookie_coexist` |
| W3 | `tests/cli/clawctl/agent/test_integration_gate.py` | Gate acceptance tests didn't assert hosts.json write | Added `_hosts_json_agent_integrations` helper + persistence assertion |

</details>

<details>
<summary>Review 3 Details (Rating 4/5)</summary>

No blocking issues. All iter-2 blockers verified closed. Rating threshold >3/5 met; iteration ceiling (3) reached.

</details>

## Callouts

- [UNRESOLVED] Real-host UAT on wolf-i openclaw was **not run**.
  - Best guess applied: the only openclaw agent on wolf-i (`wolf-i`) is in `failed` state (age 0s per `clawctl agent get`) and cannot serve as a UAT target. `esper-mac-oc` on `esper-macmini` is a ready darwin openclaw but a different host — not the plan's Linux target.
  - Reviewer: please run the Phase 2 UAT (Scenario 1 in `.itx/499/00_PLAN.md`) before merging. Recommended sequence: `clawctl agent create wolf-i-oc --type openclaw --host wolf-i --cleanup-failed` → attach a `slack-work` integration with a real xoxp token → `sync` → `chat` and verify the slack MCP tool call succeeds → detach + sync + verify `mcp` key drops from `~/.openclaw/openclaw.json`.

- [DECISION] `os_family` threading on the canonical sync path uses `renderer(inputs, os_family=_os_family)` directly, not the `functools.partial` wrapper the iter-1 reviewer suggested.
  - Why: the iter-2 reviewer flagged the earlier `try/except TypeError` shim as silencing programming errors. Updating all 13 test stubs to accept `**_kwargs` is a one-line-per-stub change with no runtime cost and gives us a clean signature contract.
  - Alternatives considered: `functools.partial` wrapper (would keep old stub signatures alive but leave the darwin gap silent for any future kwarg addition).
  - Reviewer: confirm or push back.

- [DECISION] GUI has no per-agent-type "Slack card" — the integration attach flow is generic and gated server-side.
  - Why: `gui/src/app/integrations/page.tsx` renders whatever the `/types` endpoint returns; adding `slack-user`/`slack-cookie` to `_OPENCLAW_SUPPORTED_INTEGRATIONS` flips the attach gate for openclaw without any GUI change needed.
  - Reviewer: confirm.

- [ENVIRONMENT] ATX review path was CLI (`atx review request`), not MCP. Per the orchestrator override in the task prompt. Session state at `.itx/835/atx-session.json` with `transport: cli`.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
