### PR TITLE
docs(changelog): add `### Internal` subsection to changelog scaffold

### DIFF
--- a/.claude/skills/itx-release/SKILL.md
+++ b/.claude/skills/itx-release/SKILL.md
@@ -89,8 +89,8 @@ Do NOT touch:
     Then reset the root `CHANGELOG.md` to the empty template — keep the
     `# Changelog` preamble and the `docs/releases/` archive note, drop all
     shipped entries, and leave a bare `## [Unreleased]` with empty
-    `### BREAKING` / `### Added` / `### Changed` / `### Fixed` /
-    `### Documentation` subsections. Use the existing archived release as the
+    `### BREAKING` / `### Added` / `### Changed` / `### Fixed` / `### Documentation` /
+    `### Internal` subsections. Use the existing archived release as the
     structural reference (see `docs/releases/26.6.0/CHANGELOG.md`, the first
     one created under this convention).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,3 +105,5 @@ cut. The `itx:release` skill archives this section into a new
   through the render context. (#910)
 
 ### Documentation
+
+### Internal


### PR DESCRIPTION
## Summary

Adds `### Internal` subsection under `## [Unreleased]` in root `CHANGELOG.md` so the SDLC exec runbook's "append under `### Internal`" instruction anchors against real markdown structure. Also updates the `itx:release` skill's reset-template description to include `### Internal` so future release cuts preserve it.

## Changes

- `CHANGELOG.md` — added bare `### Internal` heading under `## [Unreleased]` (after `### Documentation`, matching archive convention)
- `.claude/skills/itx-release/SKILL.md` — added `### Internal` to the reset-template subsection list so the heading survives future `[Unreleased]` resets

## Testing

- [x] `make test` passes (4633 passed, 8 skipped)
- [x] `make lint` passes (ruff check clean)
- [x] Manual verification completed — `### Internal` placement matches archived releases; SKILL.md reset-template wording consistent with other subsection descriptions

## ATX Review

### Review Summary

**Final Review: Rating 3.5/5**
**Total Cost: $1.25 | Total Time: 4m 27s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3.5/5 | None | Ready | $1.25 | 4m 27s | platform-playbooks, test-coverage, cli-ux |

<!-- Note: ATX does not expose model information per agent. -->

<details>
<summary>Review 1 Details (Rating 3.5/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| N/A | — | No blocking issues | — |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `AGENTS.md:108` (Update Rules) | `### Internal` absent from contributor-facing "Update Rules" — no guidance on when to use it or what qualifies as "internal" | Acknowledged — will address in follow-up (add `### Internal` semantics to Update Rules) |
| W2 | PR body / `.hermes/skills/release-announcements/SKILL.md` | Hermes release-announcements skill has no awareness of `### Internal`; clarification: this file was not modified in this PR | Fixed — corrected the PR body; hermes skill was not modified in this PR |
| W3 | `docs/agent-support/integrations/atlassian.md:136` + website mirror | Duplicate-command copy-paste regression (same command repeated twice). Pre-existing on branch; not introduced by this commit | Out-of-scope — pre-existing on branch, unrelated to #688 |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 | Add cross-check test that CHANGELOG.md subsection headings stay in sync with SKILL.md reset-template list | Deferred — nice-to-have structural test |
| S2 | `### Internal` ordering after `### Documentation` is correct — consistent with archive convention | Confirmed — placement matches archive convention |

</details>

---

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>

Closes #688