### PR TITLE
fix(zeroclaw): parameterize hardcoded operator-home paths in config template

### DIFF
--- a/.itx/911/00_PLAN.md
+++ b/.itx/911/00_PLAN.md
@@ -1,0 +1,89 @@
+# #911 — Parameterize hardcoded operator-home paths in the zeroclaw config template
+
+## Issue
+
+`src/clawrium/platform/registry/zeroclaw/templates/zeroclaw-config.toml.j2`
+ships with seven keys hardcoded to a specific operator's home,
+`/home/clawrium-d01/…`. When `render_zeroclaw` produces
+`.zeroclaw/config.toml` for a new agent (e.g. `e2e-zeroclaw`), those
+seven daemon-owned paths still resolve to `/home/clawrium-d01/.zeroclaw/…`.
+Every zeroclaw agent on every host writes its knowledge db, plugins,
+reports, e-stop state, security-ops playbooks + reports, and workspaces
+into the same operator's home — cross-agent data collision, and on any
+host where that operator does not exist, the daemon fails to open the
+paths at all. Also blocks the reproducer in `#913`.
+
+## Root cause
+
+The template was seeded from a real host's rendered config and the
+operator-specific home never got parameterized. Every existing test asserts
+section presence or key names — none inspects the raw path values — so the
+leak survived review and every render matrix run to date.
+
+The seven offending lines (line numbers as of `main` @ 26.7.2):
+
+| Line | Section          | Key                 |
+|------|------------------|---------------------|
+| 419  | `[knowledge]`    | `db_path`           |
+| 601  | `[plugins]`      | `plugins_dir`       |
+| 612  | `[project_intel]`| `report_output_dir` |
+| 668  | `[security.estop]`| `state_file`       |
+| 710  | `[security_ops]` | `playbooks_dir`     |
+| 711  | `[security_ops]` | `report_output_dir` |
+| 807  | `[workspace]`    | `workspaces_dir`    |
+
+## Fix
+
+1. Replace each hardcoded `/home/clawrium-d01/` with
+   `{{ home_root }}/{{ agent_name }}/`.
+2. Pass `home_root` into `_render_zeroclaw_config_template`. The variable
+   already exists in `render_zeroclaw`'s scope (`/Users` for darwin,
+   `/home` for linux — same os_family branch used for
+   `slack_mcp_binary` at line ~1505).
+
+Total surface area: one template file, three call-site changes in
+`src/clawrium/core/render.py`.
+
+## Definition of done
+
+- All 7 hardcoded paths in the zeroclaw template are parameterized.
+- Two new render tests (`test_zeroclaw_config_paths_use_agent_home_linux`,
+  `_darwin`) render for `test-agent` and assert:
+  - zero occurrences of `clawrium-d01` in the output;
+  - every previously-hardcoded key resolves under
+    `/home/test-agent/.zeroclaw/…` (linux) or
+    `/Users/test-agent/.zeroclaw/…` (darwin).
+- One new cross-agent hygiene test
+  (`tests/platform/test_template_hygiene.py`) walks every bundled
+  agent's `templates/` directory and asserts no forbidden literal
+  (starting with `clawrium-d01`) appears anywhere. Prevents the same
+  class of bug landing in future agents.
+- CHANGELOG under `## [Unreleased] → ### Fixed` references `#911` and
+  notes it also recovers `#913`.
+- `make lint` + `make test` clean.
+- Draft PR opened against `main`; body records UAT-PENDING and lists
+  the two real-host targets (wolf-i linux, mac-test darwin).
+
+## Not in scope
+
+- Automated migration for zeroclaw agents that already ran with the
+  wrong paths. Their `knowledge.db` / `plugins/` / `workspaces/` sit
+  under `/home/clawrium-d01/.zeroclaw/` and will remain there after
+  sync. Operators can `mv` manually. Documented in the PR migration
+  note.
+
+## Prompt Log
+
+## Execute
+
+**Stage**: execute
+**Skill**: (agent-driven — no slash-command invocation)
+**Timestamp**: 2026-07-14T21:40:00Z
+**Model**: claude-opus-4-7[1m]
+
+```prompt
+Ship a draft PR that fixes GitHub issue #911 in the clawrium repo.
+(See PR body for full task description.)
+```
+
+**Output**: Draft PR `fix(zeroclaw): parameterize hardcoded operator-home paths in config template` opened against `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,5 +41,6 @@ cut. The `itx:release` skill archives this section into a new
   transport / auth / protocol error). Previously the flag was
   advertised in `--help` but short-circuited to a `Not implemented`
   message. (#918)
+- Parameterized seven hardcoded operator-home paths (`/home/clawrium-d01/…`) in the zeroclaw config template so `knowledge.db`, `plugins/`, `project-reports/`, `estop-state.json`, security-ops `playbooks/` + `security-reports/`, and `workspaces/` all resolve under each agent's own home. Prevents cross-agent data collision on multi-agent hosts and recovers project-intel / knowledge features that were writing to the wrong home. Also recovers `#913`. (#911)
 
 ### Documentation

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -1519,6 +1519,7 @@ def render_zeroclaw(
     )
     toml_body = _render_zeroclaw_config_template(
         agent_name=inputs.agent_name,
+        home_root=home_root,
         gateway=inputs.gateway,
         provider=provider,
         discord_channel=discord_channel,
@@ -1634,6 +1635,7 @@ def _zeroclaw_template():
 def _render_zeroclaw_config_template(
     *,
     agent_name: str,
+    home_root: str = "/home",
     gateway: "GatewayInputs",
     provider: "ProviderInputs",
     discord_channel: "ChannelInputs | None",
@@ -1658,6 +1660,7 @@ def _render_zeroclaw_config_template(
     template = _zeroclaw_template()
     return template.render(
         agent_name=agent_name,
+        home_root=home_root,
         gateway=gateway,
         provider=provider,
         discord_channel=discord_channel,

--- a/src/clawrium/platform/registry/zeroclaw/templates/zeroclaw-config.toml.j2
+++ b/src/clawrium/platform/registry/zeroclaw/templates/zeroclaw-config.toml.j2
@@ -416,7 +416,7 @@ timeout_secs = 30
 [knowledge]
 auto_capture = false
 cross_workspace_search = false
-db_path = "/home/clawrium-d01/.zeroclaw/knowledge.db"
+db_path = "{{ home_root }}/{{ agent_name }}/.zeroclaw/knowledge.db"
 enabled = false
 max_nodes = 100000
 suggest_on_query = true
@@ -598,7 +598,7 @@ max_steps = 20
 auto_discover = false
 enabled = false
 max_plugins = 50
-plugins_dir = "/home/clawrium-d01/.zeroclaw/plugins"
+plugins_dir = "{{ home_root }}/{{ agent_name }}/.zeroclaw/plugins"
 
 [plugins.security]
 signature_mode = "disabled"
@@ -609,7 +609,7 @@ default_language = "en"
 enabled = false
 include_git_data = true
 include_jira_data = false
-report_output_dir = "/home/clawrium-d01/.zeroclaw/project-reports"
+report_output_dir = "{{ home_root }}/{{ agent_name }}/.zeroclaw/project-reports"
 risk_sensitivity = "medium"
 
 [proxy]
@@ -665,7 +665,7 @@ sign_events = false
 [security.estop]
 enabled = false
 require_otp_to_resume = true
-state_file = "/home/clawrium-d01/.zeroclaw/estop-state.json"
+state_file = "{{ home_root }}/{{ agent_name }}/.zeroclaw/estop-state.json"
 
 [security.nevis]
 client_id = ""
@@ -707,8 +707,8 @@ rp_origin = "http://localhost:42617"
 auto_triage = false
 enabled = false
 max_auto_severity = "low"
-playbooks_dir = "/home/clawrium-d01/.zeroclaw/playbooks"
-report_output_dir = "/home/clawrium-d01/.zeroclaw/security-reports"
+playbooks_dir = "{{ home_root }}/{{ agent_name }}/.zeroclaw/playbooks"
+report_output_dir = "{{ home_root }}/{{ agent_name }}/.zeroclaw/security-reports"
 require_approval_for_actions = true
 
 [shell_tool]
@@ -804,4 +804,4 @@ enabled = false
 isolate_audit = true
 isolate_memory = true
 isolate_secrets = true
-workspaces_dir = "/home/clawrium-d01/.zeroclaw/workspaces"
+workspaces_dir = "{{ home_root }}/{{ agent_name }}/.zeroclaw/workspaces"

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -1268,6 +1268,72 @@ def test_zeroclaw_requires_gateway():
         render_zeroclaw(inputs)
 
 
+# #911: previously the zeroclaw config template hardcoded
+# `/home/clawrium-d01/…` (an operator-specific home) at seven daemon-owned
+# paths — knowledge db, plugins dir, project-intel reports, e-stop state,
+# security-ops playbooks + reports, and workspaces dir. Every rendered
+# zeroclaw agent pointed those paths at a single operator's home,
+# regardless of the agent's actual name — cross-agent data collision.
+# These two tests lock the fix: config paths must resolve under the
+# agent's own home for both linux and darwin.
+_ZEROCLAW_AGENT_HOMED_KEYS = (
+    "db_path",
+    "plugins_dir",
+    "state_file",
+    "playbooks_dir",
+    "workspaces_dir",
+    # `report_output_dir` appears twice (project_intel + security_ops).
+    "report_output_dir",
+)
+
+
+def _extract_key_value(toml_body: str, key: str) -> list[str]:
+    """Return every value assigned to `key` in a TOML body (`key = "value"`)."""
+    import re
+
+    return re.findall(rf'^\s*{re.escape(key)}\s*=\s*"([^"]+)"', toml_body, flags=re.M)
+
+
+def test_zeroclaw_config_paths_use_agent_home_linux():
+    inputs = RenderInputs(
+        agent_name="test-agent",
+        agent_type="zeroclaw",
+        provider=ProviderInputs(name="p", type="openrouter", api_key="k"),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, allow_public_bind=True),
+    )
+    toml = render_zeroclaw(inputs, os_family="linux").files[".zeroclaw/config.toml"]
+    # No operator-specific home leaks into the render.
+    assert "clawrium-d01" not in toml, (
+        "hardcoded operator home leaked into zeroclaw config render"
+    )
+    # Every previously-hardcoded key must resolve under the agent's own home.
+    for key in _ZEROCLAW_AGENT_HOMED_KEYS:
+        values = _extract_key_value(toml, key)
+        assert values, f"expected at least one `{key} = …` line in rendered TOML"
+        for value in values:
+            assert value.startswith("/home/test-agent/.zeroclaw/"), (
+                f"{key!r} resolved to {value!r}, expected /home/test-agent/.zeroclaw/…"
+            )
+
+
+def test_zeroclaw_config_paths_use_agent_home_darwin():
+    inputs = RenderInputs(
+        agent_name="test-agent",
+        agent_type="zeroclaw",
+        provider=ProviderInputs(name="p", type="openrouter", api_key="k"),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, allow_public_bind=True),
+    )
+    toml = render_zeroclaw(inputs, os_family="darwin").files[".zeroclaw/config.toml"]
+    assert "clawrium-d01" not in toml
+    for key in _ZEROCLAW_AGENT_HOMED_KEYS:
+        values = _extract_key_value(toml, key)
+        assert values, f"expected at least one `{key} = …` line in rendered TOML"
+        for value in values:
+            assert value.startswith("/Users/test-agent/.zeroclaw/"), (
+                f"{key!r} resolved to {value!r}, expected /Users/test-agent/.zeroclaw/…"
+            )
+
+
 def test_openclaw_openrouter_prefixes_model():
     inputs = _baseline_inputs(ptype="openrouter")
     inputs = RenderInputs(

--- a/tests/platform/test_template_hygiene.py
+++ b/tests/platform/test_template_hygiene.py
@@ -1,0 +1,74 @@
+"""Cross-agent template hygiene guards.
+
+#911: the zeroclaw config template shipped for months with a hardcoded
+operator-specific home (`/home/clawrium-d01/…`) at seven daemon-owned
+paths — a copy-paste from a real host that survived review because no
+test looked at the raw template string, only at rendered output for
+one agent name. This module walks every bundled agent's `templates/`
+directory and asserts the same class of leak never resurfaces in any
+agent (zeroclaw, openclaw, hermes, or future additions).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Literal strings that must NEVER appear in a shipped template. These are
+# real operator homes / hostnames pulled from prior copy-paste incidents.
+# Add to this list when a new incident is discovered — the assertion is
+# cheap and the false-positive rate is effectively zero for these names.
+_FORBIDDEN_LITERALS = (
+    "clawrium-d01",  # #911 — zeroclaw operator home
+)
+
+
+def _registry_root() -> Path:
+    # tests/platform/test_template_hygiene.py → .../src/clawrium/platform/registry
+    return (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "clawrium"
+        / "platform"
+        / "registry"
+    )
+
+
+def _iter_template_files() -> list[Path]:
+    root = _registry_root()
+    assert root.is_dir(), f"registry root not found at {root}"
+    files: list[Path] = []
+    # Every `templates/` subdir under any agent-type folder.
+    for template_dir in root.glob("*/templates"):
+        if not template_dir.is_dir():
+            continue
+        for path in template_dir.rglob("*"):
+            if path.is_file():
+                files.append(path)
+    assert files, "no template files discovered under registry/*/templates/"
+    return files
+
+
+def test_no_operator_specific_home_in_any_template():
+    """No forbidden literal (operator-specific homes, hostnames) may appear
+    in any bundled agent template. Prevents the #911 class of bug across
+    zeroclaw, openclaw, hermes, and future agent types.
+    """
+    offenders: list[tuple[Path, str, int]] = []
+    for path in _iter_template_files():
+        try:
+            body = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            # Binary asset (e.g. a bundled image). Skip — the leak class
+            # is a text-template concern.
+            continue
+        for literal in _FORBIDDEN_LITERALS:
+            count = body.count(literal)
+            if count:
+                offenders.append((path, literal, count))
+    assert not offenders, (
+        "forbidden literals found in bundled templates:\n"
+        + "\n".join(
+            f"  {p.relative_to(_registry_root())}: {lit!r} × {n}"
+            for (p, lit, n) in offenders
+        )
+    )


### PR DESCRIPTION
## Summary

- Replace seven hardcoded `/home/clawrium-d01/…` paths in `src/clawrium/platform/registry/zeroclaw/templates/zeroclaw-config.toml.j2` with `{{ home_root }}/{{ agent_name }}/…` so every rendered zeroclaw agent's `knowledge.db`, `plugins/`, `project-reports/`, `estop-state.json`, security-ops `playbooks/` + `security-reports/`, and `workspaces/` resolve under the agent's own home.
- Wire `home_root` through `_render_zeroclaw_config_template` in `src/clawrium/core/render.py`. `home_root` already exists in `render_zeroclaw`'s scope from the `os_family` branch used for `slack_mcp_binary`.
- Add cross-agent hygiene test that walks every bundled agent's `templates/` and asserts no forbidden operator-specific literal ever ships.

## Testing

### Test Results
- [x] All existing tests pass (`make test-py` — 4543 passed, 8 skipped)
- [x] Linter passes (`make lint`)
- [x] New tests added for new functionality

### Test Coverage
- Files changed:
  - `src/clawrium/platform/registry/zeroclaw/templates/zeroclaw-config.toml.j2` (7 lines parameterized)
  - `src/clawrium/core/render.py` (3 call-site changes)
  - `CHANGELOG.md` (Fixed entry)
- New tests:
  - `tests/core/test_render.py::test_zeroclaw_config_paths_use_agent_home_linux`
  - `tests/core/test_render.py::test_zeroclaw_config_paths_use_agent_home_darwin`
  - `tests/platform/test_template_hygiene.py::test_no_operator_specific_home_in_any_template`
- Coverage impact: increased (three new tests, no removals)

### Manual Testing
Render-level verification only in-worktree. Real-host UAT pending — see below.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation for user-provided data (agent_name is validated upstream by `_validate_agent_name`)
- [x] No SQL injection, XSS, or command injection risks (path values are already TOML-escaped by the existing `toq` filter for other keys; these paths are constructed from validated agent_name so no filter change is needed)
- [x] Dependencies are from trusted sources (no new deps)

## Migration Note

Existing zeroclaw agents that ran with the wrong paths have `knowledge.db` / `plugins/` / `workspaces/` under `/home/clawrium-d01/.zeroclaw/`. After sync they'll point at the correct (empty) home. Operators can `mv` manually. Automated migration is out of scope.

## UAT status: PENDING

Needs verification on:
- **wolf-i** (linux) — install a fresh zeroclaw agent, run `clawctl agent configure`, verify `~/.zeroclaw/config.toml` on host now contains `/home/<agent-name>/.zeroclaw/…` at all seven keys.
- **mac-test** (darwin, 100.120.88.97) — same flow, verify `/Users/<agent-name>/.zeroclaw/…`.

## Reviewer Notes

The hygiene test also scanned openclaw and hermes templates — no other forbidden literal found. Zeroclaw was the sole affected agent.

Closes #911, closes #913

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)