### PR TITLE
docs: sync website Slack integration support pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,5 @@ cut. The `itx:release` skill archives this section into a new
 - GUI lifecycle endpoints (`start`, `stop`, `restart`) now return HTTP 502 instead of HTTP 200 with `success: false` when the underlying lifecycle operation fails without raising an exception (#712)
 
 ### Documentation
+
+- Synced the website agent-support pages for Hermes, OpenClaw, and ZeroClaw with the shipped Slack integration docs so the release blog's Slack links resolve and the docs site can build again.

--- a/website/docs/agent-support/hermes.md
+++ b/website/docs/agent-support/hermes.md
@@ -68,7 +68,7 @@ Hermes supports three channels managed by clawctl: a loopback OpenAI-compatible 
 | **Log streaming** | ✅ | `journalctl -u hermes-<agent_name>.service` on the agent host |
 | **Onboarding wizard** | ✅ | 4 stages: `providers` (required) → `identity` (auto-skipped) → `channels` (cli, discord, slack) → `validate` |
 | **Identity files (`SOUL.md` / `AGENTS.md`)** | ✅ | Hermes-managed inside `~/.hermes/`. The identity onboarding stage auto-skips (by design — hermes owns these). `SOUL.md` is reachable via `clawctl agent memory read/write/info` (routed to `~/.hermes/SOUL.md`). |
-| **MCP server registration** | ✅ | Supported for `atlassian` integrations — hermes launches `uvx --from mcp-atlassian==<pinned> mcp-atlassian` as a subprocess and exposes Jira + Confluence tools. See [Atlassian integration](integrations/atlassian.md). |
+| **MCP server registration** | ✅ | Supported for `atlassian` and `slack-user` / `slack-cookie` integrations — hermes launches each as a stdio subprocess and exposes their tools. See [Atlassian integration](integrations/atlassian.md) and [Slack integration](integrations/slack.md). |
 | **`~/.hermes/state.db` (session/transcript history)** | 📋 | Out of scope for memory CLI |
 | **OAuth / webhook secrets** | 📋 | Deferred |
 
@@ -384,6 +384,30 @@ sudo userdel -r <agent-name>
 Then re-run `clawctl agent delete <name> --force`.
 
 </details>
+
+---
+
+## Slack integration
+
+Hermes agents can attach the [Slack integration](integrations/slack.md) (`--type slack-user` recommended, `--type slack-cookie` discouraged fallback) to gain outbound Slack tool calls via the [`korotovsky/slack-mcp-server`](https://github.com/korotovsky/slack-mcp-server) stdio subprocess. See the [Slack integration doc](integrations/slack.md) for the full token acquisition, security posture, and end-to-end walkthrough.
+
+Hermes-specific details:
+
+- **Config surface:** the Slack MCP subprocess is rendered into the `mcp_servers:` block of `~/.hermes/config.yaml` (mode 0600), adjacent to the atlassian branch. Renderer: [`src/clawrium/core/render.py:render_hermes`](https://github.com/ric03uec/clawrium/blob/main/src/clawrium/core/render.py). The subprocess env block carries the `SLACK_MCP_XOX*` tokens verbatim; no separate `.env` write path.
+- **Binary install location:** `~/<agent-name>/.local/bin/slack-mcp-server` — same path pattern as the atlassian `uvx` binary, but Slack ships as a single Go binary so there is no Python runtime dependency.
+- **First MCP subprocess on Darwin.** Slack is the first MCP subprocess supported on Darwin hermes (atlassian macOS was deferred). `clawctl agent sync` installs the darwin arm64 / x86_64 tarball via the dedicated `install_slack_mcp_macos.yaml` runbook. The `workspace_excluded` invariants and `no_log: true` render behavior apply identically on Linux and macOS.
+- **Composite blast-radius warning applies.** Attaching both the Slack **channel** (inbound, see [Slack channel](channels/slack.md)) and the Slack **integration** (outbound) to the same hermes agent enables a prompt-injection tool-call exfiltration path. See [integrations/slack.md → Composite blast-radius warning](integrations/slack.md#composite-blast-radius-warning) — for high-sensitivity workspaces, split inbound and outbound into two separate hermes agents.
+
+Quick attach + sync:
+
+```bash
+printf 'SLACK_MCP_XOXP_TOKEN=xoxp-...' | \
+  clawctl integration registry create slack --type slack-user --credential-stdin
+clawctl agent integration attach <hermes-name> --integration slack
+clawctl agent sync <hermes-name>
+```
+
+Then `clawctl agent chat <hermes-name>` — the model gains `channels_list`, `conversations_history`, `conversations_add_message`, `conversations_search_messages`, and `conversations_replies` under the `mcp_my_slack_*` prefix.
 
 ---
 

--- a/website/docs/agent-support/openclaw.md
+++ b/website/docs/agent-support/openclaw.md
@@ -71,6 +71,7 @@ Integrations allow the agent to interact with external tools and services:
 | Integration | Status | Configuration | Use Case |
 |-------------|:------:|---------------|----------|
 | **[Atlassian (Jira + Confluence)](integrations/atlassian.md)** | ✅ | Single API token covers both Jira and Confluence | Issue tracking, docs / knowledge base |
+| **[Slack (MCP tool integration)](integrations/slack.md)** | ✅ | `slack-user` (xoxp; recommended) or `slack-cookie` (xoxc + xoxd; fragile fallback) | Outbound Slack tool calls via [`korotovsky/slack-mcp-server`](https://github.com/korotovsky/slack-mcp-server) stdio subprocess |
 | **[GitHub](integrations/github.md)** | 🚧 | [Milestone SEA](integrations/github.md) | PR reviews, issues |
 | **[GitLab](integrations/gitlab.md)** | 📋 | [Not Planned](integrations/gitlab.md) | PRs welcome |
 | **[Linear](integrations/linear.md)** | 📋 | [Not Planned](integrations/linear.md) | PRs welcome |
@@ -86,7 +87,7 @@ Integrations allow the agent to interact with external tools and services:
 | **Multi-Provider** | ✅ | Switch providers per request |
 | **Secrets Management** | ✅ | Per-instance secret storage |
 | **Token Tracking** | 🚧 | Coming Q2 2026 |
-| **MCP Tools** | 🚧 | Coming Q2 2026 |
+| **MCP Tools** | ✅ | Slack MCP tools are supported via the [Slack integration](integrations/slack.md); additional MCP-backed integrations remain incremental. |
 | **Auto-Restart** | ✅ | Supervisor-managed |
 | **Log Streaming** | ✅ | Real-time log access |
 | **Onboarding Wizard** | ✅ | Guided 4-stage setup |
@@ -123,6 +124,30 @@ clawctl agent start my-assistant
 
 ```bash
 clawctl agent chat my-assistant
+```
+
+---
+
+## Slack integration
+
+OpenClaw agents can attach the [Slack integration](integrations/slack.md) (`--type slack-user` recommended, `--type slack-cookie` discouraged fallback) — the outbound Slack tool surface backed by [`korotovsky/slack-mcp-server`](https://github.com/korotovsky/slack-mcp-server). See the [Slack integration doc](integrations/slack.md) for token acquisition, security posture, and the full walkthrough.
+
+OpenClaw-specific details:
+
+- **Config surface:** the Slack MCP subprocess is rendered into `mcp.servers.<slug>` of `~/.openclaw/openclaw.json` on the agent host. Renderer: [`_render_openclaw_json`](https://github.com/ric03uec/clawrium/blob/main/src/clawrium/core/render.py) in `src/clawrium/core/render.py`.
+- **Conditional emission (byte-lock guarantee):** the top-level `mcp` key is emitted **only** when at least one MCP-emitting integration is attached. OpenClaw agents with no Slack integration render byte-identical to the pre-#835 output — upgrading to this release does **not** touch `openclaw.json` on existing agents.
+- **Binary install location:** `~/<agent-name>/.local/bin/slack-mcp-server` — single-binary Go install, SHA256-pinned per (os, arch). Same source of truth (`playbook_resolver._MCP_SLACK_VERSION` + SHA256 maps) as the hermes install.
+- **macOS support (GA):** `clawctl agent sync` installs the darwin arm64 / x86_64 tarball via the dedicated `install_slack_mcp_macos.yaml` runbook. OpenClaw macOS is GA per #770, so Slack on darwin is a first-class combination.
+- **Attach gate:** attaching a `slack-user` or `slack-cookie` integration to an openclaw agent is accepted by the CLI's attach-time gate (Phase 2 of #499); attempts to attach to unsupported agent types exit 2 with a hint.
+- **Composite blast-radius warning applies** if you attach a future Slack channel + this Slack integration to the same agent. See [integrations/slack.md → Composite blast-radius warning](integrations/slack.md#composite-blast-radius-warning). (Slack **channel** on openclaw is on the SEA milestone; today only the Slack **integration** is attachable on openclaw, so the composite risk is future-only for openclaw.)
+
+Quick attach + sync:
+
+```bash
+printf 'SLACK_MCP_XOXP_TOKEN=xoxp-...' | \
+  clawctl integration registry create slack --type slack-user --credential-stdin
+clawctl agent integration attach <openclaw-name> --integration slack
+clawctl agent sync <openclaw-name>
 ```
 
 ---

--- a/website/docs/agent-support/zeroclaw.md
+++ b/website/docs/agent-support/zeroclaw.md
@@ -4,7 +4,7 @@ ZeroClaw is the [ZeroClaw Labs Rust agent runtime](https://github.com/zeroclaw-l
 
 **Status:** 🚧 In Development
 
-**Best for:** Low-resource hosts (Raspberry Pi 2/3 armv7l, aarch64 SBCs, small x86_64 servers) that need a minimal, single-binary AI agent with file-based personality and a LAN-reachable chat endpoint. ZeroClaw is intentionally narrower than [Hermes](hermes.md) (no OpenAI-compatible HTTP, no MCP integrations) and narrower than [OpenClaw](openclaw.md) (no Discord/web channels).
+**Best for:** Low-resource hosts (Raspberry Pi 2/3 armv7l, aarch64 SBCs, small x86_64 servers) that need a minimal, single-binary AI agent with file-based personality, optional MCP-backed integrations, and a LAN-reachable chat endpoint. ZeroClaw is intentionally narrower than [Hermes](hermes.md) (no OpenAI-compatible HTTP) and narrower than [OpenClaw](openclaw.md) (no Discord/web channels).
 
 **Pinned version:** `v0.7.5`. The release tarball SHA256 is pinned per architecture in `src/clawrium/platform/registry/zeroclaw/manifest.yaml` for five `(os, os_version, arch)` combinations; every version bump requires re-pinning all five.
 
@@ -65,7 +65,7 @@ ZeroClaw's only chat surface is the daemon's own WebSocket endpoint at `GET /ws/
 | **`clawctl agent chat <zeroclaw-name>`** | ✅ | Connects to `ws://<host>:42617/ws/chat` with `Authorization: Bearer <paired-token>`. See [Use the WebSocket chat surface](#3-use-the-websocket-chat-surface). |
 | **OpenAI-compatible HTTP API** | ❌ | Not exposed by upstream ZeroClaw. Use [Hermes](hermes.md) when an OpenAI-style HTTP endpoint is required. |
 | **[Discord](channels/discord.md)** | ✅ | Native — rendered as `[channels.discord]` in `config.toml`. Bot token is **inline TOML**, not env-based (differs from hermes). Schema follows zeroclaw v0.7.5 upstream: `bot_token`, `allowed_guilds`, `allowed_users`, `reply_to_mentions_only`, `draft_update_interval_ms`. Configure via `clawctl agent configure <name> --stage channels`. |
-| **Slack** | ❌ | Not supported (use [OpenClaw](openclaw.md) or [Hermes](hermes.md)). Tracked as a follow-up. |
+| **Slack channel** | ❌ | Not supported (use [OpenClaw](openclaw.md) or [Hermes](hermes.md) for inbound Slack). Tracked as a follow-up. |
 | **Web / WhatsApp / Telegram / Email / Matrix** | ❌ | Not supported. |
 
 ---
@@ -86,6 +86,7 @@ ZeroClaw's only chat surface is the daemon's own WebSocket endpoint at `GET /ws/
 | **Personality block in `config.toml`** | ✅ | `[personality]` with `name`, `timezone`, `communication_style` defaults; rendered with `force: no` semantics through Ansible's template default — re-running configure preserves the file because `notify` only fires when content actually changes. |
 | **Bootstrap file (`BOOTSTRAP.md`)** | ✅ | **Not rendered by clawctl.** The ZeroClaw daemon generates `BOOTSTRAP.md` on first boot and self-deletes it after use. Never appears in `clawctl agent memory get --agent`. |
 | **[GitHub integration](integrations/github.md)** | ✅ | Two-layer wiring (#422): tokens land in a systemd drop-in (`/etc/systemd/system/zeroclaw-<name>.service.d/10-zeroclaw-env.conf`) so the daemon's environment has `GITHUB_TOKEN`, AND in `[autonomy] shell_env_passthrough` in `config.toml` so the agent's shell tool can actually see them (required: zeroclaw auto-strips `_TOKEN`-pattern vars unless explicitly allow-listed). `gh auth login --with-token` runs as a soft-dep convenience when `gh` is on the host. |
+| **[Slack integration](integrations/slack.md)** | ✅ | Outbound Slack tool surface via `korotovsky/slack-mcp-server` stdio subprocess. `slack-user` (xoxp) recommended; `slack-cookie` (xoxc + xoxd) discouraged fallback. Rendered as `[[mcp.servers]]` array-of-tables in `~/.zeroclaw/config.toml`. **armv7l coverage gap**: upstream ships no armv7 asset at v1.3.0 — Raspberry Pi 2/3 hosts cannot install this integration. See [Slack integration → Binary distribution](integrations/slack.md#binary-distribution). |
 | **Jira / GitLab / Linear / Notion integrations** | 📋 | Deferred. No native consumer in zeroclaw v0.7.5; would require either a `[mcp.servers]` block (potential future path) or per-integration env passthrough. Tracked as a follow-up. |
 | **Hardware support (GPIO / serial / debug probes)** | 📋 | Deferred. |
 | **Tunnel providers (Cloudflare / Tailscale / Ngrok / custom)** | 📋 | Deferred. Reach the gateway over your own SSH tunnel or LAN. |
@@ -144,7 +145,7 @@ The wizard walks through:
 |-------|----------|
 | **providers** | Required. Pick from your registered clawctl providers; clawctl validates connectivity via `provider_test`. |
 | **identity** | Auto-skipped. ZeroClaw manages its own identity through the workspace MD files (`SOUL.md`, `IDENTITY.md`, …) which clawctl renders below — there is no separate identity wizard. |
-| **channels** | Required. ZeroClaw confirms the always-on CLI channel and offers a `discord` opt-in. Selecting `discord` prompts for the bot token (persists to `secrets.json` as `DISCORD_BOT_TOKEN`) plus optional allowlists; clawctl renders the result as `[channels.discord]` in `~/.zeroclaw/config.toml`. Slack remains unsupported on ZeroClaw — use [Hermes](hermes.md) or [OpenClaw](openclaw.md) for Slack. |
+| **channels** | Required. ZeroClaw confirms the always-on CLI channel and offers a `discord` opt-in. Selecting `discord` prompts for the bot token (persists to `secrets.json` as `DISCORD_BOT_TOKEN`) plus optional allowlists; clawctl renders the result as `[channels.discord]` in `~/.zeroclaw/config.toml`. Slack **channel** remains unsupported on ZeroClaw — use [Hermes](hermes.md) or [OpenClaw](openclaw.md) for inbound Slack. |
 | **validate** | Local validation only, three steps for zeroclaw: (1) agent install record, (2) provider config + API key, (3) provider connectivity. The control-machine SOUL.md check is skipped — zeroclaw owns its identity through `~/.zeroclaw/workspace/` on the agent host, not under `~/.config/clawrium/agents/zeroclaw/`. The playbook's own post-render readiness probe (`GET /health/providers`) is separate from this stage. The manifest's `binary_check` task (`zeroclaw --version`) is not dispatched yet — remote version verification is planned. |
 
 Configure renders TWO things on the agent host, then runs the pairing handshake against the freshly started daemon.
@@ -404,11 +405,36 @@ The render is idempotent (force: no), so this is safe to run against a partially
 
 ---
 
+## Slack integration
+
+ZeroClaw agents can attach the [Slack integration](integrations/slack.md) (`--type slack-user` recommended, `--type slack-cookie` discouraged fallback) — the outbound Slack tool surface backed by [`korotovsky/slack-mcp-server`](https://github.com/korotovsky/slack-mcp-server). See the [Slack integration doc](integrations/slack.md) for token acquisition, security posture, and the full walkthrough.
+
+ZeroClaw-specific details:
+
+- **Config surface:** the Slack MCP subprocess is rendered as `[[mcp.servers]]` array-of-tables in `~/.zeroclaw/config.toml` (mode 0600). Renderer: [`render_zeroclaw`](https://github.com/ric03uec/clawrium/blob/main/src/clawrium/core/render.py) in `src/clawrium/core/render.py`.
+- **Conditional emission (byte-lock guarantee):** the `[[mcp.servers]]` blocks are emitted **only** when at least one Slack integration is attached, and `[mcp].enabled` flips to `true` in the same conditional. ZeroClaw agents with no Slack integration render the byte-locked `[mcp]` block with `deferred_loading = true`, `enabled = false`, and **no `servers` key at all** — this preserves TOML validity (the previous inline `servers = []` was incompatible with `[[mcp.servers]]` array-of-tables; see Phase 3 of #499).
+- **Bearer-rotation ordering (#437 guard):** on every `clawctl agent sync`, Slack render + hydration completes **before** `_zeroclaw_repair_after_start` rotates the gateway bearer. A render-time hydration failure short-circuits the sync with **zero** `gateway_token_rotated` events — the daemon is never left holding a stale bearer against a fresh `hosts.json.gateway.auth`. Remote `clawctl agent chat` sessions still get a clean 401 on the next request after a successful sync and must reconnect; that is unchanged.
+- **armv7l coverage gap.** Upstream `korotovsky/slack-mcp-server` publishes no armv7 asset at v1.3.0. Raspberry Pi 2/3 hosts (the primary armv7l ZeroClaw targets) **cannot install this integration** — the dedicated sync-time `install_slack_mcp.yaml` runbook's arch-guard task fails fast with a pointer at the upstream release page. Real-host UAT for the Phase 3 release ran on wolf-i x86_64; armv7l coverage is tracked as a follow-up. Linux aarch64 (e.g. Raspberry Pi 4/5, ARM cloud instances) and Linux x86_64 both ship upstream.
+- **Attach gate:** attaching a `slack-user` or `slack-cookie` integration to a zeroclaw agent is accepted by the CLI's attach-time gate (Phase 3 of #499).
+- **Composite blast-radius warning:** ZeroClaw does not support the Slack **channel** (inbound) today — see the Channel Support table above. As a result, the composite prompt-injection risk documented in [integrations/slack.md → Composite blast-radius warning](integrations/slack.md#composite-blast-radius-warning) does not apply to zeroclaw in this iteration.
+
+Quick attach + sync (Linux x86_64 / aarch64 hosts):
+
+```bash
+printf 'SLACK_MCP_XOXP_TOKEN=xoxp-...' | \
+  clawctl integration registry create slack --type slack-user --credential-stdin
+clawctl agent integration attach <zeroclaw-name> --integration slack
+clawctl agent sync <zeroclaw-name>
+```
+
+---
+
 ## Deferred items / follow-ups
 
 The following are explicitly out of scope for issue #112 and tracked as separate follow-ups:
 
-- **Non-GitHub integrations** — GitLab, Atlassian (Jira + Confluence), Linear, Notion. Tracked as follow-ups; the upstream `[mcp.servers]` block is the most likely landing pad. GitHub is supported as of #422 — see the Feature Support table above.
+- **Non-GitHub integrations** — GitLab, Atlassian (Jira + Confluence), Linear, Notion. Tracked as follow-ups; the upstream `[mcp.servers]` block is the most likely landing pad. GitHub is supported as of #422 and Slack is supported as of #836 — see the Feature Support table above.
+- **`slack-mcp-server` armv7l asset** — upstream ships no armv7 tarball at v1.3.0, so Raspberry Pi 2/3 hosts cannot install the Slack integration. Tracked in the #499 follow-up chain.
 - **Hardware** — GPIO, serial, debug-probe support.
 - **Tunnel providers** — Cloudflare Tunnel, Tailscale, Ngrok, custom tunnels. Use SSH tunneling in the meantime.
 - **Encrypted secrets** — ChaCha20-Poly1305 secret encryption is upstream-only for now.


### PR DESCRIPTION
## Summary
- sync the website copies of the Hermes, OpenClaw, and ZeroClaw support pages with the shipped Slack integration docs
- restore the `#slack-integration` anchor targets referenced by the Slack integration page and release blog
- document the website docs sync in the unreleased changelog

## Testing
- `npm run build` (in `website/`)

## Reviewer Notes
- This fixes the broken Docusaurus build that was blocking GitHub Pages from publishing the already-merged `v26.7.0` release blog.
- The repo has `mcp.review_enabled = true`, but the ATX MCP review tool was not exposed in this session. I used the available `code-reviewer` agent as a fallback, fixed its blocking findings, and then did a final manual diff review before opening this PR.
