### PR TITLE
feat(nemoclaw): phase 1 — validity gate, doctor probe, purge stale residue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,24 @@ cut. The `itx:release` skill archives this section into a new
   - **Migration**: none for operators — the first `clawctl agent sync` after upgrading materializes the fix. Existing hermes/openclaw agents that were provisioned before this release and never had `gh auth setup-git` run manually will get `~/.gitconfig` populated on their next sync.
   - **Playbook contract change**: the `Render ~/.gitconfig for each git integration` and `GitHub CLI authentication block` tasks are **removed** from every `configure.yaml` (hermes, openclaw Linux + macOS, zeroclaw, ethos). Any third-party fork that invoked those playbooks directly must move github wiring to their sync path.
   - The `src/clawrium/platform/templates/gitconfig.j2` template file and the `shared_template_path` Ansible extravar are **deleted** — no consumers remain.
+- **Removed the `nc` agent-type alias.** The alias was stale — no
+  `nemoclaw` agent type exists in the registry, so `clawctl agent
+  create --type nc <…>` was silently mapping to a nonexistent target
+  instead of failing loudly. Recovery: pass a real agent type
+  (`--type openclaw`, `--type zeroclaw`, `--type hermes`, `--type
+  ethos`). No automated migration — the alias had zero live use sites
+  in bundled Clawrium code. Part of Phase 1 groundwork for the
+  NemoClaw runtime substrate (#11 / #943).
 
 ### Added
 
+- `clawctl doctor nemoclaw` — read-only probe that verifies the pinned
+  NemoClaw upstream release
+  ([`NVIDIA/NemoClaw`](https://github.com/NVIDIA/NemoClaw)) is
+  reachable, the pinned tag exists, and the local architecture is
+  supported. The probe never downloads the tarball and never touches
+  any host. Phase 1 of the NemoClaw rollout (#11 / #943); Phase 2
+  wires the runtime into OpenClaw's install path.
 - `clawctl agent doctor <name>` — read-only health diagnostics command that
   runs five checks in dependency order (SSH reachable → unit running →
   gateway reachable → token stored → onboarding complete) and prints a

--- a/docs/agent-support/hermes.md
+++ b/docs/agent-support/hermes.md
@@ -167,7 +167,7 @@ Hermes is the only agent type in clawrium that accepts more than one provider at
 | 9 | `title_generation` | Generating session / transcript titles. |
 | 10 | `curator` | Memory curation / pruning. |
 
-The slot list comes from upstream `NousResearch/hermes-agent` (`hermes_cli/config.py`) and is mirrored in `src/clawrium/core/provider_attachments.py:AUXILIARY_SLOTS`. `zeroclaw`, `openclaw`, and `nemoclaw` reject `--role` and continue to enforce the single-provider invariant.
+The slot list comes from upstream `NousResearch/hermes-agent` (`hermes_cli/config.py`) and is mirrored in `src/clawrium/core/provider_attachments.py:AUXILIARY_SLOTS`. `zeroclaw` and `openclaw` reject `--role` and continue to enforce the single-provider invariant.
 
 #### Attach a primary and an auxiliary
 

--- a/docs/agent-support/nemoclaw.md
+++ b/docs/agent-support/nemoclaw.md
@@ -1,0 +1,69 @@
+# NemoClaw Support Matrix
+
+NemoClaw is NVIDIA's sandbox runtime for agent workloads
+([`github.com/NVIDIA/NemoClaw`](https://github.com/NVIDIA/NemoClaw),
+[`docs.nvidia.com/nemoclaw`](https://docs.nvidia.com/nemoclaw/latest/)).
+In Clawrium, NemoClaw is **not an agent type** — it is a runtime
+substrate that OpenClaw will run inside starting in phase 2 of the
+[#11 rollout](https://github.com/ric03uec/clawrium/issues/11).
+
+**Status:** 🚧 In Development (Phase 1 of #11 shipping — groundwork only)
+
+**Role in the fleet:** invisible-by-default sandbox around OpenClaw. It
+does not appear in `clawctl agent get`, `clawctl agent create`, or the
+agent registry.
+
+---
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Fully supported and tested |
+| 🚧 | In development / Planned |
+| ❌ | Not supported |
+| 📋 | Not planned (PRs welcome) |
+
+---
+
+## Rollout phases (issue #11)
+
+| Phase | Ships | Operator-visible surface |
+|-------|-------|--------------------------|
+| **1 — Groundwork** (this release) | 🚧 | `clawctl doctor nemoclaw` reports `reachable / correct-sha / arch-match` for the pinned upstream tag. `clawctl` shows no `nc` alias; `clawctl agent registry get` no longer lists a phantom `nemoclaw` row. |
+| **2 — On hosts, sandboxed openclaw available** | 📋 | `clawctl host prepare <host>` installs NemoClaw; new `clawctl agent create --type openclaw <…>` runs inside a NemoClaw sandbox. Bare openclaw still supported side-by-side. |
+| **3 — Bare openclaw deleted (BREAKING)** | 📋 | Every OpenClaw runs inside a NemoClaw sandbox. `clawctl agent get` grows a `runtime: nemoclaw@<version>` column on OpenClaw rows. `clawctl host validate <host>` aggregates per-sandbox health. |
+| **4 — Provider credentials leave the openclaw process** | 📋 | Provider `api_key` / `base_url` are handed to the NemoClaw gateway on `clawctl agent configure`; no `*_API_KEY` is visible from inside the OpenClaw sandbox. |
+
+---
+
+## Verifying the pin
+
+```bash
+clawctl doctor nemoclaw
+```
+
+Runs four read-only checks and exits non-zero on any failure:
+
+| Check | What it does |
+|-------|--------------|
+| `reachable` | `GET /repos/NVIDIA/NemoClaw` — repo resolves. |
+| `tag-exists` | `GET /repos/NVIDIA/NemoClaw/tags` — the pinned tag is present upstream. |
+| `correct-sha` | Local `TARBALL_SHA256` table has a value for the local arch (**Phase 1 pins ship the tarball SHA as `pending-upstream-freeze`** — this check will report UNKNOWN until Phase 2 release prep populates it). |
+| `arch-match` | Local architecture is in the `SUPPORTED_ARCHES` set (`x86_64`, `aarch64`). |
+
+The probe never downloads the tarball and never touches any host. It is
+safe to run on the operator's laptop.
+
+---
+
+## Upstream references
+
+- Repo: [`github.com/NVIDIA/NemoClaw`](https://github.com/NVIDIA/NemoClaw)
+- Docs: [`docs.nvidia.com/nemoclaw`](https://docs.nvidia.com/nemoclaw/latest/)
+- Pinned version constant: `clawrium.core.nemoclaw.NEMOCLAW_VERSION`
+
+The pin is the single write-side of a 3-way lockstep contract (constant
+↔ OpenClaw manifest ↔ install runbook `nemoclaw_version` var) — the
+manifest and runbook wire land in Phase 2 alongside the lockstep
+regression test.

--- a/gui/src/components/topology/topology-graph.test.ts
+++ b/gui/src/components/topology/topology-graph.test.ts
@@ -204,7 +204,7 @@ describe("computeTopology", () => {
     );
   });
 
-  it("supports zeroclaw, openclaw and nemoclaw agent types", () => {
+  it("supports opaque agent_type strings (zeroclaw, openclaw, phantomclaw)", () => {
     const data = makeData([
       {
         hostname: "host-a",
@@ -219,7 +219,7 @@ describe("computeTopology", () => {
           }),
           makeAgent({
             agent_key: "n1",
-            agent_type: "nemoclaw",
+            agent_type: "phantomclaw",
             provider: "openrouter-1",
             provider_type: "openrouter",
             provider_endpoint: null,

--- a/src/clawrium/cli/__init__.py
+++ b/src/clawrium/cli/__init__.py
@@ -17,6 +17,7 @@ from clawrium import format_version
 from clawrium.cli.clawctl.agent import agent_app
 from clawrium.cli.clawctl.audit import audit_app
 from clawrium.cli.clawctl.channel import channel_app
+from clawrium.cli.clawctl.doctor import doctor_app
 from clawrium.cli.clawctl.host import host_app
 from clawrium.cli.clawctl.integration import integration_app
 from clawrium.cli.clawctl.provider import provider_app
@@ -91,6 +92,7 @@ app.add_typer(channel_app, name="channel")
 app.add_typer(integration_app, name="integration")
 app.add_typer(skill_app, name="skill")
 app.add_typer(audit_app, name="audit")
+app.add_typer(doctor_app, name="doctor")
 
 # Declarative fleet management verbs: apply / diff / delete -f
 from clawrium.cli.clawctl.apply import apply as _apply_cmd  # noqa: E402

--- a/src/clawrium/cli/agent.py
+++ b/src/clawrium/cli/agent.py
@@ -729,8 +729,8 @@ def _run_channels_stage(
     # Channel-type hint must mirror `_hydrate_channels_from_canonical`
     # in `core/lifecycle.py` (`if resolved_type in ("hermes", "zeroclaw",
     # "ethos"):`). Only those three types pull channels from the
-    # canonical store on configure; openclaw and nemoclaw have no
-    # canonical channel hydration today, so directing their operators
+    # canonical store on configure; openclaw has no
+    # canonical channel hydration today, so directing its operators
     # at `clawctl channel attach` would silently no-op on sync
     # (ATX #794 iter-4 W1). zeroclaw has no native Slack channel
     # (#422), so only discord is listed there. `cli` is an in-process
@@ -746,7 +746,7 @@ def _run_channels_stage(
         installed_name or "<agent-name>"
     )
     if channel_examples is None:
-        # openclaw / nemoclaw / unknown — no canonical hydration path.
+        # openclaw / unknown — no canonical hydration path.
         console.print(
             "[yellow]This wizard is deprecated.[/yellow] "
             f"`{claw_type}` does not currently support attaching "

--- a/src/clawrium/cli/clawctl/doctor/__init__.py
+++ b/src/clawrium/cli/clawctl/doctor/__init__.py
@@ -1,0 +1,39 @@
+"""`clawctl doctor` — read-only diagnostic probes.
+
+This group hosts one probe per external substrate that Clawrium depends
+on but does not own. Each probe fetches upstream metadata (release tag,
+tarball URL, checksum) and reports whether Clawrium's pin matches
+reality, without touching any host.
+
+Probes shipped so far:
+
+- ``clawctl doctor nemoclaw`` — verify the NemoClaw substrate pin in
+  ``clawrium.core.nemoclaw`` against ``github.com/NVIDIA/NemoClaw``.
+  Phase 1 of issue #11.
+
+Note: agent-level diagnostics live under ``clawctl agent doctor <name>``
+and remain the right entry point for a specific agent's health. Group
+this ``doctor`` namespace by *substrate* rather than by agent.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from clawrium.cli.clawctl.doctor.nemoclaw import doctor_nemoclaw
+
+__all__ = ["doctor_app"]
+
+
+doctor_app = typer.Typer(
+    name="doctor",
+    help="Read-only diagnostic probes for external substrates Clawrium depends on.",
+    no_args_is_help=True,
+    rich_markup_mode=None,
+    add_completion=False,
+)
+
+doctor_app.command(
+    name="nemoclaw",
+    help="Verify the pinned NemoClaw upstream release is reachable and shas match.",
+)(doctor_nemoclaw)

--- a/src/clawrium/cli/clawctl/doctor/nemoclaw.py
+++ b/src/clawrium/cli/clawctl/doctor/nemoclaw.py
@@ -1,0 +1,137 @@
+"""`clawctl doctor nemoclaw` — Phase 1 read-only probe (issue #943).
+
+Contract: fetch upstream release metadata for the pinned
+``clawrium.core.nemoclaw.NEMOCLAW_VERSION`` and print a small table with
+three checks — ``reachable``, ``correct-sha``, ``arch-match``. Exits
+non-zero on any FAIL / UNKNOWN so CI + shell pipelines can gate on it.
+
+The probe never downloads the tarball. It hits two endpoints only:
+
+- ``GET /repos/NVIDIA/NemoClaw`` — confirms the repo resolves.
+- ``GET /repos/NVIDIA/NemoClaw/tags`` — confirms the pinned tag exists.
+
+Phase-1 pins ship with ``TARBALL_SHA256`` sentinels of ``None`` (the
+tarball artefacts are frozen upstream during phase-2 release
+preparation). Until then, ``correct-sha`` is reported as
+``pending-upstream-freeze`` — the probe still fails so an operator does
+not mistake it for green, but the message distinguishes "we haven't
+frozen the SHA yet" from "the SHA drifted".
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import urllib.error
+import urllib.request
+from typing import Any, Callable  # noqa: F401 — Callable kept for type hints on helpers
+
+import typer
+
+from clawrium.core import nemoclaw as _nemoclaw
+
+__all__ = ["doctor_nemoclaw"]
+
+_GITHUB_API = "https://api.github.com"
+_USER_AGENT = "clawctl-doctor-nemoclaw/1"
+
+
+def _default_fetch(url: str) -> dict[str, Any] | list[Any]:
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _current_arch() -> str:
+    """Return normalized arch string matching SUPPORTED_ARCHES."""
+    m = platform.machine().lower()
+    if m in ("x86_64", "amd64"):
+        return "x86_64"
+    if m in ("aarch64", "arm64"):
+        return "aarch64"
+    return m
+
+
+def _check_reachable(fetch: Callable[[str], Any]) -> tuple[str, str]:
+    try:
+        payload = fetch(f"{_GITHUB_API}/repos/{_nemoclaw.UPSTREAM_REPO}")
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError) as e:
+        return "FAIL", f"unreachable: {e}"
+    if isinstance(payload, dict) and payload.get("full_name") == _nemoclaw.UPSTREAM_REPO:
+        return "PASS", f"{_nemoclaw.UPSTREAM_REPO} resolves"
+    return "FAIL", f"unexpected payload for {_nemoclaw.UPSTREAM_REPO}"
+
+
+def _check_tag_exists(fetch: Callable[[str], Any]) -> tuple[str, str]:
+    try:
+        payload = fetch(f"{_GITHUB_API}/repos/{_nemoclaw.UPSTREAM_REPO}/tags")
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError) as e:
+        return "FAIL", f"tag-list fetch failed: {e}"
+    if not isinstance(payload, list):
+        return "FAIL", "tag-list response was not a JSON array"
+    for entry in payload:
+        if isinstance(entry, dict) and entry.get("name") == _nemoclaw.NEMOCLAW_VERSION:
+            return "PASS", f"tag {_nemoclaw.NEMOCLAW_VERSION} present upstream"
+    return "FAIL", f"tag {_nemoclaw.NEMOCLAW_VERSION} not found in first page of tags"
+
+
+def _check_sha() -> tuple[str, str]:
+    arch = _current_arch()
+    expected = _nemoclaw.TARBALL_SHA256.get(arch)
+    if arch not in _nemoclaw.SUPPORTED_ARCHES:
+        return "FAIL", f"arch {arch!r} not in SUPPORTED_ARCHES"
+    if expected is None:
+        return "UNKNOWN", "pending-upstream-freeze"
+    return "PASS", f"sha256 pinned for {arch}: {expected[:12]}…"
+
+
+def _check_arch_match() -> tuple[str, str]:
+    arch = _current_arch()
+    if arch in _nemoclaw.SUPPORTED_ARCHES:
+        return "PASS", f"local arch {arch} in {list(_nemoclaw.SUPPORTED_ARCHES)}"
+    return (
+        "FAIL",
+        f"local arch {arch} not in SUPPORTED_ARCHES {list(_nemoclaw.SUPPORTED_ARCHES)}",
+    )
+
+
+def _print_row(check: str, status: str, detail: str) -> None:
+    typer.echo(f"  {check:<14} {status:<8} {detail}")
+
+
+def doctor_nemoclaw() -> None:
+    """Run the four checks and print a pass/fail table.
+
+    Tests inject a stub network fetch by
+    ``monkeypatch.setattr(probe_mod, "_default_fetch", ...)`` — the
+    module-level indirection avoids a ``Callable`` parameter on the
+    Typer command (Typer cannot render it as a click option and refuses
+    to load the entire app).
+    """
+    fetch = _default_fetch
+
+    typer.echo(
+        f"NemoClaw substrate probe (pin: {_nemoclaw.NEMOCLAW_VERSION}, "
+        f"repo: {_nemoclaw.UPSTREAM_REPO})"
+    )
+    typer.echo("")
+    typer.echo(f"  {'CHECK':<14} {'STATUS':<8} DETAIL")
+
+    results: list[tuple[str, str, str]] = []
+    for name, fn in (
+        ("reachable", lambda: _check_reachable(fetch)),
+        ("tag-exists", lambda: _check_tag_exists(fetch)),
+        ("correct-sha", _check_sha),
+        ("arch-match", _check_arch_match),
+    ):
+        status, detail = fn()
+        _print_row(name, status, detail)
+        results.append((name, status, detail))
+
+    typer.echo("")
+    if all(r[1] == "PASS" for r in results):
+        typer.echo("All checks passed.")
+        return
+    failed = [r[0] for r in results if r[1] != "PASS"]
+    typer.echo(f"Non-passing checks: {', '.join(failed)}")
+    raise typer.Exit(code=1)

--- a/src/clawrium/core/lifecycle.py
+++ b/src/clawrium/core/lifecycle.py
@@ -133,7 +133,6 @@ class LifecycleResult(TypedDict):
 ALIAS_TO_CANONICAL = {
     "opc": "openclaw",
     "zc": "zeroclaw",
-    "nc": "nemoclaw",
     "ethos": "ethos",
 }
 

--- a/src/clawrium/core/nemoclaw.py
+++ b/src/clawrium/core/nemoclaw.py
@@ -1,0 +1,57 @@
+"""NemoClaw runtime substrate — Phase 1 skeleton (issue #11 / #943).
+
+This module holds the pinned NemoClaw upstream version and the per-arch
+tarball URL / SHA256 table that downstream phases will consume:
+
+- Phase 2 wires the CLI wrapper (onboard / start / stop / status / logs /
+  destroy) and adds `install_nemoclaw.yaml` runbooks that read
+  `NEMOCLAW_VERSION` + `TARBALL_URLS` + `TARBALL_SHA256` via the version-
+  lockstep test.
+- Phase 3 delegates the openclaw lifecycle verbs to this wrapper.
+
+Phase 1 intentionally ships **no behavior** — only the pinned constants
+and the `clawctl doctor nemoclaw` probe (see
+`clawrium.cli.clawctl.doctor.nemoclaw`) that verifies these values
+against `https://api.github.com/repos/NVIDIA/NemoClaw` before any host
+work lands. Bumping the pin here is the single write-side of the phase-2
+3-way lockstep contract (constant ↔ manifest ↔ runbook var).
+"""
+
+from __future__ import annotations
+
+UPSTREAM_REPO = "NVIDIA/NemoClaw"
+UPSTREAM_DOCS = "https://docs.nvidia.com/nemoclaw/latest/"
+
+NEMOCLAW_VERSION = "v0.0.94"
+
+_TARBALL_URL_TEMPLATE = (
+    "https://github.com/NVIDIA/NemoClaw/releases/download/"
+    "{version}/nemoclaw-{version}-{arch}.tar.zst"
+)
+
+SUPPORTED_ARCHES = ("x86_64", "aarch64")
+
+
+def tarball_url(arch: str, version: str = NEMOCLAW_VERSION) -> str:
+    """Return the upstream tarball URL for the given arch + version.
+
+    Raises ValueError on unsupported arches so callers fail loudly at
+    the boundary rather than requesting a nonexistent asset.
+    """
+    if arch not in SUPPORTED_ARCHES:
+        raise ValueError(
+            f"nemoclaw: unsupported arch {arch!r}; "
+            f"supported: {', '.join(SUPPORTED_ARCHES)}"
+        )
+    return _TARBALL_URL_TEMPLATE.format(version=version, arch=arch)
+
+
+# Per-arch SHA256 for the pinned NEMOCLAW_VERSION tarball. Populated by
+# the phase-2 lockstep test / release automation once the tarball is
+# frozen upstream. Phase 1 ships the map with `None` sentinels so the
+# doctor probe can report `sha=pending-upstream-freeze` clearly instead
+# of hard-crashing during the validity gate.
+TARBALL_SHA256: dict[str, str | None] = {
+    "x86_64": None,
+    "aarch64": None,
+}

--- a/src/clawrium/gui/routes/skills.py
+++ b/src/clawrium/gui/routes/skills.py
@@ -172,8 +172,8 @@ def _compatibility_map(ref: SkillRef, metadata: dict[str, Any]) -> dict[str, boo
     the GUI doesn't have to special-case native skills.
 
     Claw list comes from ``NATIVE_REGISTRIES`` so any future claw
-    (e.g. ``nemoclaw``) added to ``core.skills`` automatically appears
-    in the compatibility map. ``sorted()`` for stable JSON ordering.
+    added to ``core.skills`` automatically appears in the compatibility
+    map. ``sorted()`` for stable JSON ordering.
     """
     claws = sorted(NATIVE_REGISTRIES)
     if ref.registry == "clawrium":

--- a/tests/cli/clawctl/agent/test_doctor.py
+++ b/tests/cli/clawctl/agent/test_doctor.py
@@ -126,12 +126,12 @@ def test_doctor_unknown_renderer_type(fleet_dir, monkeypatch) -> None:
     """ATX iter-1 B5 — `_RENDERER_NAMES` miss must be surfaced as broken."""
     from clawrium.cli.clawctl.agent import doctor as doctor_mod
 
-    nemoclaw_inputs = RenderInputs(
+    phantom_inputs = RenderInputs(
         agent_name="wise-hypatia",
-        agent_type="nemoclaw",  # Not in _RENDERER_NAMES.
+        agent_type="phantomclaw",  # Not in _RENDERER_NAMES.
         provider=ProviderInputs(name="x", type="anthropic", api_key="k"),
     )
-    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda n: nemoclaw_inputs)
+    monkeypatch.setattr(doctor_mod, "build_render_inputs", lambda n: phantom_inputs)
 
     result = runner.invoke(app, ["agent", "doctor", "wise-hypatia"])
     assert result.exit_code != 0

--- a/tests/cli/clawctl/doctor/test_nemoclaw.py
+++ b/tests/cli/clawctl/doctor/test_nemoclaw.py
@@ -1,0 +1,105 @@
+"""Tests for `clawctl doctor nemoclaw` — Phase 1 of #11 / #943.
+
+The probe is pure-local except for two GitHub API endpoints; we stub
+the fetch callable so tests never hit the network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from clawrium.cli import app
+from clawrium.cli.clawctl.doctor import nemoclaw as probe_mod
+from clawrium.core import nemoclaw as nemoclaw_mod
+
+runner = CliRunner()
+
+
+def _fake_fetch_ok(url: str) -> Any:
+    if url.endswith(f"/repos/{nemoclaw_mod.UPSTREAM_REPO}"):
+        return {"full_name": nemoclaw_mod.UPSTREAM_REPO}
+    if url.endswith(f"/repos/{nemoclaw_mod.UPSTREAM_REPO}/tags"):
+        return [{"name": nemoclaw_mod.NEMOCLAW_VERSION}]
+    raise AssertionError(f"unexpected url: {url}")
+
+
+def _fake_fetch_repo_missing(url: str) -> Any:
+    raise OSError("network down")
+
+
+def _fake_fetch_tag_missing(url: str) -> Any:
+    if url.endswith(f"/repos/{nemoclaw_mod.UPSTREAM_REPO}"):
+        return {"full_name": nemoclaw_mod.UPSTREAM_REPO}
+    if url.endswith("/tags"):
+        return [{"name": "v0.0.1"}]
+    raise AssertionError(f"unexpected url: {url}")
+
+
+def test_doctor_pending_sha_fails_non_zero(monkeypatch):
+    """Phase 1 pins ship with SHA=None → correct-sha is UNKNOWN
+    → command must exit non-zero (green would falsely reassure
+    operators before the upstream tarball is frozen)."""
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr(probe_mod, "_default_fetch", _fake_fetch_ok)
+    result = runner.invoke(app, ["doctor", "nemoclaw"])
+    assert result.exit_code == 1, result.output
+    assert "reachable" in result.output
+    assert "PASS" in result.output
+    assert "tag-exists" in result.output
+    assert "pending-upstream-freeze" in result.output
+    assert "correct-sha" in result.output
+
+
+def test_doctor_all_pass_when_sha_pinned(monkeypatch):
+    """When SHA is pinned for the local arch, all four checks pass and
+    the command exits 0."""
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setitem(nemoclaw_mod.TARBALL_SHA256, "x86_64", "a" * 64)
+    monkeypatch.setattr(probe_mod, "_default_fetch", _fake_fetch_ok)
+    try:
+        result = runner.invoke(app, ["doctor", "nemoclaw"])
+    finally:
+        nemoclaw_mod.TARBALL_SHA256["x86_64"] = None
+    assert result.exit_code == 0, result.output
+    assert "All checks passed" in result.output
+
+
+def test_doctor_unreachable_repo_fails(monkeypatch):
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr(probe_mod, "_default_fetch", _fake_fetch_repo_missing)
+    result = runner.invoke(app, ["doctor", "nemoclaw"])
+    assert result.exit_code == 1
+    assert "FAIL" in result.output
+    assert "unreachable" in result.output
+
+
+def test_doctor_missing_tag_fails(monkeypatch):
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr(probe_mod, "_default_fetch", _fake_fetch_tag_missing)
+    result = runner.invoke(app, ["doctor", "nemoclaw"])
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+def test_doctor_unsupported_arch_fails(monkeypatch):
+    monkeypatch.setattr("platform.machine", lambda: "riscv64")
+    monkeypatch.setattr(probe_mod, "_default_fetch", _fake_fetch_ok)
+    result = runner.invoke(app, ["doctor", "nemoclaw"])
+    assert result.exit_code == 1
+    assert "arch-match" in result.output
+    assert "SUPPORTED_ARCHES" in result.output
+
+
+def test_tarball_url_rejects_unknown_arch():
+    with pytest.raises(ValueError, match="unsupported arch"):
+        nemoclaw_mod.tarball_url("riscv64")
+
+
+def test_tarball_url_shape():
+    url = nemoclaw_mod.tarball_url("x86_64")
+    assert url.startswith("https://github.com/NVIDIA/NemoClaw/releases/download/")
+    assert nemoclaw_mod.NEMOCLAW_VERSION in url
+    assert "x86_64" in url

--- a/tests/core/test_agent_exec.py
+++ b/tests/core/test_agent_exec.py
@@ -133,7 +133,7 @@ def test_run_agent_exec_timeout(monkeypatch, patched_env):
 
 def test_unknown_claw_type_raises(patched_env):
     with pytest.raises(agent_exec.AgentExecError):
-        agent_exec.run_agent_exec("10.0.0.1", "x", "nemoclaw", ["foo"])
+        agent_exec.run_agent_exec("10.0.0.1", "x", "phantomclaw", ["foo"])
 
 
 @pytest.mark.parametrize("cmd_argv", [[], None])

--- a/tests/core/test_install_openclaw_prerender.py
+++ b/tests/core/test_install_openclaw_prerender.py
@@ -77,7 +77,7 @@ def test_install_non_openclaw_passes_empty_string_for_prerendered_var():
     `prerendered_openclaw_config_json = ""` and only overwrites it when
     `claw_name == "openclaw"`. This test pins the contract by reading
     the source: for non-openclaw claw_names (hermes / zeroclaw /
-    nemoclaw), the install ansible vars must carry an empty string for
+    any future non-openclaw type), the install ansible vars must carry an empty string for
     `prerendered_openclaw_config_json`. We assert the contract by
     checking the source code, since `run_installation` is too deeply
     nested to call ergonomically and the openclaw-only guard is the

--- a/tests/core/test_launchd_openclaw.py
+++ b/tests/core/test_launchd_openclaw.py
@@ -74,7 +74,7 @@ def test_render_openclaw_plist_paths_target_user_home():
 
 def test_unsupported_agent_type_raises():
     with pytest.raises(ValueError, match="unsupported agent_type"):
-        label_for("o1", agent_type="nemoclaw")
+        label_for("o1", agent_type="phantomclaw")
 
 
 def test_hermes_default_agent_type_unchanged():

--- a/tests/core/test_playbook_resolver.py
+++ b/tests/core/test_playbook_resolver.py
@@ -208,7 +208,7 @@ class TestUnitPathFor:
         from clawrium.core.playbook_resolver import unit_path_for
 
         with _pytest.raises(ValueError, match="unsupported agent_type"):
-            unit_path_for("linux", "nemoclaw", "alpha")
+            unit_path_for("linux", "phantomclaw", "alpha")
 
     def test_darwin_zeroclaw_raises_value_error(self):
         """ATX iter-1 B3: zeroclaw has no launchd label prefix

--- a/tests/test_gui_agent_skills_routes.py
+++ b/tests/test_gui_agent_skills_routes.py
@@ -255,7 +255,7 @@ def test_install_422_on_unsupported_claw_type(monkeypatch):
     is reserved for the genuine apply-failure class.
     """
     _stub_resolved(monkeypatch)
-    detail = "Skills apply for 'nemoclaw' has no playbook"
+    detail = "Skills apply for 'phantomclaw' has no playbook"
     _stub_apply(monkeypatch, raises=SkillApplyNotSupported(detail))
     with pytest.raises(HTTPException) as exc:
         _run(agents_route.install_agent_skill("tdd-hermes", "clawrium", "tdd"))
@@ -266,7 +266,7 @@ def test_install_422_on_unsupported_claw_type(monkeypatch):
 
 def test_remove_422_on_unsupported_claw_type(monkeypatch):
     _stub_resolved(monkeypatch)
-    detail = "Skills apply for 'nemoclaw' has no playbook"
+    detail = "Skills apply for 'phantomclaw' has no playbook"
     _stub_apply(monkeypatch, raises=SkillApplyNotSupported(detail))
     with pytest.raises(HTTPException) as exc:
         _run(agents_route.remove_agent_skill("tdd-hermes", "clawrium", "tdd"))
@@ -452,7 +452,7 @@ def test_install_state_is_rolled_back_on_apply_failure(monkeypatch):
         ("clawrium", "tdd", "openclaw", True),
         ("clawrium", "tdd", "zeroclaw", True),
         # Unknown agent type fails closed via check_agent_compatibility.
-        ("clawrium", "tdd", "nemoclaw", False),
+        ("clawrium", "tdd", "phantomclaw", False),
         # Catalog row that doesn't exist fails closed at load_skill.
         ("clawrium", "missing-skill", "hermes", False),
     ],

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -423,7 +423,7 @@ class TestRunLifecyclePlaybook:
         assert inventory["all"]["vars"]["dashboard_port"] == 45100
 
     def test_non_hermes_agent_does_not_get_dashboard_port(self, tmp_path: Path):
-        """ATX B2: zeroclaw / openclaw / nemoclaw must NOT receive a
+        """ATX B2: zeroclaw / openclaw must NOT receive a
         dashboard_port var. The agent-type guard is the only thing
         preventing future playbook tasks guarded by `when: dashboard_port
         is defined` from firing on the wrong claw."""

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -33,6 +33,31 @@ from clawrium.core.lifecycle import (
 )
 
 
+class TestAliasToCanonical:
+    """Regression guards for `lifecycle.ALIAS_TO_CANONICAL`.
+
+    Any silent re-introduction of an alias pointing at a phantom agent
+    type (see #943 for the `nc → nemoclaw` removal) would cause
+    `--type <alias>` to map to a nonexistent registry entry without a
+    clean failure — the whole point of removing the alias.
+    """
+
+    def test_nc_alias_absent(self):
+        from clawrium.core import lifecycle
+
+        assert "nc" not in lifecycle.ALIAS_TO_CANONICAL
+        assert "nemoclaw" not in lifecycle.ALIAS_TO_CANONICAL.values()
+
+    def test_alias_targets_are_registered_types(self):
+        from clawrium.core import lifecycle
+
+        registered = {"openclaw", "zeroclaw", "hermes", "ethos"}
+        for alias, target in lifecycle.ALIAS_TO_CANONICAL.items():
+            assert target in registered, (
+                f"alias {alias!r} → {target!r} points at an unregistered type"
+            )
+
+
 class TestGetLifecyclePlaybookPath:
     """Tests for playbook path resolution."""
 

--- a/website/docs/agent-support/hermes.md
+++ b/website/docs/agent-support/hermes.md
@@ -167,7 +167,7 @@ Hermes is the only agent type in clawrium that accepts more than one provider at
 | 9 | `title_generation` | Generating session / transcript titles. |
 | 10 | `curator` | Memory curation / pruning. |
 
-The slot list comes from upstream `NousResearch/hermes-agent` (`hermes_cli/config.py`) and is mirrored in `src/clawrium/core/provider_attachments.py:AUXILIARY_SLOTS`. `zeroclaw`, `openclaw`, and `nemoclaw` reject `--role` and continue to enforce the single-provider invariant.
+The slot list comes from upstream `NousResearch/hermes-agent` (`hermes_cli/config.py`) and is mirrored in `src/clawrium/core/provider_attachments.py:AUXILIARY_SLOTS`. `zeroclaw` and `openclaw` reject `--role` and continue to enforce the single-provider invariant.
 
 #### Attach a primary and an auxiliary
 

--- a/website/docs/agent-support/nemoclaw.md
+++ b/website/docs/agent-support/nemoclaw.md
@@ -1,0 +1,69 @@
+# NemoClaw Support Matrix
+
+NemoClaw is NVIDIA's sandbox runtime for agent workloads
+([`github.com/NVIDIA/NemoClaw`](https://github.com/NVIDIA/NemoClaw),
+[`docs.nvidia.com/nemoclaw`](https://docs.nvidia.com/nemoclaw/latest/)).
+In Clawrium, NemoClaw is **not an agent type** — it is a runtime
+substrate that OpenClaw will run inside starting in phase 2 of the
+[#11 rollout](https://github.com/ric03uec/clawrium/issues/11).
+
+**Status:** 🚧 In Development (Phase 1 of #11 shipping — groundwork only)
+
+**Role in the fleet:** invisible-by-default sandbox around OpenClaw. It
+does not appear in `clawctl agent get`, `clawctl agent create`, or the
+agent registry.
+
+---
+
+## Legend
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ | Fully supported and tested |
+| 🚧 | In development / Planned |
+| ❌ | Not supported |
+| 📋 | Not planned (PRs welcome) |
+
+---
+
+## Rollout phases (issue #11)
+
+| Phase | Ships | Operator-visible surface |
+|-------|-------|--------------------------|
+| **1 — Groundwork** (this release) | 🚧 | `clawctl doctor nemoclaw` reports `reachable / correct-sha / arch-match` for the pinned upstream tag. `clawctl` shows no `nc` alias; `clawctl agent registry get` no longer lists a phantom `nemoclaw` row. |
+| **2 — On hosts, sandboxed openclaw available** | 📋 | `clawctl host prepare <host>` installs NemoClaw; new `clawctl agent create --type openclaw <…>` runs inside a NemoClaw sandbox. Bare openclaw still supported side-by-side. |
+| **3 — Bare openclaw deleted (BREAKING)** | 📋 | Every OpenClaw runs inside a NemoClaw sandbox. `clawctl agent get` grows a `runtime: nemoclaw@<version>` column on OpenClaw rows. `clawctl host validate <host>` aggregates per-sandbox health. |
+| **4 — Provider credentials leave the openclaw process** | 📋 | Provider `api_key` / `base_url` are handed to the NemoClaw gateway on `clawctl agent configure`; no `*_API_KEY` is visible from inside the OpenClaw sandbox. |
+
+---
+
+## Verifying the pin
+
+```bash
+clawctl doctor nemoclaw
+```
+
+Runs four read-only checks and exits non-zero on any failure:
+
+| Check | What it does |
+|-------|--------------|
+| `reachable` | `GET /repos/NVIDIA/NemoClaw` — repo resolves. |
+| `tag-exists` | `GET /repos/NVIDIA/NemoClaw/tags` — the pinned tag is present upstream. |
+| `correct-sha` | Local `TARBALL_SHA256` table has a value for the local arch (**Phase 1 pins ship the tarball SHA as `pending-upstream-freeze`** — this check will report UNKNOWN until Phase 2 release prep populates it). |
+| `arch-match` | Local architecture is in the `SUPPORTED_ARCHES` set (`x86_64`, `aarch64`). |
+
+The probe never downloads the tarball and never touches any host. It is
+safe to run on the operator's laptop.
+
+---
+
+## Upstream references
+
+- Repo: [`github.com/NVIDIA/NemoClaw`](https://github.com/NVIDIA/NemoClaw)
+- Docs: [`docs.nvidia.com/nemoclaw`](https://docs.nvidia.com/nemoclaw/latest/)
+- Pinned version constant: `clawrium.core.nemoclaw.NEMOCLAW_VERSION`
+
+The pin is the single write-side of a 3-way lockstep contract (constant
+↔ OpenClaw manifest ↔ install runbook `nemoclaw_version` var) — the
+manifest and runbook wire land in Phase 2 alongside the lockstep
+regression test.

--- a/website/docs/reference/cli/registry.md
+++ b/website/docs/reference/cli/registry.md
@@ -33,7 +33,6 @@ $ clawctl agent registry get
 ┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ zeroclaw   │ 0.1.0          │ Zero-config Claude assistant   │
 │ openclaw   │ 0.2.0          │ OpenAI-powered assistant       │
-│ nemoclaw   │ 0.1.0          │ Local Ollama-based assistant   │
 └────────────┴────────────────┴────────────────────────────────┘
 ```
 


### PR DESCRIPTION
## Summary

Phase 1 of parent #11 (NemoClaw rollout). Ships the read-only
`clawctl doctor nemoclaw` probe + `core/nemoclaw.py` skeleton and
purges stale nemoclaw residue that predated the current 4-phase plan.
**No host-side behavior yet** — Phase 2 wires the runtime into
openclaw's install path.

Base: `main` (subtask of #11; parent orchestrator is `clawrium-issue-11`).

## Changes

- `src/clawrium/core/nemoclaw.py` (new) — pinned `NEMOCLAW_VERSION = v0.0.94` (per orchestrator directive, supersedes plan's `v0.0.44`), upstream tarball URL template, per-arch `SHA256` map with `pending-upstream-freeze` sentinels.
- `clawctl doctor` group + `clawctl doctor nemoclaw` — 4 read-only checks (`reachable / tag-exists / correct-sha / arch-match`) against `api.github.com/repos/NVIDIA/NemoClaw`. No downloads, no host contact. Exits non-zero while SHA sentinels remain unfrozen.
- Removed `"nc": "nemoclaw"` alias in `core/lifecycle.py` — the alias mapped to a phantom type that never existed in the registry. **BREAKING**.
- Removed phantom `nemoclaw` row in `website/docs/reference/cli/registry.md`; dropped incidental mention in `docs/agent-support/hermes.md` + website mirror.
- Renamed `nemoclaw` unknown-type canaries in tests to `phantomclaw` (7 tests). Comment cleanup in `cli/agent.py` + `gui/routes/skills.py`.
- `docs/agent-support/nemoclaw.md` (new) + website mirror.
- `CHANGELOG.md` `### BREAKING` for `nc` alias + `### Added` for doctor probe.

## Testing

- [x] `make test` — 4647 passed, 8 skipped
- [x] `make lint` — clean (both `ruff` + `next lint`)
- [x] Manual verification: `clawctl doctor nemoclaw`, `clawctl agent registry get`, `clawctl agent create --type nc`

## Real-host UAT

**Host**: wolf-i (wolf.tailf7742d.ts.net, Ubuntu 24.04, x86_64)
**Date**: 2026-07-24
**Clawrium version**: `clawctl 26.7.2 (git: aec6ad0)`

### Primary happy path

```
$ clawctl doctor nemoclaw
NemoClaw substrate probe (pin: v0.0.94, repo: NVIDIA/NemoClaw)

  CHECK          STATUS   DETAIL
  reachable      PASS     NVIDIA/NemoClaw resolves
  tag-exists     PASS     tag v0.0.94 present upstream
  correct-sha    UNKNOWN  pending-upstream-freeze
  arch-match     PASS     local arch x86_64 in ['x86_64', 'aarch64']

Non-passing checks: correct-sha    # exit 1 — by design; not a green
                                   # signal until Phase 2 freezes SHAs
```

- `clawctl --help` — no `nc` alias visible ✅
- `clawctl agent registry get` — lists only `ethos / hermes / openclaw / zeroclaw` (no `nemoclaw` row) ✅
- `clawctl agent create foo --type nc --host wolf-i` — `Error: unknown agent type 'nc'` with hint ✅
- `hosts.json` unchanged (probe is read-only) ✅

### Non-regression: attached integrations (`clawctl agent sync`)

| Agent | Type | Integration(s) | Verified how | Result |
|---|---|---|---|---|
| clawrium-triage | hermes | clawrium-github | `clawctl agent sync` | **FAIL** — pre-existing (see Callouts) |
| clawrium-gtm | hermes | clawrium-github | `clawctl agent sync` | **FAIL** — pre-existing (see Callouts) |
| clawrium-exec | hermes | clawrium-github | `clawctl agent sync` | PASS |
| clawrium-maurice | hermes | clawrium-github | `clawctl agent sync` | PASS |
| clawrium-d01 | zeroclaw | clawrium-d01-github | `clawctl agent sync` | PASS |

### Non-regression: plain-lifecycle agents

| Agent | Type | Verified how | Result |
|---|---|---|---|
| espresso | hermes | `clawctl agent sync espresso` | **FAIL** — pre-existing (see Callouts) |
| e2e-hermes | hermes | `clawctl agent sync e2e-hermes` | **FAIL** — pre-existing (see Callouts) |
| e2e-zeroclaw | zeroclaw | `clawctl agent sync e2e-zeroclaw` | PASS |
| e2e-openclaw | openclaw | `clawctl agent sync e2e-openclaw` | PASS |
| ep6-hermes | hermes | `clawctl agent sync ep6-hermes` | PASS |

**6/10 wolf-i agents synced clean.** The 4 failures are all pre-existing environmental drift on wolf-i (see `[ENVIRONMENT]` Callouts below) — none of them touch code paths this PR modifies. Same-shape agents on the same code path (e.g. `clawrium-maurice` is a hermes+integration identical in shape to failing `clawrium-triage`; `ep6-hermes` is a plain hermes identical to failing `espresso`) synced clean, isolating the failures to per-agent `hosts.json` state rather than the shared lifecycle path.

## Callouts

- **[DECISION] Version pin is `v0.0.94`, not the plan's `v0.0.44`.**
  - Why: the parent orchestrator's #11 comment directed this child to use `v0.0.94` (the latest upstream tag) rather than the plan text's `v0.0.44`, and confirmed via direct `GET /repos/NVIDIA/NemoClaw` + `/tags`.
  - Reviewer: confirm the pin choice or push back with a specific older tag.

- **[DECISION] `TARBALL_SHA256` sentinels are `None`, not empty strings.**
  - Why: NVIDIA/NemoClaw uses git tags only (no GitHub Releases with per-arch artifacts), so per-arch tarball SHAs cannot be frozen from this PR. The Phase 2 plan already scopes the release-time SHA freeze; `None` + a `pending-upstream-freeze` UNKNOWN status makes it obvious rather than silently green.
  - Alternatives considered: hardcode a placeholder SHA (bad — passes silently), block Phase 1 (rejected — the plan explicitly delays SHA freeze to Phase 2 release prep).
  - Reviewer: confirm the sentinel-plus-non-zero-exit contract, or say if you'd prefer the probe to report PASS with a "phase-1 pin only" caveat.

- **[DECISION] Rename `nemoclaw` test canaries to `phantomclaw` rather than the more generic `unknown-type`.**
  - Why: matches the project's `-claw` naming convention, is unambiguously fictional, and reads as intent-preserving in the test bodies (still clearly a "not-a-supported-agent-type" marker). `unknown-type` would have read as a string literal rather than a fake type.
  - Reviewer: swap if a different placeholder name is preferred.

- **[DECISION] The `doctor` group lives at `clawctl doctor <substrate>`, distinct from the existing `clawctl agent doctor <name>`.**
  - Why: agent-level diagnostics belong under `agent` (per-instance health); substrate-level probes are fleet-scoped and belong at the top. Splitting namespaces avoids polluting `agent doctor`'s per-name argument shape.
  - How to apply: any future substrate probe (e.g. `docker`, `nvm`, `nemoclaw`) drops into `src/clawrium/cli/clawctl/doctor/<substrate>.py`.

- **[DECISION] The `doctor_nemoclaw` command takes no arguments; test injection is via `monkeypatch.setattr(probe_mod, "_default_fetch", ...)`.**
  - Why: Typer cannot render a `Callable` parameter on a command (it fails app-load with `RuntimeError: Type not yet supported`), breaking every clawctl invocation. First iteration hit this — module-level indirection sidesteps it.
  - Reviewer: verify the indirection matches the project's testing style; every other clawctl command uses the same monkeypatch-module-attr pattern.

- **[ENVIRONMENT] 4/10 wolf-i sync failures are pre-existing state drift, not regressions from this PR.**
  - `clawrium-triage`, `clawrium-gtm`, `espresso`: `_verify_health: no gateway port persisted for '<name>'. install.py never allocated one — the agent install is incomplete.` — this is the install-incomplete error surfaced by #737 (merged as fd9e72f), not new behavior.
  - `e2e-hermes`: `refusing to sync: rendered body removes host-side secrets (.hermes/.env: would remove ['GITHUB_TOKEN'])` — a secret-owner drift; the channel/integration that owned `GITHUB_TOKEN` is no longer attached.
  - Same-shape agents on the same shared code path (hermes+integration `clawrium-maurice`; plain hermes `ep6-hermes`) synced clean, proving the failures are per-agent state, not shared-code regressions from this PR. This PR touches only: (a) one dict entry in `ALIAS_TO_CANONICAL`, (b) doc strings, (c) test canaries, (d) two new files. None of that can cause "no gateway port persisted" or "secret would be removed" — both are hosts.json / secret-store state on wolf-i.
  - Reviewer: confirm this is acceptable to ship. Recovery for the 4 stuck agents is out-of-scope for Phase 1 and belongs in a follow-up cleanup PR (or an operator-side `clawctl agent create` re-run + secret restore per the error hints).

- **[TODO-FOLLOWUP] SHA256 population + doctor-probe UNKNOWN → PASS transition.**
  - Tracked: Phase 2 (parent #11 planning §5, "3-way version-pin lockstep test"). The manifest wire + install runbook + release-time SHA freeze all land together.

## ATX Review

**Final Review: Rating 3.5/5**
**Total Cost: $1.50 | Total Time: 5m 12s**

| Review | Rating | Blocking Issues | Status | Cost | Time | Agents |
|--------|--------|-----------------|--------|------|------|--------|
| 1 | 3.5/5 | B1 | Fixed in 0977a36; W1 (gui) also fixed; W2-W4 deferred as additive edge-case hardening | $1.50 | 5m 12s | leader, test-coverage, gui-routes, cli-ux (failed), lifecycle-core (failed) |

> Note: `cli-ux` and `lifecycle-core` specialists failed with model-configuration infrastructure errors (not review errors). The remaining specialists (test-coverage, gui-routes) completed and the review body is authoritative for what was verified — per memory `atx task JSON rating vs review body`, the review body is the source of truth over the JSON rating field.

<details>
<summary>Review 1 Details (Rating 3.5/5)</summary>

**Blocking Issues:**

| # | File | Issue | Resolution |
|---|------|-------|------------|
| B1 | `tests/test_lifecycle.py` | The `nc` alias removal had zero regression coverage — a future diff re-adding it would pass CI undetected. | **Fixed** in 0977a36 — added `TestAliasToCanonical` with two guards: `assert 'nc' not in ALIAS_TO_CANONICAL` and a broader assertion that every alias target is a registered type. |

**Warnings:**

| # | File | Warning | Action |
|---|------|---------|--------|
| W1 (gui-routes) | `gui/src/components/topology/topology-graph.test.ts:207,222` | Test still used `agent_type: 'nemoclaw'` fixture after this PR renamed the Python-side canaries to `phantomclaw`. Inconsistent cleanup. | **Fixed** in 0977a36 — renamed to `phantomclaw` and updated the test description string. |
| W1 (test-coverage) | `tests/cli/clawctl/doctor/test_nemoclaw.py:96-105` | `tarball_url()` only tested for `x86_64`. Missing: `aarch64`, custom `version` param. | Deferred — additive edge-case hardening; Phase 2 already scopes the 3-way lockstep test which will cover per-arch URL rendering. |
| W2 (test-coverage) | `test_nemoclaw.py:87-93` | `test_doctor_unsupported_arch_fails` doesn't explicitly verify `correct-sha`'s FAIL branch for unsupported arches. | Deferred — same rationale. |
| W3 (test-coverage) | `test_nemoclaw.py:70-76` | `test_doctor_unreachable_repo_fails` stub raises for ALL urls; substring assertion could match from the wrong row. | Deferred — same rationale. |
| W4 (test-coverage) | `doctor/nemoclaw.py:71` | `_check_tag_exists` non-list JSON branch is untested. | Deferred — same rationale. |

**Suggestions:**

| # | Suggestion | Action |
|---|------------|--------|
| S1 (test-coverage) | Remove redundant `try/finally` in `test_doctor_all_pass_when_sha_pinned` (rely on `monkeypatch.setitem` only). | Deferred — belt-and-suspenders is intentional; harmless. |
| S2 (test-coverage) | Add parameterized `_current_arch()` tests for `amd64`/`arm64` aliases. | Deferred — hardening. |
| S3 (gui-routes) | `gui/src/hooks/use-agent.ts:78` vestige comment. | Explicitly out-of-scope per reviewer. |

**Rating threshold**: 3.5/5 > 3.0 (required per AGENTS.md ATX enforcement rules). B1 fixed → no unresolved blockers. Skipping ATX iter-2 per the "iteration ceiling (non-blocking)" clause of `/itx:execute` — the exit criteria are met (rating > 3, no blockers).

</details>

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Co-Authored-By: @atx-ci <269048218+atx-ci@users.noreply.github.com>

