### PR TITLE
daily-docs-sweep 2026-07-12

### DIFF
--- a/docs/agent-support/hermes.md
+++ b/docs/agent-support/hermes.md
@@ -298,18 +298,22 @@ In the GUI, every hermes agent dashboard has an **"Open Agent UI"** button in th
 The dashboard binds loopback on the agent host — it is **not reachable over the LAN**. `clawctl agent open` establishes:
 
 ```
-your-machine:127.0.0.1:<random>  ──SSH-L──►  agent-host:127.0.0.1:<dashboard-port>
+your-machine:127.0.0.1:<port>  ──SSH-L──►  agent-host:127.0.0.1:<dashboard-port>
 ```
+
+The `<port>` is chosen from the OS ephemeral range on first connect and then **persisted** — on reconnection after an SSH drop, the tunnel manager reuses the same local port so your browser URL remains stable. If the preferred port is occupied, out of range, or invalid, it falls back to a fresh ephemeral port.
 
 Authentication piggybacks on the SSH key Ansible already uses for the host. The dashboard itself has no password / bearer-token wall: anyone with shell access to the agent host (root or the agent's UNIX user) could already reach loopback directly, so adding an extra in-process auth layer would offer no real defense beyond what SSH already provides.
 
 State for each tunnel is persisted at `~/.config/clawrium/tunnels/<agent_key>.json` (PID, local port, SSH command-line signature). A second `clawctl agent open` for the same agent reuses the live tunnel rather than spawning a duplicate; the GUI does the same via the `/api/fleet/agents/{key}/web-ui` endpoint. Tunnels opened by the GUI auto-close after 30 minutes of inactivity (a reaper task runs every 5 minutes). CLI tunnels close on `Ctrl-C` (SIGINT), on SIGTERM (the CLI installs a SIGTERM handler that mirrors SIGINT cleanup), or when the `clawctl` process exits normally (`atexit`). A hard `kill -9 <pid>` (SIGKILL) cannot be caught and will leak the underlying `ssh` subprocess; the next `clawctl agent open` against the same agent will detect and evict the stale state via the PID + cmdline guard.
 
+SSH keepalive is set to `ServerAliveInterval=60` × `ServerAliveCountMax=10` — a 10-minute silence ceiling before the tunnel is considered dead (up from ~90 s), reducing spurious disconnects during brief network interruptions.
+
 If the dashboard is unreachable, the most common causes are:
 
 - `hermes-dashboard-<agent-name>.service` is not running — `clawctl agent start <name>` re-enables both gateway and dashboard units.
 - The host's SSH key has rotated and `ssh -i <key>` can no longer authenticate — delete and re-create the host (`clawctl host delete <host> --force && clawctl host create <host> --user xclm --alias <name>`) and re-apply the manual setup commands `clawctl` prints.
-- Local-port conflict — the tunnel manager picks an ephemeral free port each time, so this should be rare; check `~/.config/clawrium/tunnels/<agent>.json` and remove it if stale.
+- Local-port conflict — the tunnel manager reuses the previous local port, so conflicts are rare; check `~/.config/clawrium/tunnels/<agent>.json` and remove it if stale.
 
 ---
 


### PR DESCRIPTION
## Summary

- Update SSH tunnel documentation to reflect port persistence across reconnections (PR #886)
- Add SSH keepalive configuration details (60s interval × 10 count = 10-minute silence ceiling)

## Changes

### `docs/agent-support/hermes.md`

- Port diagram updated from `<random>` to `<port>` — tunnel now reuses previous local port on reconnection
- Added paragraph explaining port persistence behavior and fallback when preferred port is unavailable
- Added SSH keepalive configuration paragraph with before/after values
- Updated local-port conflict troubleshooting: "picks an ephemeral free port each time" → "reuses the previous local port"

## Testing

- Verified `docs/agent-support/hermes.md` contains no remaining stale references to ephemeral port selection
- Confirmed `website/docs/agent-support/hermes.md` does not contain the tunnel section (pre-existing structural difference — website version omits the Native dashboard section entirely)
- No other stale "ephemeral port" or "random port" references found across `docs/`

---

🤖 Auto-generated by docs-sweep cron job. No human review of content required — this PR only closes documentation gaps from recently merged PRs.