### PR TITLE
feat(manifest): generate SSH keypair during clawctl apply host creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Added
 
+- `clawctl apply` now generates an ed25519 SSH keypair for new Host resources
+  that declare `bootstrap: true`, printing the public key with instructions to
+  add it to `authorized_keys` on the remote host. Previously the host record
+  was written to `hosts.json` but no key was generated, causing every
+  subsequent Ansible operation to fail with "No SSH key found for host"
+  (#902).
+
 ### Changed
 
 ### Fixed

--- a/src/clawrium/core/manifest/executor.py
+++ b/src/clawrium/core/manifest/executor.py
@@ -187,9 +187,31 @@ def _create_host(host_res) -> str | None:
     try:
         add_host(host_dict)
     except DuplicateHostError:
-        pass  # idempotent
+        pass  # idempotent — key may already exist too
     except Exception as exc:
         return str(exc)
+
+    # Generate SSH keypair when bootstrap=True and no key exists yet.
+    # This mirrors what `clawctl host create` does so `apply` is truly
+    # self-contained for new hosts.
+    if host_res.spec.bootstrap:
+        from clawrium.core.keys import (
+            generate_host_keypair,
+            get_host_private_key,
+            read_public_key,
+        )
+
+        key_id = host_res.spec.hostname
+        if not get_host_private_key(key_id):
+            try:
+                generate_host_keypair(key_id)
+            except Exception as exc:
+                return f"SSH key generation failed for {key_id}: {exc}"
+            pub_key = read_public_key(key_id)
+            print(f"  [bootstrap] Generated SSH keypair for {key_id} (key_id: {key_id})")
+            print("  [bootstrap] Add this public key to /home/xclm/.ssh/authorized_keys on the remote host:")
+            print(f"  {pub_key}")
+
     return None
 
 

--- a/tests/test_manifest_apply.py
+++ b/tests/test_manifest_apply.py
@@ -7,13 +7,20 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from clawrium.core.manifest.parser import parse_file, parse_directory
-from clawrium.core.manifest.schema import ManifestDocument
+from clawrium.core.manifest.schema import (
+    HostResource,
+    HostSpec,
+    ManifestDocument,
+    ResourceMetadata,
+)
 from clawrium.core.manifest.validator import validate_refs, collect_secret_refs
 from clawrium.core.manifest.differ import compute
+from clawrium.core.manifest.executor import _create_host
 from clawrium.core.manifest.state import ActualState, ActualAgent
 
 
@@ -463,3 +470,81 @@ def test_collect_secret_refs_empty_when_no_credentials(tmp_path: Path) -> None:
     doc = parse_file(f)
     refs = collect_secret_refs(doc)
     assert refs == []
+
+
+# ── test 8: _create_host SSH key bootstrap ────────────────────────────────────
+
+def _make_host_resource(hostname: str, bootstrap: bool = False) -> HostResource:
+    return HostResource(
+        metadata=ResourceMetadata(name=hostname, labels={}),
+        spec=HostSpec(hostname=hostname, user="xclm", port=22, bootstrap=bootstrap),
+    )
+
+
+def test_create_host_bootstrap_true_generates_keypair() -> None:
+    """When bootstrap=True and no key exists, _create_host calls generate_host_keypair."""
+    host_res = _make_host_resource("192.168.1.48", bootstrap=True)
+
+    with (
+        patch("clawrium.core.hosts.add_host"),
+        patch("clawrium.core.keys.get_host_private_key", return_value=None),
+        patch("clawrium.core.keys.generate_host_keypair") as mock_gen,
+        patch(
+            "clawrium.core.keys.read_public_key",
+            return_value="ssh-ed25519 AAAA... clawrium",
+        ) as mock_read_pub,
+    ):
+        err = _create_host(host_res)
+
+    assert err is None
+    mock_gen.assert_called_once_with("192.168.1.48")
+    mock_read_pub.assert_called_once_with("192.168.1.48")
+
+
+def test_create_host_bootstrap_false_no_keypair_generated() -> None:
+    """When bootstrap=False, _create_host does NOT call generate_host_keypair."""
+    host_res = _make_host_resource("192.168.1.99", bootstrap=False)
+
+    with (
+        patch("clawrium.core.hosts.add_host"),
+        patch("clawrium.core.keys.generate_host_keypair") as mock_gen,
+    ):
+        err = _create_host(host_res)
+
+    assert err is None
+    mock_gen.assert_not_called()
+
+
+def test_create_host_bootstrap_true_key_already_exists_no_regenerate() -> None:
+    """When bootstrap=True but key already exists, generate_host_keypair is NOT called."""
+    host_res = _make_host_resource("192.168.1.50", bootstrap=True)
+    fake_key_path = MagicMock()
+
+    with (
+        patch("clawrium.core.hosts.add_host"),
+        patch("clawrium.core.keys.get_host_private_key", return_value=fake_key_path),
+        patch("clawrium.core.keys.generate_host_keypair") as mock_gen,
+    ):
+        err = _create_host(host_res)
+
+    assert err is None
+    mock_gen.assert_not_called()
+
+
+def test_create_host_bootstrap_keypair_generation_error_returns_error_string() -> None:
+    """When generate_host_keypair raises, _create_host returns a descriptive error string."""
+    host_res = _make_host_resource("192.168.1.51", bootstrap=True)
+
+    with (
+        patch("clawrium.core.hosts.add_host"),
+        patch("clawrium.core.keys.get_host_private_key", return_value=None),
+        patch(
+            "clawrium.core.keys.generate_host_keypair",
+            side_effect=OSError("disk full"),
+        ),
+    ):
+        err = _create_host(host_res)
+
+    assert err is not None
+    assert "192.168.1.51" in err
+    assert "disk full" in err


### PR DESCRIPTION
## Summary

- When a `Host` resource has `bootstrap: true`, `clawctl apply` now generates an ed25519 SSH keypair under `~/.config/clawrium/keys/<key_id>/` if one does not already exist.
- The public key is printed to stdout with instructions to add it to `authorized_keys` on the remote host, mirroring what `clawctl host create` does.
- Hosts without `bootstrap: true` are unaffected — the new code path is fully opt-in.

## Testing

### Test Results
- [x] All existing tests pass (`make test`) — 4550 Python + 329 JS
- [x] Linter passes (`make lint`)
- [x] New tests added for `_create_host` bootstrap behavior

### Test Coverage
- Files changed: `src/clawrium/core/manifest/executor.py`, `tests/test_manifest_apply.py`, `CHANGELOG.md`
- New tests:
  - `test_create_host_bootstrap_true_generates_keypair` — asserts `generate_host_keypair` is called when `bootstrap=True` and no key exists
  - `test_create_host_bootstrap_false_no_keypair_generated` — asserts key generation is skipped when `bootstrap=False`
  - `test_create_host_bootstrap_true_key_already_exists_no_regenerate` — asserts idempotency (no re-generation if key already present)
  - `test_create_host_bootstrap_keypair_generation_error_returns_error_string` — asserts errors surface cleanly

### Manual Testing
Verified `examples/ethos/fleet.yaml` (which already has `bootstrap: true`) parses correctly and the schema accepts it.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Key generation delegates entirely to `core/keys.py:generate_host_keypair` (existing battle-tested code)
- [x] No SSH connection attempted — purely local key generation
- [x] No SQL injection, XSS, or command injection risks

## Reviewer Notes

The `bootstrap` field already existed on `HostSpec` with `default=False` — no schema changes were needed. The key generation runs after `add_host` succeeds (or on idempotent duplicate), gated on `get_host_private_key` returning `None`, so re-running `apply` never overwrites an existing keypair.

Closes #902

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)