### PR TITLE
fix(cli): implement 'agent chat --once' single-shot mode

### DIFF
--- a/.itx/918/00_PLAN.md
+++ b/.itx/918/00_PLAN.md
@@ -1,0 +1,91 @@
+# Issue #918 — Implement `clawctl agent chat --once`
+
+## Problem
+
+`clawctl agent chat <name> --once "hello"` advertises single-shot mode in
+`--help` but currently prints `Not implemented: agent chat --once` and
+exits. The stub short-circuit lives at
+`src/clawrium/cli/clawctl/agent/chat.py:35-39`. The underlying transport
+already streams a full turn via `_chat_loop` in
+`src/clawrium/cli/chat.py`; the `input()` fallback at
+`chat.py:571-579` already proves piped input works. What is missing is
+~25 LOC of glue that skips the REPL loop, sends a single user message,
+awaits one top-level completion, prints the response, and exits.
+
+## Design
+
+1. **Thread `once` from clawctl → legacy chat → loop.**
+   - `clawctl/agent/chat.py:chat()` passes `once=once` when delegating.
+   - `cli/chat.py:chat()` accepts a new `once: Optional[str] = None`
+     kwarg and forwards it into `_chat_loop` via `asyncio.run(...)`.
+   - `_chat_loop` branches on `once is not None`.
+
+2. **Single-shot branch inside `_chat_loop`.**
+   - Skip the interactive prompt entirely (no `_read_user_input`, no
+     `PromptSession`, no banner reused from the interactive path).
+   - Call `backend.send_message(...)` once with a fixed timeout — the
+     lesser of the `--timeout` CLI value and the once-mode idle cap
+     (`_ONCE_IDLE_TIMEOUT_SECONDS = 60.0`).
+   - Print the final assembled text to stdout (streaming deltas via
+     `on_delta` for parity with the REPL).
+   - Close the backend in a `finally`.
+   - Exit code 0 on success. Existing exception classes
+     (`ChatAuthenticationError`, `ChatConnectionError`,
+     `ChatProtocolError`) already surface non-zero exits via the
+     outer `chat()` handlers with useful stderr messages — the
+     once branch reuses them, no new error path needed.
+
+3. **Suppress interactive-only chrome in once mode.**
+   - The pre-existing `Connected target:` and "Type /exit ..." banners
+     in `chat()` are gated on `once is None` so scripted callers get
+     clean stdout containing only the reply.
+
+4. **Remove the stub short-circuit and rewrite the help string.**
+   - Drop `echo_not_implemented(...)` in
+     `src/clawrium/cli/clawctl/agent/chat.py`.
+   - Update the flag help text to:
+     `Send one message, print the reply, and exit. Exit code 0 on success, non-zero on transport error.`
+
+5. **Update tests.**
+   - `tests/cli/clawctl/agent/test_chat.py::test_chat_once_uses_canonical_placeholder`
+     is the ATX iter-1 contract assertion. It is a standalone test
+     asserting the "Not implemented" string; remove the whole test
+     (there is no table iteration in that file).
+   - Add three new tests in the same file:
+     - `test_chat_once_sends_single_message_and_exits` — monkeypatch
+       `cli.chat.chat` with a spy that asserts `once="hello"` is
+       forwarded, returns exit code 0.
+   - Add pure `_chat_loop` tests in `tests/test_cli_chat_once.py`
+     with a fake `ChatBackend` (async send returning a canned reply)
+     covering the three deliverables:
+     - single send + stdout contains reply + exit 0
+     - transport error → non-zero exit
+     - no interactive prompt / banner printed
+
+## Non-goals
+
+- Multi-turn tool loops. The MVP is one send, one completion. The
+  60 s idle cap guards a stuck agent.
+- Memory / session isolation. `--once` uses the same session key as
+  an interactive turn ("main" by default). Callers who want isolation
+  pass `--session direct:<key>`.
+- `--once-timeout` flag. The idle cap lands as a module constant
+  (`_ONCE_IDLE_TIMEOUT_SECONDS = 60.0`) to keep the surface area
+  small — can be promoted to a flag in a follow-up if operators
+  ask.
+
+## Files touched
+
+- `src/clawrium/cli/clawctl/agent/chat.py`
+- `src/clawrium/cli/chat.py`
+- `tests/cli/clawctl/agent/test_chat.py`
+- `tests/test_cli_chat_once.py` (new)
+- `CHANGELOG.md`
+
+## Verification
+
+- `make lint` clean.
+- `make test` clean.
+- Real-host UAT deferred to PR description (marked PENDING; needs
+  wolf-i verification of `--once "reply pong"` returning `pong` with
+  exit 0, plus killed-agent → non-zero exit within 30 s).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,5 +36,10 @@ cut. The `itx:release` skill archives this section into a new
   device-auth provider is now also wired through `build_render_inputs`
   without requiring a stored API key.
 - `clawctl agent sync` no longer prints a spurious `warning: registry record missing for <type> after sync` line for zeroclaw agents whose instance name differs from their type. The post-sync state transition now looks up the agent by its instance name instead of its type (#917).
+- `clawctl agent chat <name> --once "msg"` now sends a single message,
+  prints the reply, and exits with code 0 on success (non-zero on
+  transport / auth / protocol error). Previously the flag was
+  advertised in `--help` but short-circuited to a `Not implemented`
+  message. (#918)
 
 ### Documentation

--- a/src/clawrium/cli/chat.py
+++ b/src/clawrium/cli/chat.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import re
 import sys
-from typing import Any, TypedDict
+from typing import Any, Optional, TypedDict
 
 import typer
 from prompt_toolkit import PromptSession
@@ -56,6 +56,14 @@ class GatewayConfig(TypedDict, total=False):
     device_id: str
     device_private_key: str
 
+
+# Single-shot mode hard cap. `--once` skips the REPL and awaits ONE top-
+# level completion, so a stuck agent must not hang the caller forever.
+# The effective per-request timeout in once mode is min(--timeout,
+# _ONCE_IDLE_TIMEOUT_SECONDS); the CLI --timeout still bounds slow but
+# progressing turns. Kept as a module constant rather than a flag to
+# keep the surface small — promotable in a follow-up if operators ask.
+_ONCE_IDLE_TIMEOUT_SECONDS = 60.0
 
 _SESSION_PATTERN = re.compile(r"^[a-zA-Z0-9_:.-]{1,255}$")
 
@@ -120,6 +128,14 @@ def chat(
         "--idle-timeout",
         min=0.0,
         help="Seconds to wait for user input before auto-exit (0 disables).",
+    ),
+    once: Optional[str] = typer.Option(
+        None,
+        "--once",
+        help=(
+            "Send one message, print the reply, and exit. Exit code 0 on "
+            "success, non-zero on transport error."
+        ),
     ),
 ) -> None:
     """Start an interactive chat session with an installed agent.
@@ -217,28 +233,32 @@ def chat(
     # on the gateway daemon for the lifetime of the WebSocket. The old
     # generic "in-memory only" line was accurate for hermes but
     # misleading for zeroclaw.
-    if chat_type == "openai" and session != "main":
-        console.print(
-            "[dim]`--session` is accepted but has no effect for this agent type "
-            "— conversation history is in-memory only and will not be routed to "
-            "a named session.[/dim]"
-        )
-    elif chat_type == "zeroclaw" and session != "main":
-        console.print(
-            "[dim]`--session` is accepted but has no effect for zeroclaw — the "
-            "gateway daemon owns session state for the duration of this "
-            "WebSocket connection.[/dim]"
-        )
+    # Scripted callers (`--once`) get clean stdout containing only the
+    # reply. The session-noop notices and interactive banners are
+    # gated on interactive mode.
+    if once is None:
+        if chat_type == "openai" and session != "main":
+            console.print(
+                "[dim]`--session` is accepted but has no effect for this agent type "
+                "— conversation history is in-memory only and will not be routed to "
+                "a named session.[/dim]"
+            )
+        elif chat_type == "zeroclaw" and session != "main":
+            console.print(
+                "[dim]`--session` is accepted but has no effect for zeroclaw — the "
+                "gateway daemon owns session state for the duration of this "
+                "WebSocket connection.[/dim]"
+            )
 
-    console.print(
-        f"[green]Connected target:[/green] {rich_escape(str(display_agent))} on {rich_escape(str(display_host))}"
-    )
-    if chat_type == "openai":
         console.print(
-            "Type /exit or press Ctrl+D to end. Use /reset to clear conversation history."
+            f"[green]Connected target:[/green] {rich_escape(str(display_agent))} on {rich_escape(str(display_host))}"
         )
-    else:
-        console.print("Type /exit or press Ctrl+D to end the chat session.")
+        if chat_type == "openai":
+            console.print(
+                "Type /exit or press Ctrl+D to end. Use /reset to clear conversation history."
+            )
+        else:
+            console.print("Type /exit or press Ctrl+D to end the chat session.")
 
     attempted_reconnect = False
     while True:
@@ -260,6 +280,7 @@ def chat(
                     idle_timeout_seconds=idle_timeout,
                     chat_type=chat_type,
                     agent_label=str(display_agent),
+                    once=once,
                 )
             )
             if attempted_reconnect:
@@ -377,6 +398,46 @@ def chat(
             raise typer.Exit(code=1)
 
 
+async def _chat_once(
+    backend: ChatBackend,
+    session_key: str,
+    response_timeout_seconds: float,
+    message: str,
+) -> None:
+    """Single-shot chat turn: connect, send one message, print reply, close.
+
+    Exceptions (`ChatAuthenticationError`, `ChatConnectionError`,
+    `ChatProtocolError`) propagate to the outer `chat()` handlers, which
+    render a diagnostic and exit non-zero. Stdout stays clean — only the
+    assembled reply is written via `console.print` — so scripted callers
+    (`clawctl agent chat <name> --once "hi"`) can consume it directly.
+
+    The per-request timeout is capped at `_ONCE_IDLE_TIMEOUT_SECONDS` so
+    a stuck agent cannot hang the caller indefinitely even if the
+    operator passed a large `--timeout`.
+    """
+    effective_timeout = min(response_timeout_seconds, _ONCE_IDLE_TIMEOUT_SECONDS)
+    await backend.connect()
+    try:
+        # Stream nothing to stdout during the turn; we print the full
+        # assembled reply after `send_message` returns. This keeps the
+        # scripted-caller contract simple: one newline-terminated reply
+        # on stdout, no partial writes interleaved with progress noise.
+        final_text = await backend.send_message(
+            message=message,
+            session_key=session_key,
+            on_delta=None,
+            response_timeout_seconds=effective_timeout,
+        )
+    finally:
+        await backend.close()
+
+    if final_text:
+        console.print(final_text, markup=False, highlight=False)
+    else:
+        console.print("[no response]", markup=False, highlight=False)
+
+
 async def _chat_loop(
     backend: ChatBackend,
     session_key: str,
@@ -384,7 +445,17 @@ async def _chat_loop(
     idle_timeout_seconds: float,
     chat_type: str = "websocket",
     agent_label: str = "agent",
+    once: Optional[str] = None,
 ) -> None:
+    if once is not None:
+        await _chat_once(
+            backend=backend,
+            session_key=session_key,
+            response_timeout_seconds=response_timeout_seconds,
+            message=once,
+        )
+        return
+
     with console.status("Connecting to agent...", spinner="dots"):
         await backend.connect()
 

--- a/src/clawrium/cli/clawctl/agent/chat.py
+++ b/src/clawrium/cli/clawctl/agent/chat.py
@@ -1,10 +1,10 @@
 """`clawctl agent chat <name>` — interactive chat session.
 
 Delegates to the existing `cli/chat.py:chat` implementation. The
-`--once` flag is exposed as plan §4 requested but, in this bundle, is
-informational only: the legacy chat command does not yet expose a
-single-shot mode, so `--once "msg"` prints a notice and exits 0. Full
-single-shot support is a follow-up.
+`--once` flag opts into single-shot mode: the delegated implementation
+skips the REPL, sends the message, prints the reply, and exits. All
+transport / auth / protocol errors surface as non-zero exit codes with
+the same diagnostics the interactive path uses.
 """
 
 from __future__ import annotations
@@ -13,7 +13,6 @@ from typing import Optional
 
 import typer
 
-from clawrium.cli.clawctl._stub import echo_not_implemented
 from clawrium.cli.clawctl.agent._shared import safe_resolve_agent
 
 
@@ -27,16 +26,16 @@ def chat(
         300.0, "--idle-timeout", min=0.0, help="Idle timeout (0 disables)."
     ),
     once: Optional[str] = typer.Option(
-        None, "--once", help="Send one message and exit (placeholder)."
+        None,
+        "--once",
+        help=(
+            "Send one message, print the reply, and exit. Exit code 0 on "
+            "success, non-zero on transport error."
+        ),
     ),
 ) -> None:
     """Start an interactive chat with an agent."""
     safe_resolve_agent(name)  # validates existence
-    if once is not None:
-        # ATX iter-1 W6: use canonical placeholder so probes match the
-        # contract asserted in tests/cli/test_app.py.
-        echo_not_implemented("agent", "chat --once")
-        return
     from clawrium.cli.chat import chat as _legacy_chat
 
     _legacy_chat(
@@ -44,4 +43,5 @@ def chat(
         session=session,
         timeout=timeout,
         idle_timeout=idle_timeout,
+        once=once,
     )

--- a/tests/cli/clawctl/agent/test_chat.py
+++ b/tests/cli/clawctl/agent/test_chat.py
@@ -1,4 +1,4 @@
-"""Tests for `clawctl agent chat` (ATX iter-1 B8)."""
+"""Tests for `clawctl agent chat` (ATX iter-1 B8, issue #918)."""
 
 from __future__ import annotations
 
@@ -15,11 +15,20 @@ def test_chat_unknown_agent_errors(fleet_dir) -> None:
     assert "not found" in result.output
 
 
-def test_chat_once_uses_canonical_placeholder(fleet_dir) -> None:
-    """ATX iter-1 W6: placeholder must use canonical `Not implemented:` line."""
+def test_chat_once_forwards_flag_to_legacy(fleet_dir, monkeypatch) -> None:
+    """Issue #918: `--once` must reach the delegated chat implementation
+    verbatim so the single-shot path can consume it."""
+    called: list[dict] = []
+
+    def fake_chat(**kwargs):
+        called.append(kwargs)
+
+    monkeypatch.setattr("clawrium.cli.chat.chat", fake_chat)
     result = runner.invoke(app, ["agent", "chat", "wise-hypatia", "--once", "hi"])
     assert result.exit_code == 0
-    assert "Not implemented: agent chat --once" in result.output
+    assert len(called) == 1
+    assert called[0]["agent_name"] == "wise-hypatia"
+    assert called[0]["once"] == "hi"
 
 
 def test_chat_without_once_invokes_backend(fleet_dir, monkeypatch) -> None:
@@ -33,3 +42,4 @@ def test_chat_without_once_invokes_backend(fleet_dir, monkeypatch) -> None:
     assert result.exit_code == 0
     assert len(called) == 1
     assert called[0]["agent_name"] == "wise-hypatia"
+    assert called[0]["once"] is None

--- a/tests/test_cli_chat_once.py
+++ b/tests/test_cli_chat_once.py
@@ -1,0 +1,170 @@
+"""Tests for `_chat_once` — the `clawctl agent chat --once` single-shot
+branch inside `src/clawrium/cli/chat.py`.
+
+Covers issue #918:
+- single send + stdout contains reply + exit code 0
+- transport error → non-zero exit with stderr diagnostic
+- no interactive prompt or connection banner printed in once mode
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable
+
+import pytest
+
+from clawrium.cli import chat as chat_module
+from clawrium.core.chat import ChatConnectionError
+
+
+class _FakeBackend:
+    """Minimal ChatBackend Protocol implementation for once-mode tests.
+
+    - `reply` is the string returned from `send_message`.
+    - `send_error` (if set) is raised from `send_message` instead.
+    - Records the messages that were sent so the test can assert exactly
+      one send happened per `_chat_once` invocation.
+    """
+
+    def __init__(
+        self,
+        reply: str = "",
+        send_error: Exception | None = None,
+    ) -> None:
+        self.reply = reply
+        self.send_error = send_error
+        self.sent: list[str] = []
+        self.connected = False
+        self.closed = False
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def send_message(
+        self,
+        message: str,
+        session_key: str,
+        on_delta: Callable[[str], None] | None = None,
+        response_timeout_seconds: float = 120.0,
+    ) -> str:
+        self.sent.append(message)
+        if self.send_error is not None:
+            raise self.send_error
+        return self.reply
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def clear_history(self) -> None:  # pragma: no cover — protocol shim
+        return None
+
+    @property
+    def is_connected(self) -> bool:
+        return self.connected and not self.closed
+
+
+def _run_once(
+    backend: _FakeBackend,
+    message: str = "hello",
+    timeout: float = 30.0,
+) -> None:
+    asyncio.run(
+        chat_module._chat_once(
+            backend=backend,
+            session_key="main",
+            response_timeout_seconds=timeout,
+            message=message,
+        )
+    )
+
+
+def test_chat_once_sends_single_message_and_exits(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    backend = _FakeBackend(reply="pong")
+    _run_once(backend, message="ping")
+
+    assert backend.sent == ["ping"]
+    assert backend.connected is True
+    assert backend.closed is True
+
+    captured = capsys.readouterr()
+    assert "pong" in captured.out
+
+
+def test_chat_once_returns_nonzero_on_transport_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    backend = _FakeBackend(send_error=ChatConnectionError("boom: agent unreachable"))
+
+    with pytest.raises(ChatConnectionError):
+        _run_once(backend, message="hi")
+
+    # Backend was still closed even though send failed (finally clause).
+    assert backend.closed is True
+    # The outer `chat()` translates ChatConnectionError to typer.Exit(1)
+    # with a diagnostic; the once helper simply propagates.
+
+
+def test_chat_once_no_repl_prompt(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Assert once-mode never touches the interactive prompt path."""
+    called: list[Any] = []
+
+    async def _boom_read_user_input(*args: Any, **kwargs: Any) -> str:
+        called.append(args)
+        raise AssertionError("REPL prompt reached in --once mode")
+
+    monkeypatch.setattr(chat_module, "_read_user_input", _boom_read_user_input)
+
+    backend = _FakeBackend(reply="ok")
+    _run_once(backend, message="q")
+
+    assert called == []
+    captured = capsys.readouterr()
+    # Interactive-only banners must NOT appear in the stdout / stderr
+    # stream when running in once mode. `_chat_once` never prints
+    # "Connecting to agent..." or a "you>" prompt.
+    assert "Connecting to agent" not in captured.out
+    assert "you>" not in captured.out
+    assert "Type /exit" not in captured.out
+
+
+def test_chat_once_prints_placeholder_on_empty_reply(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    backend = _FakeBackend(reply="")
+    _run_once(backend, message="q")
+
+    captured = capsys.readouterr()
+    assert "[no response]" in captured.out
+
+
+def test_chat_once_caps_timeout_at_hard_limit() -> None:
+    """The `--timeout` value is passed through, but capped at the
+    module-level `_ONCE_IDLE_TIMEOUT_SECONDS` so a stuck agent cannot
+    hang a scripted caller past the cap."""
+    captured_timeout: list[float] = []
+
+    class _CapturingBackend(_FakeBackend):
+        async def send_message(
+            self,
+            message: str,
+            session_key: str,
+            on_delta: Callable[[str], None] | None = None,
+            response_timeout_seconds: float = 120.0,
+        ) -> str:
+            captured_timeout.append(response_timeout_seconds)
+            return await super().send_message(
+                message, session_key, on_delta, response_timeout_seconds
+            )
+
+    backend = _CapturingBackend(reply="ok")
+    # Pass a --timeout well above the hard cap; the effective per-request
+    # timeout the backend sees must be _ONCE_IDLE_TIMEOUT_SECONDS.
+    _run_once(backend, message="q", timeout=600.0)
+
+    assert captured_timeout == [chat_module._ONCE_IDLE_TIMEOUT_SECONDS]


### PR DESCRIPTION
## Summary

- Wires `clawctl agent chat <name> --once "msg"` through to a new `_chat_once` helper in `src/clawrium/cli/chat.py` — connects, sends one user message, awaits one top-level completion, prints the assembled reply to stdout, closes the backend, and exits 0.
- REPL chrome is suppressed in once mode: no `Connecting to agent...` spinner, no `Connected target:` banner, no session-noop notice, no `you>` prompt. Scripted callers see only the reply on stdout.
- Per-request timeout is capped at `_ONCE_IDLE_TIMEOUT_SECONDS = 60.0` so a stuck agent cannot hang a scripted caller beyond the cap, even if the operator passed a very large `--timeout`.
- Transport / auth / protocol errors propagate through the existing `ChatAuthenticationError` / `ChatConnectionError` / `ChatProtocolError` handlers in `chat()`, which already render diagnostics and exit non-zero — no new error path needed.
- Removed the ATX iter-1 placeholder short-circuit + updated `--help`: `Send one message, print the reply, and exit. Exit code 0 on success, non-zero on transport error.`

## Testing

### Test Results
- [x] All existing tests pass (`make test` → 4545 passed, 8 skipped + 329 vitest passed)
- [x] Linter passes (`make lint` → ruff + eslint clean)
- [x] New tests added for new functionality

### Test Coverage
- Files changed: `src/clawrium/cli/chat.py`, `src/clawrium/cli/clawctl/agent/chat.py`, `tests/cli/clawctl/agent/test_chat.py`, `CHANGELOG.md`
- New tests: `tests/test_cli_chat_once.py` (5 tests) + `tests/cli/clawctl/agent/test_chat.py::test_chat_once_forwards_flag_to_legacy`
- Coverage impact: increased — `_chat_once` fully covered including timeout-cap invariant and error propagation

### Manual Testing

**UAT status: PENDING** — needs wolf-i verification of:
1. `clawctl agent chat wise-hypatia --once "reply pong"` → prints `pong`, exits 0.
2. Kill the agent daemon → `clawctl agent chat <name> --once "hi"` → non-zero exit within 30 s with a `Connection failed` diagnostic on stderr.
3. Stale bearer scenario → `Authentication failed` diagnostic, non-zero exit.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (session key validated via existing `_SESSION_PATTERN`; `once` value is opaque payload passed straight to backend)
- [x] No SQL injection, XSS, or command injection risks
- [x] Dependencies are from trusted sources (no new deps)

## Reviewer Notes

**Non-goals** (deferred):

- Multi-turn tool loops. The MVP is one send / one completion. If the agent enters an internal tool loop, the 60 s idle cap protects the caller. A future `--once-follow-tools` flag could extend this.
- Memory / session isolation. `--once` reuses whatever `--session` was passed (default `main`), same as an interactive turn. Callers who want isolation pass `--session direct:<key>`.
- Idle-timeout as a CLI flag. Landed as a module constant `_ONCE_IDLE_TIMEOUT_SECONDS`. Promotable to `--once-timeout` in a follow-up if operators ask.

**ATX contract handling:** the placeholder assertion at `tests/cli/clawctl/agent/test_chat.py::test_chat_once_uses_canonical_placeholder` was a single standalone test (not a table iteration over multiple placeholders). It has been replaced with `test_chat_once_forwards_flag_to_legacy` which asserts the new positive behavior — the `--once` value now reaches `cli.chat.chat` verbatim.

Closes #918

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)