### PR TITLE
fix(doctor): add ethos renderer + gateway diagnostic fields (#923)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Fixed
 
+- `clawctl agent doctor <name>` now works for **ethos agents** (#923). Previously the command
+  failed with `Error: no renderer registered for agent type 'ethos'` because the doctor
+  dispatch table only covered hermes, zeroclaw, and openclaw. Fix adds a `render_ethos()`
+  Python renderer that exercises the same five Jinja2 templates as the Ansible configure
+  playbook (`.ethos/.env`, `.ethos/config.yaml`, and three personality files), extends
+  `GatewayInputs` with `api_key` and `internal_port` fields (populated from the gateway
+  blob for ethos; default-empty for all other types), and surfaces both fields in the
+  doctor gateway diagnostic block.
 - Ethos agents stuck in `onboarding.state=pending` (e.g. due to SSH drop or provider API
   unreachable during configure) now auto-recover when `clawctl agent start` is called.
   `start_agent` re-runs configure before raising `LifecycleError`; if recovery succeeds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,20 @@ cut. The `itx:release` skill archives this section into a new
   `GatewayInputs` with `api_key` and `internal_port` fields (populated from the gateway
   blob for ethos; default-empty for all other types), and surfaces both fields in the
   doctor gateway diagnostic block.
+- Ethos configure/sync now render config through the same Python renderer doctor uses
+  (#924 review of #923). `clawctl agent configure` pre-renders all five ethos config
+  files via `render_ethos` and the configure playbook deploys the bytes with
+  `copy: content:` instead of templating server-side; `clawctl agent sync` gains an
+  ethos entry in the canonical renderer table. This collapses the dual Jinja2 render
+  path (Python for doctor vs Ansible for configure) — the bug class #622 closed for
+  hermes. Also from the same review: the doctor gateway block (api_key presence,
+  internal_port) now appears in the default table output and is emitted only for
+  ethos agents in JSON/YAML output; renderer errors surface as a structured
+  `status: broken` report instead of a traceback; an explicit
+  `gateway.internal_port: 0` is no longer silently replaced with the 44410 default,
+  and non-numeric values produce an actionable config error; `provider`/`model`
+  values in the rendered ethos `config.yaml` are now JSON-quoted so model ids with
+  colons cannot produce unparseable YAML.
 - Ethos agents stuck in `onboarding.state=pending` (e.g. due to SSH drop or provider API
   unreachable during configure) now auto-recover when `clawctl agent start` is called.
   `start_agent` re-runs configure before raising `LifecycleError`; if recovery succeeds

--- a/src/clawrium/cli/clawctl/agent/doctor.py
+++ b/src/clawrium/cli/clawctl/agent/doctor.py
@@ -183,9 +183,15 @@ def _inputs_block(inputs: RenderInputs) -> dict:
             "auth": _present(inputs.gateway.auth),
             "bind": inputs.gateway.bind,
             "allow_public_bind": inputs.gateway.allow_public_bind,
-            "api_key": _present(inputs.gateway.api_key),
-            "internal_port": inputs.gateway.internal_port,
         }
+        # W1 (#924): api_key / internal_port are ethos-only gateway
+        # fields. Emitting them unconditionally would silently widen the
+        # JSON schema for every zeroclaw/openclaw agent with a gateway
+        # block (`"api_key": "missing"`, `"internal_port": 0`) — noise
+        # for consumers parsing `-o json`.
+        if inputs.agent_type == "ethos":
+            gateway["api_key"] = _present(inputs.gateway.api_key)
+            gateway["internal_port"] = inputs.gateway.internal_port
     return {
         "provider": provider,
         "channels": channels,
@@ -234,7 +240,16 @@ def _report(name: str, claw_record: dict) -> dict:
         report["error"] = str(exc)
         return report
     report["inputs"] = _inputs_block(inputs)
-    rendered = _render_for(inputs)
+    # W5 (#924): the renderer itself can raise AgentConfigError (duplicate
+    # channel type, gateway=None, unsupported provider). Doctor's contract
+    # is a structured `status: broken` report + non-zero exit — never an
+    # unhandled traceback.
+    try:
+        rendered = _render_for(inputs)
+    except AgentConfigError as exc:
+        report["status"] = "broken"
+        report["error"] = str(exc)
+        return report
     if rendered is None:
         report["status"] = "broken"
         report["error"] = (
@@ -308,6 +323,24 @@ def _render_table(report: dict) -> str:
                 )
         else:
             lines.append("Resolved integrations: none")
+
+        # W2 (#924): the gateway diagnostic block must be visible in the
+        # default table output too, not only via `-o json` / `-o yaml` —
+        # the api_key present/missing signal is the primary thing an
+        # ethos operator runs doctor for.
+        gw = inputs.get("gateway")
+        if gw:
+            lines.append("")
+            lines.append("Resolved gateway:")
+            lines.append(f"  host:           {_s(gw['host'])}")
+            lines.append(f"  port:           {gw['port']}")
+            lines.append(f"  auth:           {gw['auth']}")
+            if gw["bind"]:
+                lines.append(f"  bind:           {_s(gw['bind'])}")
+            if "api_key" in gw:
+                lines.append(f"  api_key:        {gw['api_key']}")
+            if "internal_port" in gw:
+                lines.append(f"  internal_port:  {gw['internal_port']}")
 
         files = report["files"]
         lines.append("")

--- a/src/clawrium/cli/clawctl/agent/doctor.py
+++ b/src/clawrium/cli/clawctl/agent/doctor.py
@@ -37,6 +37,7 @@ from clawrium.core.render import (
     RenderedFiles,
     RenderInputs,
     build_render_inputs,
+    render_ethos,  # noqa: F401 — re-exported for test monkeypatching.
     render_hermes,  # noqa: F401 — re-exported for test monkeypatching.
     render_openclaw,  # noqa: F401 — re-exported for test monkeypatching.
     render_zeroclaw,  # noqa: F401 — re-exported for test monkeypatching.
@@ -48,6 +49,7 @@ from clawrium.core.render import (
 # import time) lets `monkeypatch.setattr(doctor_mod, "render_X", ...)`
 # work without callers having to know about the dispatch table.
 _RENDERER_NAMES = {
+    "ethos": "render_ethos",
     "hermes": "render_hermes",
     "zeroclaw": "render_zeroclaw",
     "openclaw": "render_openclaw",
@@ -181,6 +183,8 @@ def _inputs_block(inputs: RenderInputs) -> dict:
             "auth": _present(inputs.gateway.auth),
             "bind": inputs.gateway.bind,
             "allow_public_bind": inputs.gateway.allow_public_bind,
+            "api_key": _present(inputs.gateway.api_key),
+            "internal_port": inputs.gateway.internal_port,
         }
     return {
         "provider": provider,

--- a/src/clawrium/cli/clawctl/agent/sync.py
+++ b/src/clawrium/cli/clawctl/agent/sync.py
@@ -55,6 +55,9 @@ _PHASES = (
 
 
 _RENDERERS = {
+    # #924 (ATX B1): ethos renders through render_ethos on every path
+    # (doctor, configure, sync, and this --dry-run --diff table).
+    "ethos": "render_ethos",
     "hermes": "render_hermes",
     "zeroclaw": "render_zeroclaw",
     "openclaw": "render_openclaw",

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -2837,6 +2837,64 @@ def configure_agent(
             # bad hosts.json shape, IOError on baseline read — surface
             # as a clean (False, msg) instead of an unhandled traceback.
             return False, f"Openclaw render failed (internal): {exc}"
+    elif resolved_type == "ethos":
+        # #924 (ATX B1): pre-render all five canonical ethos files via
+        # render_ethos so the configure playbook deploys them with
+        # `copy: content:` instead of templating server-side. This
+        # collapses the dual-render path (Python Jinja2 for doctor vs
+        # Ansible Jinja2 for configure) into a single engine — the same
+        # class of bug #622 closed for hermes. Doctor (#923) renders
+        # through the same function, so its report is byte-identical to
+        # what configure writes.
+        from clawrium.core.render import (
+            AgentConfigError,
+            build_render_inputs,
+            render_ethos,
+        )
+
+        try:
+            import dataclasses as _dataclasses
+
+            from clawrium.core.render import GatewayInputs
+
+            render_inputs = build_render_inputs(unix_agent_name)
+            # The gateway bearer was already validated against
+            # secrets.json above (the `merged_gateway["api_key"]` block
+            # is authoritative — a stale hosts.json copy is ignored
+            # there). Pin the render to that exact value so the
+            # pre-rendered .env can never diverge from the config the
+            # playbook's verify tasks check.
+            if render_inputs.gateway is not None:
+                gw = _dataclasses.replace(
+                    render_inputs.gateway, api_key=ethos_api_key
+                )
+            else:
+                # hosts.json gateway shape was missing; mirror the
+                # reconstruction the merge block above applied to
+                # config_data so configure still recovers legacy
+                # installs instead of failing the render.
+                merged_gw = config_data.get("gateway") or {}
+                gw = GatewayInputs(
+                    host="127.0.0.1",
+                    port=int(merged_gw.get("port", 3000) or 3000),
+                    api_key=ethos_api_key,
+                    internal_port=int(
+                        merged_gw.get("internal_port", 44410) or 44410
+                    ),
+                )
+            render_inputs = _dataclasses.replace(render_inputs, gateway=gw)
+            rendered = render_ethos(render_inputs)
+            prerendered_files.update(rendered.files)
+        except AgentConfigError as exc:
+            # Loud failure at assembly time: unsupported provider,
+            # duplicate channel type, missing gateway block. Nothing
+            # pushed to host.
+            return False, f"Ethos render failed: {exc}"
+        except Exception as exc:
+            # Mirror hermes' broad except: TemplateError, KeyError on a
+            # bad hosts.json shape, IOError on template read — surface
+            # as a clean (False, msg) instead of an unhandled traceback.
+            return False, f"Ethos render failed: {exc}"
 
     # #734 / #755 Openclaw brave plugin preflight on the configure
     # path. Plugin install itself now lives in
@@ -2936,6 +2994,22 @@ def configure_agent(
         # hermes/zeroclaw bearers.
         "prerendered_openclaw_config_json": prerendered_files.get(
             ".openclaw/openclaw.json", ""
+        ),
+        # #924 (ATX B1): ethos canonical files, pre-rendered by
+        # render_ethos above. Keys match the rendered.files dict so the
+        # var name and the file path stay locked together.
+        "prerendered_ethos_env": prerendered_files.get(".ethos/.env", ""),
+        "prerendered_ethos_config_yaml": prerendered_files.get(
+            ".ethos/config.yaml", ""
+        ),
+        "prerendered_ethos_soul_md": prerendered_files.get(
+            ".ethos/personalities/default/SOUL.md", ""
+        ),
+        "prerendered_ethos_toolset_yaml": prerendered_files.get(
+            ".ethos/personalities/default/toolset.yaml", ""
+        ),
+        "prerendered_ethos_personality_config_yaml": prerendered_files.get(
+            ".ethos/personalities/default/config.yaml", ""
         ),
     }
 

--- a/src/clawrium/core/lifecycle_canonical.py
+++ b/src/clawrium/core/lifecycle_canonical.py
@@ -53,6 +53,7 @@ from clawrium.core.keys import get_host_private_key
 from clawrium.core.playbook_resolver import home_root_for, unit_path_for
 from clawrium.core.render import (
     build_render_inputs,
+    render_ethos,
     render_hermes,
     render_openclaw,
     render_zeroclaw,
@@ -79,6 +80,10 @@ __all__ = [
 
 
 _RENDERERS = {
+    # #924 (ATX B1): ethos syncs through the same render_ethos the
+    # doctor command and configure_agent use — single Jinja2 engine,
+    # single source of truth for the five on-host config files.
+    "ethos": render_ethos,
     "hermes": render_hermes,
     "zeroclaw": render_zeroclaw,
     "openclaw": render_openclaw,

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -43,6 +43,7 @@ __all__ = [
     "render_hermes",
     "render_zeroclaw",
     "render_openclaw",
+    "render_ethos",
     "supported_integrations_for_agent_type",
 ]
 
@@ -623,11 +624,20 @@ def build_render_inputs(agent_name: str) -> RenderInputs:
             auth=_clean_secret(read_gateway_auth(gateway_blob)),
             bind=str(gateway_blob.get("bind", "")),
             allow_public_bind=bool(gateway_blob.get("allow_public_bind", True)),
-            # ethos-only: api_key and internal_port live in the gateway blob
-            # for ethos agents (written by install.py). Other agent types leave
-            # these at their defaults (empty string / 0).
-            api_key=_clean_secret(str(gateway_blob.get("api_key", "") or "")),
-            internal_port=int(gateway_blob.get("internal_port", 0) or 0),
+            # ethos-only: api_key (ETHOS_GATEWAY_API_KEY) and internal_port
+            # (ACP port, default 44410) live in the gateway blob for ethos
+            # agents (written by install.py). Gated on agent_type so a stray
+            # api_key in a zeroclaw/openclaw blob doesn't mislead doctor output.
+            api_key=(
+                _clean_secret(str(gateway_blob.get("api_key", "") or ""))
+                if agent_type == "ethos"
+                else ""
+            ),
+            internal_port=(
+                int(gateway_blob.get("internal_port") or 44410)
+                if agent_type == "ethos"
+                else 0
+            ),
         )
 
     # --- Hermes multi-provider bundle (hermes-only) ------------------------
@@ -2334,11 +2344,6 @@ def supported_integrations_for_agent_type(agent_type: str) -> frozenset[str] | N
 # ethos renderer
 # ---------------------------------------------------------------------------
 
-_ETHOS_SUPPORTED_PROVIDERS: frozenset[str] = frozenset(
-    {"anthropic", "openai", "openrouter", "codex"}
-)
-
-
 @_functools.lru_cache(maxsize=8)
 def _ethos_template(template_name: str):
     """Load + compile an ethos template once per process."""
@@ -2384,10 +2389,11 @@ def render_ethos(inputs: RenderInputs) -> RenderedFiles:
     """
     _validate_agent_name(inputs.agent_name)
     ptype = inputs.provider.type
-    if ptype not in _ETHOS_SUPPORTED_PROVIDERS:
+    _supported = _AGENT_TYPE_PROVIDER_SUPPORT.get("ethos", frozenset())
+    if ptype not in _supported:
         raise AgentConfigError(
             f"render_ethos does not support provider type {ptype!r}. "
-            f"Supported: {sorted(_ETHOS_SUPPORTED_PROVIDERS)}"
+            f"Supported: {sorted(_supported)}"
         )
     if inputs.gateway is None:
         raise AgentConfigError(
@@ -2399,8 +2405,22 @@ def render_ethos(inputs: RenderInputs) -> RenderedFiles:
     # templates were originally Ansible templates whose `config` extravar
     # carries the hosts.json agent-config blob verbatim; we reconstruct
     # the relevant sub-keys from RenderInputs.
+    #
+    # Guard: ethos channels are keyed by type (one entry per type). Raise
+    # early when a duplicate type would silently shadow the first — same
+    # invariant as hermes/zeroclaw/openclaw channel dedup guards.
+    seen_channel_types: dict[str, str] = {}
     channels_dict: dict = {}
     for ch in inputs.channels:
+        prior = seen_channel_types.get(ch.type)
+        if prior is not None:
+            raise AgentConfigError(
+                f"duplicate channel type {ch.type!r} on agent "
+                f"{inputs.agent_name!r}: channels {prior!r} and "
+                f"{ch.name!r} both registered as {ch.type!r}. "
+                f"Detach one with `clawctl agent channel detach`."
+            )
+        seen_channel_types[ch.type] = ch.name
         channels_dict[ch.type] = {
             "enabled": True,
             "bot_token": ch.bot_token,
@@ -2430,8 +2450,11 @@ def render_ethos(inputs: RenderInputs) -> RenderedFiles:
 
     integrations_dict: dict = {}
     for it in inputs.integrations:
-        entry: dict = {"type": it.type}
+        # Set credentials first so `it.type` always wins if a credential
+        # key happens to be named "type".
+        entry: dict = {}
         entry.update(dict(it.credentials))
+        entry["type"] = it.type
         integrations_dict[it.name] = entry
 
     ctx = dict(

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -608,6 +608,38 @@ def build_render_inputs(agent_name: str) -> RenderInputs:
         # default unconditionally here is safe and keeps the assembler
         # agent-type-agnostic.
         host_raw = _clean_secret(gateway_blob.get("host")).strip()
+        # ethos-only: api_key (ETHOS_GATEWAY_API_KEY) and internal_port
+        # (ACP port, default 44410) live in the gateway blob for ethos
+        # agents (written by install.py). Gated on agent_type so a stray
+        # api_key in a zeroclaw/openclaw blob doesn't mislead doctor output.
+        #
+        # W3 (#924): explicit None/blank check instead of `or 44410` — an
+        # explicit `internal_port: 0` must surface as 0 (a misconfiguration
+        # the operator should see), not silently substitute the default,
+        # and a whitespace-only string must fall back to the default
+        # instead of crashing on `int('  ')`. A non-numeric value raises
+        # AgentConfigError so doctor reports `status: broken` instead of
+        # an unhandled traceback.
+        ethos_api_key = ""
+        ethos_internal_port = 0
+        if agent_type == "ethos":
+            ethos_api_key = _clean_secret(
+                str(gateway_blob.get("api_key", "") or "")
+            )
+            raw_internal_port = gateway_blob.get("internal_port")
+            if isinstance(raw_internal_port, str):
+                raw_internal_port = raw_internal_port.strip() or None
+            if raw_internal_port is None:
+                ethos_internal_port = 44410
+            else:
+                try:
+                    ethos_internal_port = int(raw_internal_port)
+                except (TypeError, ValueError) as exc:
+                    raise AgentConfigError(
+                        f"agent {agent_name!r} has a non-integer "
+                        f"gateway.internal_port "
+                        f"{gateway_blob.get('internal_port')!r} in hosts.json"
+                    ) from exc
         gateway_input = GatewayInputs(
             # W6 (ATX #555 polish): NUL in host value would silently
             # truncate the TOML at parse time. Sanitize at assembly
@@ -624,20 +656,8 @@ def build_render_inputs(agent_name: str) -> RenderInputs:
             auth=_clean_secret(read_gateway_auth(gateway_blob)),
             bind=str(gateway_blob.get("bind", "")),
             allow_public_bind=bool(gateway_blob.get("allow_public_bind", True)),
-            # ethos-only: api_key (ETHOS_GATEWAY_API_KEY) and internal_port
-            # (ACP port, default 44410) live in the gateway blob for ethos
-            # agents (written by install.py). Gated on agent_type so a stray
-            # api_key in a zeroclaw/openclaw blob doesn't mislead doctor output.
-            api_key=(
-                _clean_secret(str(gateway_blob.get("api_key", "") or ""))
-                if agent_type == "ethos"
-                else ""
-            ),
-            internal_port=(
-                int(gateway_blob.get("internal_port") or 44410)
-                if agent_type == "ethos"
-                else 0
-            ),
+            api_key=ethos_api_key,
+            internal_port=ethos_internal_port,
         )
 
     # --- Hermes multi-provider bundle (hermes-only) ------------------------
@@ -2346,7 +2366,13 @@ def supported_integrations_for_agent_type(agent_type: str) -> frozenset[str] | N
 
 @_functools.lru_cache(maxsize=8)
 def _ethos_template(template_name: str):
-    """Load + compile an ethos template once per process."""
+    """Load + compile an ethos template once per process.
+
+    Same shape as `_hermes_template` above (S4 #924): the
+    `jinja2.Environment` is constructed inside this lru-cached loader,
+    so it runs once per template name (≤5 per process) — the compiled
+    `Template` object is what gets cached and reused on every render.
+    """
     from importlib.resources import files
 
     import re as _re

--- a/src/clawrium/core/render.py
+++ b/src/clawrium/core/render.py
@@ -244,6 +244,9 @@ class GatewayInputs:
     auth: str = ""
     bind: str = ""
     allow_public_bind: bool = True
+    # ethos-only fields; stay empty/0 for all other agent types.
+    api_key: str = field(default="", repr=False)
+    internal_port: int = 0
 
 
 @dataclass(frozen=True)
@@ -620,6 +623,11 @@ def build_render_inputs(agent_name: str) -> RenderInputs:
             auth=_clean_secret(read_gateway_auth(gateway_blob)),
             bind=str(gateway_blob.get("bind", "")),
             allow_public_bind=bool(gateway_blob.get("allow_public_bind", True)),
+            # ethos-only: api_key and internal_port live in the gateway blob
+            # for ethos agents (written by install.py). Other agent types leave
+            # these at their defaults (empty string / 0).
+            api_key=_clean_secret(str(gateway_blob.get("api_key", "") or "")),
+            internal_port=int(gateway_blob.get("internal_port", 0) or 0),
         )
 
     # --- Hermes multi-provider bundle (hermes-only) ------------------------
@@ -2320,3 +2328,133 @@ def supported_integrations_for_agent_type(agent_type: str) -> frozenset[str] | N
     type the renderer does not personally know about.
     """
     return _AGENT_TYPE_INTEGRATION_SUPPORT.get(agent_type)
+
+
+# ---------------------------------------------------------------------------
+# ethos renderer
+# ---------------------------------------------------------------------------
+
+_ETHOS_SUPPORTED_PROVIDERS: frozenset[str] = frozenset(
+    {"anthropic", "openai", "openrouter", "codex"}
+)
+
+
+@_functools.lru_cache(maxsize=8)
+def _ethos_template(template_name: str):
+    """Load + compile an ethos template once per process."""
+    from importlib.resources import files
+
+    import re as _re
+
+    from jinja2 import Environment, StrictUndefined
+
+    template_source = (
+        files("clawrium.platform.registry.ethos.templates")
+        .joinpath(template_name)
+        .read_text(encoding="utf-8")
+    )
+    env = Environment(
+        undefined=StrictUndefined,
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+        autoescape=False,
+    )
+    # `regex_replace` is an Ansible built-in used in the GitHub integration
+    # block of ethos.env.j2 to sanitize variable names.
+    env.filters["regex_replace"] = lambda v, pattern, replacement="": _re.sub(
+        pattern, replacement, str(v)
+    )
+    return env.from_string(template_source)
+
+
+def _render_ethos_template(template_name: str, **context) -> str:
+    return _ethos_template(template_name).render(**context)
+
+
+def render_ethos(inputs: RenderInputs) -> RenderedFiles:
+    """Render ethos config files from RenderInputs.
+
+    Produces the same set of files as the ethos configure.yaml playbook:
+      - `.ethos/.env`                              — provider key + gateway + channels
+      - `.ethos/config.yaml`                       — provider + model
+      - `.ethos/personalities/default/SOUL.md`    — agent identity
+      - `.ethos/personalities/default/toolset.yaml` — tools (static)
+      - `.ethos/personalities/default/config.yaml` — memory config (static)
+    """
+    _validate_agent_name(inputs.agent_name)
+    ptype = inputs.provider.type
+    if ptype not in _ETHOS_SUPPORTED_PROVIDERS:
+        raise AgentConfigError(
+            f"render_ethos does not support provider type {ptype!r}. "
+            f"Supported: {sorted(_ETHOS_SUPPORTED_PROVIDERS)}"
+        )
+    if inputs.gateway is None:
+        raise AgentConfigError(
+            f"render_ethos requires gateway config for agent "
+            f"{inputs.agent_name!r}; none supplied"
+        )
+
+    # Build the `config` dict the ethos Jinja2 templates expect. The
+    # templates were originally Ansible templates whose `config` extravar
+    # carries the hosts.json agent-config blob verbatim; we reconstruct
+    # the relevant sub-keys from RenderInputs.
+    channels_dict: dict = {}
+    for ch in inputs.channels:
+        channels_dict[ch.type] = {
+            "enabled": True,
+            "bot_token": ch.bot_token,
+            "app_token": ch.app_token,
+            "allowed_users": list(ch.allowed_users),
+            "allowed_channels": list(ch.allowed_channels),
+            "allowed_guilds": list(ch.allowed_guilds),
+            "allow_all_users": ch.allow_all_users,
+            "home_channel": ch.home_channel,
+            "home_channel_name": ch.home_channel_name,
+            "home_channel_thread_id": ch.home_channel_thread_id,
+            "require_mention": ch.require_mention,
+        }
+
+    config = {
+        "provider": {
+            "type": inputs.provider.type,
+            "default_model": inputs.provider.default_model,
+        },
+        "gateway": {
+            "port": inputs.gateway.port,
+            "internal_port": inputs.gateway.internal_port,
+            "api_key": inputs.gateway.api_key,
+        },
+        "channels": channels_dict,
+    }
+
+    integrations_dict: dict = {}
+    for it in inputs.integrations:
+        entry: dict = {"type": it.type}
+        entry.update(dict(it.credentials))
+        integrations_dict[it.name] = entry
+
+    ctx = dict(
+        agent_name=inputs.agent_name,
+        config=config,
+        provider_api_key=inputs.provider.api_key,
+        integrations=integrations_dict,
+    )
+
+    env_body = _render_ethos_template("ethos.env.j2", **ctx)
+    config_body = _render_ethos_template("ethos-config.yaml.j2", **ctx)
+    soul_body = _render_ethos_template("ethos-soul.md.j2", **ctx)
+    toolset_body = _render_ethos_template("ethos-toolset.yaml.j2", **ctx)
+    personality_config_body = _render_ethos_template(
+        "ethos-personality-config.yaml.j2", **ctx
+    )
+
+    return RenderedFiles(
+        files={
+            ".ethos/.env": env_body,
+            ".ethos/config.yaml": config_body,
+            ".ethos/personalities/default/SOUL.md": soul_body,
+            ".ethos/personalities/default/config.yaml": personality_config_body,
+            ".ethos/personalities/default/toolset.yaml": toolset_body,
+        }
+    )

--- a/src/clawrium/platform/registry/ethos/playbooks/configure.yaml
+++ b/src/clawrium/platform/registry/ethos/playbooks/configure.yaml
@@ -90,10 +90,16 @@
       no_log: true
       notify: Restart ethos service
 
-    # Render ~/.ethos/.env from template
-    - name: Render ~/.ethos/.env from template
-      ansible.builtin.template:
-        src: "{{ template_path }}/ethos.env.j2"
+    # All five config files below are deployed as pre-rendered bytes from
+    # clawrium.core.render.render_ethos (#924 ATX B1, same pattern as
+    # hermes #622). The canonical Python renderer owns the single source
+    # of truth for the file contents; Ansible just lays the bytes down.
+    # Do NOT switch these back to ansible.builtin.template — a second
+    # (server-side) Jinja2 engine is exactly the dual-render-path bug
+    # class #622 closed.
+    - name: Deploy ~/.ethos/.env (pre-rendered canonical content)
+      ansible.builtin.copy:
+        content: "{{ prerendered_ethos_env }}"
         dest: "{{ ethos_home }}/.env"
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
@@ -102,10 +108,9 @@
       no_log: true
       notify: Restart ethos service
 
-    # Render ~/.ethos/config.yaml from template
-    - name: Render ~/.ethos/config.yaml from template
-      ansible.builtin.template:
-        src: "{{ template_path }}/ethos-config.yaml.j2"
+    - name: Deploy ~/.ethos/config.yaml (pre-rendered canonical content)
+      ansible.builtin.copy:
+        content: "{{ prerendered_ethos_config_yaml }}"
         dest: "{{ ethos_home }}/config.yaml"
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
@@ -114,10 +119,9 @@
       no_log: true
       notify: Restart ethos service
 
-    # Render default personality SOUL.md
-    - name: Render SOUL.md for default personality
-      ansible.builtin.template:
-        src: "{{ template_path }}/ethos-soul.md.j2"
+    - name: Deploy SOUL.md for default personality (pre-rendered)
+      ansible.builtin.copy:
+        content: "{{ prerendered_ethos_soul_md }}"
         dest: "{{ ethos_home }}/personalities/default/SOUL.md"
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
@@ -126,10 +130,9 @@
       no_log: true
       notify: Restart ethos service
 
-    # Render default personality toolset.yaml
-    - name: Render toolset.yaml for default personality
-      ansible.builtin.template:
-        src: "{{ template_path }}/ethos-toolset.yaml.j2"
+    - name: Deploy toolset.yaml for default personality (pre-rendered)
+      ansible.builtin.copy:
+        content: "{{ prerendered_ethos_toolset_yaml }}"
         dest: "{{ ethos_home }}/personalities/default/toolset.yaml"
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"
@@ -138,10 +141,9 @@
       no_log: true
       notify: Restart ethos service
 
-    # Render default personality config.yaml
-    - name: Render personality config.yaml for default personality
-      ansible.builtin.template:
-        src: "{{ template_path }}/ethos-personality-config.yaml.j2"
+    - name: Deploy personality config.yaml for default personality (pre-rendered)
+      ansible.builtin.copy:
+        content: "{{ prerendered_ethos_personality_config_yaml }}"
         dest: "{{ ethos_home }}/personalities/default/config.yaml"
         owner: "{{ agent_name }}"
         group: "{{ agent_name }}"

--- a/src/clawrium/platform/registry/ethos/templates/ethos-config.yaml.j2
+++ b/src/clawrium/platform/registry/ethos/templates/ethos-config.yaml.j2
@@ -2,13 +2,17 @@ schemaVersion: 1
 {% set provider = config.provider | default({}) %}
 {% set provider_type = provider.type | default('') %}
 {% set model_id = provider.default_model | default('') %}
+{# W4 (#924): user-supplied strings are emitted via `tojson` — a JSON
+   string is a valid (double-quoted) YAML scalar, so a model id with a
+   colon (e.g. `anthropic/claude-3.5-sonnet:20241022`) cannot produce
+   unparseable YAML or inject sibling keys. #}
 {% if provider_type %}
-provider: {{ provider_type }}
+provider: {{ provider_type | tojson }}
 {% else %}
 provider: anthropic
 {% endif %}
 apiKey: ${secrets:providers/{{ provider_type | default('anthropic') }}/apiKey}
 {% if model_id %}
-model: {{ model_id }}
+model: {{ model_id | tojson }}
 {% endif %}
 personality: default

--- a/tests/cli/clawctl/agent/test_doctor.py
+++ b/tests/cli/clawctl/agent/test_doctor.py
@@ -17,6 +17,7 @@ from clawrium.cli import app
 from clawrium.core.render import (
     AgentConfigError,
     ChannelInputs,
+    GatewayInputs,
     IntegrationInputs,
     ProviderInputs,
     RenderInputs,
@@ -222,3 +223,93 @@ def test_doctor_broken_json_includes_error(fleet_dir, monkeypatch) -> None:
     payload = json.loads(body[: arr_end + 1])
     assert payload[0]["status"] == "broken"
     assert "BOT_TOKEN" in payload[0]["error"]
+
+
+# ---------------------------------------------------------------------------
+# B3 regression guard: ethos dispatches to render_ethos, exits 0 (#923)
+# ---------------------------------------------------------------------------
+
+_ETHOS_INPUTS = RenderInputs(
+    agent_name="kevin",
+    agent_type="ethos",
+    provider=ProviderInputs(
+        name="openrouter-primary",
+        type="openrouter",
+        default_model="anthropic/claude-opus-4.7",
+        api_key="sk-or-xxx",
+    ),
+    channels=(),
+    integrations=(),
+    gateway=GatewayInputs(
+        host="0.0.0.0",
+        port=44400,
+        auth="ethos-tkn",
+        bind="lan",
+        api_key="ethos-gw-key",
+        internal_port=44410,
+    ),
+)
+
+_ETHOS_FILES = RenderedFiles(
+    files={
+        ".ethos/.env": "OPENROUTER_API_KEY='sk-or-xxx'\n",
+        ".ethos/config.yaml": "provider:\n  type: openrouter\n",
+        ".ethos/personalities/default/SOUL.md": "# kevin\n",
+        ".ethos/personalities/default/config.yaml": "memory: {}\n",
+        ".ethos/personalities/default/toolset.yaml": "tools: []\n",
+    }
+)
+
+
+_ETHOS_CLAW_RECORD = {
+    "type": "ethos",
+    "agent_name": "kevin",
+    "providers": ["openrouter-primary"],
+    "channels": [],
+    "integrations": [],
+    "skills": [],
+}
+
+
+def test_doctor_ethos_dispatches_and_exits_zero(fleet_dir, monkeypatch) -> None:
+    """B3 regression guard (#923): ethos must dispatch to render_ethos and exit 0.
+
+    Before the fix, doctor exited non-zero with
+    'no renderer registered for agent type ethos'.
+    """
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    monkeypatch.setattr(
+        doctor_mod,
+        "safe_resolve_agent",
+        lambda name: ({"hostname": "host-1"}, "ethos:kevin", _ETHOS_CLAW_RECORD),
+    )
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda name: _ETHOS_INPUTS)
+    monkeypatch.setattr(doctor_mod, "render_ethos", lambda inputs: _ETHOS_FILES)
+
+    result = runner.invoke(app, ["agent", "doctor", "kevin"])
+    assert result.exit_code == 0, result.output
+    assert "Status:  ok" in result.output
+    assert "ethos" in result.output
+
+
+def test_doctor_ethos_gateway_fields_present_in_json(fleet_dir, monkeypatch) -> None:
+    """api_key and internal_port surface in the doctor JSON output for ethos."""
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    monkeypatch.setattr(
+        doctor_mod,
+        "safe_resolve_agent",
+        lambda name: ({"hostname": "host-1"}, "ethos:kevin", _ETHOS_CLAW_RECORD),
+    )
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda name: _ETHOS_INPUTS)
+    monkeypatch.setattr(doctor_mod, "render_ethos", lambda inputs: _ETHOS_FILES)
+
+    result = runner.invoke(app, ["agent", "doctor", "kevin", "-o", "json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    gw = payload[0]["inputs"]["gateway"]
+    assert gw["api_key"] == "present"
+    assert gw["internal_port"] == 44410
+    # Secret value must not appear.
+    assert "ethos-gw-key" not in result.output

--- a/tests/cli/clawctl/agent/test_doctor.py
+++ b/tests/cli/clawctl/agent/test_doctor.py
@@ -276,7 +276,13 @@ def test_doctor_ethos_dispatches_and_exits_zero(fleet_dir, monkeypatch) -> None:
 
     Before the fix, doctor exited non-zero with
     'no renderer registered for agent type ethos'.
+
+    W7 (#924): the renderer stub is a MagicMock with call assertions so a
+    subtler dispatch bug (e.g. routing ethos to render_hermes) fails this
+    test instead of still exiting 0 through the wrong renderer.
     """
+    from unittest.mock import MagicMock
+
     from clawrium.cli.clawctl.agent import doctor as doctor_mod
 
     monkeypatch.setattr(
@@ -285,12 +291,17 @@ def test_doctor_ethos_dispatches_and_exits_zero(fleet_dir, monkeypatch) -> None:
         lambda name: ({"hostname": "host-1"}, "ethos:kevin", _ETHOS_CLAW_RECORD),
     )
     monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda name: _ETHOS_INPUTS)
-    monkeypatch.setattr(doctor_mod, "render_ethos", lambda inputs: _ETHOS_FILES)
+    mock_render_ethos = MagicMock(return_value=_ETHOS_FILES)
+    mock_render_hermes = MagicMock(return_value=_ETHOS_FILES)
+    monkeypatch.setattr(doctor_mod, "render_ethos", mock_render_ethos)
+    monkeypatch.setattr(doctor_mod, "render_hermes", mock_render_hermes)
 
     result = runner.invoke(app, ["agent", "doctor", "kevin"])
     assert result.exit_code == 0, result.output
     assert "Status:  ok" in result.output
     assert "ethos" in result.output
+    mock_render_ethos.assert_called_once_with(_ETHOS_INPUTS)
+    mock_render_hermes.assert_not_called()
 
 
 def test_doctor_ethos_gateway_fields_present_in_json(fleet_dir, monkeypatch) -> None:
@@ -313,3 +324,112 @@ def test_doctor_ethos_gateway_fields_present_in_json(fleet_dir, monkeypatch) -> 
     assert gw["internal_port"] == 44410
     # Secret value must not appear.
     assert "ethos-gw-key" not in result.output
+
+
+def test_doctor_ethos_gateway_fields_present_in_yaml(fleet_dir, monkeypatch) -> None:
+    """S2 (#924): YAML mirror of the JSON test — api_key reads 'present'
+    and the raw secret value never appears in the YAML output."""
+    import yaml
+
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    monkeypatch.setattr(
+        doctor_mod,
+        "safe_resolve_agent",
+        lambda name: ({"hostname": "host-1"}, "ethos:kevin", _ETHOS_CLAW_RECORD),
+    )
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda name: _ETHOS_INPUTS)
+    monkeypatch.setattr(doctor_mod, "render_ethos", lambda inputs: _ETHOS_FILES)
+
+    result = runner.invoke(app, ["agent", "doctor", "kevin", "-o", "yaml"])
+    assert result.exit_code == 0, result.output
+    payload = yaml.safe_load(result.output)
+    gw = payload[0]["inputs"]["gateway"]
+    assert gw["api_key"] == "present"
+    assert gw["internal_port"] == 44410
+    assert "ethos-gw-key" not in result.output
+
+
+def test_doctor_ethos_gateway_fields_visible_in_table(fleet_dir, monkeypatch) -> None:
+    """W2 (#924): the gateway diagnostic block must appear in the default
+    table output, not only via `-o json` / `-o yaml`."""
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    monkeypatch.setattr(
+        doctor_mod,
+        "safe_resolve_agent",
+        lambda name: ({"hostname": "host-1"}, "ethos:kevin", _ETHOS_CLAW_RECORD),
+    )
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda name: _ETHOS_INPUTS)
+    monkeypatch.setattr(doctor_mod, "render_ethos", lambda inputs: _ETHOS_FILES)
+
+    result = runner.invoke(app, ["agent", "doctor", "kevin"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "Resolved gateway:" in out
+    assert "api_key:        present" in out
+    assert "internal_port:  44410" in out
+    assert "ethos-gw-key" not in out
+
+
+def test_doctor_non_ethos_gateway_omits_ethos_only_fields(
+    fleet_dir, monkeypatch
+) -> None:
+    """W1 (#924): a non-ethos agent with a gateway block must NOT emit the
+    ethos-only api_key / internal_port keys in JSON output — that would
+    silently widen the schema for consumers parsing `-o json`."""
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    zc_inputs = RenderInputs(
+        agent_name="wise-hypatia",
+        agent_type="openclaw",
+        provider=ProviderInputs(
+            name="anthropic-primary",
+            type="anthropic",
+            default_model="claude-opus",
+            api_key="sk-xxx",
+        ),
+        channels=(),
+        integrations=(),
+        gateway=GatewayInputs(host="0.0.0.0", port=40000, auth="tkn", bind="lan"),
+    )
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda name: zc_inputs)
+    monkeypatch.setattr(doctor_mod, "render_openclaw", lambda inputs: _OK_FILES)
+
+    result = runner.invoke(app, ["agent", "doctor", "wise-hypatia", "-o", "json"])
+    assert result.exit_code == 0, result.output
+    gw = json.loads(result.output)[0]["inputs"]["gateway"]
+    assert "api_key" not in gw
+    assert "internal_port" not in gw
+    # The generic gateway fields still surface.
+    assert gw["port"] == 40000
+    assert gw["auth"] == "present"
+
+
+def test_doctor_renderer_config_error_reports_broken(fleet_dir, monkeypatch) -> None:
+    """W5 (#924): an AgentConfigError raised by the renderer itself (not
+    build_render_inputs) must surface as a structured status=broken report
+    with a non-zero exit — never an unhandled traceback."""
+    from clawrium.cli.clawctl.agent import doctor as doctor_mod
+
+    monkeypatch.setattr(
+        doctor_mod,
+        "safe_resolve_agent",
+        lambda name: ({"hostname": "host-1"}, "ethos:kevin", _ETHOS_CLAW_RECORD),
+    )
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda name: _ETHOS_INPUTS)
+
+    def _boom(inputs):
+        raise AgentConfigError("duplicate channel type 'slack' on agent 'kevin'")
+
+    monkeypatch.setattr(doctor_mod, "render_ethos", _boom)
+
+    result = runner.invoke(app, ["agent", "doctor", "kevin", "-o", "json"])
+    assert result.exit_code != 0
+    # The JSON payload still prints to stdout before the non-zero exit.
+    # Extract the first JSON-array prefix (the error banner follows it).
+    body = result.output
+    arr_end = body.rfind("]")
+    payload = json.loads(body[: arr_end + 1])
+    assert payload[0]["status"] == "broken"
+    assert "duplicate channel type" in payload[0]["error"]

--- a/tests/cli/clawctl/agent/test_doctor_audit.py
+++ b/tests/cli/clawctl/agent/test_doctor_audit.py
@@ -50,11 +50,16 @@ def test_audit_fixture_loads() -> None:
 
 
 def test_audit_fixture_rows_have_required_fields() -> None:
+    # S3 (#924): derive the allowed type set from doctor's dispatch table
+    # instead of a hardcoded copy, so a newly supported agent type (e.g.
+    # ethos) can appear in a future fixture refresh without editing here.
+    from clawrium.cli.clawctl.agent.doctor import _RENDERER_NAMES
+
     payload = json.loads(FIXTURE.read_text())
     for row in payload["agents"]:
         assert "name" in row
         assert "type" in row
-        assert row["type"] in {"hermes", "zeroclaw", "openclaw"}
+        assert row["type"] in _RENDERER_NAMES
         assert row["expected_status"] in {"ok", "broken"}
         if row["expected_status"] == "broken":
             assert "expected_error_contains" in row, (

--- a/tests/core/test_lifecycle_ethos_prerender.py
+++ b/tests/core/test_lifecycle_ethos_prerender.py
@@ -1,0 +1,270 @@
+"""Tests for the #924 ethos prerender block in lifecycle.configure_agent.
+
+Validates that `configure_agent` for ethos pre-renders all five canonical
+config files via `render_ethos` and surfaces the bytes through
+`ansible_vars` so the configure playbook can `copy: content:` them.
+Mirrors the hermes coverage at `tests/core/test_lifecycle_hermes_prerender.py`
+(issue #622) and the openclaw coverage at
+`tests/core/test_lifecycle_openclaw_prerender.py` (issue #756).
+
+The load-bearing assertion is PARITY: the bytes produced by the configure
+pre-render path must be byte-identical to what the canonical sync path
+(`render_ethos(build_render_inputs(...))`) produces for the same inputs.
+If parity ever breaks, the two render paths have diverged again — exactly
+the dual-render-path regression the #924 ATX review (B1) flagged.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from clawrium.core import lifecycle
+from clawrium.core.render import build_render_inputs, render_ethos
+
+
+_GW_KEY = "a" * 64
+
+_ETHOS_FILE_VARS = {
+    ".ethos/.env": "prerendered_ethos_env",
+    ".ethos/config.yaml": "prerendered_ethos_config_yaml",
+    ".ethos/personalities/default/SOUL.md": "prerendered_ethos_soul_md",
+    ".ethos/personalities/default/toolset.yaml": "prerendered_ethos_toolset_yaml",
+    ".ethos/personalities/default/config.yaml": (
+        "prerendered_ethos_personality_config_yaml"
+    ),
+}
+
+
+@pytest.fixture
+def ethos_configure_env(monkeypatch, tmp_path):
+    captured = {}
+
+    host = {
+        "hostname": "host-1",
+        "user": "xclm",
+        "port": 22,
+        "key_id": "host-1",
+        "agents": {
+            "kevin": {
+                "type": "ethos",
+                "agent_name": "kevin",
+                "providers": [],
+                "config": {
+                    "gateway": {
+                        "port": 3000,
+                        "internal_port": 44412,
+                        "api_key": _GW_KEY,
+                    },
+                },
+            }
+        },
+    }
+    monkeypatch.setattr(lifecycle, "get_host", lambda _h: host)
+
+    fake_key = tmp_path / "id_rsa"
+    fake_key.write_text("PRIVATE")
+    monkeypatch.setattr(lifecycle, "get_host_private_key", lambda _k: fake_key)
+
+    # Instance secrets — configure_agent validates ETHOS_GATEWAY_API_KEY
+    # against secrets.json (authoritative) before the prerender block.
+    monkeypatch.setattr(
+        lifecycle,
+        "get_instance_secrets",
+        lambda _k: {"ETHOS_GATEWAY_API_KEY": {"value": _GW_KEY}},
+    )
+
+    monkeypatch.setattr(
+        "clawrium.core.integrations.get_agent_integrations",
+        lambda *_a, **_kw: [],
+    )
+
+    def _record(**kwargs):
+        captured["inventory"] = kwargs.get("inventory")
+        captured["playbook"] = kwargs.get("playbook")
+        return SimpleNamespace(status="successful", rc=0, stats=None)
+
+    monkeypatch.setattr(
+        lifecycle.ansible_runner, "run", MagicMock(side_effect=_record)
+    )
+
+    monkeypatch.setattr(lifecycle, "update_host", lambda *_a, **_kw: True)
+
+    return SimpleNamespace(host=host, captured=captured, tmp_path=tmp_path)
+
+
+@pytest.fixture
+def render_stores(monkeypatch):
+    """Stub the same set of collaborators build_render_inputs touches."""
+    state = {
+        "agent": None,
+        "providers": {},
+        "provider_api_keys": {},
+        "provider_aws": {},
+        "channels": {},
+        "channel_tokens": {},
+        "integrations": {},
+        "integration_creds": {},
+        "agent_channels": [],
+        "agent_integrations": [],
+    }
+
+    monkeypatch.setattr(
+        "clawrium.core.hosts.get_agent_by_name",
+        lambda _n: state["agent"],
+    )
+    monkeypatch.setattr(
+        "clawrium.core.providers.get_provider",
+        lambda n: state["providers"].get(n),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.providers.get_provider_api_key",
+        lambda n: state["provider_api_keys"].get(n),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.providers.get_provider_aws_credentials",
+        lambda n: state["provider_aws"].get(n, (None, None)),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.channels.get_agent_channels",
+        lambda *_a: list(state["agent_channels"]),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.channels.get_channel",
+        lambda n: state["channels"].get(n),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.channels.get_channel_token",
+        lambda n, key="BOT_TOKEN": state["channel_tokens"].get((n, key)),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.integrations.get_agent_integrations",
+        lambda *_a: list(state["agent_integrations"]),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.integrations.get_integration",
+        lambda n: state["integrations"].get(n),
+    )
+    monkeypatch.setattr(
+        "clawrium.core.integrations.get_integration_credentials",
+        lambda n: dict(state["integration_creds"].get(n, {})),
+    )
+    return state
+
+
+def _seed_ethos_agent(render_stores, env, *, ptype="openrouter"):
+    attachments = [{"name": "prov", "role": "primary", "model": ""}]
+    render_stores["agent"] = (
+        {"hostname": "host-1"},
+        "ethos",
+        {
+            "agent_name": "kevin",
+            "providers": attachments,
+            "config": {
+                "gateway": {
+                    "port": 3000,
+                    "internal_port": 44412,
+                    "api_key": _GW_KEY,
+                },
+            },
+        },
+    )
+    render_stores["providers"]["prov"] = {
+        "name": "prov",
+        "type": ptype,
+        "default_model": "anthropic/claude-opus-4.7",
+    }
+    if ptype != "codex":
+        render_stores["provider_api_keys"]["prov"] = "sk-test-1"
+    env.host["agents"]["kevin"]["providers"] = attachments
+
+
+def _invoke_configure(env):
+    return lifecycle.configure_agent(
+        hostname="host-1",
+        claw_name="ethos",
+        config_data={
+            "provider": {
+                "name": "prov",
+                "type": "openrouter",
+                "default_model": "anthropic/claude-opus-4.7",
+            },
+        },
+        agent_name="kevin",
+    )
+
+
+def test_configure_agent_ethos_prerenders_all_five_files(
+    ethos_configure_env, render_stores
+):
+    """configure_agent must populate every `prerendered_ethos_*` extravar
+    with non-empty bytes for a healthy openrouter agent."""
+    _seed_ethos_agent(render_stores, ethos_configure_env)
+
+    ok, err = _invoke_configure(ethos_configure_env)
+    assert ok, f"configure_agent failed: {err}"
+
+    inv = ethos_configure_env.captured["inventory"]
+    ansible_vars = inv["all"]["vars"]
+    for path, var in _ETHOS_FILE_VARS.items():
+        assert ansible_vars.get(var), (
+            f"{var} empty — the ethos prerender branch did not populate "
+            f"the extravar for {path}"
+        )
+
+
+def test_configure_and_sync_render_byte_identical(
+    ethos_configure_env, render_stores
+):
+    """PARITY (load-bearing, #924 B1). The configure pre-render bytes
+    (extravars) MUST equal the canonical sync render bytes
+    (`render_ethos(build_render_inputs(...))`) for every file. If this
+    test ever fails, the dual-render-path bug class (#622) is back."""
+    _seed_ethos_agent(render_stores, ethos_configure_env)
+
+    ok, err = _invoke_configure(ethos_configure_env)
+    assert ok, f"configure_agent failed: {err}"
+
+    inv = ethos_configure_env.captured["inventory"]
+    ansible_vars = inv["all"]["vars"]
+
+    sync_rendered = render_ethos(build_render_inputs("kevin"))
+    for path, var in _ETHOS_FILE_VARS.items():
+        assert ansible_vars[var] == sync_rendered.files[path], (
+            f"configure vs sync rendered bytes diverged for {path}"
+        )
+
+
+def test_configure_agent_ethos_env_carries_secrets_bearer(
+    ethos_configure_env, render_stores
+):
+    """The pre-rendered .env must carry the secrets.json-validated
+    ETHOS_GATEWAY_API_KEY — the value the playbook's verify task greps
+    for and the daemon will enforce."""
+    _seed_ethos_agent(render_stores, ethos_configure_env)
+
+    ok, err = _invoke_configure(ethos_configure_env)
+    assert ok, f"configure_agent failed: {err}"
+
+    env_body = ethos_configure_env.captured["inventory"]["all"]["vars"][
+        "prerendered_ethos_env"
+    ]
+    assert f"ETHOS_GATEWAY_API_KEY='{_GW_KEY}'" in env_body
+    assert "ETHOS_GATEWAY_PORT=44412" in env_body
+
+
+def test_configure_agent_ethos_render_error_surfaces_cleanly(
+    ethos_configure_env, render_stores
+):
+    """AgentConfigError from render_ethos must surface as a clean
+    (False, error_message) return — nothing pushed to the host. Trigger
+    via an unsupported provider type (bedrock)."""
+    _seed_ethos_agent(render_stores, ethos_configure_env, ptype="bedrock")
+    render_stores["provider_aws"]["prov"] = ("AKIA-1", "secret-1")
+
+    ok, err = _invoke_configure(ethos_configure_env)
+    assert not ok
+    assert "Ethos render failed" in (err or "")
+    assert "inventory" not in ethos_configure_env.captured

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -26,6 +26,7 @@ from clawrium.core.render import (
     ProviderInputs,
     RenderInputs,
     build_render_inputs,
+    render_ethos,
     render_hermes,
     render_openclaw,
     render_zeroclaw,
@@ -474,6 +475,40 @@ def _baseline_inputs(*, ptype: str = "openrouter") -> RenderInputs:
     )
 
 
+def _ethos_inputs(*, ptype: str = "openrouter") -> RenderInputs:
+    """Minimal but valid RenderInputs for an ethos agent."""
+    if ptype == "codex":
+        provider = ProviderInputs(name="cx", type="codex", default_model="codex-1")
+    elif ptype == "anthropic":
+        provider = ProviderInputs(
+            name="an", type="anthropic", default_model="claude-opus-4-7", api_key="sk-ant-1"
+        )
+    elif ptype == "openai":
+        provider = ProviderInputs(
+            name="oa", type="openai", default_model="gpt-5", api_key="sk-oa-1"
+        )
+    else:
+        provider = ProviderInputs(
+            name="or", type="openrouter", default_model="anthropic/claude-opus-4.7", api_key="sk-or-1"
+        )
+    return RenderInputs(
+        agent_name="kevin",
+        agent_type="ethos",
+        provider=provider,
+        channels=(),
+        integrations=(),
+        api_server=None,
+        gateway=GatewayInputs(
+            host="0.0.0.0",
+            port=44400,
+            auth="ethos-tkn",
+            bind="lan",
+            api_key="ethos-gw-key",
+            internal_port=44410,
+        ),
+    )
+
+
 @pytest.mark.parametrize(
     "renderer,ptype",
     [
@@ -500,12 +535,18 @@ def _baseline_inputs(*, ptype: str = "openrouter") -> RenderInputs:
         (render_openclaw, "litellm"),
         (render_openclaw, "opencode"),
         (render_openclaw, "opencode-go"),
+        (render_ethos, "openrouter"),
+        (render_ethos, "anthropic"),
+        (render_ethos, "openai"),
+        (render_ethos, "codex"),
     ],
 )
 def test_renderer_is_idempotent(renderer, ptype):
     """Property test: identical inputs → byte-identical outputs."""
     if renderer is render_zeroclaw:
         inputs = _zeroclaw_inputs(ptype=ptype)
+    elif renderer is render_ethos:
+        inputs = _ethos_inputs(ptype=ptype)
     else:
         inputs = _baseline_inputs(ptype=ptype)
     out1 = renderer(inputs)
@@ -6443,3 +6484,234 @@ def test_zeroclaw_config_full_toml_parses_for_all_variants():
         # tomllib.loads raises on invalid TOML — the test fails
         # with the parser's line/col.
         tomllib.loads(toml)
+
+
+# ---------------------------------------------------------------------------
+# render_ethos — B2 / #923
+# ---------------------------------------------------------------------------
+
+
+_ETHOS_EXPECTED_PATHS = frozenset(
+    {
+        ".ethos/.env",
+        ".ethos/config.yaml",
+        ".ethos/personalities/default/SOUL.md",
+        ".ethos/personalities/default/config.yaml",
+        ".ethos/personalities/default/toolset.yaml",
+    }
+)
+
+
+def test_render_ethos_produces_five_non_empty_files():
+    """All five config paths are present and non-empty for a basic openrouter setup."""
+    out = render_ethos(_ethos_inputs())
+    assert set(out.files.keys()) == _ETHOS_EXPECTED_PATHS
+    for path, body in out.files.items():
+        assert body.strip(), f"{path} rendered empty"
+
+
+def test_render_ethos_provider_api_key_in_env():
+    """provider_api_key (OPENROUTER_API_KEY) flows through to .env."""
+    out = render_ethos(_ethos_inputs(ptype="openrouter"))
+    env = out.files[".ethos/.env"]
+    assert "sk-or-1" in env
+
+
+def test_render_ethos_gateway_api_key_and_internal_port_in_env():
+    """gateway.api_key and gateway.internal_port are present in .env."""
+    inputs = _ethos_inputs()
+    out = render_ethos(inputs)
+    env = out.files[".ethos/.env"]
+    assert "ethos-gw-key" in env
+    assert "44410" in env
+
+
+def test_render_ethos_rejects_unsupported_provider():
+    """AgentConfigError for a provider type ethos doesn't support (e.g. bedrock)."""
+    inputs = RenderInputs(
+        agent_name="kevin",
+        agent_type="ethos",
+        provider=ProviderInputs(
+            name="br",
+            type="bedrock",
+            default_model="anthropic.claude-v3-sonnet",
+            aws_access_key="AKIA-1",
+            aws_secret_key="secret-1",
+        ),
+        channels=(),
+        integrations=(),
+        api_server=None,
+        gateway=GatewayInputs(host="0.0.0.0", port=44400, auth="tkn", bind="lan"),
+    )
+    with pytest.raises(AgentConfigError, match="render_ethos does not support"):
+        render_ethos(inputs)
+
+
+def test_render_ethos_rejects_none_gateway():
+    """AgentConfigError when gateway is None — ethos requires a gateway block."""
+    inputs = RenderInputs(
+        agent_name="kevin",
+        agent_type="ethos",
+        provider=ProviderInputs(
+            name="or", type="openrouter", default_model="m", api_key="sk-or-1"
+        ),
+        channels=(),
+        integrations=(),
+        api_server=None,
+        gateway=None,
+    )
+    with pytest.raises(AgentConfigError, match="requires gateway config"):
+        render_ethos(inputs)
+
+
+def test_render_ethos_rejects_duplicate_channel_type():
+    """B1 guard: two channels of the same type raise AgentConfigError."""
+    slack_ch = ChannelInputs(
+        name="slack-a",
+        type="slack",
+        bot_token="xoxb-1",
+        app_token="xapp-1",
+    )
+    slack_ch2 = ChannelInputs(
+        name="slack-b",
+        type="slack",
+        bot_token="xoxb-2",
+        app_token="xapp-2",
+    )
+    inputs = RenderInputs(
+        agent_name="kevin",
+        agent_type="ethos",
+        provider=ProviderInputs(
+            name="or", type="openrouter", default_model="m", api_key="sk-or-1"
+        ),
+        channels=(slack_ch, slack_ch2),
+        integrations=(),
+        api_server=None,
+        gateway=GatewayInputs(host="0.0.0.0", port=44400, auth="tkn", bind="lan"),
+    )
+    with pytest.raises(AgentConfigError, match="duplicate channel type"):
+        render_ethos(inputs)
+
+
+def test_render_ethos_integration_type_wins_over_credential_key():
+    """S5: entry['type'] must equal it.type even if credentials contain 'type'."""
+    inputs = RenderInputs(
+        agent_name="kevin",
+        agent_type="ethos",
+        provider=ProviderInputs(
+            name="or", type="openrouter", default_model="m", api_key="sk-or-1"
+        ),
+        channels=(),
+        integrations=(
+            IntegrationInputs(
+                name="gh",
+                type="github",
+                credentials=(("GITHUB_TOKEN", "ghp-1"), ("type", "should-be-ignored")),
+            ),
+        ),
+        api_server=None,
+        gateway=GatewayInputs(host="0.0.0.0", port=44400, auth="tkn", bind="lan"),
+    )
+    out = render_ethos(inputs)
+    env = out.files[".ethos/.env"]
+    # The rendered env must not embed the stray credential value as the
+    # integration type; it must use "github".
+    assert "github" in env or "GITHUB_TOKEN" in env
+
+
+# ---------------------------------------------------------------------------
+# build_render_inputs — ethos gateway blob fields (B4 / #923)
+# ---------------------------------------------------------------------------
+
+
+def test_build_render_inputs_populates_ethos_gateway_api_key_and_internal_port(stores):
+    """B4: api_key and internal_port from gateway blob are surfaced in GatewayInputs
+    for ethos agents. Other agent types must receive empty/0 defaults."""
+    stores.agent = (
+        {"hostname": "host-1"},
+        "ethos",
+        {
+            "agent_name": "kevin",
+            "providers": [{"name": "or", "role": "primary", "model": ""}],
+            "config": {
+                "gateway": {
+                    "host": "0.0.0.0",
+                    "port": 44400,
+                    "auth": "ethos-tkn",
+                    "bind": "lan",
+                    "api_key": "ethos-gw-key",
+                    "internal_port": 44410,
+                }
+            },
+        },
+    )
+    stores.providers["or"] = {
+        "name": "or",
+        "type": "openrouter",
+        "default_model": "anthropic/claude-opus-4.7",
+    }
+    stores.provider_api_keys["or"] = "sk-or-1"
+    inputs = build_render_inputs("kevin")
+    assert inputs.gateway is not None
+    assert inputs.gateway.api_key == "ethos-gw-key"
+    assert inputs.gateway.internal_port == 44410
+
+
+def test_build_render_inputs_ethos_gateway_internal_port_defaults_to_44410(stores):
+    """When internal_port is absent from the gateway blob, it defaults to 44410."""
+    stores.agent = (
+        {"hostname": "host-1"},
+        "ethos",
+        {
+            "agent_name": "kevin",
+            "providers": [{"name": "or", "role": "primary", "model": ""}],
+            "config": {
+                "gateway": {
+                    "host": "0.0.0.0",
+                    "port": 44400,
+                    "auth": "ethos-tkn",
+                    "api_key": "ethos-gw-key",
+                }
+            },
+        },
+    )
+    stores.providers["or"] = {
+        "name": "or",
+        "type": "openrouter",
+        "default_model": "anthropic/claude-opus-4.7",
+    }
+    stores.provider_api_keys["or"] = "sk-or-1"
+    inputs = build_render_inputs("kevin")
+    assert inputs.gateway is not None
+    assert inputs.gateway.internal_port == 44410
+
+
+def test_build_render_inputs_non_ethos_gateway_api_key_stays_empty(stores):
+    """W5: a zeroclaw agent with an api_key in its gateway blob must NOT
+    have that key surfaced in GatewayInputs.api_key (gate is agent_type-specific)."""
+    stores.agent = (
+        {"hostname": "host-1"},
+        "zeroclaw",
+        {
+            "agent_name": "zc1",
+            "providers": [{"name": "or", "role": "primary", "model": ""}],
+            "config": {
+                "gateway": {
+                    "host": "0.0.0.0",
+                    "port": 40000,
+                    "auth": "tkn",
+                    "api_key": "should-be-ignored",
+                }
+            },
+        },
+    )
+    stores.providers["or"] = {
+        "name": "or",
+        "type": "openrouter",
+        "default_model": "m",
+    }
+    stores.provider_api_keys["or"] = "sk-or-1"
+    inputs = build_render_inputs("zc1")
+    assert inputs.gateway is not None
+    assert inputs.gateway.api_key == ""
+    assert inputs.gateway.internal_port == 0

--- a/tests/core/test_render.py
+++ b/tests/core/test_render.py
@@ -6614,9 +6614,15 @@ def test_render_ethos_integration_type_wins_over_credential_key():
     )
     out = render_ethos(inputs)
     env = out.files[".ethos/.env"]
-    # The rendered env must not embed the stray credential value as the
-    # integration type; it must use "github".
-    assert "github" in env or "GITHUB_TOKEN" in env
+    # W6 (#924): the GITHUB_TOKEN lines are only emitted when the
+    # integration's resolved type is exactly 'github'. If the stray
+    # credential key ("type": "should-be-ignored") clobbered `it.type`,
+    # the template's `integration.type == 'github'` guard would be False
+    # and no token line would render — so these assertions fail exactly
+    # when the production `entry["type"] = it.type` line is removed.
+    assert "GITHUB_TOKEN='ghp-1'" in env
+    assert "GITHUB_TOKEN_GH='ghp-1'" in env
+    assert "should-be-ignored" not in env
 
 
 # ---------------------------------------------------------------------------
@@ -6624,25 +6630,15 @@ def test_render_ethos_integration_type_wins_over_credential_key():
 # ---------------------------------------------------------------------------
 
 
-def test_build_render_inputs_populates_ethos_gateway_api_key_and_internal_port(stores):
-    """B4: api_key and internal_port from gateway blob are surfaced in GatewayInputs
-    for ethos agents. Other agent types must receive empty/0 defaults."""
+def _ethos_agent_with_gateway(stores, gateway_blob: dict) -> None:
+    """Wire a minimal ethos agent whose gateway blob is `gateway_blob`."""
     stores.agent = (
         {"hostname": "host-1"},
         "ethos",
         {
             "agent_name": "kevin",
             "providers": [{"name": "or", "role": "primary", "model": ""}],
-            "config": {
-                "gateway": {
-                    "host": "0.0.0.0",
-                    "port": 44400,
-                    "auth": "ethos-tkn",
-                    "bind": "lan",
-                    "api_key": "ethos-gw-key",
-                    "internal_port": 44410,
-                }
-            },
+            "config": {"gateway": gateway_blob},
         },
     )
     stores.providers["or"] = {
@@ -6651,39 +6647,113 @@ def test_build_render_inputs_populates_ethos_gateway_api_key_and_internal_port(s
         "default_model": "anthropic/claude-opus-4.7",
     }
     stores.provider_api_keys["or"] = "sk-or-1"
+
+
+@pytest.mark.parametrize(
+    ("gateway_blob", "expected_api_key", "expected_internal_port"),
+    [
+        # B4: both fields present flow through verbatim.
+        (
+            {
+                "host": "0.0.0.0",
+                "port": 44400,
+                "auth": "ethos-tkn",
+                "bind": "lan",
+                "api_key": "ethos-gw-key",
+                "internal_port": 44412,
+            },
+            "ethos-gw-key",
+            44412,
+        ),
+        # S1: internal_port absent → default 44410.
+        (
+            {
+                "host": "0.0.0.0",
+                "port": 44400,
+                "auth": "ethos-tkn",
+                "api_key": "ethos-gw-key",
+            },
+            "ethos-gw-key",
+            44410,
+        ),
+        # S1: api_key absent → empty string, internal_port unaffected.
+        (
+            {
+                "host": "0.0.0.0",
+                "port": 44400,
+                "auth": "ethos-tkn",
+                "internal_port": 44412,
+            },
+            "",
+            44412,
+        ),
+        # W3 (#924): an explicit 0 must surface as 0 — the old `or 44410`
+        # idiom silently substituted the default for it.
+        (
+            {
+                "host": "0.0.0.0",
+                "port": 44400,
+                "auth": "ethos-tkn",
+                "api_key": "ethos-gw-key",
+                "internal_port": 0,
+            },
+            "ethos-gw-key",
+            0,
+        ),
+        # W3 (#924): a whitespace-only string is truthy — the old idiom
+        # crashed on int('  '). Now it falls back to the default.
+        (
+            {
+                "host": "0.0.0.0",
+                "port": 44400,
+                "auth": "ethos-tkn",
+                "api_key": "ethos-gw-key",
+                "internal_port": "  ",
+            },
+            "ethos-gw-key",
+            44410,
+        ),
+        # Numeric string is accepted (hosts.json hand-edits).
+        (
+            {
+                "host": "0.0.0.0",
+                "port": 44400,
+                "auth": "ethos-tkn",
+                "api_key": "ethos-gw-key",
+                "internal_port": " 44415 ",
+            },
+            "ethos-gw-key",
+            44415,
+        ),
+    ],
+)
+def test_build_render_inputs_ethos_gateway_fields(
+    stores, gateway_blob, expected_api_key, expected_internal_port
+):
+    """B4 + W3 + S1 (#923/#924): api_key and internal_port extraction from
+    the ethos gateway blob, including default and degenerate-value cases."""
+    _ethos_agent_with_gateway(stores, gateway_blob)
     inputs = build_render_inputs("kevin")
     assert inputs.gateway is not None
-    assert inputs.gateway.api_key == "ethos-gw-key"
-    assert inputs.gateway.internal_port == 44410
+    assert inputs.gateway.api_key == expected_api_key
+    assert inputs.gateway.internal_port == expected_internal_port
 
 
-def test_build_render_inputs_ethos_gateway_internal_port_defaults_to_44410(stores):
-    """When internal_port is absent from the gateway blob, it defaults to 44410."""
-    stores.agent = (
-        {"hostname": "host-1"},
-        "ethos",
+def test_build_render_inputs_ethos_non_numeric_internal_port_raises(stores):
+    """W3 (#924): garbage internal_port surfaces as AgentConfigError (doctor
+    renders it as status=broken), not an unhandled ValueError."""
+    _ethos_agent_with_gateway(
+        stores,
         {
-            "agent_name": "kevin",
-            "providers": [{"name": "or", "role": "primary", "model": ""}],
-            "config": {
-                "gateway": {
-                    "host": "0.0.0.0",
-                    "port": 44400,
-                    "auth": "ethos-tkn",
-                    "api_key": "ethos-gw-key",
-                }
-            },
+            "host": "0.0.0.0",
+            "port": 44400,
+            "auth": "ethos-tkn",
+            "api_key": "ethos-gw-key",
+            "internal_port": "not-a-port",
         },
     )
-    stores.providers["or"] = {
-        "name": "or",
-        "type": "openrouter",
-        "default_model": "anthropic/claude-opus-4.7",
-    }
-    stores.provider_api_keys["or"] = "sk-or-1"
-    inputs = build_render_inputs("kevin")
-    assert inputs.gateway is not None
-    assert inputs.gateway.internal_port == 44410
+    with pytest.raises(AgentConfigError, match="non-integer gateway.internal_port"):
+        build_render_inputs("kevin")
 
 
 def test_build_render_inputs_non_ethos_gateway_api_key_stays_empty(stores):

--- a/tests/test_registry_ethos.py
+++ b/tests/test_registry_ethos.py
@@ -198,3 +198,96 @@ def test_ethos_env_template_has_telegram():
     ethos_pkg = files("clawrium.platform.registry.ethos")
     content = (ethos_pkg / "templates" / "ethos.env.j2").read_text()
     assert "TELEGRAM_BOT_TOKEN" in content
+
+
+# ---------------------------------------------------------------------------
+# #924 (ATX B1): the five ethos config files are deployed as pre-rendered
+# bytes from core/render.py:render_ethos via `ansible.builtin.copy:
+# content:` tasks. If the extravar names drift between Python
+# (lifecycle.configure_agent) and Ansible, the playbook silently deploys
+# an empty file. These tests pin the var name for every dest and forbid a
+# partial revert to server-side `template:` tasks.
+# ---------------------------------------------------------------------------
+
+def _ethos_configure_tasks():
+    from importlib.resources import files
+
+    import yaml
+
+    ethos_pkg = files("clawrium.platform.registry.ethos")
+    content = (ethos_pkg / "playbooks" / "configure.yaml").read_text()
+    data = yaml.safe_load(content)
+    return data[0]["tasks"]
+
+
+def test_ethos_configure_copies_prerendered_bytes():
+    """Every canonical config file lands via `copy: content:` reading the
+    matching `prerendered_ethos_*` extravar, mode 0600."""
+    copies = {}
+    for task in _ethos_configure_tasks():
+        block = task.get("ansible.builtin.copy") or task.get("copy")
+        if isinstance(block, dict) and "content" in block:
+            copies[block.get("dest", "")] = block
+
+    for dest_suffix, var in [
+        ("/.env", "prerendered_ethos_env"),
+        ("}}/config.yaml", "prerendered_ethos_config_yaml"),
+        ("personalities/default/SOUL.md", "prerendered_ethos_soul_md"),
+        ("personalities/default/toolset.yaml", "prerendered_ethos_toolset_yaml"),
+        (
+            "personalities/default/config.yaml",
+            "prerendered_ethos_personality_config_yaml",
+        ),
+    ]:
+        matches = [
+            block
+            for dest, block in copies.items()
+            if dest.endswith(dest_suffix)
+        ]
+        assert matches, f"no copy task lands a dest ending in {dest_suffix!r}"
+        block = matches[0]
+        assert block["content"].strip() == "{{ " + var + " }}", (
+            f"copy task content var drifted for {dest_suffix!r}: "
+            f"{block['content']!r}"
+        )
+        assert str(block.get("mode")) == "0600"
+
+
+def test_ethos_configure_has_no_template_tasks_for_canonical_files():
+    """Defense-in-depth against a partial revert (#924 B1): no `template:`
+    task may render the five canonical .j2 files server-side — that is the
+    dual-render-path bug class #622 closed for hermes."""
+    forbidden = {
+        "ethos.env.j2",
+        "ethos-config.yaml.j2",
+        "ethos-soul.md.j2",
+        "ethos-toolset.yaml.j2",
+        "ethos-personality-config.yaml.j2",
+    }
+    for task in _ethos_configure_tasks():
+        tpl_block = task.get("ansible.builtin.template") or task.get("template")
+        if not isinstance(tpl_block, dict):
+            continue
+        src = tpl_block.get("src", "") or ""
+        assert not any(name in src for name in forbidden), (
+            f"template task still renders {src!r} server-side; the five "
+            f"canonical ethos files must deploy via copy: content: "
+            f"(prerendered by render_ethos)"
+        )
+
+
+def test_ethos_registered_in_canonical_sync_renderers():
+    """#924 B1: `clawctl agent sync` must render ethos through the same
+    render_ethos the doctor command and configure_agent use."""
+    from clawrium.core.lifecycle_canonical import _RENDERERS
+    from clawrium.core.render import render_ethos
+
+    assert _RENDERERS.get("ethos") is render_ethos
+
+
+def test_ethos_registered_in_sync_cli_diff_renderers():
+    """#924 B1: the `sync --dry-run --diff` renderer-name table must also
+    know ethos, or the diff path reports 'no renderer for agent type'."""
+    from clawrium.cli.clawctl.agent.sync import _RENDERERS as _CLI_RENDERERS
+
+    assert _CLI_RENDERERS.get("ethos") == "render_ethos"


### PR DESCRIPTION
## Summary

- `clawctl agent doctor <name>` now works for ethos agents — previously failed with `no renderer registered for agent type 'ethos'`
- Adds `render_ethos()` Python renderer that exercises all five Jinja2 config templates (`.ethos/.env`, `.ethos/config.yaml`, three personality files)
- Extends `GatewayInputs` with `api_key` and `internal_port` fields (ethos-only; gated behind `agent_type == "ethos"` so other agents are unaffected)
- Surfaces `api_key` (presence) and `internal_port` (value) in the doctor gateway diagnostic block

## Changes

### `src/clawrium/core/render.py`
- `GatewayInputs`: added `api_key: str = ""` and `internal_port: int = 0` fields
- `build_render_inputs`: populate both fields from gateway blob when `agent_type == "ethos"`; default-empty/0 for all other types (W5 gate)
- `render_ethos()`: new renderer — validates provider type against `_AGENT_TYPE_PROVIDER_SUPPORT["ethos"]`, raises `AgentConfigError` on duplicate channel type (B1), assembles Jinja2 context matching the Ansible template contract, renders five files
- Removed standalone `_ETHOS_SUPPORTED_PROVIDERS` — uses `_AGENT_TYPE_PROVIDER_SUPPORT["ethos"]` directly (W2)
- Integration dict assembly: `entry["type"]` set after `entry.update(credentials)` so `it.type` always wins (S5)
- `render_ethos` added to `__all__`

### `src/clawrium/cli/clawctl/agent/doctor.py`
- `_RENDERER_NAMES`: added `"ethos": "render_ethos"` entry
- `_inputs_block`: surfaces `api_key` (presence) and `internal_port` (value) in the gateway block
- `render_ethos` imported with `# noqa: F401` for monkeypatching

### `tests/core/test_render.py`
- `render_ethos` imported
- `_ethos_inputs()` factory for all four supported provider types
- Idempotency parametrize extended with `(render_ethos, "openrouter/anthropic/openai/codex")`
- New tests: five output paths non-empty, provider_api_key in env, gateway.api_key + internal_port in env, bad-provider rejection, gateway=None rejection, duplicate-channel-type rejection, integration `type` key precedence
- B4 tests: `build_render_inputs` populates `gateway.api_key`/`internal_port` for ethos, defaults `internal_port` to 44410, non-ethos agents get empty/0

### `tests/cli/clawctl/agent/test_doctor.py`
- B3 regression guard: ethos dispatches to `render_ethos` and exits 0
- JSON output test: `gateway.api_key == "present"` and `gateway.internal_port == 44410`; secret value absent from output

## Testing

### Test Results
- All 4622 Python tests pass (`make test`)
- Lint clean (`make lint`)
- All 329 GUI tests pass

### Test Coverage
- New tests: 14 in `test_render.py`, 2 in `test_doctor.py`

## ATX Review Summary

**Final: all blocking issues from both review rounds resolved**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 2/5 | B1, B2, B3, B4 | All fixed | — | — | — |
| 2 | 2/5 | B1 (dual render path) | Fixed in `0ebffc5` | $2.70 | 8m 4s | leader, cli-ux, render-engine, security-reviewer, test-coverage |

<details>
<summary>Review 1 Details (Rating 2/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `render.py:render_ethos` | Missing duplicate-channel-type guard (present in all other renderers) | Fixed — `seen_channel_types` guard added |
| B2 | `tests/core/test_render.py` | No unit tests for `render_ethos` | Fixed — 12 tests added covering all paths |
| B3 | `tests/cli/.../test_doctor.py` | No regression test for the ethos doctor dispatch (the root bug) | Fixed — 2 regression tests added |
| B4 | `tests/core/test_render.py` | No test for gateway blob → `GatewayInputs.api_key`/`internal_port` assembly | Fixed — 3 tests added |

**Warnings (resolved or acknowledged):**

| # | File | Warning | Action |
|---|------|---------|--------|
| W2 | `render.py` | Standalone `_ETHOS_SUPPORTED_PROVIDERS` risks drifting from `_AGENT_TYPE_PROVIDER_SUPPORT` | Fixed — removed, uses dict directly |
| W5 | `render.py:build_render_inputs` | `api_key`/`internal_port` extracted unconditionally from all agent types | Fixed — gated on `agent_type == "ethos"` |
| S5 | `render.py:render_ethos` | `entry["type"]` set before `update(credentials)` | Fixed — set after |
| W9 | `ethos.env.j2` | `shell_quote` macro skips NUL/CR/LF sanitization | Acknowledged — pre-existing Ansible template; changing it would break `configure.yaml` |
| W10 | `ethos-config.yaml.j2` | `model_id` emitted without YAML quoting filter | Acknowledged — pre-existing Ansible template |

</details>

<details>
<summary>Review 2 Details (Rating 2/5) — fixed in commit 0ebffc5</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `ethos/playbooks/configure.yaml` + `core/render.py` | Dual render path violates the #622 contract — configure templated the five .j2 files server-side (Ansible Jinja2) while doctor rendered them in Python | Fixed — `configure_agent` pre-renders via `render_ethos` and the playbook deploys with `copy: content:`; `sync_agent_canonical._RENDERERS` + the sync CLI diff table gain ethos entries; parity test suite added (`tests/core/test_lifecycle_ethos_prerender.py`) |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `doctor.py:_inputs_block` | api_key/internal_port emitted for non-ethos agents (JSON schema widening) | Fixed — gated on `agent_type == "ethos"` + regression test |
| W2 | `doctor.py:_render_table` | Gateway diagnostics invisible in default table output | Fixed — `Resolved gateway:` section added |
| W3 | `core/render.py` | `or 44410` idiom: explicit 0 silently replaced; `int('  ')` crash | Fixed — explicit None/blank check; non-numeric raises `AgentConfigError` |
| W4 | `ethos-config.yaml.j2` | Unquoted provider/model YAML injection | Fixed — `tojson` (template is Python-rendered only after B1) |
| W5 | `doctor.py:_report` | Unhandled `AgentConfigError` from `_render_for` | Fixed — try/except → structured `status: broken` |
| W6 | `tests/core/test_render.py` | Vacuous integration-type assertion | Fixed — asserts the exact GITHUB_TOKEN lines gated on type resolution |
| W7 | `tests/.../test_doctor.py` | Bare-lambda dispatch stub | Fixed — MagicMock + `assert_called_once_with` + `render_hermes.assert_not_called()` |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Merge build_render_inputs ethos tests into one parametrize | Fixed — 6-case parametrize |
| S2 | YAML-mode negative assertion test | Fixed |
| S3 | Derive audit fixture type set from `_RENDERER_NAMES` | Fixed |
| S4 | Hoist `jinja2.Environment` to module level | No change needed — `_ethos_template` already matches the `_hermes_template` shape (Environment built once inside the lru-cached loader); documented in docstring |

</details>

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>

Closes #923
