### PR TITLE
fix(cli/agent): sanitize remote-host and exception output (#453)

### DIFF
--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -19,7 +19,7 @@ from rich.panel import Panel
 
 from clawrium.cli.agent_skill import agent_skill_app
 from clawrium.cli.install import install as install_command
-from clawrium.cli.output._sanitize import sanitize_passthrough
+from clawrium.cli.output._sanitize import sanitize, sanitize_passthrough
 from clawrium.cli.status import status as status_command
 from clawrium.core.config import get_config_dir
 from clawrium.core.hosts import (
@@ -48,6 +48,17 @@ console = Console()
 err_console = Console(stderr=True)
 
 VALID_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9._-]+$")
+
+def _safe(text: str) -> str:
+    """Sanitize + Rich-escape a remote/exception string in one call.
+
+    Delegates to the canonical ``cli.output._sanitize.sanitize`` (strips
+    C0/C1 control bytes and UAX#9 bidi + zero-width codepoints), then
+    Rich-escapes so residual ``[`` / ``]`` in the payload cannot open a
+    markup span. Issue #453 — closes the bidi + markup-injection gap on
+    lifecycle event and exception rendering.
+    """
+    return rich_escape(sanitize(str(text)))
 
 STAGE_TO_CURRENT_STATE = {
     "providers": OnboardingState.PROVIDERS,
@@ -149,7 +160,7 @@ def _print_configure_warnings(stage: str, message: str) -> None:
         if agent_label:
             console.print(
                 f"  [yellow]Gateway token rotated for "
-                f"{rich_escape(agent_label)}. Active chat sessions on "
+                f"{_safe(agent_label)}. Active chat sessions on "
                 f"other machines will need to reconnect.[/yellow]"
             )
         else:
@@ -165,7 +176,7 @@ def _print_configure_warnings(stage: str, message: str) -> None:
         # integrations.json, which may be hand-edited and contain Rich
         # tokens like `[bold]`. Without escape Rich would either garble the
         # output or raise MarkupError mid-configure.
-        console.print(f"  [yellow]{rich_escape(message)}[/yellow]")
+        console.print(f"  [yellow]{_safe(message)}[/yellow]")
 
 
 def _validate_name_component(name: str, component_type: str) -> None:
@@ -431,7 +442,9 @@ def _run_providers_stage(
     try:
         providers = load_providers()
     except ProvidersFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] Providers file corrupted: {e}")
+        console.print(
+            f"[red]Error:[/red] Providers file corrupted: {_safe(str(e))}"
+        )
         return False
     except FileNotFoundError:
         providers = []
@@ -480,7 +493,7 @@ def _run_providers_stage(
         _sync_provider_config(host, claw_type, selected, installed_name)
         console.print("[green]✓[/green]")
     except Exception as e:
-        console.print(f"[red]✗[/red] {rich_escape(str(e))}")
+        console.print(f"[red]✗[/red] {_safe(str(e))}")
         agent_name = installed_name or claw_type
         console.print(
             f"[red]Error:[/red] Failed to apply provider configuration. "
@@ -509,7 +522,7 @@ def _run_providers_stage(
         except Exception as e:
             console.print(
                 f"[red]✗[/red] Failed to update provider metadata: "
-                f"{rich_escape(str(e))}"
+                f"{_safe(str(e))}"
             )
             return False
         console.print("[green]✓[/green] Provider configuration updated")
@@ -528,7 +541,7 @@ def _run_providers_stage(
         console.print("[green]✓[/green]")
         return True
     except Exception as e:
-        console.print(f"[red]✗[/red] {rich_escape(str(e))}")
+        console.print(f"[red]✗[/red] {_safe(str(e))}")
         return False
 
 
@@ -571,7 +584,7 @@ def _run_identity_stage(
                 console.print(f"  [green]✓[/green] Imported {src_file.name}")
             except Exception as e:
                 console.print(
-                    f"[red]Error:[/red] Failed to copy {src_file.name}: {rich_escape(str(e))}"
+                    f"[red]Error:[/red] Failed to copy {src_file.name}: {_safe(str(e))}"
                 )
                 return False
 
@@ -587,7 +600,7 @@ def _run_identity_stage(
                 console.print("  [green]✓[/green] Created default SOUL.md")
             except Exception as e:
                 console.print(
-                    f"[red]Error:[/red] Failed to write SOUL.md: {rich_escape(str(e))}"
+                    f"[red]Error:[/red] Failed to write SOUL.md: {_safe(str(e))}"
                 )
                 return False
     else:
@@ -621,7 +634,7 @@ def _run_identity_stage(
             console.print(f"  [green]✓[/green] Created {soul_path}")
         except Exception as e:
             console.print(
-                f"[red]Error:[/red] Failed to write SOUL.md: {rich_escape(str(e))}"
+                f"[red]Error:[/red] Failed to write SOUL.md: {_safe(str(e))}"
             )
             return False
 
@@ -675,7 +688,9 @@ def _run_identity_stage(
             console.print("[green]✓[/green]")
         else:
             console.print("[red]✗[/red]")
-            console.print(f"  [yellow]Warning:[/yellow] Workspace sync failed: {error}")
+            console.print(
+                f"  [yellow]Warning:[/yellow] Workspace sync failed: {_safe(str(error))}"
+            )
             console.print(
                 "  [dim]Identity files saved locally. Sync later with 'clawctl agent sync'[/dim]"
             )
@@ -683,7 +698,7 @@ def _run_identity_stage(
     except Exception as e:
         console.print("[red]✗[/red]")
         console.print(
-            f"  [yellow]Warning:[/yellow] Workspace sync failed: {rich_escape(str(e))}"
+            f"  [yellow]Warning:[/yellow] Workspace sync failed: {_safe(str(e))}"
         )
         console.print(
             "  [dim]Identity files saved locally. Sync later with 'clawctl agent sync'[/dim]"
@@ -700,7 +715,7 @@ def _run_identity_stage(
             complete_stage(host, agent_name, "identity", StageStatus.COMPLETE)
         except Exception as e:
             console.print(
-                f"[red]Error:[/red] Failed to save identity stage: {rich_escape(str(e))}"
+                f"[red]Error:[/red] Failed to save identity stage: {_safe(str(e))}"
             )
             return False
 
@@ -1273,7 +1288,7 @@ def _run_channels_stage(
             _sync_channel_config(host, claw_type, channels_config, installed_name)
             console.print("[green]✓[/green]")
         except Exception as e:
-            console.print(f"[red]✗[/red] {rich_escape(str(e))}")
+            console.print(f"[red]✗[/red] {_safe(str(e))}")
             agent_name = installed_name or claw_type
             console.print(
                 f"[dim]Retry with: clawctl agent configure {rich_escape(agent_name)} --stage channels[/dim]"
@@ -1449,7 +1464,7 @@ def _run_channels_stage(
             _sync_channel_config(host, claw_type, channels_config, installed_name)
             console.print("[green]✓[/green]")
         except Exception as e:
-            console.print(f"[red]✗[/red] {rich_escape(str(e))}")
+            console.print(f"[red]✗[/red] {_safe(str(e))}")
             agent_name = installed_name or claw_type
             console.print(
                 f"[dim]Retry with: clawctl agent configure {rich_escape(agent_name)} --stage channels[/dim]"
@@ -1487,7 +1502,7 @@ def _run_channels_stage(
             )
         except Exception as e:
             console.print(
-                f"[red]✗[/red] Failed to update channel metadata: {rich_escape(str(e))}"
+                f"[red]✗[/red] Failed to update channel metadata: {_safe(str(e))}"
             )
             return False
         console.print("[green]✓[/green] Channels configuration updated")
@@ -1504,7 +1519,7 @@ def _run_channels_stage(
         return True
     except Exception as e:
         console.print(
-            f"[red]Error:[/red] Failed to save channels stage: {rich_escape(str(e))}"
+            f"[red]Error:[/red] Failed to save channels stage: {_safe(str(e))}"
         )
         return False
 
@@ -1598,7 +1613,7 @@ def _run_validate_stage(
     else:
         console.print("  [red]✗[/red] Agent installation check failed")
         for error in install_result.errors:
-            console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+            console.print(f"    [red]Error:[/red] {_safe(error)}")
         all_errors.extend(install_result.errors)
 
     if not skip_soul_check:
@@ -1610,12 +1625,12 @@ def _run_validate_stage(
         if soul_result.passed:
             console.print("  [green]✓[/green] SOUL.md exists and readable")
             for warning in soul_result.warnings:
-                console.print(f"    [yellow]Warning:[/yellow] {rich_escape(warning)}")
+                console.print(f"    [yellow]Warning:[/yellow] {_safe(warning)}")
                 all_warnings.append(warning)
         else:
             console.print("  [red]✗[/red] SOUL.md validation failed")
             for error in soul_result.errors:
-                console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+                console.print(f"    [red]Error:[/red] {_safe(error)}")
             all_errors.extend(soul_result.errors)
 
     step_idx += 1
@@ -1625,7 +1640,7 @@ def _run_validate_stage(
         provider_id = provider_result.details.get("provider_id", "unknown")
         provider_type = provider_result.details.get("provider_type", "unknown")
         console.print(
-            f"  [green]✓[/green] Provider: {rich_escape(provider_id)} ({rich_escape(provider_type)})"
+            f"  [green]✓[/green] Provider: {_safe(provider_id)} ({_safe(provider_type)})"
         )
 
         console.print("  Checking API key...")
@@ -1642,12 +1657,12 @@ def _run_validate_stage(
         else:
             console.print("  [red]✗[/red] API key validation failed")
             for error in key_result.errors:
-                console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+                console.print(f"    [red]Error:[/red] {_safe(error)}")
             all_errors.extend(key_result.errors)
     else:
         console.print("  [red]✗[/red] Provider configuration missing")
         for error in provider_result.errors:
-            console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+            console.print(f"    [red]Error:[/red] {_safe(error)}")
         all_errors.extend(provider_result.errors)
 
     step_idx += 1
@@ -1663,12 +1678,12 @@ def _run_validate_stage(
             else:
                 console.print("  [green]✓[/green] Provider connectivity OK")
             for warning in conn_result.warnings:
-                console.print(f"    [yellow]Warning:[/yellow] {rich_escape(warning)}")
+                console.print(f"    [yellow]Warning:[/yellow] {_safe(warning)}")
                 all_warnings.append(warning)
         else:
             console.print("  [red]✗[/red] Provider connectivity test failed")
             for error in conn_result.errors:
-                console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+                console.print(f"    [red]Error:[/red] {_safe(error)}")
             all_errors.extend(conn_result.errors)
     else:
         console.print("  [dim]Skipped (no provider configured)[/dim]")
@@ -1701,7 +1716,7 @@ def _run_validate_stage(
                 endpoint = conn_result.details.get("gateway_url")
                 if endpoint:
                     console.print(
-                        f"  [green]✓[/green] Gateway reachable: {rich_escape(str(endpoint))}"
+                        f"  [green]✓[/green] Gateway reachable: {_safe(str(endpoint))}"
                     )
                 else:
                     console.print("  [green]✓[/green] Gateway connectivity OK")
@@ -1709,7 +1724,7 @@ def _run_validate_stage(
                 gateway_status = "failed"
                 console.print("  [red]✗[/red] Gateway health check failed")
                 for error in conn_result.errors:
-                    console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+                    console.print(f"    [red]Error:[/red] {_safe(error)}")
                 all_errors.extend(conn_result.errors)
     elif claw_type == "hermes":
         # hermes runs three checks on the agent host (binary + .env +
@@ -1740,7 +1755,7 @@ def _run_validate_stage(
                 hermes_health_status = "failed"
                 console.print("  [red]✗[/red] hermes health check failed")
                 for error in hermes_result.errors:
-                    console.print(f"    [red]Error:[/red] {rich_escape(error)}")
+                    console.print(f"    [red]Error:[/red] {_safe(error)}")
                 all_errors.extend(hermes_result.errors)
 
     console.print()
@@ -1788,7 +1803,7 @@ def _run_validate_stage(
         return True
     except Exception as e:
         console.print(
-            f"[red]Error:[/red] Failed to save validate stage: {rich_escape(str(e))}"
+            f"[red]Error:[/red] Failed to save validate stage: {_safe(str(e))}"
         )
         return False
 
@@ -1911,7 +1926,7 @@ def _run_edit_config(
         try:
             edited_config = json.loads(edited_content)
         except json.JSONDecodeError as e:
-            console.print(f"\n[red]Error:[/red] Invalid JSON: {e}")
+            console.print(f"\n[red]Error:[/red] Invalid JSON: {_safe(str(e))}")
             console.print("\nYour edited file has been preserved at:")
             console.print(f"  {config_file}")
             console.print("\nFix the JSON error and try again with:")
@@ -1934,7 +1949,7 @@ def _run_edit_config(
         )
 
         if not success:
-            console.print(f"\n[red]Error:[/red] Sync failed: {error}")
+            console.print(f"\n[red]Error:[/red] Sync failed: {_safe(str(error))}")
             console.print("\nYour edited file has been preserved at:")
             console.print(f"  {config_file}")
             preserve_temp_dir = True
@@ -1963,7 +1978,7 @@ def _run_edit_config(
                     )
                     raise typer.Exit(code=1)
             except LifecycleError as e:
-                console.print(f"[red]Error:[/red] Restart failed: {e}")
+                console.print(f"[red]Error:[/red] Restart failed: {_safe(str(e))}")
                 raise typer.Exit(code=1)
         else:
             console.print(
@@ -2089,10 +2104,10 @@ def configure(
             installed_name,
         ) = _resolve_agent_instance(claw_name)
     except HostsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except AgentNameResolutionError as e:
-        console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
         console.print("\nCancelled.")
@@ -2119,10 +2134,10 @@ def configure(
             initialize_onboarding(hostname, installed_name)
             current_state = get_onboarding_state(hostname, installed_name)
         except AgentNotFoundError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            console.print(f"[red]Error:[/red] {_safe(str(e))}")
             raise typer.Exit(code=1)
     except AgentNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
 
     console.print(
@@ -2248,7 +2263,7 @@ def configure(
                     )
                 except Exception as e:
                     console.print(
-                        f"[red]Error:[/red] Failed to skip stage: {rich_escape(str(e))}"
+                        f"[red]Error:[/red] Failed to skip stage: {_safe(str(e))}"
                     )
                     raise typer.Exit(code=1)
                 # Also advance the state pointer so the next required stage's
@@ -2278,7 +2293,7 @@ def configure(
                 try:
                     transition_state(hostname, installed_name, current_stage_state)
                 except InvalidTransitionError as e:
-                    console.print(f"[red]Error:[/red] {e}")
+                    console.print(f"[red]Error:[/red] {_safe(str(e))}")
                     raise typer.Exit(code=1)
 
             if stage_name == "validate":
@@ -2304,7 +2319,7 @@ def configure(
             try:
                 transition_state(hostname, installed_name, next_state)
             except InvalidTransitionError as e:
-                console.print(f"[red]Error:[/red] {e}")
+                console.print(f"[red]Error:[/red] {_safe(str(e))}")
                 raise typer.Exit(code=1)
 
             _stage_complete(stage_name)
@@ -2433,9 +2448,9 @@ def remove(
 
         def on_event(stage: str, message: str) -> None:
             if stage == "validate":
-                console.print(f"  [dim]{message}[/dim]")
+                console.print(f"  [dim]{_safe(message)}[/dim]")
             elif stage == "remove":
-                console.print(f"  {message}")
+                console.print(f"  {_safe(message)}")
 
         try:
             if installed_name in host_data.get("agents", {}):
@@ -2445,7 +2460,7 @@ def remove(
             else:
                 result = remove_agent(hostname, claw_type, on_event=on_event)
         except LifecycleError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            console.print(f"[red]Error:[/red] {_safe(str(e))}")
             raise typer.Exit(code=1)
 
         if result["success"]:
@@ -2458,10 +2473,10 @@ def remove(
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except AgentNameResolutionError as e:
-        console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
         console.print("\nCancelled.")
@@ -2498,7 +2513,7 @@ def start(
                 initialize_onboarding(hostname, installed_name)
                 current_state = get_onboarding_state(hostname, installed_name)
             except AgentNotFoundError as e:
-                console.print(f"[red]Error:[/red] {e}")
+                console.print(f"[red]Error:[/red] {_safe(str(e))}")
                 raise typer.Exit(code=1)
 
         if current_state != OnboardingState.READY and not force:
@@ -2516,9 +2531,9 @@ def start(
 
         def on_event(stage: str, message: str) -> None:
             if stage == "validate":
-                console.print(f"  [dim]{message}[/dim]")
+                console.print(f"  [dim]{_safe(message)}[/dim]")
             elif stage == "start":
-                console.print(f"  {message}")
+                console.print(f"  {_safe(message)}")
             elif stage == "gateway_token_rotated":
                 _print_configure_warnings(stage, message)
 
@@ -2539,7 +2554,7 @@ def start(
                     on_event=on_event,
                 )
         except LifecycleError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            console.print(f"[red]Error:[/red] {_safe(str(e))}")
             raise typer.Exit(code=1)
 
         if result["success"]:
@@ -2553,10 +2568,10 @@ def start(
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except AgentNameResolutionError as e:
-        console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
         console.print("\nCancelled.")
@@ -2591,9 +2606,9 @@ def stop(
 
         def on_event(stage: str, message: str) -> None:
             if stage == "validate":
-                console.print(f"  [dim]{message}[/dim]")
+                console.print(f"  [dim]{_safe(message)}[/dim]")
             elif stage == "stop":
-                console.print(f"  {message}")
+                console.print(f"  {_safe(message)}")
 
         try:
             if installed_name in host_data.get("agents", {}):
@@ -2612,7 +2627,7 @@ def stop(
                     on_event=on_event,
                 )
         except LifecycleError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            console.print(f"[red]Error:[/red] {_safe(str(e))}")
             raise typer.Exit(code=1)
 
         if result["success"]:
@@ -2625,10 +2640,10 @@ def stop(
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except AgentNameResolutionError as e:
-        console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
         console.print("\nCancelled.")
@@ -2659,14 +2674,14 @@ def restart(
 
         def on_event(stage: str, message: str) -> None:
             if stage in ("validate", "restart"):
-                console.print(f"  [dim]{message}[/dim]")
+                console.print(f"  [dim]{_safe(message)}[/dim]")
             elif stage == "gateway_token_rotated":
                 # ATX W3: route structured rotation events through the
                 # shared renderer so the operator sees the yellow notice
                 # documented in AGENTS.md instead of raw JSON.
                 _print_configure_warnings(stage, message)
             else:
-                console.print(f"  {message}")
+                console.print(f"  {_safe(message)}")
 
         try:
             if installed_name in host_data.get("agents", {}):
@@ -2679,7 +2694,7 @@ def restart(
             else:
                 result = restart_agent(hostname, claw_type, on_event=on_event)
         except LifecycleError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            console.print(f"[red]Error:[/red] {_safe(str(e))}")
             raise typer.Exit(code=1)
 
         if result["success"]:
@@ -2693,10 +2708,10 @@ def restart(
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except AgentNameResolutionError as e:
-        console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
         console.print("\nCancelled.")
@@ -2743,7 +2758,7 @@ def sync(
         def on_event(stage: str, message: str) -> None:
             # configure stage gets dim, sync stage gets normal
             if stage == "configure":
-                console.print(f"  [dim]{message}[/dim]")
+                console.print(f"  [dim]{_safe(message)}[/dim]")
             elif stage == "gateway_token_rotated":
                 # ATX W3: structured rotation events get the yellow
                 # notice from the shared renderer, not raw JSON.
@@ -2753,7 +2768,7 @@ def sync(
                 # `[Errno 13]`-style OSError text doesn't trigger
                 # MarkupError mid-stream. Producers in core/ emit raw
                 # strings; the rendering boundary is here.
-                console.print(f"  {rich_escape(message)}")
+                console.print(f"  {_safe(message)}")
 
         try:
             result = sync_agent(
@@ -2764,7 +2779,7 @@ def sync(
                 on_event=on_event,
             )
         except LifecycleError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            console.print(f"[red]Error:[/red] {_safe(str(e))}")
             raise typer.Exit(code=1)
 
         if result["success"]:
@@ -2783,10 +2798,10 @@ def sync(
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except AgentNameResolutionError as e:
-        console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
         console.print("\nCancelled.")
@@ -2852,10 +2867,10 @@ def open_ui(
             claw_name
         )
     except AgentNameResolutionError as e:
-        err_console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        err_console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except HostsFileCorruptedError as e:
-        err_console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        err_console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
 
     resolved = resolve_web_ui(installed_name)
@@ -2879,7 +2894,7 @@ def open_ui(
     except Exception as e:  # noqa: BLE001 — best-effort probe; surface but don't crash
         err_console.print(
             f"[yellow]Warning:[/yellow] Could not verify agent status "
-            f"({rich_escape(str(e))}); proceeding."
+            f"({_safe(str(e))}); proceeding."
         )
         health = None
 
@@ -2909,7 +2924,7 @@ def open_ui(
     try:
         local_port = ensure_tunnel(installed_name)
     except TunnelError as e:
-        err_console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        err_console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
 
     local_url = f"http://127.0.0.1:{local_port}/"
@@ -2972,10 +2987,10 @@ def doctor(
             _resolve_agent_instance(agent_name)
         )
     except AgentNameResolutionError as e:
-        err_console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        err_console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
     except HostsFileCorruptedError as e:
-        err_console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        err_console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
 
     # Header
@@ -3205,7 +3220,7 @@ def integrations_list(
     try:
         hostname, claw_type, name = get_installed_claw(claw_name)
     except AgentNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
 
     assigned = get_agent_integrations(hostname, name)
@@ -3228,7 +3243,7 @@ def integrations_list(
     try:
         all_integrations = {i["name"]: i for i in load_integrations()}
     except IntegrationsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
 
     for integration_name in assigned:
@@ -3271,14 +3286,14 @@ def integrations_add(
     try:
         hostname, claw_type, name = get_installed_claw(claw_name)
     except AgentNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
 
     # Verify integration exists
     try:
         integration = get_integration(integration_name)
     except IntegrationsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
 
     if not integration:
@@ -3295,10 +3310,10 @@ def integrations_add(
     try:
         added = add_agent_integration(hostname, name, integration_name)
     except IntegrationSingletonViolation as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         console.print(
             "[dim]Hint: detach the existing one first with "
-            f"'clawctl agent integration remove {rich_escape(claw_name)} {rich_escape(e.existing_name)}'.[/dim]"
+            f"'clawctl agent integration remove {_safe(claw_name)} {_safe(e.existing_name)}'.[/dim]"
         )
         raise typer.Exit(code=1)
 
@@ -3332,7 +3347,7 @@ def integrations_remove(
     try:
         hostname, claw_type, name = get_installed_claw(claw_name)
     except AgentNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {_safe(str(e))}")
         raise typer.Exit(code=1)
 
     # Check if integration is assigned


### PR DESCRIPTION
Fixes #453.

## Summary

Wraps remote-host lifecycle event strings, exception messages, and error-return paths in `src/clawrium/cli/agent.py` through a new `_safe(text)` helper that composes the canonical `cli.output._sanitize.sanitize` (strips C0/C1 control + UAX#9 bidi/zero-width codepoints) with `rich_escape`. Closes the bidi + Rich-markup injection gap on:

- **B3** — five lifecycle `on_event` callbacks (`remove`, `start`, `stop`, `restart`, `sync`).
- **B4** — ~25 `console.print(f"[red]Error:[/red] {e}")` sites plus variant `{e}` interpolations.
- **W1** — workspace-sync and validate-stage error-string return paths.
- **W2** — `_print_configure_warnings` bidi gap on WARNING and gateway-token-rotation events.
- Extras from ATX iteration: `_run_validate_stage` provider/warning/endpoint render sites and the `IntegrationSingletonViolation` hint.

## Testing

- `make test` (Python + GUI vitest) — 4633 passed, 8 skipped; 329 GUI tests passed.
- `make lint` — ruff + next lint pass.
- Manual: file parses; `_safe` short-circuits when no dangerous codepoint present via the underlying `sanitize()` guard.

### Security Checklist
- [x] No hardcoded secrets or credentials
- [x] Input validation preserved
- [x] Fix addresses SQL/XSS-adjacent output-injection surface (bidi + Rich markup) end-to-end for agent.py
- [x] Uses the canonical sanitizer from `cli/output/_sanitize.py` — no new regex fork

## ATX Review Summary

**Final Review: Rating 4/5**

| Review | Rating | Blocking | Status | Cost | Agents |
|--------|--------|----------|--------|------|--------|
| 1 | 3.5/5 | None | W1/W2 addressed | $1.32 | architecture-specialist, clawctl-cli-reviewer |
| 2 | 3.5/5 | B1 (_run_validate_stage holes) | Addressed | $1.06 | architecture-specialist, clawctl-cli-reviewer |
| 3 | 4/5 | None | Ready — only opt-in suggestions | ~$1.0 | architecture-specialist, clawctl-cli-reviewer |

Non-blocking follow-up suggestions from Review 3 (promote `_safe` into `cli/output/_sanitize.py`, rename to `_safe_markup`, sweep other CLI modules) are recorded for a follow-up issue — out of scope for this bug fix.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>