### PR TITLE
fix(cli/agent): sanitize remote-host and exception output (#453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,17 @@ cut. The `itx:release` skill archives this section into a new
 
 ### Fixed
 
+- `clawctl agent` output paths now sanitize remote-host lifecycle messages
+  and exception strings before rendering with Rich (#453). Every
+  `on_event` callback (remove/start/stop/restart/sync), every
+  `[red]Error:[/red] {e}` interpolation, and the WARNING-prefixed
+  `_print_configure_warnings` path now route operator-visible text
+  through `sanitize()` (bidi/zero-width/control-char strip) and
+  `rich_escape()` (or `_sanitize_exception_text`) so a compromised
+  remote host cannot inject Rich markup (`[link=...]`) or Unicode bidi
+  override codepoints (U+202A–U+202E, U+2066–U+2069) into the
+  operator's terminal.
+
 - `tests/test_gui_routes_fleet.py::test_fleet_health_returns_200_under_concurrent_clients` and `test_fleet_health_host_filter_forwarded` — module-level `asyncio.Lock()` (`_LAST_ACCESS_LOCK`) was bound to the first pytest event loop, causing `RuntimeError: Lock is bound to a different event loop` on subsequent tests. Migrated to the same per-loop lazy accessor pattern (`_get_last_access_lock`) already used for the fleet-health semaphore. The concurrent-clients test also switched from `executor.shutdown(wait=False, cancel_futures=True)` to a `with`-block so futures complete normally instead of being force-cancelled, eliminating spurious `CancelledError` (#676).
 
 - `clawctl agent doctor <name>` now works for **ethos agents** (#923). Previously the command

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -18,8 +18,9 @@ from rich.markup import escape as rich_escape
 from rich.panel import Panel
 
 from clawrium.cli.agent_skill import agent_skill_app
+from clawrium.cli.chat import _sanitize_exception_text
 from clawrium.cli.install import install as install_command
-from clawrium.cli.output._sanitize import sanitize_passthrough
+from clawrium.cli.output._sanitize import sanitize, sanitize_passthrough
 from clawrium.cli.status import status as status_command
 from clawrium.core.config import get_config_dir
 from clawrium.core.hosts import (
@@ -149,7 +150,7 @@ def _print_configure_warnings(stage: str, message: str) -> None:
         if agent_label:
             console.print(
                 f"  [yellow]Gateway token rotated for "
-                f"{rich_escape(agent_label)}. Active chat sessions on "
+                f"{rich_escape(sanitize(agent_label))}. Active chat sessions on "
                 f"other machines will need to reconnect.[/yellow]"
             )
         else:
@@ -160,12 +161,12 @@ def _print_configure_warnings(stage: str, message: str) -> None:
         return
 
     if message.startswith("WARNING:"):
-        # Escape `message` before embedding in a Rich markup span — the
+        # Sanitize + escape before embedding in a Rich markup span. The
         # lifecycle warning interpolates `integration_type` from
         # integrations.json, which may be hand-edited and contain Rich
-        # tokens like `[bold]`. Without escape Rich would either garble the
-        # output or raise MarkupError mid-configure.
-        console.print(f"  [yellow]{rich_escape(message)}[/yellow]")
+        # tokens like `[bold]` (rich_escape) or bidi override codepoints
+        # (sanitize) that would reorder the operator's terminal output.
+        console.print(f"  [yellow]{rich_escape(sanitize(message))}[/yellow]")
 
 
 def _validate_name_component(name: str, component_type: str) -> None:
@@ -431,7 +432,10 @@ def _run_providers_stage(
     try:
         providers = load_providers()
     except ProvidersFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] Providers file corrupted: {e}")
+        console.print(
+            f"[red]Error:[/red] Providers file corrupted: "
+            f"{rich_escape(_sanitize_exception_text(e))}"
+        )
         return False
     except FileNotFoundError:
         providers = []
@@ -480,7 +484,7 @@ def _run_providers_stage(
         _sync_provider_config(host, claw_type, selected, installed_name)
         console.print("[green]✓[/green]")
     except Exception as e:
-        console.print(f"[red]✗[/red] {rich_escape(str(e))}")
+        console.print(f"[red]✗[/red] {rich_escape(_sanitize_exception_text(e))}")
         agent_name = installed_name or claw_type
         console.print(
             f"[red]Error:[/red] Failed to apply provider configuration. "
@@ -509,7 +513,7 @@ def _run_providers_stage(
         except Exception as e:
             console.print(
                 f"[red]✗[/red] Failed to update provider metadata: "
-                f"{rich_escape(str(e))}"
+                f"{rich_escape(_sanitize_exception_text(e))}"
             )
             return False
         console.print("[green]✓[/green] Provider configuration updated")
@@ -528,7 +532,7 @@ def _run_providers_stage(
         console.print("[green]✓[/green]")
         return True
     except Exception as e:
-        console.print(f"[red]✗[/red] {rich_escape(str(e))}")
+        console.print(f"[red]✗[/red] {rich_escape(_sanitize_exception_text(e))}")
         return False
 
 
@@ -571,7 +575,7 @@ def _run_identity_stage(
                 console.print(f"  [green]✓[/green] Imported {src_file.name}")
             except Exception as e:
                 console.print(
-                    f"[red]Error:[/red] Failed to copy {src_file.name}: {rich_escape(str(e))}"
+                    f"[red]Error:[/red] Failed to copy {src_file.name}: {rich_escape(_sanitize_exception_text(e))}"
                 )
                 return False
 
@@ -587,7 +591,7 @@ def _run_identity_stage(
                 console.print("  [green]✓[/green] Created default SOUL.md")
             except Exception as e:
                 console.print(
-                    f"[red]Error:[/red] Failed to write SOUL.md: {rich_escape(str(e))}"
+                    f"[red]Error:[/red] Failed to write SOUL.md: {rich_escape(_sanitize_exception_text(e))}"
                 )
                 return False
     else:
@@ -621,7 +625,7 @@ def _run_identity_stage(
             console.print(f"  [green]✓[/green] Created {soul_path}")
         except Exception as e:
             console.print(
-                f"[red]Error:[/red] Failed to write SOUL.md: {rich_escape(str(e))}"
+                f"[red]Error:[/red] Failed to write SOUL.md: {rich_escape(_sanitize_exception_text(e))}"
             )
             return False
 
@@ -675,7 +679,10 @@ def _run_identity_stage(
             console.print("[green]✓[/green]")
         else:
             console.print("[red]✗[/red]")
-            console.print(f"  [yellow]Warning:[/yellow] Workspace sync failed: {error}")
+            console.print(
+                f"  [yellow]Warning:[/yellow] Workspace sync failed: "
+                f"{rich_escape(sanitize(str(error)))}"
+            )
             console.print(
                 "  [dim]Identity files saved locally. Sync later with 'clawctl agent sync'[/dim]"
             )
@@ -683,7 +690,7 @@ def _run_identity_stage(
     except Exception as e:
         console.print("[red]✗[/red]")
         console.print(
-            f"  [yellow]Warning:[/yellow] Workspace sync failed: {rich_escape(str(e))}"
+            f"  [yellow]Warning:[/yellow] Workspace sync failed: {rich_escape(_sanitize_exception_text(e))}"
         )
         console.print(
             "  [dim]Identity files saved locally. Sync later with 'clawctl agent sync'[/dim]"
@@ -700,7 +707,7 @@ def _run_identity_stage(
             complete_stage(host, agent_name, "identity", StageStatus.COMPLETE)
         except Exception as e:
             console.print(
-                f"[red]Error:[/red] Failed to save identity stage: {rich_escape(str(e))}"
+                f"[red]Error:[/red] Failed to save identity stage: {rich_escape(_sanitize_exception_text(e))}"
             )
             return False
 
@@ -1273,7 +1280,7 @@ def _run_channels_stage(
             _sync_channel_config(host, claw_type, channels_config, installed_name)
             console.print("[green]✓[/green]")
         except Exception as e:
-            console.print(f"[red]✗[/red] {rich_escape(str(e))}")
+            console.print(f"[red]✗[/red] {rich_escape(_sanitize_exception_text(e))}")
             agent_name = installed_name or claw_type
             console.print(
                 f"[dim]Retry with: clawctl agent configure {rich_escape(agent_name)} --stage channels[/dim]"
@@ -1449,7 +1456,7 @@ def _run_channels_stage(
             _sync_channel_config(host, claw_type, channels_config, installed_name)
             console.print("[green]✓[/green]")
         except Exception as e:
-            console.print(f"[red]✗[/red] {rich_escape(str(e))}")
+            console.print(f"[red]✗[/red] {rich_escape(_sanitize_exception_text(e))}")
             agent_name = installed_name or claw_type
             console.print(
                 f"[dim]Retry with: clawctl agent configure {rich_escape(agent_name)} --stage channels[/dim]"
@@ -1487,7 +1494,7 @@ def _run_channels_stage(
             )
         except Exception as e:
             console.print(
-                f"[red]✗[/red] Failed to update channel metadata: {rich_escape(str(e))}"
+                f"[red]✗[/red] Failed to update channel metadata: {rich_escape(_sanitize_exception_text(e))}"
             )
             return False
         console.print("[green]✓[/green] Channels configuration updated")
@@ -1504,7 +1511,7 @@ def _run_channels_stage(
         return True
     except Exception as e:
         console.print(
-            f"[red]Error:[/red] Failed to save channels stage: {rich_escape(str(e))}"
+            f"[red]Error:[/red] Failed to save channels stage: {rich_escape(_sanitize_exception_text(e))}"
         )
         return False
 
@@ -1788,7 +1795,7 @@ def _run_validate_stage(
         return True
     except Exception as e:
         console.print(
-            f"[red]Error:[/red] Failed to save validate stage: {rich_escape(str(e))}"
+            f"[red]Error:[/red] Failed to save validate stage: {rich_escape(_sanitize_exception_text(e))}"
         )
         return False
 
@@ -1911,7 +1918,10 @@ def _run_edit_config(
         try:
             edited_config = json.loads(edited_content)
         except json.JSONDecodeError as e:
-            console.print(f"\n[red]Error:[/red] Invalid JSON: {e}")
+            console.print(
+                f"\n[red]Error:[/red] Invalid JSON: "
+                f"{rich_escape(_sanitize_exception_text(e))}"
+            )
             console.print("\nYour edited file has been preserved at:")
             console.print(f"  {config_file}")
             console.print("\nFix the JSON error and try again with:")
@@ -1934,7 +1944,10 @@ def _run_edit_config(
         )
 
         if not success:
-            console.print(f"\n[red]Error:[/red] Sync failed: {error}")
+            console.print(
+                f"\n[red]Error:[/red] Sync failed: "
+                f"{rich_escape(sanitize(str(error)))}"
+            )
             console.print("\nYour edited file has been preserved at:")
             console.print(f"  {config_file}")
             preserve_temp_dir = True
@@ -1959,11 +1972,15 @@ def _run_edit_config(
                     )
                 else:
                     console.print(
-                        f"[red]Error:[/red] Restart failed: {restart_result['error']}"
+                        f"[red]Error:[/red] Restart failed: "
+                        f"{rich_escape(sanitize(str(restart_result['error'])))}"
                     )
                     raise typer.Exit(code=1)
             except LifecycleError as e:
-                console.print(f"[red]Error:[/red] Restart failed: {e}")
+                console.print(
+                    f"[red]Error:[/red] Restart failed: "
+                    f"{rich_escape(_sanitize_exception_text(e))}"
+                )
                 raise typer.Exit(code=1)
         else:
             console.print(
@@ -2089,10 +2106,10 @@ def configure(
             installed_name,
         ) = _resolve_agent_instance(claw_name)
     except HostsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except AgentNameResolutionError as e:
-        console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
         console.print("\nCancelled.")
@@ -2119,10 +2136,10 @@ def configure(
             initialize_onboarding(hostname, installed_name)
             current_state = get_onboarding_state(hostname, installed_name)
         except AgentNotFoundError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
             raise typer.Exit(code=1)
     except AgentNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
 
     console.print(
@@ -2248,7 +2265,7 @@ def configure(
                     )
                 except Exception as e:
                     console.print(
-                        f"[red]Error:[/red] Failed to skip stage: {rich_escape(str(e))}"
+                        f"[red]Error:[/red] Failed to skip stage: {rich_escape(_sanitize_exception_text(e))}"
                     )
                     raise typer.Exit(code=1)
                 # Also advance the state pointer so the next required stage's
@@ -2278,7 +2295,7 @@ def configure(
                 try:
                     transition_state(hostname, installed_name, current_stage_state)
                 except InvalidTransitionError as e:
-                    console.print(f"[red]Error:[/red] {e}")
+                    console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
                     raise typer.Exit(code=1)
 
             if stage_name == "validate":
@@ -2304,7 +2321,7 @@ def configure(
             try:
                 transition_state(hostname, installed_name, next_state)
             except InvalidTransitionError as e:
-                console.print(f"[red]Error:[/red] {e}")
+                console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
                 raise typer.Exit(code=1)
 
             _stage_complete(stage_name)
@@ -2432,10 +2449,11 @@ def remove(
         )
 
         def on_event(stage: str, message: str) -> None:
+            safe_msg = rich_escape(sanitize(message))
             if stage == "validate":
-                console.print(f"  [dim]{message}[/dim]")
+                console.print(f"  [dim]{safe_msg}[/dim]")
             elif stage == "remove":
-                console.print(f"  {message}")
+                console.print(f"  {safe_msg}")
 
         try:
             if installed_name in host_data.get("agents", {}):
@@ -2445,7 +2463,7 @@ def remove(
             else:
                 result = remove_agent(hostname, claw_type, on_event=on_event)
         except LifecycleError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
             raise typer.Exit(code=1)
 
         if result["success"]:
@@ -2458,10 +2476,10 @@ def remove(
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except AgentNameResolutionError as e:
-        console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
         console.print("\nCancelled.")
@@ -2498,7 +2516,7 @@ def start(
                 initialize_onboarding(hostname, installed_name)
                 current_state = get_onboarding_state(hostname, installed_name)
             except AgentNotFoundError as e:
-                console.print(f"[red]Error:[/red] {e}")
+                console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
                 raise typer.Exit(code=1)
 
         if current_state != OnboardingState.READY and not force:
@@ -2515,12 +2533,14 @@ def start(
         )
 
         def on_event(stage: str, message: str) -> None:
-            if stage == "validate":
-                console.print(f"  [dim]{message}[/dim]")
-            elif stage == "start":
-                console.print(f"  {message}")
-            elif stage == "gateway_token_rotated":
+            if stage == "gateway_token_rotated":
                 _print_configure_warnings(stage, message)
+                return
+            safe_msg = rich_escape(sanitize(message))
+            if stage == "validate":
+                console.print(f"  [dim]{safe_msg}[/dim]")
+            elif stage == "start":
+                console.print(f"  {safe_msg}")
 
         try:
             if installed_name in host_data.get("agents", {}):
@@ -2539,7 +2559,7 @@ def start(
                     on_event=on_event,
                 )
         except LifecycleError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
             raise typer.Exit(code=1)
 
         if result["success"]:
@@ -2553,10 +2573,10 @@ def start(
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except AgentNameResolutionError as e:
-        console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
         console.print("\nCancelled.")
@@ -2590,10 +2610,11 @@ def stop(
         )
 
         def on_event(stage: str, message: str) -> None:
+            safe_msg = rich_escape(sanitize(message))
             if stage == "validate":
-                console.print(f"  [dim]{message}[/dim]")
+                console.print(f"  [dim]{safe_msg}[/dim]")
             elif stage == "stop":
-                console.print(f"  {message}")
+                console.print(f"  {safe_msg}")
 
         try:
             if installed_name in host_data.get("agents", {}):
@@ -2612,7 +2633,7 @@ def stop(
                     on_event=on_event,
                 )
         except LifecycleError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
             raise typer.Exit(code=1)
 
         if result["success"]:
@@ -2625,10 +2646,10 @@ def stop(
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except AgentNameResolutionError as e:
-        console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
         console.print("\nCancelled.")
@@ -2658,15 +2679,17 @@ def restart(
         )
 
         def on_event(stage: str, message: str) -> None:
-            if stage in ("validate", "restart"):
-                console.print(f"  [dim]{message}[/dim]")
-            elif stage == "gateway_token_rotated":
+            if stage == "gateway_token_rotated":
                 # ATX W3: route structured rotation events through the
                 # shared renderer so the operator sees the yellow notice
                 # documented in AGENTS.md instead of raw JSON.
                 _print_configure_warnings(stage, message)
+                return
+            safe_msg = rich_escape(sanitize(message))
+            if stage in ("validate", "restart"):
+                console.print(f"  [dim]{safe_msg}[/dim]")
             else:
-                console.print(f"  {message}")
+                console.print(f"  {safe_msg}")
 
         try:
             if installed_name in host_data.get("agents", {}):
@@ -2679,7 +2702,7 @@ def restart(
             else:
                 result = restart_agent(hostname, claw_type, on_event=on_event)
         except LifecycleError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
             raise typer.Exit(code=1)
 
         if result["success"]:
@@ -2693,10 +2716,10 @@ def restart(
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except AgentNameResolutionError as e:
-        console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
         console.print("\nCancelled.")
@@ -2741,19 +2764,27 @@ def sync(
         )
 
         def on_event(stage: str, message: str) -> None:
-            # configure stage gets dim, sync stage gets normal
-            if stage == "configure":
-                console.print(f"  [dim]{message}[/dim]")
-            elif stage == "gateway_token_rotated":
+            if stage == "gateway_token_rotated":
                 # ATX W3: structured rotation events get the yellow
                 # notice from the shared renderer, not raw JSON.
                 _print_configure_warnings(stage, message)
+                return
+            # rich-escape + full sanitize() (not sanitize_passthrough):
+            # producers in core/ emit raw single-line lifecycle strings
+            # sourced from ansible-runner output on the remote host.
+            # A compromised host can inject Rich markup (`[link=...]`)
+            # or bidi override codepoints to visually reorder the
+            # operator's terminal. sanitize() also strips C0/C1 control
+            # bytes (\r/\n/\t) — the passthrough variant is reserved
+            # for NDJSON event payloads (issue #413) where the operator
+            # explicitly opted into whitespace preservation. Terminal
+            # renders here must not honor injected CR/LF that could
+            # overwrite earlier output.
+            safe_msg = rich_escape(sanitize(message))
+            if stage == "configure":
+                console.print(f"  [dim]{safe_msg}[/dim]")
             else:
-                # ATX iter-5 W1-NEW: rich-escape so an emit containing
-                # `[Errno 13]`-style OSError text doesn't trigger
-                # MarkupError mid-stream. Producers in core/ emit raw
-                # strings; the rendering boundary is here.
-                console.print(f"  {rich_escape(message)}")
+                console.print(f"  {safe_msg}")
 
         try:
             result = sync_agent(
@@ -2764,7 +2795,7 @@ def sync(
                 on_event=on_event,
             )
         except LifecycleError as e:
-            console.print(f"[red]Error:[/red] {e}")
+            console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
             raise typer.Exit(code=1)
 
         if result["success"]:
@@ -2783,10 +2814,10 @@ def sync(
             raise typer.Exit(code=1)
 
     except HostsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except AgentNameResolutionError as e:
-        console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except KeyboardInterrupt:
         console.print("\nCancelled.")
@@ -2852,10 +2883,10 @@ def open_ui(
             claw_name
         )
     except AgentNameResolutionError as e:
-        err_console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        err_console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except HostsFileCorruptedError as e:
-        err_console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        err_console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
 
     resolved = resolve_web_ui(installed_name)
@@ -2879,7 +2910,7 @@ def open_ui(
     except Exception as e:  # noqa: BLE001 — best-effort probe; surface but don't crash
         err_console.print(
             f"[yellow]Warning:[/yellow] Could not verify agent status "
-            f"({rich_escape(str(e))}); proceeding."
+            f"({rich_escape(_sanitize_exception_text(e))}); proceeding."
         )
         health = None
 
@@ -2909,7 +2940,7 @@ def open_ui(
     try:
         local_port = ensure_tunnel(installed_name)
     except TunnelError as e:
-        err_console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        err_console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
 
     local_url = f"http://127.0.0.1:{local_port}/"
@@ -2972,10 +3003,10 @@ def doctor(
             _resolve_agent_instance(agent_name)
         )
     except AgentNameResolutionError as e:
-        err_console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        err_console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
     except HostsFileCorruptedError as e:
-        err_console.print(f"[red]Error:[/red] {rich_escape(str(e))}")
+        err_console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
 
     # Header
@@ -3205,7 +3236,7 @@ def integrations_list(
     try:
         hostname, claw_type, name = get_installed_claw(claw_name)
     except AgentNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
 
     assigned = get_agent_integrations(hostname, name)
@@ -3228,7 +3259,7 @@ def integrations_list(
     try:
         all_integrations = {i["name"]: i for i in load_integrations()}
     except IntegrationsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
 
     for integration_name in assigned:
@@ -3271,14 +3302,14 @@ def integrations_add(
     try:
         hostname, claw_type, name = get_installed_claw(claw_name)
     except AgentNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
 
     # Verify integration exists
     try:
         integration = get_integration(integration_name)
     except IntegrationsFileCorruptedError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
 
     if not integration:
@@ -3295,7 +3326,7 @@ def integrations_add(
     try:
         added = add_agent_integration(hostname, name, integration_name)
     except IntegrationSingletonViolation as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         console.print(
             "[dim]Hint: detach the existing one first with "
             f"'clawctl agent integration remove {rich_escape(claw_name)} {rich_escape(e.existing_name)}'.[/dim]"
@@ -3332,7 +3363,7 @@ def integrations_remove(
     try:
         hostname, claw_type, name = get_installed_claw(claw_name)
     except AgentNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {rich_escape(_sanitize_exception_text(e))}")
         raise typer.Exit(code=1)
 
     # Check if integration is assigned


### PR DESCRIPTION
Fixes #453.

## Summary

Route every operator-visible string in `src/clawrium/cli/agent.py` sourced from
ansible-runner lifecycle output or Python exception state through
`sanitize()` + `rich_escape()` (or `_sanitize_exception_text()` for
exceptions) before Rich renders it.

- **B3** — all five lifecycle `on_event` callbacks (remove/start/stop/restart/sync) sanitize + escape `message` before dim/normal print.
- **B4** — every `[red]Error:[/red] {e}` interpolation goes through `rich_escape(_sanitize_exception_text(e))`.
- **W1** — error-string returns (`error` from `configure_agent`, `restart_result['error']`) sanitize + escape.
- **W2** — `_print_configure_warnings` WARNING branch and the structured `gateway_token_rotated` `agent_label` both bidi-strip before rich_escape.

Also sanitizes the pre-existing `rich_escape(str(e))` sites (AgentNameResolutionError et al.) for consistency, addressing the ATX iter-1 W1 finding.

## Test plan

- `make lint` — clean
- `make test` — 4633 passed, 8 skipped
- GUI vitest — 329 passed

## ATX Review Summary

**Final review: 2.5/5** (3 iterations, hard cap hit)

| Review | Rating | Blocking | Warnings | Status |
|--------|--------|----------|----------|--------|
| 1 | 3.0/5 | 0 | 3 | Addressed W1 (`AgentNameResolutionError` sanitize sweep) and W3 (CHANGELOG entry). B1/B2 out of scope (cross-module refactor + require touching `cli/chat.py`). |
| 2 | 3.5/5 | 0 | 2 | Added comment justifying `sanitize()` vs `sanitize_passthrough()` for terminal-render path (S2). Remaining W1 (promote `_sanitize_exception_text` to `output/_sanitize.py`) is a cross-file refactor outside the scope of #453 — tracked as follow-up. |
| 3 | 2.5/5 | 3 | 3 | Blockers B1 (`--workspace` flag removal), B2 (BREAKING changelog entry for the flag removal), and B3 (`_validate_name_component` exit code) are **pre-existing repo policy items unrelated to #453**. Shipping per hard cap. |

Remaining warnings (all follow-ups):
- Cross-module import of `_sanitize_exception_text` — should relocate to `cli/output/_sanitize.py`. Out of scope for #453.
- Duplicated `on_event` shape across 5 command handlers — factor into helper. Out of scope.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>