### PR TITLE
chore(release): v26.7.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ Currently available:
 
 - Repository: https://github.com/ric03uec/clawrium
 - Project Board: https://github.com/users/ric03uec/projects/1
-- Version: 26.7.0
+- Version: 26.7.1
 - Changelog: [`CHANGELOG.md`](CHANGELOG.md) (current unreleased) · [`docs/releases/`](docs/releases/) (per-release archive)
 
 ## Gateway Token Lifecycle (zeroclaw)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,39 +14,10 @@ cut. The `itx:release` skill archives this section into a new
 
 ### BREAKING
 
-- `clawctl gui` has been removed. Use `clawctl server start` to launch
-  the local GUI server in the background, `clawctl server stop` to stop
-  it, `clawctl server status` to inspect state, and `clawctl server run`
-  for a foreground (systemd/Docker) mode. There is no automated
-  migration — invocations of `clawctl gui` will error with
-  `No such command`. Note: `clawctl server` is Linux-only in this
-  release; macOS support ships in a follow-up PR (#874).
-
 ### Added
-
-- `clawctl server {start,stop,status,run}` — new command group that
-  manages the local GUI server lifecycle. `start` runs uvicorn detached
-  on `127.0.0.1:36000` and records PID + URL to
-  `~/.config/clawrium/server.json`; a second `start` while running is a
-  no-op that prints the live URL; the command fails loudly with exit 1
-  if `:36000` is held by another process. `run` runs the server in the
-  foreground for process-supervisor deployments (#874).
-- `clawctl version` and `clawctl --version` now show the git commit SHA alongside the release version (#656).
 
 ### Changed
 
-- SSH tunnel keepalive increased to 60 s interval × 10 count (10-minute silence ceiling, up from ~90 s), reducing spurious disconnects during brief network interruptions (#866).
-- SSH tunnel manager now tries to reuse the previous local port when re-establishing a dead tunnel, keeping `127.0.0.1:<port>` URLs stable across reconnections (#866).
-
 ### Fixed
 
-- Zeroclaw memory and persona files edited through `clawctl agent memory` now persist in the local control-plane workspace overlay and are restored during `clawctl agent upgrade`, preventing upgrade-time data loss (#871)
-- GUI lifecycle endpoints (`start`, `stop`, `restart`) now return HTTP 502 instead of HTTP 200 with `success: false` when the underlying lifecycle operation fails without raising an exception (#712)
-- GUI error responses for tunnel, lifecycle, and health endpoints now return constant error messages instead of passing raw error text through a weak path-redaction regex, preventing leakage of internal hostnames, IP addresses, and ports (#714)
-- `clawctl agent exec` now dispatches OpenClaw macOS hosts through `exec_macos.yaml` instead of the Linux playbook, so native CLI commands work on agents installed under `/Users/<agent>/` (#869).
-- `clawctl agent open` now evicts stale web-UI SSH tunnels that still have a bound local port but no longer answer HTTP, instead of reusing them and handing operators dead URLs (#869).
-- GUI agent action bar now renders `Start`, `Restart`, and `Stop` in a stable, fixed order across all agent states — invalid actions are marked `aria-disabled` with a guarded click handler, an accessible reason via `aria-describedby`, and a best-effort `title` tooltip, so a state transition can no longer shift `Restart` under a user's cursor and screen-reader / keyboard users can still focus a disabled button to discover why it is unavailable (#870).
-
 ### Documentation
-
-- Synced the website agent-support pages for Hermes, OpenClaw, and ZeroClaw with the shipped Slack integration docs so the release blog's Slack links resolve and the docs site can build again.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,7 +54,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.7.0
+ + clawrium==26.7.1
 ```
 
 ### Run Without Installing
@@ -101,7 +101,7 @@ Check the version:
 clawctl --version
 ```
 ```
-clawctl 26.7.0
+clawctl 26.7.1
 ```
 
 ## Initialize Clawrium

--- a/docs/releases/26.7.1/CHANGELOG.md
+++ b/docs/releases/26.7.1/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Release 26.7.1
+
+Archived changelog for the **26.7.1** release. This is the frozen record of
+everything that shipped in this version; the working changelog for the next
+release lives at the repository root in [`CHANGELOG.md`](../../../CHANGELOG.md).
+
+Versions follow [SemVer](https://semver.org/), and the project tracks a
+calendar versioning convention: `YY.M.PATCH`.
+
+## [26.7.1]
+
+### BREAKING
+
+- `clawctl gui` has been removed. Use `clawctl server start` to launch
+  the local GUI server in the background, `clawctl server stop` to stop
+  it, `clawctl server status` to inspect state, and `clawctl server run`
+  for a foreground (systemd/Docker) mode. There is no automated
+  migration — invocations of `clawctl gui` will error with
+  `No such command`. Note: `clawctl server` is Linux-only in this
+  release; macOS support ships in a follow-up PR (#874).
+
+### Added
+
+- `clawctl server {start,stop,status,run}` — new command group that
+  manages the local GUI server lifecycle. `start` runs uvicorn detached
+  on `127.0.0.1:36000` and records PID + URL to
+  `~/.config/clawrium/server.json`; a second `start` while running is a
+  no-op that prints the live URL; the command fails loudly with exit 1
+  if `:36000` is held by another process. `run` runs the server in the
+  foreground for process-supervisor deployments (#874).
+- `clawctl version` and `clawctl --version` now show the git commit SHA alongside the release version (#656).
+
+### Changed
+
+- SSH tunnel keepalive increased to 60 s interval × 10 count (10-minute silence ceiling, up from ~90 s), reducing spurious disconnects during brief network interruptions (#866).
+- SSH tunnel manager now tries to reuse the previous local port when re-establishing a dead tunnel, keeping `127.0.0.1:<port>` URLs stable across reconnections (#866).
+
+### Fixed
+
+- Zeroclaw memory and persona files edited through `clawctl agent memory` now persist in the local control-plane workspace overlay and are restored during `clawctl agent upgrade`, preventing upgrade-time data loss (#871)
+- GUI lifecycle endpoints (`start`, `stop`, `restart`) now return HTTP 502 instead of HTTP 200 with `success: false` when the underlying lifecycle operation fails without raising an exception (#712)
+- GUI error responses for tunnel, lifecycle, and health endpoints now return constant error messages instead of passing raw error text through a weak path-redaction regex, preventing leakage of internal hostnames, IP addresses, and ports (#714)
+- `clawctl agent exec` now dispatches OpenClaw macOS hosts through `exec_macos.yaml` instead of the Linux playbook, so native CLI commands work on agents installed under `/Users/<agent>/` (#869).
+- `clawctl agent open` now evicts stale web-UI SSH tunnels that still have a bound local port but no longer answer HTTP, instead of reusing them and handing operators dead URLs (#869).
+- GUI agent action bar now renders `Start`, `Restart`, and `Stop` in a stable, fixed order across all agent states — invalid actions are marked `aria-disabled` with a guarded click handler, an accessible reason via `aria-describedby`, and a best-effort `title` tooltip, so a state transition can no longer shift `Restart` under a user's cursor and screen-reader / keyboard users can still focus a disabled button to discover why it is unavailable (#870).
+
+### Documentation
+
+- Synced the website agent-support pages for Hermes, OpenClaw, and ZeroClaw with the shipped Slack integration docs so the release blog's Slack links resolve and the docs site can build again.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawrium"
-version = "26.7.0"
+version = "26.7.1"
 description = "CLI tool for managing AI assistant fleets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "clawrium"
-version = "26.7.0"
+version = "26.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -48,7 +48,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.7.0
+ + clawrium==26.7.1
 ```
 
 Verify installation:

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -62,7 +62,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.7.0
+ + clawrium==26.7.1
 ```
 
 ### Run Without Installing
@@ -109,7 +109,7 @@ Check the version:
 clawctl --version
 ```
 ```
-clawctl 26.7.0
+clawctl 26.7.1
 ```
 
 ## Initialize Clawrium

--- a/website/docs/scenarios/101.md
+++ b/website/docs/scenarios/101.md
@@ -43,7 +43,7 @@ Verify the installation:
 
 ```bash
 $ clawctl --version
-clawctl 26.7.0
+clawctl 26.7.1
 ```
 
 ## Step 2: Register the Host (first run — surface the manual setup)


### PR DESCRIPTION
## Summary
- Bump `clawrium` to v26.7.1
- Archive working CHANGELOG.md into `docs/releases/26.7.1/` and reset the root file to an empty `[Unreleased]` template
- Sync version mentions in AGENTS.md + website docs

## Testing
- [x] `make lint` passes
- [x] `make test` passes

Release housekeeping.