### PR TITLE
fix(#753): validate agent_name at sync boundary before path interpolation

### DIFF
--- a/.itx/753/00_PLAN.md
+++ b/.itx/753/00_PLAN.md
@@ -1,0 +1,116 @@
+# Implementation Plan: #753 — Validate agent_name before path interpolation in sync_agent_canonical
+
+**Issue**: https://github.com/ric03uec/clawrium/issues/753
+**Labels**: type:bug, complexity:s, type:security
+
+## Problem Statement
+
+`sync_agent_canonical` and its helpers (`_get_host_openclaw_version`, `_restart_unit`) interpolate `agent_name` directly into filesystem paths (e.g., `/home/{agent_name}/.openclaw/bin/openclaw`) and systemd unit names (e.g., `{agent_type}-{agent_name}.service`). While `shlex.quote()` prevents shell command injection, it does NOT prevent path traversal — an `agent_name` like `..` or `foo/../bar` escapes the `/home/` prefix.
+
+`agent_name` originates from `hosts.json` (operator-controlled), but defense-in-depth validation should reject malformed entries at the boundary, before any SSH round-trips.
+
+Many core modules already validate agent names with `_AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")` — `lifecycle_canonical.py` is the notable gaps.
+
+## Approach
+
+Add the same regex validator to `lifecycle_canonical.py` that exists in `agent_exec.py`, `launchd.py`, `render.py`, `skills_apply.py`, `skills_state.py`, `agent_shell.py`, and `memory.py`. Call the validator at the top of `sync_agent_canonical`, before any render, SSH, or ansible work.
+
+### Why validate in sync layer (not just render layer)?
+
+The render layer (`render.py:976`) does call `_validate_agent_name`, but it's gated behind per-agent-type branches (`_validate_agent_name(inputs.agent_name)` is called inside `render_hermes`, `render_zeroclaw`, `render_openclaw`). The sync layer is the unified entry point and should validate unconditionally before delegating to any downstream subsystem. The test suite should confirm that invalid names are rejected without triggering render-type-specific paths.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `src/clawrium/core/lifecycle_canonical.py` | Add `_AGENT_NAME_RE`, `_validate_agent_name()`, call at top of `sync_agent_canonical` |
+| `tests/core/test_lifecycle_canonical.py` | Add validation test class (5 tests) |
+
+## Implementation Steps
+
+### Step 1: Add regex and validator to `lifecycle_canonical.py`
+
+After the existing module-level constants (after `_SECRET_KEY_SUFFIXES` around line 108), add:
+
+```python
+# Defense-in-depth: agent_name from hosts.json must match the same
+# character/length constraints enforced by agent_exec.py, launchd.py,
+# render.py, skills_apply.py, skills_state.py, agent_shell.py, and
+# memory.py. Reject path traversal (`..`) and uppercase at the sync
+# boundary before any SSH round-trip. (Issue #753)
+_AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
+
+
+def _validate_agent_name(agent_name: str) -> None:
+    """Raise `CanonicalSyncError` if agent_name fails format validation."""
+    if not isinstance(agent_name, str) or not _AGENT_NAME_RE.match(agent_name):
+        raise CanonicalSyncError(f"invalid agent_name: {agent_name!r}")
+```
+
+### Step 2: Call validator at top of `sync_agent_canonical`
+
+Insert `_validate_agent_name(agent_name)` as the first operational line in the function body, after the `emit` helper definition (line ~1756), before `emit("validate", ...)` and `build_render_inputs(agent_name)` at line 1758. This ensures rejection before any render input assembly, SSH connection, or workspace staging.
+
+Placement rationale:
+- Before `build_render_inputs(agent_name)` — avoids triggering render-layer side effects on bad input
+- Before `_open_ssh` at line 1853 — no network cost for invalid names
+- After the `emit` helper definition — can still log the rejection if needed
+
+### Step 3: Add tests to `tests/core/test_lifecycle_canonical.py`
+
+Add a new test class `TestAgentNameValidation` with 5 parameterized tests covering:
+
+| Test ID | Case | Agent Name | Expected |
+|---|---|---|---|
+| T1 | Path traversal (dotdot) | `".."` | `CanonicalSyncError` with `invalid agent_name` |
+| T2 | Path traversal (nested) | `"foo/../bar"` | Same as T1 |
+| T3 | Uppercase rejection | `"Wolf"` | Same as T1 |
+| T4 | Length exceeded | `"a" * 33` | Same as T1 |
+| T5 | Valid name passes | `"wolf-i"` | No validation error (may fail downstream on missing mocks) |
+
+**Test approach**: For T1-T4, the validation happens BEFORE `build_render_inputs`, so no mocking of render inputs or probe is needed — just call `sync_agent_canonical` with the bad name and assert `CanonicalSyncError`. The `_default_probe_present` autouse fixture won't matter since the function exits early.
+
+For T5, minimal mocking of `build_render_inputs` is needed to prevent downstream errors, mirroring the pattern in `test_sync_agent_missing_from_hosts_raises` (line 525). The assertion is that the validation step does NOT raise, and execution proceeds to the existing mocked downstream path.
+
+**Key assertion for all T1-T4**: `_open_ssh` is never called. Verified by monkeypatching `_open_ssh` to raise on invocation and confirming the error is `CanonicalSyncError` from validation, not from the SSH stub.
+
+## Test Strategy
+
+1. **Parameterized rejection tests** (T1-T4): Each invalid name triggers `CanonicalSyncError` with `"invalid agent_name"` in the message. No downstream mocking needed since validation exits before any other work.
+
+2. **Positive acceptance test** (T5): Valid name `"wolf-i"` passes validation. Mock `build_render_inputs` and `_open_ssh` to let execution proceed past validation. Assert no `CanonicalSyncError` from name validation specifically.
+
+3. **SSH-not-called assertion**: For rejection tests, monkeypatch `_open_ssh` to raise `RuntimeError("SSH opened")`. The `CanonicalSyncError` should be raised first, proving no SSH connection was attempted.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Name validation breaks legitimate agent names | Regex matches existing agent_exec.py pattern (in use, proven). All current agent names in tests use lowercase alphanumeric. |
+| Validator called too late (after SSH) | Code review + tests asserting `_open_ssh` not called on invalid names |
+| Regex duplication across modules | Accepted pattern — every module that reads `agent_name` independently validates. Precedent: 7+ modules already have this constant. |
+
+## Verification
+
+- `make test` passes, including new validation tests
+- Manual: edit `hosts.json` with `agent_name: ".."`, run `clawctl agent sync`, observe fast failure with error message
+- `make lint` passes (ruff/flake8)
+
+## Subtasks
+
+None — single task execution. This is a focused, single-file change with co-located tests.
+
+---
+
+## Prompt Log
+
+### Planning
+
+**Stage**: planning
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-07-04T07:28:00Z
+**Model**: qwen3.6-27b
+
+```prompt
+Create an implementation plan for GitHub issue #753 in the Clawrium repository at /home/devashish/workspace/ric03uec/clawrium.
+```

--- a/.itx/753/01_EXECUTION.md
+++ b/.itx/753/01_EXECUTION.md
@@ -1,0 +1,16 @@
+# Execution Log — Issue #753
+
+## execution
+
+**Stage**: execution
+**Skill**: /itx:execute
+**Timestamp**: 2026-07-05T16:56:00Z
+**Model**: claude-opus-4-7
+
+```prompt
+/itx-execute 753 --worktree
+```
+
+**Output**: Resumed pre-existing implementation in worktree
+`clawrium-issue-753`. Verified `make lint` + `make test` (305 gui + 325
+core) pass. Proceeding with commit → push → ATX review → PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,29 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Fixed
 
+- **`agent_name` now validated at the sync boundary before any path or
+  shell interpolation (#753).** `sync_agent_canonical` delegates to
+  `core.names.validate_agent_name` and rejects malformed `agent_name`
+  values (path traversal like `..` or `foo/../bar`, uppercase, over
+  32 characters, empty, shell metacharacters, reserved Unix accounts
+  like `root` / `xclm`) with a fast `CanonicalSyncError("invalid
+  agent_name ...")` before opening any SSH connection, staging a
+  workspace, or assembling render inputs. Defense-in-depth: an
+  operator-corrupted `hosts.json` entry now fails fast at the CLI
+  layer instead of surfacing as a confusing SSH probe error or worse,
+  interpolating into `/home/{name}/.openclaw/bin/openclaw` and
+  `openclaw-{name}.service`.
+
+- **`core.names.validate_agent_name` no longer accepts a trailing
+  newline (#753 ATX iter-1 B1).** The validator's regex switched
+  from `re.match(r"^[a-z][a-z0-9_-]{0,31}$", …)` to
+  `re.fullmatch(…)`. Python's `$` in default (non-MULTILINE) mode
+  matches the position immediately before a final `\n`, so
+  `"wolf-i\n"` previously slipped past — and that newline would flow
+  downstream into systemd unit names and filesystem paths. All
+  existing callers (`clawctl agent create`, GUI create form, sync
+  boundary) automatically gain the tightened check.
+
 - **Zeroclaw slack-mcp-server install location restored to the
   sync-time runbook documented in Phase 3 CHANGELOG (#851, #499).**
   Main's Phase 3 CHANGELOG entry told operators the install ran via

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -315,6 +315,27 @@ class CanonicalSyncError(Exception):
     """Any failure in the canonical sync pipeline."""
 
 
+def _validate_agent_name(agent_name: str) -> None:
+    """Raise `CanonicalSyncError` if `agent_name` fails format validation.
+
+    Defense-in-depth against a corrupted or tampered `hosts.json`
+    entry: reject path traversal (`..`, `foo/../bar`), shell
+    metacharacters, uppercase, over-length names, and collisions with
+    reserved Unix accounts (root, daemon, xclm, ...) at the sync
+    boundary BEFORE any SSH round-trip or render input assembly.
+    Delegates to `core.names.validate_agent_name` so the sync
+    boundary is a strict superset of the `clawctl agent create`
+    boundary — no drift between the two regexes. Issue #753.
+    """
+    from clawrium.core.names import validate_agent_name
+
+    if not isinstance(agent_name, str):
+        raise CanonicalSyncError(f"invalid agent_name: {agent_name!r}")
+    ok, err = validate_agent_name(agent_name)
+    if not ok:
+        raise CanonicalSyncError(f"invalid agent_name {agent_name!r}: {err}")
+
+
 class SecretRemovalRefused(CanonicalSyncError):
     """Raised when the rendered body would remove a host-side secret.
 
@@ -1754,6 +1775,8 @@ def sync_agent_canonical(
         if on_event is not None:
             on_event(stage, message)
         logger.info("[%s] %s", stage, message)
+
+    _validate_agent_name(agent_name)
 
     emit("validate", f"assembling render inputs for {agent_name}")
     inputs = build_render_inputs(agent_name)

--- a/src/clawrium/core/names.py
+++ b/src/clawrium/core/names.py
@@ -265,7 +265,12 @@ def validate_agent_name(name: str) -> tuple[bool, str]:
     if len(name) > 32:
         return (False, f"Name must be 32 characters or less (got {len(name)})")
 
-    if not re.match(r"^[a-z][a-z0-9_-]{0,31}$", name):
+    # `fullmatch` (not `re.match` + `^…$`) is required: Python's `$` in
+    # default mode ALSO matches the position immediately before a final
+    # `\n`, so `re.match(r"^…$", "wolf\n")` returns a match. That
+    # trailing newline would then flow into systemd unit names and
+    # filesystem paths downstream. (Issue #753, ATX iter-1 B1.)
+    if not re.fullmatch(r"[a-z][a-z0-9_-]{0,31}", name):
         return (
             False,
             "Name must start with a lowercase letter and contain only lowercase letters, digits, hyphens, and underscores",

--- a/tests/core/test_lifecycle_canonical.py
+++ b/tests/core/test_lifecycle_canonical.py
@@ -550,6 +550,125 @@ def test_sync_agent_missing_from_hosts_raises(monkeypatch):
         sync_agent_canonical("alpha")
 
 
+# ---------------------------------------------------------------------------
+# Issue #753: agent_name validation at the sync boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "..",                # path traversal (dotdot)
+        "foo/../bar",        # path traversal (nested)
+        "Wolf",              # uppercase
+        "a" * 33,            # too long
+        "",                  # empty string
+        "root",              # reserved Unix account
+        "xclm",              # reserved clawrium account
+        "wolf-i\n",          # trailing newline (ATX iter-1 B1 regression guard)
+        "wolf\x00",          # NUL byte
+        ";wolf",             # shell metacharacter
+        "wolf|bar",          # shell pipe
+        "wolf agent",        # space
+        "wolf$IFS",          # env var expansion
+    ],
+    ids=[
+        "dotdot",
+        "nested-traversal",
+        "uppercase",
+        "too-long",
+        "empty",
+        "reserved-root",
+        "reserved-xclm",
+        "trailing-newline",
+        "nul-byte",
+        "semicolon",
+        "pipe",
+        "space",
+        "dollar-ifs",
+    ],
+)
+def test_sync_rejects_invalid_agent_name(monkeypatch, bad_name):
+    """#753: `sync_agent_canonical` must reject malformed `agent_name`
+    values at the boundary — before any render input assembly, SSH
+    round-trip, or ansible work. The validation short-circuits with a
+    `CanonicalSyncError` naming the rejected value.
+
+    `build_render_inputs` is monkeypatched to raise so the test fails
+    loudly if the validator ever lets execution slip past it. (Both
+    valid regex-only cases AND reserved-name cases must trip before
+    any render work happens.)
+    """
+    def _boom_render(*_a, **_kw):
+        raise AssertionError("build_render_inputs called before validation")
+
+    monkeypatch.setattr(lc, "build_render_inputs", _boom_render)
+
+    with pytest.raises(CanonicalSyncError, match="invalid agent_name"):
+        sync_agent_canonical(bad_name)
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [None, 42, [], {}, b"wolf"],
+    ids=["none", "int", "list", "dict", "bytes"],
+)
+def test_sync_rejects_non_string_agent_name(monkeypatch, bad_name):
+    """#753 W2 (ATX iter-1): non-string `agent_name` (e.g. from a
+    tampered hosts.json with a JSON list / null / int in the name
+    slot) must be rejected by the isinstance guard BEFORE reaching
+    `core.names.validate_agent_name` (which would `TypeError` on a
+    non-string input)."""
+    def _boom_render(*_a, **_kw):
+        raise AssertionError("build_render_inputs called before validation")
+
+    monkeypatch.setattr(lc, "build_render_inputs", _boom_render)
+
+    with pytest.raises(CanonicalSyncError, match="invalid agent_name"):
+        sync_agent_canonical(bad_name)
+
+
+@pytest.mark.parametrize(
+    "good_name",
+    ["a", "a" * 32, "wolf_i", "wolf-i", "z9"],
+    ids=["single-char-min", "max-length-32", "with-underscore", "with-hyphen", "letter-digit"],
+)
+def test_validate_agent_name_accepts_boundary_valid_names(good_name):
+    """#753 W3 (ATX iter-1): direct positive boundary tests for
+    `_validate_agent_name` — 1-char min, 32-char max, underscore,
+    hyphen, letter-digit. Regression guard against a future tightening
+    of `{0,31}` → `{0,30}` or dropping underscore support that
+    `wolf-i` (the common 6-char case) would silently mask."""
+    # No exception = pass. Isolates the validator predicate without
+    # sync_agent_canonical's 3-layer mock stack (S5 from ATX iter-1).
+    lc._validate_agent_name(good_name)
+
+
+def test_sync_accepts_valid_agent_name(monkeypatch):
+    """#753: a well-formed agent_name (e.g. `wolf-i`) must pass
+    validation and reach the existing downstream mocked path. Any
+    `CanonicalSyncError` here is expected to come from the
+    `not found in hosts.json` guard, NOT from name validation."""
+    from clawrium.core.render import (
+        GatewayInputs,
+        ProviderInputs,
+        RenderInputs,
+    )
+
+    inputs = RenderInputs(
+        agent_name="wolf-i",
+        agent_type="hermes",
+        provider=ProviderInputs(name="o", type="openrouter", api_key="k"),
+        gateway=GatewayInputs(host="h", port=1),
+    )
+    monkeypatch.setattr(lc, "build_render_inputs", lambda _: inputs)
+    monkeypatch.setattr(lc, "get_agent_by_name", lambda _: None)
+
+    # Should raise the "not found" error, NOT "invalid agent_name".
+    with pytest.raises(CanonicalSyncError, match="not found in hosts.json"):
+        sync_agent_canonical("wolf-i")
+
+
 def test_sync_force_bypass_writes_through_secret_removal(monkeypatch):
     """force=True must allow a sync that removes host-side secrets."""
     from clawrium.core.render import (

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -168,6 +168,26 @@ class TestValidateClawName:
         valid, msg = validate_agent_name("")
         assert len(msg) > 0
 
+    def test_rejects_trailing_newline(self):
+        """#753 ATX iter-1 B1: `re.match(r"^…$", "wolf\\n")` returns a
+        match in default (non-MULTILINE) mode because `$` matches the
+        position before a final `\\n`. Regression guard on the fix
+        from `re.match` → `re.fullmatch`."""
+        valid, msg = validate_agent_name("wolf-i\n")
+        assert valid is False
+        assert "lowercase" in msg.lower()
+
+    def test_rejects_embedded_newline(self):
+        """#753 ATX iter-1 B1 companion: embedded (non-trailing)
+        newline must also be rejected."""
+        valid, _ = validate_agent_name("wolf\ni")
+        assert valid is False
+
+    def test_rejects_nul_byte(self):
+        """#753 ATX iter-1 W4: NUL byte in agent name."""
+        valid, _ = validate_agent_name("wolf\x00")
+        assert valid is False
+
 
 class TestIsNameAvailableOnHost:
     """Tests for is_name_available_on_host function."""


### PR DESCRIPTION
## Summary
- Add `_validate_agent_name()` to `lifecycle_canonical.py` that delegates to `core.names.validate_agent_name` — rejects malformed agent names before any SSH connection, workspace staging, or render input assembly
- Fix `re.match` → `re.fullmatch` in `validate_agent_name` to close a trailing newline bypass (Python's `$` matches position before final newline in default mode)

## Testing

### Test Results
- [x] All existing tests pass (`make test` — 305 tests)
- [x] Linter passes (`make lint` — ruff + ESLint)
- [x] New tests added: 23 tests across 3 new test functions

### Test Coverage
- Files changed: `src/clawrium/core/lifecycle_canonical.py`, `src/clawrium/core/names.py`, `tests/core/test_lifecycle_canonical.py`, `tests/test_names.py`
- New tests: 23 unit tests (13 parametrized bad names + 5 non-string types + 5 boundary valid names + 1 happy path + 3 newline/NUL tests)
- Coverage impact: increased (new validation path fully covered)

### Manual Testing
N/A — purely validation logic with unit test coverage.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (agent_name from hosts.json)
- [x] No path traversal risks (explicitly tested with `..` and `foo/../bar`)
- [x] No shell injection risks (shell metacharacters explicitly rejected)
- [x] Defense-in-depth validation at sync boundary before path interpolation

## ATX Review Summary

**Final Review: Rating 4/5 (2 agents, test-coverage timed out)**

| Review | Rating | Blocking Issues | Status |
|--------|--------|-----------------|--------|
| 1 | 4/5 | None — 7 suggestions/lifecycle, 7 suggestions/security, 0 test-coverage | Ready |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 4/5)</summary>

**lifecycle-core (Rating 4/5) — No blocking issues:**

| # | File | Severity | Finding | Action |
|---|------|----------|---------|--------|
| S1 | `lifecycle.py:1122, 2090` | Suggestion | `restart_agent` and `configure_agent` also interpolate `agent_name` into paths without same guard | Acknowledged — follow-up issue |
| S2 | `lifecycle_canonical.py:333` | Suggestion | Non-string branch error could include actual type for operator debugging | Out-of-scope |
| S3 | `lifecycle_canonical.py:329` | Suggestion | Deferred import could use module-level or have circular-import comment | Out-of-scope, code style |
| S4 | `test_lifecycle_canonical.py:566` | Suggestion | Test omits Unicode homoglyph cases (e.g., `"wolf\u2010i"`) | Acknowledged |

**security-reviewer (Rating 4/5) — No blocking issues:**

| # | File | Severity | Finding | Action |
|---|------|----------|---------|--------|
| S5 | `lifecycle.py` | Suggestion | 5 Linux entry points lack validation; macOS side covered via `launchd` | Acknowledged — follow-up |
| S6 | `names.py:200-244` | Suggestion | `RESERVED_UNIX_NAMES` omits cloud defaults (`pi`, `ubuntu`, `ec2-user`) | Out-of-scope |
| S7 | `names.py:282-283` | Suggestion | Error message inlines full blocklist to terminal output | Out-of-scope |

**test-coverage:** Failed (exit 143, timeout). Manual assessment: test matrix covers regex edges, path traversal, shell metacharacters, non-string types, boundary valid names, and happy path.

</details>

## Reviewer Notes
- Implementation delegates to `core.names` — single source of truth, no regex drift
- Validation short-circuits before any SSH round-trip (`_open_ssh` not called on invalid names)
- Follow-up: extend `_validate_agent_name` to all Linux lifecycle entry points in `lifecycle.py`
- Follow-up: expand `RESERVED_UNIX_NAMES` with cloud-image defaults (`pi`, `ubuntu`, `ec2-user`)

Closes #753

---

> 🤖 Generated with [opencode](https://opencode.ai) using **Qwen3.6-27B** (vllm-inx/Qwen3.6-27B)

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
