### PR TITLE
daily-docs-sweep 2026-07-16

### DIFF
--- a/website/docs/agent-support/hermes.md
+++ b/website/docs/agent-support/hermes.md
@@ -298,18 +298,22 @@ In the GUI, every hermes agent dashboard has an **"Open Agent UI"** button in th
 The dashboard binds loopback on the agent host — it is **not reachable over the LAN**. `clawctl agent open` establishes:
 
 ```
-your-machine:127.0.0.1:<random>  ──SSH-L──►  agent-host:127.0.0.1:<dashboard-port>
+your-machine:127.0.0.1:<port>  ──SSH-L──►  agent-host:127.0.0.1:<dashboard-port>
 ```
+
+The `<port>` is chosen from the OS ephemeral range on first connect and then **persisted** — on reconnection after an SSH drop, the tunnel manager reuses the same local port so your browser URL remains stable. If the preferred port is occupied, out of range, or invalid, it falls back to a fresh ephemeral port.
 
 Authentication piggybacks on the SSH key Ansible already uses for the host. The dashboard itself has no password / bearer-token wall: anyone with shell access to the agent host (root or the agent's UNIX user) could already reach loopback directly, so adding an extra in-process auth layer would offer no real defense beyond what SSH already provides.
 
 State for each tunnel is persisted at `~/.config/clawrium/tunnels/<agent_key>.json` (PID, local port, SSH command-line signature). A second `clawctl agent open` for the same agent reuses the live tunnel rather than spawning a duplicate; the GUI does the same via the `/api/fleet/agents/{key}/web-ui` endpoint. Tunnels opened by the GUI auto-close after 30 minutes of inactivity (a reaper task runs every 5 minutes). CLI tunnels close on `Ctrl-C` (SIGINT), on SIGTERM (the CLI installs a SIGTERM handler that mirrors SIGINT cleanup), or when the `clawctl` process exits normally (`atexit`). A hard `kill -9 <pid>` (SIGKILL) cannot be caught and will leak the underlying `ssh` subprocess; the next `clawctl agent open` against the same agent will detect and evict the stale state via the PID + cmdline guard.
 
+SSH keepalive is set to `ServerAliveInterval=60` × `ServerAliveCountMax=10` — a 10-minute silence ceiling before the tunnel is considered dead (up from ~90 s), reducing spurious disconnects during brief network interruptions.
+
 If the dashboard is unreachable, the most common causes are:
 
 - `hermes-dashboard-<agent-name>.service` is not running — `clawctl agent start <name>` re-enables both gateway and dashboard units.
 - The host's SSH key has rotated and `ssh -i <key>` can no longer authenticate — delete and re-create the host (`clawctl host delete <host> --force && clawctl host create <host> --user xclm --alias <name>`) and re-apply the manual setup commands `clawctl` prints.
-- Local-port conflict — the tunnel manager picks an ephemeral free port each time, so this should be rare; check `~/.config/clawrium/tunnels/<agent>.json` and remove it if stale.
+- Local-port conflict — the tunnel manager reuses the previous local port, so conflicts are rare; check `~/.config/clawrium/tunnels/<agent>.json` and remove it if stale.
 
 ---
 


### PR DESCRIPTION
## Summary

- Sync `website/docs/agent-support/hermes.md` with canonical `docs/agent-support/hermes.md` for tunnel port persistence and SSH keepalive improvements (PR #886, documented in PR #888)

## Changes

**website/docs/agent-support/hermes.md**:
- Add port persistence paragraph: local port is chosen once and persisted across reconnections
- Add SSH keepalive configuration: `ServerAliveInterval=60` × `ServerAliveCountMax=10` (10-minute silence ceiling)
- Update tunnel diagram: `<port>` instead of `<random>` to reflect persistence behavior
- Update local-port conflict note: tunnel manager reuses previous local port, not ephemeral each time

## Testing

### Mirror Verification
- `diff docs/agent-support/hermes.md website/docs/agent-support/hermes.md` — only expected Docusaurus link-format differences remain (relative → absolute paths)

### Scope
- PRs #921 (zeroclaw template fix) and #896 (dead code removal) contain no user-facing behavior changes — correctly excluded
- PRs #888 and #897 were docs-only — verified website mirrors are now current

---

🤖 Auto-generated by docs-sweep cron job
