### PR TITLE
fix: persist zeroclaw memory overlay across upgrade

### DIFF
--- a/.itx/871/00_PLAN.md
+++ b/.itx/871/00_PLAN.md
@@ -1,0 +1,98 @@
+# Issue #871 Plan
+
+## Summary
+
+Fix zeroclaw memory persistence so operator-edited memory files live in the local control-plane workspace overlay, survive `clawctl agent upgrade`, and remain consistent across read, write, delete, sync, and upgrade flows.
+
+## Problem
+
+`clawctl agent memory edit` currently writes memory files directly to the remote host via the zeroclaw `memory_write.yaml` playbook. The local overlay under `~/.config/clawrium/agents/zeroclaw/<agent>/workspace/` is not updated, but `push_workspace_phase()` only syncs files from that local overlay. During upgrade, `clawctl agent upgrade` runs `run_installation(..., force=True)` and then restarts the agent, but it does not call workspace sync. That leaves the local control-plane with no persisted copy to restore, so memory/persona files can disappear from the remote workspace.
+
+## Goals
+
+- Make the local control-plane workspace overlay the source of truth for zeroclaw memory files.
+- Persist successful memory writes locally as well as remotely.
+- Mirror successful memory deletes locally so later syncs do not resurrect deleted files.
+- Read from the local overlay first, with a legacy remote fallback when local state is missing.
+- Ensure the `agent upgrade` path rehydrates overlay-backed files onto the remote host.
+- Add regression coverage for the data-loss path.
+
+## Non-Goals
+
+- Redesigning the full workspace overlay system.
+- Changing GUI or CLI surface area beyond behavior inherited from core memory helpers.
+- Expanding zeroclaw memory file allowlists or limits.
+
+## Implementation Plan
+
+### 1. Add local overlay persistence helpers in `src/clawrium/core/memory.py`
+
+- Add small helpers to resolve the local workspace overlay path for an agent memory file and ensure its parent directory exists.
+- Reuse existing validation and per-agent resolution logic so the write/read/delete code paths stay centralized in `core/memory.py`.
+
+### 2. Make memory reads overlay-first with legacy fallback
+
+- Update `read_memory_file()` to:
+  - resolve and validate the target agent/file as it does today,
+  - return the local overlay copy when it exists,
+  - fall back to the current remote playbook read path when the local copy is absent.
+- Keep the fallback so existing agents with remote-only memory state still work before their next edit/sync/upgrade.
+
+### 3. Mirror successful writes and deletes into the local overlay
+
+- Update `write_memory_file()` so a successful remote write also writes the same bytes into the local workspace overlay.
+- Update `delete_memory_files()` so successful remote deletes also remove the local overlay copies.
+- Preserve failure semantics: do not mutate local state when the remote operation fails.
+
+### 4. Restore overlay files during upgrade/reinstall
+
+- Update the upgrade/install path so `clawctl agent upgrade` re-pushes workspace overlay files after installation and before the post-install restart flow completes.
+- Prefer reusing the existing `push_workspace_phase()` contract rather than creating a second restore implementation.
+- Ensure zeroclaw’s existing gateway-token rotation invariants remain intact when this path runs.
+
+### 5. Add regression tests
+
+- Extend `tests/test_core_memory.py` to cover:
+  - local-overlay-first reads,
+  - remote fallback reads when local state is absent,
+  - successful write mirroring into the local overlay,
+  - successful delete mirroring from the local overlay,
+  - no local mutation when remote playbook execution fails.
+- Extend upgrade/install coverage to prove overlay-backed memory files are restored on the upgrade path that currently reproduces the bug.
+- Update any existing tests whose expectations assume remote-only memory behavior.
+
+### 6. Update release notes
+
+- Add a `### Fixed` entry to the root `CHANGELOG.md` describing that zeroclaw memory/persona files now persist through upgrade because the control-plane overlay is kept in sync and restored.
+
+## Risks And Checks
+
+- Upgrade restore must happen on the real `agent upgrade` control path, not only on `agent sync`, otherwise the reported reproduction remains broken.
+- Delete parity is required; otherwise a later sync will recreate files the operator intentionally removed.
+- Legacy remote fallback must remain narrow so it does not silently hide local-overlay regressions.
+- Test coverage should target the exact upgrade path (`run_installation` + post-install lifecycle flow), not only isolated helper behavior.
+
+## Subtasks
+
+No GitHub subtasks are needed. This is one tightly-scoped data-loss fix with shared core logic and regression coverage, and splitting it would add coordination overhead without reducing implementation risk.
+
+## Validation
+
+- `make test`
+- `make lint`
+- Targeted tests covering core memory behavior and upgrade/install regression cases
+
+## Prompt Log
+
+## Plan Create
+
+**Stage**: plan
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-07-10T05:45:19Z
+**Model**: openai/gpt-5.4
+
+```prompt
+871
+```
+
+**Output**: Created the implementation plan for issue #871 covering local memory-overlay persistence, upgrade rehydration, tests, and release-note updates.

--- a/.itx/871/01_EXECUTION.md
+++ b/.itx/871/01_EXECUTION.md
@@ -22,6 +22,9 @@ Implemented the issue #871 fix in the worktree branch `issue-871-memory-overlay-
 - Review 1: `10b097fd-7999-4edc-951b-4369eba44423` - Rating `2.5/5`, blocking. Fixed missing failure-path tests, corrected remote-success/local-failure semantics in memory helpers, and adjusted upgrade flow handling.
 - Review 2: `e4851058-2aa6-4e5c-9758-2599896bfaf9` - Rating `2/5`, blocking. Fixed helper path hardening, tightened upgrade failure reporting, and added broader regression coverage.
 - Review 3: `87fd3613-fdc8-4124-98f7-f4559bb7ee7f` - Rating `2/5`, blocking. Restored the documented workspace-failure short-circuit before restart, added absolute/symlink escape tests plus tempfile cleanup coverage, and strengthened exact upgrade call assertions.
+- Review 4: `584fd3b2-6b89-4c00-9dd1-138bab14d94a` - Rating `2.5/5`, blocking. Most blockers were stale coverage claims, but it surfaced real hardening follow-ups around symlinked workspace roots, batch delete continuation, exception guards, and clearer zeroclaw bearer warnings.
+- Review 5: `da44a1d6-a05a-470b-8c82-c839f269ae0a` - Rating `2.5/5`, blocking. Fixed the symlink-root error contract to use `OSError(ELOOP)`, mirrored the guard on delete, and added the missing non-pairing bearer-hint assertion.
+- Review 6: `dc18b6b7-172d-4604-be3f-a0f5f69ab197` - Rating `3/5`, blocking. Added zeroclaw exception-path coverage, generalized the pairing hint to use `agent_type`, mirrored the TOCTOU note on delete, and hardened the ordering test mock signature.
 
 ## Environment Notes
 
@@ -32,7 +35,7 @@ Implemented the issue #871 fix in the worktree branch `issue-871-memory-overlay-
 - Local overlay copies now back zeroclaw memory reads, writes, and deletes.
 - Legacy remote-only memory content backfills into the local overlay on first successful read.
 - `clawctl agent upgrade` now re-pushes the local overlay before any zeroclaw restart path, and workspace restore failure correctly short-circuits before restart.
-- Regression coverage now exercises the main data-loss path plus helper hardening and failure branches.
+- Regression coverage now exercises the main data-loss path plus helper hardening, exception paths, ordering invariants, and failure branches.
 
 ## Execute
 

--- a/.itx/871/01_EXECUTION.md
+++ b/.itx/871/01_EXECUTION.md
@@ -1,0 +1,48 @@
+# Issue #871 Execution
+
+Implemented the issue #871 fix in the worktree branch `issue-871-memory-overlay-upgrade`.
+
+## Changes
+
+- Added local overlay helpers in `src/clawrium/core/memory.py` so memory reads are overlay-first, successful remote reads backfill the local overlay, successful writes persist locally, and successful deletes remove local overlay copies.
+- Updated `src/clawrium/cli/clawctl/agent/upgrade.py` to re-push the local workspace overlay immediately after install and before zeroclaw restart/pair rotation, with surfaced failure output if restore fails.
+- Added regression coverage in `tests/test_core_memory.py` for overlay-first reads, remote fallback backfill, write mirroring, delete mirroring, and remote-failure no-mutation behavior.
+- Added upgrade-path regression coverage in `tests/cli/test_agent_upgrade.py` for successful workspace restore wiring and failure short-circuit behavior.
+- Updated `CHANGELOG.md` with the user-facing fix note.
+
+## Verification
+
+- `uv sync --frozen --no-install-project`
+- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_core_memory.py tests/cli/test_agent_upgrade.py -q`
+- `PYTHONPATH=src .venv/bin/python -m ruff check src tests`
+- `PYTHONPATH=src .venv/bin/python -m pytest -q`
+
+## ATX Review
+
+- Review 1: `10b097fd-7999-4edc-951b-4369eba44423` - Rating `2.5/5`, blocking. Fixed missing failure-path tests, corrected remote-success/local-failure semantics in memory helpers, and adjusted upgrade flow handling.
+- Review 2: `e4851058-2aa6-4e5c-9758-2599896bfaf9` - Rating `2/5`, blocking. Fixed helper path hardening, tightened upgrade failure reporting, and added broader regression coverage.
+- Review 3: `87fd3613-fdc8-4124-98f7-f4559bb7ee7f` - Rating `2/5`, blocking. Restored the documented workspace-failure short-circuit before restart, added absolute/symlink escape tests plus tempfile cleanup coverage, and strengthened exact upgrade call assertions.
+
+## Environment Notes
+
+- `make test` and `make lint` could not run in this worktree because editable-package build setup expects `src/clawrium/gui/frontend`, which is absent in this checkout. Verification was completed via direct source execution with `PYTHONPATH=src` instead.
+
+## Outcome
+
+- Local overlay copies now back zeroclaw memory reads, writes, and deletes.
+- Legacy remote-only memory content backfills into the local overlay on first successful read.
+- `clawctl agent upgrade` now re-pushes the local overlay before any zeroclaw restart path, and workspace restore failure correctly short-circuits before restart.
+- Regression coverage now exercises the main data-loss path plus helper hardening and failure branches.
+
+## Execute
+
+**Stage**: execute
+**Skill**: /itx:execute
+**Timestamp**: 2026-07-10T05:50:00Z
+**Model**: openai/gpt-5.4
+
+```prompt
+Execute the implementation plan for GitHub issue 871 in a worktree. use atx cli for review.
+```
+
+**Output**: Implemented local memory-overlay persistence, upgrade-time workspace restoration, regression tests, and release-note updates for issue #871.

--- a/.itx/871/atx-session.json
+++ b/.itx/871/atx-session.json
@@ -1,16 +1,12 @@
 {
-  "session_id": "87fd3613-fdc8-4124-98f7-f4559bb7ee7f",
+  "session_id": "dc18b6b7-172d-4604-be3f-a0f5f69ab197",
   "transport": "cli",
-  "commit_sha": "2a45b40ede4ac8585460ed5cbdf1775efad18fae",
-  "iteration": 3,
-  "last_rating": 2,
+  "commit_sha": "a4a5ac176eaecd61c8d94a180f1cc117303297c1",
+  "iteration": 6,
+  "last_rating": 3,
   "last_blockers": [
-    "B1",
-    "B2",
-    "B3",
-    "B4",
-    "B5"
+    "B1"
   ],
-  "started_at": "2026-07-10T15:05:18Z",
-  "updated_at": "2026-07-10T15:57:41Z"
+  "started_at": "2026-07-10T19:40:19Z",
+  "updated_at": "2026-07-10T19:48:39Z"
 }

--- a/.itx/871/atx-session.json
+++ b/.itx/871/atx-session.json
@@ -1,0 +1,16 @@
+{
+  "session_id": "87fd3613-fdc8-4124-98f7-f4559bb7ee7f",
+  "transport": "cli",
+  "commit_sha": "2a45b40ede4ac8585460ed5cbdf1775efad18fae",
+  "iteration": 3,
+  "last_rating": 2,
+  "last_blockers": [
+    "B1",
+    "B2",
+    "B3",
+    "B4",
+    "B5"
+  ],
+  "started_at": "2026-07-10T15:05:18Z",
+  "updated_at": "2026-07-10T15:57:41Z"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Fixed
 
+- Zeroclaw memory and persona files edited through `clawctl agent memory` now persist in the local control-plane workspace overlay and are restored during `clawctl agent upgrade`, preventing upgrade-time data loss (#871)
 - GUI lifecycle endpoints (`start`, `stop`, `restart`) now return HTTP 502 instead of HTTP 200 with `success: false` when the underlying lifecycle operation fails without raising an exception (#712)
 - GUI error responses for tunnel, lifecycle, and health endpoints now return constant error messages instead of passing raw error text through a weak path-redaction regex, preventing leakage of internal hostnames, IP addresses, and ports (#714)
 

--- a/src/clawrium/cli/clawctl/agent/upgrade.py
+++ b/src/clawrium/cli/clawctl/agent/upgrade.py
@@ -220,12 +220,25 @@ def upgrade(
         if not use_json:
             stream_action(resource=resource, message=f"{stage}: {json.dumps(payload)}")
 
-    ws_result = push_workspace_phase(
-        host=host,
-        agent_type=agent_type,
-        agent_name=on_host_name,
-        on_event=_emit_workspace if not use_json else None,
-    )
+    workspace_hint = "run `clawctl agent sync` after fixing the local workspace overlay"
+    if agent_type in _PAIRING_AGENT_TYPES:
+        workspace_hint += (
+            f"; {agent_type} bearer state may also be stale until you run "
+            "`clawctl agent sync` or `clawctl agent restart`"
+        )
+
+    try:
+        ws_result = push_workspace_phase(
+            host=host,
+            agent_type=agent_type,
+            agent_name=on_host_name,
+            on_event=_emit_workspace if not use_json else None,
+        )
+    except Exception as exc:
+        emit_error(
+            f"upgrade installed but workspace restore crashed: {exc}",
+            hint=workspace_hint,
+        )
     workspace_error = (
         (ws_result.error or "unknown workspace error")
         if not ws_result.success
@@ -234,7 +247,7 @@ def upgrade(
     if workspace_error:
         emit_error(
             f"upgrade installed but workspace restore failed: {workspace_error}",
-            hint="run `clawctl agent sync` after fixing the local workspace overlay",
+            hint=workspace_hint,
         )
 
     # ATX B2 (issue #592): zeroclaw's install playbook does NOT pair

--- a/src/clawrium/cli/clawctl/agent/upgrade.py
+++ b/src/clawrium/cli/clawctl/agent/upgrade.py
@@ -214,6 +214,29 @@ def upgrade(
         emit_error(f"upgrade failed: {exc}")
         return
 
+    from clawrium.core.workspace_sync import push_workspace_phase
+
+    def _emit_workspace(stage: str, payload: dict) -> None:
+        if not use_json:
+            stream_action(resource=resource, message=f"{stage}: {json.dumps(payload)}")
+
+    ws_result = push_workspace_phase(
+        host=host,
+        agent_type=agent_type,
+        agent_name=on_host_name,
+        on_event=_emit_workspace if not use_json else None,
+    )
+    workspace_error = (
+        (ws_result.error or "unknown workspace error")
+        if not ws_result.success
+        else None
+    )
+    if workspace_error:
+        emit_error(
+            f"upgrade installed but workspace restore failed: {workspace_error}",
+            hint="run `clawctl agent sync` after fixing the local workspace overlay",
+        )
+
     # ATX B2 (issue #592): zeroclaw's install playbook does NOT pair
     # (see `core/install.py:1069`); the bearer token lives in the
     # configure path. After a forced reinstall the daemon mints a new
@@ -241,7 +264,7 @@ def upgrade(
                 hostname=hostname,
                 claw_name=agent_type,
                 agent_name=on_host_name,
-                on_event=_emit_lifecycle,
+                on_event=_emit_lifecycle if not use_json else None,
             )
         except LifecycleError as exc:
             emit_error(

--- a/src/clawrium/core/memory.py
+++ b/src/clawrium/core/memory.py
@@ -26,6 +26,7 @@ import logging
 import os
 import re
 import shutil
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import TypedDict
@@ -657,6 +658,84 @@ def _manifest_workspace_path(claw_type: str, unix_name: str) -> str:
     return raw
 
 
+def _local_memory_workspace_root(claw_type: str, unix_name: str) -> Path:
+    """Return the local control-plane workspace overlay root for one agent."""
+    return get_config_dir() / "agents" / claw_type / unix_name / "workspace"
+
+
+def _local_memory_file_path(claw_type: str, unix_name: str, filename: str) -> Path:
+    """Return the local control-plane path for one workspace-relative file."""
+    if Path(filename).is_absolute() or "\\" in filename:
+        raise ValueError(f"filename escapes workspace root: {filename!r}")
+    workspace_root = _local_memory_workspace_root(claw_type, unix_name)
+    candidate = workspace_root / Path(*filename.split("/"))
+    resolved_root = workspace_root.resolve()
+    resolved_candidate = candidate.resolve(strict=False)
+    try:
+        resolved_candidate.relative_to(resolved_root)
+    except ValueError as e:
+        raise ValueError(f"filename escapes workspace root: {filename!r}") from e
+    return candidate
+
+
+def _read_local_memory_file(claw_type: str, unix_name: str, filename: str) -> str | None:
+    """Read one memory file from the local control-plane overlay if present."""
+    path = _local_memory_file_path(claw_type, unix_name, filename)
+    if not path.is_file():
+        return None
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as e:
+        logger.warning("Memory local read failed for %s: %s", path, e)
+        return None
+
+
+def _write_local_memory_file(
+    claw_type: str, unix_name: str, filename: str, content: str
+) -> None:
+    """Persist one memory file into the local control-plane overlay."""
+    workspace_root = _local_memory_workspace_root(claw_type, unix_name)
+    workspace_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path = _local_memory_file_path(claw_type, unix_name, filename)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(content)
+            temp_path = Path(handle.name)
+        os.chmod(temp_path, 0o600)
+        temp_path.replace(path)
+    except OSError:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+        raise
+
+
+def _delete_local_memory_files(claw_type: str, unix_name: str, files: list[str]) -> None:
+    """Delete local overlay copies for the given workspace-relative files."""
+    workspace_root = _local_memory_workspace_root(claw_type, unix_name)
+    for filename in files:
+        path = _local_memory_file_path(claw_type, unix_name, filename)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            raise
+        for parent in path.parents:
+            if parent == workspace_root:
+                break
+            try:
+                parent.rmdir()
+            except OSError:
+                break
+
+
 def get_memory_info(hostname: str, agent_name: str) -> MemoryStats | None:
     """Return memory stats for a memory-capable agent or None if unavailable."""
     host, unix_name, claw_type = _resolve_agent_with_memory(hostname, agent_name)
@@ -765,6 +844,10 @@ def read_memory_file(hostname: str, agent_name: str, filename: str) -> str | Non
     except MemoryOpError:
         return None
 
+    local_content = _read_local_memory_file(claw_type, unix_name, filename)
+    if local_content is not None:
+        return local_content
+
     extra_vars = {"agent_name": unix_name, "memory_filename": filename}
     result, log_dir, setup_error = _run_memory_playbook(
         host, claw_type, "memory_read", extra_vars, timeout=30
@@ -792,10 +875,20 @@ def read_memory_file(hostname: str, agent_name: str, filename: str) -> str | Non
                 content_b64 = res.get("content")
                 if content_b64:
                     try:
-                        return base64.b64decode(content_b64).decode("utf-8")
+                        content = base64.b64decode(content_b64).decode("utf-8")
                     except (ValueError, UnicodeDecodeError) as e:
                         logger.warning("Failed to decode memory content: %s", e)
                         return None
+                    try:
+                        _write_local_memory_file(claw_type, unix_name, filename, content)
+                    except OSError as e:
+                        logger.warning(
+                            "Memory local backfill failed for %s/%s: %s",
+                            unix_name,
+                            filename,
+                            e,
+                        )
+                    return content
         return None
     finally:
         if log_dir is not None:
@@ -876,6 +969,24 @@ def write_memory_file(
             return False, "Memory write timed out"
         if result.status != "successful":
             return False, _extract_failure_message(result, result.status)
+        try:
+            _write_local_memory_file(claw_type, unix_name, filename, content)
+        except OSError as e:
+            logger.warning(
+                "Memory local persist failed for %s/%s after remote success: %s",
+                unix_name,
+                filename,
+                e,
+            )
+            try:
+                _delete_local_memory_files(claw_type, unix_name, [filename])
+            except OSError as cleanup_error:
+                logger.warning(
+                    "Memory local cleanup failed for %s/%s after persist error: %s",
+                    unix_name,
+                    filename,
+                    cleanup_error,
+                )
         return True, None
     finally:
         if log_dir is not None:
@@ -943,6 +1054,15 @@ def delete_memory_files(
             return False, "Memory delete timed out"
         if result.status != "successful":
             return False, _extract_failure_message(result, result.status)
+        try:
+            _delete_local_memory_files(claw_type, unix_name, files)
+        except OSError as e:
+            logger.warning(
+                "Memory local delete failed for %s/%s after remote success: %s",
+                unix_name,
+                ", ".join(files),
+                e,
+            )
         return True, None
     finally:
         if log_dir is not None:

--- a/src/clawrium/core/memory.py
+++ b/src/clawrium/core/memory.py
@@ -22,6 +22,7 @@ present an "unavailable" state instead of raising.
 from __future__ import annotations
 
 import base64
+import errno
 import logging
 import os
 import re
@@ -695,6 +696,10 @@ def _write_local_memory_file(
 ) -> None:
     """Persist one memory file into the local control-plane overlay."""
     workspace_root = _local_memory_workspace_root(claw_type, unix_name)
+    if workspace_root.is_symlink():
+        raise OSError(errno.ELOOP, os.strerror(errno.ELOOP), str(workspace_root))
+    # TOCTOU: best-effort guard only; pathlib cannot make the symlink check
+    # and directory creation atomic without dropping to lower-level os APIs.
     workspace_root.mkdir(parents=True, exist_ok=True, mode=0o700)
     path = _local_memory_file_path(claw_type, unix_name, filename)
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -721,12 +726,22 @@ def _write_local_memory_file(
 def _delete_local_memory_files(claw_type: str, unix_name: str, files: list[str]) -> None:
     """Delete local overlay copies for the given workspace-relative files."""
     workspace_root = _local_memory_workspace_root(claw_type, unix_name)
+    if workspace_root.is_symlink():
+        raise OSError(errno.ELOOP, os.strerror(errno.ELOOP), str(workspace_root))
+    # TOCTOU: best-effort guard only; pathlib cannot make the symlink check
+    # and unlink atomic without dropping to lower-level os APIs.
+    first_error: OSError | None = None
+    failure_count = 0
     for filename in files:
         path = _local_memory_file_path(claw_type, unix_name, filename)
         try:
             path.unlink(missing_ok=True)
-        except OSError:
-            raise
+        except OSError as e:
+            logger.warning("Memory local unlink failed for %s: %s", path, e)
+            failure_count += 1
+            if first_error is None:
+                first_error = e
+            continue
         for parent in path.parents:
             if parent == workspace_root:
                 break
@@ -734,6 +749,13 @@ def _delete_local_memory_files(claw_type: str, unix_name: str, files: list[str])
                 parent.rmdir()
             except OSError:
                 break
+    if first_error is not None:
+        logger.warning(
+            "Memory local unlink: %d of %d files failed",
+            failure_count,
+            len(files),
+        )
+        raise first_error
 
 
 def get_memory_info(hostname: str, agent_name: str) -> MemoryStats | None:

--- a/tests/cli/test_agent_upgrade.py
+++ b/tests/cli/test_agent_upgrade.py
@@ -12,12 +12,13 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
 from clawrium.cli import app
+from clawrium.core.lifecycle import LifecycleError
 
 runner = CliRunner()
 
@@ -326,13 +327,124 @@ def test_upgrade_zeroclaw_invokes_restart_agent_for_bearer_rotation(
     with patch(
         "clawrium.core.install.run_installation", side_effect=_fake_install
     ), patch(
+        "clawrium.core.workspace_sync.push_workspace_phase",
+        return_value=MagicMock(success=True),
+    ) as mock_push, patch(
         "clawrium.core.lifecycle.restart_agent", side_effect=_fake_restart
     ) as mock_restart:
         result = runner.invoke(
             app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
         )
     assert result.exit_code == 0, result.output
-    mock_restart.assert_called_once()
+    mock_push.assert_called_once()
+    assert mock_push.call_args.kwargs["agent_type"] == "zeroclaw"
+    assert mock_push.call_args.kwargs["agent_name"] == "test-agent"
+    assert mock_push.call_args.kwargs["host"]["alias"] == "h1"
+    assert mock_push.call_args.kwargs["host"]["hostname"] == "192.168.1.100"
+    assert mock_push.call_args.kwargs["on_event"] is not None
+    mock_restart.assert_called_once_with(
+        hostname="192.168.1.100",
+        claw_name="zeroclaw",
+        agent_name="test-agent",
+        on_event=ANY,
+    )
+
+
+def test_upgrade_surfaces_workspace_restore_failure(
+    isolated_config: Path, _patch_drift_clean
+):
+    _write_host(isolated_config, "zeroclaw", "0.6.0")
+
+    def _fake_install(*args, **kwargs):
+        return {
+            "success": True,
+            "agent": "zeroclaw",
+            "version": "0.7.5",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+        }
+
+    with patch(
+        "clawrium.core.install.run_installation", side_effect=_fake_install
+    ), patch(
+        "clawrium.core.workspace_sync.push_workspace_phase",
+        return_value=MagicMock(success=False, error="workspace push failed"),
+    ), patch(
+        "clawrium.core.lifecycle.restart_agent",
+        return_value={"success": True, "agent": "zeroclaw", "host": "192.168.1.100"},
+    ) as mock_restart:
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+
+    assert result.exit_code != 0, result.output
+    mock_restart.assert_not_called()
+    assert "workspace restore failed" in result.output.lower()
+    assert "workspace push failed" in result.output
+
+
+def test_upgrade_openclaw_surfaces_workspace_restore_failure(
+    isolated_config: Path, _patch_drift_clean
+):
+    _write_host(isolated_config, "openclaw", "0.6.0")
+
+    def _fake_install(*args, **kwargs):
+        return {
+            "success": True,
+            "agent": "openclaw",
+            "version": "0.7.5",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+        }
+
+    with patch(
+        "clawrium.core.install.run_installation", side_effect=_fake_install
+    ), patch(
+        "clawrium.core.workspace_sync.push_workspace_phase",
+        return_value=MagicMock(success=False, error="workspace push failed"),
+    ):
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+
+    assert result.exit_code != 0, result.output
+    assert "workspace restore failed" in result.output.lower()
+    assert "workspace push failed" in result.output
+
+
+def test_upgrade_reports_workspace_failure_when_restart_raises(
+    isolated_config: Path, _patch_drift_clean
+):
+    _write_host(isolated_config, "zeroclaw", "0.6.0")
+
+    def _fake_install(*args, **kwargs):
+        return {
+            "success": True,
+            "agent": "zeroclaw",
+            "version": "0.7.5",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+        }
+
+    with patch(
+        "clawrium.core.install.run_installation", side_effect=_fake_install
+    ), patch(
+        "clawrium.core.workspace_sync.push_workspace_phase",
+        return_value=MagicMock(success=False, error="workspace push failed"),
+    ), patch(
+        "clawrium.core.lifecycle.restart_agent",
+        side_effect=LifecycleError("restart blew up"),
+    ):
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+
+    assert result.exit_code != 0, result.output
+    assert "workspace restore failed" in result.output.lower()
+    assert "workspace push failed" in result.output
 
 
 def test_upgrade_zeroclaw_surfaces_failed_restart_as_error(

--- a/tests/cli/test_agent_upgrade.py
+++ b/tests/cli/test_agent_upgrade.py
@@ -305,6 +305,7 @@ def test_upgrade_zeroclaw_invokes_restart_agent_for_bearer_rotation(
     `gateway_token_rotated` fires per AGENTS.md.
     """
     _write_host(isolated_config, "zeroclaw", "0.6.0")
+    call_order: list[str] = []
 
     def _fake_install(*args, **kwargs):
         return {
@@ -317,6 +318,7 @@ def test_upgrade_zeroclaw_invokes_restart_agent_for_bearer_rotation(
         }
 
     def _fake_restart(*args, **kwargs):
+        call_order.append("restart")
         return {
             "success": True,
             "agent": kwargs.get("agent_name") or "zeroclaw",
@@ -328,7 +330,9 @@ def test_upgrade_zeroclaw_invokes_restart_agent_for_bearer_rotation(
         "clawrium.core.install.run_installation", side_effect=_fake_install
     ), patch(
         "clawrium.core.workspace_sync.push_workspace_phase",
-        return_value=MagicMock(success=True),
+        side_effect=lambda *args, **kwargs: (
+            call_order.append("workspace") or MagicMock(success=True)
+        ),
     ) as mock_push, patch(
         "clawrium.core.lifecycle.restart_agent", side_effect=_fake_restart
     ) as mock_restart:
@@ -342,6 +346,7 @@ def test_upgrade_zeroclaw_invokes_restart_agent_for_bearer_rotation(
     assert mock_push.call_args.kwargs["host"]["alias"] == "h1"
     assert mock_push.call_args.kwargs["host"]["hostname"] == "192.168.1.100"
     assert mock_push.call_args.kwargs["on_event"] is not None
+    assert call_order == ["workspace", "restart"]
     mock_restart.assert_called_once_with(
         hostname="192.168.1.100",
         claw_name="zeroclaw",
@@ -382,6 +387,7 @@ def test_upgrade_surfaces_workspace_restore_failure(
     mock_restart.assert_not_called()
     assert "workspace restore failed" in result.output.lower()
     assert "workspace push failed" in result.output
+    assert "bearer state may also be stale" in result.output.lower()
 
 
 def test_upgrade_openclaw_surfaces_workspace_restore_failure(
@@ -412,6 +418,69 @@ def test_upgrade_openclaw_surfaces_workspace_restore_failure(
     assert result.exit_code != 0, result.output
     assert "workspace restore failed" in result.output.lower()
     assert "workspace push failed" in result.output
+    assert "bearer state may also be stale" not in result.output.lower()
+
+
+def test_upgrade_surfaces_workspace_restore_exception(
+    isolated_config: Path, _patch_drift_clean
+):
+    _write_host(isolated_config, "openclaw", "0.6.0")
+
+    def _fake_install(*args, **kwargs):
+        return {
+            "success": True,
+            "agent": "openclaw",
+            "version": "0.7.5",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+        }
+
+    with patch(
+        "clawrium.core.install.run_installation", side_effect=_fake_install
+    ), patch(
+        "clawrium.core.workspace_sync.push_workspace_phase",
+        side_effect=RuntimeError("workspace blew up"),
+    ):
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+
+    assert result.exit_code != 0, result.output
+    assert "workspace restore crashed" in result.output.lower()
+    assert "workspace blew up" in result.output
+    assert "bearer state may also be stale" not in result.output.lower()
+
+
+def test_upgrade_zeroclaw_surfaces_workspace_restore_exception(
+    isolated_config: Path, _patch_drift_clean
+):
+    _write_host(isolated_config, "zeroclaw", "0.6.0")
+
+    def _fake_install(*args, **kwargs):
+        return {
+            "success": True,
+            "agent": "zeroclaw",
+            "version": "0.7.5",
+            "host": "192.168.1.100",
+            "playbooks_run": [],
+            "error": None,
+        }
+
+    with patch(
+        "clawrium.core.install.run_installation", side_effect=_fake_install
+    ), patch(
+        "clawrium.core.workspace_sync.push_workspace_phase",
+        side_effect=RuntimeError("workspace blew up"),
+    ):
+        result = runner.invoke(
+            app, ["agent", "upgrade", "test-agent", "--yes"], env=os.environ
+        )
+
+    assert result.exit_code != 0, result.output
+    assert "workspace restore crashed" in result.output.lower()
+    assert "workspace blew up" in result.output
+    assert "zeroclaw bearer state may also be stale" in result.output.lower()
 
 
 def test_upgrade_reports_workspace_failure_when_restart_raises(

--- a/tests/test_core_memory.py
+++ b/tests/test_core_memory.py
@@ -2043,6 +2043,30 @@ class TestLocalOverlayPersistence:
 
         assert list(overlay.glob(".*.tmp")) == []
 
+    def test_write_local_memory_file_rejects_symlinked_workspace_root(
+        self, isolated_config: Path
+    ):
+        overlay_parent = isolated_config / "agents" / "zeroclaw" / "zc-work"
+        overlay_parent.mkdir(parents=True)
+        target = isolated_config / "elsewhere"
+        target.mkdir(parents=True)
+        (overlay_parent / "workspace").symlink_to(target, target_is_directory=True)
+
+        with pytest.raises(OSError, match="Too many levels of symbolic links"):
+            _write_local_memory_file("zeroclaw", "zc-work", "SOUL.md", "content")
+
+    def test_delete_local_memory_file_rejects_symlinked_workspace_root(
+        self, isolated_config: Path
+    ):
+        overlay_parent = isolated_config / "agents" / "zeroclaw" / "zc-work"
+        overlay_parent.mkdir(parents=True)
+        target = isolated_config / "elsewhere"
+        target.mkdir(parents=True)
+        (overlay_parent / "workspace").symlink_to(target, target_is_directory=True)
+
+        with pytest.raises(OSError, match="Too many levels of symbolic links"):
+            _delete_local_memory_files("zeroclaw", "zc-work", ["SOUL.md"])
+
     def test_delete_local_memory_files_keeps_nonempty_parent_dir(
         self, isolated_config: Path
     ):
@@ -2057,6 +2081,36 @@ class TestLocalOverlayPersistence:
 
         assert sibling.exists()
         assert memory_dir.exists()
+
+    def test_delete_local_memory_files_continues_after_unlink_error(
+        self, isolated_config: Path, caplog: pytest.LogCaptureFixture
+    ):
+        overlay = isolated_config / "agents" / "zeroclaw" / "zc-work" / "workspace"
+        memory_dir = overlay / "memory"
+        memory_dir.mkdir(parents=True)
+        keep = memory_dir / "one.md"
+        remove = memory_dir / "two.md"
+        keep.write_text("1", encoding="utf-8")
+        remove.write_text("2", encoding="utf-8")
+        real_unlink = Path.unlink
+
+        def _unlink_fail_once(path: Path, missing_ok: bool = False):
+            if path == keep:
+                raise OSError("permission denied")
+            return real_unlink(path, missing_ok=missing_ok)
+
+        with (
+            patch("pathlib.Path.unlink", autospec=True, side_effect=_unlink_fail_once),
+            caplog.at_level(logging.WARNING),
+        ):
+            with pytest.raises(OSError, match="permission denied"):
+                _delete_local_memory_files(
+                    "zeroclaw", "zc-work", ["memory/one.md", "memory/two.md"]
+                )
+
+        assert keep.exists()
+        assert not remove.exists()
+        assert "Memory local unlink failed" in caplog.text
 
     def test_read_prefers_local_overlay_copy(self, isolated_config: Path):
         overlay = isolated_config / "agents" / "zeroclaw" / "zc-work" / "workspace"

--- a/tests/test_core_memory.py
+++ b/tests/test_core_memory.py
@@ -1,6 +1,8 @@
 """Tests for openclaw memory operations."""
 
 import base64
+import logging
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -11,12 +13,15 @@ from clawrium.core.memory import (
     MEMORY_TOP_LEVEL_FILES,
     MemoryOpError,
     _cleanup_artifacts,
+    _delete_local_memory_files,
     _extract_failure_message,
+    _local_memory_file_path,
     _parse_memory_info_stdout,
     _resolve_agent_with_memory,
     _resolve_openclaw_agent,
     _validate_agent_name,
     _validate_memory_filename,
+    _write_local_memory_file,
     delete_memory_files,
     get_memory_info,
     is_file_writable,
@@ -1996,6 +2001,389 @@ class TestZeroclawDispatch:
         # Sanity-check: at least one allowed personality file appears in the
         # error listing so an operator can see what IS writable.
         assert "SOUL.md" in err
+
+
+class TestLocalOverlayPersistence:
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "../../etc/passwd",
+            "/etc/passwd",
+            "memory/../../etc/passwd",
+            "..\\..\\etc\\passwd",
+        ],
+    )
+    def test_local_memory_file_path_rejects_workspace_escape(self, filename: str):
+        with pytest.raises(ValueError, match="escapes workspace root"):
+            _local_memory_file_path("zeroclaw", "zc-work", filename)
+
+    def test_local_memory_file_path_rejects_symlink_escape(self, isolated_config: Path):
+        overlay = isolated_config / "agents" / "zeroclaw" / "zc-work" / "workspace"
+        outside = isolated_config / "outside"
+        overlay.mkdir(parents=True)
+        outside.mkdir(parents=True)
+        (overlay / "escape").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="escapes workspace root"):
+            _local_memory_file_path("zeroclaw", "zc-work", "escape/secrets.txt")
+
+    def test_write_local_memory_file_cleans_tempfile_on_failure(self, isolated_config: Path):
+        overlay = isolated_config / "agents" / "zeroclaw" / "zc-work" / "workspace"
+        overlay.mkdir(parents=True)
+        real_chmod = os.chmod
+
+        def _chmod_fail_once(path: str | os.PathLike[str], mode: int) -> None:
+            if str(path).endswith(".tmp"):
+                raise OSError("chmod failed")
+            real_chmod(path, mode)
+
+        with patch("clawrium.core.memory.os.chmod", side_effect=_chmod_fail_once):
+            with pytest.raises(OSError, match="chmod failed"):
+                _write_local_memory_file("zeroclaw", "zc-work", "SOUL.md", "content")
+
+        assert list(overlay.glob(".*.tmp")) == []
+
+    def test_delete_local_memory_files_keeps_nonempty_parent_dir(
+        self, isolated_config: Path
+    ):
+        overlay = isolated_config / "agents" / "zeroclaw" / "zc-work" / "workspace"
+        memory_dir = overlay / "memory"
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "one.md").write_text("1", encoding="utf-8")
+        sibling = memory_dir / "two.md"
+        sibling.write_text("2", encoding="utf-8")
+
+        _delete_local_memory_files("zeroclaw", "zc-work", ["memory/one.md"])
+
+        assert sibling.exists()
+        assert memory_dir.exists()
+
+    def test_read_prefers_local_overlay_copy(self, isolated_config: Path):
+        overlay = isolated_config / "agents" / "zeroclaw" / "zc-work" / "workspace"
+        overlay.mkdir(parents=True)
+        (overlay / "SOUL.md").write_text("local soul", encoding="utf-8")
+
+        with (
+            patch(
+                "clawrium.core.memory._resolve_agent_with_memory",
+                return_value=(_host_with_zeroclaw(), "zc-work", "zeroclaw"),
+            ),
+            patch(
+                "clawrium.core.memory._run_memory_playbook",
+                side_effect=AssertionError("remote read must not run when local copy exists"),
+            ),
+        ):
+            content = read_memory_file("192.168.1.36", "zc-work", "SOUL.md")
+
+        assert content == "local soul"
+
+    def test_read_remote_fallback_backfills_local_overlay(self, isolated_config: Path):
+        host = _host_with_zeroclaw()
+        playbook_dir = isolated_config / "zeroclaw-pb"
+        playbook_dir.mkdir(parents=True)
+        (playbook_dir / "memory_read.yaml").write_text("---\n")
+        ssh_key = isolated_config / "id_rsa"
+        ssh_key.write_text("key")
+
+        encoded = base64.b64encode(b"remote soul").decode("ascii")
+        result = _runner_result(
+            "successful",
+            [{"event": "runner_on_ok", "event_data": {"res": {"content": encoded}}}],
+        )
+
+        with (
+            patch(
+                "clawrium.core.memory._resolve_agent_with_memory",
+                return_value=(host, "zc-work", "zeroclaw"),
+            ),
+            patch("clawrium.core.memory._get_playbook_dir", return_value=playbook_dir),
+            patch(
+                "clawrium.core.memory.core_keys.get_host_private_key",
+                return_value=ssh_key,
+            ),
+            patch("clawrium.core.memory.ansible_runner.run", return_value=result),
+        ):
+            content = read_memory_file("192.168.1.36", "zc-work", "SOUL.md")
+
+        assert content == "remote soul"
+        assert (
+            isolated_config
+            / "agents"
+            / "zeroclaw"
+            / "zc-work"
+            / "workspace"
+            / "SOUL.md"
+        ).read_text(encoding="utf-8") == "remote soul"
+
+    def test_read_remote_fallback_returns_content_when_local_backfill_fails(
+        self, isolated_config: Path, caplog: pytest.LogCaptureFixture
+    ):
+        host = _host_with_zeroclaw()
+        playbook_dir = isolated_config / "zeroclaw-pb-backfill-fail"
+        playbook_dir.mkdir(parents=True)
+        (playbook_dir / "memory_read.yaml").write_text("---\n")
+        ssh_key = isolated_config / "id_rsa.backfill"
+        ssh_key.write_text("key")
+
+        encoded = base64.b64encode(b"remote soul").decode("ascii")
+        result = _runner_result(
+            "successful",
+            [{"event": "runner_on_ok", "event_data": {"res": {"content": encoded}}}],
+        )
+
+        with (
+            patch(
+                "clawrium.core.memory._resolve_agent_with_memory",
+                return_value=(host, "zc-work", "zeroclaw"),
+            ),
+            patch("clawrium.core.memory._get_playbook_dir", return_value=playbook_dir),
+            patch(
+                "clawrium.core.memory.core_keys.get_host_private_key",
+                return_value=ssh_key,
+            ),
+            patch("clawrium.core.memory.ansible_runner.run", return_value=result),
+            patch(
+                "clawrium.core.memory._write_local_memory_file",
+                side_effect=OSError("disk full"),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            content = read_memory_file("192.168.1.36", "zc-work", "SOUL.md")
+
+        assert content == "remote soul"
+        assert "Memory local backfill failed" in caplog.text
+
+    def test_write_mirrors_successful_remote_write_locally(self, isolated_config: Path):
+        host = _host_with_zeroclaw()
+        playbook_dir = isolated_config / "zeroclaw-write-pb"
+        playbook_dir.mkdir(parents=True)
+        (playbook_dir / "memory_write.yaml").write_text("---\n")
+        ssh_key = isolated_config / "id_rsa.write"
+        ssh_key.write_text("key")
+        result = _runner_result("successful", [])
+
+        with (
+            patch(
+                "clawrium.core.memory._resolve_agent_with_memory",
+                return_value=(host, "zc-work", "zeroclaw"),
+            ),
+            patch("clawrium.core.memory._get_playbook_dir", return_value=playbook_dir),
+            patch(
+                "clawrium.core.memory.core_keys.get_host_private_key",
+                return_value=ssh_key,
+            ),
+            patch("clawrium.core.memory.ansible_runner.run", return_value=result),
+        ):
+            ok, err = write_memory_file(
+                "192.168.1.36", "zc-work", "SOUL.md", "persist me"
+            )
+
+        assert ok is True
+        assert err is None
+        assert (
+            isolated_config
+            / "agents"
+            / "zeroclaw"
+            / "zc-work"
+            / "workspace"
+            / "SOUL.md"
+        ).read_text(encoding="utf-8") == "persist me"
+
+    def test_write_does_not_mutate_local_overlay_on_remote_failure(
+        self, isolated_config: Path
+    ):
+        host = _host_with_zeroclaw()
+        playbook_dir = isolated_config / "zeroclaw-write-fail-pb"
+        playbook_dir.mkdir(parents=True)
+        (playbook_dir / "memory_write.yaml").write_text("---\n")
+        ssh_key = isolated_config / "id_rsa.write.fail"
+        ssh_key.write_text("key")
+        result = _runner_result("failed", [])
+
+        with (
+            patch(
+                "clawrium.core.memory._resolve_agent_with_memory",
+                return_value=(host, "zc-work", "zeroclaw"),
+            ),
+            patch("clawrium.core.memory._get_playbook_dir", return_value=playbook_dir),
+            patch(
+                "clawrium.core.memory.core_keys.get_host_private_key",
+                return_value=ssh_key,
+            ),
+            patch("clawrium.core.memory.ansible_runner.run", return_value=result),
+            patch(
+                "clawrium.core.memory._extract_failure_message",
+                return_value="remote write failed",
+            ),
+        ):
+            ok, err = write_memory_file("192.168.1.36", "zc-work", "SOUL.md", "nope")
+
+        assert ok is False
+        assert err == "remote write failed"
+        assert not (
+            isolated_config
+            / "agents"
+            / "zeroclaw"
+            / "zc-work"
+            / "workspace"
+            / "SOUL.md"
+        ).exists()
+
+    def test_write_returns_success_when_local_overlay_persist_fails(
+        self, isolated_config: Path, caplog: pytest.LogCaptureFixture
+    ):
+        host = _host_with_zeroclaw()
+        playbook_dir = isolated_config / "zeroclaw-write-local-fail-pb"
+        playbook_dir.mkdir(parents=True)
+        (playbook_dir / "memory_write.yaml").write_text("---\n")
+        ssh_key = isolated_config / "id_rsa.write.local.fail"
+        ssh_key.write_text("key")
+        result = _runner_result("successful", [])
+
+        with (
+            patch(
+                "clawrium.core.memory._resolve_agent_with_memory",
+                return_value=(host, "zc-work", "zeroclaw"),
+            ),
+            patch("clawrium.core.memory._get_playbook_dir", return_value=playbook_dir),
+            patch(
+                "clawrium.core.memory.core_keys.get_host_private_key",
+                return_value=ssh_key,
+            ),
+            patch("clawrium.core.memory.ansible_runner.run", return_value=result),
+            patch(
+                "clawrium.core.memory._write_local_memory_file",
+                side_effect=OSError("disk full"),
+            ),
+            patch("clawrium.core.memory._delete_local_memory_files") as mock_cleanup,
+            caplog.at_level(logging.WARNING),
+        ):
+            ok, err = write_memory_file(
+                "192.168.1.36", "zc-work", "SOUL.md", "persist me"
+            )
+
+        assert ok is True
+        assert err is None
+        mock_cleanup.assert_called_once_with("zeroclaw", "zc-work", ["SOUL.md"])
+        assert "Memory local persist failed" in caplog.text
+
+    def test_delete_mirrors_successful_remote_delete_locally(self, isolated_config: Path):
+        host = _host_with_zeroclaw()
+        playbook_dir = isolated_config / "zeroclaw-delete-pb"
+        playbook_dir.mkdir(parents=True)
+        (playbook_dir / "memory_delete.yaml").write_text("---\n")
+        ssh_key = isolated_config / "id_rsa.delete"
+        ssh_key.write_text("key")
+        result = _runner_result("successful", [])
+        overlay_file = (
+            isolated_config
+            / "agents"
+            / "zeroclaw"
+            / "zc-work"
+            / "workspace"
+            / "memory"
+            / "2026-05-15.md"
+        )
+        overlay_file.parent.mkdir(parents=True)
+        overlay_file.write_text("daily note", encoding="utf-8")
+
+        with (
+            patch(
+                "clawrium.core.memory._resolve_agent_with_memory",
+                return_value=(host, "zc-work", "zeroclaw"),
+            ),
+            patch("clawrium.core.memory._get_playbook_dir", return_value=playbook_dir),
+            patch(
+                "clawrium.core.memory.core_keys.get_host_private_key",
+                return_value=ssh_key,
+            ),
+            patch("clawrium.core.memory.ansible_runner.run", return_value=result),
+        ):
+            ok, err = delete_memory_files(
+                "192.168.1.36", "zc-work", ["memory/2026-05-15.md"]
+            )
+
+        assert ok is True
+        assert err is None
+        assert not overlay_file.exists()
+        assert not overlay_file.parent.exists()
+
+    def test_delete_does_not_mutate_local_overlay_on_remote_failure(
+        self, isolated_config: Path
+    ):
+        host = _host_with_zeroclaw()
+        playbook_dir = isolated_config / "zeroclaw-delete-fail-pb"
+        playbook_dir.mkdir(parents=True)
+        (playbook_dir / "memory_delete.yaml").write_text("---\n")
+        ssh_key = isolated_config / "id_rsa.delete.fail"
+        ssh_key.write_text("key")
+        result = _runner_result("failed", [])
+        overlay_file = (
+            isolated_config
+            / "agents"
+            / "zeroclaw"
+            / "zc-work"
+            / "workspace"
+            / "AGENTS.md"
+        )
+        overlay_file.parent.mkdir(parents=True)
+        overlay_file.write_text("keep me", encoding="utf-8")
+
+        with (
+            patch(
+                "clawrium.core.memory._resolve_agent_with_memory",
+                return_value=(host, "zc-work", "zeroclaw"),
+            ),
+            patch("clawrium.core.memory._get_playbook_dir", return_value=playbook_dir),
+            patch(
+                "clawrium.core.memory.core_keys.get_host_private_key",
+                return_value=ssh_key,
+            ),
+            patch("clawrium.core.memory.ansible_runner.run", return_value=result),
+            patch(
+                "clawrium.core.memory._extract_failure_message",
+                return_value="remote delete failed",
+            ),
+        ):
+            ok, err = delete_memory_files("192.168.1.36", "zc-work", ["AGENTS.md"])
+
+        assert ok is False
+        assert err == "remote delete failed"
+        assert overlay_file.read_text(encoding="utf-8") == "keep me"
+
+    def test_delete_returns_success_when_local_overlay_delete_fails(
+        self, isolated_config: Path, caplog: pytest.LogCaptureFixture
+    ):
+        host = _host_with_zeroclaw()
+        playbook_dir = isolated_config / "zeroclaw-delete-local-fail-pb"
+        playbook_dir.mkdir(parents=True)
+        (playbook_dir / "memory_delete.yaml").write_text("---\n")
+        ssh_key = isolated_config / "id_rsa.delete.local.fail"
+        ssh_key.write_text("key")
+        result = _runner_result("successful", [])
+
+        with (
+            patch(
+                "clawrium.core.memory._resolve_agent_with_memory",
+                return_value=(host, "zc-work", "zeroclaw"),
+            ),
+            patch("clawrium.core.memory._get_playbook_dir", return_value=playbook_dir),
+            patch(
+                "clawrium.core.memory.core_keys.get_host_private_key",
+                return_value=ssh_key,
+            ),
+            patch("clawrium.core.memory.ansible_runner.run", return_value=result),
+            patch(
+                "clawrium.core.memory._delete_local_memory_files",
+                side_effect=OSError("permission denied"),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            ok, err = delete_memory_files("192.168.1.36", "zc-work", ["AGENTS.md"])
+
+        assert ok is True
+        assert err is None
+        assert "Memory local delete failed" in caplog.text
 
 
 # ----- ATX iter 5 W1: openclaw allowlist negative-path coverage ------------


### PR DESCRIPTION
## Summary

- persist zeroclaw memory and persona files in the local control-plane workspace overlay and backfill legacy remote-only reads into that overlay
- restore the local workspace overlay during `clawctl agent upgrade` before any zeroclaw restart path, preserving the documented workspace-failure short-circuit semantics
- add regression coverage for overlay-first reads, write/delete mirroring, helper hardening, and upgrade restore behavior; document the fix in `CHANGELOG.md` and `.itx/871/`

## Testing

### Test Results
- [x] Focused memory and upgrade tests pass (`PYTHONPATH=src .venv/bin/python -m pytest tests/test_core_memory.py tests/cli/test_agent_upgrade.py -q`)
- [x] Source-based lint passes (`PYTHONPATH=src .venv/bin/python -m ruff check src tests`)
- [x] Full source-based test suite passes (`PYTHONPATH=src .venv/bin/python -m pytest -q`)
- [ ] `make test`
- [ ] `make lint`

### Test Coverage
- Files changed: `src/clawrium/core/memory.py`, `src/clawrium/cli/clawctl/agent/upgrade.py`, `tests/test_core_memory.py`, `tests/cli/test_agent_upgrade.py`, `CHANGELOG.md`, `.itx/871/00_PLAN.md`, `.itx/871/01_EXECUTION.md`, `.itx/871/atx-session.json`
- New tests: expanded `TestLocalOverlayPersistence` coverage and added upgrade workspace-restore regression cases in `tests/cli/test_agent_upgrade.py`
- Coverage impact: increased for local-overlay memory flows, helper hardening, and upgrade restore behavior

### Manual Testing
- Not run; this change was verified through focused and full automated test passes executed directly from `src`.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources

## ATX Review Summary

**Final Review: Rating 3/5**
**Total Cost: $9.80540405 | Total Time: 1h 8m 15s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2.5/5 | B1, B2, B3, B4, B5 | All fixed | $1.71029565 | 12m24s | leader, test-coverage, security-reviewer, lifecycle-core, cli-ux, gui-routes, platform-playbooks, render-engine |
| 2 | 2/5 | B1, B2 | All fixed | $1.3074598000000002 | 9m06s | leader, gui-routes, platform-playbooks, render-engine, test-coverage, cli-ux, security-reviewer, lifecycle-core |
| 3 | 2/5 | B1, B2, B3, B4, B5 | Fixed after review; no fourth ATX pass requested | $1.5628513000000002 | 13m26s | leader, lifecycle-core, security-reviewer, test-coverage, cli-ux, gui-routes, platform-playbooks, render-engine |
| 4 | 2.5/5 | B1, B2, B3, B4, B5 | Verified real hardening gaps fixed; stale coverage claims skipped | $2.4418937499999998 | 11m05s | leader, cli-ux, gui-routes, render-engine, test-coverage, platform-playbooks, lifecycle-core, security-reviewer |
| 5 | 2.5/5 | B1, B2, B3 | Fixed after review | $1.2363874499999998 | 15m49s | leader, gui-routes, platform-playbooks, render-engine, test-coverage, cli-ux, security-reviewer, lifecycle-core |
| 6 | 3/5 | B1 | Fixed after review; no seventh ATX pass requested | $1.5465161 | 6m25s | leader, gui-routes, lifecycle-core, platform-playbooks, render-engine, cli-ux, test-coverage, security-reviewer |

> **Note**: ATX CLI returned structured findings even when the leader parse reported partial coverage (`no <output> block found`).

<details>
<summary>Review 1 Details (Rating 2.5/5)</summary>

**Blocking Issues**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_core_memory.py` | Missing backfill-on-read failure coverage | Fixed with warning-path coverage asserting remote content still returns when local backfill fails |
| B2 | `tests/test_core_memory.py` | Missing local-write failure coverage | Fixed with a test covering remote success plus local persist failure |
| B3 | `tests/test_core_memory.py` | Missing local-delete failure coverage | Fixed with a test covering remote success plus local delete failure |
| B4 | `src/clawrium/core/memory.py` | Remote success was converted into user-visible failure on local overlay write/delete errors | Fixed by treating remote success as authoritative and logging overlay failures as warnings |
| B5 | `src/clawrium/cli/clawctl/agent/upgrade.py` | Upgrade failure handling around workspace restore / restart ordering was incorrect | Fixed in subsequent iterations; final flow now short-circuits on workspace restore failure before restart |

**Warnings**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `tests/test_core_memory.py` | Missing additional cleanup assertions | Added direct helper cleanup coverage |
| W2 | `src/clawrium/core/memory.py` | Local overlay writes were non-atomic | Switched to temp-file + replace semantics |

</details>

<details>
<summary>Review 4 Details (Rating 2.5/5)</summary>

**Blocking Issues**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `src/clawrium/core/memory.py` | Symlinked workspace root could bypass the local overlay contract | Fixed with explicit symlink-root rejection in write and later mirrored to delete |
| B2 | `src/clawrium/core/memory.py` | Partial local delete failures stopped later file cleanup | Fixed by continuing after unlink failures, then re-raising the first error |
| B3 | `tests/cli/test_agent_upgrade.py` | Missing non-pairing negative assertion for bearer warning | Fixed with explicit openclaw assertion |
| B4 | `src/clawrium/cli/clawctl/agent/upgrade.py` | Unexpected workspace-sync exceptions were unguarded | Fixed with `push_workspace_phase()` exception handling |
| B5 | review output | Several coverage claims did not reproduce against the current branch | Validated manually and skipped as stale |

**Warnings**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `upgrade.py` | Clarify bearer staleness on workspace failure | Fixed |
| W2 | `memory.py` | Reject symlinked workspace root before local write | Fixed |
| W3 | `memory.py` | Report scope of partial local delete failures | Fixed with summary warning |
| W4 | playbook follow-up | Linux workspace playbook path guard | Deferred as out-of-scope for this bug fix |
| W5 | `upgrade.py` | Missing exception guard around workspace restore | Fixed |

</details>

<details>
<summary>Review 5 Details (Rating 2.5/5)</summary>

**Blocking Issues**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `src/clawrium/core/memory.py` | Symlink-root guard raised `ValueError`, but callers only handled `OSError` | Fixed by switching to `OSError(ELOOP)` |
| B2 | `tests/test_core_memory.py` | Claimed unlink-failure test path identity bug | Did not reproduce; existing test uses absolute paths and was kept |
| B3 | `tests/cli/test_agent_upgrade.py` | Missing negative bearer-hint assertion on openclaw failure | Fixed |

**Warnings**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `memory.py` | Delete path also needed the symlink-root guard | Fixed |
| W2 | `memory.py` | TOCTOU limitation should be documented | Fixed on write path and later mirrored on delete |
| W3 | `memory.py` | Report how many local delete operations failed | Fixed |

</details>

<details>
<summary>Review 6 Details (Rating 3/5)</summary>

**Blocking Issues**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/cli/test_agent_upgrade.py` | No zeroclaw exception-path coverage for workspace restore crash handling | Fixed with zeroclaw-specific exception-path test and matching pairing warning assertion |

**Warnings**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `upgrade.py` | Pairing warning hardcoded `zeroclaw` instead of using `agent_type` | Fixed |
| W2 | `upgrade.py` | Error text could include more agent/host identity | Acknowledged; left unchanged to avoid broadening user-facing output in this bug fix |
| W3 | `memory.py` | Delete-path guard lacked the same TOCTOU note as write path | Fixed |
| W4 | `memory.py` | Intermediate-directory race remains best-effort only | Acknowledged |
| W5 | `tests/test_core_memory.py` | Partial-delete coverage does not yet exercise a 2-of-3 summary-count case | Acknowledged |
| W6 | `tests/cli/test_agent_upgrade.py` | Ordering-test lambda should accept positional args too | Fixed |

</details>

<details>
<summary>Review 2 Details (Rating 2/5)</summary>

**Blocking Issues**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `src/clawrium/core/memory.py` | Local helper needed explicit path-containment hardening | Fixed with absolute/backslash rejection plus resolved-path containment checks |
| B2 | `src/clawrium/cli/clawctl/agent/upgrade.py` | Upgrade workspace/restart failure reporting still had structural issues | Fixed in the next pass by restoring strict workspace short-circuit behavior |

**Warnings**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `src/clawrium/core/memory.py` | Potential stale local cache if both local persist and cleanup fail | Acknowledged; warning remains and a future sync/edit heals the copy |
| W2 | `src/clawrium/core/memory.py` | Preserve raw `OSError` and remove redundant chmod | Fixed |

</details>

<details>
<summary>Review 3 Details (Rating 2/5)</summary>

**Blocking Issues**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `src/clawrium/cli/clawctl/agent/upgrade.py` | Zeroclaw restart still ran after workspace restore failure | Fixed by restoring documented short-circuit before restart |
| B2 | `src/clawrium/cli/clawctl/agent/upgrade.py` | Ternary readability / precedence concern | Fixed with explicit parentheses |
| B3 | `src/clawrium/core/memory.py`, `tests/test_core_memory.py` | Path hardening coverage needed absolute and symlink escape tests | Fixed with broader negative-path coverage |
| B4 | `src/clawrium/core/memory.py`, `tests/test_core_memory.py` | Missing direct helper branch coverage | Fixed with tempfile cleanup and non-empty parent-dir tests |
| B5 | `tests/cli/test_agent_upgrade.py` | Upgrade tests did not assert exact call contracts | Fixed with explicit `push_workspace_phase()` and `restart_agent()` call assertions |

**Warnings**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `src/clawrium/core/memory.py` | Intermediate dir permissions can still be filtered by umask | Acknowledged |
| W2 | review process | No fourth ATX pass after the final blocker fixes | Acknowledged; validated with focused + full tests instead |

</details>

## Callouts

- [DECISION] `clawctl agent upgrade` now reuses `push_workspace_phase()` directly instead of introducing a second restore implementation.
  - Why: it preserves the existing workspace overlay contract and inherits the documented failure-before-restart invariant.
  - Alternatives considered: adding a bespoke install-time file restore path in `core/install.py`.
  - Reviewer: confirm or push back.

- [DECISION] Remote memory write/delete success is treated as authoritative even if the local overlay update fails afterward.
  - Why: surfacing a hard CLI failure after the remote change already landed would misreport the actual remote state; warnings plus later sync/edit recovery is a better match.
  - Alternatives considered: returning an error after remote success, which ATX flagged as misleading.
  - Reviewer: confirm or push back.

- [ENVIRONMENT] `make test` / `make lint` could not run in this worktree because editable-package build setup expects `src/clawrium/gui/frontend`, which is absent in this checkout.
  - Example: verification used `PYTHONPATH=src` with direct pytest and ruff invocations instead.

- [UNRESOLVED] ATX review reached 3/5 on review 6, but the final zeroclaw exception-path fix landed afterward and was not followed by a seventh ATX pass.
  - Best guess applied: carry the full ATX history into the PR and rely on the focused + full green verification after the last fixes.
  - Reviewer: please verify.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>
