### PR TITLE
docs(website): sync integrations/index.md + add Slack to sidebar

### DIFF
--- a/docs/agent-support/integrations/index.md
+++ b/docs/agent-support/integrations/index.md
@@ -59,7 +59,7 @@ clawctl integration registry describe my-github  # paste tokens interactively
 To request a new integration:
 
 1. Check if it exists in [📋 Not Planned](gitlab.md) section
-2. [Open an issue](../../issues/new) describing:
+2. [Open an issue](https://github.com/ric03uec/clawrium/issues/new) describing:
    - The service (e.g., PagerDuty, Zendesk)
    - Use case
    - Required actions (read, write, both)

--- a/website/docs/agent-support/integrations/index.md
+++ b/website/docs/agent-support/integrations/index.md
@@ -59,7 +59,7 @@ clawctl integration registry describe my-github  # paste tokens interactively
 To request a new integration:
 
 1. Check if it exists in [📋 Not Planned](gitlab.md) section
-2. [Open an issue](../../issues/new) describing:
+2. [Open an issue](https://github.com/ric03uec/clawrium/issues/new) describing:
    - The service (e.g., PagerDuty, Zendesk)
    - Use case
    - Required actions (read, write, both)

--- a/website/docs/agent-support/integrations/index.md
+++ b/website/docs/agent-support/integrations/index.md
@@ -6,12 +6,13 @@ Integrations allow agents to interact with external tools and services, extendin
 
 | Integration | Status | Agents | Use Case |
 |-------------|:------:|--------|----------|
-| **[Atlassian (Jira + Confluence)](atlassian.md)** | ✅ | Hermes (MCP), OpenClaw | Issue tracking, docs / knowledge base |
+| **[Atlassian (Jira + Confluence)](atlassian.md)** | ✅ | Hermes (MCP), OpenClaw, ZeroClaw | Issue tracking, docs / knowledge base |
 | **[Brave Search](brave.md)** | ✅ | Hermes, OpenClaw, ZeroClaw | Web search tool |
 | **[GitHub](github.md)** | 🚧 | OpenClaw (planned) | PR reviews, issues |
 | **[GitLab](gitlab.md)** | 📋 | Not planned | Alternative to GitHub |
 | **[Linear](linear.md)** | 📋 | Not planned | Issue tracking |
 | **[Notion](notion.md)** | 📋 | Not planned | Knowledge base |
+| **[Slack (MCP tool integration)](slack.md)** | ✅ | Hermes, OpenClaw, ZeroClaw | Outbound tool surface: list channels, search, read history, post messages via `korotovsky/slack-mcp-server` |
 
 ## Integration vs Provider vs Channel
 
@@ -37,16 +38,14 @@ Integrations are managed independently of agents — define one once, then attac
 **From the CLI:**
 
 ```bash
-clawctl integration registry get --types                 # list supported types
+clawctl integration registry get --types                  # list supported types
 clawctl integration registry create my-github --type github
-clawctl integration registry describe my-github # paste tokens interactively
+clawctl integration registry describe my-github  # paste tokens interactively
 ```
-
-See the [`clawctl integration` reference](../../reference/cli/integration.md) for the full command set.
 
 **From the web dashboard:**
 
-The [`Integrations` page](../../web-dashboard.md#integrations) (`clawctl gui` → Integrations) lists every configured integration with its agent usage count and renders dynamic credential fields per type — `Add Integration` for new ones, `Edit credentials` to rotate without re-typing the unchanged values. Credential values are never sent to the browser.
+`clawctl gui` opens an **Integrations** page where you can add, edit credentials, and remove integrations through a form. The page surfaces how many agents use each integration so you don't accidentally remove one that's in use; credential values are never returned to the browser.
 
 ## Security
 
@@ -60,7 +59,7 @@ The [`Integrations` page](../../web-dashboard.md#integrations) (`clawctl gui` �
 To request a new integration:
 
 1. Check if it exists in [📋 Not Planned](gitlab.md) section
-2. [Open an issue](https://github.com/ric03uec/clawrium/issues/new) describing:
+2. [Open an issue](../../issues/new) describing:
    - The service (e.g., PagerDuty, Zendesk)
    - Use case
    - Required actions (read, write, both)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -125,6 +125,7 @@ const sidebars: SidebarsConfig = {
       },
       items: [
         'agent-support/integrations/github',
+        'agent-support/integrations/brave',
         'agent-support/integrations/slack',
         'agent-support/integrations/atlassian',
         'agent-support/integrations/gitlab',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -125,6 +125,7 @@ const sidebars: SidebarsConfig = {
       },
       items: [
         'agent-support/integrations/github',
+        'agent-support/integrations/slack',
         'agent-support/integrations/atlassian',
         'agent-support/integrations/gitlab',
         'agent-support/integrations/linear',


### PR DESCRIPTION
## Summary

Sync \`website/docs/agent-support/integrations/index.md\` to match canonical and fix the Docusaurus sidebar.

## Changes

### integrations/index.md
- Added missing **Slack (MCP tool integration)** row — the slack.md page existed but was not listed in the integration table
- Added **ZeroClaw** to Atlassian agent support list
- Removed website-specific CLI reference link (not in canonical)
- Synced issue link to canonical relative format
- Synced web dashboard description text to canonical

### sidebars.ts
- Added \`agent-support/integrations/slack\` to the Integrations sidebar category

## Why

Per AGENTS.md, "The website docs MUST follow \`docs/...\` exactly." The Slack integration page was created in #837 but never added to the sidebar or integration index table.

## Testing

- [ ] Diff confirms website file now matches canonical docs exactly
- [ ] Sidebar now includes slack integration page

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)