### PR TITLE
feat(#846): pin slack MCP toolset name to `slack`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,36 @@ cut. The `itx:release` skill archives this section into a new
 
 ### BREAKING
 
+- **Slack MCP toolset name pinned to `slack` across all agent types.**
+  The rendered `mcp_servers.<key>:` (hermes YAML), `mcp.servers.<key>`
+  (openclaw JSON), and `[[mcp.servers]].name` (zeroclaw TOML) are now
+  always the literal `slack` — regardless of the operator-supplied
+  integration name in `clawctl integration registry`. Previously the
+  key was derived from `_integration_slug(<integration-name>)`, so an
+  integration named e.g. `work_slack` produced tools prefixed
+  `work_slack_*` and a zeroclaw agent surfaced a server named
+  `slack-work_slack`. Post-#846 all three surfaces render `slack` and
+  tools show as `slack_*` — matching the naming convention of other
+  built-in toolsets (`web`, `browser`, `terminal`, `file`, `atlassian`).
+
+  The `clawctl integration registry create` command additionally rejects
+  any name other than `slack` for `--type slack-user` / `--type
+  slack-cookie` at CLI time, keeping the registry record aligned with
+  the rendered key.
+
+  **Recovery:** existing installs need no operator action on the host —
+  the renderer normalizes the slug on next `clawctl agent sync` and the
+  new MCP toolset key ships automatically. The only visible change on
+  the agent is the tool-name prefix, from `<old-name>_*` → `slack_*`.
+  If you scripted a hermes skill or agent memory against the previous
+  tool names, update the references. If your registry record is named
+  anything other than `slack` (e.g. `work_slack`), the registry list
+  will still show that name but the rendered toolset is `slack`; to
+  realign the two surfaces run `clawctl integration registry remove
+  <oldname>` and re-create as `clawctl integration registry create
+  slack --type slack-user` (or `slack-cookie`). No automated migration.
+  (#846)
+
 - **`clawctl mcp` group removed entirely.** The placeholder group
   (`clawctl mcp registry get` / `describe`) that shipped in #834 has
   been deleted. Invoking any `clawctl mcp …` command now returns

--- a/src/clawrium/cli/clawctl/integration.py
+++ b/src/clawrium/cli/clawctl/integration.py
@@ -293,6 +293,20 @@ def create(
     except InvalidIntegrationTypeError as exc:
         emit_error(str(exc))
 
+    # #846: slack MCP toolset name is pinned to `slack` at render time
+    # (see `render_hermes` / `render_openclaw` / `render_zeroclaw`).
+    # Reject the create at CLI-time when the operator picks a different
+    # name so the integrations.json record and the rendered mcp_servers
+    # key stay in sync — otherwise the registry would advertise
+    # `work_slack` while every agent config surfaces the toolset as
+    # `slack`.
+    if integration_type in ("slack-user", "slack-cookie") and name != "slack":
+        emit_error(
+            f"slack integrations must be named 'slack' (got {name!r}); "
+            f"the rendered MCP toolset key is fixed",
+            hint=f"clawctl integration registry create slack --type {integration_type} ...",
+        )
+
     try:
         if get_integration(name):
             emit_error(

--- a/src/clawrium/cli/clawctl/integration.py
+++ b/src/clawrium/cli/clawctl/integration.py
@@ -41,6 +41,7 @@ from clawrium.core.integrations import (
     IntegrationsFileCorruptedError,
     InvalidIntegrationNameError,
     InvalidIntegrationTypeError,
+    SLACK_INTEGRATION_TYPES,
     add_integration,
     get_credentials_for_type,
     get_integration,
@@ -299,12 +300,31 @@ def create(
     # name so the integrations.json record and the rendered mcp_servers
     # key stay in sync — otherwise the registry would advertise
     # `work_slack` while every agent config surfaces the toolset as
-    # `slack`.
-    if integration_type in ("slack-user", "slack-cookie") and name != "slack":
+    # `slack`. Shared type set (`SLACK_INTEGRATION_TYPES`) keeps this in
+    # lockstep with the lifecycle_canonical helpers so a future third
+    # slack auth variant lands here in one edit.
+    if integration_type in SLACK_INTEGRATION_TYPES and name != "slack":
+        # #846 iter-2 (ATX W1/W2 fix): operator-facing WHY + a
+        # type-specific hint that names the actual credential keys so
+        # the operator can copy-paste without cross-referencing
+        # `registry get --types`.
+        if integration_type == "slack-user":
+            hint_flags = "--credential SLACK_MCP_XOXP_TOKEN=<xoxp-token>"
+        else:  # slack-cookie
+            hint_flags = (
+                "--credential SLACK_MCP_XOXC_TOKEN=<xoxc-token> "
+                "--credential SLACK_MCP_XOXD_TOKEN=<xoxd-token>"
+            )
         emit_error(
             f"slack integrations must be named 'slack' (got {name!r}); "
-            f"the rendered MCP toolset key is fixed",
-            hint=f"clawctl integration registry create slack --type {integration_type} ...",
+            f"agent configs (hermes / openclaw / zeroclaw) always emit "
+            f"this integration's MCP toolset as 'slack', so the registry "
+            f"name must match or the attached toolset is invisible to "
+            f"the agent",
+            hint=(
+                f"clawctl integration registry create slack "
+                f"--type {integration_type} {hint_flags}"
+            ),
         )
 
     try:

--- a/src/clawrium/core/integrations.py
+++ b/src/clawrium/core/integrations.py
@@ -43,11 +43,20 @@ __all__ = [
     "IntegrationInUseError",
     "IntegrationSingletonViolation",
     "SINGLETON_INTEGRATION_TYPES",
+    "SLACK_INTEGRATION_TYPES",
 ]
 
 # Integration types that cannot be attached more than once per agent.
 # Enforced atomically inside `add_agent_integration`'s update_host closure.
 SINGLETON_INTEGRATION_TYPES = frozenset({"git"})
+
+# #846: slack-* integration types share a pinned MCP toolset slug (`slack`)
+# and a matching CLI-time naming rule. Consumers: CLI create guard
+# (`cli/clawctl/integration.py`) and the render-layer type checks in
+# `core/render.py`. Kept here (not in `render.py` or the CLI) to avoid
+# a cross-module cycle and so any future third slack auth variant lands
+# in exactly one place.
+SLACK_INTEGRATION_TYPES = frozenset({"slack-user", "slack-cookie"})
 
 INTEGRATIONS_FILE = "integrations.json"
 

--- a/src/clawrium/core/integrations.py
+++ b/src/clawrium/core/integrations.py
@@ -50,12 +50,20 @@ __all__ = [
 # Enforced atomically inside `add_agent_integration`'s update_host closure.
 SINGLETON_INTEGRATION_TYPES = frozenset({"git"})
 
-# #846: slack-* integration types share a pinned MCP toolset slug (`slack`)
-# and a matching CLI-time naming rule. Consumers: CLI create guard
-# (`cli/clawctl/integration.py`) and the render-layer type checks in
-# `core/render.py`. Kept here (not in `render.py` or the CLI) to avoid
-# a cross-module cycle and so any future third slack auth variant lands
-# in exactly one place.
+# #846: slack-* integration types share a pinned MCP toolset slug
+# (`slack`) and a matching CLI-time naming rule. Consumer today: the
+# CLI create guard (`cli/clawctl/integration.py`). Kept at the core
+# layer (not inline in the CLI) so a future third slack auth variant
+# lands here in one edit.
+#
+# NOTE: `core/render.py` and `core/lifecycle_canonical.py` still have
+# inline `("slack-user", "slack-cookie")` literals (4 sites in
+# render.py; 3 per-agent-type frozensets in lifecycle_canonical.py).
+# Those were intentionally left in place in the #846 diff — the
+# lifecycle_canonical sets narrow per-agent-type, not by shared
+# semantics, and the render.py literals sit inside branches that
+# already spell the type by name. Broadening this constant into
+# either module would be an unrelated refactor.
 SLACK_INTEGRATION_TYPES = frozenset({"slack-user", "slack-cookie"})
 
 INTEGRATIONS_FILE = "integrations.json"

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -1163,19 +1163,26 @@ def render_hermes(
                         "xoxd_token": xoxd,
                     }
                 )
-            # #846 iter-2 (ATX B1 fix): slack integrations do NOT flow
-            # into `integration_views`. The env-template loop
-            # (`hermes-env.canonical.j2`) branches on `intg.type` and
-            # has no slack case, so the append was inert — but the
-            # dict carried the operator-derived `slug`, not the pinned
-            # `_SLACK_MCP_SLUG`. Any future env-template branch reading
-            # `intg.slug` for slack would surface the wrong value.
-            # Skip the append entirely; mirrors the openclaw W7
-            # discipline at `render_openclaw`.
-            continue
-        integration_views.append(
-            {"type": integration.type, "slug": slug, "creds": creds}
-        )
+        # #846 iter-2 (ATX B1 fix): slack integrations do NOT flow
+        # into `integration_views`. The env-template loop
+        # (`hermes-env.canonical.j2`) branches on `intg.type` and has
+        # no slack case, so the append is inert — but the dict would
+        # carry the operator-derived `slug`, not the pinned
+        # `_SLACK_MCP_SLUG`. Any future env-template branch reading
+        # `intg.slug` for slack would surface the wrong value.
+        # Mirrors the openclaw W7 discipline at `render_openclaw`.
+        #
+        # #846 iter-3 (ATX S1 fix): a structural guard, not a
+        # `continue` inside the slack branch. The pre-iter-3 shape
+        # `if slack: ...; continue` was correct today but a future
+        # refactor that dropped the `continue` — or reordered the
+        # slack branch below the append — would silently re-introduce
+        # the B1 regression. Gating the append on `not-slack` at the
+        # outer scope removes that footgun.
+        if integration.type not in ("slack-user", "slack-cookie"):
+            integration_views.append(
+                {"type": integration.type, "slug": slug, "creds": creds}
+            )
 
     ollama_base_url = ""
     if ptype == "ollama":

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -1071,21 +1071,25 @@ def render_hermes(
                 }
             )
         if integration.type in ("slack-user", "slack-cookie"):
-            # Slack MCP subprocess (korotovsky/slack-mcp-server). Slug is
-            # already restricted by `_integration_slug` (alnum + underscore)
-            # so it is safe to emit as an unquoted YAML key downstream.
-            lo_slug = slug.lower()
-            if not lo_slug:
-                raise AgentConfigError(
-                    f"render_hermes: integration name {integration.name!r} "
-                    f"slugifies to empty — refusing to emit an unnamed YAML key"
-                )
+            # #846: the mcp_servers YAML key (and therefore the tool-name
+            # prefix hermes exposes to the model) is pinned to the literal
+            # `slack` — matches the naming convention of hermes' other
+            # built-in toolsets (`web`, `browser`, `terminal`, `file`,
+            # `atlassian`) instead of leaking whatever the operator named
+            # their integration in `clawctl integration registry`.
+            lo_slug = "slack"
             if lo_slug in seen_mcp_slugs:
+                # The colliding key here is always `slack`. Either the
+                # operator attached a second slack integration (only one
+                # is supported per agent) or an atlassian integration
+                # named `slack` claimed the key first — the message
+                # covers both by pointing at the shared YAML mapping.
                 raise AgentConfigError(
-                    f"render_hermes: mcp_servers integration names collide "
-                    f"on YAML key {lo_slug!r} (slack branch); another "
-                    f"attached integration already claims this slug — "
-                    f"rename one to differentiate after slugification"
+                    f"render_hermes: mcp_servers key 'slack' already "
+                    f"claimed by another attached integration when "
+                    f"rendering slack integration {integration.name!r}. "
+                    f"Only one slack workspace per agent is supported; "
+                    f"detach the conflicting integration first"
                 )
             seen_mcp_slugs.add(lo_slug)
             # #834 (ATX iter-1 W2): validate required tokens are non-empty
@@ -1396,20 +1400,18 @@ def render_zeroclaw(
         if integration.type not in ("slack-user", "slack-cookie"):
             continue
         creds = dict(integration.credentials)
-        slug = _integration_slug(integration.name)
-        lo_slug = slug.lower()
-        if not lo_slug:
-            raise AgentConfigError(
-                f"render_zeroclaw: integration name "
-                f"{integration.name!r} slugifies to empty — "
-                f"refusing to emit an unnamed [[mcp.servers]] block"
-            )
+        # #846: the `name` field on the emitted `[[mcp.servers]]` block
+        # (and therefore the MCP toolset name zeroclaw exposes to the
+        # model) is pinned to the literal `slack` — see the hermes
+        # branch in `render_hermes` for rationale.
+        lo_slug = "slack"
         if lo_slug in seen_mcp_slugs:
             raise AgentConfigError(
-                f"render_zeroclaw: mcp.servers integration names "
-                f"collide on slug {lo_slug!r} (slack branch); "
-                f"another attached integration already claims this "
-                f"slug — rename one to differentiate after slugification"
+                f"render_zeroclaw: mcp.servers name 'slack' already "
+                f"claimed by another attached integration when "
+                f"rendering slack integration {integration.name!r}. "
+                f"Only one slack workspace per agent is supported; "
+                f"detach the conflicting integration first"
             )
         seen_mcp_slugs.add(lo_slug)
         if integration.type == "slack-user":
@@ -1811,26 +1813,18 @@ def render_openclaw(
             # doesn't see a credential-less entry it would silently
             # drop, and future readers of `integration_views` know
             # every dict there produces env output.
-            # #835: build a slack MCP subprocess view for
-            # `_render_openclaw_json`. Mirrors the hermes slack view
-            # builder at render.py:1073 line-for-line: same slug
-            # collision + empty-slug + missing-token guards; same
-            # (xoxp_token, xoxc_token, xoxd_token) tuple layout so the
-            # JSON emitter downstream stays symmetric with the hermes
-            # Jinja loop.
-            slug = _integration_slug(integration.name)
-            lo_slug = slug.lower()
-            if not lo_slug:
-                raise AgentConfigError(
-                    f"render_openclaw: integration name {integration.name!r} "
-                    f"slugifies to empty — refusing to emit an unnamed JSON key"
-                )
+            #
+            # #846: the JSON key (and therefore the MCP toolset name)
+            # is pinned to the literal `slack` — see the hermes branch
+            # above for rationale.
+            lo_slug = "slack"
             if lo_slug in seen_mcp_slugs:
                 raise AgentConfigError(
-                    f"render_openclaw: mcp.servers integration names collide "
-                    f"on JSON key {lo_slug!r} (slack branch); another "
-                    f"attached integration already claims this slug — "
-                    f"rename one to differentiate after slugification"
+                    f"render_openclaw: mcp.servers key 'slack' already "
+                    f"claimed by another attached integration when "
+                    f"rendering slack integration {integration.name!r}. "
+                    f"Only one slack workspace per agent is supported; "
+                    f"detach the conflicting integration first"
                 )
             seen_mcp_slugs.add(lo_slug)
             if integration.type == "slack-user":

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -899,6 +899,16 @@ def _integration_slug(name: str) -> str:
     return "".join(c for c in upper if c.isalnum() or c == "_")
 
 
+# #846: the MCP toolset key hermes / openclaw / zeroclaw expose to the
+# model for a slack integration is pinned to this literal — decoupled
+# from whatever the operator named their integration in
+# `clawctl integration registry`. Matches the built-in-toolset naming
+# convention (`web`, `browser`, `terminal`, `file`, `atlassian`). All
+# three view builders reference this constant so a future rename
+# (should the pin ever move) lands in exactly one place.
+_SLACK_MCP_SLUG = "slack"
+
+
 # W4 (ATX round 3): the legacy `_HERMES_PROVIDER_ENV` dispatch table was
 # removed in this commit. The Jinja template `hermes-env.canonical.j2`
 # is now the only source of truth for provider.type → env-var mapping
@@ -1025,7 +1035,15 @@ def render_hermes(
     # let an atlassian integration named `work` and a slack integration
     # named `work` slug-collide silently (YAML last-key-wins). One shared
     # set catches the cross-type collision.
-    seen_mcp_slugs: set[str] = set()
+    #
+    # #846 iter-2 (ATX B2 fix): tracking dict, not bare set — value is
+    # the (type, name) tuple of the FIRST integration to claim the key
+    # so a collision message can accurately identify the reserver
+    # instead of guessing "another slack integration". Necessary now
+    # that atlassian remains operator-slugged while slack is pinned
+    # to `slack`; an operator-named atlassian `slack` collision must
+    # not be reported as "duplicate slack workspace".
+    seen_mcp_slugs: dict[str, tuple[str, str]] = {}
     last_github_token = ""
     for integration in inputs.integrations:
         creds = dict(integration.credentials)
@@ -1053,13 +1071,15 @@ def render_hermes(
                     f"slugifies to empty — refusing to emit an unnamed YAML key"
                 )
             if lo_slug in seen_mcp_slugs:
+                prev_type, prev_name = seen_mcp_slugs[lo_slug]
                 raise AgentConfigError(
-                    f"render_hermes: mcp_servers integration names collide "
-                    f"on YAML key {lo_slug!r} (atlassian branch); another "
-                    f"attached integration already claims this slug — "
-                    f"rename one to differentiate after slugification"
+                    f"render_hermes: mcp_servers YAML key {lo_slug!r} "
+                    f"already claimed by attached {prev_type} integration "
+                    f"{prev_name!r} when rendering atlassian integration "
+                    f"{integration.name!r} — rename one to differentiate "
+                    f"after slugification"
                 )
-            seen_mcp_slugs.add(lo_slug)
+            seen_mcp_slugs[lo_slug] = (integration.type, integration.name)
             url = creds.get("ATLASSIAN_URL", "").rstrip("/")
             atlassian_views.append(
                 {
@@ -1072,26 +1092,28 @@ def render_hermes(
             )
         if integration.type in ("slack-user", "slack-cookie"):
             # #846: the mcp_servers YAML key (and therefore the tool-name
-            # prefix hermes exposes to the model) is pinned to the literal
-            # `slack` — matches the naming convention of hermes' other
-            # built-in toolsets (`web`, `browser`, `terminal`, `file`,
-            # `atlassian`) instead of leaking whatever the operator named
-            # their integration in `clawctl integration registry`.
-            lo_slug = "slack"
+            # prefix hermes exposes to the model) is pinned to
+            # `_SLACK_MCP_SLUG` — matches the naming convention of hermes'
+            # other built-in toolsets (`web`, `browser`, `terminal`,
+            # `file`, `atlassian`) instead of leaking whatever the
+            # operator named their integration in
+            # `clawctl integration registry`.
+            lo_slug = _SLACK_MCP_SLUG
             if lo_slug in seen_mcp_slugs:
-                # The colliding key here is always `slack`. Either the
-                # operator attached a second slack integration (only one
-                # is supported per agent) or an atlassian integration
-                # named `slack` claimed the key first — the message
-                # covers both by pointing at the shared YAML mapping.
+                prev_type, prev_name = seen_mcp_slugs[lo_slug]
+                # #846 iter-2 (ATX B2 fix): name the first-reserver so
+                # an atlassian-named-slack collision does not read as
+                # "duplicate slack workspace". Recovery path depends on
+                # which type claimed first — detach the reserver.
                 raise AgentConfigError(
-                    f"render_hermes: mcp_servers key 'slack' already "
-                    f"claimed by another attached integration when "
+                    f"render_hermes: mcp_servers YAML key "
+                    f"{_SLACK_MCP_SLUG!r} already claimed by attached "
+                    f"{prev_type} integration {prev_name!r} when "
                     f"rendering slack integration {integration.name!r}. "
-                    f"Only one slack workspace per agent is supported; "
-                    f"detach the conflicting integration first"
+                    f"Only one integration may claim this key per agent; "
+                    f"detach {prev_name!r} first"
                 )
-            seen_mcp_slugs.add(lo_slug)
+            seen_mcp_slugs[lo_slug] = (integration.type, integration.name)
             # #834 (ATX iter-1 W2): validate required tokens are non-empty
             # before threading into the template. `_clean_secret` in
             # `build_render_inputs` already strips NUL/CR/LF, so an empty
@@ -1141,6 +1163,16 @@ def render_hermes(
                         "xoxd_token": xoxd,
                     }
                 )
+            # #846 iter-2 (ATX B1 fix): slack integrations do NOT flow
+            # into `integration_views`. The env-template loop
+            # (`hermes-env.canonical.j2`) branches on `intg.type` and
+            # has no slack case, so the append was inert — but the
+            # dict carried the operator-derived `slug`, not the pinned
+            # `_SLACK_MCP_SLUG`. Any future env-template branch reading
+            # `intg.slug` for slack would surface the wrong value.
+            # Skip the append entirely; mirrors the openclaw W7
+            # discipline at `render_openclaw`.
+            continue
         integration_views.append(
             {"type": integration.type, "slug": slug, "creds": creds}
         )
@@ -1402,16 +1434,19 @@ def render_zeroclaw(
         creds = dict(integration.credentials)
         # #846: the `name` field on the emitted `[[mcp.servers]]` block
         # (and therefore the MCP toolset name zeroclaw exposes to the
-        # model) is pinned to the literal `slack` — see the hermes
-        # branch in `render_hermes` for rationale.
-        lo_slug = "slack"
+        # model) is pinned to `_SLACK_MCP_SLUG` — see the hermes branch
+        # in `render_hermes` for rationale. Zeroclaw does not emit
+        # atlassian into `[[mcp.servers]]`, so the collision can only
+        # be slack-vs-slack.
+        lo_slug = _SLACK_MCP_SLUG
         if lo_slug in seen_mcp_slugs:
             raise AgentConfigError(
-                f"render_zeroclaw: mcp.servers name 'slack' already "
-                f"claimed by another attached integration when "
-                f"rendering slack integration {integration.name!r}. "
-                f"Only one slack workspace per agent is supported; "
-                f"detach the conflicting integration first"
+                f"render_zeroclaw: mcp.servers name "
+                f"{_SLACK_MCP_SLUG!r} already claimed by another "
+                f"attached slack integration when rendering "
+                f"{integration.name!r}. Only one slack workspace per "
+                f"agent is supported; detach the conflicting "
+                f"integration first"
             )
         seen_mcp_slugs.add(lo_slug)
         if integration.type == "slack-user":
@@ -1815,16 +1850,19 @@ def render_openclaw(
             # every dict there produces env output.
             #
             # #846: the JSON key (and therefore the MCP toolset name)
-            # is pinned to the literal `slack` — see the hermes branch
-            # above for rationale.
-            lo_slug = "slack"
+            # is pinned to `_SLACK_MCP_SLUG` — see the hermes branch
+            # above for rationale. Openclaw does not emit atlassian
+            # to `mcp.servers`, so the collision can only be
+            # slack-vs-slack; the error message stays type-specific.
+            lo_slug = _SLACK_MCP_SLUG
             if lo_slug in seen_mcp_slugs:
                 raise AgentConfigError(
-                    f"render_openclaw: mcp.servers key 'slack' already "
-                    f"claimed by another attached integration when "
-                    f"rendering slack integration {integration.name!r}. "
-                    f"Only one slack workspace per agent is supported; "
-                    f"detach the conflicting integration first"
+                    f"render_openclaw: mcp.servers key "
+                    f"{_SLACK_MCP_SLUG!r} already claimed by another "
+                    f"attached slack integration when rendering "
+                    f"{integration.name!r}. Only one slack workspace per "
+                    f"agent is supported; detach the conflicting "
+                    f"integration first"
                 )
             seen_mcp_slugs.add(lo_slug)
             if integration.type == "slack-user":

--- a/src/clawrium/platform/registry/zeroclaw/templates/zeroclaw-config.toml.j2
+++ b/src/clawrium/platform/registry/zeroclaw/templates/zeroclaw-config.toml.j2
@@ -468,7 +468,7 @@ deferred_loading = true
 {% if slack_integrations %}enabled = true
 {% for entry in slack_integrations %}
 [[mcp.servers]]
-name = "slack-{{ entry.slug }}"
+name = "{{ entry.slug }}"
 command = "{{ slack_mcp_binary | toq }}"
 args = ["--transport", "stdio"]
 {% if entry.auth == 'user' -%}

--- a/tests/cli/clawctl/agent/test_integration_gate.py
+++ b/tests/cli/clawctl/agent/test_integration_gate.py
@@ -105,14 +105,14 @@ def test_attach_slack_user_to_openclaw_succeeds(fleet_dir, stdin_not_tty) -> Non
     coming-soon contract in #499 is meant to prevent. (ATX #835 iter-2
     W6)."""
     _create_integration(
-        "slack-work", "slack-user", {"SLACK_MCP_XOXP_TOKEN": "xoxp-1"}
+        "slack", "slack-user", {"SLACK_MCP_XOXP_TOKEN": "xoxp-1"}
     )
     result = runner.invoke(
         app,
-        ["agent", "integration", "attach", "slack-work", "--agent", "wise-hypatia"],
+        ["agent", "integration", "attach", "slack", "--agent", "wise-hypatia"],
     )
     assert result.exit_code == 0, result.output
-    assert "slack-work" in _hosts_json_agent_integrations(
+    assert "slack" in _hosts_json_agent_integrations(
         fleet_dir, "wise-hypatia"
     )
 
@@ -121,7 +121,7 @@ def test_attach_slack_cookie_to_openclaw_succeeds(fleet_dir, stdin_not_tty) -> N
     """#835 (Phase 2): cookie mode is also accepted on openclaw. Also
     asserts hosts.json persistence per ATX #835 iter-2 W6."""
     _create_integration(
-        "slack-legacy",
+        "slack",
         "slack-cookie",
         {"SLACK_MCP_XOXC_TOKEN": "xoxc-1", "SLACK_MCP_XOXD_TOKEN": "xoxd-1"},
     )
@@ -131,13 +131,13 @@ def test_attach_slack_cookie_to_openclaw_succeeds(fleet_dir, stdin_not_tty) -> N
             "agent",
             "integration",
             "attach",
-            "slack-legacy",
+            "slack",
             "--agent",
             "wise-hypatia",
         ],
     )
     assert result.exit_code == 0, result.output
-    assert "slack-legacy" in _hosts_json_agent_integrations(
+    assert "slack" in _hosts_json_agent_integrations(
         fleet_dir, "wise-hypatia"
     )
 
@@ -148,21 +148,21 @@ def test_attach_slack_user_to_zeroclaw_succeeds(fleet_dir, stdin_not_tty) -> Non
     transition. Replaces the Phase-1 rejection test."""
     _add_zeroclaw_agent(fleet_dir, name="kevin")
     _create_integration(
-        "slack-work", "slack-user", {"SLACK_MCP_XOXP_TOKEN": "xoxp-1"}
+        "slack", "slack-user", {"SLACK_MCP_XOXP_TOKEN": "xoxp-1"}
     )
     result = runner.invoke(
         app,
-        ["agent", "integration", "attach", "slack-work", "--agent", "kevin"],
+        ["agent", "integration", "attach", "slack", "--agent", "kevin"],
     )
     assert result.exit_code == 0, result.output
-    assert "slack-work" in _hosts_json_agent_integrations(fleet_dir, "kevin")
+    assert "slack" in _hosts_json_agent_integrations(fleet_dir, "kevin")
 
 
 def test_attach_slack_cookie_to_zeroclaw_succeeds(fleet_dir, stdin_not_tty) -> None:
     """#836: zeroclaw + slack-cookie also accepted."""
     _add_zeroclaw_agent(fleet_dir, name="kevin")
     _create_integration(
-        "slack-legacy",
+        "slack",
         "slack-cookie",
         {"SLACK_MCP_XOXC_TOKEN": "xoxc-1", "SLACK_MCP_XOXD_TOKEN": "xoxd-1"},
     )
@@ -172,13 +172,13 @@ def test_attach_slack_cookie_to_zeroclaw_succeeds(fleet_dir, stdin_not_tty) -> N
             "agent",
             "integration",
             "attach",
-            "slack-legacy",
+            "slack",
             "--agent",
             "kevin",
         ],
     )
     assert result.exit_code == 0, result.output
-    assert "slack-legacy" in _hosts_json_agent_integrations(fleet_dir, "kevin")
+    assert "slack" in _hosts_json_agent_integrations(fleet_dir, "kevin")
 
 
 # ---------------------------------------------------------------------------
@@ -191,11 +191,11 @@ def test_attach_slack_user_to_hermes_succeeds(fleet_dir, stdin_not_tty) -> None:
     this through unchanged."""
     _add_hermes_agent(fleet_dir, name="maurice")
     _create_integration(
-        "slack-work", "slack-user", {"SLACK_MCP_XOXP_TOKEN": "xoxp-1"}
+        "slack", "slack-user", {"SLACK_MCP_XOXP_TOKEN": "xoxp-1"}
     )
     result = runner.invoke(
         app,
-        ["agent", "integration", "attach", "slack-work", "--agent", "maurice"],
+        ["agent", "integration", "attach", "slack", "--agent", "maurice"],
     )
     assert result.exit_code == 0, result.output
 
@@ -206,13 +206,13 @@ def test_attach_slack_cookie_to_hermes_succeeds(fleet_dir, stdin_not_tty) -> Non
     be invisible without this positive test."""
     _add_hermes_agent(fleet_dir, name="maurice")
     _create_integration(
-        "slack-legacy",
+        "slack",
         "slack-cookie",
         {"SLACK_MCP_XOXC_TOKEN": "xoxc-1", "SLACK_MCP_XOXD_TOKEN": "xoxd-1"},
     )
     result = runner.invoke(
         app,
-        ["agent", "integration", "attach", "slack-legacy", "--agent", "maurice"],
+        ["agent", "integration", "attach", "slack", "--agent", "maurice"],
     )
     assert result.exit_code == 0, result.output
 

--- a/tests/cli/clawctl/integration/test_slack.py
+++ b/tests/cli/clawctl/integration/test_slack.py
@@ -154,7 +154,13 @@ def test_slack_user_token_not_leaked_by_describe(
 def test_create_slack_user_wrong_name_rejected(fleet_dir, stdin_not_tty) -> None:
     """#846: any name other than `slack` for a slack-user integration
     must be rejected at CLI-time so the registry record matches the
-    rendered mcp_servers key."""
+    rendered mcp_servers key. Also pins:
+      - `emit_error` exit code (1) — a silent flip to 2 would break
+        shell scripts checking `$?`.
+      - Hint text — must contain the exact `clawctl` recovery command
+        AND the type-specific credential flag names so operators can
+        copy-paste without cross-referencing `registry get --types`.
+    """
     result = runner.invoke(
         app,
         [
@@ -168,12 +174,17 @@ def test_create_slack_user_wrong_name_rejected(fleet_dir, stdin_not_tty) -> None
             "SLACK_MCP_XOXP_TOKEN=xoxp-1",
         ],
     )
-    assert result.exit_code != 0
+    assert result.exit_code == 1, result.output
     assert "must be named 'slack'" in result.output
+    assert "clawctl integration registry create slack" in result.output
+    assert "--type slack-user" in result.output
+    assert "SLACK_MCP_XOXP_TOKEN" in result.output
 
 
 def test_create_slack_cookie_wrong_name_rejected(fleet_dir, stdin_not_tty) -> None:
-    """#846: mirror the slack-user gate for the cookie auth path."""
+    """#846: mirror the slack-user gate for the cookie auth path.
+    Verifies both required credential flags (XOXC + XOXD) appear in
+    the hint text."""
     result = runner.invoke(
         app,
         [
@@ -189,5 +200,9 @@ def test_create_slack_cookie_wrong_name_rejected(fleet_dir, stdin_not_tty) -> No
             "SLACK_MCP_XOXD_TOKEN=xoxd-1",
         ],
     )
-    assert result.exit_code != 0
+    assert result.exit_code == 1, result.output
     assert "must be named 'slack'" in result.output
+    assert "clawctl integration registry create slack" in result.output
+    assert "--type slack-cookie" in result.output
+    assert "SLACK_MCP_XOXC_TOKEN" in result.output
+    assert "SLACK_MCP_XOXD_TOKEN" in result.output

--- a/tests/cli/clawctl/integration/test_slack.py
+++ b/tests/cli/clawctl/integration/test_slack.py
@@ -6,6 +6,10 @@ wiring Slack. Ensure both types round-trip through create → describe
 → describe --output=json → delete without leaking credentials to
 stdout or leaving orphan records.
 
+#846: slack integrations must be named exactly `slack` — the rendered
+MCP toolset key is pinned to `slack` at render time so the registry
+name has to match or the two surfaces drift.
+
 Attach-to-agent behavior lives in `test_integration_gate.py`.
 """
 
@@ -25,7 +29,7 @@ def test_create_slack_user_non_interactive(fleet_dir, stdin_not_tty) -> None:
             "integration",
             "registry",
             "create",
-            "slack-work",
+            "slack",
             "--type",
             "slack-user",
             "--credential",
@@ -33,7 +37,7 @@ def test_create_slack_user_non_interactive(fleet_dir, stdin_not_tty) -> None:
         ],
     )
     assert result.exit_code == 0, result.output
-    assert "integration/slack-work" in result.output
+    assert "integration/slack" in result.output
 
 
 def test_create_slack_cookie_non_interactive(fleet_dir, stdin_not_tty) -> None:
@@ -43,7 +47,7 @@ def test_create_slack_cookie_non_interactive(fleet_dir, stdin_not_tty) -> None:
             "integration",
             "registry",
             "create",
-            "slack-legacy",
+            "slack",
             "--type",
             "slack-cookie",
             "--credential",
@@ -53,7 +57,7 @@ def test_create_slack_cookie_non_interactive(fleet_dir, stdin_not_tty) -> None:
         ],
     )
     assert result.exit_code == 0, result.output
-    assert "integration/slack-legacy" in result.output
+    assert "integration/slack" in result.output
 
 
 def test_create_slack_user_missing_token_fails(fleet_dir, stdin_not_tty) -> None:
@@ -65,7 +69,7 @@ def test_create_slack_user_missing_token_fails(fleet_dir, stdin_not_tty) -> None
             "integration",
             "registry",
             "create",
-            "bad-slack",
+            "slack",
             "--type",
             "slack-user",
             "--credential",
@@ -87,7 +91,7 @@ def test_create_slack_cookie_missing_second_token_fails(
             "integration",
             "registry",
             "create",
-            "half-slack",
+            "slack",
             "--type",
             "slack-cookie",
             "--credential",
@@ -106,7 +110,7 @@ def test_create_slack_user_credential_stdin(fleet_dir, stdin_not_tty) -> None:
             "integration",
             "registry",
             "create",
-            "slack-stdin",
+            "slack",
             "--type",
             "slack-user",
             "--credential-stdin",
@@ -127,7 +131,7 @@ def test_slack_user_token_not_leaked_by_describe(
             "integration",
             "registry",
             "create",
-            "slack-work",
+            "slack",
             "--type",
             "slack-user",
             "--credential",
@@ -136,7 +140,54 @@ def test_slack_user_token_not_leaked_by_describe(
     )
     result = runner.invoke(
         app,
-        ["integration", "registry", "describe", "slack-work"],
+        ["integration", "registry", "describe", "slack"],
     )
     assert result.exit_code == 0
     assert "xoxp-super-secret" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# #846: slack integrations must be named exactly `slack`.
+# ---------------------------------------------------------------------------
+
+
+def test_create_slack_user_wrong_name_rejected(fleet_dir, stdin_not_tty) -> None:
+    """#846: any name other than `slack` for a slack-user integration
+    must be rejected at CLI-time so the registry record matches the
+    rendered mcp_servers key."""
+    result = runner.invoke(
+        app,
+        [
+            "integration",
+            "registry",
+            "create",
+            "work_slack",
+            "--type",
+            "slack-user",
+            "--credential",
+            "SLACK_MCP_XOXP_TOKEN=xoxp-1",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "must be named 'slack'" in result.output
+
+
+def test_create_slack_cookie_wrong_name_rejected(fleet_dir, stdin_not_tty) -> None:
+    """#846: mirror the slack-user gate for the cookie auth path."""
+    result = runner.invoke(
+        app,
+        [
+            "integration",
+            "registry",
+            "create",
+            "mcp_slack",
+            "--type",
+            "slack-cookie",
+            "--credential",
+            "SLACK_MCP_XOXC_TOKEN=xoxc-1",
+            "--credential",
+            "SLACK_MCP_XOXD_TOKEN=xoxd-1",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "must be named 'slack'" in result.output

--- a/tests/cli/clawctl/integration/test_slack.py
+++ b/tests/cli/clawctl/integration/test_slack.py
@@ -176,6 +176,11 @@ def test_create_slack_user_wrong_name_rejected(fleet_dir, stdin_not_tty) -> None
     )
     assert result.exit_code == 1, result.output
     assert "must be named 'slack'" in result.output
+    # #846 iter-3 (ATX W3 fix): pin a unique substring from the
+    # operator-facing WHY body so a future refactor that dropped the
+    # explanation (leaving only the terse "must be named 'slack'"
+    # marker) would fail this test rather than degrade silently.
+    assert "invisible to the agent" in result.output
     assert "clawctl integration registry create slack" in result.output
     assert "--type slack-user" in result.output
     assert "SLACK_MCP_XOXP_TOKEN" in result.output
@@ -202,6 +207,11 @@ def test_create_slack_cookie_wrong_name_rejected(fleet_dir, stdin_not_tty) -> No
     )
     assert result.exit_code == 1, result.output
     assert "must be named 'slack'" in result.output
+    # #846 iter-3 (ATX W3 fix): pin a unique substring from the
+    # operator-facing WHY body so a future refactor that dropped the
+    # explanation (leaving only the terse "must be named 'slack'"
+    # marker) would fail this test rather than degrade silently.
+    assert "invisible to the agent" in result.output
     assert "clawctl integration registry create slack" in result.output
     assert "--type slack-cookie" in result.output
     assert "SLACK_MCP_XOXC_TOKEN" in result.output

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -1502,9 +1502,20 @@ def test_hermes_atlassian_slug_collision_raises():
     )
     # #846 iter-2 (ATX B2 fix): error message names the first-reserving
     # integration by (type, name) instead of the pre-#846 generic
-    # "collide on YAML key" text. Regex tracks the new shape.
-    with pytest.raises(AgentConfigError, match="already claimed by attached"):
+    # "collide on YAML key" text.
+    # #846 iter-3 (ATX W2 fix): pin BOTH the marker phrase AND the
+    # first-reserver's name in the message body. A regression that
+    # silently degraded to a generic error (dropping the (type, name)
+    # tuple) would still contain the marker phrase but would fail the
+    # name assertion.
+    with pytest.raises(AgentConfigError) as exc_info:
         render_hermes(inputs)
+    msg = str(exc_info.value)
+    assert "already claimed by attached" in msg
+    assert "my-atlassian" in msg, (
+        f"collision message must name the first-reserver so the "
+        f"operator's recovery path is unambiguous; got: {msg!r}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -5271,6 +5282,56 @@ def test_hermes_no_slack_baseline_unchanged():
     assert yaml == expected
 
 
+def test_hermes_slack_env_file_unchanged_by_slack_integration():
+    """#846 iter-3 (ATX W1 fix): regression guard for the B1 fix.
+
+    The B1 fix stopped slack integrations from flowing into
+    `integration_views` (the view list the env-template iterates).
+    Today the env template has no slack branch, so adding or removing
+    a slack integration MUST leave `.hermes/.env` byte-identical.
+
+    If a future edit either (a) drops the outer `not in slack-*` guard
+    from the `integration_views.append` site OR (b) adds a slack case
+    to `hermes-env.canonical.j2`, credentials (XOXP / XOXC / XOXD)
+    would start appearing in `.env` — a silent secret-leak vector.
+    This test catches (a) directly; it catches (b) by asserting the
+    baseline `.env` shape has NO slack env var lines. If a legitimate
+    slack env-var emission ever ships, this test MUST be updated in
+    the same commit so the leak surface stays gated by a byte-lock."""
+    base = _baseline_inputs(ptype="openrouter")
+    without_slack = RenderInputs(
+        agent_name="alpha",
+        agent_type="hermes",
+        provider=base.provider,
+        channels=(),
+        integrations=(),
+    )
+    with_slack = RenderInputs(
+        agent_name="alpha",
+        agent_type="hermes",
+        provider=base.provider,
+        channels=(),
+        integrations=(
+            IntegrationInputs(
+                name="slack",
+                type="slack-user",
+                credentials=(("SLACK_MCP_XOXP_TOKEN", "xoxp-super-secret"),),
+            ),
+        ),
+    )
+    env_a = render_hermes(without_slack).files[".hermes/.env"]
+    env_b = render_hermes(with_slack).files[".hermes/.env"]
+    assert env_a == env_b, (
+        "B1 regression: attaching a slack integration must not change "
+        f"`.hermes/.env`. Diff:\n---without---\n{env_a}\n---with---\n{env_b}"
+    )
+    # Belt-and-suspenders: the actual token value MUST NOT appear
+    # anywhere in the env output, even if a future refactor keeps
+    # `env_a == env_b` but adds a masked-value line to both.
+    assert "xoxp-super-secret" not in env_b
+    assert "SLACK_MCP_XOXP_TOKEN" not in env_b
+
+
 def test_hermes_slack_two_integrations_collide():
     """#846: only one slack integration per agent is supported — the
     second attach hits the shared-`slack`-key collision guard. Replaces
@@ -5397,12 +5458,27 @@ def test_hermes_atlassian_darwin_home_root_applied():
 
 def test_hermes_slack_atlassian_cross_type_slug_collision_raises():
     """#834 (ATX iter-1 B2) / #846: atlassian and slack both emit under
-    the same `mcp_servers:` YAML mapping. An atlassian integration
-    named `slack` (which slugifies to `slack`) and a slack-user
-    integration (which pins its slug to `slack` post-#846) collide on
-    the shared key. One shared set catches the cross-type collision
-    that the two-set implementation would silently last-write-win."""
+    the same `mcp_servers:` YAML mapping. Post-#846, slack pins its
+    slug to `slack`. An atlassian integration whose slug also
+    collapses to `slack` (any name that slugifies to `slack` — the
+    stripped-and-uppercased form of e.g. `slack-x` also matches after
+    `.lower()`) claims the shared key first; the subsequent slack
+    integration must collide."""
     base = _baseline_inputs(ptype="openrouter")
+    # #846 iter-3 (ATX S4 fix): the atlassian fixture must use a name
+    # DISTINCT from the pinned slug so the "prev_name in message"
+    # assertion has real discriminative power. Using name="slack"
+    # made the assertion trivially true (slug and name identical), so
+    # the check couldn't tell whether prev_name actually surfaced in
+    # the error. Use "slack-a" → slugifies via `_integration_slug` →
+    # uppercase "SLACK_A" → lowered back to "slack_a" — which does NOT
+    # collide. Use exact "slack" (bare) which slugifies to itself so
+    # the collision fires, but keep a distinct STRING assertion below.
+    #
+    # Actually simpler: use "slack" for atlassian (slugifies to
+    # "slack") and assert on the type token "atlassian" — which never
+    # appears in a bare slack-workspace-collision error, so it IS
+    # discriminative.
     inputs = RenderInputs(
         agent_name="alpha",
         agent_type="hermes",
@@ -5425,22 +5501,19 @@ def test_hermes_slack_atlassian_cross_type_slug_collision_raises():
         ),
         api_server=base.api_server,
     )
-    # #846 iter-2 (ATX B2 fix): the collision message MUST name the
-    # first-reserver by type ("atlassian") + name ("slack"), not read as
-    # a duplicate-slack-workspace error. This is the whole reason the
-    # `seen_mcp_slugs` set was promoted to a `{slug: (type, name)}`
-    # dict in the hermes view builder.
+    # #846 iter-2 (ATX B2 fix): the collision message MUST identify the
+    # first-reserver by its type ("atlassian") so an atlassian-named-
+    # slack collision does not read as a duplicate-slack-workspace
+    # error. The "atlassian" token is the real B2 discriminator — it
+    # never appears in a bare slack-vs-slack error path.
     with pytest.raises(AgentConfigError) as exc_info:
         render_hermes(inputs)
     msg = str(exc_info.value)
     assert "'slack' already claimed" in msg
     assert "atlassian" in msg, (
-        f"collision message must name the atlassian reserver so the "
-        f"operator's recovery path is clear; got: {msg!r}"
-    )
-    assert "'slack'" in msg, (
-        f"collision message must name the reserver by its integration "
-        f"name; got: {msg!r}"
+        f"collision message must name the atlassian reserver by TYPE "
+        f"so the operator's recovery path (detach atlassian) is "
+        f"clear; got: {msg!r}"
     )
 
 

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -1500,7 +1500,10 @@ def test_hermes_atlassian_slug_collision_raises():
         ),
         api_server=base.api_server,
     )
-    with pytest.raises(AgentConfigError, match="collide on YAML key"):
+    # #846 iter-2 (ATX B2 fix): error message names the first-reserving
+    # integration by (type, name) instead of the pre-#846 generic
+    # "collide on YAML key" text. Regex tracks the new shape.
+    with pytest.raises(AgentConfigError, match="already claimed by attached"):
         render_hermes(inputs)
 
 
@@ -5422,8 +5425,23 @@ def test_hermes_slack_atlassian_cross_type_slug_collision_raises():
         ),
         api_server=base.api_server,
     )
-    with pytest.raises(AgentConfigError, match="'slack' already claimed"):
+    # #846 iter-2 (ATX B2 fix): the collision message MUST name the
+    # first-reserver by type ("atlassian") + name ("slack"), not read as
+    # a duplicate-slack-workspace error. This is the whole reason the
+    # `seen_mcp_slugs` set was promoted to a `{slug: (type, name)}`
+    # dict in the hermes view builder.
+    with pytest.raises(AgentConfigError) as exc_info:
         render_hermes(inputs)
+    msg = str(exc_info.value)
+    assert "'slack' already claimed" in msg
+    assert "atlassian" in msg, (
+        f"collision message must name the atlassian reserver so the "
+        f"operator's recovery path is clear; got: {msg!r}"
+    )
+    assert "'slack'" in msg, (
+        f"collision message must name the reserver by its integration "
+        f"name; got: {msg!r}"
+    )
 
 
 def test_hermes_slack_user_missing_xoxp_raises():

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -5120,9 +5120,12 @@ def test_render_openclaw_litellm_empty_default_model_raises_at_entry():
 
 
 def test_hermes_slack_user_mcp_byte_lock():
-    """#834: full byte-lock of the slack-user branch. Field order and
-    the single SLACK_MCP_XOXP_TOKEN env line are contract — any silent
-    reorder would drift the on-host config from what tests validated."""
+    """#834 / #846: full byte-lock of the slack-user branch. Field order
+    and the single SLACK_MCP_XOXP_TOKEN env line are contract — any
+    silent reorder would drift the on-host config from what tests
+    validated. Post-#846 the YAML key is pinned to `slack` regardless
+    of the integration's registered name (retroactive normalization for
+    pre-#846 installs named e.g. `slack-work`)."""
     base = _baseline_inputs(ptype="anthropic")
     inputs = RenderInputs(
         agent_name="alpha",
@@ -5147,7 +5150,7 @@ def test_hermes_slack_user_mcp_byte_lock():
         "  title_generation:\n"
         "    model: \"claude-haiku-4-5-20251001\"\n"
         "mcp_servers:\n"
-        "  slack_work:\n"
+        "  slack:\n"
         '    command: "/home/alpha/.local/bin/slack-mcp-server"\n'
         '    args: ["--transport", "stdio"]\n'
         "    env:\n"
@@ -5157,9 +5160,9 @@ def test_hermes_slack_user_mcp_byte_lock():
 
 
 def test_hermes_slack_cookie_mcp_byte_lock():
-    """#834: byte-lock the slack-cookie branch. Two env vars, in
+    """#834 / #846: byte-lock the slack-cookie branch. Two env vars, in
     declared order (XOXC then XOXD) — mirrors the Slack MCP server's
-    documented env convention."""
+    documented env convention. YAML key pinned to `slack` (#846)."""
     base = _baseline_inputs(ptype="anthropic")
     inputs = RenderInputs(
         agent_name="alpha",
@@ -5187,7 +5190,7 @@ def test_hermes_slack_cookie_mcp_byte_lock():
         "  title_generation:\n"
         "    model: \"claude-haiku-4-5-20251001\"\n"
         "mcp_servers:\n"
-        "  slack_legacy:\n"
+        "  slack:\n"
         '    command: "/home/alpha/.local/bin/slack-mcp-server"\n'
         '    args: ["--transport", "stdio"]\n'
         "    env:\n"
@@ -5229,12 +5232,13 @@ def test_hermes_atlassian_and_slack_coexist_in_mcp_servers():
     # Atlassian block present
     assert "  my_atl:" in yaml
     assert "mcp-atlassian==0.21.1" in yaml
-    # Slack block present, following atlassian in template loop order
-    assert "  slack_work:" in yaml
+    # Slack block present (#846: key pinned to `slack`), following
+    # atlassian in template loop order
+    assert "  slack:" in yaml
     assert "/home/alpha/.local/bin/slack-mcp-server" in yaml
     assert "SLACK_MCP_XOXP_TOKEN: 'xoxp-1'" in yaml
     # Order: atlassian entry precedes slack entry
-    assert yaml.index("my_atl:") < yaml.index("slack_work:")
+    assert yaml.index("my_atl:") < yaml.index("slack:")
 
 
 def test_hermes_no_slack_baseline_unchanged():
@@ -5264,9 +5268,13 @@ def test_hermes_no_slack_baseline_unchanged():
     assert yaml == expected
 
 
-def test_hermes_slack_slug_collision_raises():
-    """#834: distinct integration names that slug-collide must raise
-    rather than silently drop one entry (mirrors atlassian guard)."""
+def test_hermes_slack_two_integrations_collide():
+    """#846: only one slack integration per agent is supported — the
+    second attach hits the shared-`slack`-key collision guard. Replaces
+    the pre-#846 slug-collision test which fed two names that both
+    slugified to the same value; post-#846 the slug is fixed to `slack`
+    for every slack-* integration, so any second attempt trips the guard
+    regardless of registered name."""
     base = _baseline_inputs(ptype="openrouter")
     inputs = RenderInputs(
         agent_name=base.agent_name,
@@ -5274,42 +5282,50 @@ def test_hermes_slack_slug_collision_raises():
         provider=base.provider,
         integrations=(
             IntegrationInputs(
-                name="slack-a", type="slack-user",
+                name="slack", type="slack-user",
                 credentials=(("SLACK_MCP_XOXP_TOKEN", "x1"),),
             ),
             IntegrationInputs(
-                name="slack_a", type="slack-user",
+                name="slack", type="slack-user",
                 credentials=(("SLACK_MCP_XOXP_TOKEN", "x2"),),
             ),
         ),
         api_server=base.api_server,
     )
-    with pytest.raises(AgentConfigError, match="collide on YAML key"):
+    with pytest.raises(AgentConfigError, match="'slack' already claimed"):
         render_hermes(inputs)
 
 
-def test_hermes_slack_empty_slug_raises():
-    """#834: integration names that slugify to empty must raise
-    rather than emit an unnamed YAML key (mirrors atlassian guard)."""
+def test_hermes_slack_renders_slack_key_regardless_of_registered_name():
+    """#846: retroactive normalization. Pre-#846 installs may hold slack
+    integration records named e.g. `work_slack`, `!!!`, or any other
+    string the pre-#846 CLI accepted. The renderer MUST pin the YAML
+    key to `slack` for all of them so no operator has to
+    remove-and-recreate to get the fix. Replaces the pre-#846
+    `slugifies to empty` guard test (dead once the slug is fixed)."""
     base = _baseline_inputs(ptype="openrouter")
-    inputs = RenderInputs(
-        agent_name=base.agent_name,
-        agent_type=base.agent_type,
-        provider=base.provider,
-        integrations=(
-            IntegrationInputs(
-                name="!!!",
-                type="slack-cookie",
-                credentials=(
-                    ("SLACK_MCP_XOXC_TOKEN", "xc"),
-                    ("SLACK_MCP_XOXD_TOKEN", "xd"),
+    for legacy_name in ("work_slack", "!!!", "mcp_slack", "s"):
+        inputs = RenderInputs(
+            agent_name=base.agent_name,
+            agent_type=base.agent_type,
+            provider=base.provider,
+            integrations=(
+                IntegrationInputs(
+                    name=legacy_name,
+                    type="slack-cookie",
+                    credentials=(
+                        ("SLACK_MCP_XOXC_TOKEN", "xc"),
+                        ("SLACK_MCP_XOXD_TOKEN", "xd"),
+                    ),
                 ),
             ),
-        ),
-        api_server=base.api_server,
-    )
-    with pytest.raises(AgentConfigError, match="slugifies to empty"):
-        render_hermes(inputs)
+            api_server=base.api_server,
+        )
+        yaml = render_hermes(inputs).files[".hermes/config.yaml"]
+        assert "  slack:\n" in yaml, (
+            f"integration named {legacy_name!r} should render as `slack:` "
+            f"but did not — retroactive normalization failed"
+        )
 
 
 def test_hermes_slack_user_darwin_byte_lock():
@@ -5340,7 +5356,7 @@ def test_hermes_slack_user_darwin_byte_lock():
         "  title_generation:\n"
         "    model: \"claude-haiku-4-5-20251001\"\n"
         "mcp_servers:\n"
-        "  slack_work:\n"
+        "  slack:\n"
         '    command: "/Users/alpha/.local/bin/slack-mcp-server"\n'
         '    args: ["--transport", "stdio"]\n'
         "    env:\n"
@@ -5377,11 +5393,12 @@ def test_hermes_atlassian_darwin_home_root_applied():
 
 
 def test_hermes_slack_atlassian_cross_type_slug_collision_raises():
-    """#834 (ATX iter-1 B2): atlassian and slack both emit under the
-    same `mcp_servers:` YAML mapping. Two integrations that slugify to
-    the same key MUST raise — one shared set catches the cross-type
-    collision that the two-set implementation would silently
-    last-write-wins."""
+    """#834 (ATX iter-1 B2) / #846: atlassian and slack both emit under
+    the same `mcp_servers:` YAML mapping. An atlassian integration
+    named `slack` (which slugifies to `slack`) and a slack-user
+    integration (which pins its slug to `slack` post-#846) collide on
+    the shared key. One shared set catches the cross-type collision
+    that the two-set implementation would silently last-write-win."""
     base = _baseline_inputs(ptype="openrouter")
     inputs = RenderInputs(
         agent_name="alpha",
@@ -5389,7 +5406,7 @@ def test_hermes_slack_atlassian_cross_type_slug_collision_raises():
         provider=base.provider,
         integrations=(
             IntegrationInputs(
-                name="work",
+                name="slack",
                 type="atlassian",
                 credentials=(
                     ("ATLASSIAN_API_TOKEN", "tk"),
@@ -5398,14 +5415,14 @@ def test_hermes_slack_atlassian_cross_type_slug_collision_raises():
                 ),
             ),
             IntegrationInputs(
-                name="work",
+                name="slack",
                 type="slack-user",
                 credentials=(("SLACK_MCP_XOXP_TOKEN", "xoxp-1"),),
             ),
         ),
         api_server=base.api_server,
     )
-    with pytest.raises(AgentConfigError, match="collide on YAML key"):
+    with pytest.raises(AgentConfigError, match="'slack' already claimed"):
         render_hermes(inputs)
 
 
@@ -5595,7 +5612,9 @@ def test_openclaw_json_slack_user_mcp_block():
     parsed = json.loads(body)
     assert parsed["mcp"] == {
         "servers": {
-            "slack_work": {
+            # #846: JSON key pinned to `slack`, not the operator's
+            # integration name (`slack-work` here).
+            "slack": {
                 "command": "/home/alpha/.local/bin/slack-mcp-server",
                 "args": ["--transport", "stdio"],
                 "env": {"SLACK_MCP_XOXP_TOKEN": "xoxp-1"},
@@ -5623,7 +5642,8 @@ def test_openclaw_json_slack_cookie_mcp_block():
     )
     body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
     parsed = json.loads(body)
-    slack = parsed["mcp"]["servers"]["slack_legacy"]
+    # #846: JSON key pinned to `slack` regardless of registered name.
+    slack = parsed["mcp"]["servers"]["slack"]
     assert slack["command"] == "/home/alpha/.local/bin/slack-mcp-server"
     assert slack["args"] == ["--transport", "stdio"]
     assert slack["env"] == {
@@ -5663,7 +5683,8 @@ def test_openclaw_json_slack_command_path_darwin_home_root():
         ]
         parsed = json.loads(body)
         expected = f"{home_root_for(os_family)}/alpha/.local/bin/slack-mcp-server"
-        assert parsed["mcp"]["servers"]["slack_work"]["command"] == expected
+        # #846: JSON key pinned to `slack` regardless of registered name.
+        assert parsed["mcp"]["servers"]["slack"]["command"] == expected
 
 
 def test_openclaw_json_render_openclaw_json_legacy_kwargs_backward_compat():
@@ -5685,44 +5706,56 @@ def test_openclaw_json_render_openclaw_json_legacy_kwargs_backward_compat():
     assert "mcp" not in parsed
 
 
-def test_openclaw_json_slack_slug_collision_raises():
-    """#835 (mirror hermes guard): distinct integration names that
-    slug-collide must raise rather than silently drop one entry."""
+def test_openclaw_json_slack_two_integrations_collide():
+    """#835 / #846: only one slack integration per agent is supported.
+    Post-#846 the JSON key is pinned to `slack` for every slack-*
+    integration, so a second attach trips the shared-key collision
+    guard regardless of registered name."""
     inputs = _openclaw_baseline_inputs(
         integrations=(
             IntegrationInputs(
-                name="slack-a",
+                name="slack",
                 type="slack-user",
                 credentials=(("SLACK_MCP_XOXP_TOKEN", "x1"),),
             ),
             IntegrationInputs(
-                name="slack_a",
+                name="slack",
                 type="slack-user",
                 credentials=(("SLACK_MCP_XOXP_TOKEN", "x2"),),
             ),
         ),
     )
-    with pytest.raises(AgentConfigError, match="collide on JSON key"):
+    with pytest.raises(AgentConfigError, match="'slack' already claimed"):
         render_openclaw(inputs)
 
 
-def test_openclaw_json_slack_empty_slug_raises():
-    """#835 (mirror hermes guard): integration names that slugify to
-    empty must raise rather than emit an unnamed JSON key."""
-    inputs = _openclaw_baseline_inputs(
-        integrations=(
-            IntegrationInputs(
-                name="!!!",
-                type="slack-cookie",
-                credentials=(
-                    ("SLACK_MCP_XOXC_TOKEN", "xc"),
-                    ("SLACK_MCP_XOXD_TOKEN", "xd"),
+def test_openclaw_json_slack_renders_slack_key_regardless_of_registered_name():
+    """#846: retroactive normalization mirror of the hermes test —
+    pre-#846 openclaw slack records with any legacy name must still
+    render as the fixed JSON key `slack` on next sync. Replaces the
+    pre-#846 `slugifies to empty` guard test."""
+    import json
+
+    for legacy_name in ("work_slack", "!!!", "mcp_slack", "s"):
+        inputs = _openclaw_baseline_inputs(
+            integrations=(
+                IntegrationInputs(
+                    name=legacy_name,
+                    type="slack-cookie",
+                    credentials=(
+                        ("SLACK_MCP_XOXC_TOKEN", "xc"),
+                        ("SLACK_MCP_XOXD_TOKEN", "xd"),
+                    ),
                 ),
             ),
-        ),
-    )
-    with pytest.raises(AgentConfigError, match="slugifies to empty"):
-        render_openclaw(inputs)
+        )
+        body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
+        parsed = json.loads(body)
+        assert "slack" in parsed["mcp"]["servers"], (
+            f"integration named {legacy_name!r} should render under "
+            f"`mcp.servers.slack` but did not — retroactive normalization "
+            f"failed"
+        )
 
 
 def test_openclaw_json_slack_user_missing_token_raises():
@@ -5855,21 +5888,23 @@ def test_openclaw_json_slack_unknown_auth_mode_raises():
         )
 
 
-def test_openclaw_json_slack_user_and_cookie_coexist():
-    """#835 iter-2: two slack integrations of different types on the
-    same agent must both emit — no short-circuit after the first entry.
-    Guards against a future refactor collapsing the for-loop."""
-    import json
-
+def test_openclaw_json_slack_user_and_cookie_second_attach_collides():
+    """#835 iter-2 / #846: pre-#846 this test verified two slack
+    integrations of different types (`slack-user` + `slack-cookie`)
+    could coexist under distinct `mcp.servers.<slug>` keys derived from
+    the operator's integration names. Post-#846 the JSON key is pinned
+    to `slack` for every slack-* integration, so a second attach — of
+    any auth type — trips the shared-key collision guard. Retained as
+    a regression against a future refactor that might drop the guard."""
     inputs = _openclaw_baseline_inputs(
         integrations=(
             IntegrationInputs(
-                name="slack-work",
+                name="slack",
                 type="slack-user",
                 credentials=(("SLACK_MCP_XOXP_TOKEN", "xoxp-1"),),
             ),
             IntegrationInputs(
-                name="slack-legacy",
+                name="slack",
                 type="slack-cookie",
                 credentials=(
                     ("SLACK_MCP_XOXC_TOKEN", "xoxc-1"),
@@ -5878,17 +5913,8 @@ def test_openclaw_json_slack_user_and_cookie_coexist():
             ),
         ),
     )
-    body = render_openclaw(inputs).files[".openclaw/openclaw.json"]
-    parsed = json.loads(body)
-    servers = parsed["mcp"]["servers"]
-    assert set(servers.keys()) == {"slack_work", "slack_legacy"}
-    assert servers["slack_work"]["env"] == {
-        "SLACK_MCP_XOXP_TOKEN": "xoxp-1",
-    }
-    assert servers["slack_legacy"]["env"] == {
-        "SLACK_MCP_XOXC_TOKEN": "xoxc-1",
-        "SLACK_MCP_XOXD_TOKEN": "xoxd-1",
-    }
+    with pytest.raises(AgentConfigError, match="'slack' already claimed"):
+        render_openclaw(inputs)
 
 
 # ============================================================================
@@ -5967,7 +5993,11 @@ def test_zeroclaw_config_slack_user_emits_mcp_server_block():
     servers = parsed["mcp"]["servers"]
     assert len(servers) == 1
     entry = servers[0]
-    assert entry["name"] == "slack-slack_work"
+    # #846: `name` is pinned to `slack` — the pre-#846 template wrapped
+    # the operator's slug in a `slack-` prefix (`slack-slack_work`);
+    # post-#846 the template emits the slug directly and the slug is
+    # `slack`.
+    assert entry["name"] == "slack"
     assert entry["command"] == "/home/alpha/.local/bin/slack-mcp-server"
     assert entry["args"] == ["--transport", "stdio"]
     assert entry["env"] == {"SLACK_MCP_XOXP_TOKEN": "xoxp-1"}
@@ -5995,7 +6025,8 @@ def test_zeroclaw_config_slack_cookie_emits_two_env_vars():
     servers = parsed["mcp"]["servers"]
     assert len(servers) == 1
     entry = servers[0]
-    assert entry["name"] == "slack-slack_legacy"
+    # #846: `name` pinned to `slack` (see slack_user emits test above).
+    assert entry["name"] == "slack"
     assert entry["command"] == "/home/alpha/.local/bin/slack-mcp-server"
     assert entry["env"] == {
         "SLACK_MCP_XOXC_TOKEN": "xoxc-1",
@@ -6003,20 +6034,23 @@ def test_zeroclaw_config_slack_cookie_emits_two_env_vars():
     }
 
 
-def test_zeroclaw_config_slack_two_integrations_stable_order():
-    """#836: two slack integrations attached → two `[[mcp.servers]]`
-    blocks in declared order. Mirrors the openclaw coexistence test."""
-    import tomllib
-
+def test_zeroclaw_config_slack_two_integrations_collide():
+    """#846: replaces the pre-#846 `two_integrations_stable_order` test.
+    Only one slack integration per zeroclaw agent is supported —
+    both attempts collide on the fixed `slack` name so the second
+    attach raises. Retains the two-integration input shape from the
+    original test to guarantee the collision path is exercised the same
+    way the operator would hit it (attach a second slack integration
+    after the first is already configured)."""
     inputs = _zeroclaw_slack_inputs(
         integrations=(
             IntegrationInputs(
-                name="slack-work",
+                name="slack",
                 type="slack-user",
                 credentials=(("SLACK_MCP_XOXP_TOKEN", "xoxp-1"),),
             ),
             IntegrationInputs(
-                name="slack-legacy",
+                name="slack",
                 type="slack-cookie",
                 credentials=(
                     ("SLACK_MCP_XOXC_TOKEN", "xoxc-1"),
@@ -6025,19 +6059,8 @@ def test_zeroclaw_config_slack_two_integrations_stable_order():
             ),
         ),
     )
-    toml = render_zeroclaw(inputs).files[".zeroclaw/config.toml"]
-    parsed = tomllib.loads(toml)
-    servers = parsed["mcp"]["servers"]
-    assert len(servers) == 2
-    assert [s["name"] for s in servers] == [
-        "slack-slack_work",
-        "slack-slack_legacy",
-    ]
-    assert servers[0]["env"] == {"SLACK_MCP_XOXP_TOKEN": "xoxp-1"}
-    assert servers[1]["env"] == {
-        "SLACK_MCP_XOXC_TOKEN": "xoxc-1",
-        "SLACK_MCP_XOXD_TOKEN": "xoxd-1",
-    }
+    with pytest.raises(AgentConfigError, match="'slack' already claimed"):
+        render_zeroclaw(inputs)
 
 
 def test_zeroclaw_config_slack_command_path_darwin_home_root():
@@ -6067,44 +6090,38 @@ def test_zeroclaw_config_slack_command_path_darwin_home_root():
         assert parsed["mcp"]["servers"][0]["command"] == expected
 
 
-def test_zeroclaw_config_slack_slug_collision_raises():
-    """#836 (mirror openclaw guard): distinct integration names that
-    slug-collide must raise rather than silently drop one entry."""
-    inputs = _zeroclaw_slack_inputs(
-        integrations=(
-            IntegrationInputs(
-                name="slack-a",
-                type="slack-user",
-                credentials=(("SLACK_MCP_XOXP_TOKEN", "x1"),),
-            ),
-            IntegrationInputs(
-                name="slack_a",
-                type="slack-user",
-                credentials=(("SLACK_MCP_XOXP_TOKEN", "x2"),),
-            ),
-        ),
-    )
-    with pytest.raises(AgentConfigError, match="collide on slug"):
-        render_zeroclaw(inputs)
+def test_zeroclaw_config_slack_renders_slack_name_regardless_of_registered_name():
+    """#846: retroactive normalization mirror of the hermes/openclaw
+    tests — a pre-#846 zeroclaw slack integration record named e.g.
+    `work_slack`, `!!!`, or `slack-a` must still render as
+    `name = "slack"` on the emitted `[[mcp.servers]]` block. Replaces
+    both the pre-#846 slug-collision and slugifies-to-empty guard
+    tests, which relied on the operator-supplied name flowing through
+    to the emitted key."""
+    import tomllib
 
-
-def test_zeroclaw_config_slack_empty_slug_raises():
-    """#836 (mirror openclaw guard): integration names that slugify to
-    empty must raise rather than emit an unnamed [[mcp.servers]] block."""
-    inputs = _zeroclaw_slack_inputs(
-        integrations=(
-            IntegrationInputs(
-                name="!!!",
-                type="slack-cookie",
-                credentials=(
-                    ("SLACK_MCP_XOXC_TOKEN", "xc"),
-                    ("SLACK_MCP_XOXD_TOKEN", "xd"),
+    for legacy_name in ("work_slack", "!!!", "slack-a", "s"):
+        inputs = _zeroclaw_slack_inputs(
+            integrations=(
+                IntegrationInputs(
+                    name=legacy_name,
+                    type="slack-cookie",
+                    credentials=(
+                        ("SLACK_MCP_XOXC_TOKEN", "xc"),
+                        ("SLACK_MCP_XOXD_TOKEN", "xd"),
+                    ),
                 ),
             ),
-        ),
-    )
-    with pytest.raises(AgentConfigError, match="slugifies to empty"):
-        render_zeroclaw(inputs)
+        )
+        toml = render_zeroclaw(inputs).files[".zeroclaw/config.toml"]
+        parsed = tomllib.loads(toml)
+        servers = parsed["mcp"]["servers"]
+        assert len(servers) == 1
+        assert servers[0]["name"] == "slack", (
+            f"integration named {legacy_name!r} should render with "
+            f"`name = \"slack\"` but did not — retroactive normalization "
+            f"failed"
+        )
 
 
 def test_zeroclaw_config_slack_user_missing_token_raises():
@@ -6172,39 +6189,30 @@ def test_zeroclaw_config_no_slack_matches_pre_836_shape_no_servers_key():
 
 def test_zeroclaw_config_full_toml_parses_for_all_variants():
     """#836 TOML parseability guard: for each of (0 slack, 1 slack-user,
-    1 slack-cookie, 2 slack integrations), the rendered config.toml
-    MUST parse with tomllib. This is the defense-in-depth against B2
-    recurrence — any future edit that lands invalid TOML for any
-    variant fails here before it reaches a real zeroclaw daemon."""
+    1 slack-cookie), the rendered config.toml MUST parse with tomllib.
+    This is the defense-in-depth against B2 recurrence — any future
+    edit that lands invalid TOML for any variant fails here before it
+    reaches a real zeroclaw daemon.
+
+    #846: the "two slack integrations" variant that previously lived
+    here is no longer exercised — the shared-`slack`-key collision
+    guard now short-circuits render for a second attach. That
+    collision path is covered by
+    `test_zeroclaw_config_slack_two_integrations_collide`."""
     import tomllib
 
     variants: list[tuple[IntegrationInputs, ...]] = [
         (),
         (
             IntegrationInputs(
-                name="slack-work",
+                name="slack",
                 type="slack-user",
                 credentials=(("SLACK_MCP_XOXP_TOKEN", "xoxp-1"),),
             ),
         ),
         (
             IntegrationInputs(
-                name="slack-legacy",
-                type="slack-cookie",
-                credentials=(
-                    ("SLACK_MCP_XOXC_TOKEN", "xoxc-1"),
-                    ("SLACK_MCP_XOXD_TOKEN", "xoxd-1"),
-                ),
-            ),
-        ),
-        (
-            IntegrationInputs(
-                name="slack-work",
-                type="slack-user",
-                credentials=(("SLACK_MCP_XOXP_TOKEN", "xoxp-1"),),
-            ),
-            IntegrationInputs(
-                name="slack-legacy",
+                name="slack",
                 type="slack-cookie",
                 credentials=(
                     ("SLACK_MCP_XOXC_TOKEN", "xoxc-1"),


### PR DESCRIPTION
## Summary

- Pins the rendered slack MCP toolset key to the literal `slack` across all three agent types (hermes YAML `mcp_servers.slack:`, openclaw JSON `mcp.servers.slack`, zeroclaw TOML `[[mcp.servers]] name = "slack"`) — regardless of the operator-supplied integration name.
- Enforces `--name slack` at CLI time on `clawctl integration registry create --type slack-user|slack-cookie` so the registry record stays aligned with the rendered key.
- Retroactive normalization at the view-builder layer: pre-#846 installs with legacy names (e.g. `work_slack`) sync straight to the new `slack:` key on next `clawctl agent sync` with zero host action.

Closes #846.

## Testing

- `make lint` — clean (ruff + next-lint).
- `make test-py` — 4368 passed, 2 skipped. New / updated tests:
  - Hermes / openclaw / zeroclaw byte-lock tests updated to expect the pinned `slack` key regardless of the operator's registered integration name.
  - `test_hermes_slack_renders_slack_key_regardless_of_registered_name` (+ openclaw / zeroclaw mirrors) covers the retroactive normalization for legacy names (`work_slack`, `!!!`, `mcp_slack`, `s`, `slack-a`).
  - `test_hermes_slack_two_integrations_collide` (+ openclaw / zeroclaw mirrors) replaces the pre-#846 slug-collision tests — verifies the shared-`slack`-key collision guard.
  - `test_hermes_slack_env_file_unchanged_by_slack_integration` — regression guard for the ATX B1 fix (integration_views no longer receives slack; slack tokens can't leak into `.hermes/.env`).
  - `test_hermes_atlassian_slug_collision_raises` / `test_hermes_slack_atlassian_cross_type_slug_collision_raises` — verify the promoted `dict[str, (type, name)]` collision tracker names the first-reserver in the error body.
  - CLI wrong-name tests pin exit code `== 1`, hint command text, and the operator-facing WHY body substring (`invisible to the agent`).
- **Real-host UAT: NOT RUN.** I did not run wolf-i / esper-mac agent-sync UAT for this diff. The test surface covers renderer output byte-for-byte and CLI guard behavior, but the "no PR without real-host UAT" invariant is not satisfied — please gate the merge on real-host verification (attach a slack-* integration named `slack` to a hermes / openclaw / zeroclaw agent, sync, confirm the emitted config carries `mcp_servers.slack:` and tools surface as `slack_*`).

## Breaking change

Documented in CHANGELOG.md under `[Unreleased] ### BREAKING`. Existing installs need no operator action on the host — the renderer normalizes on next sync. On-agent tool names rename from `<old-integration-name>_*` → `slack_*`. Agent memory / skill definitions referencing the old prefix must be updated. If the registry name is not `slack`, `clawctl integration registry list` will still show it but the rendered toolset is `slack` — realign with `clawctl integration registry remove <oldname>` + `create slack --type slack-user|slack-cookie`.

## ATX Review Summary

**Final Review: Rating 4/5** (clears merge bar). Iter-1 surfaced four blocking-tier warnings + five warnings + three suggestions; all resolved or explicitly acknowledged. Iter-2 rated 4/5 with four non-blocking warnings; all applied in iter-3.

| Review | Rating | Blocking | Status | Agents |
|--------|--------|----------|--------|--------|
| 1 (base commit) | not-passing | B1–B4 | All fixed / acknowledged in iter-2 | leader, render-engine, cli-ux, platform-playbooks |
| 2 (iter-2) | 4/5 | none | 4 W-tier findings all fixed in iter-3 | leader, cli-ux, lifecycle-core, security, test-coverage |

> **Note**: ATX does not expose per-agent model information.

<details>
<summary>Review 1 Details (iter-1 → iter-2)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `render.py:1144` | Hermes `integration_views` append carried operator-derived slug for slack — inert today but a latent footgun | Fixed — slack integrations no longer flow into `integration_views` (openclaw W7 discipline). Iter-3 hardened via outer-scope guard so `continue` isn't load-bearing. |
| B2 | `render.py:1048-1062` | Atlassian-vs-slack collision message misleading (says "duplicate slack workspace" when the reserver is atlassian) | Fixed — hermes `seen_mcp_slugs` promoted from `set[str]` to `dict[str, tuple[type, name]]` so the error names the actual first-reserver. |
| B3 | `render.py:1080,1407,1820` | Silent tool-name rename on pre-existing installs | Acknowledged — CHANGELOG documents as BREAKING. Event plumbing for a render-time warning is out of scope for #846. |
| B4 | `integration.py:303` | CLI guard only fires on `create`, not on hypothetical bulk/`import` | Acknowledged — no `integration registry import` or rename command exists today; the guard covers the only live create surface. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `integration.py:305-306` | Error WHY clause used internal jargon | Fixed — operator-facing WHY body (`invisible to the agent`). |
| W2 | `integration.py:307` | Hint used `...` instead of type-specific credential flags | Fixed — hint branches on `integration_type` and names the exact env keys. |
| W3 | `integration.py:303` | Inline `("slack-user", "slack-cookie")` tuple | Fixed — new `SLACK_INTEGRATION_TYPES` frozenset in `core/integrations.py`. |
| W4 | `test_slack.py:171,193` | Tests used `exit_code != 0` (loose) | Fixed — pinned `== 1`. |
| W5 | `test_slack.py:154-193` | Tests didn't verify hint text content | Fixed — assert exact recovery command + credential-key names. |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Extract `_SLACK_MCP_SLUG` module constant | Fixed — all three view builders reference it. |
| S2 | Zeroclaw template still reads `{{ entry.slug }}` — could hardcode | Skipped — reviewer's own note called this "acceptable for cross-agent template symmetry". |
| S3 | Type-specific hint | Fixed (merged into W2). |

</details>

<details>
<summary>Review 2 Details (iter-2 → iter-3, final)</summary>

**Blocking Issues:** none.

**Warnings (all fixed in iter-3):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `tests/core/test_render.py` | B1 fix had no `.env`-level regression coverage | Fixed — `test_hermes_slack_env_file_unchanged_by_slack_integration` byte-locks `.hermes/.env` with vs. without a slack integration, plus token-value + env-var-name absence checks. |
| W2 | `tests/core/test_render.py:1506` | Atlassian collision test only asserted marker phrase | Fixed — now asserts `my-atlassian` (the first-reserver's name) appears in the error body. |
| W3 | `tests/cli/clawctl/integration/test_slack.py:178,204` | WHY body text unasserted | Fixed — pinned `"invisible to the agent"` substring. |
| W4 | `src/clawrium/core/integrations.py:53-58` | Docstring overpromised — claimed render.py + lifecycle_canonical as consumers | Fixed — narrowed to name the CLI as sole consumer and explicitly note the remaining inline literals are intentional. |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Convert `if slack + continue` to `if/elif` chain (structural safety) | Fixed — replaced with outer-scope `if not slack: integration_views.append(...)` guard. |
| S2 | Comment openclaw/zeroclaw set-vs-dict divergence | Skipped — informational only; the reviewer flagged it as a future-refactor hint, not a current-diff gap. |
| S3 | Follow-up: add matching `continue` after hermes atlassian branch to close the same latent-leak vector | Skipped — reviewer explicitly noted "Out of scope for #846". Worth filing as a follow-up. |
| S4 | Cross-type collision test had a tautological `assert "'slack'" in msg` (slug and fixture name identical) | Fixed — removed the tautology, kept the discriminative `"atlassian"` assertion. |

</details>

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>