### PR TITLE
docs(releases): merge 26.7.1 notes into 26.7.2 archive

### DIFF
--- a/docs/releases/26.7.2/CHANGELOG.md
+++ b/docs/releases/26.7.2/CHANGELOG.md
@@ -7,13 +7,40 @@ release lives at the repository root in [`CHANGELOG.md`](../../../CHANGELOG.md).
 Versions follow [SemVer](https://semver.org/), and the project tracks a
 calendar versioning convention: `YY.M.PATCH`.
 
+> **Note on v26.7.1.** All content originally cut as 26.7.1 is included
+> below. v26.7.1 was tagged but the PyPI publish workflow failed on a
+> sdist bug; nothing was published under that version. v26.7.2 carries
+> everything from 26.7.1 plus the fix (see the `### Fixed` entry starting
+> with **Publish pipeline unbroken**). The historical
+> [26.7.1 archive](../26.7.1/CHANGELOG.md) is retained for reference.
+
 ## [26.7.2]
 
 ### BREAKING
 
+- `clawctl gui` has been removed. Use `clawctl server start` to launch
+  the local GUI server in the background, `clawctl server stop` to stop
+  it, `clawctl server status` to inspect state, and `clawctl server run`
+  for a foreground (systemd/Docker) mode. There is no automated
+  migration — invocations of `clawctl gui` will error with
+  `No such command`. Note: `clawctl server` is Linux-only in this
+  release; macOS support ships in a follow-up PR (#874).
+
 ### Added
 
+- `clawctl server {start,stop,status,run}` — new command group that
+  manages the local GUI server lifecycle. `start` runs uvicorn detached
+  on `127.0.0.1:36000` and records PID + URL to
+  `~/.config/clawrium/server.json`; a second `start` while running is a
+  no-op that prints the live URL; the command fails loudly with exit 1
+  if `:36000` is held by another process. `run` runs the server in the
+  foreground for process-supervisor deployments (#874).
+- `clawctl version` and `clawctl --version` now show the git commit SHA alongside the release version (#656).
+
 ### Changed
+
+- SSH tunnel keepalive increased to 60 s interval × 10 count (10-minute silence ceiling, up from ~90 s), reducing spurious disconnects during brief network interruptions (#866).
+- SSH tunnel manager now tries to reuse the previous local port when re-establishing a dead tunnel, keeping `127.0.0.1:<port>` URLs stable across reconnections (#866).
 
 ### Fixed
 
@@ -25,5 +52,13 @@ calendar versioning convention: `YY.M.PATCH`.
   (the hatch_build hook mis-used hatchling's build-scheme arg as the
   package version). Both fixed in #892; v26.7.2 is the first successful
   publish since v26.7.0.
+- Zeroclaw memory and persona files edited through `clawctl agent memory` now persist in the local control-plane workspace overlay and are restored during `clawctl agent upgrade`, preventing upgrade-time data loss (#871)
+- GUI lifecycle endpoints (`start`, `stop`, `restart`) now return HTTP 502 instead of HTTP 200 with `success: false` when the underlying lifecycle operation fails without raising an exception (#712)
+- GUI error responses for tunnel, lifecycle, and health endpoints now return constant error messages instead of passing raw error text through a weak path-redaction regex, preventing leakage of internal hostnames, IP addresses, and ports (#714)
+- `clawctl agent exec` now dispatches OpenClaw macOS hosts through `exec_macos.yaml` instead of the Linux playbook, so native CLI commands work on agents installed under `/Users/<agent>/` (#869).
+- `clawctl agent open` now evicts stale web-UI SSH tunnels that still have a bound local port but no longer answer HTTP, instead of reusing them and handing operators dead URLs (#869).
+- GUI agent action bar now renders `Start`, `Restart`, and `Stop` in a stable, fixed order across all agent states — invalid actions are marked `aria-disabled` with a guarded click handler, an accessible reason via `aria-describedby`, and a best-effort `title` tooltip, so a state transition can no longer shift `Restart` under a user's cursor and screen-reader / keyboard users can still focus a disabled button to discover why it is unavailable (#870).
 
 ### Documentation
+
+- Synced the website agent-support pages for Hermes, OpenClaw, and ZeroClaw with the shipped Slack integration docs so the release blog's Slack links resolve and the docs site can build again.


### PR DESCRIPTION
## Summary

v26.7.1 was tagged but the PyPI publish workflow failed on a sdist bug (fixed in #892). v26.7.2 is the first release since v26.7.0 to reach users, so it effectively ships everything originally cut as 26.7.1 *plus* the fix.

The `docs/releases/26.7.2/CHANGELOG.md` archive previously listed only the build fix, understating what shipped. This PR merges the full 26.7.1 changelog into the 26.7.2 archive and adds a header note pointing to the retained `docs/releases/26.7.1/` archive for historical context.

The GitHub release body for v26.7.2 has also been rewritten (out-of-band via `gh release edit`) to reflect the merged content.

## Testing
- Docs-only change, no code affected.
- No `26.7.1` references remain in the 26.7.2 archive body: `grep -c '26\.7\.1' docs/releases/26.7.2/CHANGELOG.md` returns the expected reference-only mentions in the header note.