### PR TITLE
daily-docs-sweep 2026-07-14

### DIFF
--- a/docs/agent-support/integrations/index.md
+++ b/docs/agent-support/integrations/index.md
@@ -45,7 +45,7 @@ clawctl integration registry describe my-github  # paste tokens interactively
 
 **From the web dashboard:**
 
-`clawctl gui` opens an **Integrations** page where you can add, edit credentials, and remove integrations through a form. The page surfaces how many agents use each integration so you don't accidentally remove one that's in use; credential values are never returned to the browser.
+`clawctl server start` opens the web dashboard, which includes an **Integrations** page where you can add, edit credentials, and remove integrations through a form. The page surfaces how many agents use each integration so you don't accidentally remove one that's in use; credential values are never returned to the browser.
 
 ## Security
 

--- a/website/docs/agent-support/integrations/index.md
+++ b/website/docs/agent-support/integrations/index.md
@@ -45,7 +45,7 @@ clawctl integration registry describe my-github  # paste tokens interactively
 
 **From the web dashboard:**
 
-`clawctl gui` opens an **Integrations** page where you can add, edit credentials, and remove integrations through a form. The page surfaces how many agents use each integration so you don't accidentally remove one that's in use; credential values are never returned to the browser.
+`clawctl server start` opens the web dashboard, which includes an **Integrations** page where you can add, edit credentials, and remove integrations through a form. The page surfaces how many agents use each integration so you don't accidentally remove one that's in use; credential values are never returned to the browser.
 
 ## Security
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -39,7 +39,7 @@ End-to-end walkthrough: install `clawctl`, register a host, deploy a [Hermes](ht
   </iframe>
 </div>
 
-75-second narrated tour of every tab in `clawctl gui` — Dashboard, Agents, Topology, Providers, Skills, Integrations, Settings. Full reference in the [Web Dashboard guide](./web-dashboard.md).
+75-second narrated tour of every tab in the web dashboard — Dashboard, Agents, Topology, Providers, Skills, Integrations, Settings. Full reference in the [Web Dashboard guide](./web-dashboard.md).
 
 ## What is an Agent?
 
@@ -68,7 +68,7 @@ Clawrium gives you `kubectl`-style fleet control for AI agents:
 - **Specialized agents.** Run a fleet of purpose-built agents - a research agent, a support agent, an internal assistant - each with its own context and configuration.
 - **Model flexibility.** Use any provider: OpenAI, Anthropic, local Ollama, or self-hosted inference.
 - **Lifecycle management.** Upgrades, rollbacks, secrets rotation - handled from one place.
-- **Local web dashboard.** `clawctl gui` opens a visual fleet view on `127.0.0.1` — chat with agents, browse topology, manage providers. See the [Web Dashboard guide](./web-dashboard.md).
+- **Local web dashboard.** `clawctl server start` opens a visual fleet view on `127.0.0.1` — chat with agents, browse topology, manage providers. See the [Web Dashboard guide](./web-dashboard.md).
 
 ## How It Works
 
@@ -132,11 +132,11 @@ Installing openclaw on homelab...
 ```
 
 ```bash
-# Open the local web dashboard
-clawctl gui
+# Start the local web dashboard
+clawctl server start
 ```
 ```
-Clawrium GUI starting on http://127.0.0.1:36000 — press Ctrl+C to stop
+Server started at http://127.0.0.1:36000 (pid 48291)
 ```
 
 ## Key Concepts

--- a/website/docs/reference/cli/gui.md
+++ b/website/docs/reference/cli/gui.md
@@ -1,70 +1,13 @@
 ---
 sidebar_position: 8
-description: Command reference for launching the local web dashboard
-keywords: [cli, gui, dashboard, web ui, command reference]
+description: Deprecated — use clawctl server instead
+keywords: [cli, gui, deprecated, migration]
 ---
 
-# clawctl gui
+import { Redirect } from '@docusaurus/router';
 
-Launch the local web GUI dashboard.
+# clawctl gui (deprecated)
 
-## Synopsis
+> **This page has moved.** `clawctl gui` was removed in v26.7.2. Use [`clawctl server`](./server.md) instead.
 
-```bash
-clawctl gui [options]
-```
-
-`clawctl gui` starts a small FastAPI server on the management machine and opens your default browser to the Clawrium dashboard. The server binds to `127.0.0.1` only — it is **never reachable from the network**.
-
-Running in the foreground; press <kbd>Ctrl+C</kbd> to stop. For a terminal-based equivalent, use `clawctl tui`.
-
-## Options
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--port`, `-p` | `36000` | Local TCP port to bind. Must be 1–65535. |
-| `--no-open` | `false` | Skip auto-opening the browser. Useful for headless / SSH sessions. |
-
-## Examples
-
-```bash
-# Default: bind 127.0.0.1:36000 and open the browser
-clawctl gui
-
-# Custom port (useful when 36000 is taken)
-clawctl gui --port 38000
-
-# Run the server without opening a browser (SSH / tmux / CI)
-clawctl gui --no-open
-```
-
-## What you get
-
-The dashboard surfaces the same data as the CLI, with a few interactive niceties:
-
-- **Dashboard** — fleet counts, 24h token usage, recent agent activity
-- **Topology** — visual map of hosts and the agents running on them, with per-host hardware badges (architecture, GPU vendor)
-- **Providers** — list of configured LLM providers + a searchable model catalog
-- **Integrations** — manage GitHub / GitLab / Atlassian / Linear / Notion integrations and credentials (counterpart to [`clawctl integration`](./integration.md))
-- **Agent detail** — chat with a running agent, view logs, edit memory, inspect config
-- **Settings** — version info, usage DB controls (export / clear), Danger Zone
-
-A walkthrough with screenshots lives in the [Web Dashboard guide](../../web-dashboard.md).
-
-## Installation requirement
-
-The GUI ships in the default install of Clawrium — no extra steps. See [Installation](../../installation.md) if you haven't installed Clawrium yet.
-
-## Security notes
-
-- The server **never binds** to `0.0.0.0`. Multi-machine access is out of scope; use SSH port-forwarding if you need to view the dashboard from another machine.
-- API responses do not include credentials. Agent gateway tokens stay in the secrets store and are only used server-side when proxying chat requests.
-- Log fetching over SSH uses each host's registered key (`-i`) with strict host-key checking; hostnames coming from `hosts.json` are validated before they reach the SSH argv.
-
-## Troubleshooting
-
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| `address already in use` | Port 36000 taken by another process | `clawctl gui --port 38000` or `lsof -ti :36000` to find the conflict |
-| Browser opens then 404 | Frontend bundle not staged | Re-install Clawrium; the bundle ships inside the wheel. If you're running from source, `make build-ui` builds and stages it. |
-| Page renders, every API call 404s | You're hitting `next dev` on :3000 instead of the FastAPI server on :36000 | Open `http://127.0.0.1:36000`, not `:3000` |
+<Redirect to="/docs/reference/cli/server" />

--- a/website/docs/reference/cli/server.md
+++ b/website/docs/reference/cli/server.md
@@ -1,0 +1,184 @@
+---
+sidebar_position: 9
+description: Command reference for managing the local GUI server lifecycle
+keywords: [cli, server, gui, dashboard, web ui, start, stop, status, command reference]
+---
+
+# clawctl server
+
+Manage the local GUI server lifecycle.
+
+> **Breaking change in v26.7.2:** `clawctl gui` has been removed. Use `clawctl server start` to launch the dashboard in the background. See the migration notes below.
+
+## Synopsis
+
+```bash
+clawctl server {start|stop|status|run} [options]
+```
+
+The `clawctl server` command group manages the local web GUI dashboard server. Unlike the legacy `clawctl gui` (which ran in the foreground), the new commands support both detached background mode and foreground supervisor mode.
+
+> **Note:** `clawctl server` is **Linux-only** in this release. macOS support ships in a follow-up.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| [`clawctl server start`](#clawctl-server-start) | Start the GUI server in the background (detached) |
+| [`clawctl server stop`](#clawctl-server-stop) | Stop the running GUI server |
+| [`clawctl server status`](#clawctl-server-status) | Show whether the server is running |
+| [`clawctl server run`](#clawctl-server-run) | Run the GUI server in the foreground (systemd/Docker) |
+
+---
+
+## clawctl server start
+
+Start the GUI server detached from the current shell.
+
+```bash
+clawctl server start
+```
+
+Runs uvicorn on `127.0.0.1:36000` and records PID + URL to `~/.config/clawrium/server.json`. Idempotent: a second invocation while the server is already running prints the live URL and exits 0. The command fails with exit 1 if port `:36000` is held by another process.
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Server started successfully, or already running (idempotent) |
+| 1 | Port in use by foreign process, startup failure, or unsupported platform |
+
+### Example
+
+```bash
+$ clawctl server start
+Server started at http://127.0.0.1:36000 (pid 48291)
+
+# Second invocation (idempotent)
+$ clawctl server start
+Server already running at http://127.0.0.1:36000
+```
+
+---
+
+## clawctl server stop
+
+Stop the running GUI server.
+
+```bash
+clawctl server stop
+```
+
+Reads the PID from `~/.config/clawrium/server.json` and sends a termination signal. No-op with a clear message if no server is running.
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Server stopped successfully, or not running (no-op) |
+| 1 | Stop failed (e.g., PID belongs to a process owned by another user) |
+
+### Example
+
+```bash
+$ clawctl server stop
+Server stopped (pid 48291, http://127.0.0.1:36000)
+
+$ clawctl server stop
+Server is not running
+```
+
+---
+
+## clawctl server status
+
+Show whether the GUI server is running.
+
+```bash
+clawctl server status
+```
+
+Prints running/stopped state, URL, host, port, PID, and start timestamp.
+
+### Example
+
+```bash
+$ clawctl server status
+Status:    running
+URL:       http://127.0.0.1:36000
+Host:      127.0.0.1
+Port:      36000
+PID:       48291
+Started:   2026-07-13T14:56:00Z
+```
+
+---
+
+## clawctl server run
+
+Run the GUI server in the foreground (blocking).
+
+```bash
+clawctl server run
+```
+
+Intended for systemd, Docker, or other process-supervisor deployments. Does not write the state file — the process manager owns lifecycle. Press <kbd>Ctrl+C</kbd> to stop.
+
+### Example
+
+```bash
+$ clawctl server run
+Serving GUI at http://127.0.0.1:36000 — press Ctrl+C to stop
+INFO:     Started server process [48291]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:36000 (Press CTRL+C to quit)
+```
+
+---
+
+## Migration from `clawctl gui`
+
+If you were using `clawctl gui`, replace it as follows:
+
+| Old command | New command |
+|-------------|-------------|
+| `clawctl gui` | `clawctl server start` |
+| `clawctl gui --port 38000` | Not yet supported — port is fixed at 36000 |
+| `clawctl gui --no-open` | `clawctl server start` (no browser auto-open) |
+| `Ctrl+C` to stop | `clawctl server stop` |
+
+State is stored in `~/.config/clawrium/server.json` (PID, URL, host, port, start time).
+
+---
+
+## What you get
+
+The dashboard surfaces the same data as the CLI, with a few interactive niceties:
+
+- **Dashboard** — fleet counts, 24h token usage, recent agent activity
+- **Topology** — visual map of hosts and the agents running on them, with per-host hardware badges (architecture, GPU vendor)
+- **Providers** — list of configured LLM providers + a searchable model catalog
+- **Integrations** — manage GitHub / GitLab / Atlassian / Linear / Notion integrations and credentials (counterpart to [`clawctl integration`](./integration.md))
+- **Agent detail** — chat with a running agent, view logs, edit memory, inspect config
+- **Settings** — version info, usage DB controls (export / clear), Danger Zone
+
+A walkthrough with screenshots lives in the [Web Dashboard guide](../../web-dashboard.md).
+
+---
+
+## Security notes
+
+- The server **never binds** to `0.0.0.0`. Multi-machine access is out of scope; use SSH port-forwarding if you need to view the dashboard from another machine.
+- API responses do not include credentials. Agent gateway tokens stay in the secrets store and are only used server-side when proxying chat requests.
+- Log fetching over SSH uses each host's registered key (`-i`) with strict host-key checking; hostnames coming from `hosts.json` are validated before they reach the SSH argv.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `port already in use` | Port 36000 taken by another process | `lsof -ti :36000` to find the conflict, then kill or stop it |
+| Server starts but browser shows 404 | Frontend bundle not staged | Re-install Clawrium; the bundle ships inside the wheel. If running from source, `make build-ui` builds and stages it. |
+| Page renders, every API call 404s | You're hitting `next dev` on :3000 instead of the server on :36000 | Open `http://127.0.0.1:36000`, not `:3000` |

--- a/website/docs/web-dashboard.md
+++ b/website/docs/web-dashboard.md
@@ -8,10 +8,10 @@ keywords: [gui, web dashboard, ui, fleet, topology, providers, integrations, cha
 Clawrium ships with a local web dashboard that mirrors most of the CLI but renders it visually. Launch it with one command, and use it instead of the CLI when you'd rather click than type.
 
 ```bash
-clawctl gui
+clawctl server start
 ```
 
-The server binds to `127.0.0.1:36000` only — it is **never reachable from the network**. Your browser opens to the dashboard automatically. Press <kbd>Ctrl+C</kbd> to stop.
+The server binds to `127.0.0.1:36000` only — it is **never reachable from the network**. Use `clawctl server stop` to shut it down. For foreground/supervisor mode (systemd, Docker), use `clawctl server run`.
 
 > Prefer the terminal? `clawctl tui` gives you the same fleet overview without leaving the shell.
 
@@ -118,4 +118,4 @@ The GUI is a read-leaning convenience layer; the CLI remains the source of truth
 
 ## Troubleshooting
 
-See the [`clawctl gui` CLI reference](./reference/cli/gui.md#troubleshooting) for symptom / fix pairs (port-in-use, missing extras, dev-vs-prod port confusion).
+See the [`clawctl server` CLI reference](./reference/cli/server.md#troubleshooting) for symptom / fix pairs (port-in-use, missing extras, dev-vs-prod port confusion).


### PR DESCRIPTION
## Summary

Daily documentation sweep: migrate stale `clawctl gui` references to `clawctl server` following the v26.7.2 breaking change.

## Changes

- **Add** `website/docs/reference/cli/server.md` — full CLI reference for `clawctl server {start,stop,status,run}` including migration notes from the legacy `clawctl gui`
- **Redirect** `website/docs/reference/cli/gui.md` → `server.md` via Docusaurus `<Redirect>` (the old command no longer exists)
- **Update** `website/docs/intro.md` — replace `clawctl gui` with `clawctl server start` in feature list and quick-ref examples
- **Update** `website/docs/web-dashboard.md` — replace launch command and troubleshooting link
- **Update** `docs/agent-support/integrations/index.md` + `website/docs/agent-support/integrations/index.md` — replace `clawctl gui` with `clawctl server start` in both canonical and website mirrors

## Testing

### Test Results
- [x] No code changes — documentation only
- [x] `docs/installation.md` ↔ `website/docs/installation.md` mirrors verified consistent
- [x] All remaining `clawctl gui` references in `website/docs/` are intentional (migration context in server.md and redirect in gui.md)
- [x] Both canonical and website mirrors of `agent-support/integrations/index.md` updated

### Files Changed
- `docs/agent-support/integrations/index.md` (1 line)
- `website/docs/agent-support/integrations/index.md` (1 line)
- `website/docs/intro.md` (3 lines)
- `website/docs/reference/cli/gui.md` (redirect replacement)
- `website/docs/reference/cli/server.md` (new — 184 lines)
- `website/docs/web-dashboard.md` (2 lines)

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] No user-provided data handling

---

🤖 Generated by clawrium-docs-sweep cron job