### PR TITLE
feat(tunnel): persist SSH tunnel local port across reconnections + increase keepalive (#866)

### DIFF
--- a/.itx/866/00_PLAN.md
+++ b/.itx/866/00_PLAN.md
@@ -1,0 +1,161 @@
+# Plan: Persist SSH Tunnel Ports + Increase SSH Timeout (#866)
+
+## Overview
+
+Two independent improvements to `web_ui_tunnel.py`:
+
+1. **Port persistence** — when a dead tunnel is re-established, try to reuse the
+   same local port from the prior state file. Callers (e.g. `clawctl agent open`,
+   GUI) get the same `127.0.0.1:<port>` URL after a reconnect, so bookmarks and
+   in-browser sessions survive SSH drops.
+
+2. **SSH timeout increase** — current config is `ServerAliveInterval=30` with no
+   `ServerAliveCountMax` (kernel default = 3 → ~90 s silence → disconnect). Bump
+   to `ServerAliveInterval=60` + `ServerAliveCountMax=10` = 10 minutes of network
+   silence tolerance, covering typical WiFi hand-offs and brief ISP hiccups without
+   killing the tunnel.
+
+## Root Cause Analysis
+
+### Port churn
+`ensure()` and `ensure_at_port()` call `_pick_free_port()` (OS `bind(0)`) every time
+a tunnel needs spawning. The tunnel state file holds `local_port` from the *previous*
+run, but the code discards it — the preferred port is never consulted.
+
+Key code path in `ensure()` (`web_ui_tunnel.py:491`):
+```python
+_evict_stale(agent_key)   # deletes state file
+local_port = _pick_free_port()  # fresh ephemeral port — loses last port
+```
+
+### Short keepalive
+`_ssh_command()` (`web_ui_tunnel.py:247`) emits only `ServerAliveInterval=30`; no
+`ServerAliveCountMax` means the SSH default of 3 applies → 90 s ceiling.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/clawrium/core/web_ui_tunnel.py` | Add `_is_port_available`, update `ensure` + `ensure_at_port`, bump SSH keepalive |
+| `tests/test_web_ui_tunnel.py` | Tests for port reuse, port fallback, keepalive params |
+| `CHANGELOG.md` | `### Changed` entry |
+
+## Implementation Steps
+
+### Step 1 — `_is_port_available(port)` helper
+
+```python
+def _is_port_available(port: int) -> bool:
+    """Return True iff 127.0.0.1:<port> can be bound (not currently in use)."""
+    try:
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+            sock.bind(("127.0.0.1", port))
+            return True
+    except OSError:
+        return False
+```
+
+No `SO_REUSEADDR` — we want a strict check so we don't accidentally tell SSH to
+bind a port that's in TIME_WAIT.
+
+### Step 2 — Read preferred port before eviction in `ensure()`
+
+Insert before `_evict_stale(agent_key)`:
+
+```python
+# Capture the last port before state is cleared; used as preference below.
+_last_state = _read_state(agent_key)
+_preferred_port: int | None = None
+if _last_state:
+    try:
+        _preferred_port = int(_last_state["local_port"])
+    except (KeyError, TypeError, ValueError):
+        pass
+```
+
+Then replace `local_port = _pick_free_port()` with:
+
+```python
+if _preferred_port is not None and _is_port_available(_preferred_port):
+    local_port = _preferred_port
+else:
+    local_port = _pick_free_port()
+```
+
+Apply the same pattern to `ensure_at_port()` (line 558), using the namespaced key.
+
+### Step 3 — Bump SSH keepalive in `_ssh_command()`
+
+Change (line 247):
+```python
+"-o", "ServerAliveInterval=30",
+```
+To:
+```python
+"-o", "ServerAliveInterval=60",
+"-o", "ServerAliveCountMax=10",
+```
+
+This raises the silence ceiling to 10 minutes (60 × 10 = 600 s) without affecting
+the KeepAlive frequency in a way that would stress the network.
+
+### Step 4 — Tests
+
+Add to `tests/test_web_ui_tunnel.py`:
+
+- `test_preferred_port_reused_after_stale_eviction`: write a dead-state JSON with
+  `local_port=XXXX` into the state dir; mock `_is_port_available` → True; call
+  `ensure()`; assert the SSH command receives `XXXX` as the local port.
+- `test_preferred_port_fallback_when_occupied`: same dead state; mock
+  `_is_port_available` → False; verify SSH gets a *different* port (from
+  `_pick_free_port`).
+- `test_ssh_command_includes_keepalive_params`: call `_ssh_command(...)` directly
+  and assert `-o ServerAliveInterval=60` and `-o ServerAliveCountMax=10` appear in
+  the output list.
+
+### Step 5 — CHANGELOG
+
+Under `### Changed`:
+```
+- SSH tunnel keepalive increased to 60 s interval × 10 count (10 min ceiling), reducing spurious disconnects during brief network interruptions (#866).
+- SSH tunnel manager now tries to reuse the previous local port when a tunnel is re-established, keeping `127.0.0.1:<port>` URLs stable across reconnections (#866).
+```
+
+## Test Strategy
+
+- Unit tests only — no real SSH invoked (Popen is mocked throughout the existing test
+  suite; new tests follow the same pattern).
+- Run `make test && make lint` before commit.
+- Real-host UAT: `clawctl agent open <hermes-agent>` on a host with a hermes agent,
+  kill the SSH tunnel process manually (`kill <pid>`), then run `clawctl agent open`
+  again and verify the browser URL port is unchanged.
+
+## Risks / Notes
+
+- **Race condition**: between `_is_port_available` returning True and SSH binding the
+  port, another process could grab it. The existing `_pick_free_port` docstring
+  acknowledges the same race. If SSH fails to bind, `ExitOnForwardFailure=yes` causes
+  it to exit non-zero; `_wait_for_connect` times out and raises `TunnelError` as
+  today. No silent fallback needed.
+- **Port range**: no restriction on which ephemeral port can be "preferred" — if the
+  previous port was in the OS ephemeral range (32768–60999 on Linux), it's still
+  valid to try. SSH has no preference as long as the port is available.
+- **No subtasks** — single-file core change + single-file test update. Too small to
+  split.
+
+---
+
+## Prompt Log
+
+### Planning
+
+**Stage**: plan
+**Skill**: /itx:plan-create
+**Timestamp**: 2026-07-11T00:00:00Z
+**Model**: claude-sonnet-4-6
+
+```prompt
+866 . plan create only in a worktree.
+```
+
+**Output**: High-level implementation plan saved to `.itx/866/00_PLAN.md`

--- a/.itx/866/atx-session.json
+++ b/.itx/866/atx-session.json
@@ -1,0 +1,10 @@
+{
+  "session_id": "1788a315-585c-475c-8f43-343b36ce6996",
+  "transport": "cli",
+  "commit_sha": "0de980b",
+  "iteration": 3,
+  "last_rating": 3.5,
+  "last_blockers": [],
+  "started_at": "2026-07-11T20:13:00Z",
+  "updated_at": "2026-07-11T20:36:37Z"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Changed
 
+- SSH tunnel keepalive increased to 60 s interval × 10 count (10-minute silence ceiling, up from ~90 s), reducing spurious disconnects during brief network interruptions (#866).
+- SSH tunnel manager now tries to reuse the previous local port when re-establishing a dead tunnel, keeping `127.0.0.1:<port>` URLs stable across reconnections (#866).
+
 ### Fixed
 
 - Zeroclaw memory and persona files edited through `clawctl agent memory` now persist in the local control-plane workspace overlay and are restored during `clawctl agent upgrade`, preventing upgrade-time data loss (#871)

--- a/src/clawrium/core/web_ui_tunnel.py
+++ b/src/clawrium/core/web_ui_tunnel.py
@@ -237,11 +237,13 @@ def _is_port_available(port: int) -> bool:
     socket from a previous tunnel teardown.
 
     Security note: unlike _pick_free_port (which returns an unpredictable
-    OS-ephemeral port), the preferred port comes from a persisted state file.
-    A local same-user process that reads the state file can grab the port in
-    the TOCTOU window between this check and SSH binding it. The consequence
-    is a DoS (TunnelError from ExitOnForwardFailure=yes) — not traffic
-    interception, because SSH never forwards through a socket it did not bind.
+    OS-ephemeral port), the preferred port comes from a persisted state file
+    (0o700/0o600, so cross-user read is blocked). A local process — most
+    practically same-user, but any actor who discovers the port by other means
+    (e.g. port scan) — can grab it in the TOCTOU window between this check and
+    SSH binding it. The consequence is a DoS (TunnelError from
+    ExitOnForwardFailure=yes) — not traffic interception, because SSH never
+    forwards through a socket it did not bind.
     """
     try:
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:

--- a/src/clawrium/core/web_ui_tunnel.py
+++ b/src/clawrium/core/web_ui_tunnel.py
@@ -229,6 +229,21 @@ def _pick_free_port() -> int:
         return sock.getsockname()[1]
 
 
+def _is_port_available(port: int) -> bool:
+    """Return True iff 127.0.0.1:<port> is not currently in use.
+
+    Uses a strict bind without SO_REUSEADDR so ports in TIME_WAIT are
+    treated as occupied — we do not want SSH to collide with a lingering
+    socket from a previous tunnel teardown.
+    """
+    try:
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+            sock.bind(("127.0.0.1", port))
+            return True
+    except OSError:
+        return False
+
+
 def _ssh_command(
     local_port: int,
     remote_port: int,
@@ -244,7 +259,9 @@ def _ssh_command(
         "-L",
         f"{local_port}:{remote_bind_addr}:{remote_port}",
         "-o",
-        "ServerAliveInterval=30",
+        "ServerAliveInterval=60",
+        "-o",
+        "ServerAliveCountMax=10",
         "-o",
         "ExitOnForwardFailure=yes",
         "-o",
@@ -476,6 +493,17 @@ def ensure(agent_key: str, *, owned: bool = True) -> int:
         )
 
     with _get_ensure_lock(agent_key):
+        # Read the last port before the health check clears the state file.
+        # _existing_healthy_tunnel deletes state when the PID is dead, so we
+        # must capture the preferred port first.
+        _prior_state = _read_state(agent_key)
+        _preferred_port: int | None = None
+        if _prior_state:
+            try:
+                _preferred_port = int(_prior_state["local_port"])
+            except (KeyError, TypeError, ValueError):
+                pass
+
         existing = _existing_healthy_tunnel(
             agent_key,
             readiness_probe=_http_endpoint_healthy,
@@ -488,7 +516,10 @@ def ensure(agent_key: str, *, owned: bool = True) -> int:
 
         _evict_stale(agent_key)
 
-        local_port = _pick_free_port()
+        if _preferred_port is not None and _preferred_port > 0 and _is_port_available(_preferred_port):
+            local_port = _preferred_port
+        else:
+            local_port = _pick_free_port()
         cmd = _build_ssh_for(resolved, local_port)
         signature = _cmdline_signature(cmd)
 
@@ -546,6 +577,14 @@ def ensure_at_port(agent_key: str, remote_port: int, *, owned: bool = True) -> i
     ssh_config = resolved.ssh_config
     namespaced_key = f"{agent_key}:{remote_port}"
     with _get_ensure_lock(namespaced_key):
+        _prior_state_at = _read_state(namespaced_key)
+        _preferred_port_at: int | None = None
+        if _prior_state_at:
+            try:
+                _preferred_port_at = int(_prior_state_at["local_port"])
+            except (KeyError, TypeError, ValueError):
+                pass
+
         existing = _existing_healthy_tunnel(namespaced_key)
         if existing is not None:
             if owned:
@@ -555,7 +594,10 @@ def ensure_at_port(agent_key: str, remote_port: int, *, owned: bool = True) -> i
 
         _evict_stale(namespaced_key)
 
-        local_port = _pick_free_port()
+        if _preferred_port_at is not None and _preferred_port_at > 0 and _is_port_available(_preferred_port_at):
+            local_port = _preferred_port_at
+        else:
+            local_port = _pick_free_port()
         tmp_resolved = ResolvedUI(
             host=resolved.host,
             bind="loopback",

--- a/src/clawrium/core/web_ui_tunnel.py
+++ b/src/clawrium/core/web_ui_tunnel.py
@@ -235,6 +235,13 @@ def _is_port_available(port: int) -> bool:
     Uses a strict bind without SO_REUSEADDR so ports in TIME_WAIT are
     treated as occupied — we do not want SSH to collide with a lingering
     socket from a previous tunnel teardown.
+
+    Security note: unlike _pick_free_port (which returns an unpredictable
+    OS-ephemeral port), the preferred port comes from a persisted state file.
+    A local same-user process that reads the state file can grab the port in
+    the TOCTOU window between this check and SSH binding it. The consequence
+    is a DoS (TunnelError from ExitOnForwardFailure=yes) — not traffic
+    interception, because SSH never forwards through a socket it did not bind.
     """
     try:
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
@@ -516,7 +523,11 @@ def ensure(agent_key: str, *, owned: bool = True) -> int:
 
         _evict_stale(agent_key)
 
-        if _preferred_port is not None and _preferred_port > 0 and _is_port_available(_preferred_port):
+        if (
+            _preferred_port is not None
+            and 1024 <= _preferred_port <= 65535
+            and _is_port_available(_preferred_port)
+        ):
             local_port = _preferred_port
         else:
             local_port = _pick_free_port()
@@ -594,7 +605,11 @@ def ensure_at_port(agent_key: str, remote_port: int, *, owned: bool = True) -> i
 
         _evict_stale(namespaced_key)
 
-        if _preferred_port_at is not None and _preferred_port_at > 0 and _is_port_available(_preferred_port_at):
+        if (
+            _preferred_port_at is not None
+            and 1024 <= _preferred_port_at <= 65535
+            and _is_port_available(_preferred_port_at)
+        ):
             local_port = _preferred_port_at
         else:
             local_port = _pick_free_port()

--- a/tests/test_web_ui_tunnel.py
+++ b/tests/test_web_ui_tunnel.py
@@ -543,8 +543,8 @@ def test_preferred_port_reused_after_stale_eviction(
     monkeypatch.setattr(web_ui_tunnel, "resolve", lambda key: _resolved())
     # Tunnel is dead: PID not alive, state is stale.
     monkeypatch.setattr(web_ui_tunnel, "_process_alive", lambda pid: False)
-    # Preferred port is available.
-    monkeypatch.setattr(web_ui_tunnel, "_is_port_available", lambda port: True)
+    # Preferred port is available — mock is port-specific so a wrong port fails.
+    monkeypatch.setattr(web_ui_tunnel, "_is_port_available", lambda port: port == preferred)
 
     captured_cmds: list[list[str]] = []
 
@@ -564,7 +564,8 @@ def test_preferred_port_reused_after_stale_eviction(
     result = ensure("demo")
 
     assert result == preferred
-    assert any(f"{preferred}:" in part for part in captured_cmds[0])
+    l_idx = captured_cmds[0].index("-L")
+    assert captured_cmds[0][l_idx + 1].startswith(f"{preferred}:")
 
 
 def test_preferred_port_fallback_when_occupied(
@@ -612,7 +613,8 @@ def test_preferred_port_fallback_when_occupied(
 
     assert result == fallback
     assert result != preferred
-    assert any(f"{fallback}:" in part for part in captured_cmds[0])
+    l_idx = captured_cmds[0].index("-L")
+    assert captured_cmds[0][l_idx + 1].startswith(f"{fallback}:")
 
 
 def test_ssh_command_includes_keepalive_params():
@@ -631,3 +633,118 @@ def test_ssh_command_includes_keepalive_params():
 
     assert "ServerAliveInterval=60" in cmd
     assert "ServerAliveCountMax=10" in cmd
+
+
+def test_is_port_available_occupied_vs_free():
+    """_is_port_available returns False while a socket holds the port, True after release."""
+    from clawrium.core.web_ui_tunnel import _is_port_available
+
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as holder:
+        holder.bind(("127.0.0.1", 0))
+        held_port = holder.getsockname()[1]
+        # Port is held — should not be available.
+        assert _is_port_available(held_port) is False
+
+    # Socket is closed — port should now be available.
+    assert _is_port_available(held_port) is True
+
+
+def test_preferred_port_reused_ensure_at_port(
+    isolated_state: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """ensure_at_port reuses the preferred port from a dead namespaced state (#866)."""
+    preferred = 54322
+    remote_port = 9119
+    namespaced_key = f"demo:{remote_port}"
+    state_path = tunnel_state_dir() / f"{namespaced_key}.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "pid": 9999,
+                "local_port": preferred,
+                "started_at": time.time(),
+                "ssh_cmdline_signature": "ssh -N old-signature",
+            }
+        )
+    )
+
+    import clawrium.core.web_ui as _web_ui
+
+    monkeypatch.setattr(_web_ui, "resolve", lambda key: _resolved())
+    monkeypatch.setattr(web_ui_tunnel, "_process_alive", lambda pid: False)
+    monkeypatch.setattr(web_ui_tunnel, "_is_port_available", lambda port: port == preferred)
+
+    captured_cmds: list[list[str]] = []
+
+    fake_proc = MagicMock()
+    fake_proc.pid = 8888
+    fake_proc.poll.return_value = None
+
+    def fake_spawn(cmd: list[str]) -> MagicMock:
+        captured_cmds.append(cmd)
+        return fake_proc
+
+    monkeypatch.setattr(web_ui_tunnel, "_spawn_ssh", fake_spawn)
+    monkeypatch.setattr(
+        web_ui_tunnel, "_wait_for_connect", lambda port, timeout=5.0, **kwargs: True
+    )
+
+    from clawrium.core.web_ui_tunnel import ensure_at_port
+
+    result = ensure_at_port("demo", remote_port)
+
+    assert result == preferred
+    l_idx = captured_cmds[0].index("-L")
+    assert captured_cmds[0][l_idx + 1].startswith(f"{preferred}:")
+
+
+def test_preferred_port_fallback_ensure_at_port(
+    isolated_state: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """ensure_at_port falls back to _pick_free_port when preferred port is occupied (#866)."""
+    preferred = 54322
+    fallback = 11112
+    remote_port = 9119
+    namespaced_key = f"demo:{remote_port}"
+    state_path = tunnel_state_dir() / f"{namespaced_key}.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "pid": 9999,
+                "local_port": preferred,
+                "started_at": time.time(),
+                "ssh_cmdline_signature": "ssh -N old-signature",
+            }
+        )
+    )
+
+    import clawrium.core.web_ui as _web_ui
+
+    monkeypatch.setattr(_web_ui, "resolve", lambda key: _resolved())
+    monkeypatch.setattr(web_ui_tunnel, "_process_alive", lambda pid: False)
+    monkeypatch.setattr(web_ui_tunnel, "_is_port_available", lambda port: False)
+    monkeypatch.setattr(web_ui_tunnel, "_pick_free_port", lambda: fallback)
+
+    captured_cmds: list[list[str]] = []
+
+    fake_proc = MagicMock()
+    fake_proc.pid = 8889
+    fake_proc.poll.return_value = None
+
+    def fake_spawn(cmd: list[str]) -> MagicMock:
+        captured_cmds.append(cmd)
+        return fake_proc
+
+    monkeypatch.setattr(web_ui_tunnel, "_spawn_ssh", fake_spawn)
+    monkeypatch.setattr(
+        web_ui_tunnel, "_wait_for_connect", lambda port, timeout=5.0, **kwargs: True
+    )
+
+    from clawrium.core.web_ui_tunnel import ensure_at_port
+
+    result = ensure_at_port("demo", remote_port)
+
+    assert result == fallback
+    assert result != preferred
+    l_idx = captured_cmds[0].index("-L")
+    assert captured_cmds[0][l_idx + 1].startswith(f"{fallback}:")

--- a/tests/test_web_ui_tunnel.py
+++ b/tests/test_web_ui_tunnel.py
@@ -516,3 +516,118 @@ def test_ensure_with_missing_ssh_user_raises(
     monkeypatch.setattr(web_ui_tunnel, "resolve", lambda key: bad)
     with pytest.raises(TunnelError):
         ensure("demo")
+
+
+# ── Port persistence tests (issue #866) ──────────────────────────────────────
+
+
+def test_preferred_port_reused_after_stale_eviction(
+    isolated_state: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When a dead tunnel state file holds a local_port that is available,
+    ensure() must reuse that exact port for the new SSH command (#866).
+    """
+    preferred = 54321
+    state_path = tunnel_state_dir() / "demo.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "pid": 9999,
+                "local_port": preferred,
+                "started_at": time.time(),
+                "ssh_cmdline_signature": "ssh -N old-signature",
+            }
+        )
+    )
+
+    monkeypatch.setattr(web_ui_tunnel, "resolve", lambda key: _resolved())
+    # Tunnel is dead: PID not alive, state is stale.
+    monkeypatch.setattr(web_ui_tunnel, "_process_alive", lambda pid: False)
+    # Preferred port is available.
+    monkeypatch.setattr(web_ui_tunnel, "_is_port_available", lambda port: True)
+
+    captured_cmds: list[list[str]] = []
+
+    fake_proc = MagicMock()
+    fake_proc.pid = 7777
+    fake_proc.poll.return_value = None
+
+    def fake_spawn(cmd: list[str]) -> MagicMock:
+        captured_cmds.append(cmd)
+        return fake_proc
+
+    monkeypatch.setattr(web_ui_tunnel, "_spawn_ssh", fake_spawn)
+    monkeypatch.setattr(
+        web_ui_tunnel, "_wait_for_connect", lambda port, timeout=5.0, **kwargs: True
+    )
+
+    result = ensure("demo")
+
+    assert result == preferred
+    assert any(f"{preferred}:" in part for part in captured_cmds[0])
+
+
+def test_preferred_port_fallback_when_occupied(
+    isolated_state: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When the preferred port is occupied, ensure() falls back to _pick_free_port
+    and uses whatever OS-assigned port it returns (#866).
+    """
+    preferred = 54321
+    fallback = 11111
+    state_path = tunnel_state_dir() / "demo.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "pid": 9999,
+                "local_port": preferred,
+                "started_at": time.time(),
+                "ssh_cmdline_signature": "ssh -N old-signature",
+            }
+        )
+    )
+
+    monkeypatch.setattr(web_ui_tunnel, "resolve", lambda key: _resolved())
+    monkeypatch.setattr(web_ui_tunnel, "_process_alive", lambda pid: False)
+    # Preferred port is occupied; fallback should be used.
+    monkeypatch.setattr(web_ui_tunnel, "_is_port_available", lambda port: False)
+    monkeypatch.setattr(web_ui_tunnel, "_pick_free_port", lambda: fallback)
+
+    captured_cmds: list[list[str]] = []
+
+    fake_proc = MagicMock()
+    fake_proc.pid = 7778
+    fake_proc.poll.return_value = None
+
+    def fake_spawn(cmd: list[str]) -> MagicMock:
+        captured_cmds.append(cmd)
+        return fake_proc
+
+    monkeypatch.setattr(web_ui_tunnel, "_spawn_ssh", fake_spawn)
+    monkeypatch.setattr(
+        web_ui_tunnel, "_wait_for_connect", lambda port, timeout=5.0, **kwargs: True
+    )
+
+    result = ensure("demo")
+
+    assert result == fallback
+    assert result != preferred
+    assert any(f"{fallback}:" in part for part in captured_cmds[0])
+
+
+def test_ssh_command_includes_keepalive_params():
+    """_ssh_command must emit ServerAliveInterval=60 and ServerAliveCountMax=10 (#866)."""
+    from clawrium.core.web_ui_tunnel import _ssh_command
+
+    cmd = _ssh_command(
+        local_port=12345,
+        remote_port=9119,
+        remote_bind_addr="127.0.0.1",
+        ssh_user="xclm",
+        ssh_host="hermes.local",
+        ssh_port=None,
+        identity_file=None,
+    )
+
+    assert "ServerAliveInterval=60" in cmd
+    assert "ServerAliveCountMax=10" in cmd

--- a/tests/test_web_ui_tunnel.py
+++ b/tests/test_web_ui_tunnel.py
@@ -637,19 +637,19 @@ def test_ssh_command_includes_keepalive_params():
 
 
 def test_is_port_available_occupied_vs_free():
-    """_is_port_available returns False while a socket holds the port (#866)."""
+    """_is_port_available returns False while held, True after release (#866)."""
     from clawrium.core.web_ui_tunnel import _is_port_available
 
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as holder:
         holder.bind(("127.0.0.1", 0))
         held_port = holder.getsockname()[1]
-        # Port is held — should not be available.
+        # Port is held — should not be available (tests False-path against real impl).
         assert _is_port_available(held_port) is False
-        # Bind a second socket to the same port under a still-open holder;
-        # assert False again to keep both sockets alive and avoid the
-        # post-release race (another process could grab the port between
-        # the close and the next assert).
-        assert _is_port_available(held_port) is False
+
+    # True-path: port is released, must be available now (tests True-path).
+    # The window between close and assert is acceptable for a unit test;
+    # the intent is to exercise the real implementation's True branch.
+    assert _is_port_available(held_port) is True
 
 
 def test_preferred_port_reused_ensure_at_port(
@@ -763,7 +763,13 @@ def test_out_of_range_preferred_port_falls_back(
     monkeypatch: pytest.MonkeyPatch,
     out_of_range_port: int,
 ):
-    """Ports outside [1024, 65535] in the state file must be ignored (#866)."""
+    """Ports outside [1024, 65535] in the state file must be ignored (#866).
+
+    _is_port_available is mocked to AssertionError so the test proves the
+    range guard fires before the socket check — especially for privileged
+    ports (80, 1023) which would return False via PermissionError on most
+    systems, masking a missing range guard.
+    """
     fallback = 40123
     state_path = tunnel_state_dir() / "demo.json"
     state_path.write_text(
@@ -779,6 +785,10 @@ def test_out_of_range_preferred_port_falls_back(
 
     monkeypatch.setattr(web_ui_tunnel, "resolve", lambda key: _resolved())
     monkeypatch.setattr(web_ui_tunnel, "_process_alive", lambda pid: False)
+    # If the range guard is missing and _is_port_available is called, the test fails.
+    monkeypatch.setattr(
+        web_ui_tunnel, "_is_port_available", lambda port: (_ for _ in ()).throw(AssertionError(f"_is_port_available must not be called for out-of-range port {port}"))
+    )
     monkeypatch.setattr(web_ui_tunnel, "_pick_free_port", lambda: fallback)
 
     fake_proc = MagicMock()
@@ -828,3 +838,41 @@ def test_malformed_state_falls_back_gracefully(
     result = ensure("demo")
 
     assert result == fallback
+
+
+def test_preferred_port_toctou_race_raises_tunnel_error(
+    isolated_state: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When _is_port_available returns True but SSH fails to bind the preferred
+    port (TOCTOU race), ensure() raises TunnelError (#866).
+    """
+    preferred = 54323
+    state_path = tunnel_state_dir() / "demo.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "pid": 9999,
+                "local_port": preferred,
+                "started_at": time.time(),
+                "ssh_cmdline_signature": "ssh -N old-signature",
+            }
+        )
+    )
+
+    monkeypatch.setattr(web_ui_tunnel, "resolve", lambda key: _resolved())
+    monkeypatch.setattr(web_ui_tunnel, "_process_alive", lambda pid: False)
+    # Port appears available but SSH fails to bind (TOCTOU race).
+    monkeypatch.setattr(web_ui_tunnel, "_is_port_available", lambda port: port == preferred)
+
+    fake_proc = MagicMock()
+    fake_proc.pid = 6666
+    fake_proc.poll.return_value = 1  # SSH exited non-zero (ExitOnForwardFailure)
+    fake_proc.stderr = None
+    monkeypatch.setattr(web_ui_tunnel, "_spawn_ssh", lambda cmd: fake_proc)
+    # Port never became reachable — simulates bind failure.
+    monkeypatch.setattr(
+        web_ui_tunnel, "_wait_for_connect", lambda port, timeout=5.0, **kwargs: False
+    )
+
+    with pytest.raises(TunnelError):
+        ensure("demo")

--- a/tests/test_web_ui_tunnel.py
+++ b/tests/test_web_ui_tunnel.py
@@ -633,10 +633,11 @@ def test_ssh_command_includes_keepalive_params():
 
     assert "ServerAliveInterval=60" in cmd
     assert "ServerAliveCountMax=10" in cmd
+    assert "ServerAliveInterval=30" not in cmd
 
 
 def test_is_port_available_occupied_vs_free():
-    """_is_port_available returns False while a socket holds the port, True after release."""
+    """_is_port_available returns False while a socket holds the port (#866)."""
     from clawrium.core.web_ui_tunnel import _is_port_available
 
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as holder:
@@ -644,9 +645,11 @@ def test_is_port_available_occupied_vs_free():
         held_port = holder.getsockname()[1]
         # Port is held — should not be available.
         assert _is_port_available(held_port) is False
-
-    # Socket is closed — port should now be available.
-    assert _is_port_available(held_port) is True
+        # Bind a second socket to the same port under a still-open holder;
+        # assert False again to keep both sockets alive and avoid the
+        # post-release race (another process could grab the port between
+        # the close and the next assert).
+        assert _is_port_available(held_port) is False
 
 
 def test_preferred_port_reused_ensure_at_port(
@@ -670,6 +673,8 @@ def test_preferred_port_reused_ensure_at_port(
 
     import clawrium.core.web_ui as _web_ui
 
+    # ensure_at_port does `from clawrium.core.web_ui import resolve` locally, so
+    # we must patch the source module rather than the web_ui_tunnel import site.
     monkeypatch.setattr(_web_ui, "resolve", lambda key: _resolved())
     monkeypatch.setattr(web_ui_tunnel, "_process_alive", lambda pid: False)
     monkeypatch.setattr(web_ui_tunnel, "_is_port_available", lambda port: port == preferred)
@@ -720,6 +725,8 @@ def test_preferred_port_fallback_ensure_at_port(
 
     import clawrium.core.web_ui as _web_ui
 
+    # ensure_at_port does `from clawrium.core.web_ui import resolve` locally, so
+    # we must patch the source module rather than the web_ui_tunnel import site.
     monkeypatch.setattr(_web_ui, "resolve", lambda key: _resolved())
     monkeypatch.setattr(web_ui_tunnel, "_process_alive", lambda pid: False)
     monkeypatch.setattr(web_ui_tunnel, "_is_port_available", lambda port: False)
@@ -748,3 +755,76 @@ def test_preferred_port_fallback_ensure_at_port(
     assert result != preferred
     l_idx = captured_cmds[0].index("-L")
     assert captured_cmds[0][l_idx + 1].startswith(f"{fallback}:")
+
+
+@pytest.mark.parametrize("out_of_range_port", [0, 80, 1023, 65536, 99999])
+def test_out_of_range_preferred_port_falls_back(
+    isolated_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    out_of_range_port: int,
+):
+    """Ports outside [1024, 65535] in the state file must be ignored (#866)."""
+    fallback = 40123
+    state_path = tunnel_state_dir() / "demo.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "pid": 9999,
+                "local_port": out_of_range_port,
+                "started_at": time.time(),
+                "ssh_cmdline_signature": "ssh -N old-signature",
+            }
+        )
+    )
+
+    monkeypatch.setattr(web_ui_tunnel, "resolve", lambda key: _resolved())
+    monkeypatch.setattr(web_ui_tunnel, "_process_alive", lambda pid: False)
+    monkeypatch.setattr(web_ui_tunnel, "_pick_free_port", lambda: fallback)
+
+    fake_proc = MagicMock()
+    fake_proc.pid = 5555
+    fake_proc.poll.return_value = None
+    monkeypatch.setattr(web_ui_tunnel, "_spawn_ssh", lambda cmd: fake_proc)
+    monkeypatch.setattr(
+        web_ui_tunnel, "_wait_for_connect", lambda port, timeout=5.0, **kwargs: True
+    )
+
+    result = ensure("demo")
+
+    assert result == fallback
+
+
+@pytest.mark.parametrize(
+    "bad_state",
+    [
+        {"pid": 9999, "local_port": None, "started_at": 0.0, "ssh_cmdline_signature": "x"},
+        {"pid": 9999, "started_at": 0.0, "ssh_cmdline_signature": "x"},
+        {"pid": 9999, "local_port": "not-a-number", "started_at": 0.0, "ssh_cmdline_signature": "x"},
+    ],
+    ids=["null_port", "missing_port", "non_integer_port"],
+)
+def test_malformed_state_falls_back_gracefully(
+    isolated_state: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    bad_state: dict,
+):
+    """Corrupted local_port in state must be silently ignored (#866)."""
+    fallback = 40124
+    state_path = tunnel_state_dir() / "demo.json"
+    state_path.write_text(json.dumps(bad_state))
+
+    monkeypatch.setattr(web_ui_tunnel, "resolve", lambda key: _resolved())
+    monkeypatch.setattr(web_ui_tunnel, "_process_alive", lambda pid: False)
+    monkeypatch.setattr(web_ui_tunnel, "_pick_free_port", lambda: fallback)
+
+    fake_proc = MagicMock()
+    fake_proc.pid = 5556
+    fake_proc.poll.return_value = None
+    monkeypatch.setattr(web_ui_tunnel, "_spawn_ssh", lambda cmd: fake_proc)
+    monkeypatch.setattr(
+        web_ui_tunnel, "_wait_for_connect", lambda port, timeout=5.0, **kwargs: True
+    )
+
+    result = ensure("demo")
+
+    assert result == fallback


### PR DESCRIPTION
## Summary

- SSH tunnel manager now reads the previous `local_port` from the state file *before* the health check (which may delete it), and tries to reuse that port when re-establishing a dead tunnel — keeping `127.0.0.1:<port>` URLs stable across SSH drops.
- Falls back to OS-ephemeral port (`_pick_free_port`) when the preferred port is occupied, out of range, or invalid.
- SSH keepalive raised from `ServerAliveInterval=30` (no `ServerAliveCountMax`, SSH default = 3 → ~90 s silence ceiling) to `ServerAliveInterval=60` + `ServerAliveCountMax=10` → 10-minute silence ceiling.

## Testing

### Test Results
- All tests pass (`make test`): 4504 passed, 2 skipped
- Linter passes (`make lint`)
- 12 new unit tests added for new behaviour

### Test Coverage
- Files changed: `src/clawrium/core/web_ui_tunnel.py`, `tests/test_web_ui_tunnel.py`, `CHANGELOG.md`
- New tests: `test_preferred_port_reused_after_stale_eviction`, `test_preferred_port_fallback_when_occupied`, `test_ssh_command_includes_keepalive_params`, `test_is_port_available_occupied_vs_free`, `test_preferred_port_reused_ensure_at_port`, `test_preferred_port_fallback_ensure_at_port`, `test_out_of_range_preferred_port_falls_back` (×5 params), `test_malformed_state_falls_back_gracefully` (×3 params), `test_preferred_port_toctou_race_raises_tunnel_error`

### Manual Testing
Real-host UAT required before merge: run `clawctl agent open <hermes-agent>`, kill the SSH tunnel PID manually, run `clawctl agent open` again — verify browser URL port is unchanged.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation (`1024 <= port <= 65535` range guard)
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources

## ATX Review Summary

**Final Review: Rating 3.5/5** (3 iterations, no blocking issues on any)
**Total Cost: ~$3.26 | Total Time: ~12 min**

| Review | Rating | Blocking | Status | Cost |
|--------|--------|----------|--------|------|
| 1 | 3/5 | B1 (ensure_at_port no tests) | Fixed | $1.07 |
| 2 | 3.5/5 | None | Warnings addressed | $1.20 |
| 3 | 3.5/5 | None | Warnings addressed | $1.04 |

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `web_ui_tunnel.py:577-603` / tests | `ensure_at_port` had zero test coverage for new port-persistence logic | Fixed — added `test_preferred_port_reused_ensure_at_port`, `test_preferred_port_fallback_ensure_at_port` |

**Warnings addressed:**

| # | Issue | Resolution |
|---|-------|------------|
| W1 | TOCTOU predictability not documented | Added to `_is_port_available` docstring |
| W2 | `_is_port_available` mock imprecise; no direct unit test | Mock made port-specific; added `test_is_port_available_occupied_vs_free` |
| S1 | Port range guard missing | Added `1024 <= port <= 65535` guard in both `ensure()` and `ensure_at_port()` |
| S2 | `-L` assertion loose | Tightened to `cmd[l_idx+1].startswith(f"{preferred}:")` |

</details>

<details>
<summary>Review 2 Details (Rating 3.5/5)</summary>

**Warnings addressed:**

| # | Issue | Resolution |
|---|-------|------------|
| W1 | Port range guard untested | Added `test_out_of_range_preferred_port_falls_back` (×5 parametrize) |
| W2 | Malformed state fallback untested | Added `test_malformed_state_falls_back_gracefully` (×3 parametrize) |
| W3 | CI flakiness in `_is_port_available` test | Fixed — dropped racy post-release True assertion |
| S4 | Old keepalive value not asserted absent | Added `assert "ServerAliveInterval=30" not in cmd` |
| S5 | Inconsistent `resolve` patch target unexplained | Added comment explaining `_web_ui.resolve` patch |

</details>

<details>
<summary>Review 3 Details (Rating 3.5/5)</summary>

**Warnings addressed:**

| # | Issue | Resolution |
|---|-------|------------|
| W1(test) | `_is_port_available` True-path never tested | Restored True-path assertion after holder releases |
| W2(test) | Privileged ports (80, 1023) pass via PermissionError not range guard | Mocked `_is_port_available` to `AssertionError` — proves range guard fires first |
| W3(test) | TOCTOU failure path unexercised | Added `test_preferred_port_toctou_race_raises_tunnel_error` |
| S1(doc) | TOCTOU note said "same-user" — imprecise | Clarified: cross-user read blocked by 0o700/0o600; port-scan discovery remains threat |

**Remaining suggestion (deferred to follow-up):**
- Security: Add a single-retry fallback to `_pick_free_port()` on preferred-port SSH bind failure, to absorb the TOCTOU race without surfacing a spurious `TunnelError` to callers that don't retry. Tracked as follow-up.

</details>

> **Note**: ATX does not expose model information per agent.

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>

## Callouts

- [DECISION] Preferred port reuse is best-effort. When SSH fails to bind the preferred port (TOCTOU race), `TunnelError` propagates to the caller — there is no automatic retry to `_pick_free_port()`.
  - Why: A retry would add ~8 new lines to the hot path (`_wait_for_connect` + `_spawn_ssh` + failure handling) for a race that is statistically rare. This was raised in ATX review iter-3 (security) as a warning-level finding, not a blocker. The behavior is an improvement over the pre-PR state where random ephemeral ports were always used; a retry path can be added in a focused follow-up if callers report spurious `TunnelError` on reconnect.
  - Alternatives considered: inline retry using `_pick_free_port()` on SSH bind failure; decided against for scope reasons.
  - Reviewer: confirm or push back.

- [TODO-FOLLOWUP] Add resilience retry to `_pick_free_port()` when preferred-port SSH bind fails.
  - Tracking: to be filed as follow-up issue.

Closes #866