### PR TITLE
fix(openclaw): handle macOS exec and stale ui tunnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ cut. The `itx:release` skill archives this section into a new
 
 - GUI lifecycle endpoints (`start`, `stop`, `restart`) now return HTTP 502 instead of HTTP 200 with `success: false` when the underlying lifecycle operation fails without raising an exception (#712)
 - GUI error responses for tunnel, lifecycle, and health endpoints now return constant error messages instead of passing raw error text through a weak path-redaction regex, preventing leakage of internal hostnames, IP addresses, and ports (#714)
-- `clawctl agent exec` now dispatches OpenClaw macOS hosts through `exec_macos.yaml` instead of the Linux playbook, so native CLI commands work on agents installed under `/Users/<agent>/`.
-- `clawctl agent open` now evicts stale web-UI SSH tunnels that still have a bound local port but no longer answer HTTP, instead of reusing them and handing operators dead URLs.
+- `clawctl agent exec` now dispatches OpenClaw macOS hosts through `exec_macos.yaml` instead of the Linux playbook, so native CLI commands work on agents installed under `/Users/<agent>/` (#869).
+- `clawctl agent open` now evicts stale web-UI SSH tunnels that still have a bound local port but no longer answer HTTP, instead of reusing them and handing operators dead URLs (#869).
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ cut. The `itx:release` skill archives this section into a new
 
 - GUI lifecycle endpoints (`start`, `stop`, `restart`) now return HTTP 502 instead of HTTP 200 with `success: false` when the underlying lifecycle operation fails without raising an exception (#712)
 - GUI error responses for tunnel, lifecycle, and health endpoints now return constant error messages instead of passing raw error text through a weak path-redaction regex, preventing leakage of internal hostnames, IP addresses, and ports (#714)
+- `clawctl agent exec` now dispatches OpenClaw macOS hosts through `exec_macos.yaml` instead of the Linux playbook, so native CLI commands work on agents installed under `/Users/<agent>/`.
+- `clawctl agent open` now evicts stale web-UI SSH tunnels that still have a bound local port but no longer answer HTTP, instead of reusing them and handing operators dead URLs.
 
 ### Documentation
 

--- a/src/clawrium/core/agent_exec.py
+++ b/src/clawrium/core/agent_exec.py
@@ -186,6 +186,8 @@ def run_agent_exec(
         playbook = _playbook_path(claw_type, os_family)
     except FileNotFoundError as e:
         return "", str(e), 255
+    except ValueError as e:
+        return "", f"os_family='{os_family}' is not supported by clawrium: {e}", 255
 
     key_id = host.get("key_id") or host["hostname"]
     ssh_key = core_keys.get_host_private_key(key_id)

--- a/src/clawrium/core/agent_exec.py
+++ b/src/clawrium/core/agent_exec.py
@@ -33,6 +33,7 @@ import ansible_runner
 
 from clawrium.core import keys as core_keys
 from clawrium.core.config import get_config_dir
+from clawrium.core.playbook_resolver import normalize_os_family, resolve_agent_playbook
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +64,8 @@ class AgentExecError(Exception):
     """Raised for caller-recoverable errors before invoking ansible_runner."""
 
 
-def _playbook_path(claw_type: str) -> Path:
-    return _REGISTRY_DIR / claw_type / "playbooks" / "exec.yaml"
+def _playbook_path(claw_type: str, os_family: str = "linux") -> Path:
+    return resolve_agent_playbook(claw_type, "exec", os_family)
 
 
 def _logs_dir() -> Path:
@@ -174,15 +175,17 @@ def run_agent_exec(
     if not _AGENT_NAME_RE.match(agent_name):
         raise AgentExecError(f"invalid agent_name: {agent_name!r}")
 
-    playbook = _playbook_path(claw_type)
-    if not playbook.exists():
-        return "", f"Playbook not found: {playbook}", 255
-
     from clawrium.core.hosts import get_host
 
     host = get_host(hostname)
     if not host:
         return "", f"host '{hostname}' not found", 255
+
+    os_family = normalize_os_family(host)
+    try:
+        playbook = _playbook_path(claw_type, os_family)
+    except FileNotFoundError as e:
+        return "", str(e), 255
 
     key_id = host.get("key_id") or host["hostname"]
     ssh_key = core_keys.get_host_private_key(key_id)

--- a/src/clawrium/core/web_ui_tunnel.py
+++ b/src/clawrium/core/web_ui_tunnel.py
@@ -30,7 +30,7 @@ import time
 from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from clawrium.core.config import get_config_dir, init_config_dir
 from clawrium.core.web_ui import BIND_ADDRESS_MAP, ResolvedUI, resolve
@@ -188,6 +188,25 @@ def _local_port_bound(port: int) -> bool:
         return False
 
 
+def _http_endpoint_healthy(port: int) -> bool:
+    """Return True iff an HTTP endpoint on 127.0.0.1:<port> answers a probe.
+
+    A bound local port is not enough for reused SSH tunnels: the SSH process can
+    stay alive while the remote dashboard behind the forward is gone, which makes
+    browser opens fail later with connection resets. We send a tiny HEAD request
+    and require at least one response byte so stale forwards are evicted eagerly.
+    """
+    request = b"HEAD / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+    try:
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+            sock.settimeout(0.5)
+            sock.connect(("127.0.0.1", port))
+            sock.sendall(request)
+            return bool(sock.recv(1))
+    except (ConnectionResetError, BrokenPipeError, OSError):
+        return False
+
+
 def _pick_free_port() -> int:
     """Bind to an ephemeral port on loopback and return the chosen number.
 
@@ -294,7 +313,11 @@ def _cmdline_matches(actual: str, signature: str) -> bool:
     return actual_tokens == expected_tokens
 
 
-def _existing_healthy_tunnel(agent_key: str) -> TunnelInfo | None:
+def _existing_healthy_tunnel(
+    agent_key: str,
+    *,
+    readiness_probe: Callable[[int], bool] | None = None,
+) -> TunnelInfo | None:
     state = _read_state(agent_key)
     if not state:
         return None
@@ -315,6 +338,10 @@ def _existing_healthy_tunnel(agent_key: str) -> TunnelInfo | None:
         _delete_state(agent_key)
         return None
     if not _local_port_bound(local_port):
+        _terminate(pid, signature)
+        _delete_state(agent_key)
+        return None
+    if readiness_probe is not None and not readiness_probe(local_port):
         _terminate(pid, signature)
         _delete_state(agent_key)
         return None
@@ -356,11 +383,17 @@ def _close_owned_tunnels() -> None:
             logger.debug("atexit close failed for %s", agent_key, exc_info=True)
 
 
-def _wait_for_connect(port: int, timeout: float = _CONNECT_TIMEOUT_S) -> bool:
+def _wait_for_connect(
+    port: int,
+    timeout: float = _CONNECT_TIMEOUT_S,
+    *,
+    readiness_probe: Callable[[int], bool] | None = None,
+) -> bool:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if _local_port_bound(port):
-            return True
+            if readiness_probe is None or readiness_probe(port):
+                return True
         time.sleep(_CONNECT_POLL_INTERVAL_S)
     return False
 
@@ -435,7 +468,10 @@ def ensure(agent_key: str, *, owned: bool = True) -> int:
         )
 
     with _get_ensure_lock(agent_key):
-        existing = _existing_healthy_tunnel(agent_key)
+        existing = _existing_healthy_tunnel(
+            agent_key,
+            readiness_probe=_http_endpoint_healthy,
+        )
         if existing is not None:
             if owned:
                 _OWNED_TUNNELS.add(agent_key)
@@ -449,7 +485,10 @@ def ensure(agent_key: str, *, owned: bool = True) -> int:
         signature = _cmdline_signature(cmd)
 
         proc = _spawn_ssh(cmd)
-        if not _wait_for_connect(local_port):
+        if not _wait_for_connect(
+            local_port,
+            readiness_probe=_http_endpoint_healthy,
+        ):
             if proc.poll() is None:
                 try:
                     proc.terminate()

--- a/src/clawrium/core/web_ui_tunnel.py
+++ b/src/clawrium/core/web_ui_tunnel.py
@@ -193,16 +193,24 @@ def _http_endpoint_healthy(port: int) -> bool:
 
     A bound local port is not enough for reused SSH tunnels: the SSH process can
     stay alive while the remote dashboard behind the forward is gone, which makes
-    browser opens fail later with connection resets. We send a tiny HEAD request
+    browser opens fail later with connection resets. We send a tiny GET request
     and require at least one response byte so stale forwards are evicted eagerly.
     """
-    request = b"HEAD / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+    request = b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
     try:
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+            # The local accept is effectively immediate; the remote side of the
+            # SSH forward can still take longer to answer over a tailnet/WAN hop.
             sock.settimeout(0.5)
             sock.connect(("127.0.0.1", port))
             sock.sendall(request)
-            return bool(sock.recv(1))
+            sock.settimeout(2.0)
+            try:
+                return bool(sock.recv(1))
+            except TimeoutError:
+                # Treat an established-but-slow HTTP endpoint as alive; the stale
+                # tunnel failure mode we care about is EOF/RST from a dead remote.
+                return True
     except (ConnectionResetError, BrokenPipeError, OSError):
         return False
 

--- a/src/clawrium/platform/registry/hermes/playbooks/exec_macos.yaml
+++ b/src/clawrium/platform/registry/hermes/playbooks/exec_macos.yaml
@@ -1,0 +1,40 @@
+---
+# macOS counterpart to exec.yaml. Keep the same read-only exec shape while
+# switching home paths to /Users/<agent> per the dispatcher's OS-family fork.
+- hosts: all
+  gather_facts: false
+  vars:
+    binary: "/Users/{{ agent_name }}/.local/bin/hermes"
+    workdir: "/Users/{{ agent_name }}/.hermes"
+  tasks:
+    - name: Validate agent_name (defense-in-depth)
+      ansible.builtin.fail:
+        msg: "Invalid agent_name"
+      when:
+        - agent_name is not match('^[a-z][a-z0-9_-]{0,31}$')
+
+    - name: Run agent exec command
+      ansible.builtin.command:
+        argv: "{{ [binary] + cmd_argv }}"
+        chdir: "{{ workdir }}"
+      become: true
+      become_user: "{{ agent_name }}"
+      environment:
+        HOME: "/Users/{{ agent_name }}"
+        PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+      register: exec_result
+      failed_when: false
+      changed_when: false
+      no_log: true
+
+    - name: Emit stdout
+      ansible.builtin.debug:
+        msg: "EXEC_STDOUT={{ exec_result.stdout | default('') | b64encode }}"
+
+    - name: Emit stderr
+      ansible.builtin.debug:
+        msg: "EXEC_STDERR={{ exec_result.stderr | default('') | b64encode }}"
+
+    - name: Emit rc
+      ansible.builtin.debug:
+        msg: "EXEC_RC={{ exec_result.rc | default(255) }}"

--- a/src/clawrium/platform/registry/zeroclaw/playbooks/exec_macos.yaml
+++ b/src/clawrium/platform/registry/zeroclaw/playbooks/exec_macos.yaml
@@ -1,0 +1,40 @@
+---
+# macOS counterpart to exec.yaml. Keep the same read-only exec shape while
+# switching home paths to /Users/<agent> per the dispatcher's OS-family fork.
+- hosts: all
+  gather_facts: false
+  vars:
+    binary: "/Users/{{ agent_name }}/bin/zeroclaw"
+    workdir: "/Users/{{ agent_name }}/.zeroclaw/workspace"
+  tasks:
+    - name: Validate agent_name (defense-in-depth)
+      ansible.builtin.fail:
+        msg: "Invalid agent_name"
+      when:
+        - agent_name is not match('^[a-z][a-z0-9_-]{0,31}$')
+
+    - name: Run agent exec command
+      ansible.builtin.command:
+        argv: "{{ [binary] + cmd_argv }}"
+        chdir: "{{ workdir }}"
+      become: true
+      become_user: "{{ agent_name }}"
+      environment:
+        HOME: "/Users/{{ agent_name }}"
+        PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+      register: exec_result
+      failed_when: false
+      changed_when: false
+      no_log: true
+
+    - name: Emit stdout
+      ansible.builtin.debug:
+        msg: "EXEC_STDOUT={{ exec_result.stdout | default('') | b64encode }}"
+
+    - name: Emit stderr
+      ansible.builtin.debug:
+        msg: "EXEC_STDERR={{ exec_result.stderr | default('') | b64encode }}"
+
+    - name: Emit rc
+      ansible.builtin.debug:
+        msg: "EXEC_RC={{ exec_result.rc | default(255) }}"

--- a/tests/core/test_agent_exec.py
+++ b/tests/core/test_agent_exec.py
@@ -136,9 +136,10 @@ def test_unknown_claw_type_raises(patched_env):
         agent_exec.run_agent_exec("10.0.0.1", "x", "nemoclaw", ["foo"])
 
 
-def test_empty_cmd_argv_raises(patched_env):
-    with pytest.raises(agent_exec.AgentExecError):
-        agent_exec.run_agent_exec("10.0.0.1", "x", "openclaw", [])
+@pytest.mark.parametrize("cmd_argv", [[], None])
+def test_empty_cmd_argv_raises(patched_env, cmd_argv):
+    with pytest.raises(agent_exec.AgentExecError, match="cmd_argv must be a non-empty list"):
+        agent_exec.run_agent_exec("10.0.0.1", "x", "openclaw", cmd_argv)
 
 
 def test_missing_ssh_key(monkeypatch, patched_env):
@@ -264,9 +265,23 @@ def test_missing_rc_marker(monkeypatch, patched_env):
         "10.0.0.1", "wolf-i", "openclaw", ["x"]
     )
     assert rc == 255
+    assert "did not report an exit code" in stderr
 
 
-def test_run_agent_exec_uses_macos_playbook_for_darwin_host(monkeypatch, patched_env):
+@pytest.mark.parametrize(
+    ("claw_type", "os_family", "expected_suffix"),
+    [
+        ("openclaw", "linux", "openclaw/playbooks/exec.yaml"),
+        ("openclaw", "darwin", "openclaw/playbooks/exec_macos.yaml"),
+        ("hermes", "linux", "hermes/playbooks/exec.yaml"),
+        ("hermes", "darwin", "hermes/playbooks/exec_macos.yaml"),
+        ("zeroclaw", "linux", "zeroclaw/playbooks/exec.yaml"),
+        ("zeroclaw", "darwin", "zeroclaw/playbooks/exec_macos.yaml"),
+    ],
+)
+def test_run_agent_exec_uses_expected_playbook_for_host_os(
+    monkeypatch, patched_env, claw_type, os_family, expected_suffix
+):
     captured = {}
 
     from clawrium.core import hosts as hosts_module
@@ -279,7 +294,7 @@ def test_run_agent_exec_uses_macos_playbook_for_darwin_host(monkeypatch, patched
             "user": "alice",
             "port": 22,
             "alias": "wolf-m",
-            "os_family": "darwin",
+            "os_family": os_family,
         },
     )
 
@@ -295,8 +310,76 @@ def test_run_agent_exec_uses_macos_playbook_for_darwin_host(monkeypatch, patched
 
     monkeypatch.setattr(agent_exec.ansible_runner, "run", fake_run)
     stdout, stderr, rc = agent_exec.run_agent_exec(
-        "10.0.0.1", "wolf-m", "openclaw", ["--version"]
+        "10.0.0.1", "wolf-m", claw_type, ["--version"]
     )
 
     assert (stdout, stderr, rc) == ("hello world", "", 0)
-    assert captured["playbook"].endswith("openclaw/playbooks/exec_macos.yaml")
+    assert captured["playbook"].endswith(expected_suffix)
+
+
+def test_run_agent_exec_returns_error_for_unrecognized_os_family(
+    monkeypatch, patched_env
+):
+    from clawrium.core import hosts as hosts_module
+
+    monkeypatch.setattr(
+        hosts_module,
+        "get_host",
+        lambda h: {
+            "hostname": h,
+            "user": "alice",
+            "port": 22,
+            "alias": "wolf-bsd",
+            "os_family": "freebsd",
+        },
+    )
+
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "10.0.0.1", "wolf-bsd", "openclaw", ["--version"]
+    )
+
+    assert stdout == ""
+    assert rc == 255
+    assert "os_family='freebsd' is not supported by clawrium" in stderr
+
+
+def test_run_agent_exec_returns_file_not_found_when_supported_os_playbook_missing(
+    monkeypatch, patched_env
+):
+    from clawrium.core import hosts as hosts_module
+
+    monkeypatch.setattr(
+        hosts_module,
+        "get_host",
+        lambda h: {
+            "hostname": h,
+            "user": "alice",
+            "port": 22,
+            "alias": "wolf-m",
+            "os_family": "darwin",
+        },
+    )
+
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "10.0.0.1", "wolf-m", "ethos", ["--version"]
+    )
+
+    assert stdout == ""
+    assert rc == 255
+    assert "does not support os_family='darwin'" in stderr
+
+
+def test_run_agent_exec_returns_runner_exception(monkeypatch, patched_env):
+    monkeypatch.setattr(
+        agent_exec.ansible_runner,
+        "run",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("connection refused")),
+    )
+
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "10.0.0.1", "wolf-i", "openclaw", ["--version"]
+    )
+
+    assert stdout == ""
+    assert rc == 255
+    assert stderr == "ansible-runner error: connection refused"

--- a/tests/core/test_agent_exec.py
+++ b/tests/core/test_agent_exec.py
@@ -264,3 +264,39 @@ def test_missing_rc_marker(monkeypatch, patched_env):
         "10.0.0.1", "wolf-i", "openclaw", ["x"]
     )
     assert rc == 255
+
+
+def test_run_agent_exec_uses_macos_playbook_for_darwin_host(monkeypatch, patched_env):
+    captured = {}
+
+    from clawrium.core import hosts as hosts_module
+
+    monkeypatch.setattr(
+        hosts_module,
+        "get_host",
+        lambda h: {
+            "hostname": h,
+            "user": "alice",
+            "port": 22,
+            "alias": "wolf-m",
+            "os_family": "darwin",
+        },
+    )
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+        return _make_result(
+            [
+                _ok_event("EXEC_STDOUT=" + base64.b64encode(b"hello world").decode()),
+                _ok_event("EXEC_STDERR=" + base64.b64encode(b"").decode()),
+                _ok_event("EXEC_RC=0"),
+            ]
+        )
+
+    monkeypatch.setattr(agent_exec.ansible_runner, "run", fake_run)
+    stdout, stderr, rc = agent_exec.run_agent_exec(
+        "10.0.0.1", "wolf-m", "openclaw", ["--version"]
+    )
+
+    assert (stdout, stderr, rc) == ("hello world", "", 0)
+    assert captured["playbook"].endswith("openclaw/playbooks/exec_macos.yaml")

--- a/tests/test_web_ui_tunnel.py
+++ b/tests/test_web_ui_tunnel.py
@@ -24,6 +24,7 @@ from clawrium.core.web_ui_tunnel import (
     _build_ssh_for,
     _cmdline_matches,
     _cmdline_signature,
+    _http_endpoint_healthy,
     _pick_free_port,
     close,
     ensure,
@@ -59,6 +60,77 @@ def test_tunnel_state_dir_is_under_config(isolated_state: Path):
 def test_pick_free_port_returns_loopback_port():
     port = _pick_free_port()
     assert 1024 < port < 65536
+
+
+def test_http_endpoint_healthy_accepts_any_http_response_byte():
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+
+    try:
+        def serve_once():
+            conn, _ = server.accept()
+            with closing(conn):
+                conn.recv(1024)
+                conn.sendall(b"HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 0\r\n\r\n")
+
+        import threading
+
+        thread = threading.Thread(target=serve_once)
+        thread.start()
+        assert _http_endpoint_healthy(port) is True
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+    finally:
+        server.close()
+
+
+def test_http_endpoint_healthy_returns_false_on_connection_reset():
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+
+    try:
+        def serve_once():
+            conn, _ = server.accept()
+            conn.close()
+
+        import threading
+
+        thread = threading.Thread(target=serve_once)
+        thread.start()
+        assert _http_endpoint_healthy(port) is False
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+    finally:
+        server.close()
+
+
+def test_http_endpoint_healthy_treats_recv_timeout_as_alive(monkeypatch: pytest.MonkeyPatch):
+    timeouts: list[float] = []
+
+    class FakeSocket:
+        def settimeout(self, value):
+            timeouts.append(value)
+
+        def connect(self, address):
+            return None
+
+        def sendall(self, data):
+            return None
+
+        def recv(self, size):
+            raise TimeoutError
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(web_ui_tunnel.socket, "socket", lambda *args, **kwargs: FakeSocket())
+
+    assert _http_endpoint_healthy(41091) is True
+    assert timeouts == [0.5, 2.0]
 
 
 def test_cmdline_signature_matches_actual_proc_format():

--- a/tests/test_web_ui_tunnel.py
+++ b/tests/test_web_ui_tunnel.py
@@ -222,6 +222,7 @@ def test_ensure_returns_existing_local_port_when_healthy(
             ),
         )
         monkeypatch.setattr(web_ui_tunnel, "resolve", lambda key: _resolved())
+        monkeypatch.setattr(web_ui_tunnel, "_http_endpoint_healthy", lambda port: True)
 
         result = ensure("demo")
         assert result == local_port
@@ -251,10 +252,61 @@ def test_ensure_evicts_stale_pid_then_spawns_new_tunnel(
     fake_proc.poll.return_value = None
     monkeypatch.setattr(web_ui_tunnel, "_spawn_ssh", lambda cmd: fake_proc)
     monkeypatch.setattr(
-        web_ui_tunnel, "_wait_for_connect", lambda port, timeout=5.0: True
+        web_ui_tunnel, "_wait_for_connect", lambda port, timeout=5.0, **kwargs: True
     )
 
     result = ensure("demo")
+    assert result > 0
+    persisted = json.loads(state_path.read_text())
+    assert persisted["pid"] == 4242
+    assert persisted["local_port"] == result
+
+
+def test_ensure_evicts_existing_tunnel_when_http_probe_fails(
+    isolated_state: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A bound-but-dead forwarded endpoint must not be reused."""
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        local_port = sock.getsockname()[1]
+
+        signature = _cmdline_signature(
+            ["ssh", "-N", "-L", f"{local_port}:127.0.0.1:9119", "xclm@hermes.local"]
+        )
+        state_path = tunnel_state_dir() / "demo.json"
+        state_path.write_text(
+            json.dumps(
+                {
+                    "pid": 1234,
+                    "local_port": local_port,
+                    "started_at": time.time(),
+                    "ssh_cmdline_signature": signature,
+                }
+            )
+        )
+
+        monkeypatch.setattr(web_ui_tunnel, "_process_alive", lambda pid: True)
+        monkeypatch.setattr(
+            web_ui_tunnel,
+            "_read_cmdline",
+            lambda pid: " ".join(
+                ["ssh", "-N", "-L", f"{local_port}:127.0.0.1:9119", "xclm@hermes.local"]
+            ),
+        )
+        monkeypatch.setattr(web_ui_tunnel, "_http_endpoint_healthy", lambda port: False)
+        monkeypatch.setattr(web_ui_tunnel, "resolve", lambda key: _resolved())
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 4242
+        fake_proc.poll.return_value = None
+        monkeypatch.setattr(web_ui_tunnel, "_spawn_ssh", lambda cmd: fake_proc)
+        monkeypatch.setattr(
+            web_ui_tunnel, "_wait_for_connect", lambda port, timeout=5.0, **kwargs: True
+        )
+
+        result = ensure("demo")
+
     assert result > 0
     persisted = json.loads(state_path.read_text())
     assert persisted["pid"] == 4242
@@ -358,7 +410,7 @@ def test_ensure_raises_when_ssh_fails_to_bind(
     fake_proc.stderr = None
     monkeypatch.setattr(web_ui_tunnel, "_spawn_ssh", lambda cmd: fake_proc)
     monkeypatch.setattr(
-        web_ui_tunnel, "_wait_for_connect", lambda port, timeout=5.0: False
+        web_ui_tunnel, "_wait_for_connect", lambda port, timeout=5.0, **kwargs: False
     )
 
     with pytest.raises(TunnelError):


### PR DESCRIPTION
## Summary
- route `clawctl agent exec` through OS-aware playbook resolution so Darwin agents use their `exec_macos.yaml` siblings instead of Linux paths
- stop `clawctl agent open` from reusing stale SSH tunnels that still bind locally but no longer have a working HTTP endpoint behind them
- add follow-up ATX fixes: macOS exec playbooks for Hermes/Zeroclaw, broader exec/tunnel regression coverage, and changelog references

## Testing
- `uv run pytest tests/core/test_agent_exec.py tests/test_web_ui_tunnel.py tests/core/test_playbook_resolver_openclaw_macos.py`
- `make lint`
- `make test`

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $2.06 | Total Time: 14m 59s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2.5/5 | B1, B2 | All fixed | $1.1692 | 8m 42s | lifecycle-core, test-coverage |
| 2 | 4/5 | B1 | Fixed | $0.8908 | 6m 17s | lifecycle-core, test-coverage |

<details>
<summary>Review 1 Details (Rating 2.5/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/core/test_agent_exec.py` | Missing coverage for unsupported/missing playbook resolution branch | Fixed - added tests for unrecognized `os_family` and real missing-playbook path |
| B2 | `tests/core/test_agent_exec.py` | Missing coverage for `ansible_runner.run` exception branch | Fixed - added `test_run_agent_exec_returns_runner_exception` |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `src/clawrium/core/agent_exec.py` | Darwin regression risk for Hermes/Zeroclaw without macOS exec playbooks | Fixed - added `hermes/playbooks/exec_macos.yaml` and `zeroclaw/playbooks/exec_macos.yaml` |
| W2 | `src/clawrium/core/web_ui_tunnel.py` | Probe timing too aggressive / HEAD portability concern | Fixed - switched to `GET`, split connect/recv timeouts, and covered recv-timeout behavior |
| W3 | `CHANGELOG.md` | New entries missing issue/PR references | Fixed - added `(#869)` |
| W4 | `tests/core/test_agent_exec.py` | No empty/None `cmd_argv` coverage | Fixed - parametrized `[]` and `None` |
| W5 | `tests/core/test_agent_exec.py` | Playbook routing test matrix incomplete | Fixed - expanded matrix across Linux and Darwin for OpenClaw/Hermes/Zeroclaw |
| W6 | `tests/core/test_agent_exec.py` | Missing stderr assertion in RC-marker failure path | Fixed - assert missing exit-code message |

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_web_ui_tunnel.py` | No direct coverage for recv-timeout path in `_http_endpoint_healthy` | Fixed - added `test_http_endpoint_healthy_treats_recv_timeout_as_alive` |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `src/clawrium/core/agent_exec.py` | Unsupported-OS error wording is slightly redundant | Acknowledged |
| W2 | `tests/test_web_ui_tunnel.py` | No explicit `ConnectionRefusedError` coverage | Acknowledged |
| W3 | `tests/test_web_ui_tunnel.py` | FakeSocket test does not fully assert call ordering | Acknowledged |

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
