### PR TITLE
fix(gui): replace regex error sanitization with constant messages (#714)

### DIFF
--- a/.itx/714/00_PLAN.md
+++ b/.itx/714/00_PLAN.md
@@ -1,0 +1,79 @@
+# Issue #714 — Execution Plan
+
+## Title
+[security] Pairing/tunnel error responses leak internal hostnames+ports (ATX W2)
+
+## Problem
+`_ABS_PATH_RE` in `src/clawrium/gui/routes/fleet.py:78` only strips POSIX absolute paths. SSH stderr fragments (e.g. `ssh: connect to host 192.168.1.42 port 22: Connection refused`) and hostnames/ports pass through verbatim into the HTTP response body, leaking internal network topology.
+
+## Affected Code — Two Leak Points
+
+Both are `TunnelError` handlers in `fleet.py` that use `_ABS_PATH_RE.sub("<path>", str(e))`:
+
+1. **`agent_web_ui` (line ~483-488)** — `/fleet/agents/{key}/web-ui` endpoint
+   - Returns `"reason": _ABS_PATH_RE.sub("<path>", str(e))`
+   - The regex `(?:/[\w.\-]+)+` matches POSIX paths but misses IP addresses, hostnames, port numbers
+
+2. **`agent_pairing_code` (line ~600-602)** — `/fleet/agents/{key}/pairing-code` endpoint
+   - Raises `HTTPException(status_code=502, detail=_ABS_PATH_RE.sub("<path>", str(e)))`
+   - Same regex weakness
+
+## Existing Pattern to Follow
+The generic `Exception` handlers at lines 493 and 611 already do this correctly — they log the full error server-side and return a constant string. The `TunnelError` handlers should match this pattern.
+
+## Fix
+
+Replace the `_ABS_PATH_RE.sub()` calls in both `TunnelError` handlers with constant error messages:
+
+### Leak Point 1: `agent_web_ui` (web-ui tunnel)
+```python
+except web_ui_tunnel.TunnelError as e:
+    logger.warning("web-ui tunnel failed for %s: %s", agent_key, e)
+    return {
+        "available": False,
+        "local_url": None,
+        "reason": "Tunnel could not be established. Check server logs for details.",
+    }
+```
+
+### Leak Point 2: `agent_pairing_code` (pairing-code tunnel)
+```python
+except web_ui_tunnel.TunnelError as e:
+    logger.warning("pairing-code tunnel failed for %s: %s", agent_key, e)
+    raise HTTPException(
+        status_code=502,
+        detail="Tunnel could not be established. Check server logs for details.",
+    ) from e
+```
+
+## Test Changes
+
+### Existing tests that ASSERT the raw error appears (must be updated):
+
+1. **`test_web_ui_reports_tunnel_failure_as_unavailable`** (line ~160 in test file)
+   - Currently asserts `"ssh failed" in body["reason"]` — **this is the bug**
+   - Must change to assert the constant string and that raw error is NOT present
+
+2. **`test_pairing_code_502_on_tunnel_failure`** (line ~340 in test file)
+   - Currently asserts `"ssh refused" in resp.json()["detail"]` — **this is the bug**
+   - Must change to assert the constant string and that raw error is NOT present
+
+### New tests to add:
+- Test with realistic SSH stderr (IP addresses, hostnames, ports) to confirm none of it leaks
+
+## Files to Change
+
+| File | Changes |
+|------|---------|
+| `src/clawrium/gui/routes/fleet.py` | Two `TunnelError` handler edits (lines ~483-488, ~600-602) |
+| `tests/test_gui_routes_fleet.py` | Update 2 existing tests + add 1-2 new tests for realistic SSH stderr |
+| `CHANGELOG.md` | Add entry under `### Fixed` |
+
+## Acceptance Criteria (from issue)
+
+- [ ] No SSH stderr / raw exception text reaches the HTTP response body for pairing/tunnel/lifecycle routes
+- [ ] Server-side log retains the full detail for operator debugging
+- [ ] Tests assert the response detail is a constant string, not interpolated from server-side state
+
+## Scope
+Small, focused change — two error handler edits + test updates. No architectural risk. Low severity bug but security-adjacent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ cut. The `itx:release` skill archives this section into a new
 ### Fixed
 
 - GUI lifecycle endpoints (`start`, `stop`, `restart`) now return HTTP 502 instead of HTTP 200 with `success: false` when the underlying lifecycle operation fails without raising an exception (#712)
+- GUI error responses for tunnel, lifecycle, and health endpoints now return constant error messages instead of passing raw error text through a weak path-redaction regex, preventing leakage of internal hostnames, IP addresses, and ports (#714)
 
 ### Documentation
 

--- a/src/clawrium/gui/routes/fleet.py
+++ b/src/clawrium/gui/routes/fleet.py
@@ -7,7 +7,6 @@ async-safe thread offloading for SSH-based health checks.
 
 import asyncio
 import logging
-import re
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
@@ -72,12 +71,6 @@ def _get_fleet_health_executor() -> ThreadPoolExecutor:
         )
     return _FLEET_HEALTH_EXECUTOR
 
-# Strip absolute filesystem paths from error strings before sending them
-# to the browser. Some `HealthResult.error` strings constructed inside
-# `core/health.py` interpolate `str(e)` from filesystem exceptions and
-# include the user's config path (e.g. ~/.config/clawrium/secrets.json).
-_ABS_PATH_RE = re.compile(r"(?:/[\w.\-]+)+")
-
 # Generic error message for lifecycle operations to avoid path leakage
 _LIFECYCLE_GENERIC_ERROR = "Lifecycle operation failed. Check server logs."
 
@@ -103,12 +96,6 @@ def _host_is_local(host: str) -> bool:
         return False
 
 
-def _sanitize_health_error(error: str | None) -> str | None:
-    if not error:
-        return error
-    return _ABS_PATH_RE.sub("<path>", error)
-
-
 def _agent_to_dict(agent: AgentViewModel) -> dict[str, Any]:
     # gateway_auth is a bearer token and must not be sent to the browser.
     # Both chat proxies (hermes + openclaw) resolve it from the secrets store
@@ -129,7 +116,7 @@ def _agent_to_dict(agent: AgentViewModel) -> dict[str, Any]:
         "missing_secrets": agent["missing_secrets"],
         "onboarding_step": agent["onboarding_step"],
         "process_running": agent["process_running"],
-        "health_error": _sanitize_health_error(agent["health_error"]),
+        "health_error": "Health check failed — see server logs." if agent.get("health_error") else None,
         "addresses": agent["addresses"],
         "provider": agent["provider"],
         "provider_type": agent["provider_type"],
@@ -192,7 +179,7 @@ async def fleet_health(host: str | None = None):
                 "agent_key": a["agent_key"],
                 "status": status.value if isinstance(status, ClawStatus) else status,
                 "process_running": a["process_running"],
-                "health_error": _sanitize_health_error(a["health_error"]),
+                "health_error": "Health check failed — see server logs." if a.get("health_error") else None,
                 "cpu_count": a["cpu_count"],
                 "memory_total_mb": a["memory_total_mb"],
                 "missing_secrets": a["missing_secrets"],
@@ -312,7 +299,7 @@ async def agent_health(agent_key: str, host: str | None = None):
         "agent_key": detail["agent_key"],
         "status": status.value if isinstance(status, ClawStatus) else status,
         "process_running": detail["process_running"],
-        "health_error": _sanitize_health_error(detail["health_error"]),
+        "health_error": "Health check failed — see server logs." if detail.get("health_error") else None,
         "cpu_count": detail["cpu_count"],
         "memory_total_mb": detail["memory_total_mb"],
         "missing_secrets": detail["missing_secrets"],
@@ -337,10 +324,10 @@ async def start_agent_endpoint(agent_key: str):
             agent_name=agent_key,
         )
     except LifecycleError as e:
-        logger.error("start_agent failed for %s: %s", agent_key, e, exc_info=True)
-        raise HTTPException(status_code=500, detail=_sanitize_health_error(str(e)))
-    except Exception as e:
-        logger.error("start_agent failed for %s: %s", agent_key, e, exc_info=True)
+        logger.error("start_agent failed for %s", agent_key, exc_info=True)
+        raise HTTPException(status_code=500, detail=_LIFECYCLE_GENERIC_ERROR) from e
+    except Exception:
+        logger.error("start_agent failed for %s", agent_key, exc_info=True)
         raise HTTPException(status_code=500, detail=_LIFECYCLE_GENERIC_ERROR)
 
     if not result.get("success"):
@@ -351,13 +338,12 @@ async def start_agent_endpoint(agent_key: str):
         )
         raise HTTPException(
             status_code=502,
-            detail=_sanitize_health_error(result.get("error")) or _LIFECYCLE_GENERIC_ERROR,
+            detail=_LIFECYCLE_GENERIC_ERROR,
         )
     return {
         "success": result["success"],
         "operation": "start",
         "agent": agent_key,
-        "error": result.get("error"),
     }
 
 
@@ -377,10 +363,10 @@ async def stop_agent_endpoint(agent_key: str):
             agent_name=agent_key,
         )
     except LifecycleError as e:
-        logger.error("stop_agent failed for %s: %s", agent_key, e, exc_info=True)
-        raise HTTPException(status_code=500, detail=_sanitize_health_error(str(e)))
-    except Exception as e:
-        logger.error("stop_agent failed for %s: %s", agent_key, e, exc_info=True)
+        logger.error("stop_agent failed for %s", agent_key, exc_info=True)
+        raise HTTPException(status_code=500, detail=_LIFECYCLE_GENERIC_ERROR) from e
+    except Exception:
+        logger.error("stop_agent failed for %s", agent_key, exc_info=True)
         raise HTTPException(status_code=500, detail=_LIFECYCLE_GENERIC_ERROR)
 
     if not result.get("success"):
@@ -391,13 +377,12 @@ async def stop_agent_endpoint(agent_key: str):
         )
         raise HTTPException(
             status_code=502,
-            detail=_sanitize_health_error(result.get("error")) or _LIFECYCLE_GENERIC_ERROR,
+            detail=_LIFECYCLE_GENERIC_ERROR,
         )
     return {
         "success": result["success"],
         "operation": "stop",
         "agent": agent_key,
-        "error": result.get("error"),
     }
 
 
@@ -417,10 +402,10 @@ async def restart_agent_endpoint(agent_key: str):
             agent_name=agent_key,
         )
     except LifecycleError as e:
-        logger.error("restart_agent failed for %s: %s", agent_key, e, exc_info=True)
-        raise HTTPException(status_code=500, detail=_sanitize_health_error(str(e)))
-    except Exception as e:
-        logger.error("restart_agent failed for %s: %s", agent_key, e, exc_info=True)
+        logger.error("restart_agent failed for %s", agent_key, exc_info=True)
+        raise HTTPException(status_code=500, detail=_LIFECYCLE_GENERIC_ERROR) from e
+    except Exception:
+        logger.error("restart_agent failed for %s", agent_key, exc_info=True)
         raise HTTPException(status_code=500, detail=_LIFECYCLE_GENERIC_ERROR)
 
     if not result.get("success"):
@@ -431,13 +416,12 @@ async def restart_agent_endpoint(agent_key: str):
         )
         raise HTTPException(
             status_code=502,
-            detail=_sanitize_health_error(result.get("error")) or _LIFECYCLE_GENERIC_ERROR,
+            detail=_LIFECYCLE_GENERIC_ERROR,
         )
     return {
         "success": result["success"],
         "operation": "restart",
         "agent": agent_key,
-        "error": result.get("error"),
     }
 
 
@@ -476,15 +460,12 @@ async def agent_web_ui(agent_key: str) -> dict[str, Any]:
 
     try:
         local_port = await asyncio.to_thread(web_ui_tunnel.ensure, agent_key)
-    except web_ui_tunnel.TunnelError as e:
-        logger.warning("web-ui tunnel failed for %s: %s", agent_key, e)
-        # TunnelError messages may contain ssh stderr that includes
-        # filesystem paths; reuse the existing path-redaction regex so
-        # nothing internal leaks to the browser body.
+    except web_ui_tunnel.TunnelError:
+        logger.warning("web-ui tunnel failed for %s", agent_key, exc_info=True)
         return {
             "available": False,
             "local_url": None,
-            "reason": _ABS_PATH_RE.sub("<path>", str(e)),
+            "reason": "Tunnel could not be established. Check server logs for details.",
         }
     except Exception:  # noqa: BLE001 — log full trace, return generic message
         logger.error("web-ui tunnel unexpected error for %s", agent_key, exc_info=True)
@@ -595,10 +576,10 @@ async def agent_pairing_code(agent_key: str) -> dict[str, Any]:
         try:
             local_port = await asyncio.to_thread(web_ui_tunnel.ensure, agent_key)
         except web_ui_tunnel.TunnelError as e:
-            logger.warning("pairing-code tunnel failed for %s: %s", agent_key, e)
+            logger.warning("pairing-code tunnel failed for %s", agent_key, exc_info=True)
             raise HTTPException(
                 status_code=502,
-                detail=_ABS_PATH_RE.sub("<path>", str(e)),
+                detail="Tunnel could not be established. Check server logs for details.",
             ) from e
         except Exception as e:  # noqa: BLE001 — log full trace, generic body
             logger.error(
@@ -631,7 +612,7 @@ async def agent_pairing_code(agent_key: str) -> dict[str, Any]:
             ),
         ) from e
     except httpx.HTTPError as e:
-        logger.warning("pairing-code upstream error for %s: %s", agent_key, e)
+        logger.warning("pairing-code upstream error for %s", agent_key, exc_info=True)
         raise HTTPException(
             status_code=502,
             detail="Could not reach the agent daemon to mint a pairing code.",

--- a/tests/test_gui_agent_detail_split.py
+++ b/tests/test_gui_agent_detail_split.py
@@ -161,7 +161,8 @@ def test_health_endpoint_returns_degraded_on_probe_exception(isolated_config: Pa
             resp = client.get("/api/fleet/agents/demo/health")
     assert resp.status_code == 200, resp.text
     body = resp.json()
-    assert body["health_error"] == "ssh probe timed out"
+    assert body["health_error"] == "Health check failed — see server logs."
+    assert "ssh probe timed out" not in body["health_error"]
     assert body["process_running"] is None
     assert body["cpu_count"] is None
     assert body["memory_total_mb"] is None

--- a/tests/test_gui_fleet_health.py
+++ b/tests/test_gui_fleet_health.py
@@ -402,30 +402,12 @@ class TestFleetHealthEndpoint:
         result = asyncio.run(fleet_mod.fleet_health(host=None))
         agent_health = result["agents"][0]
         assert agent_health["status"] == "stopped"
-        assert agent_health["health_error"] == "Connection refused"
-        assert agent_health["missing_secrets"] == ["OPENAI_API_KEY"]
+        assert agent_health["health_error"] == "Health check failed — see server logs."
+        assert "Connection refused" not in agent_health["health_error"]
         # Verify non-health fields are NOT in the response
         assert "model" not in agent_health
         assert "uptime" not in agent_health
         assert "host_alias" not in agent_health
-
-
-class TestSanitizeHealthError:
-    """The /fleet/health wire response must strip filesystem paths."""
-
-    def test_strips_absolute_path_from_health_error(self, monkeypatch):
-        from clawrium.gui.routes.fleet import _sanitize_health_error
-
-        msg = "Secrets file corrupted: /home/devashish/.config/clawrium/secrets.json is not a dict"
-        sanitized = _sanitize_health_error(msg)
-        assert "/home/devashish" not in sanitized
-        assert "<path>" in sanitized
-
-    def test_none_and_empty_pass_through(self):
-        from clawrium.gui.routes.fleet import _sanitize_health_error
-
-        assert _sanitize_health_error(None) is None
-        assert _sanitize_health_error("") == ""
 
     def test_strips_path_in_fleet_health_response(self, monkeypatch):
         agents = [
@@ -462,5 +444,6 @@ class TestSanitizeHealthError:
         )
 
         result = asyncio.run(fleet_mod.fleet_health(host=None))
+        # (#714) health_error now returns a constant string, never raw error text
+        assert result["agents"][0]["health_error"] == "Health check failed — see server logs."
         assert "/home/devashish" not in result["agents"][0]["health_error"]
-        assert "<path>" in result["agents"][0]["health_error"]

--- a/tests/test_gui_fleet_lifecycle.py
+++ b/tests/test_gui_fleet_lifecycle.py
@@ -97,7 +97,9 @@ class TestStartAgentEndpoint:
             await fleet_mod.start_agent_endpoint(agent_key)
 
         assert exc_info.value.status_code == 500
-        assert "SSH connection failed" in exc_info.value.detail
+        # (#714) LifecycleError now returns a constant message
+        assert exc_info.value.detail == fleet_mod._LIFECYCLE_GENERIC_ERROR
+        assert "SSH connection failed" not in exc_info.value.detail
 
     @pytest.mark.anyio
     async def test_start_agent_returns_500_on_unexpected_error(self, monkeypatch):
@@ -153,11 +155,13 @@ class TestStartAgentEndpoint:
             await fleet_mod.start_agent_endpoint(agent_key)
 
         assert exc_info.value.status_code == 502
-        assert "SSH key not found" in exc_info.value.detail
+        # (#714) constant message, never raw error text
+        assert exc_info.value.detail == fleet_mod._LIFECYCLE_GENERIC_ERROR
+        assert "SSH key not found" not in exc_info.value.detail
 
     @pytest.mark.anyio
-    async def test_start_agent_success_false_sanitizes_path(self, monkeypatch):
-        """Error strings with filesystem paths must be sanitized on the 502 path."""
+    async def test_start_agent_success_false_no_path_leak(self, monkeypatch):
+        """(#714) Error strings with filesystem paths must not reach the browser on the 502 path."""
         agent_key = "test-agent"
         hostname = "192.168.1.100"
         agent_type = "zeroclaw"
@@ -181,8 +185,9 @@ class TestStartAgentEndpoint:
             await fleet_mod.start_agent_endpoint(agent_key)
 
         assert exc_info.value.status_code == 502
+        # (#714) constant message, never raw error text
+        assert exc_info.value.detail == fleet_mod._LIFECYCLE_GENERIC_ERROR
         assert "/home/user/.config" not in exc_info.value.detail
-        assert "<path>" in exc_info.value.detail
 
 
 class TestStopAgentEndpoint:
@@ -263,7 +268,9 @@ class TestStopAgentEndpoint:
             await fleet_mod.stop_agent_endpoint(agent_key)
 
         assert exc_info.value.status_code == 500
-        assert "Agent not running" in exc_info.value.detail
+        # (#714) LifecycleError now returns a constant message
+        assert exc_info.value.detail == fleet_mod._LIFECYCLE_GENERIC_ERROR
+        assert "Agent not running" not in exc_info.value.detail
 
     @pytest.mark.anyio
     async def test_stop_agent_returns_500_on_unexpected_error(self, monkeypatch):
@@ -319,11 +326,13 @@ class TestStopAgentEndpoint:
             await fleet_mod.stop_agent_endpoint(agent_key)
 
         assert exc_info.value.status_code == 502
-        assert "Agent not running" in exc_info.value.detail
+        # (#714) constant message, never raw error text
+        assert exc_info.value.detail == fleet_mod._LIFECYCLE_GENERIC_ERROR
+        assert "Agent not running" not in exc_info.value.detail
 
     @pytest.mark.anyio
-    async def test_stop_agent_success_false_sanitizes_path(self, monkeypatch):
-        """Error strings with filesystem paths must be sanitized on the 502 path."""
+    async def test_stop_agent_success_false_no_path_leak(self, monkeypatch):
+        """(#714) Error strings with filesystem paths must not reach the browser on the 502 path."""
         agent_key = "test-agent"
         hostname = "192.168.1.100"
         agent_type = "zeroclaw"
@@ -347,8 +356,9 @@ class TestStopAgentEndpoint:
             await fleet_mod.stop_agent_endpoint(agent_key)
 
         assert exc_info.value.status_code == 502
+        # (#714) constant message, never raw error text
+        assert exc_info.value.detail == fleet_mod._LIFECYCLE_GENERIC_ERROR
         assert "/home/user/.config" not in exc_info.value.detail
-        assert "<path>" in exc_info.value.detail
 
 
 class TestRestartAgentEndpoint:
@@ -418,7 +428,9 @@ class TestRestartAgentEndpoint:
             await fleet_mod.restart_agent_endpoint(agent_key)
 
         assert exc_info.value.status_code == 500
-        assert "Stop failed" in exc_info.value.detail
+        # (#714) LifecycleError now returns a constant message
+        assert exc_info.value.detail == fleet_mod._LIFECYCLE_GENERIC_ERROR
+        assert "Stop failed" not in exc_info.value.detail
 
     @pytest.mark.anyio
     async def test_restart_agent_returns_500_on_unexpected_error(self, monkeypatch):
@@ -490,11 +502,13 @@ class TestRestartAgentEndpoint:
             await fleet_mod.restart_agent_endpoint(agent_key)
 
         assert exc_info.value.status_code == 502
-        assert "Stop failed" in exc_info.value.detail
+        # (#714) constant message, never raw error text
+        assert exc_info.value.detail == fleet_mod._LIFECYCLE_GENERIC_ERROR
+        assert "Stop failed" not in exc_info.value.detail
 
     @pytest.mark.anyio
-    async def test_restart_agent_success_false_sanitizes_path(self, monkeypatch):
-        """Error strings with filesystem paths must be sanitized on the 502 path."""
+    async def test_restart_agent_success_false_no_path_leak(self, monkeypatch):
+        """(#714) Error strings with filesystem paths must not reach the browser on the 502 path."""
         agent_key = "test-agent"
         hostname = "192.168.1.100"
         agent_type = "zeroclaw"
@@ -518,5 +532,7 @@ class TestRestartAgentEndpoint:
             await fleet_mod.restart_agent_endpoint(agent_key)
 
         assert exc_info.value.status_code == 502
+        # (#714) constant message, never raw error text
+        assert exc_info.value.detail == fleet_mod._LIFECYCLE_GENERIC_ERROR
         assert "/home/user/.config" not in exc_info.value.detail
-        assert "<path>" in exc_info.value.detail
+        assert "restart.log" not in exc_info.value.detail

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -201,7 +201,42 @@ def test_web_ui_reports_tunnel_failure_as_unavailable(isolated_config: Path):
     body = resp.json()
     assert body["available"] is False
     assert body["local_url"] is None
-    assert "ssh failed" in body["reason"]
+    # (#714) TunnelError handler must return a constant string, never the raw error
+    assert body["reason"] == "Tunnel could not be established. Check server logs for details."
+    assert "ssh failed" not in body["reason"]
+
+
+def test_web_ui_tunnel_error_no_ssh_stderr_leak(isolated_config: Path):
+    """(#714) Realistic SSH stderr with IP, hostname, port must never reach the response body."""
+    _seed_hosts(isolated_config, "hermes")
+    resolved = ResolvedUI(
+        host="192.168.1.100",
+        remote_port=9119,
+        bind="loopback",
+        ssh_config={"user": "xclm"},
+    )
+    from clawrium.core.web_ui_tunnel import TunnelError
+
+    ssh_stderr = (
+        "ssh: connect to host 10.0.0.42 port 22: Connection refused"
+    )
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=resolved),
+        patch(
+            "clawrium.core.web_ui_tunnel.ensure",
+            side_effect=TunnelError(ssh_stderr),
+        ),
+    ):
+        with TestClient(app) as client:
+            resp = client.get("/api/fleet/agents/demo/web-ui")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["available"] is False
+    assert "10.0.0.42" not in resp.text
+    assert "port 22" not in resp.text
+    assert "Connection refused" not in resp.text
+    assert body["reason"] == "Tunnel could not be established. Check server logs for details."
 
 
 def test_web_ui_returns_unavailable_on_unexpected_tunnel_exception(
@@ -434,8 +469,36 @@ def test_pairing_code_502_on_tunnel_failure(isolated_config: Path):
         with TestClient(app) as client:
             resp = client.post("/api/fleet/agents/demo/pairing-code")
     assert resp.status_code == 502
-    assert "ssh refused" in resp.json()["detail"]
+    # (#714) TunnelError handler must return a constant string, never the raw error
+    assert resp.json()["detail"] == "Tunnel could not be established. Check server logs for details."
+    assert "ssh refused" not in resp.json()["detail"]
     assert "zc_test_bearer" not in resp.text
+
+
+def test_pairing_code_502_on_tunnel_failure_no_ssh_stderr_leak(
+    isolated_config: Path,
+):
+    """(#714) Realistic SSH stderr with IPs, hostnames, ports must never leak."""
+    from clawrium.core.web_ui_tunnel import TunnelError
+
+    ssh_stderr = (
+        "ssh: connect to host 10.0.0.42 port 22: Connection refused"
+    )
+    _seed_hosts(isolated_config, "zeroclaw", _zeroclaw_config())
+    with (
+        patch("clawrium.core.web_ui.resolve", return_value=_zeroclaw_resolved()),
+        patch(
+            "clawrium.core.web_ui_tunnel.ensure",
+            side_effect=TunnelError(ssh_stderr),
+        ),
+    ):
+        with TestClient(app) as client:
+            resp = client.post("/api/fleet/agents/demo/pairing-code")
+    assert resp.status_code == 502
+    assert resp.json()["detail"] == "Tunnel could not be established. Check server logs for details."
+    assert "10.0.0.42" not in resp.text
+    assert "port 22" not in resp.text
+    assert "Connection refused" not in resp.text
 
 
 def test_pairing_code_success(isolated_config: Path):
@@ -1070,7 +1133,7 @@ def test_fleet_health_returns_health_data(isolated_config: Path):
 
 
 def test_fleet_health_sanitizes_path_in_health_error(isolated_config: Path):
-    """_sanitize_health_error regex branch must run when health_error contains a path."""
+    """(#714) health_error now returns a constant string, never raw error text."""
     vm = _agent_vm(health_error="/home/user/.config/clawrium/secrets.json: permission denied")
     with patch(
         "clawrium.gui.routes.fleet.get_fleet_data",
@@ -1080,7 +1143,8 @@ def test_fleet_health_sanitizes_path_in_health_error(isolated_config: Path):
             resp = client.get("/api/fleet/health")
     assert resp.status_code == 200
     agent = resp.json()["agents"][0]
-    assert agent["health_error"] == "<path>: permission denied"
+    assert agent["health_error"] == "Health check failed — see server logs."
+    assert "/home/user/.config" not in resp.text
 
 
 def test_fleet_health_504_on_timeout(isolated_config: Path):
@@ -1293,8 +1357,8 @@ def test_start_agent_success(isolated_config: Path):
     mock_start.assert_called_once_with("192.168.1.100", "hermes", agent_name="demo")
 
 
-def test_start_agent_lifecycle_error_sanitized(isolated_config: Path):
-    """LifecycleError detail must be path-sanitized before reaching the browser (W1)."""
+def test_start_agent_lifecycle_error_uses_safe_message(isolated_config: Path):
+    """(#714) LifecycleError must not leak paths or SSH stderr to the browser."""
     _seed_hosts(isolated_config, "hermes")
     with patch(
         "clawrium.gui.routes.fleet.start_agent",
@@ -1303,8 +1367,8 @@ def test_start_agent_lifecycle_error_sanitized(isolated_config: Path):
         with TestClient(app) as client:
             resp = client.post("/api/agents/demo/start")
     assert resp.status_code == 500
+    assert resp.json()["detail"] == "Lifecycle operation failed. Check server logs."
     assert "/home/user/.config" not in resp.json()["detail"]
-    assert "<path>" in resp.json()["detail"]
 
 
 def test_start_agent_generic_exception_uses_safe_message(isolated_config: Path):
@@ -1329,11 +1393,13 @@ def test_start_agent_returns_502_when_result_success_false(isolated_config: Path
         with TestClient(app) as client:
             resp = client.post("/api/agents/demo/start")
     assert resp.status_code == 502
-    assert "daemon failed to start" in resp.json()["detail"]
+    # (#714) success=False path also returns constant message, never raw error text
+    assert resp.json()["detail"] == "Lifecycle operation failed. Check server logs."
+    assert "daemon failed to start" not in resp.json()["detail"]
 
 
-def test_start_agent_502_sanitizes_path_in_error(isolated_config: Path):
-    """Error with filesystem path gets sanitized on the 502 path (#712)."""
+def test_start_agent_502_no_path_leak(isolated_config: Path):
+    """(#714) Filesystem paths in result.error never reach the browser."""
     _seed_hosts(isolated_config, "hermes")
     with patch(
         "clawrium.gui.routes.fleet.start_agent",
@@ -1345,8 +1411,8 @@ def test_start_agent_502_sanitizes_path_in_error(isolated_config: Path):
         with TestClient(app) as client:
             resp = client.post("/api/agents/demo/start")
     assert resp.status_code == 502
+    assert resp.json()["detail"] == "Lifecycle operation failed. Check server logs."
     assert "/home/user/.config" not in resp.json()["detail"]
-    assert "<path>" in resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------
@@ -1375,7 +1441,8 @@ def test_stop_agent_success(isolated_config: Path):
     mock_stop.assert_called_once_with("192.168.1.100", "hermes", agent_name="demo")
 
 
-def test_stop_agent_lifecycle_error_sanitized(isolated_config: Path):
+def test_stop_agent_lifecycle_error_uses_safe_message(isolated_config: Path):
+    """(#714) LifecycleError must not leak paths or SSH stderr to the browser."""
     _seed_hosts(isolated_config, "hermes")
     with patch(
         "clawrium.gui.routes.fleet.stop_agent",
@@ -1384,8 +1451,8 @@ def test_stop_agent_lifecycle_error_sanitized(isolated_config: Path):
         with TestClient(app) as client:
             resp = client.post("/api/agents/demo/stop")
     assert resp.status_code == 500
+    assert resp.json()["detail"] == "Lifecycle operation failed. Check server logs."
     assert "/home/user/.config" not in resp.json()["detail"]
-    assert "<path>" in resp.json()["detail"]
 
 
 def test_stop_agent_generic_exception_uses_safe_message(isolated_config: Path):
@@ -1410,11 +1477,13 @@ def test_stop_agent_returns_502_when_result_success_false(isolated_config: Path)
         with TestClient(app) as client:
             resp = client.post("/api/agents/demo/stop")
     assert resp.status_code == 502
-    assert "agent not running" in resp.json()["detail"]
+    # (#714) success=False path also returns constant message, never raw error text
+    assert resp.json()["detail"] == "Lifecycle operation failed. Check server logs."
+    assert "agent not running" not in resp.json()["detail"]
 
 
-def test_stop_agent_502_sanitizes_path_in_error(isolated_config: Path):
-    """Error with filesystem path gets sanitized on the 502 path (#712)."""
+def test_stop_agent_502_no_path_leak(isolated_config: Path):
+    """(#714) Filesystem paths in result.error never reach the browser."""
     _seed_hosts(isolated_config, "hermes")
     with patch(
         "clawrium.gui.routes.fleet.stop_agent",
@@ -1426,8 +1495,8 @@ def test_stop_agent_502_sanitizes_path_in_error(isolated_config: Path):
         with TestClient(app) as client:
             resp = client.post("/api/agents/demo/stop")
     assert resp.status_code == 502
+    assert resp.json()["detail"] == "Lifecycle operation failed. Check server logs."
     assert "/home/user/.config" not in resp.json()["detail"]
-    assert "<path>" in resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------
@@ -1456,7 +1525,8 @@ def test_restart_agent_success(isolated_config: Path):
     mock_restart.assert_called_once_with("192.168.1.100", "hermes", agent_name="demo")
 
 
-def test_restart_agent_lifecycle_error_sanitized(isolated_config: Path):
+def test_restart_agent_lifecycle_error_uses_safe_message(isolated_config: Path):
+    """(#714) LifecycleError must not leak paths or SSH stderr to the browser."""
     _seed_hosts(isolated_config, "hermes")
     with patch(
         "clawrium.gui.routes.fleet.restart_agent",
@@ -1465,8 +1535,8 @@ def test_restart_agent_lifecycle_error_sanitized(isolated_config: Path):
         with TestClient(app) as client:
             resp = client.post("/api/agents/demo/restart")
     assert resp.status_code == 500
+    assert resp.json()["detail"] == "Lifecycle operation failed. Check server logs."
     assert "/home/user/.config" not in resp.json()["detail"]
-    assert "<path>" in resp.json()["detail"]
 
 
 def test_restart_agent_generic_exception_uses_safe_message(isolated_config: Path):
@@ -1491,11 +1561,13 @@ def test_restart_agent_returns_502_when_result_success_false(isolated_config: Pa
         with TestClient(app) as client:
             resp = client.post("/api/agents/demo/restart")
     assert resp.status_code == 502
-    assert "stop phase timed out" in resp.json()["detail"]
+    # (#714) success=False path also returns constant message, never raw error text
+    assert resp.json()["detail"] == "Lifecycle operation failed. Check server logs."
+    assert "stop phase timed out" not in resp.json()["detail"]
 
 
-def test_restart_agent_502_sanitizes_path_in_error(isolated_config: Path):
-    """Error with filesystem path gets sanitized on the 502 path (#712)."""
+def test_restart_agent_502_no_path_leak(isolated_config: Path):
+    """(#714) Filesystem paths in result.error never reach the browser."""
     _seed_hosts(isolated_config, "hermes")
     with patch(
         "clawrium.gui.routes.fleet.restart_agent",
@@ -1507,8 +1579,8 @@ def test_restart_agent_502_sanitizes_path_in_error(isolated_config: Path):
         with TestClient(app) as client:
             resp = client.post("/api/agents/demo/restart")
     assert resp.status_code == 502
+    assert resp.json()["detail"] == "Lifecycle operation failed. Check server logs."
     assert "/home/user/.config" not in resp.json()["detail"]
-    assert "<path>" in resp.json()["detail"]
 
 
 def test_fleet_endpoint_returns_tier1_model(isolated_config: Path):


### PR DESCRIPTION
## Summary

- Replace brittle `_sanitize_health_error` / `_ABS_PATH_RE` regex with constant error messages across all fleet.py error paths
- Fix same vulnerability class in lifecycle endpoints (start/stop/restart) that was also using the weak regex
- Remove `error` field from success responses to prevent raw backend text from reaching response body
- Remove dead `_sanitize_health_error` function and `_ABS_PATH_RE` regex (no remaining call sites)

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — 4450 Python + 305 GUI tests
- [x] Linter passes (`make lint`)
- [x] New tests added for realistic SSH stderr leakage (IPs, hostnames, ports)
- [x] ATX review completed (4 rounds, final rating 4/5, 0 blockers)

### Test Coverage
- Files changed: 7 (fleet.py, 4 test files, CHANGELOG.md, .itx/714/00_PLAN.md)
- New tests: 2 dedicated leak-prevention tests (`test_web_ui_tunnel_error_no_ssh_stderr_leak`, `test_pairing_code_502_on_tunnel_failure_no_ssh_stderr_leak`)
- Updated tests: 14 existing tests across 4 test files
- Removed tests: 3 (dead `TestSanitizeHealthError` class)
- Coverage impact: Maintained — all error paths now verified with dual assertions (constant message equality + negative assertion for raw error text)

### Manual Testing
N/A — fully unit-test covered with FastAPI TestClient

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources

## Reviewer Notes
- W1 (integrations.py) and W2 (agents.py) from final ATX review are **out of scope** — same vulnerability class but different route files. Should be tracked as follow-up issues.
- S1 (logger consistency at fleet.py:285) is minor and deferred.

---

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: \$5.41 | Total Time: ~19m**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3.5/5 | B1 (lifecycle leak) | Fixed | \$1.64 | ~5m | leader, security-reviewer, gui-routes |
| 2 | 3/5 | B1 (exc_info context) | Fixed | \$0.98 | ~5m | leader, gui-routes |
| 3 | 2/5 | B1 (health_error leak) | Fixed | \$1.36 | ~5m | leader, security-reviewer |
| 4 | 3/5 | B1 (success response) | Fixed | \$1.43 | ~4m | leader, security-reviewer |
| 5 | **4/5** | None | **Ready** | \$1.43 | ~4m | leader, security-reviewer |

> **Note**: ATX does not expose model information per agent.

### Findings Summary

| Finding | Rounds Affected | Status | Resolution |
|---------|----------------|--------|------------|
| Lifecycle endpoints leak via `_sanitize_health_error` | 1 | Fixed | Replaced with `_LIFECYCLE_GENERIC_ERROR` constant |
| `exc_info=True` in non-exception context | 2 | Fixed | Removed `exc_info=True`, restored error string in logger |
| `health_error` still leaks via `_sanitize_health_error` | 3 | Fixed | Replaced with constant message |
| Success responses return `result.get("error")` unsanitized | 4 | Fixed | Removed `error` field from success responses |
| `integrations.py` same leak class | 5 | Out of scope | Follow-up issue |
| `agents.py` agent-exec same leak class | 5 | Out of scope | Follow-up issue |

<details>
<summary>Review 1 Details (Rating 3.5/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `fleet.py:341,354,381,394,421,434` | Lifecycle endpoints also leak via `_sanitize_health_error` — same weak regex on SSH/ansible stderr | Fixed — replaced with `_LIFECYCLE_GENERIC_ERROR` constant |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `fleet.py:479` | Unused exception variable `as e` in TunnelError handler | Fixed — removed `as e` where unused |

</details>

<details>
<summary>Review 2 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `fleet.py:347-351,387-391,427-431` | `exc_info=True` in non-exception context — `sys.exc_info()` is `(None, None, None)` in success=false branches, so error string is silently dropped from logs | Fixed — removed `exc_info=True`, restored error string in logger format |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | `except Exception as e:` where `e` is unused | Fixed — changed to bare `except Exception:` |

</details>

<details>
<summary>Review 3 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `fleet.py:132,195,315` | `health_error` field still leaks raw SSH stderr via `_sanitize_health_error` — the primary leak issue #714 describes, and the PR did not touch it | Fixed — replaced with constant message "Health check failed — see server logs." |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `fleet.py:75-109` | `_ABS_PATH_RE` and `_sanitize_health_error` are NOT dead code — 3 live callsites | Fixed — removed dead code and stale `TestSanitizeHealthError` test class |

</details>

<details>
<summary>Review 4 Details (Rating 4/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `fleet.py:347,387,427` | Success-path responses still return `"error": result.get("error")` unsanitized — footgun that will silently reintroduce the leak on first backend change that populates the field | Fixed — removed `error` field from success responses entirely |

**Warnings (Deferred — out of scope for this PR):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `integrations.py:101,114` | Same leak class: `IntegrationsFileCorruptedError` returns absolute paths | Follow-up issue |
| W2 | `agents.py:1279` | Same leak class: `AgentExecError` returns SSH stderr with hostnames | Follow-up issue |

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
Authored-By: Pi<Qwen3.6-27B FP8 (256K, inx GB10)>