### PR TITLE
chore(release): v26.7.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ Currently available:
 
 - Repository: https://github.com/ric03uec/clawrium
 - Project Board: https://github.com/users/ric03uec/projects/1
-- Version: 26.7.1
+- Version: 26.7.2
 - Changelog: [`CHANGELOG.md`](CHANGELOG.md) (current unreleased) · [`docs/releases/`](docs/releases/) (per-release archive)
 
 ## Gateway Token Lifecycle (zeroclaw)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,7 +54,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.7.1
+ + clawrium==26.7.2
 ```
 
 ### Run Without Installing
@@ -101,7 +101,7 @@ Check the version:
 clawctl --version
 ```
 ```
-clawctl 26.7.1
+clawctl 26.7.2
 ```
 
 ## Initialize Clawrium

--- a/docs/releases/26.7.2/CHANGELOG.md
+++ b/docs/releases/26.7.2/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Release 26.7.2
+
+Archived changelog for the **26.7.2** release. This is the frozen record of
+everything that shipped in this version; the working changelog for the next
+release lives at the repository root in [`CHANGELOG.md`](../../../CHANGELOG.md).
+
+Versions follow [SemVer](https://semver.org/), and the project tracks a
+calendar versioning convention: `YY.M.PATCH`.
+
+## [26.7.2]
+
+### BREAKING
+
+### Added
+
+### Changed
+
+### Fixed
+
+- **Publish pipeline unbroken.** The v26.7.1 PyPI publish workflow failed
+  because the sdist was empty (`[tool.hatch.build.targets.sdist] include`
+  from PR #779 turned hatch's default file selection into an exclusive
+  whitelist, dropping `skills/`, `src/clawrium/**`, tests, and everything
+  else) and the wheel would have shipped with `__version__ = 'standard'`
+  (the hatch_build hook mis-used hatchling's build-scheme arg as the
+  package version). Both fixed in #892; v26.7.2 is the first successful
+  publish since v26.7.0.
+
+### Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawrium"
-version = "26.7.1"
+version = "26.7.2"
 description = "CLI tool for managing AI assistant fleets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "clawrium"
-version = "26.7.1"
+version = "26.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-runner" },

--- a/website/docs/guides/quickstart.md
+++ b/website/docs/guides/quickstart.md
@@ -48,7 +48,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.7.1
+ + clawrium==26.7.2
 ```
 
 Verify installation:

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -62,7 +62,7 @@ uv tool install clawrium
 ```
 Resolved 1 package in 523ms
 Installed 1 package in 12ms
- + clawrium==26.7.1
+ + clawrium==26.7.2
 ```
 
 ### Run Without Installing
@@ -109,7 +109,7 @@ Check the version:
 clawctl --version
 ```
 ```
-clawctl 26.7.1
+clawctl 26.7.2
 ```
 
 ## Initialize Clawrium

--- a/website/docs/scenarios/101.md
+++ b/website/docs/scenarios/101.md
@@ -43,7 +43,7 @@ Verify the installation:
 
 ```bash
 $ clawctl --version
-clawctl 26.7.1
+clawctl 26.7.2
 ```
 
 ## Step 2: Register the Host (first run — surface the manual setup)


### PR DESCRIPTION
## Summary
- Bump `clawrium` to v26.7.2 — first successful publish since v26.7.0
- v26.7.1 tag exists but publish failed on the sdist bug fixed in #892; this release carries that fix
- Archive working CHANGELOG.md into `docs/releases/26.7.2/` and reset the root file to an empty `[Unreleased]` template
- Sync version mentions in AGENTS.md + website docs

## Testing
- [x] `make lint` passes
- [x] `make test` passes (329 tests)
- [x] Local `uv build` succeeds, wheel ships `__version__ = '26.7.2'` with real git SHA

Release housekeeping.