### PR TITLE
fix(gui): make asyncio primitives per-event-loop to eliminate test flakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Fixed
 
+- `tests/test_gui_routes_fleet.py::test_fleet_health_returns_200_under_concurrent_clients` and `test_fleet_health_host_filter_forwarded` — module-level `asyncio.Lock()` (`_LAST_ACCESS_LOCK`) was bound to the first pytest event loop, causing `RuntimeError: Lock is bound to a different event loop` on subsequent tests. Migrated to the same per-loop lazy accessor pattern (`_get_last_access_lock`) already used for the fleet-health semaphore. The concurrent-clients test also switched from `executor.shutdown(wait=False, cancel_futures=True)` to a `with`-block so futures complete normally instead of being force-cancelled, eliminating spurious `CancelledError` (#676).
+
 - `clawctl agent doctor <name>` now works for **ethos agents** (#923). Previously the command
   failed with `Error: no renderer registered for agent type 'ethos'` because the doctor
   dispatch table only covered hermes, zeroclaw, and openclaw. Fix adds a `render_ethos()`

--- a/src/clawrium/gui/routes/fleet.py
+++ b/src/clawrium/gui/routes/fleet.py
@@ -77,8 +77,25 @@ _LIFECYCLE_GENERIC_ERROR = "Lifecycle operation failed. Check server logs."
 # Per-agent last-access timestamp for the GUI web-ui tunnel reaper. Keys
 # are agent_key strings; values are wall-clock unix seconds from the most
 # recent /web-ui hit. The reaper task in server.py reads this map.
-_LAST_ACCESS_LOCK = asyncio.Lock()
+
+
+def _get_last_access_lock() -> asyncio.Lock:
+    """Return a per-loop Lock for WEB_UI_LAST_ACCESS.
+
+    Same lazy-initialization pattern as `_get_fleet_health_semaphore` so
+    pytest (which creates a fresh event loop per test) does not trip on
+    "Lock is bound to a different event loop" errors.
+    """
+    loop = asyncio.get_running_loop()
+    lock = getattr(loop, "_clawrium_last_access_lock", None)
+    if lock is None:
+        lock = asyncio.Lock()
+        loop._clawrium_last_access_lock = lock  # type: ignore[attr-defined]
+    return lock
+
+
 WEB_UI_LAST_ACCESS: dict[str, float] = {}
+
 
 
 def _host_is_local(host: str) -> bool:
@@ -475,7 +492,7 @@ async def agent_web_ui(agent_key: str) -> dict[str, Any]:
             "reason": "Internal error establishing tunnel; see server logs.",
         }
 
-    async with _LAST_ACCESS_LOCK:
+    async with _get_last_access_lock():
         WEB_UI_LAST_ACCESS[agent_key] = time.time()
 
     return {
@@ -592,7 +609,7 @@ async def agent_pairing_code(agent_key: str) -> dict[str, Any]:
                 detail="Internal error establishing tunnel; see server logs.",
             ) from e
 
-        async with _LAST_ACCESS_LOCK:
+        async with _get_last_access_lock():
             WEB_UI_LAST_ACCESS[agent_key] = time.time()
         base = f"http://127.0.0.1:{local_port}"
 
@@ -756,7 +773,7 @@ async def reap_idle_tunnels(threshold_seconds: float = 1800.0) -> int:
     """
     closed = 0
     now = time.time()
-    async with _LAST_ACCESS_LOCK:
+    async with _get_last_access_lock():
         stale = [
             key
             for key, ts in WEB_UI_LAST_ACCESS.items()
@@ -767,7 +784,7 @@ async def reap_idle_tunnels(threshold_seconds: float = 1800.0) -> int:
     for key in stale:
         # Re-check under the lock: a concurrent /web-ui request may have
         # re-stamped this key between the initial snapshot and now.
-        async with _LAST_ACCESS_LOCK:
+        async with _get_last_access_lock():
             if key in WEB_UI_LAST_ACCESS:
                 continue
         # Lock released before the blocking close() so concurrent /web-ui

--- a/tests/test_gui_routes_fleet.py
+++ b/tests/test_gui_routes_fleet.py
@@ -1171,12 +1171,9 @@ def test_fleet_health_returns_200_under_concurrent_clients(isolated_config: Path
         "clawrium.gui.routes.fleet.get_fleet_data",
         return_value=([vm], _fleet_summary()),
     ):
-        executor = _TPE(max_workers=3)
-        try:
+        with _TPE(max_workers=3) as executor:
             futures = [executor.submit(_probe) for _ in range(3)]
             results = [f.result(timeout=15) for f in futures]
-        finally:
-            executor.shutdown(wait=False, cancel_futures=True)
 
     assert len(results) == 3, f"only {len(results)} threads completed"
     assert all(s == 200 for s in results), results


### PR DESCRIPTION
## Summary

Replaces the module-level `_LAST_ACCESS_LOCK = asyncio.Lock()` in `src/clawrium/gui/routes/fleet.py` with a lazy per-loop accessor `_get_last_access_lock()`, using the same pattern already established for `_get_fleet_health_semaphore`. Fixes two Ubuntu-CI flakes: `test_fleet_health_returns_200_under_concurrent_clients` (`CancelledError` on forced-cancel teardown) and `test_fleet_health_host_filter_forwarded` (`RuntimeError: Lock is bound to a different event loop`).

## Changes

- `src/clawrium/gui/routes/fleet.py` — replaced `_LAST_ACCESS_LOCK = asyncio.Lock()` with `_get_last_access_lock()` lazy accessor; updated all 4 call sites (`agent_web_ui`, `agent_pairing_code`, and two in `reap_idle_tunnels`).
- `tests/test_gui_routes_fleet.py` — switched concurrent-clients test from `shutdown(wait=False, cancel_futures=True)` to `with _TPE(...)` context manager (implicit `shutdown(wait=True)`) to prevent `CancelledError` during teardown.
- `CHANGELOG.md` — documented the fix under `### Fixed`.

## Testing

- [x] `make test` passes — 4633 python + 329 GUI tests
- [x] `make lint` passes — ruff + next lint clean
- [x] Manual verification completed — 20/20 iterations of both flaky tests pass locally (`for i in $(seq 1 20); do uv run pytest tests/test_gui_routes_fleet.py::test_fleet_health_returns_200_under_concurrent_clients tests/test_gui_routes_fleet.py::test_fleet_health_host_filter_forwarded -x -q || break; done`)

## ATX Review

### Review Summary

**Final Review: Rating 3/5**
**Total Cost: $1.03 | Total Time: 4m 36s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3/5 | 0 formal, 1 leader-flagged (B1 coverage gap) | Warnings acknowledged | $1.03 | 4m 36s | gui-routes, test-coverage |

<!-- Note: ATX does not expose model information per agent. Models used: claude-sonnet-4-6, claude-opus-4-6, gpt-5.1-codex-max, gpt-5.3-codex. -->

<details>
<summary>Review 1 Details (Rating 3/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `src/clawrium/gui/routes/fleet.py:82-94` | `_get_last_access_lock()` has no direct test for its per-loop isolation invariant; regression in the None-guard would go uncaught. | Acknowledged — will add a direct unit test in a follow-up (`asyncio.run` twice → distinct locks; twice inside one coroutine → identical) |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 | `src/clawrium/gui/routes/fleet.py:82-94` | Per-loop lock does not protect the module-level `WEB_UI_LAST_ACCESS` dict across loops; correctness relies on the uvicorn single-loop invariant which is undocumented. | Acknowledged — will document the single-loop invariant in the accessor docstring in follow-up. |
| W2 | `src/clawrium/gui/server.py:74,80` | Pre-existing: shutdown lifespan reads `WEB_UI_LAST_ACCESS.keys()` + `.clear()` with no lock. | Out-of-scope — pre-existing on main; tracked separately. |
| W3 | `src/clawrium/gui/routes/fleet.py:57-63` | Per-loop `Semaphore(2)` (existing pattern, not touched by this PR) doesn't bound global concurrency across multi-loop scenarios. | Out-of-scope — the semaphore was already this way; this PR only mirrors the pattern for the lock. Tracked separately. |

**Suggestions:**

| # | Location | Suggestion | Action |
|---|----------|------------|--------|
| S1 | `src/clawrium/gui/routes/fleet.py:89-93` | Monkey-patching `loop._clawrium_last_access_lock` is not idiomatic. Consider a module-level `dict[int, asyncio.Lock]` keyed by `id(loop)`. | Deferred — matches existing pattern in-file; refactoring both accessors is a separate follow-up. |
| S2 | `src/clawrium/gui/routes/fleet.py:784-789` | Re-check comment wording is slightly misleading (says "re-stamped" but the initial block already pops). | Deferred — trivial docstring wording tweak. |
| S3 | `tests/test_gui_routes_fleet.py:1174-1179` | Consider asserting response bodies (not just status) so contention 503/504s surface. | Deferred — current status assertion is sufficient for this flake regression. |

</details>

---

Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>

Closes #676
