### PR TITLE
daily-docs-sweep 2026-07-25

### DIFF
--- a/docs/agent-support/integrations/github.md
+++ b/docs/agent-support/integrations/github.md
@@ -1,6 +1,6 @@
 # GitHub
 
-**Status:** ✅ Supported on Hermes and ZeroClaw (#419, #422). 📋 Planned for OpenClaw.
+**Status:** ✅ Supported on Hermes, ZeroClaw, OpenClaw, and Ethos (#419, #422, #649).
 
 GitHub integration allows agents to clone repos, open pull requests, comment on issues, and search code from inside the agent's shell tool. The credential is a Personal Access Token (classic) or a fine-grained token — see [Create Fine-Grained Token for One Repo](#create-fine-grained-token-for-one-repo) below.
 
@@ -79,12 +79,16 @@ Agent: Analyzing commits since v2.0.0...
 
 ## Use with Clawrium
 
-When configuring your agent:
+The standard workflow is attach + sync:
 
 ```bash
-clawctl agent configure my-agent
-# Enter the fine-grained token when prompted for GitHub credentials
+clawctl agent integration attach my-agent my-github
+clawctl agent sync my-agent
 ```
+
+`sync` handles everything: renders the token into the agent's environment, runs `gh auth login --with-token` and `gh auth setup-git` on the host as the agent user, and writes `~/.gitconfig` for `git`-type integrations. No manual `ssh xclm@host -- 'sudo -u <agent> gh auth setup-git'` steps are needed.
+
+> **Note:** `gh` (GitHub CLI) is installed as part of agent host setup and is a **hard requirement** — if the binary is missing on the host, sync will raise a `CanonicalSyncError` rather than silently skipping.
 
 The key difference from classic tokens: fine-grained tokens let you scope to specific repos and grant minimal permissions per resource type.
 
@@ -92,16 +96,23 @@ The key difference from classic tokens: fine-grained tokens let you scope to spe
 
 ## How clawctl Wires GitHub to Each Agent Type
 
+All agent types now use the same sync-path wiring hook (`_setup_github_integration` in `core/lifecycle_canonical.py`). On every `clawctl agent sync <name>`:
+
+1. **`git`-type integrations first**: `~/.gitconfig` `[user]` / `[init]` / `[pull]` / `[core]` sections are rendered via `sudo -u <agent> tee`.
+2. **`github`-type integrations second**: `gh auth login --with-token` (token via stdin — never in argv) followed by `gh auth setup-git` which appends the `[credential]` helper block to `~/.gitconfig`.
+
+The ordering matters: `gitconfig` render must precede `setup-git` because `setup-git` appends `[credential]` to the file. If no `git`/`github` integration is attached, the hook is a fast no-op (zero SSH round-trips).
+
 ### Hermes — env vars in `~/.hermes/.env`
 
-Hermes natively reads `GITHUB_TOKEN` from its environment. `clawctl agent integration attach <hermes> <gh-name>` followed by `clawctl agent sync <hermes>` renders the following into `~/.hermes/.env` (mode 0600):
+Hermes natively reads `GITHUB_TOKEN` from its environment. After `clawctl agent integration attach` + `sync`, the following is rendered into `~/.hermes/.env` (mode 0600):
 
 ```env
 GITHUB_TOKEN_WORK_GH='ghp_...'
 GITHUB_TOKEN='ghp_...'      # tracks the alphabetically-last github integration
 ```
 
-`clawctl` then runs `gh auth login --with-token` as the agent user (soft dep — skipped if `gh` is not on the host). See [hermes/playbooks/configure.yaml](https://github.com/ric03uec/clawrium/blob/main/src/clawrium/platform/registry/hermes/playbooks/configure.yaml) lines 118–145.
+In addition to the env var, `gh auth login --with-token` and `gh auth setup-git` run as the agent user so `git push` / `git pull` over HTTPS from the agent shell work without manual setup.
 
 ### ZeroClaw — two layers, both required
 
@@ -114,7 +125,11 @@ ZeroClaw's shell tool **auto-strips** any env var matching `_TOKEN` / `_SECRET` 
 
 Both layers are populated automatically by `clawctl agent sync <zeroclaw>` after `clawctl agent integration attach`. The drop-in template is `src/clawrium/platform/registry/zeroclaw/templates/zeroclaw-env.conf.j2`; the autonomy block lives in `config.toml.j2`. Re-running `clawctl agent sync` re-renders both atomically and triggers a single service restart (daemon_reload + restart, handled by the configure playbook's restart handler).
 
-Like hermes, a `gh auth login --with-token` is run as the agent user when `gh` is present on the host — convenience only; the env-var path works without it.
+The sync path also runs `gh auth login --with-token` and `gh auth setup-git` as the agent user, so `git push` works from the shell tool without manual setup.
+
+### OpenClaw & Ethos — sync-path wiring only
+
+OpenClaw and Ethos agents do not use the systemd env-var or shell_env_passthrough layers. Instead, `clawctl agent sync` runs `gh auth login --with-token` and `gh auth setup-git` directly on the host as the agent user, which populates `~/.config/gh/hosts.yml` and the `[credential]` block in `~/.gitconfig`. This is sufficient for `git push` / `git pull` over HTTPS from the agent shell — no manual `ssh xclm@host -- 'sudo -u <agent> gh auth setup-git'` steps are required.
 
 ```toml
 # Rendered in ~/.zeroclaw/config.toml when github integrations are assigned:
@@ -165,14 +180,35 @@ The agent then has `GITHUB_TOKEN_WORK_GH` and `GITHUB_TOKEN_PERSONAL_GH` availab
 
 ---
 
-## OpenClaw (Not Yet Supported)
+## Git Integration (`git` type)
 
-OpenClaw does not yet consume GitHub credentials. Use a hermes or zeroclaw agent for GitHub workflows, or follow the workaround below for OpenClaw-only fleets.
+A `git`-type integration (distinct from `github`) configures `~/.gitconfig` with `[user]`, `[init]`, `[pull]`, and `[core]` sections for the agent user. This enables `git push` / `git pull` over HTTPS when combined with `gh auth setup-git` (which `github` integrations handle). On its own, it sets up author identity, default branch naming, and fetch strategies:
 
-## Workaround for OpenClaw
+```bash
+clawctl integration registry create my-git --type git
+clawctl agent integration attach my-agent my-git
+clawctl agent sync my-agent
+```
 
-1. **CLI Tools:** Manually `gh auth login` on the OpenClaw host outside of clawctl.
-2. **API via curl:** Make direct API calls inside chat using a hard-coded token (not recommended for production).
+The rendered `~/.gitconfig` includes:
+- `[user]` — name and email from the integration record
+- `[init]` — `defaultBranch` for `git init`
+- `[pull]` — `rebase = true` for rebase-on-pull behavior
+- `[core]` — `editor` (shell-metachar sanitized, `vim` by default)
+
+Both `github` and `git` integrations can be attached to the same agent — `sync` processes `git` first, then `github`, so the credential helper lands after the other sections.
+
+---
+
+## Migrating from Manual GitHub Setup
+
+Before v26.7.2, `git push` from an agent shell required manual `gh auth setup-git` via SSH. If you have existing agents with this workaround:
+
+1. Attach the integration: `clawctl agent integration attach <name> <gh-integration>`
+2. Sync: `clawctl agent sync <name>`
+3. Verify: `clawctl agent chat <name>` → `gh auth status` should show "Logged in to github.com"
+
+The next `clawctl agent sync` will wire everything automatically. The manual `~/.gitconfig` entries `gh auth setup-git` previously wrote will be preserved (the sync hook is idempotent — it only appends `[credential]` if not already present).
 
 ---
 

--- a/docs/agent-support/integrations/index.md
+++ b/docs/agent-support/integrations/index.md
@@ -8,7 +8,7 @@ Integrations allow agents to interact with external tools and services, extendin
 |-------------|:------:|--------|----------|
 | **[Atlassian (Jira + Confluence)](atlassian.md)** | ✅ | Hermes (MCP), OpenClaw, ZeroClaw | Issue tracking, docs / knowledge base |
 | **[Brave Search](brave.md)** | ✅ | Hermes, OpenClaw, ZeroClaw | Web search tool |
-| **[GitHub](github.md)** | 🚧 | OpenClaw (planned) | PR reviews, issues |
+|| **[GitHub](github.md)** | ✅ | Hermes, ZeroClaw, OpenClaw, Ethos | PR reviews, issues, git push/pull, code search |
 | **[GitLab](gitlab.md)** | 📋 | Not planned | Alternative to GitHub |
 | **[Linear](linear.md)** | 📋 | Not planned | Issue tracking |
 | **[Notion](notion.md)** | 📋 | Not planned | Knowledge base |

--- a/website/docs/agent-support/integrations/github.md
+++ b/website/docs/agent-support/integrations/github.md
@@ -1,6 +1,6 @@
 # GitHub
 
-**Status:** ✅ Supported on Hermes and ZeroClaw (#419, #422). 📋 Planned for OpenClaw.
+**Status:** ✅ Supported on Hermes, ZeroClaw, OpenClaw, and Ethos (#419, #422, #649).
 
 GitHub integration allows agents to clone repos, open pull requests, comment on issues, and search code from inside the agent's shell tool. The credential is a Personal Access Token (classic) or a fine-grained token — see [Create Fine-Grained Token for One Repo](#create-fine-grained-token-for-one-repo) below.
 
@@ -79,12 +79,16 @@ Agent: Analyzing commits since v2.0.0...
 
 ## Use with Clawrium
 
-When configuring your agent:
+The standard workflow is attach + sync:
 
 ```bash
-clawctl agent configure my-agent
-# Enter the fine-grained token when prompted for GitHub credentials
+clawctl agent integration attach my-agent my-github
+clawctl agent sync my-agent
 ```
+
+`sync` handles everything: renders the token into the agent's environment, runs `gh auth login --with-token` and `gh auth setup-git` on the host as the agent user, and writes `~/.gitconfig` for `git`-type integrations. No manual `ssh xclm@host -- 'sudo -u <agent> gh auth setup-git'` steps are needed.
+
+> **Note:** `gh` (GitHub CLI) is installed as part of agent host setup and is a **hard requirement** — if the binary is missing on the host, sync will raise a `CanonicalSyncError` rather than silently skipping.
 
 The key difference from classic tokens: fine-grained tokens let you scope to specific repos and grant minimal permissions per resource type.
 
@@ -92,16 +96,23 @@ The key difference from classic tokens: fine-grained tokens let you scope to spe
 
 ## How clawctl Wires GitHub to Each Agent Type
 
+All agent types now use the same sync-path wiring hook (`_setup_github_integration` in `core/lifecycle_canonical.py`). On every `clawctl agent sync <name>`:
+
+1. **`git`-type integrations first**: `~/.gitconfig` `[user]` / `[init]` / `[pull]` / `[core]` sections are rendered via `sudo -u <agent> tee`.
+2. **`github`-type integrations second**: `gh auth login --with-token` (token via stdin — never in argv) followed by `gh auth setup-git` which appends the `[credential]` helper block to `~/.gitconfig`.
+
+The ordering matters: `gitconfig` render must precede `setup-git` because `setup-git` appends `[credential]` to the file. If no `git`/`github` integration is attached, the hook is a fast no-op (zero SSH round-trips).
+
 ### Hermes — env vars in `~/.hermes/.env`
 
-Hermes natively reads `GITHUB_TOKEN` from its environment. `clawctl agent integration attach <hermes> <gh-name>` followed by `clawctl agent sync <hermes>` renders the following into `~/.hermes/.env` (mode 0600):
+Hermes natively reads `GITHUB_TOKEN` from its environment. After `clawctl agent integration attach` + `sync`, the following is rendered into `~/.hermes/.env` (mode 0600):
 
 ```env
 GITHUB_TOKEN_WORK_GH='ghp_...'
 GITHUB_TOKEN='ghp_...'      # tracks the alphabetically-last github integration
 ```
 
-`clawctl` then runs `gh auth login --with-token` as the agent user (soft dep — skipped if `gh` is not on the host). See [hermes/playbooks/configure.yaml](https://github.com/ric03uec/clawrium/blob/main/src/clawrium/platform/registry/hermes/playbooks/configure.yaml) lines 118–145.
+In addition to the env var, `gh auth login --with-token` and `gh auth setup-git` run as the agent user so `git push` / `git pull` over HTTPS from the agent shell work without manual setup.
 
 ### ZeroClaw — two layers, both required
 
@@ -114,7 +125,11 @@ ZeroClaw's shell tool **auto-strips** any env var matching `_TOKEN` / `_SECRET` 
 
 Both layers are populated automatically by `clawctl agent sync <zeroclaw>` after `clawctl agent integration attach`. The drop-in template is `src/clawrium/platform/registry/zeroclaw/templates/zeroclaw-env.conf.j2`; the autonomy block lives in `config.toml.j2`. Re-running `clawctl agent sync` re-renders both atomically and triggers a single service restart (daemon_reload + restart, handled by the configure playbook's restart handler).
 
-Like hermes, a `gh auth login --with-token` is run as the agent user when `gh` is present on the host — convenience only; the env-var path works without it.
+The sync path also runs `gh auth login --with-token` and `gh auth setup-git` as the agent user, so `git push` works from the shell tool without manual setup.
+
+### OpenClaw & Ethos — sync-path wiring only
+
+OpenClaw and Ethos agents do not use the systemd env-var or shell_env_passthrough layers. Instead, `clawctl agent sync` runs `gh auth login --with-token` and `gh auth setup-git` directly on the host as the agent user, which populates `~/.config/gh/hosts.yml` and the `[credential]` block in `~/.gitconfig`. This is sufficient for `git push` / `git pull` over HTTPS from the agent shell — no manual `ssh xclm@host -- 'sudo -u <agent> gh auth setup-git'` steps are required.
 
 ```toml
 # Rendered in ~/.zeroclaw/config.toml when github integrations are assigned:
@@ -165,14 +180,35 @@ The agent then has `GITHUB_TOKEN_WORK_GH` and `GITHUB_TOKEN_PERSONAL_GH` availab
 
 ---
 
-## OpenClaw (Not Yet Supported)
+## Git Integration (`git` type)
 
-OpenClaw does not yet consume GitHub credentials. Use a hermes or zeroclaw agent for GitHub workflows, or follow the workaround below for OpenClaw-only fleets.
+A `git`-type integration (distinct from `github`) configures `~/.gitconfig` with `[user]`, `[init]`, `[pull]`, and `[core]` sections for the agent user. This enables `git push` / `git pull` over HTTPS when combined with `gh auth setup-git` (which `github` integrations handle). On its own, it sets up author identity, default branch naming, and fetch strategies:
 
-## Workaround for OpenClaw
+```bash
+clawctl integration registry create my-git --type git
+clawctl agent integration attach my-agent my-git
+clawctl agent sync my-agent
+```
 
-1. **CLI Tools:** Manually `gh auth login` on the OpenClaw host outside of clawctl.
-2. **API via curl:** Make direct API calls inside chat using a hard-coded token (not recommended for production).
+The rendered `~/.gitconfig` includes:
+- `[user]` — name and email from the integration record
+- `[init]` — `defaultBranch` for `git init`
+- `[pull]` — `rebase = true` for rebase-on-pull behavior
+- `[core]` — `editor` (shell-metachar sanitized, `vim` by default)
+
+Both `github` and `git` integrations can be attached to the same agent — `sync` processes `git` first, then `github`, so the credential helper lands after the other sections.
+
+---
+
+## Migrating from Manual GitHub Setup
+
+Before v26.7.2, `git push` from an agent shell required manual `gh auth setup-git` via SSH. If you have existing agents with this workaround:
+
+1. Attach the integration: `clawctl agent integration attach <name> <gh-integration>`
+2. Sync: `clawctl agent sync <name>`
+3. Verify: `clawctl agent chat <name>` → `gh auth status` should show "Logged in to github.com"
+
+The next `clawctl agent sync` will wire everything automatically. The manual `~/.gitconfig` entries `gh auth setup-git` previously wrote will be preserved (the sync hook is idempotent — it only appends `[credential]` if not already present).
 
 ---
 

--- a/website/docs/agent-support/integrations/index.md
+++ b/website/docs/agent-support/integrations/index.md
@@ -8,7 +8,7 @@ Integrations allow agents to interact with external tools and services, extendin
 |-------------|:------:|--------|----------|
 | **[Atlassian (Jira + Confluence)](atlassian.md)** | ✅ | Hermes (MCP), OpenClaw, ZeroClaw | Issue tracking, docs / knowledge base |
 | **[Brave Search](brave.md)** | ✅ | Hermes, OpenClaw, ZeroClaw | Web search tool |
-| **[GitHub](github.md)** | 🚧 | OpenClaw (planned) | PR reviews, issues |
+|| **[GitHub](github.md)** | ✅ | Hermes, ZeroClaw, OpenClaw, Ethos | PR reviews, issues, git push/pull, code search |
 | **[GitLab](gitlab.md)** | 📋 | Not planned | Alternative to GitHub |
 | **[Linear](linear.md)** | 📋 | Not planned | Issue tracking |
 | **[Notion](notion.md)** | 📋 | Not planned | Knowledge base |


### PR DESCRIPTION
## Summary

Automated documentation sweep for merged PRs from the last 24 hours.

## PRs Analyzed

| PR | Title | User-Facing? | Action |
|----|-------|-------------|--------|
| [#942](https://github.com/ric03uec/clawrium/pull/942) | fix(sync): move github+git integration wiring to canonical sync path (#649) | Yes | **Docs updated** |
| [#940](https://github.com/ric03uec/clawrium/pull/940) | fix(install): clearer error for missing/partial host facts (#737) | Minor UX | Already in CHANGELOG, no additional docs needed |
| [#939](https://github.com/ric03uec/clawrium/pull/939) | refactor(cli/agent): remove unreachable channels-stage wizard body (#860) | No | Internal dead-code removal, skipped |
| [#941](https://github.com/ric03uec/clawrium/pull/941) | docs(itx): 4-phase plan + scaffold for #11 | No | Plan-only, skipped |

## Changes Made

### PR #942 - GitHub/Git Integration Sync Wiring

The GitHub integration docs were significantly out of date after PR #942 moved github+git wiring from `configure.yaml` to the canonical sync path:

**`docs/agent-support/integrations/github.md`** (+ `website/docs/` mirror):
- Updated status line: GitHub is now supported on all four agent types (hermes, zeroclaw, openclaw, ethos)
- Replaced "Use with Clawrium" section: old `clawctl agent configure` workflow to new attach + sync workflow
- Added sync-path wiring hook description (`_setup_github_integration`)
- Removed stale "soft dep" language for `gh` - it is now a hard requirement
- Removed stale `configure.yaml` line references
- Added OpenClaw & Ethos wiring section (previously marked "Not Yet Supported")
- Added Git Integration section documenting the `git`-type integration
- Added Migration guide for operators who previously wired github manually

**`docs/agent-support/integrations/index.md`** (+ `website/docs/` mirror):
- GitHub status: planned to supported, agents: "OpenClaw (planned)" to "Hermes, ZeroClaw, OpenClaw, Ethos"

### Mirror Verification

- `diff docs/agent-support/integrations/github.md website/docs/agent-support/integrations/github.md` -> identical
- `diff docs/agent-support/integrations/index.md website/docs/agent-support/integrations/index.md` -> identical

## Testing

- All existing tests pass (`make test` - no code changes)
- Linter passes (`make lint` - no code changes)
- File write verification: both docs and website files confirmed non-empty and readable
- Mirror verification: `diff` confirms docs/ and website/docs/ are byte-identical
- No stale references to old naming remain (searched for "soft dep", "OpenClaw (planned)", configure.yaml github references)

---

Generated by clawrium-gtm docs-sweep cron job
