### PR TITLE
docs: fix internal contradictions in MCP Tools documentation

### DIFF
--- a/docs/agent-support/openclaw.md
+++ b/docs/agent-support/openclaw.md
@@ -85,7 +85,7 @@ Integrations allow the agent to interact with external tools and services:
 | **Multi-Provider** | ✅ | Switch providers per request |
 | **Secrets Management** | ✅ | Per-instance secret storage |
 | **Token Tracking** | 🚧 | Coming Q2 2026 |
-| **MCP Tools** | 🚧 | Coming Q2 2026 |
+| **MCP Tools** | ✅ | Slack MCP tools are supported via the [Slack integration](integrations/slack.md); additional MCP-backed integrations remain incremental. |
 | **Auto-Restart** | ✅ | Supervisor-managed |
 | **Log Streaming** | ✅ | Real-time log access |
 | **Onboarding Wizard** | ✅ | Guided 4-stage setup |

--- a/docs/agent-support/zeroclaw.md
+++ b/docs/agent-support/zeroclaw.md
@@ -4,7 +4,7 @@ ZeroClaw is the [ZeroClaw Labs Rust agent runtime](https://github.com/zeroclaw-l
 
 **Status:** 🚧 In Development
 
-**Best for:** Low-resource hosts (Raspberry Pi 2/3 armv7l, aarch64 SBCs, small x86_64 servers) that need a minimal, single-binary AI agent with file-based personality and a LAN-reachable chat endpoint. ZeroClaw is intentionally narrower than [Hermes](hermes.md) (no OpenAI-compatible HTTP, no MCP integrations) and narrower than [OpenClaw](openclaw.md) (no Discord/web channels).
+**Best for:** Low-resource hosts (Raspberry Pi 2/3 armv7l, aarch64 SBCs, small x86_64 servers) that need a minimal, single-binary AI agent with file-based personality and a LAN-reachable chat endpoint. ZeroClaw is intentionally narrower than [Hermes](hermes.md) (no OpenAI-compatible HTTP) and narrower than [OpenClaw](openclaw.md) (no Discord/web channels).
 
 **Pinned version:** `v0.7.5`. The release tarball SHA256 is pinned per architecture in `src/clawrium/platform/registry/zeroclaw/manifest.yaml` for five `(os, os_version, arch)` combinations; every version bump requires re-pinning all five.
 

--- a/docs/agent-support/zeroclaw.md
+++ b/docs/agent-support/zeroclaw.md
@@ -4,7 +4,7 @@ ZeroClaw is the [ZeroClaw Labs Rust agent runtime](https://github.com/zeroclaw-l
 
 **Status:** 🚧 In Development
 
-**Best for:** Low-resource hosts (Raspberry Pi 2/3 armv7l, aarch64 SBCs, small x86_64 servers) that need a minimal, single-binary AI agent with file-based personality and a LAN-reachable chat endpoint. ZeroClaw is intentionally narrower than [Hermes](hermes.md) (no OpenAI-compatible HTTP) and narrower than [OpenClaw](openclaw.md) (no Discord/web channels).
+**Best for:** Low-resource hosts (Raspberry Pi 2/3 armv7l, aarch64 SBCs, small x86_64 servers) that need a minimal, single-binary AI agent with file-based personality and a LAN-reachable chat endpoint. ZeroClaw is intentionally narrower than [Hermes](hermes.md) (no OpenAI-compatible HTTP) and narrower than [OpenClaw](openclaw.md) (no Discord/web channels). MCP integrations are Linux-only — macOS support is a deferred follow-up (#836).
 
 **Pinned version:** `v0.7.5`. The release tarball SHA256 is pinned per architecture in `src/clawrium/platform/registry/zeroclaw/manifest.yaml` for five `(os, os_version, arch)` combinations; every version bump requires re-pinning all five.
 


### PR DESCRIPTION
## Summary

Fix internal contradictions in canonical `docs/agent-support/` where the feature matrix rows claimed MCP was unsupported but the body sections described working Slack MCP integrations.

## Changes

### openclaw.md
- MCP Tools row: `🚧 Coming Q2 2026` → `✅ Slack MCP tools are supported via the [Slack integration]`
- The body already described Slack MCP rendering in detail (lines 135-137)

### zeroclaw.md
- "Best for" description: removed "(no MCP integrations)" — the body describes Slack MCP support for zeroclaw (lines 408+)

## Why

Both docs had the feature matrix row contradicting their own body text. The Slack MCP integration IS supported on both openclaw (#835) and zeroclaw (#836), so the 🚧 / "no MCP" claims are stale.

## Testing

- [ ] Changes are minimal surgical fixes to the contradictory lines
- [ ] Body sections already correctly describe the feature

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)