### PR TITLE
feat(hermes): bump upstream pin 2026.5.29.2 → 2026.7.1 (#815)

### DIFF
--- a/.itx/815/02_EXECUTE.md
+++ b/.itx/815/02_EXECUTE.md
@@ -1,0 +1,119 @@
+# Execution log — issue #815 (hermes 2026.5.29.2 → 2026.7.1)
+
+## Execute — Round 1
+
+**Stage**: execute
+**Skill**: /itx-execute
+**Timestamp**: 2026-07-02T22:26:00Z
+**Model**: claude-opus-4-7[1m]
+
+```prompt
+/itx-execute 815
+```
+
+**Output**: manifest + CHANGELOG + registry test updated locally. Real-host
+UAT on wolf-i **BLOCKED** at step 6 (upgrade regression guard) by an
+upstream regression in `NousResearch/hermes-agent`'s `install.sh` at
+v2026.7.1. No commit, no push, no PR opened.
+
+## Execute — Round 2 (playbook workaround)
+
+**Stage**: execute
+**Skill**: /itx-execute
+**Timestamp**: 2026-07-04T18:20:00Z
+**Model**: claude-opus-4-7[1m]
+
+```prompt
+patch the clawctl install playbook to work around the upstream v2026.7.1
+install.sh bug (tag-as-branch fetch). Approach: in the hermes
+install/upgrade playbook, before invoking upstream install.sh, run
+"git -C ~/.hermes/code fetch --tags --force origin" (or equivalent
+inside the ansible task) so refs/tags/v2026.7.1 exists locally, then the
+buggy set-branches + fetch + checkout sequence still resolves. …
+```
+
+**Output**: Playbook workaround landed on both Linux and macOS install
+playbooks. wolf-i UAT Steps 1–7 all pass. Ready to commit + push + open PR.
+
+---
+
+## Result summary
+
+| Step | Description | Result |
+|------|-------------|--------|
+| 1 | `clawctl agent create --type hermes --host wolf-i --name test-815 --provider clm-openrouter` | ✅ installed 2026.7.1 cleanly (fresh path unaffected by the patched update-only task) |
+| 2 | `clawctl agent configure test-815 --stage providers/validate` | ✅ complete |
+| 3 | `clawctl agent start test-815` | ✅ started |
+| 4 | `clawctl agent chat test-815` — one hello → `OK-815` | ✅ round-trip |
+| 5 | `clawctl agent get` READY + `clawctl agent doctor test-815` green | ✅ ok |
+| 6 | `clawctl agent upgrade clawrium-maurice` (existing 2026.5.29.2 with provider + channel + integration) | ✅ **now passes** with the playbook workaround. Post-upgrade: version=2026.7.1, provider `cm-or-primary` preserved, channel `discord-maurice` preserved, integration `clawrium-github` preserved, daemon `active`, `/health` = `{"status":"ok"}`, chat round-trip returned `OK-post-upgrade`. |
+| 7 | `clawctl agent delete test-815` | ✅ removed |
+
+## Root cause of the upstream regression
+
+The v2026.7.1 `install.sh` update path (lines 1218–1224) runs:
+
+```bash
+git remote set-branches origin v2026.7.1
+git fetch origin v2026.7.1
+git checkout v2026.7.1
+```
+
+`git remote set-branches` restricts the fetch refspec so tags are no longer
+implicitly fetched. `git fetch origin v2026.7.1` writes only to `FETCH_HEAD`
+without creating a local `refs/tags/v2026.7.1` ref, so `git checkout
+v2026.7.1` errors with `pathspec 'v2026.7.1' did not match`.
+
+The fresh-install path uses `git clone --depth 1 --branch v2026.7.1`, which
+resolves the tag correctly — that's why Step 1 (fresh install) succeeds
+without any workaround.
+
+## Playbook workaround
+
+Two new tasks added to
+`src/clawrium/platform/registry/hermes/playbooks/install.yaml` (Linux) and
+`install_macos.yaml`, sitting between "Download Hermes installer script"
+and "Install Hermes runtime":
+
+1. **Stat** `~/.hermes/code/.git` to distinguish fresh-install (no dir)
+   from update-path (dir present).
+2. **When the dir exists**, run
+   `git -C ~/.hermes/code fetch --force origin refs/tags/<tag>:refs/tags/<tag>`
+   as the agent user. The explicit refspec bypasses any branch-scoped
+   refspec left in `.git/config` by previous failed attempts, so
+   `refs/tags/<tag>` is materialized locally. When upstream's `install.sh`
+   then runs its buggy sequence, `git checkout <tag>` resolves against the
+   local tag ref and succeeds.
+
+Both tasks are gated on `not hermes_already_installed` so they no-op on the
+"same version already installed, skip" path. The stat is registered
+conditionally too, so its `.stat` attribute is guarded with `is defined`
+before being read on the second task.
+
+## clawctl re-lock quirk hit during retry
+
+After the Round-1 failed upgrade, `hosts.json` had
+`clawrium-maurice.status = "ready"`, and my recovery preserved that. On
+the retry, `clawctl agent upgrade` refused with `Name 'clawrium-maurice'
+already in use on this host` because
+`src/clawrium/core/install.py:539–550` only permits re-installation over
+records in `installed` or `failed` states. Bumping the field back to
+`installed` in `hosts.json` unblocked the retry; this is a clawctl UX
+sharp edge unrelated to #815, worth a follow-up.
+
+## Local changes shipped in this PR
+
+- `src/clawrium/platform/registry/hermes/manifest.yaml` — three new
+  `platforms[]` entries for 2026.7.1 (ubuntu 24.04/x86_64, ubuntu
+  22.04/x86_64, macos ≥14/arm64), sha256
+  `a93c65b01ea392e179cf872e182bd01a2b65c0c15f17833e9f9569033ef10e07`.
+- `src/clawrium/platform/registry/hermes/playbooks/install.yaml` — stat
+  + tag pre-fetch tasks (Linux).
+- `src/clawrium/platform/registry/hermes/playbooks/install_macos.yaml` —
+  same two tasks (macOS sibling).
+- `CHANGELOG.md` — `### Changed` entry noting the pin bump + the
+  playbook workaround, with a note to remove once upstream fixes it.
+- `tests/core/test_registry_latest_supported.py` — parametrize expects
+  `2026.7.1` for the three hermes rows.
+
+`make lint` and `make test-py` both green (4330 passed / 2 skipped).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,22 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Changed
 
+- hermes upstream pin bumped `2026.5.29.2` → `2026.7.1` (#815). New
+  `platforms[]` entries for ubuntu 24.04/x86_64, ubuntu 22.04/x86_64,
+  and macos ≥14/arm64 land in
+  `src/clawrium/platform/registry/hermes/manifest.yaml`. The upstream
+  installer is a single bash script served from raw.githubusercontent
+  and is byte-identical across OS/arch, so the sha256 is shared across
+  the new entries. `clawctl agent create --type hermes` on a supported
+  host now installs 2026.7.1; existing instances continue to work and
+  can opt in via `clawctl agent upgrade`. The hermes install playbook
+  (Linux + macOS) now pre-fetches the target tag as a local
+  `refs/tags/<tag>` ref before invoking upstream `install.sh` — a
+  workaround for a v2026.7.1 upstream bug where the update path runs
+  `git remote set-branches origin <tag>` + `git fetch origin <tag>` +
+  `git checkout <tag>` on a branch-scoped refspec, which never
+  materializes the tag locally and errors with `pathspec did not
+  match`. Tracked to remove once upstream ships a fix.
 - openclaw upstream pin bumped `2026.6.9` → `2026.6.11`. New
   `platforms[]` entries for ubuntu 24.04/x86_64, ubuntu 22.04/x86_64,
   and macos ≥14/arm64 land in

--- a/src/clawrium/platform/registry/hermes/manifest.yaml
+++ b/src/clawrium/platform/registry/hermes/manifest.yaml
@@ -269,3 +269,41 @@ platforms:
         ripgrep: "*"
         ffmpeg: "*"
         uv: "*"
+  - version: "2026.7.1"
+    os: ubuntu
+    os_version: "24.04"
+    arch: x86_64
+    sha256: "a93c65b01ea392e179cf872e182bd01a2b65c0c15f17833e9f9569033ef10e07"
+    requirements:
+      min_memory_mb: 2048
+      gpu_required: false
+      dependencies:
+        python: ">=3.11"
+        ripgrep: "*"
+        ffmpeg: "*"
+        uv: "*"
+  - version: "2026.7.1"
+    os: ubuntu
+    os_version: "22.04"
+    arch: x86_64
+    sha256: "a93c65b01ea392e179cf872e182bd01a2b65c0c15f17833e9f9569033ef10e07"
+    requirements:
+      min_memory_mb: 2048
+      gpu_required: false
+      dependencies:
+        python: ">=3.11"
+        ripgrep: "*"
+        ffmpeg: "*"
+        uv: "*"
+  - version: "2026.7.1"
+    os: macos
+    os_version: ">=14"
+    arch: arm64
+    sha256: "a93c65b01ea392e179cf872e182bd01a2b65c0c15f17833e9f9569033ef10e07"
+    requirements:
+      min_memory_mb: 2048
+      gpu_required: false
+      dependencies:
+        ripgrep: "*"
+        ffmpeg: "*"
+        uv: "*"

--- a/src/clawrium/platform/registry/hermes/playbooks/install.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/install.yaml
@@ -108,6 +108,41 @@
         checksum: "sha256:{{ claw_sha256 }}"
       when: not hermes_already_installed
 
+    # Detect whether this is an update over an existing checkout — the two
+    # tasks below only apply to that path.
+    - name: Check whether .hermes/code/.git exists (update path)
+      ansible.builtin.stat:
+        path: "/home/{{ agent_name }}/.hermes/code/.git"
+      register: hermes_code_git_stat
+      when: not hermes_already_installed
+
+    # Workaround for a v2026.7.1 upstream install.sh bug on the update
+    # path (issue #815): the installer runs
+    # `git remote set-branches origin <BRANCH>` + `git fetch origin <BRANCH>`
+    # + `git checkout <BRANCH>`. When BRANCH is a TAG (as our manifest
+    # pins are), the branch-scoped refspec suppresses implicit tag
+    # fetching, `git fetch` writes only to FETCH_HEAD, and `git checkout`
+    # errors with `pathspec '<tag>' did not match`. Pre-populating
+    # `refs/tags/<tag>` locally makes the buggy checkout resolve.
+    # TODO(#815): remove once upstream ships the fix (retarget to the
+    # patch release that includes it, or verify that the release
+    # currently pinned by manifest.yaml no longer needs it).
+    - name: Pre-fetch upstream tag as local ref (workaround for v2026.7.1 install.sh update path)
+      ansible.builtin.command:
+        chdir: "/home/{{ agent_name }}/.hermes/code"
+        argv:
+          - git
+          - fetch
+          - --force
+          - origin
+          - "refs/tags/{{ hermes_target_branch }}:refs/tags/{{ hermes_target_branch }}"
+      become_user: "{{ agent_name }}"
+      when:
+        - not hermes_already_installed
+        - hermes_code_git_stat.stat is defined
+        - hermes_code_git_stat.stat.exists | default(false)
+      changed_when: false
+
     # The hermes installer can run for 10+ minutes (git clone, uv venv, large
     # pip dependency tree). We run it async with polling so the SSH connection
     # is reused per-poll rather than held open for the entire install — this

--- a/src/clawrium/platform/registry/hermes/playbooks/install_macos.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/install_macos.yaml
@@ -135,6 +135,35 @@
         checksum: "sha256:{{ claw_sha256 }}"
       when: not hermes_already_installed
 
+    # Detect whether this is an update over an existing checkout — the
+    # two tasks below only apply to that path.
+    - name: Check whether .hermes/code/.git exists (update path)
+      ansible.builtin.stat:
+        path: "/Users/{{ agent_name }}/.hermes/code/.git"
+      register: hermes_code_git_stat
+      when: not hermes_already_installed
+
+    # Workaround for a v2026.7.1 upstream install.sh bug on the update
+    # path (issue #815). See the sibling install.yaml on Linux for the
+    # full rationale; the same bug and same fix apply on macOS because
+    # the upstream install.sh is identical across OS/arch.
+    # TODO(#815): remove once upstream ships the fix.
+    - name: Pre-fetch upstream tag as local ref (workaround for v2026.7.1 install.sh update path)
+      ansible.builtin.command:
+        chdir: "/Users/{{ agent_name }}/.hermes/code"
+        argv:
+          - git
+          - fetch
+          - --force
+          - origin
+          - "refs/tags/{{ hermes_target_branch }}:refs/tags/{{ hermes_target_branch }}"
+      become_user: "{{ agent_name }}"
+      when:
+        - not hermes_already_installed
+        - hermes_code_git_stat.stat is defined
+        - hermes_code_git_stat.stat.exists | default(false)
+      changed_when: false
+
     - name: Install Hermes runtime (non-interactive)
       ansible.builtin.command:
         argv:

--- a/tests/core/test_registry_latest_supported.py
+++ b/tests/core/test_registry_latest_supported.py
@@ -17,9 +17,9 @@ from clawrium.core.registry import latest_supported_version
         # to `>=14.5`, the 13.7 exclusion row below would still return
         # None and the regression would go undetected.
         ("openclaw", "macos", "14.0", "arm64", "2026.6.11"),
-        ("hermes", "ubuntu", "24.04", "x86_64", "2026.5.29.2"),
-        ("hermes", "ubuntu", "22.04", "x86_64", "2026.5.29.2"),
-        ("hermes", "macos", "14.5", "arm64", "2026.5.29.2"),
+        ("hermes", "ubuntu", "24.04", "x86_64", "2026.7.1"),
+        ("hermes", "ubuntu", "22.04", "x86_64", "2026.7.1"),
+        ("hermes", "macos", "14.5", "arm64", "2026.7.1"),
     ],
 )
 def test_latest_supported_per_host_filter(


### PR DESCRIPTION
## Summary

- **Manifest bump.** Three new `platforms[]` entries for hermes 2026.7.1 (ubuntu 24.04/x86_64, ubuntu 22.04/x86_64, macos ≥14/arm64) in `src/clawrium/platform/registry/hermes/manifest.yaml`. Upstream `install.sh` is byte-identical across OS/arch, so the sha256 (`a93c65b01ea392e179cf872e182bd01a2b65c0c15f17833e9f9569033ef10e07`) is shared across the new entries.
- **Upstream install.sh upgrade-path patch.** Both `hermes/playbooks/install.yaml` (Linux) and `install_macos.yaml` gain a two-task workaround between the installer download and the installer invocation:
  1. `ansible.builtin.stat` on `.hermes/code/.git` to detect the update path.
  2. If the dir exists, run — as the agent user — the equivalent of:
     ```bash
     git -C ~/.hermes/code fetch --force origin refs/tags/v2026.7.1:refs/tags/v2026.7.1
     ```
     The explicit refspec bypasses any branch-scoped fetch config left in `.git/config` by earlier failed attempts, so `refs/tags/v2026.7.1` is materialized locally before upstream `install.sh` runs its buggy `set-branches` + `fetch` + `checkout` sequence. Fresh installs skip the task entirely (no `.git` dir yet) and are unaffected.
- **wolf-i UAT Steps 1–7 all pass.** Full transcript in the Testing section below.

## Root cause of the upstream bug

`install.sh` at v2026.7.1 (lines 1218–1224) runs:

```bash
git remote set-branches origin v2026.7.1
git fetch origin v2026.7.1
git checkout v2026.7.1
```

`git remote set-branches` restricts the fetch refspec so tags are no longer implicitly fetched. `git fetch origin v2026.7.1` writes only to `FETCH_HEAD` without creating `refs/tags/v2026.7.1` locally, so `git checkout v2026.7.1` errors with `pathspec 'v2026.7.1' did not match`. Fresh installs use `git clone --depth 1 --branch v2026.7.1` and resolve the tag correctly, so only the update path is broken.

## Testing

### Test Results
- [x] All existing tests pass (`make test` → 4330 passed / 2 skipped)
- [x] Linter passes (`make lint`)
- [x] Tests updated for new expected hermes latest (`tests/core/test_registry_latest_supported.py`)

### wolf-i real-host UAT (Steps 1–7)

**Step 1–5 — fresh install `test-815` (2026.7.1):**
```
$ uv run clawctl agent create test-815 --type hermes --host wolf-i --provider clm-openrouter --yes
… PLAY RECAP … ok=26 changed=8 failed=0
agent/test-815: [claw] hermes installed successfully
agent/test-815: installed (2026.7.1)

$ uv run clawctl agent configure test-815 --stage providers --provider clm-openrouter
agent/test-815: stage providers complete

$ uv run clawctl agent configure test-815 --stage validate
agent/test-815: stage validate complete

$ uv run clawctl agent start test-815
agent/test-815: started

$ uv run clawctl agent get | grep test-815
test-815           hermes     wolf-i          clm-openrouter         ready        51s

$ echo "hello, respond with just: OK-815" | uv run clawctl agent chat test-815
… test-815> OK-815

$ uv run clawctl agent doctor test-815
Status:  ok
Resolved provider:
  name:  clm-openrouter … api_key: present
Rendered files (2): .hermes/.env, .hermes/config.yaml
```

**Step 6 — upgrade regression guard on `clawrium-maurice`:**

Pre-upgrade (`clawrium-maurice` at 2026.5.29.2 with provider + channel + integration):
```
Name:       clawrium-maurice
Version:    2026.5.29.2
Provider:   cm-or-primary
Integrations (1): clawrium-github (configured)
Channels (1):     discord-maurice
```

Upgrade run:
```
$ uv run clawctl agent upgrade clawrium-maurice --yes
TASK [Pre-fetch upstream tag as local ref (workaround for v2026.7.1 install.sh update path)]
ok: [wolf.tailf7742d.ts.net]
TASK [Install Hermes runtime (non-interactive)]
… "Hermes 2026.7.1 installed for agent 'clawrium-maurice'."
PLAY RECAP … ok=31 changed=3 failed=0
agent/clawrium-maurice: upgraded 2026.5.29.2 → 2026.7.1
```

Post-upgrade:
```
Name:       clawrium-maurice
Version:    2026.7.1
Provider:   cm-or-primary
Integrations (1): clawrium-github (configured)
Channels (1):     discord-maurice
Status:     ready

$ uv run clawctl agent shell clawrium-maurice -- '/home/clawrium-maurice/.local/bin/hermes --version; systemctl is-active hermes-clawrium-maurice; curl -fsS http://127.0.0.1:8698/health'
Hermes Agent v0.18.0 (2026.7.1) · upstream 72154ad8 · local 7c1a0295 (+2963 carried commits)
active
{"status": "ok", "platform": "hermes-agent", "version": "0.18.0"}

$ echo "hello, respond only with: OK-post-upgrade" | uv run clawctl agent chat clawrium-maurice
… clawrium-maurice> OK-post-upgrade
```

All attachments (`cm-or-primary` provider, `discord-maurice` channel, `clawrium-github` integration) survived the upgrade untouched. This confirms PR #839's attachment-preservation fix propagates to hermes.

**Step 7 — cleanup:**
```
$ uv run clawctl agent delete test-815 --yes
agent/test-815: deleted
```

### Test Coverage
- Files changed: `manifest.yaml`, `install.yaml`, `install_macos.yaml`, `CHANGELOG.md`, `tests/core/test_registry_latest_supported.py`
- New tests: N/A (existing parametrize row expectations updated to 2026.7.1)
- Coverage impact: maintained

### Manual Testing
Real-host UAT on wolf-i as above. Fresh install path and upgrade path both green.

### Security Checklist
- [x] No hardcoded secrets or credentials — sha256 pinned in manifest, tag pinned via `hermes_target_branch` extravar.
- [x] Input validation for user-provided data — playbook uses `become_user: {{ agent_name }}` and `argv:` list form (no shell injection).
- [x] No SQL injection, XSS, or command injection risks.
- [x] Dependencies are from trusted sources — upstream URL is the pinned NousResearch/hermes-agent tag.

## Callouts

- [DECISION] **Explicit tag refspec instead of `git fetch --tags --force origin`.** First iteration on wolf-i used `git fetch --tags --force origin`, which errored with `fatal: couldn't find remote ref refs/heads/v2026.7.1` because a prior failed upgrade had left `remote.origin.fetch` scoped to a nonexistent branch. Passing the explicit refspec `refs/tags/<tag>:refs/tags/<tag>` bypasses that config and materializes the tag regardless of leftover state. Reviewer: confirm this is the right shape, or push back and I'll switch to `git remote set-branches origin '*'` + `git fetch --tags` as a two-step reset.

- [DECISION] **Playbook gated on `.hermes/code/.git` existing.** The new work only fires when a checkout is present, so fresh installs (which use `git clone --depth 1 --branch <tag>` and don't need the workaround) skip it. Reviewer: confirm.

- [TODO-FOLLOWUP] **Report install.sh bug to NousResearch/hermes-agent.** Upstream should fix the tag-vs-branch confusion in `install.sh`'s update path so we can drop this workaround. Once upstream ships a patch release (likely `2026.7.2` or similar) that removes the bug, remove the two workaround tasks from both playbooks — the CHANGELOG entry and comments in both files call this out.
  - Tracking: to be filed on NousResearch/hermes-agent, and a follow-up issue opened on this repo to track dropping the workaround.

- [ENVIRONMENT] **clawctl upgrade name-uniqueness sharp edge (unrelated to #815).** After the Round-1 failed upgrade left `clawrium-maurice.status = "ready"` in `hosts.json`, the retry refused with `Name … already in use on this host` because `core/install.py:539–550` only permits re-installation over records in `installed` or `failed` state. Manually setting status back to `installed` unblocked the retry. Worth a follow-up UX issue on the upgrade path — a failed upgrade shouldn't require operator intervention on `hosts.json` to try again. Not in scope for this PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)