### PR TITLE
fix(gui): stabilize agent action bar layout (#870)

### DIFF
--- a/.itx/870/00_PLAN.md
+++ b/.itx/870/00_PLAN.md
@@ -1,0 +1,125 @@
+# Issue #870 — Stable Agent Action Bar
+
+## Goal
+
+Stabilize the agent action bar so lifecycle buttons (`Start`, `Restart`,
+`Stop`) never appear/disappear based on `liveStatus`. Buttons that are
+invalid for the current state render disabled instead of unmounting, so
+`Restart` never shifts into where the cursor is headed.
+
+## Scope
+
+**In scope** — the three lifecycle buttons in
+`gui/src/components/agent-detail/agent-header.tsx`:
+
+- `Start` (previously gated by `isStopped`)
+- `Restart` + `Stop` (previously gated by `isRunning`)
+
+**Out of scope** — buttons gated by *agent-type identity* rather than
+state (they don't shift within a given agent's page):
+
+- `Open Agent UI` (agent-type feature)
+- `Get Pairing Code` (zeroclaw only)
+- `Show Connection Token` (openclaw only)
+
+## Design decisions
+
+1. **Always render Start, Restart, Stop**, in fixed
+   `[Start, Restart, Stop]` order.
+2. **Use `aria-disabled` + guarded `onClick`**, not native `disabled`
+   — native `disabled` drops focus and native `title` is not reliably
+   exposed to AT or on touch devices (ATX iter-1 B1).
+3. **Reason wired via `aria-describedby`** pointing to per-instance
+   `sr-only` spans, ids derived from `useId()` so multiple headers
+   can co-render on a fleet/list view without id collisions
+   (ATX iter-2 W1).
+4. **Move `install_missing` hint out of the action-bar row** into its
+   own alert below, so the button row width stays stable.
+5. **Extract `lifecycleDisabledReason(status, action)` to module scope**
+   as a pure function — unit-testable without React, and a future
+   status literal only needs a single edit.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `gui/src/components/agent-detail/agent-header.tsx` | Unconditional lifecycle button render; `aria-disabled` + `useId()`-scoped `aria-describedby`; extract `lifecycleDisabledReason` helper; move install_missing alert below action row |
+| `gui/src/components/agent-detail/agent-header.test.tsx` | Add 28 tests: pure-helper table, always-rendered invariant across 5 states, stable DOM order, aria-disabled correctness, title + describedby wiring, click-guard, two-instance uniqueness |
+| `CHANGELOG.md` | Entry under `[Unreleased] > ### Fixed` referencing `#870` |
+
+## Test plan
+
+- Unit tests via `vitest run` — 28 passing for `agent-header.test.tsx`,
+  328 total across gui suite.
+- Lint via `next lint` — clean.
+- Root `make lint` fails on a pre-existing missing
+  `src/clawrium/gui/frontend` include (unrelated to this frontend-only
+  change).
+
+## ATX Review Summary
+
+Final Review: **Rating 4/5 · Iter-3**
+Total Cost: **$4.02** · Total Time: **~6m 52s**
+
+| Review | Rating | Blocking Issues | Status | Cost | Time |
+|---|---|---|---|---|---|
+| 1 | 3.5/5 | B1 (native disabled + title inaccessible) | Fixed | $1.49 | 2m 44s |
+| 2 | 4/5 | None | W1 (hardcoded ids) fixed | $1.48 | 2m 24s |
+| 3 | 4/5 | None | Ship it | $1.05 | 1m 44s |
+
+**Note**: ATX does not expose model information per agent.
+
+<details>
+<summary>Review 1 Details (Rating 3.5/5)</summary>
+
+**Blocking Issues:**
+
+| # | File | Issue | Resolution |
+|---|---|---|---|
+| B1 | `agent-header.tsx:186-236` | Native `disabled` + `title` — Firefox suppresses hover, touch shows nothing, screen readers inconsistent, disabled elements drop out of tab order | Fixed — switched to `aria-disabled` + guarded `onClick` + `aria-describedby` → sr-only reason span |
+
+**Warnings:**
+
+| # | File | Warning | Action |
+|---|---|---|---|
+| W1 | `agent-header.tsx:33-51` | Reason mapping only handles fixed status literals; transitional states could fall through | Fixed — extracted `lifecycleDisabledReason()` at module scope; covered by table-driven tests |
+| W2 | `agent-header.tsx:190,199,208,214,224,233` | `aria-label="Start agent"` overrides visible text and drops pending state ("Starting…") from accessible name | Fixed — dropped `aria-label` overrides; visible text is now the accessible name |
+</details>
+
+<details>
+<summary>Review 2 Details (Rating 4/5)</summary>
+
+**Warnings:**
+
+| # | File | Warning | Action |
+|---|---|---|---|
+| W1 | `agent-header.tsx:230-244` | Hard-coded module-scope ids (`action-start-reason` etc.) collide if AgentHeader renders twice on a page | Fixed — replaced with `useId()`-scoped ids; added two-instance uniqueness test |
+| W2 | `agent-header.tsx:210-228` | `aria-describedby` not wired during pending state — asymmetric a11y UX | Acknowledged — pending state uses visible text ("Starting…") for accessible name; describedby-parity is polish, not a defect |
+
+**Suggestions:**
+
+| # | Suggestion | Action |
+|---|---|---|
+| S1 | Extract local `<LifecycleButton />` sub-component | Deferred — three near-identical blocks; extraction is polish |
+| S2 | Return `string \| null` from `lifecycleDisabledReason` | Deferred — `""` empty-string sentinel is idiomatic and covered by tests |
+| S3 | Add keyboard Enter click-guard test | Acknowledged — mouse `.click()` exercises the same handler; keyboard path uses the same guard |
+</details>
+
+<details>
+<summary>Review 3 Details (Rating 4/5)</summary>
+
+Verdict: **Ship it.** No blocking issues.
+
+**Suggestions:**
+
+| # | Suggestion | Action |
+|---|---|---|
+| S1 | `useId()` output contains `:`; normalize with `.replace(/:/g, '')` for querySelector safety | Deferred — tests use attribute-suffix `[id$='-restart-reason']` selectors, not `#id` queries; no impact |
+| S2 | Extract `<LifecycleButton />` sub-component | Deferred — see iter-2 S1 |
+
+**Coverage note:** `test-coverage` specialist failed with upstream model
+404 across all three iterations. Manual coverage confirmed via 28
+passing tests spanning: pure helper table, always-rendered invariant
+across 5 states, stable DOM order, aria-disabled correctness, title +
+describedby wiring, click-guard, two-instance id uniqueness.
+</details>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ cut. The `itx:release` skill archives this section into a new
 - GUI error responses for tunnel, lifecycle, and health endpoints now return constant error messages instead of passing raw error text through a weak path-redaction regex, preventing leakage of internal hostnames, IP addresses, and ports (#714)
 - `clawctl agent exec` now dispatches OpenClaw macOS hosts through `exec_macos.yaml` instead of the Linux playbook, so native CLI commands work on agents installed under `/Users/<agent>/` (#869).
 - `clawctl agent open` now evicts stale web-UI SSH tunnels that still have a bound local port but no longer answer HTTP, instead of reusing them and handing operators dead URLs (#869).
+- GUI agent action bar now renders `Start`, `Restart`, and `Stop` in a stable, fixed order across all agent states — invalid actions are marked `aria-disabled` with a guarded click handler, an accessible reason via `aria-describedby`, and a best-effort `title` tooltip, so a state transition can no longer shift `Restart` under a user's cursor and screen-reader / keyboard users can still focus a disabled button to discover why it is unavailable (#870).
 
 ### Documentation
 

--- a/gui/src/components/agent-detail/agent-header.test.tsx
+++ b/gui/src/components/agent-detail/agent-header.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import type { AgentDetail, AgentDetailHealth } from "@/lib/types";
+import type { AgentDetail, AgentDetailHealth, AgentStatus } from "@/lib/types";
 
 const webUIState = { data: undefined, isLoading: false, isError: false };
 const noopMutation = { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false };
@@ -19,7 +19,7 @@ vi.mock("@/hooks", () => ({
   useAgentWebUI: () => webUIState,
 }));
 
-import { AgentHeader } from "./agent-header";
+import { AgentHeader, lifecycleDisabledReason } from "./agent-header";
 
 function makeAgent(overrides: Partial<AgentDetail> = {}): AgentDetail {
   return {
@@ -61,40 +61,206 @@ function makeHealth(
   };
 }
 
-describe("AgentHeader — health loading fallback (#758 ATX W7)", () => {
+function lifecycleButtons() {
+  return {
+    start: screen.getByTestId("action-start"),
+    restart: screen.getByTestId("action-restart"),
+    stop: screen.getByTestId("action-stop"),
+  };
+}
+
+function isAriaDisabled(el: HTMLElement) {
+  return el.getAttribute("aria-disabled") === "true";
+}
+
+describe("AgentHeader — chrome", () => {
   it("renders agent identity even when health is undefined", () => {
     render(<AgentHeader agent={makeAgent()} health={undefined} />);
     expect(screen.getByText("demo")).toBeTruthy();
-    // Type + version chip is one of the few places the header renders
-    // the agent_type — its presence confirms the chrome painted.
     expect(screen.getByText(/hermes v2026\.4\.2/)).toBeTruthy();
   });
+});
 
-  it("hides Start/Stop/Restart while health is undefined", () => {
-    // liveStatus falls back to agent.status === "checking" so isRunning
-    // and isStopped are both false — neither branch should render the
-    // lifecycle buttons.
-    render(<AgentHeader agent={makeAgent()} health={undefined} />);
-    expect(screen.queryByText("Start")).toBeNull();
-    expect(screen.queryByText("Stop")).toBeNull();
-    expect(screen.queryByText("Restart")).toBeNull();
+describe("lifecycleDisabledReason — pure mapping", () => {
+  it.each([
+    // action=start: only "stopped" is available
+    ["stopped", "start", ""],
+    ["running", "start", "Agent is not stopped"],
+    ["checking", "start", "Waiting for status…"],
+    ["install_missing", "start", "On-host install missing — reinstall required"],
+    ["degraded", "start", "Agent is not stopped"],
+    // action=restart / stop: only "running" is available
+    ["running", "restart", ""],
+    ["running", "stop", ""],
+    ["stopped", "restart", "Agent is not running"],
+    ["stopped", "stop", "Agent is not running"],
+    ["checking", "restart", "Waiting for status…"],
+    ["install_missing", "restart", "On-host install missing — reinstall required"],
+    ["install_missing", "stop", "On-host install missing — reinstall required"],
+    ["unknown", "stop", "Agent is not running"],
+  ] as const)(
+    "%s → %s = %j",
+    (status, action, expected) => {
+      expect(
+        lifecycleDisabledReason(status as AgentStatus, action as "start" | "restart" | "stop"),
+      ).toBe(expected);
+    },
+  );
+});
+
+describe("AgentHeader — stable lifecycle action bar (#870)", () => {
+  it.each([
+    ["checking (health undefined)", undefined],
+    ["stopped", makeHealth({ status: "stopped" })],
+    ["running", makeHealth({ status: "running" })],
+    ["install_missing", makeHealth({ status: "install_missing" })],
+    ["degraded", makeHealth({ status: "degraded" })],
+  ] as const)("always renders Start, Restart, Stop when %s", (_label, health) => {
+    render(<AgentHeader agent={makeAgent()} health={health} />);
+    const { start, restart, stop } = lifecycleButtons();
+    expect(start).toBeTruthy();
+    expect(restart).toBeTruthy();
+    expect(stop).toBeTruthy();
   });
 
-  it("shows Start when health reports stopped", () => {
+  it("renders lifecycle buttons in stable [Start, Restart, Stop] order", () => {
+    for (const health of [
+      undefined,
+      makeHealth({ status: "stopped" }),
+      makeHealth({ status: "running" }),
+      makeHealth({ status: "install_missing" }),
+    ] as const) {
+      const { unmount } = render(
+        <AgentHeader agent={makeAgent()} health={health} />,
+      );
+      const buttons = [
+        screen.getByTestId("action-start"),
+        screen.getByTestId("action-restart"),
+        screen.getByTestId("action-stop"),
+      ];
+      // Confirm DOM order matches array order.
+      for (let i = 0; i < buttons.length - 1; i++) {
+        expect(
+          buttons[i].compareDocumentPosition(buttons[i + 1]) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+      }
+      unmount();
+    }
+  });
+
+  it("enables Start and aria-disables Restart/Stop when stopped", () => {
     render(
       <AgentHeader
         agent={makeAgent()}
         health={makeHealth({ status: "stopped" })}
       />,
     );
-    expect(screen.getByText("Start")).toBeTruthy();
-    expect(screen.queryByText("Stop")).toBeNull();
+    const { start, restart, stop } = lifecycleButtons();
+    expect(isAriaDisabled(start)).toBe(false);
+    expect(isAriaDisabled(restart)).toBe(true);
+    expect(isAriaDisabled(stop)).toBe(true);
+    expect(restart.getAttribute("title")).toMatch(/not running/i);
+    expect(stop.getAttribute("title")).toMatch(/not running/i);
   });
 
-  it("shows Stop+Restart when health reports running", () => {
+  it("enables Restart/Stop and aria-disables Start when running", () => {
     render(<AgentHeader agent={makeAgent()} health={makeHealth()} />);
-    expect(screen.getByText("Stop")).toBeTruthy();
-    expect(screen.getByText("Restart")).toBeTruthy();
-    expect(screen.queryByText("Start")).toBeNull();
+    const { start, restart, stop } = lifecycleButtons();
+    expect(isAriaDisabled(start)).toBe(true);
+    expect(isAriaDisabled(restart)).toBe(false);
+    expect(isAriaDisabled(stop)).toBe(false);
+    expect(start.getAttribute("title")).toMatch(/not stopped/i);
+  });
+
+  it("aria-disables all lifecycle buttons while health probe is in flight", () => {
+    render(<AgentHeader agent={makeAgent()} health={undefined} />);
+    const { start, restart, stop } = lifecycleButtons();
+    expect(isAriaDisabled(start)).toBe(true);
+    expect(isAriaDisabled(restart)).toBe(true);
+    expect(isAriaDisabled(stop)).toBe(true);
+    expect(start.getAttribute("title")).toMatch(/waiting for status/i);
+  });
+
+  it("aria-disables all lifecycle buttons and shows reinstall hint when install_missing", () => {
+    render(
+      <AgentHeader
+        agent={makeAgent()}
+        health={makeHealth({ status: "install_missing" })}
+      />,
+    );
+    const { start, restart, stop } = lifecycleButtons();
+    expect(isAriaDisabled(start)).toBe(true);
+    expect(isAriaDisabled(restart)).toBe(true);
+    expect(isAriaDisabled(stop)).toBe(true);
+    expect(start.getAttribute("title")).toMatch(/install missing/i);
+    const alert = screen.getByRole("alert");
+    expect(within(alert).getByText(/On-host install missing/i)).toBeTruthy();
+  });
+
+  it("keeps aria-disabled lifecycle buttons in the tab order (native disabled is not used)", () => {
+    // Guards against regression to native `disabled`, which drops the
+    // button from the tab order and hides it from AT users trying to
+    // discover the reason.
+    render(<AgentHeader agent={makeAgent()} health={undefined} />);
+    const { start, restart, stop } = lifecycleButtons();
+    for (const btn of [start, restart, stop]) {
+      expect(btn.hasAttribute("disabled")).toBe(false);
+      expect(isAriaDisabled(btn)).toBe(true);
+    }
+  });
+
+  it("does not fire mutations when clicking an aria-disabled lifecycle button", () => {
+    // Guarded onClick — aria-disabled alone does NOT block clicks; the
+    // handler must early-return. Otherwise a keyboard Enter/Space on a
+    // focused aria-disabled button would still mutate.
+    const spy = vi.spyOn(noopMutation, "mutate");
+    spy.mockClear();
+    render(<AgentHeader agent={makeAgent()} health={undefined} />);
+    const { start, restart, stop } = lifecycleButtons();
+    start.click();
+    restart.click();
+    stop.click();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("references the reason via aria-describedby when disabled", () => {
+    render(
+      <AgentHeader
+        agent={makeAgent()}
+        health={makeHealth({ status: "stopped" })}
+      />,
+    );
+    const { restart } = lifecycleButtons();
+    const describedBy = restart.getAttribute("aria-describedby");
+    // Id comes from useId() + suffix — shape rather than exact match.
+    expect(describedBy).toMatch(/-restart-reason$/);
+    const reason = document.getElementById(describedBy!);
+    expect(reason?.textContent).toMatch(/not running/i);
+  });
+
+  it("gives each instance unique reason ids so multiple headers can co-render", () => {
+    // Guards against the module-scope-constant regression: two headers
+    // on one page (fleet/list/comparison view) must not collide on
+    // aria-describedby target ids. useId() gives per-instance suffixes.
+    const { container } = render(
+      <>
+        <AgentHeader
+          agent={makeAgent({ agent_key: "a", agent_name: "a" })}
+          health={makeHealth({ status: "stopped" })}
+        />
+        <AgentHeader
+          agent={makeAgent({ agent_key: "b", agent_name: "b" })}
+          health={makeHealth({ status: "stopped" })}
+        />
+      </>,
+    );
+    const reasonSpans = container.querySelectorAll(
+      "[id$='-restart-reason']",
+    );
+    const ids = Array.from(reasonSpans).map((el) => el.id);
+    expect(ids.length).toBe(2);
+    expect(new Set(ids).size).toBe(2);
   });
 });

--- a/gui/src/components/agent-detail/agent-header.tsx
+++ b/gui/src/components/agent-detail/agent-header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { AgentDetail, AgentDetailHealth } from "@/lib/types";
+import { useId, useState } from "react";
+import { AgentDetail, AgentDetailHealth, AgentStatus } from "@/lib/types";
 import { StatusDot } from "@/components/ui/status-dot";
 import { OSIcon } from "@/components/ui/os-icon";
 import { Button } from "@/components/ui/button";
@@ -22,6 +22,27 @@ interface AgentHeaderProps {
   health: AgentDetailHealth | undefined;
 }
 
+// #870: pure mapping from live status → operator-facing reason a
+// lifecycle action is unavailable. Returns "" when the action IS
+// available. Kept module-scope so it's unit-testable without React
+// and so a future status literal only needs a single edit.
+export function lifecycleDisabledReason(
+  status: AgentStatus,
+  action: "start" | "restart" | "stop",
+): string {
+  if (status === "install_missing") {
+    return "On-host install missing — reinstall required";
+  }
+  if (status === "checking") {
+    return "Waiting for status…";
+  }
+  if (action === "start") {
+    return status === "stopped" ? "" : "Agent is not stopped";
+  }
+  // restart + stop share the running-required gate
+  return status === "running" ? "" : "Agent is not running";
+}
+
 export function AgentHeader({ agent, health }: AgentHeaderProps) {
   const { start, stop, restart } = useAgentActions(agent.agent_key);
   // Health-derived: the SSH probe is the source of truth for the
@@ -29,7 +50,28 @@ export function AgentHeader({ agent, health }: AgentHeaderProps) {
   // Start and Restart/Stop are hidden to avoid acting on stale data.
   const liveStatus = health?.status ?? agent.status;
   const isRunning = liveStatus === "running";
-  const isStopped = liveStatus === "stopped";
+  const isInstallMissing = liveStatus === "install_missing";
+
+  // #870: lifecycle buttons render unconditionally with a stable
+  // [Start, Restart, Stop] order so state transitions cannot shift a
+  // destructive action under the user's cursor. Invalid actions are
+  // disabled via aria-disabled + guarded onClick (NOT native
+  // `disabled`) so the button stays in the tab order and screen
+  // readers announce the reason via aria-describedby — native
+  // `disabled` drops focus and native `title` is not reliably
+  // exposed to AT or on touch devices.
+  const startDisabledReason = lifecycleDisabledReason(liveStatus, "start");
+  const restartDisabledReason = lifecycleDisabledReason(liveStatus, "restart");
+  const stopDisabledReason = lifecycleDisabledReason(liveStatus, "stop");
+
+  // Per-instance ids so a fleet/list view rendering multiple headers
+  // does not collide on the aria-describedby target — AT would
+  // otherwise resolve to the first-mounted reason span and announce
+  // the wrong agent's status.
+  const reactId = useId();
+  const startReasonId = `${reactId}-start-reason`;
+  const restartReasonId = `${reactId}-restart-reason`;
+  const stopReasonId = `${reactId}-stop-reason`;
 
   // B2 (#560 / #567): backend `/web-ui` returns `available: false` with
   // a `reason` for any agent type whose manifest does not declare
@@ -162,61 +204,112 @@ export function AgentHeader({ agent, health }: AgentHeaderProps) {
               {token.isPending ? "Loading..." : "Show Connection Token"}
             </Button>
           )}
-          {isStopped && (
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={() => start.mutate()}
-              disabled={start.isPending}
-            >
-              {start.isPending ? "Starting..." : "Start"}
-            </Button>
-          )}
-          {liveStatus === "install_missing" && (
-            // #811: hosts.json claims this agent is installed, but the
-            // on-host service-manager artifact and/or home directory are
-            // gone. Start/Stop/Restart would all fail at the systemd
-            // / launchctl boundary; surface a reinstall hint instead.
-            // ATX iter-5 B1: there is no `clawctl agent install` verb
-            // — the install path is `agent create`. ATX iter-4 W2 /
-            // iter-5 W1: `role="alert"` instead of `role="status"`
-            // because the span is conditionally mounted; screen
-            // readers don't announce initial mounts of polite
-            // (status) live regions but DO announce assertive
-            // (alert) ones.
-            <span className="text-xs text-status-error" role="alert">
-              On-host install missing — run{" "}
-              <code className="font-mono">
-                clawctl agent doctor {agent.agent_name}
-              </code>
-              , then reinstall via{" "}
-              <code className="font-mono">clawctl agent delete</code>
-              {" "}+{" "}
-              <code className="font-mono">clawctl agent create</code>.
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => {
+              if (startDisabledReason || start.isPending) return;
+              start.mutate();
+            }}
+            aria-disabled={!!startDisabledReason || start.isPending}
+            aria-describedby={
+              startDisabledReason ? startReasonId : undefined
+            }
+            title={startDisabledReason || undefined}
+            className={
+              startDisabledReason || start.isPending
+                ? "opacity-50 cursor-not-allowed"
+                : ""
+            }
+            data-testid="action-start"
+          >
+            {start.isPending ? "Starting..." : "Start"}
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => {
+              if (restartDisabledReason || restart.isPending) return;
+              restart.mutate();
+            }}
+            aria-disabled={!!restartDisabledReason || restart.isPending}
+            aria-describedby={
+              restartDisabledReason ? restartReasonId : undefined
+            }
+            title={restartDisabledReason || undefined}
+            className={
+              restartDisabledReason || restart.isPending
+                ? "opacity-50 cursor-not-allowed"
+                : ""
+            }
+            data-testid="action-restart"
+          >
+            {restart.isPending ? "Restarting..." : "Restart"}
+          </Button>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={() => {
+              if (stopDisabledReason || stop.isPending) return;
+              stop.mutate();
+            }}
+            aria-disabled={!!stopDisabledReason || stop.isPending}
+            aria-describedby={
+              stopDisabledReason ? stopReasonId : undefined
+            }
+            title={stopDisabledReason || undefined}
+            className={
+              stopDisabledReason || stop.isPending
+                ? "opacity-50 cursor-not-allowed"
+                : ""
+            }
+            data-testid="action-stop"
+          >
+            {stop.isPending ? "Stopping..." : "Stop"}
+          </Button>
+          {/* Visually-hidden reason spans referenced by aria-describedby
+              so screen readers announce WHY each action is unavailable
+              — `title` alone is not reliably exposed to AT or on touch. */}
+          {startDisabledReason && (
+            <span id={startReasonId} className="sr-only">
+              {startDisabledReason}
             </span>
           )}
-          {isRunning && (
-            <>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => restart.mutate()}
-                disabled={restart.isPending}
-              >
-                {restart.isPending ? "Restarting..." : "Restart"}
-              </Button>
-              <Button
-                variant="danger"
-                size="sm"
-                onClick={() => stop.mutate()}
-                disabled={stop.isPending}
-              >
-                {stop.isPending ? "Stopping..." : "Stop"}
-              </Button>
-            </>
+          {restartDisabledReason && (
+            <span id={restartReasonId} className="sr-only">
+              {restartDisabledReason}
+            </span>
+          )}
+          {stopDisabledReason && (
+            <span id={stopReasonId} className="sr-only">
+              {stopDisabledReason}
+            </span>
           )}
         </div>
       </div>
+
+      {isInstallMissing && (
+        // #811: hosts.json claims this agent is installed, but the
+        // on-host service-manager artifact and/or home directory are
+        // gone. Start/Stop/Restart would all fail at the systemd
+        // / launchctl boundary; surface a reinstall hint. #870: the
+        // hint moved out of the action-bar row so lifecycle buttons
+        // keep a stable position across state transitions.
+        // `role="alert"` because the span is conditionally mounted;
+        // screen readers don't announce initial mounts of polite
+        // (status) live regions but DO announce assertive
+        // (alert) ones.
+        <div className="mt-2 text-xs text-status-error" role="alert">
+          On-host install missing — run{" "}
+          <code className="font-mono">
+            clawctl agent doctor {agent.agent_name}
+          </code>
+          , then reinstall via{" "}
+          <code className="font-mono">clawctl agent delete</code>
+          {" "}+{" "}
+          <code className="font-mono">clawctl agent create</code>.
+        </div>
+      )}
 
       {(start.isError || stop.isError || restart.isError) && (
         <div className="mt-2 text-xs text-status-error" role="alert">


### PR DESCRIPTION
## Summary

- Render `Start`, `Restart`, and `Stop` in a fixed order across all agent states so state transitions can no longer shift `Restart` under the user's cursor.
- Invalid actions use `aria-disabled` + guarded `onClick` + `aria-describedby` sr-only reason spans + `title` tooltip, keeping disabled buttons focusable and accessible.
- Moved the `install_missing` alert out of the action-bar row into its own block so the button row width stays stable.

Closes #870

## Testing

### Test Results
- [x] All existing tests pass (`vitest run` — 328/328 in `gui/`, 28 new for `agent-header`)
- [x] Linter passes (`next lint` in `gui/`)
- [x] New tests added covering pure-helper table, always-rendered invariant across 5 states, stable DOM order, `aria-disabled` correctness, `title` + `aria-describedby` wiring, click-guard, and two-instance `useId()` uniqueness

### Test Coverage
- Files changed: `gui/src/components/agent-detail/agent-header.tsx`, `gui/src/components/agent-detail/agent-header.test.tsx`, `CHANGELOG.md`, `.itx/870/00_PLAN.md`
- New tests: 28 in `agent-header.test.tsx`
- Coverage impact: increased (component was previously lightly tested)

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (N/A — no new inputs)
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources (no new deps)

## ATX Review Summary

**Final Review: Rating 4/5**
**Total Cost: $4.02 | Total Time: ~6m 52s**

| Review | Rating | Blocking Issues | Status | Cost | Time |
|--------|--------|-----------------|--------|------|------|
| 1 | 3.5/5 | B1 | All fixed | $1.49 | 2m 44s |
| 2 | 4/5 | None | W1 fixed | $1.48 | 2m 24s |
| 3 | 4/5 | None | Ship it | $1.05 | 1m 44s |

> **Note**: ATX does not expose model information per agent.

<details>
<summary>Review 1 Details (Rating 3.5/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `agent-header.tsx:186-236` | Native `disabled` + `title` — Firefox suppresses hover, touch shows nothing, screen readers inconsistent, disabled elements drop out of tab order | Fixed — switched to `aria-disabled` + guarded `onClick` + `aria-describedby` → sr-only reason span |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `agent-header.tsx:33-51` | Reason mapping only handles fixed status literals; transitional states could fall through | Fixed — extracted `lifecycleDisabledReason()` at module scope; covered by table-driven tests |
| W2 | `agent-header.tsx` | `aria-label="Start agent"` overrides visible text and drops pending state from accessible name | Fixed — dropped `aria-label` overrides; visible text is now the accessible name |

</details>

<details>
<summary>Review 2 Details (Rating 4/5)</summary>

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `agent-header.tsx:230-244` | Hard-coded module-scope ids collide if `AgentHeader` renders twice on a page | Fixed — replaced with `useId()`-scoped ids; added two-instance uniqueness test |
| W2 | `agent-header.tsx:210-228` | `aria-describedby` not wired during pending state — asymmetric a11y UX | Acknowledged — pending state uses visible text ("Starting…") for accessible name; describedby-parity is polish, not a defect |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Extract local `<LifecycleButton />` sub-component | Deferred — three near-identical blocks; extraction is polish |
| S2 | Return `string \| null` from `lifecycleDisabledReason` | Deferred — `""` empty-string sentinel is idiomatic and covered by tests |
| S3 | Add keyboard Enter click-guard test | Acknowledged — mouse `.click()` exercises the same handler; keyboard path uses the same guard |

</details>

<details>
<summary>Review 3 Details (Rating 4/5)</summary>

Verdict: **Ship it.** No blocking issues.

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | `useId()` output contains `:`; normalize with `.replace(/:/g, '')` for querySelector safety | Deferred — tests use attribute-suffix `[id$='-restart-reason']` selectors, not `#id` queries; no impact |
| S2 | Extract `<LifecycleButton />` sub-component | Deferred — see iter-2 S1 |

**Coverage note:** `test-coverage` specialist failed with upstream model 404 across all three iterations. Manual coverage confirmed via 28 passing tests.

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>