### PR TITLE
fix(docs): repoint openclaw release CHANGELOG links to GitHub URL

### DIFF
--- a/website/docs/agent-support/openclaw.md
+++ b/website/docs/agent-support/openclaw.md
@@ -37,7 +37,7 @@ state.
 
 **Rollback path.** There is no in-place rollback; pin the previous
 Clawrium release and re-install per the migration note in
-[`docs/releases/26.7.3/CHANGELOG.md`](../releases/26.7.3/CHANGELOG.md).
+[`docs/releases/26.7.3/CHANGELOG.md`](https://github.com/ric03uec/clawrium/blob/main/docs/releases/26.7.3/CHANGELOG.md).
 
 **macOS.** Openclaw on macOS is blocked at install pending an upstream
 NemoClaw darwin binary (#11 §7.2). Deploy openclaw on an Ubuntu 24.04+
@@ -45,7 +45,7 @@ host until that support lands.
 
 **Migration from bare openclaw.** Legacy bare records predating v26.7.3
 fail `clawctl agent sync` with a message pointing at
-[`docs/releases/26.7.3/CHANGELOG.md`](../releases/26.7.3/CHANGELOG.md).
+[`docs/releases/26.7.3/CHANGELOG.md`](https://github.com/ric03uec/clawrium/blob/main/docs/releases/26.7.3/CHANGELOG.md).
 The migration is `remove` + `create` + `configure` + `start`; there is
 no automated migration.
 


### PR DESCRIPTION
## Summary

Fixes a `npm run build` failure on `main` introduced when PR #950 (Phase 4) merged: `website/docs/agent-support/openclaw.md` links to `../releases/26.7.3/CHANGELOG.md`, but `website/docs/releases/` does not exist. The release archive lives at `docs/releases/` (engineering-only) and is intentionally not mirrored into the Docusaurus site — MDX compilation fails hard on unresolvable relative Markdown links.

Repoints both occurrences in `website/docs/agent-support/openclaw.md` to the absolute GitHub URL for the same file. The engineering copy (`docs/agent-support/openclaw.md`) already resolves correctly via `../releases/…` because both files live under `docs/`, so it is left untouched.

## Testing

- [x] `npm run build` inside `website/` completes locally (previously failed with the same error as https://github.com/ric03uec/clawrium/actions/runs/30517007687)
- [x] Grep confirms only these two links used the bad relative path

## Files changed

- `website/docs/agent-support/openclaw.md` — 2 lines

## Context

Follow-up hotfix after the NemoClaw substrate rollout landed on main this morning (#947 → #948 → #949 → #950). The commit originally sat on the merged `issue-946-provider-credentials-gateway` branch; moving it to a fresh branch against `main` so CI can unblock.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>