### PR TITLE
blog: v26.7.0 release notes

### DIFF
--- a/website/blog/2026-07-06-v26.7.0-release.md
+++ b/website/blog/2026-07-06-v26.7.0-release.md
@@ -6,7 +6,7 @@ tags: [release-notes]
 date: 2026-07-06
 ---
 
-The v26.7.0 release brings Slack MCP integration across all three GA agent types (hermes, openclaw, zeroclaw), completes workspace overlay sync on macOS for the full agent matrix, adds macOS support for \`clawctl agent shell\`, resolves the openclaw canonical-render gap, tightens sync validation and health-checking, and bumps all upstream agent pins to their latest versions.
+The v26.7.0 release brings Slack MCP integration across all three GA agent types (hermes, openclaw, zeroclaw), completes workspace overlay sync on macOS for the full agent matrix, adds macOS support for `clawctl agent shell`, resolves the openclaw canonical-render gap, tightens sync validation and health-checking, and bumps all upstream agent pins to their latest versions.
 
 <!-- truncate -->
 
@@ -14,31 +14,31 @@ The v26.7.0 release brings Slack MCP integration across all three GA agent types
 
 ### Slack MCP integration for hermes, openclaw, and zeroclaw
 
-Slack MCP support is now available for all three GA agent types. The \`slack-user\` (xoxp bearer) and \`slack-cookie\` (xoxc+xoxd) integration types attach a SHA256-pinned \`korotovsky/slack-mcp-server\` subprocess so agents can list channels, read messages, and post via MCP tool calls. Hermes support landed in Phase 1, openclaw in Phase 2, and zeroclaw in Phase 3. Each agent type has its own dedicated sync-time-runbook for binary installation (following the new "Integration Binary Install" architectural pattern), and a CLI attach-time gate rejects unsupported (agent-type, integration-type) pairs before they can corrupt \`hosts.json\`. The Slack MCP toolset name is now pinned to \`slack\` across all surfaces — tools show as \`slack_*\` regardless of the integration name in the registry.
+Slack MCP support is now available for all three GA agent types. The `slack-user` (xoxp bearer) and `slack-cookie` (xoxc+xoxd) integration types attach a SHA256-pinned `korotovsky/slack-mcp-server` subprocess so agents can list channels, read messages, and post via MCP tool calls. Hermes support landed in Phase 1, openclaw in Phase 2, and zeroclaw in Phase 3. Each agent type has its own dedicated sync-time-runbook for binary installation (following the new "Integration Binary Install" architectural pattern), and a CLI attach-time gate rejects unsupported (agent-type, integration-type) pairs before they can corrupt `hosts.json`. The Slack MCP toolset name is now pinned to `slack` across all surfaces — tools show as `slack_*` regardless of the integration name in the registry.
 
 ### Workspace overlay sync now GA on macOS for all agent types
 
-Workspace overlay sync — the feature that mirrors operator-dropped files from \`~/.config/clawrium/agents/<type>/<name>/workspace/\` to the agent host on every sync — is now fully functional on macOS for openclaw (Phase 4), zeroclaw (Phase 5), and hermes (Phase 6). Each agent type has its own \`workspace_macos.yaml\` playbook with OS-aware home-root resolution and per-type exclude lists. The complete hermes exclude list (\`config.yaml\`, \`.env\`, \`auth.json\`, \`state.db\` + WAL files, \`sessions/\`, \`logs/\`, \`skills/clawrium/\`) is enforced identically on darwin via the shared \`workspace_excluded\` Jinja filter.
+Workspace overlay sync — the feature that mirrors operator-dropped files from `~/.config/clawrium/agents/<type>/<name>/workspace/` to the agent host on every sync — is now fully functional on macOS for openclaw (Phase 4), zeroclaw (Phase 5), and hermes (Phase 6). Each agent type has its own `workspace_macos.yaml` playbook with OS-aware home-root resolution and per-type exclude lists. The complete hermes exclude list (`config.yaml`, `.env`, `auth.json`, `state.db` + WAL files, `sessions/`, `logs/`, `skills/clawrium/`) is enforced identically on darwin via the shared `workspace_excluded` Jinja filter.
 
-### \`clawctl agent shell\` now works on macOS hosts
+### `clawctl agent shell` now works on macOS hosts
 
-The \`clawctl agent shell <name> -- <cmd>\` command now supports macOS hosts. A new \`shell_macos.yaml\` playbook is selected per-OS via the playbook resolver. The kill window uses Homebrew's \`gtimeout\` (coreutils) when available, with the ansible-runner outer timeout as backstop. On darwin, \`~/.bash_profile\` is sourced first to match the macOS login-shell convention.
+The `clawctl agent shell <name> -- <cmd>` command now supports macOS hosts. A new `shell_macos.yaml` playbook is selected per-OS via the playbook resolver. The kill window uses Homebrew's `gtimeout` (coreutils) when available, with the ansible-runner outer timeout as backstop. On darwin, `~/.bash_profile` is sourced first to match the macOS login-shell convention.
 
 ### Openclaw canonical renderer consolidation
 
-The openclaw \`openclaw.json\` file is now written through a single canonical Python renderer on every code path — install, configure, and sync. The legacy Jinja template (\`openclaw.json.j2\`) has been deleted. This also fixes the litellm provider prefix bug: \`clawctl agent configure\` now correctly emits \`<provider-name>/<model>\` instead of the bare model id, which previously caused \`FailoverError: Unknown model\` errors.
+The openclaw `openclaw.json` file is now written through a single canonical Python renderer on every code path — install, configure, and sync. The legacy Jinja template (`openclaw.json.j2`) has been deleted. This also fixes the litellm provider prefix bug: `clawctl agent configure` now correctly emits `<provider-name>/<model>` instead of the bare model id, which previously caused `FailoverError: Unknown model` errors.
 
 ### Stricter sync validation and health verification
 
-Several sync-time guards now protect operators from half-baked state. \`clawctl agent sync\` validates \`agent_name\` at the CLI boundary (rejecting path traversal, uppercase, shell metacharacters, etc.) before opening any SSH connection. A new install-presence probe detects missing on-host service-manager artifacts before render — so sync fails fast with a concrete recovery hint instead of writing half-rendered config. Linux sync now probes the gateway TCP port after \`systemctl is-active\` (matching the macOS \`nc -z\` path), so \`synced (drift=0)\` is no longer printed when the gateway port is not accepting connections. Stopped agents whose install is gone are reclassified as \`INSTALL_MISSING\` with a red status pill and reinstall hint.
+Several sync-time guards now protect operators from half-baked state. `clawctl agent sync` validates `agent_name` at the CLI boundary (rejecting path traversal, uppercase, shell metacharacters, etc.) before opening any SSH connection. A new install-presence probe detects missing on-host service-manager artifacts before render — so sync fails fast with a concrete recovery hint instead of writing half-rendered config. Linux sync now probes the gateway TCP port after `systemctl is-active` (matching the macOS `nc -z` path), so `synced (drift=0)` is no longer printed when the gateway port is not accepting connections. Stopped agents whose install is gone are reclassified as `INSTALL_MISSING` with a red status pill and reinstall hint.
 
 ### Upstream pin bumps across all agent types
 
-Hermes bumped from \`2026.5.29.2\` to \`2026.7.1\`, openclaw from \`2026.6.9\` to \`2026.6.11\`, and zeroclaw from \`0.7.5\` to \`0.8.2\`. New platform entries cover Ubuntu 22.04/24.04 (x86_64), macOS ≥14 (arm64), and for zeroclaw also armv7l Debian 13 and aarch64 Ubuntu. \`clawctl agent create\` installs the latest pin; existing instances can opt in via \`clawctl agent upgrade\`.
+Hermes bumped from `2026.5.29.2` to `2026.7.1`, openclaw from `2026.6.9` to `2026.6.11`, and zeroclaw from `0.7.5` to `0.8.2`. New platform entries cover Ubuntu 22.04/24.04 (x86_64), macOS ≥14 (arm64), and for zeroclaw also armv7l Debian 13 and aarch64 Ubuntu. `clawctl agent create` installs the latest pin; existing instances can opt in via `clawctl agent upgrade`.
 
 ### CLI and GUI refinements
 
-The \`clawctl mcp\` placeholder command group has been removed entirely — Slack-backed MCP is now a first-class integration type. The GUI Integrations page renders official vendor SVG brand icons (github, gitlab, atlassian, linear, notion, brave, git) instead of two-letter type badges. The \`/create-vhs\` skill gains \`tape.output_format: gif\` support for screen-recording demos. Hermes config now renders \`model.context_length\` for litellm providers when \`context_window\` is set, and the new \`--context-window N\` flag on \`clawctl provider registry create\|edit\` persists this value.
+The `clawctl mcp` placeholder command group has been removed entirely — Slack-backed MCP is now a first-class integration type. The GUI Integrations page renders official vendor SVG brand icons (github, gitlab, atlassian, linear, notion, brave, git) instead of two-letter type badges. The `/create-vhs` skill gains `tape.output_format: gif` support for screen-recording demos. Hermes config now renders `model.context_length` for litellm providers when `context_window` is set, and the new `--context-window N` flag on `clawctl provider registry create|edit` persists this value.
 
 ## Why
 
@@ -52,11 +52,11 @@ The openclaw renderer consolidation eliminated a three-month class of bugs where
 
 Upgrade to v26.7.0:
 
-\`\`\`bash
+```bash
 uv tool install clawrium@26.7.0
-\`\`\`
+```
 
-**Breaking change note:** if you have openclaw agents with \`config.provider.default_model\` starting with \`bedrock/\`, you must update the prefix to \`amazon-bedrock/\` in \`hosts.json\` before the next sync. See the changelog for details.
+**Breaking change note:** if you have openclaw agents with `config.provider.default_model` starting with `bedrock/`, you must update the prefix to `amazon-bedrock/` in `hosts.json` before the next sync. See the changelog for details.
 
 ## Links
 

--- a/website/blog/2026-07-06-v26.7.0-release.md
+++ b/website/blog/2026-07-06-v26.7.0-release.md
@@ -1,0 +1,66 @@
+---
+slug: v26.7.0-release
+title: "What's new in clawrium v26.7.0"
+authors: [maurice]
+tags: [release-notes]
+date: 2026-07-06
+---
+
+The v26.7.0 release brings Slack MCP integration across all three GA agent types (hermes, openclaw, zeroclaw), completes workspace overlay sync on macOS for the full agent matrix, adds macOS support for \`clawctl agent shell\`, resolves the openclaw canonical-render gap, tightens sync validation and health-checking, and bumps all upstream agent pins to their latest versions.
+
+<!-- truncate -->
+
+## What changed
+
+### Slack MCP integration for hermes, openclaw, and zeroclaw
+
+Slack MCP support is now available for all three GA agent types. The \`slack-user\` (xoxp bearer) and \`slack-cookie\` (xoxc+xoxd) integration types attach a SHA256-pinned \`korotovsky/slack-mcp-server\` subprocess so agents can list channels, read messages, and post via MCP tool calls. Hermes support landed in Phase 1, openclaw in Phase 2, and zeroclaw in Phase 3. Each agent type has its own dedicated sync-time-runbook for binary installation (following the new "Integration Binary Install" architectural pattern), and a CLI attach-time gate rejects unsupported (agent-type, integration-type) pairs before they can corrupt \`hosts.json\`. The Slack MCP toolset name is now pinned to \`slack\` across all surfaces — tools show as \`slack_*\` regardless of the integration name in the registry.
+
+### Workspace overlay sync now GA on macOS for all agent types
+
+Workspace overlay sync — the feature that mirrors operator-dropped files from \`~/.config/clawrium/agents/<type>/<name>/workspace/\` to the agent host on every sync — is now fully functional on macOS for openclaw (Phase 4), zeroclaw (Phase 5), and hermes (Phase 6). Each agent type has its own \`workspace_macos.yaml\` playbook with OS-aware home-root resolution and per-type exclude lists. The complete hermes exclude list (\`config.yaml\`, \`.env\`, \`auth.json\`, \`state.db\` + WAL files, \`sessions/\`, \`logs/\`, \`skills/clawrium/\`) is enforced identically on darwin via the shared \`workspace_excluded\` Jinja filter.
+
+### \`clawctl agent shell\` now works on macOS hosts
+
+The \`clawctl agent shell <name> -- <cmd>\` command now supports macOS hosts. A new \`shell_macos.yaml\` playbook is selected per-OS via the playbook resolver. The kill window uses Homebrew's \`gtimeout\` (coreutils) when available, with the ansible-runner outer timeout as backstop. On darwin, \`~/.bash_profile\` is sourced first to match the macOS login-shell convention.
+
+### Openclaw canonical renderer consolidation
+
+The openclaw \`openclaw.json\` file is now written through a single canonical Python renderer on every code path — install, configure, and sync. The legacy Jinja template (\`openclaw.json.j2\`) has been deleted. This also fixes the litellm provider prefix bug: \`clawctl agent configure\` now correctly emits \`<provider-name>/<model>\` instead of the bare model id, which previously caused \`FailoverError: Unknown model\` errors.
+
+### Stricter sync validation and health verification
+
+Several sync-time guards now protect operators from half-baked state. \`clawctl agent sync\` validates \`agent_name\` at the CLI boundary (rejecting path traversal, uppercase, shell metacharacters, etc.) before opening any SSH connection. A new install-presence probe detects missing on-host service-manager artifacts before render — so sync fails fast with a concrete recovery hint instead of writing half-rendered config. Linux sync now probes the gateway TCP port after \`systemctl is-active\` (matching the macOS \`nc -z\` path), so \`synced (drift=0)\` is no longer printed when the gateway port is not accepting connections. Stopped agents whose install is gone are reclassified as \`INSTALL_MISSING\` with a red status pill and reinstall hint.
+
+### Upstream pin bumps across all agent types
+
+Hermes bumped from \`2026.5.29.2\` to \`2026.7.1\`, openclaw from \`2026.6.9\` to \`2026.6.11\`, and zeroclaw from \`0.7.5\` to \`0.8.2\`. New platform entries cover Ubuntu 22.04/24.04 (x86_64), macOS ≥14 (arm64), and for zeroclaw also armv7l Debian 13 and aarch64 Ubuntu. \`clawctl agent create\` installs the latest pin; existing instances can opt in via \`clawctl agent upgrade\`.
+
+### CLI and GUI refinements
+
+The \`clawctl mcp\` placeholder command group has been removed entirely — Slack-backed MCP is now a first-class integration type. The GUI Integrations page renders official vendor SVG brand icons (github, gitlab, atlassian, linear, notion, brave, git) instead of two-letter type badges. The \`/create-vhs\` skill gains \`tape.output_format: gif\` support for screen-recording demos. Hermes config now renders \`model.context_length\` for litellm providers when \`context_window\` is set, and the new \`--context-window N\` flag on \`clawctl provider registry create\|edit\` persists this value.
+
+## Why
+
+Slack was the highest-requested third-party integration. Splitting it across three phases (hermes → openclaw → zeroclaw) let us validate the sync-time binary-install pattern on each agent type before expanding, and the attach-time gate prevents the same integration-class regression from happening again with future integration types.
+
+Workspace overlay on macOS was the last missing piece of the cross-platform story. Operators running clawrium on Mac Minis could sync agents on Linux hosts for months — darwin support was a gap that made the feature incomplete.
+
+The openclaw renderer consolidation eliminated a three-month class of bugs where the legacy Jinja template diverged from the canonical renderer — litellm prefixing, gateway.auth shape, and version probing were all symptoms of having two renderers doing the same job.
+
+## Try it
+
+Upgrade to v26.7.0:
+
+\`\`\`bash
+uv tool install clawrium@26.7.0
+\`\`\`
+
+**Breaking change note:** if you have openclaw agents with \`config.provider.default_model\` starting with \`bedrock/\`, you must update the prefix to \`amazon-bedrock/\` in \`hosts.json\` before the next sync. See the changelog for details.
+
+## Links
+
+- [GitHub Release](https://github.com/ric03uec/clawrium/releases/tag/v26.7.0)
+- [Full Changelog](https://github.com/ric03uec/clawrium/blob/main/docs/releases/26.7.0/CHANGELOG.md)
+- [Slack integration guide](/docs/agent-support/integrations/slack)
+- [Sync operations guide](/docs/operations/sync)

--- a/website/blog/2026-07-06-v26.7.0-release.md
+++ b/website/blog/2026-07-06-v26.7.0-release.md
@@ -64,3 +64,7 @@ uv tool install clawrium@26.7.0
 - [Full Changelog](https://github.com/ric03uec/clawrium/blob/main/docs/releases/26.7.0/CHANGELOG.md)
 - [Slack integration guide](/docs/agent-support/integrations/slack)
 - [Sync operations guide](/docs/operations/sync)
+
+---
+
+*Drafted by **clawrium-gtm** (agent) running on **qwen3.6-27b** via Hermes Agent.*


### PR DESCRIPTION
Release blog post for clawrium v26.7.0. Covers Slack MCP integration across all agent types, macOS workspace overlay GA, `clawctl agent shell` on macOS, openclaw canonical renderer consolidation, sync validation improvements, and upstream pin bumps.

*Drafted by **clawrium-gtm** (agent) running on **qwen3.6-27b** via Hermes Agent.*
