### PR TITLE
fix(#713): narrow CORS to explicit methods+headers with allow_credentials=true

### DIFF
--- a/src/clawrium/gui/server.py
+++ b/src/clawrium/gui/server.py
@@ -91,7 +91,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:3000", "http://localhost:36000"],
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+    allow_methods=["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"],
     allow_headers=["Authorization", "Content-Type", "Accept"],
 )
 

--- a/src/clawrium/gui/server.py
+++ b/src/clawrium/gui/server.py
@@ -91,8 +91,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:3000", "http://localhost:36000"],
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+    allow_headers=["Authorization", "Content-Type", "Accept"],
 )
 
 # Register API routers

--- a/tests/test_gui_cors.py
+++ b/tests/test_gui_cors.py
@@ -66,9 +66,10 @@ def test_no_wildcard_methods():
     methods = response.headers.get("access-control-allow-methods")
     assert methods is not None
     assert "*" not in methods
-    # Should include the methods we allow
+    # Should include at least the methods we expect
     assert "GET" in methods
     assert "POST" in methods
+    assert "HEAD" in methods
 
 
 def test_no_wildcard_headers():
@@ -108,7 +109,6 @@ def test_preflight_custom_header_blocked():
     assert "X-My-Custom-Header" not in allow_headers
 
 
-
 def test_preflight_untrusted_origin():
     """Preflight from untrusted origins should not include allow-origin."""
     client = TestClient(app)
@@ -135,6 +135,7 @@ def test_preflight_allowed_method():
     assert response.status_code == 200
     assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
     methods = response.headers.get("access-control-allow-methods")
+    assert methods is not None
     assert "POST" in methods
 
 
@@ -142,7 +143,7 @@ def test_put_method_cors_headers():
     """PUT should return CORS headers for allowed origins."""
     client = TestClient(app)
     response = client.put(
-        "/api/fleet/agents/foo/memory/test.txt",
+        "/api/agents/foo/memory/test.txt",
         content=b"test",
         headers={"Origin": "http://localhost:3000"},
     )
@@ -220,6 +221,7 @@ def test_authorization_header_passes_preflight():
         },
     )
     headers = response.headers.get("access-control-allow-headers")
+    assert headers is not None
     assert "Authorization" in headers
 
 
@@ -293,13 +295,49 @@ def test_connection_token_blocked_untrusted():
 
 
 def test_origin_list_no_wildcard():
-    """S4: Regression test: origins must be explicit, never wildcard."""
-    import clawrium.gui.server as server_mod
-    for middleware_config in server_mod.app.user_middleware:
-        if hasattr(middleware_config, "cls"):
-            from fastapi.middleware.cors import CORSMiddleware
-            if middleware_config.cls is CORSMiddleware:
-                # Check allow_origins doesn't contain "*"
-                origins = middleware_config.kwargs.get("allow_origins", [])
-                assert "*" not in origins
-                break
+    """S4: Regression: wildcard origin should not be allowed back in.
+
+    Behavioral test: an explicit, non-localhost origin is blocked rather
+    than echoed back. This catches drift where allow_origins gets reset to
+    ['*'] by accident.
+    """
+    client = TestClient(app)
+    response = client.get(
+        "/api/health",
+        headers={"Origin": "http://random-non-localhost-site.com"},
+    )
+    assert response.headers.get("access-control-allow-origin") is None
+
+
+def test_head_method_cors_headers():
+    """HEAD should pass preflight CORS for allowed origins.
+
+    HEAD is listed in allow_methods so browsers can send HEAD+Authorization
+    without preflight failure. Individual endpoints may still return 405,
+    but the CORS preflight succeeds.
+    """
+    client = TestClient(app)
+    response = client.options(
+        "/api/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "HEAD",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+
+def test_methods_exact_set():
+    """Pin the exact allowed methods to prevent drift."""
+    client = TestClient(app)
+    response = client.options(
+        "/api/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    methods = response.headers.get("access-control-allow-methods") or ""
+    actual = {m.strip() for m in methods.split(",")}
+    assert actual == {"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"}

--- a/tests/test_gui_cors.py
+++ b/tests/test_gui_cors.py
@@ -1,0 +1,193 @@
+"""CORS security tests for the GUI middleware.
+
+Issue #713: Narrow CORS wildcards when allow_credentials=True to prevent
+potential credential leaks if allow_origins drifts.
+"""
+
+from fastapi.testclient import TestClient
+
+from clawrium.gui.server import app
+
+
+def test_health_endpoint_works():
+    """Baseline: health endpoint should respond."""
+    client = TestClient(app)
+    response = client.get("/api/health")
+    assert response.status_code == 200
+
+
+def test_credentials_flag_set_on_allowed_origin():
+    """Responses to allowed origins include access-control-allow-credentials."""
+    client = TestClient(app)
+    response = client.get(
+        "/api/health",
+        headers={"Origin": "http://localhost:3000"},
+    )
+    assert response.headers.get("access-control-allow-credentials") == "true"
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+
+def test_alternative_origin_localhost_36000():
+    """The localhost:36000 origin should also work."""
+    client = TestClient(app)
+    response = client.get(
+        "/api/health",
+        headers={"Origin": "http://localhost:36000"},
+    )
+    assert response.headers.get("access-control-allow-credentials") == "true"
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:36000"
+
+
+def test_untrusted_origin_no_allow_origin_header():
+    """Untrusted origins get NO access-control-allow-origin header.
+
+    This is the critical protection: the browser will not expose the
+    response to the untrusted origin when this header is absent.
+    The Access-Control-Allow-Credentials header IS always sent (that's
+    how Starlette indicates credential-support), but without the
+    matching Allow-Origin header, the browser blocks it.
+    """
+    client = TestClient(app)
+    response = client.get(
+        "/api/health",
+        headers={"Origin": "http://evil.com"},
+    )
+    # The browser will block this origin since there's no Allow-Origin
+    assert response.headers.get("access-control-allow-origin") is None
+
+
+def test_no_wildcard_methods():
+    """Preflight should list explicit methods, not wildcard."""
+    client = TestClient(app)
+    response = client.options(
+        "/api/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    methods = response.headers.get("access-control-allow-methods")
+    assert methods is not None
+    assert "*" not in methods
+    # Should include the methods we allow
+    assert "GET" in methods
+    assert "POST" in methods
+
+
+def test_no_wildcard_headers():
+    """Preflight should list explicit headers, not wildcard."""
+    client = TestClient(app)
+    response = client.options(
+        "/api/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "Content-Type",
+        },
+    )
+    headers = response.headers.get("access-control-allow-headers")
+    assert headers is not None
+    assert "*" not in headers
+    # Should include standard headers we allow
+    assert "Content-Type" in headers
+    assert "Authorization" in headers
+
+
+def test_preflight_custom_header_blocked():
+    """Preflight for custom headers should be rejected."""
+    client = TestClient(app)
+    response = client.options(
+        "/api/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "X-My-Custom-Header",
+        },
+    )
+    assert response.status_code == 400
+
+
+def test_preflight_untrusted_origin():
+    """Preflight from untrusted origins should not include allow-origin."""
+    client = TestClient(app)
+    response = client.options(
+        "/api/health",
+        headers={
+            "Origin": "http://evil.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.headers.get("access-control-allow-origin") is None
+
+
+def test_preflight_allowed_method():
+    """POST preflight should succeed for allowed origin."""
+    client = TestClient(app)
+    response = client.options(
+        "/api/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+    methods = response.headers.get("access-control-allow-methods")
+    assert "POST" in methods
+
+
+def test_put_method_allowed():
+    """PUT should work for allowed origins."""
+    client = TestClient(app)
+    response = client.put(
+        "/api/fleet/agents/foo/memory/test.txt",
+        content=b"test",
+        headers={"Origin": "http://localhost:3000"},
+    )
+    # 404 is fine (no such agent), CORS should not block it
+    assert response.status_code in (200, 404, 422)
+
+
+def test_delete_method_allowed():
+    """DELETE should work for allowed origins."""
+    client = TestClient(app)
+    response = client.delete(
+        "/api/providers/test",
+        headers={"Origin": "http://localhost:3000"},
+    )
+    assert response.status_code in (404, 422)
+
+
+def test_authorization_header_passes_preflight():
+    """Authorization header should pass preflight."""
+    client = TestClient(app)
+    response = client.options(
+        "/api/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Authorization",
+        },
+    )
+    headers = response.headers.get("access-control-allow-headers")
+    assert "Authorization" in headers
+
+
+def test_post_works():
+    """POST should work for allowed origins."""
+    client = TestClient(app)
+    response = client.post(
+        "/api/fleet/agents/foo/start",
+        headers={"Origin": "http://localhost:3000"},
+    )
+    assert response.status_code in (200, 404, 422)
+
+
+def test_patch_works():
+    """PATCH should work for allowed origins."""
+    client = TestClient(app)
+    response = client.patch(
+        "/api/integrations/test/credentials",
+        json={"credentials": {}},
+        headers={"Origin": "http://localhost:3000"},
+    )
+    assert response.status_code in (200, 404, 422)

--- a/tests/test_gui_cors.py
+++ b/tests/test_gui_cors.py
@@ -41,18 +41,15 @@ def test_alternative_origin_localhost_36000():
 def test_untrusted_origin_no_allow_origin_header():
     """Untrusted origins get NO access-control-allow-origin header.
 
-    This is the critical protection: the browser will not expose the
-    response to the untrusted origin when this header is absent.
-    The Access-Control-Allow-Credentials header IS always sent (that's
-    how Starlette indicates credential-support), but without the
-    matching Allow-Origin header, the browser blocks it.
+    The browser blocks responses without a matching Allow-Origin,
+    so this is the critical protection even though allow-credentials
+    remains set (Starlette behavior).
     """
     client = TestClient(app)
     response = client.get(
         "/api/health",
         headers={"Origin": "http://evil.com"},
     )
-    # The browser will block this origin since there's no Allow-Origin
     assert response.headers.get("access-control-allow-origin") is None
 
 
@@ -88,13 +85,14 @@ def test_no_wildcard_headers():
     headers = response.headers.get("access-control-allow-headers")
     assert headers is not None
     assert "*" not in headers
-    # Should include standard headers we allow
+    # Should include all standard headers we allow
     assert "Content-Type" in headers
     assert "Authorization" in headers
+    assert "Accept" in headers
 
 
 def test_preflight_custom_header_blocked():
-    """Preflight for custom headers should be rejected."""
+    """Preflight for unlisted headers should be rejected with 400."""
     client = TestClient(app)
     response = client.options(
         "/api/health",
@@ -105,6 +103,10 @@ def test_preflight_custom_header_blocked():
         },
     )
     assert response.status_code == 400
+    # Custom header must NOT appear in allow-headers
+    allow_headers = response.headers.get("access-control-allow-headers") or ""
+    assert "X-My-Custom-Header" not in allow_headers
+
 
 
 def test_preflight_untrusted_origin():
@@ -130,31 +132,80 @@ def test_preflight_allowed_method():
             "Access-Control-Request-Method": "POST",
         },
     )
+    assert response.status_code == 200
     assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
     methods = response.headers.get("access-control-allow-methods")
     assert "POST" in methods
 
 
-def test_put_method_allowed():
-    """PUT should work for allowed origins."""
+def test_put_method_cors_headers():
+    """PUT should return CORS headers for allowed origins."""
     client = TestClient(app)
     response = client.put(
         "/api/fleet/agents/foo/memory/test.txt",
         content=b"test",
         headers={"Origin": "http://localhost:3000"},
     )
-    # 404 is fine (no such agent), CORS should not block it
+    # 404 is fine (no such agent), but CORS should pass through
     assert response.status_code in (200, 404, 422)
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
 
 
-def test_delete_method_allowed():
-    """DELETE should work for allowed origins."""
+def test_delete_method_cors_headers():
+    """DELETE should return CORS headers for allowed origins."""
     client = TestClient(app)
     response = client.delete(
         "/api/providers/test",
         headers={"Origin": "http://localhost:3000"},
     )
     assert response.status_code in (404, 422)
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+
+def test_post_cors_headers():
+    """POST should return CORS headers for allowed origins."""
+    client = TestClient(app)
+    response = client.post(
+        "/api/agents/foo/start",
+        headers={"Origin": "http://localhost:3000"},
+    )
+    assert response.status_code in (200, 404, 422)
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+
+def test_patch_cors_headers():
+    """PATCH should return CORS headers for allowed origins."""
+    client = TestClient(app)
+    response = client.patch(
+        "/api/integrations/test/credentials",
+        json={"key": "value"},
+        headers={"Origin": "http://localhost:3000"},
+    )
+    assert response.status_code in (200, 404, 422)
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+
+def test_preflight_blocked_method_rejected():
+    """B2: Preflight for a method NOT in allow_methods should be rejected.
+
+    This is the core invariant the PR introduces: narrowing from '*'
+    to an explicit list must actually block disallowed methods.
+    TRACE is not in allow_methods, so its preflight should fail.
+    """
+    client = TestClient(app)
+    response = client.options(
+        "/api/health",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "TRACE",
+        },
+    )
+    assert response.status_code == 400
+    # Starlette sets allow-origin for the trusted origin even on rejection;
+    # the invariant is the 400 status (method blocked) + blocked method
+    # not appearing in allow-methods
+    allow_methods = response.headers.get("access-control-allow-methods") or ""
+    assert "TRACE" not in allow_methods
 
 
 def test_authorization_header_passes_preflight():
@@ -172,22 +223,83 @@ def test_authorization_header_passes_preflight():
     assert "Authorization" in headers
 
 
-def test_post_works():
-    """POST should work for allowed origins."""
+def test_pairing_code_cors():
+    """W4: Verify /pairing-code endpoint is covered by CORS middleware.
+
+    The connection-token and pairing-code endpoints return bearer secrets.
+    This test ensures the global CORS middleware applies to them.
+    """
     client = TestClient(app)
     response = client.post(
-        "/api/fleet/agents/foo/start",
+        "/api/fleet/agents/foo/pairing-code",
         headers={"Origin": "http://localhost:3000"},
     )
+    # 404 is fine (no such agent), CORS should be present
     assert response.status_code in (200, 404, 422)
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+    assert response.headers.get("access-control-allow-credentials") == "true"
 
 
-def test_patch_works():
-    """PATCH should work for allowed origins."""
+def test_connection_token_cors():
+    """W4: Verify /connection-token endpoint is covered by CORS middleware."""
     client = TestClient(app)
-    response = client.patch(
-        "/api/integrations/test/credentials",
-        json={"credentials": {}},
+    response = client.post(
+        "/api/fleet/agents/foo/connection-token",
         headers={"Origin": "http://localhost:3000"},
     )
     assert response.status_code in (200, 404, 422)
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+    assert response.headers.get("access-control-allow-credentials") == "true"
+
+
+def test_no_origin_header():
+    """W3: Requests without an Origin header should pass through without CORS headers."""
+    client = TestClient(app)
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    # No Origin means no CORS negotiation — browser requests always send Origin
+    assert response.headers.get("access-control-allow-origin") is None
+
+
+def test_wrong_scheme_origin():
+    """W3: HTTPS origin should not match HTTP localhost entries."""
+    client = TestClient(app)
+    response = client.get(
+        "/api/health",
+        headers={"Origin": "https://localhost:3000"},
+    )
+    # allow_origins uses exact match, so https won't match http
+    assert response.headers.get("access-control-allow-origin") is None
+
+
+def test_pairing_code_blocked_untrusted():
+    """W4: Verify /pairing-code endpoint blocks untrusted origins."""
+    client = TestClient(app)
+    response = client.post(
+        "/api/fleet/agents/foo/pairing-code",
+        headers={"Origin": "http://evil.com"},
+    )
+    assert response.headers.get("access-control-allow-origin") is None
+
+
+def test_connection_token_blocked_untrusted():
+    """W4: Verify /connection-token endpoint blocks untrusted origins."""
+    client = TestClient(app)
+    response = client.post(
+        "/api/fleet/agents/foo/connection-token",
+        headers={"Origin": "http://evil.com"},
+    )
+    assert response.headers.get("access-control-allow-origin") is None
+
+
+def test_origin_list_no_wildcard():
+    """S4: Regression test: origins must be explicit, never wildcard."""
+    import clawrium.gui.server as server_mod
+    for middleware_config in server_mod.app.user_middleware:
+        if hasattr(middleware_config, "cls"):
+            from fastapi.middleware.cors import CORSMiddleware
+            if middleware_config.cls is CORSMiddleware:
+                # Check allow_origins doesn't contain "*"
+                origins = middleware_config.kwargs.get("allow_origins", [])
+                assert "*" not in origins
+                break


### PR DESCRIPTION
## Summary

Narrow CORS middleware from wildcard `allow_methods=["*"]` and `allow_headers=["*"]` to explicit lists. Combined with `allow_credentials=True`, wildcard values remove CSRF protection if `allow_origins` ever drifts to include an untrusted origin.

The `/connection-token` and `/pairing-code` endpoints return bearer secrets, making this a potential exfiltration vector under misconfiguration.

## Changes

- `src/clawrium/gui/server.py` — Replace wildcards with explicit lists:
  - `allow_methods`: `["*"]` → `["GET", "POST", "PUT", "PATCH", "DELETE"]`
  - `allow_headers`: `["*"]` → `["Authorization", "Content-Type", "Accept"]`
  - `allow_origins`: unchanged (already explicit)

- `tests/test_gui_cors.py` — 24 tests covering:
  - Credentials flag set on allowed origins
  - Untrusted origins get no `Access-Control-Allow-Origin` header
  - Preflight rejects custom headers (400)
  - Preflight blocks untrusted origins
  - All HTTP methods (GET/POST/PUT/PATCH/DELETE) work from allowed origins
  - Authorization and Content-Type headers pass preflight
  - HEAD method passes preflight
  - Blocked methods (TRACE) rejected
  - Bearer endpoints (`/pairing-code`, `/connection-token`) CORS coverage

## Testing

- All 4390 tests pass
- Lint passes

## Security Impact

CORS is enforced by browsers, not servers. The server just sets the right headers. These changes ensure:
1. Only localhost:3000/36000 get `Access-Control-Allow-Origin` headers
2. Only explicit HTTP methods and headers are approved in preflight responses
3. Custom headers not in the allow list get rejected during preflight (400)

---

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $3.22 | Total Time: 10m 5s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3/5 | B1, B2 | All fixed | $4.18 | — | leader, test-coverage, gui-routes |
| 2 | 3/5 | B1 | Fixed | $3.66 | — | leader, test-coverage, gui-routes |
| 3 | 4/5 | None | Ready | $3.22 | 10m 5s | leader, test-coverage, gui-routes, security-reviewer |

> **Note**: ATX does not expose model information per agent.

---

![Reviewed by ATX](https://img.atx.ai/review-badge.svg)

Co-Authored-By: opencode <agent>
